### PR TITLE
bevy_dynamic_plugin: Don't leak memory

### DIFF
--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -13,6 +13,8 @@ keywords = ["bevy"]
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.9.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.9.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 
 # other
 libloading = { version = "0.7" }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,3 +1,5 @@
+use std::mem::ManuallyDrop;
+
 use libloading::{Library, Symbol};
 use std::ffi::OsStr;
 use thiserror::Error;
@@ -23,26 +25,144 @@ pub enum DynamicPluginLoadError {
 /// by deriving `DynamicPlugin` on a unit struct implementing [`Plugin`].
 pub unsafe fn dynamically_load_plugin<P: AsRef<OsStr>>(
     path: P,
-) -> Result<(Library, Box<dyn Plugin>), DynamicPluginLoadError> {
+) -> Result<LeakingDynamicPlugin, DynamicPluginLoadError> {
     let lib = Library::new(path).map_err(DynamicPluginLoadError::Library)?;
     let func: Symbol<CreatePlugin> = lib
         .get(b"_bevy_create_plugin")
         .map_err(DynamicPluginLoadError::Plugin)?;
     let plugin = Box::from_raw(func());
-    Ok((lib, plugin))
+    Ok(LeakingDynamicPlugin::from_raw_parts(plugin, lib))
+}
+
+/// Wraps a dynamically loaded plugin and its associated library so that they can be dropped correctly.
+///
+/// This struct leaks the library and so its memory is not freed until the program is terminated.
+/// This is in contrast to [`DroppingDynamicPlugin`] which automatically drops the library.
+pub struct LeakingDynamicPlugin {
+    plugin: Box<dyn Plugin>,
+    lib: ManuallyDrop<Library>,
+}
+
+impl LeakingDynamicPlugin {
+    /// Coverts this dynamic plugin into its raw [`Box<dyn Plugin>`] and [`Library`].
+    ///
+    /// # Safety
+    ///
+    /// The general safety concerns from [`Library::new`] apply here.
+    /// In addition the concerns from [`DroppingDynamicPlugin::from_leaky`] also apply.
+    pub unsafe fn into_raw_parts(self) -> (Box<dyn Plugin>, Library) {
+        (self.plugin, ManuallyDrop::into_inner(self.lib))
+    }
+
+    /// Creates a leaky dynamic plugin from its raw [`Box<dyn Plugin>`] and [`Library`].
+    pub fn from_raw_parts(plugin: Box<dyn Plugin>, lib: Library) -> Self {
+        Self { plugin, lib: ManuallyDrop::new(lib) }
+    }
+}
+
+impl Plugin for LeakingDynamicPlugin {
+    fn name(&self) -> &str {
+        self.plugin.name()
+    }
+
+    fn is_unique(&self) -> bool {
+        self.plugin.is_unique()
+    }
+
+    fn build(&self, app: &mut App) {
+        self.plugin.build(app);
+    }
+}
+
+/// Wraps a dynamically loaded plugin and its associated library so that they can be dropped correctly.
+///
+/// This struct does not leak the library and so its memory is freed when the app is dropped.
+/// This is in contrast to [`LeakingDynamicPlugin`] which leaks the library.
+///
+/// Leaving dangling function pointers when the app (and therefore library) is dropped is UB.
+/// See [`DroppingDynamicPlugin::from_leaky`] for more info.
+pub struct DroppingDynamicPlugin {
+    plugin: Box<dyn Plugin>,
+    lib: Library,
+}
+
+impl DroppingDynamicPlugin {
+    /// Returns a [`LeakingDynamicPlugin`].
+    pub fn into_leaky(self) -> LeakingDynamicPlugin {
+        LeakingDynamicPlugin {
+            plugin: self.plugin,
+            lib: ManuallyDrop::new(self.lib),
+        }
+    }
+
+    /// Creates an automatically-dropping dynamic plugin from a [`LeakingDynamicPlugin`].
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that all function pointers pointing to code inside the dynamic library
+    /// are dropped before the [`DroppingDynamicPlugin`] is.
+    /// This includes all `dyn Trait`, `impl Trait` and `fn(...)` definitions.
+    pub unsafe fn from_leaky(leaky: LeakingDynamicPlugin) -> Self {
+        Self {
+            plugin: leaky.plugin,
+            lib: ManuallyDrop::into_inner(leaky.lib),
+        }
+    }
+}
+
+impl Plugin for DroppingDynamicPlugin {
+    fn name(&self) -> &str {
+        self.plugin.name()
+    }
+
+    fn is_unique(&self) -> bool {
+        self.plugin.is_unique()
+    }
+
+    fn build(&self, app: &mut App) {
+        self.plugin.build(app);
+    }
 }
 
 pub trait DynamicPluginExt {
+    /// Dynamically links and builds a plugin at the given path.
+    ///
+    /// The dynamic library is never dropped
+    /// and exists in memory until the program is terminated.
+    /// Use [`load_dropping_plugin`] if you need to free this memory.
+    ///
     /// # Safety
     ///
     /// Same as [`dynamically_load_plugin`].
+    ///
+    /// [`load_allocated_plugin`]: `DyanmicPluginExt::load_allocated_plugin`
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
+    /// Dynamically links and builds a plugin at the given path.
+    ///
+    /// The dynamic library is dropped when the app is,
+    /// freeing its allocated memory,
+    /// so this method has addition safety concerns compared to [`load_plugin`]
+    ///
+    /// # Safety
+    ///
+    /// All the safety invariants from [`dynamically_load_plugin`]
+    /// and [`DroppingDynamicPlugin::from_leaky`] must hold true.
+    ///
+    /// [`load_plugin`]: `DynamicPluginExt::load_plugin`
+    unsafe fn load_dropping_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
 }
 
 impl DynamicPluginExt for App {
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
-        let (lib, plugin) = dynamically_load_plugin(path).unwrap();
-        std::mem::forget(lib); // Ensure that the library is not automatically unloaded
+        let plugin = dynamically_load_plugin(path).unwrap();
+        plugin.build(self);
+        self
+    }
+
+    unsafe fn load_dropping_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
+        let leaky = dynamically_load_plugin(path).unwrap();
+        // SAFETY: The caller ensures the invariants.
+        let plugin = DroppingDynamicPlugin::from_leaky(leaky);
         plugin.build(self);
         self
     }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -144,7 +144,7 @@ pub trait DynamicPluginExt {
     ///
     /// The dynamic library is dropped when the app is,
     /// freeing its allocated memory,
-    /// so this method has addition safety concerns compared to [`load_plugin`]
+    /// so this method has additional safety concerns compared to [`load_plugin`].
     ///
     /// # Safety
     ///

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,6 +1,7 @@
 use std::{
+    ffi::{OsStr, OsString},
     mem::ManuallyDrop,
-    sync::Arc, ffi::{OsStr, OsString},
+    sync::Arc,
 };
 
 use libloading::{Library, Symbol};

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -144,6 +144,7 @@ impl DynamicPluginLibraries {
     /// ```no_run
     /// use bevy_dynamic_plugin::{DynamicPluginLibraries, DynamicPluginExt};
     /// use bevy_app::App;
+    /// use bevy_ecs::system::ResMut;
     ///
     /// const LIB_PATH: &str = "./libmy_dyn_plugin.so";
     ///
@@ -151,7 +152,7 @@ impl DynamicPluginLibraries {
     /// unsafe { app.load_plugin(LIB_PATH) };
     /// app.add_system(remove_library);
     ///
-    /// fn remove_library(libs: ResMut<DynamicPluginLibraries>) {
+    /// fn remove_library(mut libs: ResMut<DynamicPluginLibraries>) {
     ///     unsafe { libs.mark_for_unloading(LIB_PATH) };
     ///     // Library is still loaded at this point.
     /// }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,11 +1,6 @@
 use std::{
-    mem::{self, ManuallyDrop},
-    sync::{
-        self,
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    }, ffi::{OsStr, OsString},
-    ops::DerefMut,
+    mem::ManuallyDrop,
+    sync::Arc, ffi::{OsStr, OsString},
 };
 
 use libloading::{Library, Symbol};

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -138,7 +138,7 @@ pub trait DynamicPluginExt {
     ///
     /// Same as [`dynamically_load_plugin`].
     ///
-    /// [`load_allocated_plugin`]: `DyanmicPluginExt::load_allocated_plugin`
+    /// [`load_dropping_plugin`]: `DyanmicPluginExt::load_dropping_plugin`
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
     /// Dynamically links and builds a plugin at the given path.
     ///

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -97,7 +97,7 @@ impl DynamicPlugin {
     /// # Safety
     ///
     /// The general safety concerns from [`Library::new`] apply here.
-    /// Additionally, the concerns from [`DynamicPluginLibraries::unload`] also apply.
+    /// Additionally, the concerns from [`DynamicPluginLibraries::mark_for_deallocation`] also apply.
     pub fn into_leaking(mut self) -> LeakingDynamicPlugin {
         self.should_drop.store(false, Ordering::Release);
         // SAFETY: value is immediately dropped

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -56,7 +56,10 @@ impl LeakingDynamicPlugin {
 
     /// Creates a leaky dynamic plugin from its raw [`Box<dyn Plugin>`] and [`Library`].
     pub fn from_raw_parts(plugin: Box<dyn Plugin>, lib: Library) -> Self {
-        Self { plugin, lib: ManuallyDrop::new(lib) }
+        Self {
+            plugin,
+            lib: ManuallyDrop::new(lib),
+        }
     }
 }
 

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -1,10 +1,18 @@
-use std::mem::ManuallyDrop;
+use std::{
+    mem::ManuallyDrop,
+    sync::{
+        self,
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    }, ffi::{OsStr, OsString},
+};
 
 use libloading::{Library, Symbol};
-use std::ffi::OsStr;
 use thiserror::Error;
 
 use bevy_app::{App, CreatePlugin, Plugin};
+use bevy_ecs::system::Resource;
+use bevy_utils::HashMap;
 
 /// Errors that can occur when loading a dynamic plugin
 #[derive(Debug, Error)]
@@ -37,7 +45,6 @@ pub unsafe fn dynamically_load_plugin<P: AsRef<OsStr>>(
 /// Wraps a dynamically loaded plugin and its associated library so that they can be dropped correctly.
 ///
 /// This struct leaks the library and so its memory is not freed until the program is terminated.
-/// This is in contrast to [`DroppingDynamicPlugin`] which automatically drops the library.
 pub struct LeakingDynamicPlugin {
     plugin: Box<dyn Plugin>,
     lib: ManuallyDrop<Library>,
@@ -49,17 +56,15 @@ impl LeakingDynamicPlugin {
     /// # Safety
     ///
     /// The general safety concerns from [`Library::new`] apply here.
-    /// In addition the concerns from [`DroppingDynamicPlugin::from_leaky`] also apply.
+    /// Additionally, the concerns from [`DynamicPuginLibraries::unload`] also apply.
     pub unsafe fn into_raw_parts(self) -> (Box<dyn Plugin>, Library) {
         (self.plugin, ManuallyDrop::into_inner(self.lib))
     }
 
     /// Creates a leaky dynamic plugin from its raw [`Box<dyn Plugin>`] and [`Library`].
     pub fn from_raw_parts(plugin: Box<dyn Plugin>, lib: Library) -> Self {
-        Self {
-            plugin,
-            lib: ManuallyDrop::new(lib),
-        }
+        let lib = ManuallyDrop::new(lib);
+        Self { plugin, lib }
     }
 }
 
@@ -79,51 +84,105 @@ impl Plugin for LeakingDynamicPlugin {
 
 /// Wraps a dynamically loaded plugin and its associated library so that they can be dropped correctly.
 ///
-/// This struct does not leak the library and so its memory is freed when the app is dropped.
-/// This is in contrast to [`LeakingDynamicPlugin`] which leaks the library.
-///
-/// Leaving dangling function pointers when the app (and therefore library) is dropped is UB.
-/// See [`DroppingDynamicPlugin::from_leaky`] for more info.
-pub struct DroppingDynamicPlugin {
-    plugin: Box<dyn Plugin>,
-    lib: Library,
+/// The library can be marked for deallocation with [`DynamicPluginLibraries::mark_for_deallocation`],
+/// or [`App::mark_plugin_for_deallocation`].
+pub struct DynamicPlugin {
+    leaking: Option<LeakingDynamicPlugin>,
+    should_drop: Arc<AtomicBool>,
 }
 
-impl DroppingDynamicPlugin {
-    /// Returns a [`LeakingDynamicPlugin`].
-    pub fn into_leaky(self) -> LeakingDynamicPlugin {
-        LeakingDynamicPlugin {
-            plugin: self.plugin,
-            lib: ManuallyDrop::new(self.lib),
+impl DynamicPlugin {
+    /// Coverts this dynamic plugin into its raw [`Box<dyn Plugin>`] and [`Library`].
+    ///
+    /// # Safety
+    ///
+    /// The general safety concerns from [`Library::new`] apply here.
+    /// Additionally, the concerns from [`DynamicPuginLibraries::unload`] also apply.
+    pub fn into_leaking(mut self) -> LeakingDynamicPlugin {
+        self.leaking.take().unwrap()
+    }
+
+    /// Creates a leaky dynamic plugin from its raw [`Box<dyn Plugin>`] and [`Library`].
+    pub fn from_leaking(leaking: LeakingDynamicPlugin) -> Self {
+        // This is sound because the value of `should_drop` can only be changed with unsafe code.
+        Self {
+            leaking: Some(leaking),
+            should_drop: Arc::new(AtomicBool::new(false)),
         }
     }
 
-    /// Creates an automatically-dropping dynamic plugin from a [`LeakingDynamicPlugin`].
+    pub fn should_drop(&self) -> bool {
+        self.should_drop.load(Ordering::Acquire)
+    }
+}
+
+impl Drop for DynamicPlugin {
+    fn drop(&mut self) {
+        if self.should_drop() {
+            let Some(leaking) = self.leaking.take() else {
+                return;
+            };
+            let lib = ManuallyDrop::into_inner(leaking.lib);
+            drop(lib); // explicit drop for clarity.
+        }
+    }
+}
+
+impl Plugin for DynamicPlugin {
+    fn name(&self) -> &str {
+        self.leaking.as_ref().unwrap().plugin.name()
+    }
+
+    fn is_unique(&self) -> bool {
+        self.leaking.as_ref().unwrap().plugin.is_unique()
+    }
+
+    fn build(&self, app: &mut App) {
+        self.leaking.as_ref().unwrap().plugin.build(app);
+    }
+}
+
+/// Stores all dynamic libraries loaded by [`load_plugin`] so they can be manually deallocated.
+///
+/// [`load_plugin`]: DynamicPluginExt::load_plugin
+#[derive(Resource)]
+pub struct DynamicPluginLibraries {
+    should_drop: HashMap<OsString, sync::Weak<AtomicBool>>,
+}
+
+impl DynamicPluginLibraries {
+    /// Explcitly marks a dynamically-loaded library for deallocation.
+    ///
+    /// The dynamic library would otherwise be left leaking until the program is terminated.
+    /// The library will be deallocated when its associated plugin is.
     ///
     /// # Safety
     ///
     /// The caller must ensure that all function pointers pointing to code inside the dynamic library
-    /// are dropped before the [`DroppingDynamicPlugin`] is.
-    /// This includes all `dyn Trait`, `impl Trait` and `fn(...)` definitions.
-    pub unsafe fn from_leaky(leaky: LeakingDynamicPlugin) -> Self {
-        Self {
-            plugin: leaky.plugin,
-            lib: ManuallyDrop::into_inner(leaky.lib),
+    /// are dropped before the library is unloaded.
+    /// This includes all `dyn Trait`, `impl Trait` and `fn(...)` definitions and and types containing these.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use bevy_dynamic_plugin::{DynamicPluginLibraries, DynamicPluginExt};
+    /// use bevy_app::App;
+    ///
+    /// const LIB_NAME: &str = "./libmy_dyn_plugin.so";
+    ///
+    /// let mut app = App::new();
+    /// unsafe { app.load_plugin(LIB_NAME) };
+    ///
+    /// let mut libs = app.world.remove_resource::<DynamicPluginLibraries>().unwrap();
+    /// unsafe { libs.mark_for_deallocation(LIB_NAME) };
+    /// ```
+    pub unsafe fn mark_for_deallocation<P: AsRef<OsStr>>(&mut self, name: P) {
+        let name = &name.as_ref().to_owned();
+        if let Some(weak) = self.should_drop.remove(name) {
+            if let Some(atomic) = weak.upgrade() {
+                atomic.store(true, Ordering::Release);
+            }
         }
-    }
-}
-
-impl Plugin for DroppingDynamicPlugin {
-    fn name(&self) -> &str {
-        self.plugin.name()
-    }
-
-    fn is_unique(&self) -> bool {
-        self.plugin.is_unique()
-    }
-
-    fn build(&self, app: &mut App) {
-        self.plugin.build(app);
     }
 }
 
@@ -132,41 +191,46 @@ pub trait DynamicPluginExt {
     ///
     /// The dynamic library is never dropped
     /// and exists in memory until the program is terminated.
-    /// Use [`load_dropping_plugin`] if you need to free this memory.
     ///
     /// # Safety
     ///
     /// Same as [`dynamically_load_plugin`].
-    ///
-    /// [`load_dropping_plugin`]: `DynamicPluginExt::load_dropping_plugin`
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
-    /// Dynamically links and builds a plugin at the given path.
+
+    /// Explcitly deallocates a dynamically-loaded library.
     ///
-    /// The dynamic library is dropped when the app is,
-    /// freeing its allocated memory,
-    /// so this method has additional safety concerns compared to [`load_plugin`].
+    /// The dynamic library would otherwise be left leaking until the program is terminated.
     ///
     /// # Safety
     ///
-    /// All the safety invariants from [`dynamically_load_plugin`]
-    /// and [`DroppingDynamicPlugin::from_leaky`] must hold true.
-    ///
-    /// [`load_plugin`]: `DynamicPluginExt::load_plugin`
-    unsafe fn load_dropping_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
+    /// Same as [`DynamicPluginLibraries::mark_for_deallocation`].
+    unsafe fn mark_plugin_for_deallocation<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
 }
 
 impl DynamicPluginExt for App {
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
+        let path = path.as_ref();
         let plugin = dynamically_load_plugin(path).unwrap();
+        let plugin = DynamicPlugin::from_leaking(plugin);
+
+        let mut libs = self
+            .world
+            .get_resource_or_insert_with(|| DynamicPluginLibraries {
+                should_drop: HashMap::new(),
+            });
+
+        libs.should_drop
+            .entry(path.to_owned())
+            .or_insert_with(|| Arc::downgrade(&plugin.should_drop));
+
         plugin.build(self);
         self
     }
 
-    unsafe fn load_dropping_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
-        let leaky = dynamically_load_plugin(path).unwrap();
-        // SAFETY: The caller ensures the invariants.
-        let plugin = DroppingDynamicPlugin::from_leaky(leaky);
-        plugin.build(self);
+    unsafe fn mark_plugin_for_deallocation<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
+        if let Some(mut libs) = self.world.get_resource_mut::<DynamicPluginLibraries>() {
+            libs.mark_for_deallocation(path);
+        }
         self
     }
 }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -138,7 +138,7 @@ pub trait DynamicPluginExt {
     ///
     /// Same as [`dynamically_load_plugin`].
     ///
-    /// [`load_dropping_plugin`]: `DyanmicPluginExt::load_dropping_plugin`
+    /// [`load_dropping_plugin`]: `DynamicPluginExt::load_dropping_plugin`
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self;
     /// Dynamically links and builds a plugin at the given path.
     ///

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -56,7 +56,7 @@ impl LeakingDynamicPlugin {
     /// # Safety
     ///
     /// The general safety concerns from [`Library::new`] apply here.
-    /// Additionally, the concerns from [`DynamicPluginLibraries::unload`] also apply.
+    /// Additionally, the concerns from [`DynamicPluginLibraries::mark_for_deallocation`] also apply.
     pub unsafe fn into_raw_parts(self) -> (Box<dyn Plugin>, Library) {
         (self.plugin, ManuallyDrop::into_inner(self.lib))
     }


### PR DESCRIPTION
# Objective

- Currently `bevy_dynamic_plugin::dynamically_load_plugin` calls `std::mem::forget` on the `libloading::Library` instance. An escape hatch should be added to allow users to more easily handle the unloading of dynamic plugins.

## Solution

- Add a `DynamicPlugin` struct which can be dropped manually.

- Add a new resource `DynamicPluginLibraries` which allows users to (unsafely) mark libraries for automatic unloading with `DynamicPluginLibraries::mark_for_unloading`. The library will be dropped when the associated `DynamicPlugin` is or when `mark_for_unloading` is called, whichever happens last.

---

## Changelog

- Added `DynamicPlugin`.
- Added `DynamicPluginLibraries`.
- Changed the return type of `dynamically_load_plugin` to `DynamicPlugin`.
- Added `bevy_ecs` and `bevy_utils` dependencies for `bevy_dynamic_plugin`.

## Migration Guide

- `dynamically_load_plugin` now returns a `DynamicPlugin` instead of a tuple. Call `DynamicPlugin::into_raw_parts` and `Arc::try_unwrap` on the resulting library if you need the old behavior.
