### PR TITLE
[Merged by Bors] - Fix missing sRGB conversion for dithering non-HDR pipelines

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
@@ -10,15 +10,15 @@ var hdr_sampler: sampler;
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let hdr_color = textureSample(hdr_texture, hdr_sampler, in.uv);
 
-    var output_rgb = reinhard_luminance(hdr_color.rgb);
+    var out = reinhard_luminance(hdr_color.rgb);
 
 #ifdef DEBAND_DITHER
-    output_rgb = pow(output_rgb.rgb, vec3<f32>(1.0 / 2.2));
-    output_rgb = output_rgb + screen_space_dither(in.position.xy);
+    out = vec3(to_srgb(out.r), to_srgb(out.g), to_srgb(out.b));
+    out = out + screen_space_dither(in.position.xy);
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
-    output_rgb = pow(output_rgb.rgb, vec3<f32>(2.2));
+    out = vec3(to_linear(out.r), to_linear(out.g), to_linear(out.b));
 #endif
 
-    return vec4<f32>(output_rgb, hdr_color.a);
+    return vec4<f32>(out, hdr_color.a);
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
@@ -10,15 +10,15 @@ var hdr_sampler: sampler;
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let hdr_color = textureSample(hdr_texture, hdr_sampler, in.uv);
 
-    var out = reinhard_luminance(hdr_color.rgb);
+    var output_rgb = reinhard_luminance(hdr_color.rgb);
 
 #ifdef DEBAND_DITHER
-    out = vec3(to_srgb(out.r), to_srgb(out.g), to_srgb(out.b));
-    out = out + screen_space_dither(in.position.xy);
+    output_rgb = pow(output_rgb.rgb, vec3<f32>(1.0 / 2.2));
+    output_rgb = output_rgb + screen_space_dither(in.position.xy);
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
-    out = vec3(to_linear(out.r), to_linear(out.g), to_linear(out.b));
+    output_rgb = pow(output_rgb.rgb, vec3<f32>(2.2));
 #endif
 
-    return vec4<f32>(out, hdr_color.a);
+    return vec4<f32>(output_rgb, hdr_color.a);
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
@@ -35,3 +35,18 @@ fn screen_space_dither(frag_coord: vec2<f32>) -> vec3<f32> {
     dither = fract(dither.rgb / vec3<f32>(103.0, 71.0, 97.0));
     return (dither - 0.5) / 255.0;
 }
+
+fn to_srgb(in: f32) -> f32 {
+    if in <= 0.0031308 {
+        return in * 12.92;
+    } else {
+        return pow(in, 1.0/2.4) * 1.055 - 0.055;
+    }
+}
+fn to_linear(in: f32) -> f32 {
+    if in <= 0.04045 {
+        return in / 12.92;
+    } else {
+        return pow((in + 0.055) / 1.055, 2.4);
+    }
+}

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
@@ -35,18 +35,3 @@ fn screen_space_dither(frag_coord: vec2<f32>) -> vec3<f32> {
     dither = fract(dither.rgb / vec3<f32>(103.0, 71.0, 97.0));
     return (dither - 0.5) / 255.0;
 }
-
-fn to_srgb(in: f32) -> f32 {
-    if in <= 0.0031308 {
-        return in * 12.92;
-    } else {
-        return pow(in, 1.0/2.4) * 1.055 - 0.055;
-    }
-}
-fn to_linear(in: f32) -> f32 {
-    if in <= 0.04045 {
-        return in / 12.92;
-    } else {
-        return pow((in + 0.055) / 1.055, 2.4);
-    }
-}

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -99,13 +99,13 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         output_color = tone_mapping(output_color);
 #endif
 #ifdef DEBAND_DITHER
-    var out = output_color.rgb;
-    out = vec3(to_srgb(out.r), to_srgb(out.g), to_srgb(out.b));
-    out = out + screen_space_dither(in.frag_coord.xy);
+    var output_rgb = output_color.rgb;
+    output_rgb = pow(output_rgb, vec3<f32>(1.0 / 2.2));
+    output_rgb = output_rgb + screen_space_dither(in.frag_coord.xy);
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
-    out = vec3(to_linear(out.r), to_linear(out.g), to_linear(out.b));
-    output_color = vec4(out, output_color.a);
+    output_rgb = pow(output_rgb, vec3<f32>(2.2));
+    output_color = vec4(output_rgb, output_color.a);
 #endif
     return output_color;
 }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -99,7 +99,13 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         output_color = tone_mapping(output_color);
 #endif
 #ifdef DEBAND_DITHER
-        output_color = dither(output_color, in.frag_coord.xy);
+    var out = output_color.rgb;
+    out = vec3(to_srgb(out.r), to_srgb(out.g), to_srgb(out.b));
+    out = out + screen_space_dither(in.frag_coord.xy);
+    // This conversion back to linear space is required because our output texture format is
+    // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
+    out = vec3(to_linear(out.r), to_linear(out.g), to_linear(out.b));
+    output_color = vec4(out, output_color.a);
 #endif
     return output_color;
 }


### PR DESCRIPTION
# Objective

- Fixes #6706 

Zoom in on the shadow in the following images:

## Current bevy/main

### HDR On - correct
![current-hdron](https://user-images.githubusercontent.com/2632925/202943151-ecad3cbe-a76e-46df-bac9-9e590a31a9f3.png)

### HDR Off - incorrect
![current-hdroff](https://user-images.githubusercontent.com/2632925/202943154-34e3f527-a00e-4546-931d-0691204cc6a4.png)

## This PR

### HDR On - correct
![new-hdron](https://user-images.githubusercontent.com/2632925/202943383-081990de-9a14-45bd-ac52-febcc4289079.png)

### HDR Off - corrected
![new-hdroff](https://user-images.githubusercontent.com/2632925/202943388-a3b05d79-a0f3-4b1e-b114-0a9f03efe351.png)

## Close-up comparison

### New
![Screenshot from 2022-11-20 17-46-46](https://user-images.githubusercontent.com/2632925/202943552-d45c3a48-841e-47a6-981f-776c5a9563f6.png)

### Old
![Screenshot from 2022-11-20 17-46-41](https://user-images.githubusercontent.com/2632925/202943562-555cb5a2-2b20-45f9-b250-89f2bc87af5f.png)

## Solution

- It turns out there was an outright missing sRGB conversion for dithering non-HDR cameras.
- I also tried using a precise sRGB conversion, but it had no apparent effect on the final image.

---

## Changelog

- Fix deband dithering intensity for non-HDR pipelines.
