### PR TITLE
Make font atlas grayscale

### DIFF
--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -27,7 +27,6 @@ impl Font {
             alpha[y as usize * width + x as usize] = v;
         });
 
-        // TODO: make this texture grayscale
         Image::new(
             Extent3d {
                 width: width as u32,
@@ -37,9 +36,9 @@ impl Font {
             TextureDimension::D2,
             alpha
                 .iter()
-                .flat_map(|a| vec![255, 255, 255, (*a * 255.0) as u8])
+                .flat_map(|a| vec![(*a * 255.0) as u8])
                 .collect::<Vec<u8>>(),
-            TextureFormat::Rgba8UnormSrgb,
+            TextureFormat::R8Unorm,
         )
     }
 }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -58,8 +58,8 @@ impl FontAtlas {
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
-            &[0, 0, 0, 0],
-            TextureFormat::Rgba8UnormSrgb,
+            &[0],
+            TextureFormat::R8Unorm,
         ));
         let texture_atlas = TextureAtlas::new_empty(atlas_texture, size);
         Self {

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -1,3 +1,7 @@
+// UI node type.
+let NODE_TYPE_SPRITE : u32 = 0u;
+let NODE_TYPE_TEXT : u32 = 1u;
+
 struct View {
     view_proj: mat4x4<f32>,
     inverse_view_proj: mat4x4<f32>,
@@ -36,9 +40,24 @@ var sprite_texture: texture_2d<f32>;
 @group(1) @binding(1)
 var sprite_sampler: sampler;
 
+struct Params {
+    node_type: u32,
+    pad0: u32,
+    pad1: u32,
+    pad2: u32,
+}
+@group(2) @binding(0)
+var<uniform> params: Params;
+
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = textureSample(sprite_texture, sprite_sampler, in.uv);
-    color = in.color * color;
+
+    if ((params.node_type & NODE_TYPE_TEXT) > 0u) {
+        color = in.color * color.r;
+    } else {
+        color = in.color * color;
+    }
+
     return color;
 }


### PR DESCRIPTION
# Objective

Making font atlas a grayscale texture.

## Solution

The UI pipeline is used to draw both text and sprite, so an extra uniform buffer is needed to pass a flag to differentiate between the two cases.
