### PR TITLE
Add `EntityCommands::with_child` and `EntityMut::with_child`

### DIFF
--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -157,9 +157,7 @@ mod tests {
                     .with_children(|parent| {
                         parent.spawn(node_without_zindex("1-2-0"));
                         parent.spawn(node_with_zindex("1-2-1", ZIndex::Global(-3)));
-                        parent
-                            .spawn(node_without_zindex("1-2-2"))
-                            .with_children(|_| ());
+                        parent.spawn(node_without_zindex("1-2-2")).with_child(());
                         parent.spawn(node_without_zindex("1-2-3"));
                     });
                 parent.spawn(node_without_zindex("1-3"));
@@ -168,14 +166,10 @@ mod tests {
         commands
             .spawn(node_without_zindex("2"))
             .with_children(|parent| {
-                parent
-                    .spawn(node_without_zindex("2-0"))
-                    .with_children(|_parent| ());
+                parent.spawn(node_without_zindex("2-0")).with_child(());
                 parent
                     .spawn(node_without_zindex("2-1"))
-                    .with_children(|parent| {
-                        parent.spawn(node_without_zindex("2-1-0"));
-                    });
+                    .with_child(node_without_zindex("2-1-0"));
             });
 
         commands.spawn(node_with_zindex("3", ZIndex::Global(-2)));

--- a/errors/B0004.md
+++ b/errors/B0004.md
@@ -30,15 +30,12 @@ fn setup_cube(
 ) {
     commands
         .spawn(TransformBundle::default())
-        .with_children(|parent| {
-            // cube
-            parent.spawn(PbrBundle {
+        .with_child(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
                 material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
                 transform: Transform::from_xyz(0.0, 0.5, 0.0),
                 ..default()
             });
-        });
 
     // camera
     commands.spawn(Camera3dBundle {
@@ -77,9 +74,7 @@ fn setup_cube(
         // ComputedVisibility component needed to display the cube,
         // In addition to the Transform and GlobalTransform components.
         .spawn(SpatialBundle::default())
-        .with_children(|parent| {
-            // cube
-            parent.spawn(PbrBundle {
+        .with_child(PbrBundle {
                 mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
                 material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
                 transform: Transform::from_xyz(0.0, 0.5, 0.0),

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -110,19 +110,17 @@ fn setup(
             },
             ..default()
         })
-        .with_children(|builder| {
-            builder.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::UVSphere {
-                    radius: 0.1,
-                    ..default()
-                })),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::RED,
-                    emissive: Color::rgba_linear(100.0, 0.0, 0.0, 0.0),
-                    ..default()
-                }),
+        .with_child(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::UVSphere {
+                radius: 0.1,
                 ..default()
-            });
+            })),
+            material: materials.add(StandardMaterial {
+                base_color: Color::RED,
+                emissive: Color::rgba_linear(100.0, 0.0, 0.0, 0.0),
+                ..default()
+            }),
+            ..default()
         });
 
     // green spot light
@@ -140,21 +138,19 @@ fn setup(
             },
             ..default()
         })
-        .with_children(|builder| {
-            builder.spawn(PbrBundle {
-                transform: Transform::from_rotation(Quat::from_rotation_x(PI / 2.0)),
-                mesh: meshes.add(Mesh::from(shape::Capsule {
-                    depth: 0.125,
-                    radius: 0.1,
-                    ..default()
-                })),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::GREEN,
-                    emissive: Color::rgba_linear(0.0, 100.0, 0.0, 0.0),
-                    ..default()
-                }),
+        .with_child(PbrBundle {
+            transform: Transform::from_rotation(Quat::from_rotation_x(PI / 2.0)),
+            mesh: meshes.add(Mesh::from(shape::Capsule {
+                depth: 0.125,
+                radius: 0.1,
                 ..default()
-            });
+            })),
+            material: materials.add(StandardMaterial {
+                base_color: Color::GREEN,
+                emissive: Color::rgba_linear(0.0, 100.0, 0.0, 0.0),
+                ..default()
+            }),
+            ..default()
         });
 
     // blue point light
@@ -170,19 +166,17 @@ fn setup(
             },
             ..default()
         })
-        .with_children(|builder| {
-            builder.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::UVSphere {
-                    radius: 0.1,
-                    ..default()
-                })),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::BLUE,
-                    emissive: Color::rgba_linear(0.0, 0.0, 100.0, 0.0),
-                    ..default()
-                }),
+        .with_child(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::UVSphere {
+                radius: 0.1,
                 ..default()
-            });
+            })),
+            material: materials.add(StandardMaterial {
+                base_color: Color::BLUE,
+                emissive: Color::rgba_linear(0.0, 0.0, 100.0, 0.0),
+                ..default()
+            }),
+            ..default()
         });
 
     // directional 'sun' light

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -45,14 +45,12 @@ fn setup(
             },
             Rotator,
         ))
-        .with_children(|parent| {
-            // child cube
-            parent.spawn(PbrBundle {
-                mesh: cube_handle,
-                material: cube_material_handle,
-                transform: Transform::from_xyz(0.0, 0.0, 3.0),
-                ..default()
-            });
+        // child cube
+        .with_child(PbrBundle {
+            mesh: cube_handle,
+            material: cube_material_handle,
+            transform: Transform::from_xyz(0.0, 0.0, 3.0),
+            ..default()
         });
     // light
     commands.spawn(PointLightBundle {

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -60,16 +60,14 @@ fn setup(
                     .with_scale(Vec3::splat(radius)),
                 ..default()
             })
-            .with_children(|children| {
-                children.spawn(PointLightBundle {
-                    point_light: PointLight {
-                        intensity: 1500.0,
-                        radius,
-                        color: Color::rgb(0.2, 0.2, 1.0),
-                        ..default()
-                    },
+            .with_child(PointLightBundle {
+                point_light: PointLight {
+                    intensity: 1500.0,
+                    radius,
+                    color: Color::rgb(0.2, 0.2, 1.0),
                     ..default()
-                });
+                },
+                ..default()
             });
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -83,7 +83,7 @@ fn setup(
                     },
                     ..default()
                 })
-                .with_children(|builder| {
+                .with_child(|builder| {
                     builder.spawn(PbrBundle {
                         mesh: meshes.add(Mesh::from(shape::UVSphere {
                             radius: 0.05,

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -133,18 +133,16 @@ fn setup(
                 // Add the Name component
                 orbit_controller,
             ))
-            .with_children(|p| {
-                // The satellite, placed at a distance of the planet
-                p.spawn((
-                    PbrBundle {
-                        transform: Transform::from_xyz(1.5, 0.0, 0.0),
-                        mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-                        material: materials.add(Color::rgb(0.3, 0.9, 0.3).into()),
-                        ..default()
-                    },
-                    // Add the Name component
-                    satellite,
-                ));
-            });
+            // The satellite, placed at a distance of the planet
+            .with_children((
+                PbrBundle {
+                    transform: Transform::from_xyz(1.5, 0.0, 0.0),
+                    mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
+                    material: materials.add(Color::rgb(0.3, 0.9, 0.3).into()),
+                    ..default()
+                },
+                // Add the Name component
+                satellite,
+            ));
         });
 }

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -23,18 +23,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             texture: texture.clone(),
             ..default()
         })
-        // With that entity as a parent, run a lambda that spawns its children
-        .with_children(|parent| {
-            // parent is a ChildBuilder, which has a similar API to Commands
-            parent.spawn(SpriteBundle {
-                transform: Transform::from_xyz(250.0, 0.0, 0.0).with_scale(Vec3::splat(0.75)),
-                texture: texture.clone(),
-                sprite: Sprite {
-                    color: Color::BLUE,
-                    ..default()
-                },
+        // Add a child entity
+        .with_child(SpriteBundle {
+            transform: Transform::from_xyz(250.0, 0.0, 0.0).with_scale(Vec3::splat(0.75)),
+            texture: texture.clone(),
+            sprite: Sprite {
+                color: Color::BLUE,
                 ..default()
-            });
+            },
+            ..default()
         })
         // Store parent entity for next sections
         .id();

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -136,17 +136,15 @@ fn generate_bodies(
             },
             Star,
         ))
-        .with_children(|p| {
-            p.spawn(PointLightBundle {
-                point_light: PointLight {
-                    color: Color::WHITE,
-                    intensity: 400.0,
-                    range: 100.0,
-                    radius: star_radius,
-                    ..default()
-                },
+        .with_child(PointLightBundle {
+            point_light: PointLight {
+                color: Color::WHITE,
+                intensity: 400.0,
+                range: 100.0,
+                radius: star_radius,
                 ..default()
-            });
+            },
+            ..default()
         });
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.0, 10.5, -30.0).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -65,16 +65,14 @@ fn setup_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: NORMAL_BUTTON.into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
-                        "Play",
-                        TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.9, 0.9, 0.9),
-                        },
-                    ));
-                });
+                .with_child(TextBundle::from_section(
+                    "Play",
+                    TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                ));
         })
         .id();
     commands.insert_resource(MenuData { button_entity });

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -335,17 +335,15 @@ fn spawn_bonus(
                 scene: game.bonus.handle.clone(),
                 ..default()
             })
-            .with_children(|children| {
-                children.spawn(PointLightBundle {
-                    point_light: PointLight {
-                        color: Color::rgb(1.0, 1.0, 0.0),
-                        intensity: 1000.0,
-                        range: 10.0,
-                        ..default()
-                    },
-                    transform: Transform::from_xyz(0.0, 2.0, 0.0),
+            .with_child(PointLightBundle {
+                point_light: PointLight {
+                    color: Color::rgb(1.0, 1.0, 0.0),
+                    intensity: 1000.0,
+                    range: 10.0,
                     ..default()
-                });
+                },
+                transform: Transform::from_xyz(0.0, 2.0, 0.0),
+                ..default()
             })
             .id(),
     );
@@ -387,14 +385,12 @@ fn display_score(mut commands: Commands, asset_server: Res<AssetServer>, game: R
             },
             ..default()
         })
-        .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                format!("Cake eaten: {}", game.cake_eaten),
-                TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    font_size: 80.0,
-                    color: Color::rgb(0.5, 0.5, 1.0),
-                },
-            ));
-        });
+        .with_child(TextBundle::from_section(
+            format!("Cake eaten: {}", game.cake_eaten),
+            TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 80.0,
+                color: Color::rgb(0.5, 0.5, 1.0),
+            },
+        ));
 }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -94,16 +94,14 @@ mod splash {
                 },
                 OnSplashScreen,
             ))
-            .with_children(|parent| {
-                parent.spawn(ImageBundle {
-                    style: Style {
-                        // This will set the logo to be 200px wide, and auto adjust its height
-                        size: Size::new(Val::Px(200.0), Val::Auto),
-                        ..default()
-                    },
-                    image: UiImage::new(icon),
+            .with_child(ImageBundle {
+                style: Style {
+                    // This will set the logo to be 200px wide, and auto adjust its height
+                    size: Size::new(Val::Px(200.0), Val::Auto),
                     ..default()
-                });
+                },
+                image: UiImage::new(icon),
+                ..default()
             });
         // Insert the timer as a resource
         commands.insert_resource(SplashTimer(Timer::from_seconds(1.0, TimerMode::Once)));
@@ -459,7 +457,7 @@ mod menu {
                         background_color: Color::CRIMSON.into(),
                         ..default()
                     })
-                    .with_children(|parent| {
+                    .with_child(|parent| {
                         // Display the game name
                         parent.spawn(
                             TextBundle::from_section(

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -457,7 +457,7 @@ mod menu {
                         background_color: Color::CRIMSON.into(),
                         ..default()
                     })
-                    .with_child(|parent| {
+                    .with_children(|parent| {
                         // Display the game name
                         parent.spawn(
                             TextBundle::from_section(
@@ -596,12 +596,10 @@ mod menu {
                                     },
                                     action,
                                 ))
-                                .with_children(|parent| {
-                                    parent.spawn(TextBundle::from_section(
-                                        text,
-                                        button_text_style.clone(),
-                                    ));
-                                });
+                                .with_child(TextBundle::from_section(
+                                    text,
+                                    button_text_style.clone(),
+                                ));
                         }
                     });
             });
@@ -702,9 +700,7 @@ mod menu {
                                 },
                                 MenuButtonAction::BackToSettings,
                             ))
-                            .with_children(|parent| {
-                                parent.spawn(TextBundle::from_section("Back", button_text_style));
-                            });
+                            .with_child(TextBundle::from_section("Back", button_text_style));
                     });
             });
     }
@@ -790,9 +786,7 @@ mod menu {
                                 },
                                 MenuButtonAction::BackToSettings,
                             ))
-                            .with_children(|parent| {
-                                parent.spawn(TextBundle::from_section("Back", button_text_style));
-                            });
+                            .with_child(TextBundle::from_section("Back", button_text_style));
                     });
             });
     }

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -111,19 +111,17 @@ fn setup_scene(
             },
             ..default()
         })
-        .with_children(|b| {
-            b.spawn(
-                TextBundle::from_section(
-                    "Test Button",
-                    TextStyle {
-                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                        font_size: 30.0,
-                        color: Color::BLACK,
-                    },
-                )
-                .with_text_alignment(TextAlignment::CENTER),
-            );
-        });
+        .with_child(
+            TextBundle::from_section(
+                "Test Button",
+                TextStyle {
+                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                    font_size: 30.0,
+                    color: Color::BLACK,
+                },
+            )
+            .with_text_alignment(TextAlignment::CENTER),
+        );
 }
 
 fn button_handler(

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -105,14 +105,12 @@ fn spawn_button(
             },
             IdleColor(color),
         ))
-        .with_children(|commands| {
-            commands.spawn(TextBundle::from_section(
-                format!("{i}, {j}"),
-                TextStyle {
-                    font,
-                    font_size: FONT_SIZE,
-                    color: Color::rgb(0.2, 0.2, 0.2),
-                },
-            ));
-        });
+        .with_child(TextBundle::from_section(
+            format!("{i}, {j}"),
+            TextStyle {
+                font,
+                font_size: FONT_SIZE,
+                color: Color::rgb(0.2, 0.2, 0.2),
+            },
+        ));
 }

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -128,14 +128,12 @@ fn setup(
             let (s, c) = fox_angle.sin_cos();
             let (x, z) = (radius * c, radius * s);
 
-            commands.entity(ring_parent).with_children(|builder| {
-                builder.spawn(SceneBundle {
-                    scene: fox_handle.clone(),
-                    transform: Transform::from_xyz(x, 0.0, z)
-                        .with_scale(Vec3::splat(0.01))
-                        .with_rotation(base_rotation * Quat::from_rotation_y(-fox_angle)),
-                    ..default()
-                });
+            commands.entity(ring_parent).with_child(SceneBundle {
+                scene: fox_handle.clone(),
+                transform: Transform::from_xyz(x, 0.0, z)
+                    .with_scale(Vec3::splat(0.01))
+                    .with_rotation(base_rotation * Quat::from_rotation_y(-fox_angle)),
+                ..default()
             });
         }
 

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -396,24 +396,22 @@ fn setup_triggers(
                 x,
                 y,
             ))
-            .with_children(|parent| {
-                parent.spawn((
-                    Text2dBundle {
-                        transform: Transform::from_xyz(0., 0., 1.),
-                        text: Text::from_section(
-                            format!("{:.3}", 0.),
-                            TextStyle {
-                                font: font.clone(),
-                                font_size: 16.,
-                                color: TEXT_COLOR,
-                            },
-                        )
-                        .with_alignment(TextAlignment::CENTER),
-                        ..default()
-                    },
-                    TextWithButtonValue(button_type),
-                ));
-            });
+            .with_child((
+                TextWithButtonValue(button_type),
+                Text2dBundle {
+                    transform: Transform::from_xyz(0., 0., 1.),
+                    text: Text::from_section(
+                        format!("{:.3}", 0.),
+                        TextStyle {
+                            font: font.clone(),
+                            font_size: 16.,
+                            color: TEXT_COLOR,
+                        },
+                    )
+                    .with_alignment(TextAlignment::CENTER),
+                    ..default()
+                },
+            ));
     };
 
     spawn_trigger(

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -70,15 +70,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: NORMAL_BUTTON.into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
-                        "Button",
-                        TextStyle {
-                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                            font_size: 40.0,
-                            color: Color::rgb(0.9, 0.9, 0.9),
-                        },
-                    ));
-                });
+                .with_child(TextBundle::from_section(
+                    "Button",
+                    TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 40.0,
+                        color: Color::rgb(0.9, 0.9, 0.9),
+                    },
+                ));
         });
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -95,14 +95,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
             },
             ..default()
         })
-        .with_children(|parent| {
-            parent.spawn(TextBundle::from_section(
-                "a",
-                TextStyle {
-                    font: font_handle,
-                    font_size: 60.0,
-                    color: Color::YELLOW,
-                },
-            ));
-        });
+        .with_child(TextBundle::from_section(
+            "a",
+            TextStyle {
+                font: font_handle,
+                font_size: 60.0,
+                color: Color::YELLOW,
+            },
+        ));
 }

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -38,17 +38,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: Color::rgb(0.1, 0.5, 0.1).into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
-                        "Button 1",
-                        TextStyle {
-                            font: font_handle.clone(),
-                            font_size: 40.0,
-                            // Alpha channel of the color controls transparency.
-                            color: Color::rgba(1.0, 1.0, 1.0, 0.2),
-                        },
-                    ));
-                });
+                .with_child(TextBundle::from_section(
+                    "Button 1",
+                    TextStyle {
+                        font: font_handle.clone(),
+                        font_size: 40.0,
+                        // Alpha channel of the color controls transparency.
+                        color: Color::rgba(1.0, 1.0, 1.0, 0.2),
+                    },
+                ));
         });
 
     commands
@@ -75,16 +73,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: Color::rgb(0.5, 0.1, 0.5).into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section(
-                        "Button 2",
-                        TextStyle {
-                            font: font_handle.clone(),
-                            font_size: 40.0,
-                            // Alpha channel of the color controls transparency.
-                            color: Color::rgba(1.0, 1.0, 1.0, 0.2),
-                        },
-                    ));
-                });
+                .with_child(TextBundle::from_section(
+                    "Button 2",
+                    TextStyle {
+                        font: font_handle.clone(),
+                        font_size: 40.0,
+                        // Alpha channel of the color controls transparency.
+                        color: Color::rgba(1.0, 1.0, 1.0, 0.2),
+                    },
+                ));
         });
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -176,15 +176,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: Color::rgb(0.4, 0.4, 1.0).into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(NodeBundle {
-                        style: Style {
-                            size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                            ..default()
-                        },
-                        background_color: Color::rgb(0.8, 0.8, 1.0).into(),
+                .with_child(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
                         ..default()
-                    });
+                    },
+                    background_color: Color::rgb(0.8, 0.8, 1.0).into(),
+                    ..default()
                 });
             // render order test: reddest in the back, whitest in the front (flex center)
             parent
@@ -280,17 +278,17 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     },
                     ..default()
                 })
-                .with_children(|parent| {
+                .with_child(
                     // bevy logo (image)
-                    parent.spawn(ImageBundle {
+                    ImageBundle {
                         style: Style {
                             size: Size::new(Val::Px(500.0), Val::Auto),
                             ..default()
                         },
                         image: asset_server.load("branding/bevy_logo_dark_big.png").into(),
                         ..default()
-                    });
-                });
+                    },
+                );
         });
 }
 

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -61,9 +61,7 @@ fn setup(mut commands: Commands, asset_server: ResMut<AssetServer>) {
                     background_color: Color::RED.into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(TextBundle::from_section("Size!", text_style));
-                });
+                .with_child(TextBundle::from_section("Size!", text_style));
             parent.spawn(NodeBundle {
                 style: Style {
                     size: Size::new(Val::Percent(15.), Val::Percent(15.)),

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -44,22 +44,20 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     background_color: Color::rgb(0.65, 0.65, 0.65).into(),
                     ..default()
                 })
-                .with_children(|parent| {
-                    parent.spawn(
-                        TextBundle::from_section(
-                            "Example text",
-                            TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 30.0,
-                                color: Color::WHITE,
-                            },
-                        )
-                        .with_style(Style {
-                            align_self: AlignSelf::FlexEnd,
-                            ..default()
-                        }),
-                    );
-                });
+                .with_child(
+                    TextBundle::from_section(
+                        "Example text",
+                        TextStyle {
+                            font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                            font_size: 30.0,
+                            color: Color::WHITE,
+                        },
+                    )
+                    .with_style(Style {
+                        align_self: AlignSelf::FlexEnd,
+                        ..default()
+                    }),
+                );
         });
 }
 

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -43,20 +43,18 @@ fn setup_ui(mut cmd: Commands, asset_server: Res<AssetServer>) {
         },
         ..default()
     })
-    .with_children(|root| {
-        // Text where we display current resolution
-        root.spawn((
-            TextBundle::from_section(
-                "Resolution",
-                TextStyle {
-                    font: asset_server.load("fonts/FiraMono-Medium.ttf"),
-                    font_size: 50.0,
-                    color: Color::BLACK,
-                },
-            ),
-            ResolutionText,
-        ));
-    });
+    // Text where we display current resolution
+    .with_child((
+        ResolutionText,
+        TextBundle::from_section(
+            "Resolution",
+            TextStyle {
+                font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+                font_size: 50.0,
+                color: Color::BLACK,
+            },
+        ),
+    ));
 }
 
 /// This system shows how to request the window to a new resolution


### PR DESCRIPTION
# Objective

- Adding a single child is very cumbersome, and requires the use of a complex closure.
- Fixes #6712.

## Solution

Add a `with_child(b: impl Bundle)` API.

## Changelog

Added `EntityCommands::with_child(b: impl Bundle)`  and an equivelent method on `EntityMut`  (for direct world access).

## Migration Guide

When spawning a single child with no children of its own, consider using `commands.entity(parent).with_child(child_bundle)` to make your code clearer.