### PR TITLE
Calculate the text alignment offset

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1473,6 +1473,10 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_alignment"
+path = "examples/ui/text_alignment.rs"
+
+[[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1476,6 +1476,12 @@ wasm = true
 name = "text_alignment"
 path = "examples/ui/text_alignment.rs"
 
+[package.metadata.example.text_alignment]
+name = "Text Alignment"
+description = "Demonstrates how text is displayed with each TextAlignment"
+category = "UI (User Interface)"
+wasm = false
+
 [[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1473,16 +1473,6 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
-name = "text_alignment"
-path = "examples/ui/text_alignment.rs"
-
-[package.metadata.example.text_alignment]
-name = "Text Alignment"
-description = "Demonstrates how text is displayed with each TextAlignment"
-category = "UI (User Interface)"
-wasm = false
-
-[[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1473,6 +1473,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_alignment"
+path = "examples/ui/text_alignment.rs"
+
+[package.metadata.example.text_alignment]
+name = "Text Alignment"
+description = "Demonstrates how text is displayed with each TextAlignment"
+category = "UI (User Interface)"
+wasm = false
+
+[[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -1,25 +1,25 @@
 use bevy_app::{PluginGroup, PluginGroupBuilder};
 
 /// This plugin group will add all the default plugins:
-/// * [`LogPlugin`](bevy_log::LogPlugin)
-/// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
-/// * [`TransformPlugin`](bevy_transform::TransformPlugin)
-/// * [`HierarchyPlugin`](bevy_hierarchy::HierarchyPlugin)
-/// * [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin)
-/// * [`InputPlugin`](bevy_input::InputPlugin)
-/// * [`WindowPlugin`](bevy_window::WindowPlugin)
-/// * [`AssetPlugin`](bevy_asset::AssetPlugin)
-/// * [`ScenePlugin`](bevy_scene::ScenePlugin)
-/// * [`RenderPlugin`](bevy_render::RenderPlugin) - with feature `bevy_render`
-/// * [`SpritePlugin`](bevy_sprite::SpritePlugin) - with feature `bevy_sprite`
-/// * [`PbrPlugin`](bevy_pbr::PbrPlugin) - with feature `bevy_pbr`
-/// * [`UiPlugin`](bevy_ui::UiPlugin) - with feature `bevy_ui`
-/// * [`TextPlugin`](bevy_text::TextPlugin) - with feature `bevy_text`
-/// * [`AudioPlugin`](bevy_audio::AudioPlugin) - with feature `bevy_audio`
-/// * [`GilrsPlugin`](bevy_gilrs::GilrsPlugin) - with feature `bevy_gilrs`
-/// * [`GltfPlugin`](bevy_gltf::GltfPlugin) - with feature `bevy_gltf`
-/// * [`WinitPlugin`](bevy_winit::WinitPlugin) - with feature `bevy_winit`
+/// * [`LogPlugin`](crate::log::LogPlugin)
+/// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`TimePlugin`](crate::time::TimePlugin)
+/// * [`TransformPlugin`](crate::transform::TransformPlugin)
+/// * [`HierarchyPlugin`](crate::hierarchy::HierarchyPlugin)
+/// * [`DiagnosticsPlugin`](crate::diagnostic::DiagnosticsPlugin)
+/// * [`InputPlugin`](crate::input::InputPlugin)
+/// * [`WindowPlugin`](crate::window::WindowPlugin)
+/// * [`AssetPlugin`](crate::asset::AssetPlugin)
+/// * [`ScenePlugin`](crate::scene::ScenePlugin)
+/// * [`RenderPlugin`](crate::render::RenderPlugin) - with feature `bevy_render`
+/// * [`SpritePlugin`](crate::sprite::SpritePlugin) - with feature `bevy_sprite`
+/// * [`PbrPlugin`](crate::pbr::PbrPlugin) - with feature `bevy_pbr`
+/// * [`UiPlugin`](crate::ui::UiPlugin) - with feature `bevy_ui`
+/// * [`TextPlugin`](crate::text::TextPlugin) - with feature `bevy_text`
+/// * [`AudioPlugin`](crate::audio::AudioPlugin) - with feature `bevy_audio`
+/// * [`GilrsPlugin`](crate::gilrs::GilrsPlugin) - with feature `bevy_gilrs`
+/// * [`GltfPlugin`](crate::gltf::GltfPlugin) - with feature `bevy_gltf`
+/// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit`
 ///
 /// See also [`MinimalPlugins`] for a slimmed down option
 pub struct DefaultPlugins;
@@ -118,9 +118,9 @@ impl PluginGroup for DefaultPlugins {
 }
 
 /// Minimal plugin group that will add the following plugins:
-/// * [`CorePlugin`](bevy_core::CorePlugin)
-/// * [`TimePlugin`](bevy_time::TimePlugin)
-/// * [`ScheduleRunnerPlugin`](bevy_app::ScheduleRunnerPlugin)
+/// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`TimePlugin`](crate::time::TimePlugin)
+/// * [`ScheduleRunnerPlugin`](crate::app::ScheduleRunnerPlugin)
 ///
 /// See also [`DefaultPlugins`] for a more complete set of plugins
 pub struct MinimalPlugins;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -337,7 +337,7 @@ pub fn extract_text_uinodes(
                     VerticalAlign::Center => -0.5 * text_layout_info.size.y,
                     VerticalAlign::Top => -0.5 * uinode.size().y,
                     VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
-                }
+                },
             );
 
             let text_glyphs = &text_layout_info.glyphs;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -365,7 +365,7 @@ pub fn extract_text_uinodes(
                 let extracted_transform = global_transform.compute_matrix()
                     * Mat4::from_scale(Vec3::splat(scale_factor.recip()))
                     * Mat4::from_translation(
-                        alignment_offset * scale_factor + text_glyph.position.extend(0.),
+                        alignment_offset + text_glyph.position.extend(0.),
                     );
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -360,8 +360,6 @@ pub fn extract_text_uinodes(
                 let rect = atlas.textures[index];
                 let atlas_size = Some(atlas.size);
 
-                // NOTE: Should match `bevy_text::text2d::extract_text2d_sprite`
-
                 let extracted_transform = global_transform.compute_matrix()
                     * Mat4::from_scale(Vec3::splat(scale_factor.recip()))
                     * Mat4::from_translation(alignment_offset + text_glyph.position.extend(0.));

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -327,7 +327,7 @@ pub fn extract_text_uinodes(
                 continue;
             }
 
-            let alignment_offset = Vec2::new(
+            let alignment_offset = Vec3::new(
                 match text.alignment.horizontal {
                     HorizontalAlign::Left => -0.5 * uinode.size().x,
                     HorizontalAlign::Center => -0.5 * text_layout_info.size.x,
@@ -338,8 +338,8 @@ pub fn extract_text_uinodes(
                     VerticalAlign::Top => -0.5 * uinode.size().y,
                     VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
                 },
-            )
-            .extend(0.0);
+                0.0
+            );
 
             let text_glyphs = &text_layout_info.glyphs;
             let mut color = Color::WHITE;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -327,16 +327,19 @@ pub fn extract_text_uinodes(
                 continue;
             }
 
-            let alignment_offset = (match text.alignment.vertical {
-                VerticalAlign::Center => -0.5 * text_layout_info.size.y,
-                VerticalAlign::Top => -0.5 * uinode.size().y,
-                VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
-            } * Vec3::Y)
-                + (match text.alignment.horizontal {
+            let alignment_offset = Vec2::new(
+                match text.alignment.horizontal {
                     HorizontalAlign::Left => -0.5 * uinode.size().x,
                     HorizontalAlign::Center => -0.5 * text_layout_info.size.x,
                     HorizontalAlign::Right => 0.5 * uinode.size().x - text_layout_info.size.x,
-                } * Vec3::X);
+                },
+                match text.alignment.vertical {
+                    VerticalAlign::Center => -0.5 * text_layout_info.size.y,
+                    VerticalAlign::Top => -0.5 * uinode.size().y,
+                    VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
+                },
+            )
+            .extend(0.0);
 
             let text_glyphs = &text_layout_info.glyphs;
             let mut color = Color::WHITE;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -327,7 +327,7 @@ pub fn extract_text_uinodes(
                 continue;
             }
 
-            let alignment_offset = Vec3::new(
+            let alignment_offset = Vec2::new(
                 match text.alignment.horizontal {
                     HorizontalAlign::Left => -0.5 * uinode.size().x,
                     HorizontalAlign::Center => -0.5 * text_layout_info.size.x,
@@ -337,8 +337,7 @@ pub fn extract_text_uinodes(
                     VerticalAlign::Center => -0.5 * text_layout_info.size.y,
                     VerticalAlign::Top => -0.5 * uinode.size().y,
                     VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
-                },
-                0.0,
+                }
             );
 
             let text_glyphs = &text_layout_info.glyphs;
@@ -362,7 +361,7 @@ pub fn extract_text_uinodes(
 
                 let extracted_transform = global_transform.compute_matrix()
                     * Mat4::from_scale(Vec3::splat(scale_factor.recip()))
-                    * Mat4::from_translation(alignment_offset + text_glyph.position.extend(0.));
+                    * Mat4::from_translation((alignment_offset + text_glyph.position).extend(0.));
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -362,7 +362,7 @@ pub fn extract_text_uinodes(
 
                 let extracted_transform = global_transform.compute_matrix()
                     * Mat4::from_scale(Vec3::splat(scale_factor.recip()))
-                    * Mat4::from_translation((alignment_offset * scale_factor + text_glyph.position).extend(0.));
+                    * Mat4::from_translation((alignment_offset + text_glyph.position).extend(0.));
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -338,7 +338,7 @@ pub fn extract_text_uinodes(
                     VerticalAlign::Top => -0.5 * uinode.size().y,
                     VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
                 },
-                0.0
+                0.0,
             );
 
             let text_glyphs = &text_layout_info.glyphs;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -364,9 +364,7 @@ pub fn extract_text_uinodes(
 
                 let extracted_transform = global_transform.compute_matrix()
                     * Mat4::from_scale(Vec3::splat(scale_factor.recip()))
-                    * Mat4::from_translation(
-                        alignment_offset + text_glyph.position.extend(0.),
-                    );
+                    * Mat4::from_translation(alignment_offset + text_glyph.position.extend(0.));
 
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -327,16 +327,17 @@ pub fn extract_text_uinodes(
                 continue;
             }
 
+            let node_size = uinode.size() * scale_factor;
             let alignment_offset = Vec2::new(
                 match text.alignment.horizontal {
-                    HorizontalAlign::Left => -0.5 * uinode.size().x,
+                    HorizontalAlign::Left => -0.5 * node_size.x,
                     HorizontalAlign::Center => -0.5 * text_layout_info.size.x,
-                    HorizontalAlign::Right => 0.5 * uinode.size().x - text_layout_info.size.x,
+                    HorizontalAlign::Right => 0.5 * node_size.x - text_layout_info.size.x,
                 },
                 match text.alignment.vertical {
                     VerticalAlign::Center => -0.5 * text_layout_info.size.y,
-                    VerticalAlign::Top => -0.5 * uinode.size().y,
-                    VerticalAlign::Bottom => 0.5 * uinode.size().y - text_layout_info.size.y,
+                    VerticalAlign::Top => -0.5 * node_size.y,
+                    VerticalAlign::Bottom => 0.5 * node_size.y - text_layout_info.size.y,
                 },
             );
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -314,7 +314,6 @@ Example | Description
 [Button](../examples/ui/button.rs) | Illustrates creating and updating a button
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
-[Text Alignment](../examples/ui/text_alignment.rs)| Demonstrates how text is displayed with each TextAlignment
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/README.md
+++ b/examples/README.md
@@ -314,6 +314,7 @@ Example | Description
 [Button](../examples/ui/button.rs) | Illustrates creating and updating a button
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
+[Text Alignment](../examples/ui/text_alignment.rs)| Demonstrates how text is displayed with each TextAlignment
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -18,62 +18,31 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(update)
         .run();
 }
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
-    commands
-        .spawn(NodeBundle {
-            style: Style {
-                align_items: AlignItems::Center,
-                justify_content: JustifyContent::Center,
-                size: Size::new(Val::Percent(100.), Val::Percent(100.)),
-                ..Default::default()
-            },
-            ..Default::default()
-        })
-        .with_children(|builder| {
-            builder
-                .spawn(NodeBundle {
-                    style: Style {
-                        size: Size::new(Val::Percent(80.), Val::Percent(80.)),
-                        ..Default::default()
-                    },
-                    background_color: BackgroundColor(Color::NAVY),
+    for x in 0..3 {
+        for y in 0..3 {
+            let alignment = ALIGNMENTS[x + 3 * y];
+            commands.spawn((
+                TextBundle::from_section(
+                    format!("{:?}\n{:?}", alignment.vertical, alignment.horizontal), 
+                     TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 24.0,
+                        color: Color::WHITE,
+                     }
+                )
+                .with_text_alignment(alignment)
+                .with_style(Style {
+                    position_type: PositionType::Absolute,
+                    position: UiRect { left: Val::Px(x as f32 * 210. + 5.), top: Val::Px(y as f32 * 210. + 5.), ..Default::default() },
+                    size: Size::new(Val::Px(200.), Val::Px(200.)),
                     ..Default::default()
-                })
-                .with_children(|builder| {
-                    builder.spawn(TextBundle {
-                        text: Text::from_section(
-                            "".to_string(),
-                            TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 24.0,
-                                color: Color::WHITE,
-                            },
-                        ),
-                        ..Default::default()
-                    });
-                });
-        });
-}
-
-pub fn update(
-    mut t: Local<f32>,
-    mut i: Local<usize>,
-    time: Res<Time>,
-    mut text_query: Query<&mut Text>,
-) {
-    *t -= time.delta_seconds();
-    if *t <= 0. {
-        *t = 0.5;
-        *i = (*i + 1) % ALIGNMENTS.len();
-        let mut text = text_query.single_mut();
-        text.alignment = ALIGNMENTS[*i];
-        text.sections[0].value = format!(
-            "{:?}-{:?}",
-            text.alignment.vertical, text.alignment.horizontal
-        );
+                }),
+                BackgroundColor(Color::NAVY)
+            ));
+        }
     }
 }

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -27,21 +27,25 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             let alignment = ALIGNMENTS[x + 3 * y];
             commands.spawn((
                 TextBundle::from_section(
-                    format!("{:?}\n{:?}", alignment.vertical, alignment.horizontal), 
-                     TextStyle {
+                    format!("{:?}\n{:?}", alignment.vertical, alignment.horizontal),
+                    TextStyle {
                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                         font_size: 24.0,
                         color: Color::WHITE,
-                     }
+                    },
                 )
                 .with_text_alignment(alignment)
                 .with_style(Style {
                     position_type: PositionType::Absolute,
-                    position: UiRect { left: Val::Px(x as f32 * 210. + 5.), top: Val::Px(y as f32 * 210. + 5.), ..Default::default() },
+                    position: UiRect {
+                        left: Val::Px(x as f32 * 210. + 5.),
+                        top: Val::Px(y as f32 * 210. + 5.),
+                        ..Default::default()
+                    },
                     size: Size::new(Val::Px(200.), Val::Px(200.)),
                     ..Default::default()
                 }),
-                BackgroundColor(Color::NAVY)
+                BackgroundColor(Color::NAVY),
             ));
         }
     }

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -22,7 +22,6 @@ fn main() {
         .run();
 }
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.insert_resource(UiScale { scale: 0.5 });
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(NodeBundle {
@@ -63,7 +62,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 pub fn update(
     mut t: Local<f32>,
     mut i: Local<usize>,
-    mut uiscale: ResMut<UiScale>,
     time: Res<Time>,
     mut text_query: Query<&mut Text>,
 ) {
@@ -77,12 +75,5 @@ pub fn update(
             "{:?}-{:?}",
             text.alignment.vertical, text.alignment.horizontal
         );
-
-        if *i % 2 == 0 {
-            uiscale.scale += 0.5;
-            if uiscale.scale > 5.0 {
-                uiscale.scale = 0.5;
-            }
-        }
     }
 }

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -1,4 +1,4 @@
-//! This example demonstrates how text is displayed with each TextAlignment
+//! This example demonstrates how text is displayed with each `TextAlignment`
 
 use bevy::prelude::*;
 
@@ -22,13 +22,6 @@ fn main() {
         .run();
 }
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
-    let text_style = TextStyle {
-        font: font.clone(),
-        font_size: 24.0,
-        color: Color::WHITE,
-    };
-
     commands.insert_resource(UiScale { scale: 0.5 });
     commands.spawn(Camera2dBundle::default());
     commands
@@ -53,7 +46,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .with_children(|builder| {
                     builder.spawn(TextBundle {
-                        text: Text::from_section("".to_string(), text_style.clone()),
+                        text: Text::from_section(
+                            "".to_string(),
+                            TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font_size: 24.0,
+                                color: Color::WHITE,
+                            },
+                        ),
                         ..Default::default()
                     });
                 });

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -28,34 +28,35 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 24.0,
         color: Color::WHITE,
     };
-    
-    commands.insert_resource(UiScale{ scale: 0.5 });
+
+    commands.insert_resource(UiScale { scale: 0.5 });
     commands.spawn(Camera2dBundle::default());
-    commands.spawn(NodeBundle {
-        style: Style    {
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::Center,
-            size: Size::new(Val::Percent(100.), Val::Percent(100.)),
-            ..Default::default()
-        },
-        ..Default::default()
-    }).with_children(|builder| {
-        builder.spawn(NodeBundle {
+    commands
+        .spawn(NodeBundle {
             style: Style {
-                size: Size::new(Val::Percent(80.), Val::Percent(80.)),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                size: Size::new(Val::Percent(100.), Val::Percent(100.)),
                 ..Default::default()
             },
-            background_color: BackgroundColor(Color::NAVY),
             ..Default::default()
-        }).with_children(|builder| {
-                builder.spawn(TextBundle {
-                    text: Text::from_section(
-                    "".to_string(), 
-                        text_style.clone()
-                    ),
+        })
+        .with_children(|builder| {
+            builder
+                .spawn(NodeBundle {
+                    style: Style {
+                        size: Size::new(Val::Percent(80.), Val::Percent(80.)),
+                        ..Default::default()
+                    },
+                    background_color: BackgroundColor(Color::NAVY),
                     ..Default::default()
+                })
+                .with_children(|builder| {
+                    builder.spawn(TextBundle {
+                        text: Text::from_section("".to_string(), text_style.clone()),
+                        ..Default::default()
+                    });
                 });
-            });
         });
 }
 
@@ -72,7 +73,10 @@ pub fn update(
         *i = (*i + 1) % ALIGNMENTS.len();
         let mut text = text_query.single_mut();
         text.alignment = ALIGNMENTS[*i];
-        text.sections[0].value = format!("{:?}-{:?}", text.alignment.vertical, text.alignment.horizontal);
+        text.sections[0].value = format!(
+            "{:?}-{:?}",
+            text.alignment.vertical, text.alignment.horizontal
+        );
 
         if *i % 2 == 0 {
             uiscale.scale += 0.5;

--- a/examples/ui/text_alignment.rs
+++ b/examples/ui/text_alignment.rs
@@ -1,0 +1,84 @@
+//! This example demonstrates how text is displayed with each TextAlignment
+
+use bevy::prelude::*;
+
+const ALIGNMENTS: [TextAlignment; 9] = [
+    TextAlignment::TOP_LEFT,
+    TextAlignment::TOP_CENTER,
+    TextAlignment::TOP_RIGHT,
+    TextAlignment::CENTER_LEFT,
+    TextAlignment::CENTER,
+    TextAlignment::CENTER_RIGHT,
+    TextAlignment::BOTTOM_LEFT,
+    TextAlignment::BOTTOM_CENTER,
+    TextAlignment::BOTTOM_RIGHT,
+];
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(update)
+        .run();
+}
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
+    let text_style = TextStyle {
+        font: font.clone(),
+        font_size: 24.0,
+        color: Color::WHITE,
+    };
+    
+    commands.insert_resource(UiScale{ scale: 0.5 });
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(NodeBundle {
+        style: Style    {
+            align_items: AlignItems::Center,
+            justify_content: JustifyContent::Center,
+            size: Size::new(Val::Percent(100.), Val::Percent(100.)),
+            ..Default::default()
+        },
+        ..Default::default()
+    }).with_children(|builder| {
+        builder.spawn(NodeBundle {
+            style: Style {
+                size: Size::new(Val::Percent(80.), Val::Percent(80.)),
+                ..Default::default()
+            },
+            background_color: BackgroundColor(Color::NAVY),
+            ..Default::default()
+        }).with_children(|builder| {
+                builder.spawn(TextBundle {
+                    text: Text::from_section(
+                    "".to_string(), 
+                        text_style.clone()
+                    ),
+                    ..Default::default()
+                });
+            });
+        });
+}
+
+pub fn update(
+    mut t: Local<f32>,
+    mut i: Local<usize>,
+    mut uiscale: ResMut<UiScale>,
+    time: Res<Time>,
+    mut text_query: Query<&mut Text>,
+) {
+    *t -= time.delta_seconds();
+    if *t <= 0. {
+        *t = 0.5;
+        *i = (*i + 1) % ALIGNMENTS.len();
+        let mut text = text_query.single_mut();
+        text.alignment = ALIGNMENTS[*i];
+        text.sections[0].value = format!("{:?}-{:?}", text.alignment.vertical, text.alignment.horizontal);
+
+        if *i % 2 == 0 {
+            uiscale.scale += 0.5;
+            if uiscale.scale > 5.0 {
+                uiscale.scale = 0.5;
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Objective

Fixes  #5834, #6717

Related to #5502

The alignment offset of text is never calculated. Text is translated minus half the node size regardless of what the `TextAlignment` is set to.

## Solution

Calculate the text alignment offset.

## Changelog
Added text alignment offset calculations
