### PR TITLE
[Merged by Bors] - bevy_reflect: Register missing reflected types for `bevy_render`

### DIFF
--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -6,14 +6,11 @@ mod projection;
 pub use camera::*;
 pub use camera_driver_node::*;
 pub use projection::*;
+use std::ops::Range;
 
-use crate::{
-    primitives::Aabb,
-    render_graph::RenderGraph,
-    view::{ComputedVisibility, RenderLayers, Visibility, VisibleEntities},
-    RenderApp, RenderStage,
-};
+use crate::{render_graph::RenderGraph, RenderApp, RenderStage};
 use bevy_app::{App, Plugin};
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 #[derive(Default)]
 pub struct CameraPlugin;
@@ -23,14 +20,13 @@ impl Plugin for CameraPlugin {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
             .register_type::<Option<Viewport>>()
-            .register_type::<Visibility>()
-            .register_type::<ComputedVisibility>()
-            .register_type::<VisibleEntities>()
+            .register_type::<Range<f32>>()
+            .register_type_data::<Range<f32>, ReflectSerialize>()
+            .register_type_data::<Range<f32>, ReflectDeserialize>()
             .register_type::<WindowOrigin>()
             .register_type::<ScalingMode>()
-            .register_type::<Aabb>()
             .register_type::<CameraRenderGraph>()
-            .register_type::<RenderLayers>()
+            .register_type::<RenderTarget>()
             .add_plugin(CameraProjectionPlugin::<Projection>::default())
             .add_plugin(CameraProjectionPlugin::<OrthographicProjection>::default())
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -6,11 +6,9 @@ mod projection;
 pub use camera::*;
 pub use camera_driver_node::*;
 pub use projection::*;
-use std::ops::Range;
 
 use crate::{render_graph::RenderGraph, RenderApp, RenderStage};
 use bevy_app::{App, Plugin};
-use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 #[derive(Default)]
 pub struct CameraPlugin;
@@ -20,9 +18,6 @@ impl Plugin for CameraPlugin {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
             .register_type::<Option<Viewport>>()
-            .register_type::<Range<f32>>()
-            .register_type_data::<Range<f32>, ReflectSerialize>()
-            .register_type_data::<Range<f32>, ReflectDeserialize>()
             .register_type::<WindowOrigin>()
             .register_type::<ScalingMode>()
             .register_type::<CameraRenderGraph>()

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -14,6 +14,7 @@ pub struct GlobalsPlugin;
 
 impl Plugin for GlobalsPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<GlobalsUniform>();
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<GlobalsBuffer>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -37,13 +37,10 @@ pub mod prelude {
 
 use globals::GlobalsPlugin;
 pub use once_cell;
-use prelude::ComputedVisibility;
 
 use crate::{
     camera::CameraPlugin,
-    color::Color,
     mesh::MeshPlugin,
-    primitives::{CubemapFrusta, Frustum},
     render_graph::RenderGraph,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
@@ -137,8 +134,7 @@ impl Plugin for RenderPlugin {
         app.add_asset::<Shader>()
             .add_debug_asset::<Shader>()
             .init_asset_loader::<ShaderLoader>()
-            .init_debug_asset_loader::<ShaderLoader>()
-            .register_type::<Color>();
+            .init_debug_asset_loader::<ShaderLoader>();
 
         if let Some(backends) = options.backends {
             let windows = app.world.resource_mut::<bevy_window::Windows>();
@@ -166,9 +162,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(queue.clone())
                 .insert_resource(adapter_info.clone())
                 .insert_resource(render_adapter.clone())
-                .init_resource::<ScratchMainWorld>()
-                .register_type::<Frustum>()
-                .register_type::<CubemapFrusta>();
+                .init_resource::<ScratchMainWorld>();
 
             let pipeline_cache = PipelineCache::new(device.clone());
             let asset_server = app.world.resource::<AssetServer>().clone();
@@ -327,12 +321,35 @@ impl Plugin for RenderPlugin {
             });
         }
 
-        app.add_plugin(ValidParentCheckPlugin::<ComputedVisibility>::default())
+        app.add_plugin(ValidParentCheckPlugin::<view::ComputedVisibility>::default())
             .add_plugin(WindowRenderPlugin)
             .add_plugin(CameraPlugin)
             .add_plugin(ViewPlugin)
             .add_plugin(MeshPlugin)
             .add_plugin(GlobalsPlugin);
+
+        app.register_type::<camera::Camera>()
+            .register_type::<camera::CameraRenderGraph>()
+            .register_type::<camera::OrthographicProjection>()
+            .register_type::<camera::PerspectiveProjection>()
+            .register_type::<camera::Projection>()
+            .register_type::<camera::RenderTarget>()
+            .register_type::<camera::ScalingMode>()
+            .register_type::<camera::Viewport>()
+            .register_type::<camera::WindowOrigin>()
+            .register_type::<color::Color>()
+            .register_type::<globals::GlobalsUniform>()
+            .register_type::<mesh::skinning::SkinnedMesh>()
+            .register_type::<primitives::Aabb>()
+            .register_type::<primitives::CubemapFrusta>()
+            .register_type::<primitives::Frustum>()
+            .register_type::<texture::Image>()
+            .register_type::<view::ComputedVisibility>()
+            .register_type::<view::ComputedVisibilityFlags>()
+            .register_type::<view::Msaa>()
+            .register_type::<view::RenderLayers>()
+            .register_type::<view::Visibility>()
+            .register_type::<view::VisibleEntities>();
     }
 }
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -49,7 +49,9 @@ use crate::{
 use bevy_app::{App, AppLabel, Plugin};
 use bevy_asset::{AddAsset, AssetServer};
 use bevy_ecs::prelude::*;
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::tracing::debug;
+use std::ops::Range;
 use std::{
     any::TypeId,
     ops::{Deref, DerefMut},
@@ -336,10 +338,15 @@ impl Plugin for RenderPlugin {
             .register_type::<camera::RenderTarget>()
             .register_type::<camera::ScalingMode>()
             .register_type::<camera::Viewport>()
+            .register_type::<Option<camera::Viewport>>()
+            .register_type::<Range<f32>>()
+            .register_type_data::<Range<f32>, ReflectSerialize>()
+            .register_type_data::<Range<f32>, ReflectDeserialize>()
             .register_type::<camera::WindowOrigin>()
             .register_type::<color::Color>()
             .register_type::<globals::GlobalsUniform>()
             .register_type::<mesh::skinning::SkinnedMesh>()
+            .register_type::<Vec<Entity>>()
             .register_type::<primitives::Aabb>()
             .register_type::<primitives::CubemapFrusta>()
             .register_type::<primitives::Frustum>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -41,7 +41,6 @@ pub use once_cell;
 use crate::{
     camera::CameraPlugin,
     mesh::MeshPlugin,
-    render_graph::RenderGraph,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
     view::{ViewPlugin, WindowRenderPlugin},
@@ -49,9 +48,7 @@ use crate::{
 use bevy_app::{App, AppLabel, Plugin};
 use bevy_asset::{AddAsset, AssetServer};
 use bevy_ecs::prelude::*;
-use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::tracing::debug;
-use std::ops::Range;
 use std::{
     any::TypeId,
     ops::{Deref, DerefMut},
@@ -199,7 +196,7 @@ impl Plugin for RenderPlugin {
                         .with_system(render_system.at_end()),
                 )
                 .add_stage(RenderStage::Cleanup, SystemStage::parallel())
-                .init_resource::<RenderGraph>()
+                .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(RenderInstance(instance))
                 .insert_resource(device)
                 .insert_resource(queue)
@@ -330,33 +327,10 @@ impl Plugin for RenderPlugin {
             .add_plugin(MeshPlugin)
             .add_plugin(GlobalsPlugin);
 
-        app.register_type::<camera::Camera>()
-            .register_type::<camera::CameraRenderGraph>()
-            .register_type::<camera::OrthographicProjection>()
-            .register_type::<camera::PerspectiveProjection>()
-            .register_type::<camera::Projection>()
-            .register_type::<camera::RenderTarget>()
-            .register_type::<camera::ScalingMode>()
-            .register_type::<camera::Viewport>()
-            .register_type::<Option<camera::Viewport>>()
-            .register_type::<Range<f32>>()
-            .register_type_data::<Range<f32>, ReflectSerialize>()
-            .register_type_data::<Range<f32>, ReflectDeserialize>()
-            .register_type::<camera::WindowOrigin>()
-            .register_type::<color::Color>()
-            .register_type::<globals::GlobalsUniform>()
-            .register_type::<mesh::skinning::SkinnedMesh>()
-            .register_type::<Vec<Entity>>()
+        app.register_type::<color::Color>()
             .register_type::<primitives::Aabb>()
             .register_type::<primitives::CubemapFrusta>()
-            .register_type::<primitives::Frustum>()
-            .register_type::<texture::Image>()
-            .register_type::<view::ComputedVisibility>()
-            .register_type::<view::ComputedVisibilityFlags>()
-            .register_type::<view::Msaa>()
-            .register_type::<view::RenderLayers>()
-            .register_type::<view::Visibility>()
-            .register_type::<view::VisibleEntities>();
+            .register_type::<primitives::Frustum>();
     }
 }
 

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -8,6 +8,7 @@ pub use mesh::*;
 use crate::render_asset::RenderAssetPlugin;
 use bevy_app::{App, Plugin};
 use bevy_asset::AddAsset;
+use bevy_ecs::entity::Entity;
 
 /// Adds the [`Mesh`] as an asset and makes sure that they are extracted and prepared for the GPU.
 pub struct MeshPlugin;
@@ -17,6 +18,7 @@ impl Plugin for MeshPlugin {
         app.add_asset::<Mesh>()
             .add_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_type::<skinning::SkinnedMesh>()
+            .register_type::<Vec<Entity>>()
             .add_plugin(RenderAssetPlugin::<Mesh>::default());
     }
 }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -86,6 +86,7 @@ impl Plugin for ImagePlugin {
         app.add_plugin(RenderAssetPlugin::<Image>::with_prepare_asset_label(
             PrepareAssetLabel::PreAssetPrepare,
         ))
+        .register_type::<Image>()
         .add_asset::<Image>()
         .register_asset_reflect::<Image>();
         app.world

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -31,7 +31,12 @@ pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Msaa>()
+        app.register_type::<ComputedVisibility>()
+            .register_type::<ComputedVisibilityFlags>()
+            .register_type::<Msaa>()
+            .register_type::<RenderLayers>()
+            .register_type::<Visibility>()
+            .register_type::<VisibleEntities>()
             .init_resource::<Msaa>()
             // NOTE: windows.is_changed() handles cases where a window was resized
             .add_plugin(ExtractResourcePlugin::<Msaa>::default())

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -56,7 +56,7 @@ impl Visibility {
 
 bitflags::bitflags! {
     #[derive(Reflect)]
-    pub(crate) struct ComputedVisibilityFlags: u8 {
+    pub(super) struct ComputedVisibilityFlags: u8 {
         const VISIBLE_IN_VIEW = 1 << 0;
         const VISIBLE_IN_HIERARCHY = 1 << 1;
     }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -56,7 +56,7 @@ impl Visibility {
 
 bitflags::bitflags! {
     #[derive(Reflect)]
-    struct ComputedVisibilityFlags: u8 {
+    pub(crate) struct ComputedVisibilityFlags: u8 {
         const VISIBLE_IN_VIEW = 1 << 0;
         const VISIBLE_IN_HIERARCHY = 1 << 1;
     }


### PR DESCRIPTION
# Objective 

Many types in `bevy_render` implemented `Reflect` but were not registered.

## Solution

Register all types in `bevy_render` that impl `Reflect`.

This also registers additional dependent types (i.e. field types).

> Note: Adding these dependent types would not be needed using something like #5781 😉 

---

## Changelog

- Register missing `bevy_render` types in the `TypeRegistry`:
  - `camera::RenderTarget`
  - `globals::GlobalsUniform`
  - `texture::Image`
  - `view::ComputedVisibility`
  - `view::Visibility`
  - `view::VisibleEntities`
- Register additional dependent types:
  - `view::ComputedVisibilityFlags`
  - `Vec<Entity>`