### PR TITLE
[Fixes #6224] Add logging variants of system piping

### DIFF
--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -167,7 +167,8 @@ where
 /// A collection of common adapters for [piping](super::PipeSystem) the result of a system.
 pub mod adapter {
     use crate::system::In;
-    use std::fmt::Debug;
+    use std::fmt::{Debug, Display};
+    use bevy_utils::tracing;
 
     /// Converts a regular function into a system adapter.
     ///
@@ -230,6 +231,54 @@ pub mod adapter {
     /// ```
     pub fn unwrap<T, E: Debug>(In(res): In<Result<T, E>>) -> T {
         res.unwrap()
+    }
+
+    /// System adapter that utilizes the info! macro to print system information.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// 
+    /// ```
+    pub fn info<T: Display>(In(data): In<T>) {
+        tracing::info!("{}", data);
+    }
+
+    /// System adapter that utilizes the debug! macro to debug system piping.
+    ///
+    /// # Examples
+    /// 
+    /// ```
+    /// 
+    /// ```
+    pub fn dbg<T: Debug>(In(data): In<T>) {
+        tracing::debug!("{:?}", data);
+    }
+
+    /// System adapter that utilizes the warn! macro.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// 
+    /// ```
+    pub fn warn<T: Debug>(In(res): In<Option<T>>) {
+        if let Some(warn) = res {
+            tracing::warn!("{:?}", warn);
+        }
+    }
+
+    /// System adapter that utilizes the error! macro which useful for fallible systems that should print the error message in the case of an error.
+    /// 
+    /// # Examples
+    /// 
+    /// ```
+    /// 
+    /// ```
+    pub fn error<T, E: Debug>(In(res): In<Result<T, E>>) {
+        if let Err(error) = res {
+            tracing::error!("{:?}", error);
+        }
     }
 
     /// System adapter that ignores the output of the previous system in a pipe.

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -4,10 +4,22 @@
 use anyhow::Result;
 use bevy::prelude::*;
 
+use bevy::utils::tracing::Level;
+use bevy::log::LogPlugin;
+
+
 fn main() {
     App::new()
-        .insert_resource(Message("42".to_string()))
+        .insert_resource(Message("42A".to_string()))
+        .add_plugin(LogPlugin {
+            level: Level::TRACE,
+            filter: "".to_string(),
+        })
         .add_system(parse_message_system.pipe(handler_system))
+        .add_system(data_pipe_system.pipe(system_adapter::info))
+        .add_system(parse_message_system.pipe(system_adapter::dbg))
+        .add_system(warning_pipe_system.pipe(system_adapter::warn))
+        .add_system(parse_message_system.pipe(system_adapter::error))
         .run();
 }
 
@@ -26,5 +38,17 @@ fn handler_system(In(result): In<Result<usize>>) {
     match result {
         Ok(value) => println!("parsed message: {value}"),
         Err(err) => println!("encountered an error: {err:?}"),
+    }
+}
+
+fn data_pipe_system(message: Res<Message>) -> String {
+    message.0.clone()
+}
+
+fn warning_pipe_system(message: Res<Message>) -> Option<String> {
+
+    match message.0.as_str() {
+        "No warning" => None,
+        x => Some(x.to_string()),
     }
 }


### PR DESCRIPTION
# Objective

Fixes #6224, add ``dbg``, ``info``, ``warn`` and ``error`` system piping adapter variants to expand #5776, which call the corresponding re-exported [bevy_log macros](https://docs.rs/bevy/latest/bevy/log/macro.info.html) when the result is an error.

## Solution

* Added ``dbg``, ``info``, ``warn`` and ``error`` system piping adapter variants to ``system_piping.rs``. 
* Modified and added tests for these under examples in ``system_piping.rs``.
