### PR TITLE
[Merged by Bors] - Make proc macros hygienic in bevy_reflect_derive

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
@@ -1,5 +1,6 @@
 //! Contains code related to documentation reflection (requires the `documentation` feature).
 
+use crate::fq_std::FQOption;
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use syn::{Attribute, Lit, Meta};
@@ -68,11 +69,10 @@ impl Documentation {
 
 impl ToTokens for Documentation {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        let option = quote!(::core::option::Option);
         if let Some(doc) = self.doc_string() {
-            quote!(#option::Some(#doc)).to_tokens(tokens);
+            quote!(#FQOption::Some(#doc)).to_tokens(tokens);
         } else {
-            quote!(#option::None).to_tokens(tokens);
+            quote!(#FQOption::None).to_tokens(tokens);
         }
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
@@ -68,10 +68,11 @@ impl Documentation {
 
 impl ToTokens for Documentation {
     fn to_tokens(&self, tokens: &mut TokenStream) {
+        let option = quote!(::core::option::Option);
         if let Some(doc) = self.doc_string() {
-            quote!(Some(#doc)).to_tokens(tokens);
+            quote!(#option::Some(#doc)).to_tokens(tokens);
         } else {
-            quote!(None).to_tokens(tokens);
+            quote!(#option::None).to_tokens(tokens);
         }
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
@@ -39,7 +39,7 @@ pub(crate) fn get_variant_constructors(
         let constructor_fields = fields.iter().enumerate().map(|(declar_index, field)| {
             let field_ident = ident_or_index(field.data.ident.as_ref(), declar_index);
             let field_value = if field.attrs.ignore.is_ignored() {
-                quote! { Default::default() }
+                quote! { ::core::default::Default::default() }
             } else {
                 let error_repr = field.data.ident.as_ref().map_or_else(
                     || format!("at index {reflect_index}"),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/enum_utility.rs
@@ -1,3 +1,4 @@
+use crate::fq_std::FQDefault;
 use crate::{
     derive_data::{EnumVariantFields, ReflectEnum},
     utility::ident_or_index,
@@ -39,7 +40,7 @@ pub(crate) fn get_variant_constructors(
         let constructor_fields = fields.iter().enumerate().map(|(declar_index, field)| {
             let field_ident = ident_or_index(field.data.ident.as_ref(), declar_index);
             let field_value = if field.attrs.ignore.is_ignored() {
-                quote! { ::core::default::Default::default() }
+                quote! { #FQDefault::default() }
             } else {
                 let error_repr = field.data.ident.as_ref().map_or_else(
                     || format!("at index {reflect_index}"),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
@@ -1,37 +1,37 @@
+//! This module contains unit structs that should be used inside `quote!` and `spanned_quote!` using the variable interpolation syntax in place of their equivalent structs and traits present in `std`.
+//
+//! To create hygienic proc macros, all the names must be its fully qualified form. These unit structs help us to not specify the fully qualified name every single time.
+//!
+//! # Example
+//! Instead of writing this:
+//! ```ignore
+//! quote!(
+//!     fn get_id() -> Option<i32> {
+//!         Some(0)
+//!     }
+//! )
+//! ```
+//! Or this:
+//! ```ignore
+//! quote!(
+//!     fn get_id() -> ::core::option::Option<i32> {
+//!         ::core::option::Option::Some(0)
+//!     }
+//! )
+//! ```
+//! We should write this:
+//! ```ignore
+//! use crate::fq_std::FQOption;
+//!
+//! quote!(
+//!     fn get_id() -> #FQOption<i32> {
+//!         #FQOption::Some(0)
+//!     }
+//! )
+//! ```
+
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
-
-// This module contains unit structs that should be used inside `quote!` and `spanned_quote!` using the variable interpolation syntax in place of their equivalent structs and traits present in `std`.
-//
-// To create hygienic proc macros, all the names must be its fully qualified form. These unit structs help us to not specify the fully qualified name every single time.
-//
-// # Example
-// Instead of writing this:
-// ```ignore
-// quote!(
-//     fn get_id() -> Option<i32> {
-//         Some(0)
-//     }
-// )
-// ```
-// Or this:
-// ```ignore
-// quote!(
-//     fn get_id() -> ::core::option::Option<i32> {
-//         ::core::option::Option::Some(0)
-//     }
-// )
-// ```
-// We should write this:
-// ```ignore
-// use crate::fq_std::FQOption;
-//
-// quote!(
-//     fn get_id() -> #FQOption<i32> {
-//         #FQOption::Some(0)
-//     }
-// )
-// ```
 
 pub(crate) struct FQAny;
 pub(crate) struct FQBox;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
@@ -1,6 +1,38 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
+// This module contains unit structs that should be used inside `quote!` and `spanned_quote!` using the variable interpolation syntax in place of their equivalent structs and traits present in `std`.
+//
+// To create hygienic proc macros, all the names must be its fully qualified form. These unit structs help us to not specify the fully qualified name every single time.
+//
+// # Example
+// Instead of writing this:
+// ```ignore
+// quote!(
+//     fn get_id() -> Option<i32> {
+//         Some(0)
+//     }
+// )
+// ```
+// Or this:
+// ```ignore
+// quote!(
+//     fn get_id() -> ::core::option::Option<i32> {
+//         ::core::option::Option::Some(0)
+//     }
+// )
+// ```
+// We should write this:
+// ```ignore
+// use crate::fq_std::FQOption;
+//
+// quote!(
+//     fn get_id() -> #FQOption<i32> {
+//         #FQOption::Some(0)
+//     }
+// )
+// ```
+
 pub(crate) struct FQAny;
 pub(crate) struct FQBox;
 pub(crate) struct FQClone;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
@@ -1,0 +1,45 @@
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+
+pub(crate) struct FQAny;
+pub(crate) struct FQBox;
+pub(crate) struct FQClone;
+pub(crate) struct FQDefault;
+pub(crate) struct FQOption;
+pub(crate) struct FQResult;
+
+impl ToTokens for FQAny {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::any::Any).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQBox {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::std::boxed::Box).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQClone {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::clone::Clone).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQDefault {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::default::Default).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQOption {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::option::Option).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQResult {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::result::Result).to_tokens(tokens);
+    }
+}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -2,10 +2,11 @@ use crate::container_attributes::REFLECT_DEFAULT;
 use crate::derive_data::ReflectEnum;
 use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
 use crate::field_attributes::DefaultBehavior;
+use crate::fq_std::{FQAny, FQClone, FQDefault, FQOption};
 use crate::{ReflectMeta, ReflectStruct};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{Field, Ident, Index, Lit, LitInt, LitStr, Member};
 
 /// Implements `FromReflect` for the given struct
@@ -20,17 +21,13 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
 
 /// Implements `FromReflect` for the given value type
 pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
-    let option = quote!(::core::option::Option);
-    let clone = quote!(::core::clone::Clone::clone);
-    let any = quote!(::core::any::Any);
-
     let type_name = meta.type_name();
     let bevy_reflect_path = meta.bevy_reflect_path();
     let (impl_generics, ty_generics, where_clause) = meta.generics().split_for_impl();
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #type_name #ty_generics #where_clause  {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
-                #option::Some(#clone(<dyn #any>::downcast_ref::<#type_name #ty_generics>(<dyn #bevy_reflect_path::Reflect>::as_any(reflect))?))
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #FQOption<Self> {
+                #FQOption::Some(#FQClone::clone(<dyn #FQAny>::downcast_ref::<#type_name #ty_generics>(<dyn #bevy_reflect_path::Reflect>::as_any(reflect))?))
             }
         }
     })
@@ -38,7 +35,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
 
 /// Implements `FromReflect` for the given enum type
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
-    let option = quote!(::core::option::Option);
+    let fqoption = FQOption.into_token_stream();
 
     let type_name = reflect_enum.meta().type_name();
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
@@ -53,14 +50,14 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         reflect_enum.meta().generics().split_for_impl();
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #type_name #ty_generics #where_clause  {
-            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
+            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::Reflect) -> #FQOption<Self> {
                 if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #bevy_reflect_path::Reflect::reflect_ref(#ref_value) {
                     match #bevy_reflect_path::Enum::variant_name(#ref_value) {
-                        #(#variant_names => #option::Some(#variant_constructors),)*
+                        #(#variant_names => #fqoption::Some(#variant_constructors),)*
                         name => panic!("variant with name `{}` does not exist on enum `{}`", name, ::core::any::type_name::<Self>()),
                     }
                 } else {
-                    #option::None
+                    #FQOption::None
                 }
             }
         }
@@ -78,7 +75,7 @@ impl MemberValuePair {
 }
 
 fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> TokenStream {
-    let option = quote!(::core::option::Option);
+    let fqoption = FQOption.into_token_stream();
 
     let struct_name = reflect_struct.meta().type_name();
     let generics = reflect_struct.meta().generics();
@@ -97,21 +94,21 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
 
     let constructor = if reflect_struct.meta().traits().contains(REFLECT_DEFAULT) {
         quote!(
-            let mut __this: Self = ::core::default::Default::default();
+            let mut __this: Self = #FQDefault::default();
             #(
-                if let #option::Some(__field) = #active_values() {
+                if let #fqoption::Some(__field) = #active_values() {
                     // Iff field exists -> use its value
                     __this.#active_members = __field;
                 }
             )*
-            #option::Some(__this)
+            #FQOption::Some(__this)
         )
     } else {
         let MemberValuePair(ignored_members, ignored_values) =
             get_ignored_fields(reflect_struct, is_tuple);
 
         quote!(
-            #option::Some(
+            #FQOption::Some(
                 Self {
                     #(#active_members: #active_values()?,)*
                     #(#ignored_members: #ignored_values,)*
@@ -137,11 +134,11 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #struct_name #ty_generics #where_from_reflect_clause
         {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #FQOption<Self> {
                 if let #bevy_reflect_path::ReflectRef::#ref_struct_type(#ref_struct) = #bevy_reflect_path::Reflect::reflect_ref(reflect) {
                     #constructor
                 } else {
-                    #option::None
+                    #FQOption::None
                 }
             }
         }
@@ -161,7 +158,7 @@ fn get_ignored_fields(reflect_struct: &ReflectStruct, is_tuple: bool) -> MemberV
 
                 let value = match &field.attrs.default {
                     DefaultBehavior::Func(path) => quote! {#path()},
-                    _ => quote! {::core::default::Default::default()},
+                    _ => quote! {#FQDefault::default()},
                 };
 
                 (member, value)
@@ -180,8 +177,6 @@ fn get_active_fields(
     struct_type: &Ident,
     is_tuple: bool,
 ) -> MemberValuePair {
-    let option = quote!(::core::option::Option);
-
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
 
     MemberValuePair::new(
@@ -199,19 +194,19 @@ fn get_active_fields(
                 let value = match &field.attrs.default {
                     DefaultBehavior::Func(path) => quote! {
                         (||
-                            if let #option::Some(field) = #get_field {
+                            if let #FQOption::Some(field) = #get_field {
                                 <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                             } else {
-                                #option::Some(#path())
+                                #FQOption::Some(#path())
                             }
                         )
                     },
                     DefaultBehavior::Default => quote! {
                         (||
-                            if let #option::Some(field) = #get_field {
+                            if let #FQOption::Some(field) = #get_field {
                                 <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                             } else {
-                                #option::Some(::core::default::Default::default())
+                                #FQOption::Some(#FQDefault::default())
                             }
                         )
                     },

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -20,13 +20,17 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
 
 /// Implements `FromReflect` for the given value type
 pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
+    let option = quote!(::core::option::Option);
+    let clone = quote!(::core::clone::Clone::clone);
+    let any = quote!(::core::any::Any);
+
     let type_name = meta.type_name();
     let bevy_reflect_path = meta.bevy_reflect_path();
     let (impl_generics, ty_generics, where_clause) = meta.generics().split_for_impl();
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #type_name #ty_generics #where_clause  {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
-                Some(reflect.as_any().downcast_ref::<#type_name #ty_generics>()?.clone())
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
+                #option::Some(#clone(<dyn #any>::downcast_ref::<#type_name #ty_generics>(<dyn #bevy_reflect_path::Reflect>::as_any(reflect))?))
             }
         }
     })
@@ -34,6 +38,8 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
 
 /// Implements `FromReflect` for the given enum type
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
+    let option = quote!(::core::option::Option);
+
     let type_name = reflect_enum.meta().type_name();
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
 
@@ -47,14 +53,14 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         reflect_enum.meta().generics().split_for_impl();
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #type_name #ty_generics #where_clause  {
-            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
-                if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #ref_value.reflect_ref() {
-                    match #ref_value.variant_name() {
-                        #(#variant_names => Some(#variant_constructors),)*
-                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, std::any::type_name::<Self>()),
+            fn from_reflect(#ref_value: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
+                if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #bevy_reflect_path::Reflect::reflect_ref(#ref_value) {
+                    match #bevy_reflect_path::Enum::variant_name(#ref_value) {
+                        #(#variant_names => #option::Some(#variant_constructors),)*
+                        name => panic!("variant with name `{}` does not exist on enum `{}`", name, ::core::any::type_name::<Self>()),
                     }
                 } else {
-                    None
+                    #option::None
                 }
             }
         }
@@ -72,6 +78,8 @@ impl MemberValuePair {
 }
 
 fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> TokenStream {
+    let option = quote!(::core::option::Option);
+
     let struct_name = reflect_struct.meta().type_name();
     let generics = reflect_struct.meta().generics();
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
@@ -89,21 +97,21 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
 
     let constructor = if reflect_struct.meta().traits().contains(REFLECT_DEFAULT) {
         quote!(
-            let mut __this = Self::default();
+            let mut __this: Self = ::core::default::Default::default();
             #(
-                if let Some(__field) = #active_values() {
+                if let #option::Some(__field) = #active_values() {
                     // Iff field exists -> use its value
                     __this.#active_members = __field;
                 }
             )*
-            Some(__this)
+            #option::Some(__this)
         )
     } else {
         let MemberValuePair(ignored_members, ignored_values) =
             get_ignored_fields(reflect_struct, is_tuple);
 
         quote!(
-            Some(
+            #option::Some(
                 Self {
                     #(#active_members: #active_values()?,)*
                     #(#ignored_members: #ignored_values,)*
@@ -129,11 +137,11 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
     TokenStream::from(quote! {
         impl #impl_generics #bevy_reflect_path::FromReflect for #struct_name #ty_generics #where_from_reflect_clause
         {
-            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> Option<Self> {
-                if let #bevy_reflect_path::ReflectRef::#ref_struct_type(#ref_struct) = reflect.reflect_ref() {
+            fn from_reflect(reflect: &dyn #bevy_reflect_path::Reflect) -> #option<Self> {
+                if let #bevy_reflect_path::ReflectRef::#ref_struct_type(#ref_struct) = #bevy_reflect_path::Reflect::reflect_ref(reflect) {
                     #constructor
                 } else {
-                    None
+                    #option::None
                 }
             }
         }
@@ -153,7 +161,7 @@ fn get_ignored_fields(reflect_struct: &ReflectStruct, is_tuple: bool) -> MemberV
 
                 let value = match &field.attrs.default {
                     DefaultBehavior::Func(path) => quote! {#path()},
-                    _ => quote! {Default::default()},
+                    _ => quote! {::core::default::Default::default()},
                 };
 
                 (member, value)
@@ -172,6 +180,8 @@ fn get_active_fields(
     struct_type: &Ident,
     is_tuple: bool,
 ) -> MemberValuePair {
+    let option = quote!(::core::option::Option);
+
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
 
     MemberValuePair::new(
@@ -189,19 +199,19 @@ fn get_active_fields(
                 let value = match &field.attrs.default {
                     DefaultBehavior::Func(path) => quote! {
                         (||
-                            if let Some(field) = #get_field {
+                            if let #option::Some(field) = #get_field {
                                 <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                             } else {
-                                Some(#path())
+                                #option::Some(#path())
                             }
                         )
                     },
                     DefaultBehavior::Default => quote! {
                         (||
-                            if let Some(field) = #get_field {
+                            if let #option::Some(field) = #get_field {
                                 <#ty as #bevy_reflect_path::FromReflect>::from_reflect(field)
                             } else {
-                                Some(Default::default())
+                                #option::Some(::core::default::Default::default())
                             }
                         )
                     },

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -7,6 +7,10 @@ use quote::quote;
 use syn::Fields;
 
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
+    let option = quote!(::core::option::Option);
+    let any = quote!(::core::any::Any);
+    let alloc_box = quote!(::alloc::boxed::Box);
+
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
     let enum_name = reflect_enum.meta().type_name();
 
@@ -37,7 +41,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         .get_hash_impl(bevy_reflect_path)
         .unwrap_or_else(|| {
             quote! {
-                fn reflect_hash(&self) -> Option<u64> {
+                fn reflect_hash(&self) -> #option<u64> {
                     #bevy_reflect_path::enum_hash(self)
                 }
             }
@@ -49,7 +53,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         .get_partial_eq_impl(bevy_reflect_path)
         .unwrap_or_else(|| {
             quote! {
-                fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> Option<bool> {
+                fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> #option<bool> {
                     #bevy_reflect_path::enum_partial_eq(self, value)
                 }
             }
@@ -93,45 +97,45 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         #typed_impl
 
         impl #impl_generics #bevy_reflect_path::Enum for #enum_name #ty_generics #where_clause {
-            fn field(&self, #ref_name: &str) -> Option<&dyn #bevy_reflect_path::Reflect> {
+            fn field(&self, #ref_name: &str) -> #option<&dyn #bevy_reflect_path::Reflect> {
                  match self {
                     #(#enum_field,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
-            fn field_at(&self, #ref_index: usize) -> Option<&dyn #bevy_reflect_path::Reflect> {
+            fn field_at(&self, #ref_index: usize) -> #option<&dyn #bevy_reflect_path::Reflect> {
                 match self {
                     #(#enum_field_at,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
-            fn field_mut(&mut self, #ref_name: &str) -> Option<&mut dyn #bevy_reflect_path::Reflect> {
+            fn field_mut(&mut self, #ref_name: &str) -> #option<&mut dyn #bevy_reflect_path::Reflect> {
                  match self {
                     #(#enum_field,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
-            fn field_at_mut(&mut self, #ref_index: usize) -> Option<&mut dyn #bevy_reflect_path::Reflect> {
+            fn field_at_mut(&mut self, #ref_index: usize) -> #option<&mut dyn #bevy_reflect_path::Reflect> {
                 match self {
                     #(#enum_field_at,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
-            fn index_of(&self, #ref_name: &str) -> Option<usize> {
+            fn index_of(&self, #ref_name: &str) -> #option<usize> {
                  match self {
                     #(#enum_index_of,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
-            fn name_at(&self, #ref_index: usize) -> Option<&str> {
+            fn name_at(&self, #ref_index: usize) -> #option<&str> {
                  match self {
                     #(#enum_name_at,)*
-                    _ => None,
+                    _ => #option::None,
                 }
             }
 
@@ -179,7 +183,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         impl #impl_generics #bevy_reflect_path::Reflect for #enum_name #ty_generics #where_clause {
             #[inline]
             fn type_name(&self) -> &str {
-                std::any::type_name::<Self>()
+                ::core::any::type_name::<Self>()
             }
 
             #[inline]
@@ -188,22 +192,22 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+            fn into_any(self: #alloc_box<Self>) -> #alloc_box<dyn #any> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn std::any::Any {
+            fn as_any(&self) -> &dyn #any {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+            fn as_any_mut(&mut self) -> &mut dyn #any {
                 self
             }
 
             #[inline]
-            fn into_reflect(self: Box<Self>) -> Box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #alloc_box<Self>) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -218,30 +222,30 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> Box<dyn #bevy_reflect_path::Reflect> {
-                Box::new(#bevy_reflect_path::Enum::clone_dynamic(self))
+            fn clone_value(&self) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
+                #alloc_box::new(#bevy_reflect_path::Enum::clone_dynamic(self))
             }
 
             #[inline]
-            fn set(&mut self, #ref_value: Box<dyn #bevy_reflect_path::Reflect>) -> Result<(), Box<dyn #bevy_reflect_path::Reflect>> {
-                *self = #ref_value.take()?;
+            fn set(&mut self, #ref_value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+                *self = <dyn #bevy_reflect_path::Reflect>::take(#ref_value)?;
                 Ok(())
             }
 
             #[inline]
             fn apply(&mut self, #ref_value: &dyn #bevy_reflect_path::Reflect) {
-                if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #ref_value.reflect_ref() {
-                    if #bevy_reflect_path::Enum::variant_name(self) == #ref_value.variant_name() {
+                if let #bevy_reflect_path::ReflectRef::Enum(#ref_value) = #bevy_reflect_path::Reflect::reflect_ref(#ref_value) {
+                    if #bevy_reflect_path::Enum::variant_name(self) == #bevy_reflect_path::Enum::variant_name(#ref_value) {
                         // Same variant -> just update fields
-                        match #ref_value.variant_type() {
+                        match #bevy_reflect_path::Enum::variant_type(#ref_value) {
                             #bevy_reflect_path::VariantType::Struct => {
-                                for field in #ref_value.iter_fields() {
+                                for field in #bevy_reflect_path::Enum::iter_fields(#ref_value) {
                                     let name = field.name().unwrap();
                                     #bevy_reflect_path::Enum::field_mut(self, name).map(|v| v.apply(field.value()));
                                 }
                             }
                             #bevy_reflect_path::VariantType::Tuple => {
-                                for (index, field) in #ref_value.iter_fields().enumerate() {
+                                for (index, field) in ::core::iter::Iterator::enumerate(#bevy_reflect_path::Enum::iter_fields(#ref_value)) {
                                     #bevy_reflect_path::Enum::field_at_mut(self, index).map(|v| v.apply(field.value()));
                                 }
                             }
@@ -249,15 +253,15 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                         }
                     } else {
                         // New variant -> perform a switch
-                        match #ref_value.variant_name() {
+                        match #bevy_reflect_path::Enum::variant_name(#ref_value) {
                             #(#variant_names => {
                                 *self = #variant_constructors
                             })*
-                            name => panic!("variant with name `{}` does not exist on enum `{}`", name, std::any::type_name::<Self>()),
+                            name => panic!("variant with name `{}` does not exist on enum `{}`", name, ::core::any::type_name::<Self>()),
                         }
                     }
                 } else {
-                    panic!("`{}` is not an enum", #ref_value.type_name());
+                    panic!("`{}` is not an enum", #bevy_reflect_path::Reflect::type_name(#ref_value));
                 }
             }
 
@@ -269,7 +273,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::Enum(self)
             }
 
-            fn reflect_owned(self: Box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #alloc_box<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::Enum(self)
             }
 
@@ -295,6 +299,8 @@ struct EnumImpls {
 }
 
 fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Ident) -> EnumImpls {
+    let option = quote!(::core::option::Option);
+
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
 
     let mut variant_info = Vec::new();
@@ -380,7 +386,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                 let args = get_field_args(fields, |reflect_idx, declaration_index, field| {
                     let declar_field = syn::Index::from(declaration_index);
                     enum_field_at.push(quote! {
-                        #unit { #declar_field : value, .. } if #ref_index == #reflect_idx => Some(value)
+                        #unit { #declar_field : value, .. } if #ref_index == #reflect_idx => #option::Some(value)
                     });
 
                     #[cfg(feature = "documentation")]
@@ -406,16 +412,16 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                     let field_ident = field.data.ident.as_ref().unwrap();
                     let field_name = field_ident.to_string();
                     enum_field.push(quote! {
-                        #unit{ #field_ident, .. } if #ref_name == #field_name => Some(#field_ident)
+                        #unit{ #field_ident, .. } if #ref_name == #field_name => #option::Some(#field_ident)
                     });
                     enum_field_at.push(quote! {
-                        #unit{ #field_ident, .. } if #ref_index == #reflect_idx => Some(#field_ident)
+                        #unit{ #field_ident, .. } if #ref_index == #reflect_idx => #option::Some(#field_ident)
                     });
                     enum_index_of.push(quote! {
-                        #unit{ .. } if #ref_name == #field_name => Some(#reflect_idx)
+                        #unit{ .. } if #ref_name == #field_name => #option::Some(#reflect_idx)
                     });
                     enum_name_at.push(quote! {
-                        #unit{ .. } if #ref_index == #reflect_idx => Some(#field_name)
+                        #unit{ .. } if #ref_index == #reflect_idx => #option::Some(#field_name)
                     });
 
                     #[cfg(feature = "documentation")]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -9,7 +9,7 @@ use syn::Fields;
 pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
     let option = quote!(::core::option::Option);
     let any = quote!(::core::any::Any);
-    let alloc_box = quote!(::alloc::boxed::Box);
+    let std_box = quote!(::std::boxed::Box);
 
     let bevy_reflect_path = reflect_enum.meta().bevy_reflect_path();
     let enum_name = reflect_enum.meta().type_name();
@@ -192,7 +192,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: #alloc_box<Self>) -> #alloc_box<dyn #any> {
+            fn into_any(self: #std_box<Self>) -> #std_box<dyn #any> {
                 self
             }
 
@@ -207,7 +207,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn into_reflect(self: #alloc_box<Self>) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #std_box<Self>) -> #std_box<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -222,12 +222,12 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
-                #alloc_box::new(#bevy_reflect_path::Enum::clone_dynamic(self))
+            fn clone_value(&self) -> #std_box<dyn #bevy_reflect_path::Reflect> {
+                #std_box::new(#bevy_reflect_path::Enum::clone_dynamic(self))
             }
 
             #[inline]
-            fn set(&mut self, #ref_value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+            fn set(&mut self, #ref_value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(#ref_value)?;
                 Ok(())
             }
@@ -273,7 +273,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::Enum(self)
             }
 
-            fn reflect_owned(self: #alloc_box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #std_box<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::Enum(self)
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -229,7 +229,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
             #[inline]
             fn set(&mut self, #ref_value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(#ref_value)?;
-                Ok(())
+                ::core::result::Result::Ok(())
             }
 
             #[inline]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -8,7 +8,7 @@ use syn::{Index, Member};
 pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
     let option = quote!(::core::option::Option);
     let any = quote!(::core::any::Any);
-    let alloc_box = quote!(::alloc::boxed::Box);
+    let std_box = quote!(::std::boxed::Box);
 
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
     let struct_name = reflect_struct.meta().type_name();
@@ -155,7 +155,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
 
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicStruct = ::core::default::Default::default();
-                dynamic.set_name(::alloc::string::ToString::to_string(#bevy_reflect_path::Reflect::type_name(self)));
+                dynamic.set_name(::std::string::ToString::to_string(#bevy_reflect_path::Reflect::type_name(self)));
                 #(dynamic.insert_boxed(#field_names, #bevy_reflect_path::Reflect::clone_value(&self.#field_idents));)*
                 dynamic
             }
@@ -173,7 +173,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: #alloc_box<Self>) -> #alloc_box<dyn #any> {
+            fn into_any(self: #std_box<Self>) -> #std_box<dyn #any> {
                 self
             }
 
@@ -188,7 +188,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_reflect(self: #alloc_box<Self>) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #std_box<Self>) -> #std_box<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -203,12 +203,12 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
-                #alloc_box::new(#bevy_reflect_path::Struct::clone_dynamic(self))
+            fn clone_value(&self) -> #std_box<dyn #bevy_reflect_path::Reflect> {
+                #std_box::new(#bevy_reflect_path::Struct::clone_dynamic(self))
             }
 
             #[inline]
-            fn set(&mut self, value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+            fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
                 Ok(())
             }
@@ -233,7 +233,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::Struct(self)
             }
 
-            fn reflect_owned(self: #alloc_box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #std_box<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::Struct(self)
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -210,7 +210,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             #[inline]
             fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
-                Ok(())
+                ::core::result::Result::Ok(())
             }
 
             #[inline]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -8,7 +8,7 @@ use syn::{Index, Member};
 pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
     let option = quote!(::core::option::Option);
     let any = quote!(::core::any::Any);
-    let alloc_box = quote!(::alloc::boxed::Box);
+    let std_box = quote!(::std::boxed::Box);
 
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
     let struct_name = reflect_struct.meta().type_name();
@@ -117,7 +117,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
 
             fn clone_dynamic(&self) -> #bevy_reflect_path::DynamicTupleStruct {
                 let mut dynamic: #bevy_reflect_path::DynamicTupleStruct = ::core::default::Default::default();
-                dynamic.set_name(::alloc::string::ToString::to_string(#bevy_reflect_path::Reflect::type_name(self)));
+                dynamic.set_name(::std::string::ToString::to_string(#bevy_reflect_path::Reflect::type_name(self)));
                 #(dynamic.insert_boxed(#bevy_reflect_path::Reflect::clone_value(&self.#field_idents));)*
                 dynamic
             }
@@ -135,7 +135,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: #alloc_box<Self>) -> #alloc_box<dyn #any> {
+            fn into_any(self: #std_box<Self>) -> #std_box<dyn #any> {
                 self
             }
 
@@ -150,7 +150,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn into_reflect(self: #alloc_box<Self>) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #std_box<Self>) -> #std_box<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -165,12 +165,12 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
-                #alloc_box::new(#bevy_reflect_path::TupleStruct::clone_dynamic(self))
+            fn clone_value(&self) -> #std_box<dyn #bevy_reflect_path::Reflect> {
+                #std_box::new(#bevy_reflect_path::TupleStruct::clone_dynamic(self))
             }
 
             #[inline]
-            fn set(&mut self, value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+            fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
                 Ok(())
             }
@@ -194,7 +194,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::TupleStruct(self)
             }
 
-            fn reflect_owned(self: #alloc_box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #std_box<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::TupleStruct(self)
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -172,7 +172,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
             #[inline]
             fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
-                Ok(())
+                ::core::result::Result::Ok(())
             }
 
             #[inline]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -1,3 +1,4 @@
+use crate::fq_std::{FQAny, FQBox, FQClone, FQOption, FQResult};
 use crate::impls::impl_typed;
 use crate::ReflectMeta;
 use proc_macro::TokenStream;
@@ -5,10 +6,6 @@ use quote::quote;
 
 /// Implements `GetTypeRegistration` and `Reflect` for the given type data.
 pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
-    let any = quote!(::core::any::Any);
-    let std_box = quote!(::std::boxed::Box);
-    let clone = quote!(::core::clone::Clone::clone);
-
     let bevy_reflect_path = meta.bevy_reflect_path();
     let type_name = meta.type_name();
 
@@ -54,22 +51,22 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: #std_box<Self>) -> #std_box<dyn #any> {
+            fn into_any(self: #FQBox<Self>) -> #FQBox<dyn #FQAny> {
                 self
             }
 
             #[inline]
-            fn as_any(&self) -> &dyn #any {
+            fn as_any(&self) -> &dyn #FQAny {
                 self
             }
 
             #[inline]
-            fn as_any_mut(&mut self) -> &mut dyn #any {
+            fn as_any_mut(&mut self) -> &mut dyn #FQAny {
                 self
             }
 
             #[inline]
-            fn into_reflect(self: #std_box<Self>) -> #std_box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #FQBox<Self>) -> #FQBox<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -84,24 +81,24 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> #std_box<dyn #bevy_reflect_path::Reflect> {
-                #std_box::new(#clone(self))
+            fn clone_value(&self) -> #FQBox<dyn #bevy_reflect_path::Reflect> {
+                #FQBox::new(#FQClone::clone(self))
             }
 
             #[inline]
             fn apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) {
                 let value = #bevy_reflect_path::Reflect::as_any(value);
-                if let ::core::option::Option::Some(value) = <dyn #any>::downcast_ref::<Self>(value) {
-                    *self = #clone(value);
+                if let #FQOption::Some(value) = <dyn #FQAny>::downcast_ref::<Self>(value) {
+                    *self = #FQClone::clone(value);
                 } else {
                     panic!("Value is not {}.", ::core::any::type_name::<Self>());
                 }
             }
 
             #[inline]
-            fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
+            fn set(&mut self, value: #FQBox<dyn #bevy_reflect_path::Reflect>) -> #FQResult<(), #FQBox<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
-                ::core::result::Result::Ok(())
+                #FQResult::Ok(())
             }
 
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
@@ -112,7 +109,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::Value(self)
             }
 
-            fn reflect_owned(self: #std_box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #FQBox<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::Value(self)
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -101,7 +101,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             #[inline]
             fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
-                Ok(())
+                ::core::result::Result::Ok(())
             }
 
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -6,7 +6,7 @@ use quote::quote;
 /// Implements `GetTypeRegistration` and `Reflect` for the given type data.
 pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
     let any = quote!(::core::any::Any);
-    let alloc_box = quote!(::alloc::boxed::Box);
+    let std_box = quote!(::std::boxed::Box);
     let clone = quote!(::core::clone::Clone::clone);
 
     let bevy_reflect_path = meta.bevy_reflect_path();
@@ -54,7 +54,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn into_any(self: #alloc_box<Self>) -> #alloc_box<dyn #any> {
+            fn into_any(self: #std_box<Self>) -> #std_box<dyn #any> {
                 self
             }
 
@@ -69,7 +69,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn into_reflect(self: #alloc_box<Self>) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
+            fn into_reflect(self: #std_box<Self>) -> #std_box<dyn #bevy_reflect_path::Reflect> {
                 self
             }
 
@@ -84,8 +84,8 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn clone_value(&self) -> #alloc_box<dyn #bevy_reflect_path::Reflect> {
-                #alloc_box::new(#clone(self))
+            fn clone_value(&self) -> #std_box<dyn #bevy_reflect_path::Reflect> {
+                #std_box::new(#clone(self))
             }
 
             #[inline]
@@ -99,7 +99,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
             }
 
             #[inline]
-            fn set(&mut self, value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+            fn set(&mut self, value: #std_box<dyn #bevy_reflect_path::Reflect>) -> ::core::result::Result<(), #std_box<dyn #bevy_reflect_path::Reflect>> {
                 *self = <dyn #bevy_reflect_path::Reflect>::take(value)?;
                 Ok(())
             }
@@ -112,7 +112,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
                 #bevy_reflect_path::ReflectMut::Value(self)
             }
 
-            fn reflect_owned(self: #alloc_box<Self>) -> #bevy_reflect_path::ReflectOwned {
+            fn reflect_owned(self: #std_box<Self>) -> #bevy_reflect_path::ReflectOwned {
                 #bevy_reflect_path::ReflectOwned::Value(self)
             }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -20,6 +20,7 @@ mod derive_data;
 mod documentation;
 mod enum_utility;
 mod field_attributes;
+mod fq_std;
 mod from_reflect;
 mod impls;
 mod reflect_value;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -17,7 +17,7 @@ pub(crate) fn impl_get_type_registration(
     let serialization_data = serialization_denylist.map(|denylist| {
         let denylist = denylist.into_iter();
         quote! {
-            let ignored_indices = [#(#denylist),*].into_iter();
+            let ignored_indices = ::core::iter::IntoIterator::into_iter([#(#denylist),*]);
             registration.insert::<#bevy_reflect_path::serde::SerializationData>(#bevy_reflect_path::serde::SerializationData::new(ignored_indices));
         }
     });

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -26,6 +26,10 @@ impl Parse for TraitInfo {
 /// This generates a struct that takes the form `ReflectMyTrait`. An instance of this struct can then be
 /// used to perform the conversion.
 pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStream {
+    let option = quote!(::core::option::Option);
+    let result = quote!(::core::result::Result);
+    let alloc_box = quote!(::alloc::boxed::Box);
+
     let trait_info = parse_macro_input!(input as TraitInfo);
     let item_trait = &trait_info.item_trait;
     let trait_ident = &item_trait.ident;
@@ -55,26 +59,26 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
         #item_trait
 
         #[doc = #struct_doc]
-        #[derive(Clone)]
+        #[derive(::core::clone::Clone)]
         #trait_vis struct #reflect_trait_ident {
-            get_func: fn(&dyn #bevy_reflect_path::Reflect) -> Option<&dyn #trait_ident>,
-            get_mut_func: fn(&mut dyn #bevy_reflect_path::Reflect) -> Option<&mut dyn #trait_ident>,
-            get_boxed_func: fn(Box<dyn #bevy_reflect_path::Reflect>) -> Result<Box<dyn #trait_ident>, Box<dyn #bevy_reflect_path::Reflect>>,
+            get_func: fn(&dyn #bevy_reflect_path::Reflect) -> #option<&dyn #trait_ident>,
+            get_mut_func: fn(&mut dyn #bevy_reflect_path::Reflect) -> #option<&mut dyn #trait_ident>,
+            get_boxed_func: fn(#alloc_box<dyn #bevy_reflect_path::Reflect>) -> #result<#alloc_box<dyn #trait_ident>, #alloc_box<dyn #bevy_reflect_path::Reflect>>,
         }
 
         impl #reflect_trait_ident {
             #[doc = #get_doc]
-            pub fn get<'a>(&self, reflect_value: &'a dyn #bevy_reflect_path::Reflect) -> Option<&'a dyn #trait_ident> {
+            pub fn get<'a>(&self, reflect_value: &'a dyn #bevy_reflect_path::Reflect) -> #option<&'a dyn #trait_ident> {
                 (self.get_func)(reflect_value)
             }
 
             #[doc = #get_mut_doc]
-            pub fn get_mut<'a>(&self, reflect_value: &'a mut dyn #bevy_reflect_path::Reflect) -> Option<&'a mut dyn #trait_ident> {
+            pub fn get_mut<'a>(&self, reflect_value: &'a mut dyn #bevy_reflect_path::Reflect) -> #option<&'a mut dyn #trait_ident> {
                 (self.get_mut_func)(reflect_value)
             }
 
             #[doc = #get_box_doc]
-            pub fn get_boxed(&self, reflect_value: Box<dyn #bevy_reflect_path::Reflect>) -> Result<Box<dyn #trait_ident>, Box<dyn #bevy_reflect_path::Reflect>> {
+            pub fn get_boxed(&self, reflect_value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> #result<#alloc_box<dyn #trait_ident>, #alloc_box<dyn #bevy_reflect_path::Reflect>> {
                 (self.get_boxed_func)(reflect_value)
             }
         }
@@ -83,13 +87,13 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
             fn from_type() -> Self {
                 Self {
                     get_func: |reflect_value| {
-                        reflect_value.downcast_ref::<T>().map(|value| value as &dyn #trait_ident)
+                        <dyn #bevy_reflect_path::Reflect>::downcast_ref::<T>(reflect_value).map(|value| value as &dyn #trait_ident)
                     },
                     get_mut_func: |reflect_value| {
-                        reflect_value.downcast_mut::<T>().map(|value| value as &mut dyn #trait_ident)
+                        <dyn #bevy_reflect_path::Reflect>::downcast_mut::<T>(reflect_value).map(|value| value as &mut dyn #trait_ident)
                     },
                     get_boxed_func: |reflect_value| {
-                        reflect_value.downcast::<T>().map(|value| value as Box<dyn #trait_ident>)
+                        <dyn #bevy_reflect_path::Reflect>::downcast::<T>(reflect_value).map(|value| value as #alloc_box<dyn #trait_ident>)
                     }
                 }
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -28,7 +28,7 @@ impl Parse for TraitInfo {
 pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStream {
     let option = quote!(::core::option::Option);
     let result = quote!(::core::result::Result);
-    let alloc_box = quote!(::alloc::boxed::Box);
+    let std_box = quote!(::std::boxed::Box);
 
     let trait_info = parse_macro_input!(input as TraitInfo);
     let item_trait = &trait_info.item_trait;
@@ -63,7 +63,7 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
         #trait_vis struct #reflect_trait_ident {
             get_func: fn(&dyn #bevy_reflect_path::Reflect) -> #option<&dyn #trait_ident>,
             get_mut_func: fn(&mut dyn #bevy_reflect_path::Reflect) -> #option<&mut dyn #trait_ident>,
-            get_boxed_func: fn(#alloc_box<dyn #bevy_reflect_path::Reflect>) -> #result<#alloc_box<dyn #trait_ident>, #alloc_box<dyn #bevy_reflect_path::Reflect>>,
+            get_boxed_func: fn(#std_box<dyn #bevy_reflect_path::Reflect>) -> #result<#std_box<dyn #trait_ident>, #std_box<dyn #bevy_reflect_path::Reflect>>,
         }
 
         impl #reflect_trait_ident {
@@ -78,7 +78,7 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
             }
 
             #[doc = #get_box_doc]
-            pub fn get_boxed(&self, reflect_value: #alloc_box<dyn #bevy_reflect_path::Reflect>) -> #result<#alloc_box<dyn #trait_ident>, #alloc_box<dyn #bevy_reflect_path::Reflect>> {
+            pub fn get_boxed(&self, reflect_value: #std_box<dyn #bevy_reflect_path::Reflect>) -> #result<#std_box<dyn #trait_ident>, #std_box<dyn #bevy_reflect_path::Reflect>> {
                 (self.get_boxed_func)(reflect_value)
             }
         }
@@ -93,7 +93,7 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
                         <dyn #bevy_reflect_path::Reflect>::downcast_mut::<T>(reflect_value).map(|value| value as &mut dyn #trait_ident)
                     },
                     get_boxed_func: |reflect_value| {
-                        <dyn #bevy_reflect_path::Reflect>::downcast::<T>(reflect_value).map(|value| value as #alloc_box<dyn #trait_ident>)
+                        <dyn #bevy_reflect_path::Reflect>::downcast::<T>(reflect_value).map(|value| value as #std_box<dyn #trait_ident>)
                     }
                 }
             }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -1,6 +1,5 @@
 use crate as bevy_reflect;
 use crate::prelude::ReflectDefault;
-use crate::reflect::Reflect;
 use crate::{ReflectDeserialize, ReflectSerialize};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_reflect_value};
 use glam::*;

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -1,6 +1,5 @@
 use crate as bevy_reflect;
 use crate::prelude::ReflectDefault;
-use crate::reflect::Reflect;
 use crate::{ReflectDeserialize, ReflectSerialize};
 use bevy_math::{Rect, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;


### PR DESCRIPTION
# Objective

- Fixes #3004 

## Solution

- Replaced all the types with their fully quallified names
- Replaced all trait methods and inherent methods on dyn traits with their fully qualified names
- Made a new file `fq_std.rs` that contains structs corresponding to commonly used Structs and Traits from `std`. These structs are replaced by their respective fully qualified names when used inside `quote!`