### PR TITLE
[Merged by Bors] - Clarify duplicate logger error

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -114,8 +114,8 @@ impl Plugin for LogPlugin {
             }));
         }
 
+        let finished_subscriber;
         let default_filter = { format!("{},{}", self.level, self.filter) };
-        LogTracer::init().expect("Could not set global logger as it has already been set. Please disable LogPlugin from Bevy's DefaultPlugins");
         let filter_layer = EnvFilter::try_from_default_env()
             .or_else(|_| EnvFilter::try_new(&default_filter))
             .unwrap();
@@ -166,25 +166,33 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let subscriber = subscriber.with(tracy_layer);
 
-            bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+            finished_subscriber = subscriber;
         }
 
         #[cfg(target_arch = "wasm32")]
         {
             console_error_panic_hook::set_once();
-            let subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
+            finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),
             ));
-            bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
         }
 
         #[cfg(target_os = "android")]
         {
-            let subscriber = subscriber.with(android_tracing::AndroidLayer::default());
-            bevy_utils::tracing::subscriber::set_global_default(subscriber)
-                .expect("Could not set global default tracing subscriber. If you've already set up a tracing subscriber, please disable LogPlugin from Bevy's DefaultPlugins");
+            finished_subscriber = subscriber.with(android_tracing::AndroidLayer::default());
+        }
+
+        let logger_already_set = LogTracer::init().is_err();
+        let subscriber_already_set =
+            bevy_utils::tracing::subscriber::set_global_default(finished_subscriber).is_err();
+
+        match (logger_already_set, subscriber_already_set) {
+            (true, true) => warn!(
+                "Could not set global logger and tracing subscriber as they are already set. Consider disabling LogPlugin."
+            ),
+            (true, _) => warn!("Could not set global logger as it is already set. Consider disabling LogPlugin."),
+            (_, true) => warn!("Could not set global tracing subscriber as it is already set. Consider disabling LogPlugin."),
+            _ => (),
         }
     }
 }

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -115,7 +115,7 @@ impl Plugin for LogPlugin {
         }
 
         let default_filter = { format!("{},{}", self.level, self.filter) };
-        LogTracer::init().unwrap();
+        LogTracer::init().expect("Could not set global logger as it has already been set. Please disable LogPlugin from Bevy's DefaultPlugins");
         let filter_layer = EnvFilter::try_from_default_env()
             .or_else(|_| EnvFilter::try_new(&default_filter))
             .unwrap();


### PR DESCRIPTION
# Objective

When a global tracing subscriber has already been set, `LogPlugin` panics with an error message explaining this. However, if a global logger has already been set, it simply panics on an unwrap.

#6426 mentiones the panic and has been fixed by unique plugins, but the panic can still occur if a logger has been set through different means or multiple apps are created, as in  #4934. The solution to that specific case isn't clear; this PR only fixes the missing error message.

## Solution

- ~add error message to panic~
- turn into warning