### PR TITLE
[Merged by Bors] - Make adding children idempotent

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -55,14 +55,14 @@ fn update_old_parents(world: &mut World, parent: Entity, children: &[Entity]) {
             if parent == previous {
                 warn!("Entity `{child:?}` is already a child of `{parent:?}`");
                 continue;
-            } else {
-                remove_from_children(world, previous, *child);
-                moved.push(HierarchyEvent::ChildMoved {
-                    child: *child,
-                    previous_parent: previous,
-                    new_parent: parent,
-                });
             }
+
+            remove_from_children(world, previous, *child);
+            moved.push(HierarchyEvent::ChildMoved {
+                child: *child,
+                previous_parent: previous,
+                new_parent: parent,
+            });
         }
     }
     push_events(world, moved);

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -749,9 +749,14 @@ mod tests {
     fn push_children_idempotent() {
         let mut world = World::new();
         let child = world.spawn_empty().id();
-        world
+        let parent = world
             .spawn_empty()
             .push_children(&[child])
-            .push_children(&[child]);
+            .push_children(&[child])
+            .id();
+
+        let mut query = world.query::<&Children>();
+        let children = query.get(&world, parent).unwrap();
+        assert_eq!(**children, [child]);
     }
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -6,7 +6,6 @@ use bevy_ecs::{
     system::{Command, Commands, EntityCommands},
     world::{EntityMut, World},
 };
-use bevy_log::warn;
 use smallvec::SmallVec;
 
 fn push_events(world: &mut World, events: SmallVec<[HierarchyEvent; 8]>) {
@@ -52,8 +51,8 @@ fn update_old_parents(world: &mut World, parent: Entity, children: &[Entity]) {
     let mut moved: SmallVec<[HierarchyEvent; 8]> = SmallVec::with_capacity(children.len());
     for child in children {
         if let Some(previous) = update_parent(world, *child, parent) {
+            // Do nothing if the entity already has the correct parent.
             if parent == previous {
-                warn!("Entity `{child:?}` is already a child of `{parent:?}`");
                 continue;
             }
 
@@ -292,7 +291,8 @@ pub trait BuildChildren {
     /// # }
     /// ```
     fn add_children<T>(&mut self, f: impl FnOnce(&mut ChildBuilder) -> T) -> T;
-    /// Pushes children to the back of the builder's children
+    /// Pushes children to the back of the builder's children. For any entities that are
+    /// already a child of this one, this method does nothing.
     ///
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
@@ -752,6 +752,6 @@ mod tests {
         world
             .spawn_empty()
             .push_children(&[child])
-            .push_children(&[child]); // this second push will warn
+            .push_children(&[child]);
     }
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -744,4 +744,14 @@ mod tests {
         let child = world.spawn_empty().id();
         world.spawn_empty().push_children(&[child]);
     }
+
+    #[test]
+    fn push_children_idempotent() {
+        let mut world = World::new();
+        let child = world.spawn_empty().id();
+        world
+            .spawn_empty()
+            .push_children(&[child])
+            .push_children(&[child]); // this second push will warn
+    }
 }


### PR DESCRIPTION
# Objective

* Fix #6668
* There is no need to panic when a parenting operation is redundant, as no invalid state is entered.

## Solution

Make `push_children` idempotent.
