### PR TITLE
[Merged by Bors] - Add missing docs to `World::change_tick` and `World::read_change_tick`

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1392,7 +1392,7 @@ impl World {
 
     /// Reads the current change tick of this world.
     ///
-    /// If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](#method.change_tick),
+    /// If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](Self::change_tick),
     /// which is more efficient since it does not require atomic synchronization.
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
@@ -1401,7 +1401,7 @@ impl World {
 
     /// Reads the current change tick of this world.
     ///
-    /// This does the same thing as [`Self::read_change_tick`], only this method
+    /// This does the same thing as [`read_change_tick()`](Self::read_change_tick), only this method
     /// is more efficient since it does not require atomic synchronization.
     #[inline]
     pub fn change_tick(&mut self) -> u32 {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1392,7 +1392,8 @@ impl World {
 
     /// Reads the current change tick of this world.
     ///
-    /// This does the same thing as [`Self::change_tick`], only this method uses atomic synchronization.
+    /// If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](#method.change_tick),
+    /// which is more efficient since it does not require atomic synchronization.
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
         self.change_tick.load(Ordering::Acquire)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1390,19 +1390,23 @@ impl World {
         self.change_tick.fetch_add(1, Ordering::AcqRel)
     }
 
-    /// Reads the current change tick of this world.
+    /// Reads the current [change tick] of this world.
     ///
     /// If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](Self::change_tick),
     /// which is more efficient since it does not require atomic synchronization.
+    ///
+    /// [change tick]: crate::component::Tick
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
         self.change_tick.load(Ordering::Acquire)
     }
 
-    /// Reads the current change tick of this world.
+    /// Reads the current [change tick] of this world.
     ///
     /// This does the same thing as [`read_change_tick()`](Self::read_change_tick), only this method
     /// is more efficient since it does not require atomic synchronization.
+    ///
+    /// [change tick]: crate::component::Tick
     #[inline]
     pub fn change_tick(&mut self) -> u32 {
         *self.change_tick.get_mut()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1390,23 +1390,19 @@ impl World {
         self.change_tick.fetch_add(1, Ordering::AcqRel)
     }
 
-    /// Reads the current [change tick] of this world.
+    /// Reads the current change tick of this world.
     ///
     /// If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](Self::change_tick),
     /// which is more efficient since it does not require atomic synchronization.
-    ///
-    /// [change tick]: crate::component::Tick
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
         self.change_tick.load(Ordering::Acquire)
     }
 
-    /// Reads the current [change tick] of this world.
+    /// Reads the current change tick of this world.
     ///
     /// This does the same thing as [`read_change_tick()`](Self::read_change_tick), only this method
     /// is more efficient since it does not require atomic synchronization.
-    ///
-    /// [change tick]: crate::component::Tick
     #[inline]
     pub fn change_tick(&mut self) -> u32 {
         *self.change_tick.get_mut()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1392,8 +1392,7 @@ impl World {
 
     /// Reads the current change tick of this world.
     ///
-    /// This does the same thing as [`Self::change_tick`], only this method is
-    /// less efficient due to thread synchronization.
+    /// This does the same thing as [`Self::change_tick`], only this method uses atomic synchronization.
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
         self.change_tick.load(Ordering::Acquire)
@@ -1402,7 +1401,7 @@ impl World {
     /// Reads the current change tick of this world.
     ///
     /// This does the same thing as [`Self::read_change_tick`], only this method
-    /// is more efficient since it does not require thread synchronization.
+    /// is more efficient since it does not require atomics.
     #[inline]
     pub fn change_tick(&mut self) -> u32 {
         *self.change_tick.get_mut()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1401,7 +1401,7 @@ impl World {
     /// Reads the current change tick of this world.
     ///
     /// This does the same thing as [`Self::read_change_tick`], only this method
-    /// is more efficient since it does not require atomics.
+    /// is more efficient since it does not require atomic synchronization.
     #[inline]
     pub fn change_tick(&mut self) -> u32 {
         *self.change_tick.get_mut()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1390,11 +1390,19 @@ impl World {
         self.change_tick.fetch_add(1, Ordering::AcqRel)
     }
 
+    /// Reads the current change tick of this world.
+    ///
+    /// This does the same thing as [`Self::change_tick`], only this method is
+    /// less efficient due to thread synchronization.
     #[inline]
     pub fn read_change_tick(&self) -> u32 {
         self.change_tick.load(Ordering::Acquire)
     }
 
+    /// Reads the current change tick of this world.
+    ///
+    /// This does the same thing as [`Self::read_change_tick`], only this method
+    /// is more efficient since it does not require thread synchronization.
     #[inline]
     pub fn change_tick(&mut self) -> u32 {
         *self.change_tick.get_mut()


### PR DESCRIPTION
# Objective

The methods `World::change_tick` and `World::read_change_tick` lack documentation and have confusingly similar behavior.

## Solution

Add documentation and clarify the distinction between the two functions.
