### PR TITLE
Create an initially paused timer

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -3,11 +3,13 @@ mod stopwatch;
 #[allow(clippy::module_inception)]
 mod time;
 mod timer;
+mod timer_builder;
 
 pub use fixed_timestep::*;
 pub use stopwatch::*;
 pub use time::*;
 pub use timer::*;
+pub use timer_builder::*;
 
 use bevy_ecs::system::{Res, ResMut};
 use bevy_utils::{tracing::warn, Duration, Instant};

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -45,6 +45,14 @@ impl Stopwatch {
         Default::default()
     }
 
+    /// Create a new paused `Stopwatch` with no elapsed time.
+    pub fn new_paused() -> Self {
+        Self {
+            paused: true,
+            ..Default::default()
+        }
+    }
+
     /// Returns the elapsed time since the last [`reset`](Stopwatch::reset)
     /// of the stopwatch.
     ///

--- a/crates/bevy_time/src/stopwatch.rs
+++ b/crates/bevy_time/src/stopwatch.rs
@@ -9,7 +9,7 @@ use bevy_utils::Duration;
 /// ```
 /// # use bevy_time::*;
 /// use std::time::Duration;
-/// let mut stopwatch = Stopwatch::new();
+/// let mut stopwatch = Stopwatch::new(false);
 /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
 ///
 /// stopwatch.tick(Duration::from_secs_f32(1.0)); // tick one second
@@ -32,23 +32,18 @@ pub struct Stopwatch {
 }
 
 impl Stopwatch {
-    /// Create a new unpaused `Stopwatch` with no elapsed time.
+    /// Create a new `Stopwatch` with no elapsed time.
     ///
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// let stopwatch = Stopwatch::new();
+    /// let stopwatch = Stopwatch::new(false);
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);
     /// assert_eq!(stopwatch.paused(), false);
     /// ```
-    pub fn new() -> Self {
-        Default::default()
-    }
-
-    /// Create a new paused `Stopwatch` with no elapsed time.
-    pub fn new_paused() -> Self {
+    pub fn new(paused: bool) -> Self {
         Self {
-            paused: true,
+            paused,
             ..Default::default()
         }
     }
@@ -60,7 +55,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed(), Duration::from_secs(1));
     /// ```
@@ -81,7 +76,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.tick(Duration::from_secs(1));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
     /// ```
@@ -113,7 +108,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.set_elapsed(Duration::from_secs_f32(1.0));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.0);
     /// ```
@@ -130,7 +125,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert_eq!(stopwatch.elapsed_secs(), 1.5);
     /// ```
@@ -148,7 +143,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// assert!(stopwatch.paused());
@@ -165,7 +160,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.pause();
     /// stopwatch.tick(Duration::from_secs_f32(1.0));
     /// stopwatch.unpause();
@@ -183,7 +178,7 @@ impl Stopwatch {
     /// # Examples
     /// ```
     /// # use bevy_time::*;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// assert!(!stopwatch.paused());
     /// stopwatch.pause();
     /// assert!(stopwatch.paused());
@@ -201,7 +196,7 @@ impl Stopwatch {
     /// ```
     /// # use bevy_time::*;
     /// use std::time::Duration;
-    /// let mut stopwatch = Stopwatch::new();
+    /// let mut stopwatch = Stopwatch::new(false);
     /// stopwatch.tick(Duration::from_secs_f32(1.5));
     /// stopwatch.reset();
     /// assert_eq!(stopwatch.elapsed_secs(), 0.0);

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -36,13 +36,10 @@ impl Timer {
     ///
     /// See also [`Timer::new`](Timer::new).
     pub fn new_paused(duration: Duration, mode: TimerMode) -> Self {
-        let mut stopwatch = Stopwatch::new();
-        stopwatch.pause();
-
         Self {
             duration,
             mode,
-            stopwatch,
+            stopwatch: Stopwatch::new_paused(),
             ..Default::default()
         }
     }

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -39,7 +39,7 @@ impl Timer {
         Self {
             duration,
             mode,
-            stopwatch: Stopwatch::new_paused(),
+            stopwatch: Stopwatch::new(true),
             ..Default::default()
         }
     }

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -32,6 +32,21 @@ impl Timer {
         }
     }
 
+    /// Creates a new initially paused timer with a given duration.
+    ///
+    /// See also [`Timer::new`](Timer::new).
+    pub fn new_paused(duration: Duration, mode: TimerMode) -> Self {
+        let mut stopwatch = Stopwatch::new();
+        stopwatch.pause();
+
+        Self {
+            duration,
+            mode,
+            stopwatch,
+            ..Default::default()
+        }
+    }
+
     /// Creates a new timer with a given duration in seconds.
     ///
     /// # Example
@@ -562,5 +577,18 @@ mod tests {
         t.tick(Duration::from_secs_f32(5.0));
         assert!(!t.just_finished());
         assert!(!t.finished());
+    }
+
+    #[test]
+    fn initially_paused() {
+        let mut t = Timer::new_paused(Duration::from_secs(10), TimerMode::Once);
+        t.tick(Duration::from_secs_f32(10.0));
+        assert!(t.paused());
+        assert!(!t.just_finished());
+        assert!(!t.finished());
+        t.unpause();
+        t.tick(Duration::from_secs_f32(10.0));
+        assert!(t.just_finished());
+        assert!(t.finished());
     }
 }

--- a/crates/bevy_time/src/timer_builder.rs
+++ b/crates/bevy_time/src/timer_builder.rs
@@ -1,0 +1,78 @@
+use bevy_utils::Duration;
+
+use crate::{Timer, TimerMode};
+
+#[derive(Default)]
+pub struct TimerBuilder {
+    initially_paused: bool,
+    duration: Duration,
+    mode: TimerMode,
+}
+
+impl TimerBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn duration(self, duration: Duration) -> Self {
+        Self { duration, ..self }
+    }
+
+    pub fn seconds(self, duration: f32) -> Self {
+        Self {
+            duration: Duration::from_secs_f32(duration),
+            ..self
+        }
+    }
+
+    pub fn mode(self, mode: TimerMode) -> Self {
+        Self { mode, ..self }
+    }
+
+    pub fn repeating(self) -> Self {
+        Self {
+            mode: TimerMode::Repeating,
+            ..self
+        }
+    }
+
+    pub fn paused(self) -> Self {
+        Self {
+            initially_paused: true,
+            ..self
+        }
+    }
+
+    pub fn build(self) -> Timer {
+        let mut timer = Timer::new(self.duration, self.mode);
+
+        if self.initially_paused {
+            timer.pause();
+        }
+
+        timer
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timer_builder() {
+        let t = TimerBuilder::new().seconds(10.0).build();
+        assert_eq!(t.duration(), Duration::from_secs_f32(10.0));
+        assert_eq!(t.mode(), TimerMode::Once);
+        assert!(!t.paused());
+
+        let t = TimerBuilder::new()
+            .duration(Duration::from_millis(500))
+            .repeating()
+            .paused()
+            .build();
+
+        assert_eq!(t.duration(), Duration::from_secs_f32(0.5));
+        assert_eq!(t.mode(), TimerMode::Repeating);
+        assert!(t.paused());
+    }
+}


### PR DESCRIPTION
# Objective

- Adds a possibility to create an initially paused timer, for use cases where the timer will be launched later on.

I've been often wrapping timers into a Component containing Option, e.g. `struct MyTimer(Option<Timer>)`, but it makes the code in systems very untidy.

There was also a discussion in discord regarding to this: https://discord.com/channels/691052431525675048/1019697973933899910/threads/1045330414308442174

## Solution

Two proposals for the API. I think its good to pick only one of them, and not implement both.

1. New fn

```rust
    /// Creates a new initially paused timer with a given duration.
    ///
    /// See also [`Timer::new`](Timer::new).
    pub fn new_paused(duration: Duration, mode: TimerMode) -> Self { ... }
```
2. Timer builder pattern

```rust
let t = TimerBuilder::new()
    .duration(Duration::from_millis(500))
    .repeating()
    .paused()
    .build();
```
(I did not document the timerbuilder code yet, in case that's a bad option. Seems like builder pattern is not that common in bevy codebase).

Third one would be to add paused bool flag into an existing `new` function, but that would be a breaking change. Not optimal, since paused timer creation is not very common use case.

---

