### PR TITLE
bevy_reflect: Allow `#[reflect(skip_serializing)]` on enum variant fields

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -88,9 +88,8 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
         bevy_reflect_path,
     );
 
-    let get_type_registration_impl = reflect_enum
-        .meta()
-        .get_type_registration(&where_clause_options);
+    let get_type_registration_impl = reflect_enum.get_type_registration(&where_clause_options);
+
     let (impl_generics, ty_generics, where_clause) =
         reflect_enum.meta().generics().split_for_impl();
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -25,6 +25,7 @@ mod from_reflect;
 mod impls;
 mod reflect_value;
 mod registration;
+mod serialization;
 mod trait_reflection;
 mod type_uuid;
 mod utility;

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -31,6 +31,9 @@ pub(crate) fn impl_get_type_registration(
             }
         }
         SerializationDenylist::Enum(denylist) => {
+            // This will contain a list of tuples containing:
+            // 1. The name of the variant
+            // 2. An iterator of the skipped indices
             let mut indices = proc_macro2::TokenStream::new();
             for (variant_name, variant_fields) in denylist {
                 let variant_fields = variant_fields.into_iter();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -1,9 +1,9 @@
 //! Contains code related specifically to Bevy's type registration.
 
+use crate::serialization::SerializationDenylist;
 use crate::utility::{extend_where_clause, WhereClauseOptions};
-use bit_set::BitSet;
 use proc_macro2::Ident;
-use quote::quote;
+use quote::{quote, ToTokens};
 use syn::{Generics, Path};
 
 /// Creates the `GetTypeRegistration` impl for the given type data.
@@ -14,14 +14,44 @@ pub(crate) fn impl_get_type_registration(
     registration_data: &[Ident],
     generics: &Generics,
     where_clause_options: &WhereClauseOptions,
-    serialization_denylist: Option<&BitSet<u32>>,
+    serialization_denylist: Option<&SerializationDenylist>,
 ) -> proc_macro2::TokenStream {
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
-    let serialization_data = serialization_denylist.map(|denylist| {
-        let denylist = denylist.into_iter();
-        quote! {
-            let ignored_indices = ::core::iter::IntoIterator::into_iter([#(#denylist),*]);
-            registration.insert::<#bevy_reflect_path::serde::SerializationData>(#bevy_reflect_path::serde::SerializationData::new(ignored_indices));
+
+    let serialization_data = serialization_denylist.map(|denylist| match denylist {
+        SerializationDenylist::Struct(denylist) => {
+            let denylist = denylist.into_iter();
+            quote! {
+                let ignored_indices = ::core::iter::IntoIterator::into_iter([#(#denylist),*]);
+                registration.insert(
+                    #bevy_reflect_path::serde::SerializationData::Struct(
+                        #bevy_reflect_path::serde::StructSerializationData::new(ignored_indices)
+                    )
+                );
+            }
+        }
+        SerializationDenylist::Enum(denylist) => {
+            let mut indices = proc_macro2::TokenStream::new();
+            for (variant_name, variant_fields) in denylist {
+                let variant_fields = variant_fields.into_iter();
+                quote!((
+                    #variant_name,
+                    ::core::iter::Iterator::copied(
+                        ::core::iter::IntoIterator::into_iter(
+                            &[#(#variant_fields),*] as &[usize]
+                        )
+                    )
+                ),)
+                .to_tokens(&mut indices);
+            }
+            quote! {
+                let ignored_indices = ::core::iter::IntoIterator::into_iter([#indices]);
+                registration.insert(
+                    #bevy_reflect_path::serde::SerializationData::Enum(
+                        #bevy_reflect_path::serde::EnumSerializationData::new(ignored_indices)
+                    )
+                );
+            }
         }
     });
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/serialization.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/serialization.rs
@@ -1,0 +1,76 @@
+use crate::derive_data::{EnumVariant, StructField};
+use crate::field_attributes::ReflectIgnoreBehavior;
+use bit_set::BitSet;
+
+/// A bitset of fields to ignore for serialization.
+///
+/// This uses the `#[reflect(skip_serializing)]` and `#[reflect(ignore)]` attributes to determine
+/// which fields to mark as skippable for serialization.
+///
+/// This data is encoded into a bitset over the fields' indices.
+///
+/// For enums, this also contains the name of the variant associated with the bitset.
+pub(crate) enum SerializationDenylist {
+    Struct(BitSet<usize>),
+    Enum(Vec<(String, BitSet<usize>)>),
+}
+
+impl SerializationDenylist {
+    /// Create a new bitset for a struct's fields.
+    ///
+    /// This will return a [`SerializationDenylist::Struct`] value.
+    pub fn from_struct_fields<'a>(fields: impl Iterator<Item = &'a StructField<'a>>) -> Self {
+        Self::Struct(Self::generate_bitset(fields))
+    }
+
+    /// Create a new bitset for an enum's fields.
+    ///
+    /// This will return a [`SerializationDenylist::Enum`] value.
+    pub fn from_enum_variants<'a>(variants: impl Iterator<Item = &'a EnumVariant<'a>>) -> Self {
+        Self::Enum(
+            variants
+                .map(|variant| {
+                    let name = variant.data.ident.to_string();
+                    let denylist = Self::generate_bitset(variant.fields().iter());
+                    (name, denylist)
+                })
+                .collect(),
+        )
+    }
+
+    /// Converts an iterator over fields to a bitset of ignored members.
+    ///
+    /// Takes into account the fact that always ignored (non-reflected) members are skipped.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// pub struct HelloWorld {
+    ///     reflected_field: u32      // index: 0
+    ///
+    ///     #[reflect(ignore)]
+    ///     non_reflected_field: u32  // index: N/A (not 1!)
+    ///
+    ///     #[reflect(skip_serializing)]
+    ///     non_serialized_field: u32 // index: 1
+    /// }
+    /// ```
+    /// Would convert to the `0b01` bitset (i.e second field is NOT serialized).
+    /// Keep in mind, however, that it is always recommended that
+    /// `#[reflect(skip_serializing)]` comes _before_ `#[reflect(ignore)]`.
+    /// The example above is meant for demonstration purposes only.
+    ///
+    fn generate_bitset<'a>(fields: impl Iterator<Item = &'a StructField<'a>>) -> BitSet<usize> {
+        let mut bitset = BitSet::default();
+
+        fields.fold(0, |next_idx, member| match member.attrs.ignore {
+            ReflectIgnoreBehavior::IgnoreAlways => next_idx,
+            ReflectIgnoreBehavior::IgnoreSerialization => {
+                bitset.insert(next_idx);
+                next_idx + 1
+            }
+            ReflectIgnoreBehavior::None => next_idx + 1,
+        });
+
+        bitset
+    }
+}

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -1,8 +1,6 @@
 //! General-purpose utility functions for internal usage within this crate.
 
-use crate::field_attributes::ReflectIgnoreBehavior;
 use bevy_macro_utils::BevyManifest;
-use bit_set::BitSet;
 use proc_macro2::{Ident, Span};
 use quote::quote;
 use syn::{Member, Path, Type, WhereClause};
@@ -175,40 +173,4 @@ impl<T> ResultSifter<T> {
             Ok(self.items)
         }
     }
-}
-
-/// Converts an iterator over ignore behavior of members to a bitset of ignored members.
-///
-/// Takes into account the fact that always ignored (non-reflected) members are skipped.
-///
-/// # Example
-/// ```rust,ignore
-/// pub struct HelloWorld {
-///     reflected_field: u32      // index: 0
-///
-///     #[reflect(ignore)]
-///     non_reflected_field: u32  // index: N/A (not 1!)
-///
-///     #[reflect(skip_serializing)]
-///     non_serialized_field: u32 // index: 1
-/// }
-/// ```
-/// Would convert to the `0b01` bitset (i.e second field is NOT serialized)
-///
-pub(crate) fn members_to_serialization_denylist<T>(member_iter: T) -> BitSet<u32>
-where
-    T: Iterator<Item = ReflectIgnoreBehavior>,
-{
-    let mut bitset = BitSet::default();
-
-    member_iter.fold(0, |next_idx, member| match member {
-        ReflectIgnoreBehavior::IgnoreAlways => next_idx,
-        ReflectIgnoreBehavior::IgnoreSerialization => {
-            bitset.insert(next_idx);
-            next_idx + 1
-        }
-        ReflectIgnoreBehavior::None => next_idx + 1,
-    });
-
-    bitset
 }

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -8,7 +8,7 @@ pub use type_data::*;
 
 #[cfg(test)]
 mod tests {
-    use crate::{self as bevy_reflect, DynamicTupleStruct};
+    use crate::{self as bevy_reflect, DynamicEnum, DynamicTuple, DynamicTupleStruct};
     use crate::{
         serde::{ReflectSerializer, UntypedReflectDeserializer},
         type_registry::TypeRegistry,
@@ -91,5 +91,78 @@ mod tests {
             expected.reflect_partial_eq(&deserialized).unwrap(),
             "Expected {expected:?} found {deserialized:?}"
         );
+    }
+
+    #[test]
+    fn test_serialization_enum() {
+        #[derive(Debug, Reflect)]
+        enum TestEnum {
+            Unit,
+            Tuple(
+                i32,
+                #[reflect(skip_serializing)] i32,
+                #[reflect(ignore)] i32,
+            ),
+            Struct {
+                a: i32,
+                b: i32,
+                #[reflect(skip_serializing)]
+                c: i32,
+                #[reflect(ignore)]
+                #[allow(dead_code)]
+                d: i32,
+            },
+        }
+
+        let mut registry = TypeRegistry::default();
+        registry.register::<TestEnum>();
+
+        macro_rules! assert_enum {
+            ($expected: ident, $input: ident) => {
+                let serializer = ReflectSerializer::new(&$input, &registry);
+                let serialized =
+                    ron::ser::to_string_pretty(&serializer, Default::default()).unwrap();
+
+                let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
+                let deserialized = UntypedReflectDeserializer::new(&registry)
+                    .deserialize(&mut deserializer)
+                    .unwrap()
+                    .take::<DynamicEnum>()
+                    .unwrap();
+
+                assert!(
+                    $expected.reflect_partial_eq(&deserialized).unwrap(),
+                    "expected `{:?}`, but found `{:?}`",
+                    $expected,
+                    deserialized
+                );
+            };
+        }
+
+        let test_enum = TestEnum::Unit;
+        let expected = DynamicEnum::from(TestEnum::Unit);
+        assert_enum!(expected, test_enum);
+
+        let test_enum = TestEnum::Tuple(1, 2, 3);
+        let expected = DynamicEnum::new(Reflect::type_name(&test_enum), "Tuple", {
+            let mut dyn_tuple = DynamicTuple::default();
+            dyn_tuple.insert(1);
+            dyn_tuple
+        });
+        assert_enum!(expected, test_enum);
+
+        let test_enum = TestEnum::Struct {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+        };
+        let expected = DynamicEnum::new(Reflect::type_name(&test_enum), "Struct", {
+            let mut dyn_struct = DynamicStruct::default();
+            dyn_struct.insert("a", 1);
+            dyn_struct.insert("b", 2);
+            dyn_struct
+        });
+        assert_enum!(expected, test_enum);
     }
 }

--- a/crates/bevy_reflect/src/serde/type_data.rs
+++ b/crates/bevy_reflect/src/serde/type_data.rs
@@ -1,20 +1,31 @@
+use bevy_utils::HashMap;
+use std::borrow::Cow;
 use std::collections::HashSet;
 
-/// Contains data relevant to the automatic reflect powered serialization of a type
+/// Contains data relevant to the automatic reflect powered serialization of a type.
 #[derive(Debug, Clone)]
-pub struct SerializationData {
+pub enum SerializationData {
+    Struct(StructSerializationData),
+    Enum(EnumSerializationData),
+}
+
+/// Contains data relevant to the automatic reflect powered serialization of a struct or tuple struct.
+#[derive(Debug, Clone)]
+pub struct StructSerializationData {
     ignored_field_indices: HashSet<usize>,
 }
 
-impl SerializationData {
-    /// Creates a new `SerializationData` instance given:
+impl StructSerializationData {
+    /// Creates a new `StructSerializationData` instance given:
     ///
-    /// - `ignored_iter`: the iterator of member indices to be ignored during serialization. Indices are assigned only to reflected members, those which are not reflected are skipped.
-    pub fn new<I: Iterator<Item = usize>>(ignored_iter: I) -> Self {
+    /// - `ignored_fields`: the iterator of member indices to be ignored during serialization.
+    /// Indices are assigned only to reflected members, those which are not reflected are skipped.
+    pub fn new<I: Iterator<Item = usize>>(ignored_fields: I) -> Self {
         Self {
-            ignored_field_indices: ignored_iter.collect(),
+            ignored_field_indices: ignored_fields.collect(),
         }
     }
+
     /// Returns true if the given index corresponds to a field meant to be ignored in serialization.
     ///
     /// Indices start from 0 and ignored fields are skipped.
@@ -22,7 +33,7 @@ impl SerializationData {
     /// # Example
     ///
     /// ```rust,ignore
-    /// for (idx, field) in my_struct.iter_fields().enumerate(){
+    /// for (idx, field) in my_struct.iter_fields().enumerate() {
     ///     if serialization_data.is_ignored_field(idx){
     ///        // serialize ...
     ///     }
@@ -40,5 +51,69 @@ impl SerializationData {
     /// Returns true if there are no ignored fields.
     pub fn is_empty(&self) -> bool {
         self.ignored_field_indices.is_empty()
+    }
+}
+
+/// Contains data relevant to the automatic reflect powered serialization of an enum.
+#[derive(Debug, Clone)]
+pub struct EnumSerializationData {
+    variant_serialization_data: HashMap<Cow<'static, str>, HashSet<usize>>,
+}
+
+impl EnumSerializationData {
+    /// Creates a new `EnumSerializationData` instance given:
+    ///
+    /// - `ignored_variants`: the iterator of member variant-indices pairs to be ignored during serialization.
+    /// Indices are assigned only to reflected members, those which are not reflected are skipped.
+    pub fn new<TName, TFields, TVariant>(ignored_variants: TVariant) -> Self
+    where
+        TName: Into<Cow<'static, str>>,
+        TFields: Iterator<Item = usize>,
+        TVariant: Iterator<Item = (TName, TFields)>,
+    {
+        let mut data = HashMap::new();
+        for (name, fields) in ignored_variants {
+            data.insert(name.into(), fields.collect());
+        }
+        Self {
+            variant_serialization_data: data,
+        }
+    }
+    /// Returns true if the given index corresponds to a field meant to be ignored in serialization.
+    ///
+    /// Indices start from 0 and ignored fields are skipped.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// for (idx, field) in my_variant.iter_fields().enumerate() {
+    ///     if serialization_data.is_ignored_field(field.name(), idx){
+    ///        // serialize ...
+    ///     }
+    /// }
+    /// ```
+    ///
+    /// This will return `None` if the variant does not exist.
+    pub fn is_ignored_field(&self, variant: &str, index: usize) -> Option<bool> {
+        Some(
+            self.variant_serialization_data
+                .get(variant)?
+                .contains(&index),
+        )
+    }
+
+    /// Returns the number of ignored fields for the given variant.
+    ///
+    /// This will return `None` if the variant does not exist.
+    #[allow(clippy::len_without_is_empty)]
+    pub fn len(&self, variant: &str) -> Option<usize> {
+        Some(self.variant_serialization_data.get(variant)?.len())
+    }
+
+    /// Returns true if there are no ignored fields for the given variant.
+    ///
+    /// This will return `None` if the variant does not exist.
+    pub fn is_empty(&self, variant: &str) -> Option<bool> {
+        Some(self.variant_serialization_data.get(variant)?.is_empty())
     }
 }


### PR DESCRIPTION
# Objective

Fixes #6721

## Solution

Converts `SerializationData` to an enum with variants for structs (including tuple structs) and enums. The latter allows us to store the skipped field info on a per-variant level.

---

## Changelog

- Converted `SerializationData` to an enum
- Added support for `#[reflect(skip_serializing)]` on enum variant fields

## Migration Guide

- `SerializationData` is now an enum. Custom implementations of this type data will need to be adjusted to account for this:

```rust
// OLD
let serialization_data = SerializationData::new([0, 2, 5].into_iter());

// NEW
let serialization_data = SerializationData::Struct(
  StructSerializationData::new([0, 2, 5].into_iter())
);
```
