### PR TITLE
Reflection: try_apply function

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -291,7 +291,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                                 *self = #variant_constructors
                             })*
                             name => {
-                                return Err(#bevy_reflect_path::ApplyError::WrongType("TODO".to_string()));
+                                return Err(#bevy_reflect_path::ApplyError::UnknownVariant(name.to_string(), std::any::type_name::<Self>().to_string()));
                             }
                         }
                     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -271,18 +271,14 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                                 for field in #ref_value.iter_fields() {
                                     let name = field.name().unwrap();
                                     if let Some(v) = #bevy_reflect_path::Enum::field_mut(self, name) {
-                                        if let Err(e) = v.try_apply(field.value()) {
-                                            return Err(e);
-                                        }
+                                       v.try_apply(field.value())?;
                                     }
                                 }
                             }
                             #bevy_reflect_path::VariantType::Tuple => {
                                 for (index, field) in #ref_value.iter_fields().enumerate() {
                                     if let Some(v) = #bevy_reflect_path::Enum::field_at_mut(self, index) {
-                                        if let Err(e) = v.try_apply(field.value()) {
-                                            return Err(e);
-                                        }
+                                        v.try_apply(field.value())?;
                                     }
                                 }
                             }
@@ -294,14 +290,12 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> TokenStream {
                             #(#variant_names => {
                                 *self = #variant_constructors
                             })*
-                            /* name => panic!("variant with name `{}` does not exist on enum `{}`", name, std::any::type_name::<Self>()), */
                             name => {
                                 return Err(#bevy_reflect_path::ApplyError::WrongType("TODO".to_string()));
                             }
                         }
                     }
                 } else {
-                   /*  panic!("`{}` is not an enum", #ref_value.type_name()); */
                     return Err(#bevy_reflect_path::ApplyError::WrongType("enum".to_string()));
                 }
                 Ok(())

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -220,6 +220,23 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                 }
             }
 
+            #[inline]
+            fn try_apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) -> Result<(), #bevy_reflect_path::ApplyError> {
+                if let #bevy_reflect_path::ReflectRef::Struct(struct_value) = value.reflect_ref() {
+                    for (i, value) in struct_value.iter_fields().enumerate() {
+                        let name = struct_value.name_at(i).unwrap();
+                        if let Some(v) = #bevy_reflect_path::Struct::field_mut(self, name) {
+                            if let Err(e) = v.try_apply(value) {
+                                return Err(e);
+                            }
+                        }
+                    }
+                } else {
+                    return Err(#bevy_reflect_path::ApplyError::MismatchedTypes("struct".to_string()));
+                }
+                Ok(())
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::Struct(self)
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -226,9 +226,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                     for (i, value) in struct_value.iter_fields().enumerate() {
                         let name = struct_value.name_at(i).unwrap();
                         if let Some(v) = #bevy_reflect_path::Struct::field_mut(self, name) {
-                            if let Err(e) = v.try_apply(value) {
-                                return Err(e);
-                            }
+                           v.try_apply(value)?;
                         }
                     }
                 } else {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -186,9 +186,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                 if let #bevy_reflect_path::ReflectRef::TupleStruct(struct_value) = value.reflect_ref() {
                     for (i, value) in struct_value.iter_fields().enumerate() {
                         if let Some(v) = #bevy_reflect_path::TupleStruct::field_mut(self, i) {
-                            if let Err(e) = v.try_apply(value) {
-                                return Err(e);
-                            }
+                            v.try_apply(value)?;
                         }
                     }
                 } else {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -181,6 +181,22 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> TokenStream {
                 }
             }
 
+            #[inline]
+            fn try_apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) -> Result<(), #bevy_reflect_path::ApplyError> {
+                if let #bevy_reflect_path::ReflectRef::TupleStruct(struct_value) = value.reflect_ref() {
+                    for (i, value) in struct_value.iter_fields().enumerate() {
+                        if let Some(v) = #bevy_reflect_path::TupleStruct::field_mut(self, i) {
+                            if let Err(e) = v.try_apply(value) {
+                                return Err(e);
+                            }
+                        }
+                    }
+                } else {
+                    return Err(#bevy_reflect_path::ApplyError::MismatchedTypes("TupleStruct".to_string()));
+                }
+                Ok(())
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::TupleStruct(self)
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -100,7 +100,6 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
                 if let Some(value) = value.downcast_ref::<Self>() {
                     *self = std::clone::Clone::clone(value);
                 } else {
-                    /* panic!("Value is not {}.", std::any::type_name::<Self>()); */
                     return Err(#bevy_reflect_path::ApplyError::WrongType(std::any::type_name::<Self>().to_string()));
                 }
                 Ok(())

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -94,6 +94,18 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> TokenStream {
                 }
             }
 
+             #[inline]
+            fn try_apply(&mut self, value: &dyn #bevy_reflect_path::Reflect) -> Result<(), #bevy_reflect_path::ApplyError> {
+                let value = value.as_any();
+                if let Some(value) = value.downcast_ref::<Self>() {
+                    *self = std::clone::Clone::clone(value);
+                } else {
+                    /* panic!("Value is not {}.", std::any::type_name::<Self>()); */
+                    return Err(#bevy_reflect_path::ApplyError::WrongType(std::any::type_name::<Self>().to_string()));
+                }
+                Ok(())
+            }
+
             #[inline]
             fn set(&mut self, value: Box<dyn #bevy_reflect_path::Reflect>) -> Result<(), Box<dyn #bevy_reflect_path::Reflect>> {
                 *self = value.take()?;

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -372,9 +372,7 @@ pub fn array_try_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) -> Result
         }
         for (i, value) in reflect_array.iter().enumerate() {
             let v = array.get_mut(i).unwrap();
-            if let Err(e) = v.try_apply(value) {
-                return Err(e);
-            }
+            v.try_apply(value)?;
         }
     } else {
         return Err(ApplyError::MismatchedTypes("Array".to_string()));

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -364,6 +364,15 @@ pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
     }
 }
 
+/// Tries to apply the reflected [array](Array) data to the given [array](Array) and
+/// returns a Result.
+///
+/// # Errors
+///
+/// * Returns an [`ApplyError::DifferentSize`] if the two arrays have differing lengths.
+/// * Returns an [`ApplyError::MismatchedTypes`] if the reflected value is not a
+///   [valid array](ReflectRef::Array).
+///
 #[inline]
 pub fn array_try_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) -> Result<(), ApplyError> {
     if let ReflectRef::Array(reflect_array) = reflect.reflect_ref() {

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -390,18 +390,14 @@ impl Reflect for DynamicEnum {
                         for field in value.iter_fields() {
                             let name = field.name().unwrap();
                             if let Some(v) = Enum::field_mut(self, name) {
-                                if let Err(e) = v.try_apply(field.value()) {
-                                    return Err(e);
-                                }
+                                v.try_apply(field.value())?;
                             }
                         }
                     }
                     VariantType::Tuple => {
                         for (index, field) in value.iter_fields().enumerate() {
                             if let Some(v) = Enum::field_at_mut(self, index) {
-                                if let Err(e) = v.try_apply(field.value()) {
-                                    return Err(e);
-                                }
+                                v.try_apply(field.value())?;
                             }
                         }
                     }
@@ -430,7 +426,6 @@ impl Reflect for DynamicEnum {
                 self.set_variant(value.variant_name(), dyn_variant);
             }
         } else {
-            /* panic!("`{}` is not an enum", value.type_name()); */
             return Err(ApplyError::WrongType("enum".to_string()));
         }
         Ok(())

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -1,7 +1,7 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    enum_debug, enum_hash, enum_partial_eq, DynamicInfo, DynamicStruct, DynamicTuple, Enum,
-    Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, Typed,
+    enum_debug, enum_hash, enum_partial_eq, ApplyError, DynamicInfo, DynamicStruct, DynamicTuple,
+    Enum, Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, Typed,
     VariantFieldIter, VariantType,
 };
 use std::any::Any;
@@ -378,6 +378,62 @@ impl Reflect for DynamicEnum {
         } else {
             panic!("`{}` is not an enum", value.type_name());
         }
+    }
+
+    #[inline]
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        if let ReflectRef::Enum(value) = value.reflect_ref() {
+            if Enum::variant_name(self) == value.variant_name() {
+                // Same variant -> just update fields
+                match value.variant_type() {
+                    VariantType::Struct => {
+                        for field in value.iter_fields() {
+                            let name = field.name().unwrap();
+                            if let Some(v) = Enum::field_mut(self, name) {
+                                if let Err(e) = v.try_apply(field.value()) {
+                                    return Err(e);
+                                }
+                            }
+                        }
+                    }
+                    VariantType::Tuple => {
+                        for (index, field) in value.iter_fields().enumerate() {
+                            if let Some(v) = Enum::field_at_mut(self, index) {
+                                if let Err(e) = v.try_apply(field.value()) {
+                                    return Err(e);
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            } else {
+                // New variant -> perform a switch
+                let dyn_variant = match value.variant_type() {
+                    VariantType::Unit => DynamicVariant::Unit,
+                    VariantType::Tuple => {
+                        let mut dyn_tuple = DynamicTuple::default();
+                        for field in value.iter_fields() {
+                            dyn_tuple.insert_boxed(field.value().clone_value());
+                        }
+                        DynamicVariant::Tuple(dyn_tuple)
+                    }
+                    VariantType::Struct => {
+                        let mut dyn_struct = DynamicStruct::default();
+                        for field in value.iter_fields() {
+                            dyn_struct
+                                .insert_boxed(field.name().unwrap(), field.value().clone_value());
+                        }
+                        DynamicVariant::Struct(dyn_struct)
+                    }
+                };
+                self.set_variant(value.variant_name(), dyn_variant);
+            }
+        } else {
+            /* panic!("`{}` is not an enum", value.type_name()); */
+            return Err(ApplyError::WrongType("enum".to_string()));
+        }
+        Ok(())
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -3,8 +3,9 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    Array, ArrayIter, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Reflect,
-    ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed,
+    ApplyError, Array, ArrayIter, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
+    Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration,
+    Typed,
 };
 
 impl<T: smallvec::Array + Send + Sync + 'static> Array for SmallVec<T>
@@ -104,6 +105,10 @@ where
 
     fn apply(&mut self, value: &dyn Reflect) {
         crate::list_apply(self, value);
+    }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        crate::list_try_apply(self, value)
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -817,6 +817,18 @@ impl Reflect for &'static Path {
         }
     }
 
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        let value = value.as_any();
+        if let Some(&value) = value.downcast_ref::<Self>() {
+            *self = value;
+        } else {
+            return Err(ApplyError::WrongType(
+                std::any::type_name::<Self>().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -681,193 +681,6 @@ impl_array_get_type_registration! {
     30 31 32
 }
 
-<<<<<<< HEAD
-=======
-impl Reflect for Cow<'static, str> {
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    fn get_type_info(&self) -> &'static TypeInfo {
-        <Self as Typed>::type_info()
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn apply(&mut self, value: &dyn Reflect) {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
-        } else {
-            panic!("Value is not a {}.", std::any::type_name::<Self>());
-        }
-    }
-
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
-        } else {
-            return Err(ApplyError::WrongType(
-                std::any::type_name::<Self>().to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Value(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Value(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Value(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone())
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        let mut hasher = crate::ReflectHasher::default();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
-        Hash::hash(self, &mut hasher);
-        Some(hasher.finish())
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
-        } else {
-            Some(false)
-        }
-    }
-}
-
-impl Reflect for &'static Path {
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    fn get_type_info(&self) -> &'static TypeInfo {
-        <Self as Typed>::type_info()
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn apply(&mut self, value: &dyn Reflect) {
-        let value = value.as_any();
-        if let Some(&value) = value.downcast_ref::<Self>() {
-            *self = value;
-        } else {
-            panic!("Value is not a {}.", std::any::type_name::<Self>());
-        }
-    }
-
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
-        let value = value.as_any();
-        if let Some(&value) = value.downcast_ref::<Self>() {
-            *self = value;
-        } else {
-            return Err(ApplyError::WrongType(
-                std::any::type_name::<Self>().to_string(),
-            ));
-        }
-        Ok(())
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Value(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Value(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Value(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(*self)
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        let mut hasher = crate::ReflectHasher::default();
-        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
-        Hash::hash(self, &mut hasher);
-        Some(hasher.finish())
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
-        } else {
-            Some(false)
-        }
-    }
-}
-
->>>>>>> 748732a9 (new function  for std.rs)
 impl<T: FromReflect> GetTypeRegistration for Option<T> {
     fn get_type_registration() -> TypeRegistration {
         TypeRegistration::of::<Option<T>>()
@@ -1199,6 +1012,18 @@ impl Reflect for Cow<'static, str> {
         }
     }
 
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            *self = value.clone();
+        } else {
+            return Err(ApplyError::WrongType(
+                std::any::type_name::<Self>().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
@@ -1305,6 +1130,18 @@ impl Reflect for &'static Path {
         } else {
             panic!("Value is not a {}.", std::any::type_name::<Self>());
         }
+    }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        let value = value.as_any();
+        if let Some(&value) = value.downcast_ref::<Self>() {
+            *self = value;
+        } else {
+            return Err(ApplyError::WrongType(
+                std::any::type_name::<Self>().to_string(),
+            ));
+        }
+        Ok(())
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1043,7 +1043,7 @@ impl<T: FromReflect> Reflect for Option<T> {
                 match value.variant_name() {
                     "Some" => {
                         let field = value.field_at(0);
-                        if let None = field {
+                        if field.is_none() {
                             return Err(ApplyError::AbsentField(
                                 std::any::type_name::<Option<T>>().to_string(),
                             ));

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1023,9 +1023,7 @@ impl<T: FromReflect> Reflect for Option<T> {
                 // Same variant -> just update fields
                 for (index, field) in value.iter_fields().enumerate() {
                     if let Some(v) = self.field_at_mut(index) {
-                        if let Err(e) = v.try_apply(field.value()) {
-                            return Err(e);
-                        }
+                        v.try_apply(field.value())?;
                     }
                 }
             } else {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,11 +1,11 @@
 use crate::std_traits::ReflectDefault;
 use crate::{self as bevy_reflect, ReflectFromPtr, ReflectOwned};
 use crate::{
-    map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum, DynamicMap, Enum,
-    EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter,
-    Reflect, ReflectDeserialize, ReflectMut, ReflectRef, ReflectSerialize, TupleVariantInfo,
-    TypeInfo, TypeRegistration, Typed, UnitVariantInfo, UnnamedField, ValueInfo, VariantFieldIter,
-    VariantInfo, VariantType,
+    map_apply, map_partial_eq, map_try_apply, ApplyError, Array, ArrayInfo, ArrayIter, DynamicEnum,
+    DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Map,
+    MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, ReflectSerialize,
+    TupleVariantInfo, TypeInfo, TypeRegistration, Typed, UnitVariantInfo, UnnamedField, ValueInfo,
+    VariantFieldIter, VariantInfo, VariantType,
 };
 
 use crate::utility::{GenericTypeInfoCell, NonGenericTypeInfoCell};
@@ -264,6 +264,10 @@ impl<T: FromReflect> Reflect for Vec<T> {
         crate::list_apply(self, value);
     }
 
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        crate::list_try_apply(self, value)
+    }
+
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
@@ -448,6 +452,10 @@ impl<K: FromReflect + Eq + Hash, V: FromReflect> Reflect for HashMap<K, V> {
         map_apply(self, value);
     }
 
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        map_try_apply(self, value)
+    }
+
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
@@ -587,6 +595,11 @@ impl<T: Reflect, const N: usize> Reflect for [T; N] {
     }
 
     #[inline]
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        crate::array_try_apply(self, value)
+    }
+
+    #[inline]
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
@@ -668,6 +681,181 @@ impl_array_get_type_registration! {
     30 31 32
 }
 
+<<<<<<< HEAD
+=======
+impl Reflect for Cow<'static, str> {
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_type_info(&self) -> &'static TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            *self = value.clone();
+        } else {
+            panic!("Value is not a {}.", std::any::type_name::<Self>());
+        }
+    }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            *self = value.clone();
+        } else {
+            return Err(ApplyError::WrongType(
+                std::any::type_name::<Self>().to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Value(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Value(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Value(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone())
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        let mut hasher = crate::ReflectHasher::default();
+        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(self, &mut hasher);
+        Some(hasher.finish())
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            Some(std::cmp::PartialEq::eq(self, value))
+        } else {
+            Some(false)
+        }
+    }
+}
+
+impl Reflect for &'static Path {
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_type_info(&self) -> &'static TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        let value = value.as_any();
+        if let Some(&value) = value.downcast_ref::<Self>() {
+            *self = value;
+        } else {
+            panic!("Value is not a {}.", std::any::type_name::<Self>());
+        }
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Value(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Value(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Value(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(*self)
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        let mut hasher = crate::ReflectHasher::default();
+        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(self, &mut hasher);
+        Some(hasher.finish())
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            Some(std::cmp::PartialEq::eq(self, value))
+        } else {
+            Some(false)
+        }
+    }
+}
+
+>>>>>>> 748732a9 (new function  for std.rs)
 impl<T: FromReflect> GetTypeRegistration for Option<T> {
     fn get_type_registration() -> TypeRegistration {
         TypeRegistration::of::<Option<T>>()
@@ -826,6 +1014,51 @@ impl<T: FromReflect> Reflect for Option<T> {
                 }
             }
         }
+    }
+
+    #[inline]
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> {
+        if let ReflectRef::Enum(value) = value.reflect_ref() {
+            if self.variant_name() == value.variant_name() {
+                // Same variant -> just update fields
+                for (index, field) in value.iter_fields().enumerate() {
+                    if let Some(v) = self.field_at_mut(index) {
+                        if let Err(e) = v.try_apply(field.value()) {
+                            return Err(e);
+                        }
+                    }
+                }
+            } else {
+                // New variant -> perform a switch
+                match value.variant_name() {
+                    "Some" => {
+                        let field = value.field_at(0);
+                        if let None = field {
+                            return Err(ApplyError::AbsentField(
+                                std::any::type_name::<Option<T>>().to_string(),
+                            ));
+                        }
+                        let field2 = field.unwrap().clone_value().take::<T>();
+                        if let Err(_e) = field2 {
+                            return Err(ApplyError::MismatchedFieldTypes(
+                                std::any::type_name::<Option<T>>().to_string(),
+                                std::any::type_name::<T>().to_string(),
+                            ));
+                        }
+                        *self = Some(field2.unwrap());
+                    }
+                    "None" => {
+                        *self = None;
+                    }
+                    _ => {
+                        return Err(ApplyError::WrongType(
+                            std::any::type_name::<Self>().to_string(),
+                        ))
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -328,6 +328,15 @@ pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) {
     }
 }
 
+/// Tries to apply the elements of `b` to the corresponding elements of `a` and
+/// returns a Result.
+///
+/// If the length of `b` is greater than that of `a`, the excess elements of `b`
+/// are cloned and appended to `a`.
+///
+/// # Errors
+///
+/// This function returns an [`ApplyError::MismatchedTypes`] if `b` is not a list.
 #[inline]
 pub fn list_try_apply<L: List>(a: &mut L, b: &dyn Reflect) -> Result<(), ApplyError> {
     if let ReflectRef::List(list_value) = b.reflect_ref() {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -334,9 +334,7 @@ pub fn list_try_apply<L: List>(a: &mut L, b: &dyn Reflect) -> Result<(), ApplyEr
         for (i, value) in list_value.iter().enumerate() {
             if i < a.len() {
                 if let Some(v) = a.get_mut(i) {
-                    if let Err(e) = v.try_apply(value) {
-                        return Err(e);
-                    }
+                    v.try_apply(value)?;
                 }
             } else {
                 List::push(a, value.clone_value());

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -475,9 +475,7 @@ pub fn map_try_apply<M: Map>(a: &mut M, b: &dyn Reflect) -> Result<(), ApplyErro
     if let ReflectRef::Map(map_value) = b.reflect_ref() {
         for (key, b_value) in map_value.iter() {
             if let Some(a_value) = a.get_mut(key) {
-                if let Err(e) = a_value.try_apply(b_value) {
-                    return Err(e);
-                }
+                a_value.try_apply(b_value)?;
             } else {
                 a.insert_boxed(key.clone_value(), b_value.clone_value());
             }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -470,6 +470,14 @@ pub fn map_apply<M: Map>(a: &mut M, b: &dyn Reflect) {
     }
 }
 
+/// Tries to apply the elements of reflected map `b` to the corresponding elements of map `a`
+/// and returns a Result.
+///
+/// If a key from `b` does not exist in `a`, the value is cloned and inserted.
+///
+/// # Errors
+///
+/// This function returns an [`ApplyError::MismatchedTypes`] if `b` is not a reflected map.
 #[inline]
 pub fn map_try_apply<M: Map>(a: &mut M, b: &dyn Reflect) -> Result<(), ApplyError> {
     if let ReflectRef::Map(map_value) = b.reflect_ref() {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -66,16 +66,18 @@ pub enum ReflectOwned {
 
 #[derive(Error, Debug)]
 pub enum ApplyError {
-    #[error("Attempted to apply non-{0} type to {0} type.")]
+    #[error("Attempted to apply `non-{0}` type to `{0}` type.")]
     MismatchedTypes(String),
-    #[error("Value is not a {0}.")]
+    #[error("Value is not a `{0}`.")]
     WrongType(String),
-    #[error("Attempted to apply different sized {0} types.")]
+    #[error("Attempted to apply different sized `{0}` types.")]
     DifferentSize(String),
-    #[error("Field in `Some` variant of {0} should exist")]
+    #[error("Field in `Some` variant of `{0}` should exist.")]
     AbsentField(String),
-    #[error("Field in `Some` variant of {0} should be of type {1}")]
+    #[error("Field in `Some` variant of `{0}` should be of type `{1}`.")]
     MismatchedFieldTypes(String, String),
+    #[error("Variant with name `{0}` does not exist on enum `{1}`.")]
+    UnknownVariant(String, String),
 }
 
 /// A reflected Rust type.

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -167,7 +167,7 @@ pub trait Reflect: Any + Send + Sync {
     /// panicking.
     ///
     /// Note: the value you call this function on will end up being partially mutated
-    /// if this function runs into an error along the way (types with nested values like lists).
+    /// if this function runs into an error along the way (i.e. types with nested values like lists).
     ///
     /// If a type implements a subtrait of `Reflect`, then the semantics of this
     /// method are as follows:
@@ -201,7 +201,7 @@ pub trait Reflect: Any + Send + Sync {
     ///
     /// # Errors
     ///
-    /// Derived implementations of this method will return an error:
+    /// Derived implementations of this method will return an [`ApplyError`]:
     /// - If the type of `value` is not of the same kind as `T` (e.g. if `T` is
     ///   a `List`, while `value` is a `Struct`).
     /// - If `T` is any complex type and the corresponding fields or elements of

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -458,9 +458,7 @@ impl Reflect for DynamicStruct {
             for (i, value) in struct_value.iter_fields().enumerate() {
                 let name = struct_value.name_at(i).unwrap();
                 if let Some(v) = self.field_mut(name) {
-                    if let Err(e) = v.try_apply(value) {
-                        return Err(e);
-                    }
+                    v.try_apply(value)?;
                 }
             }
         } else {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -405,9 +405,7 @@ pub fn tuple_try_apply<T: Tuple>(a: &mut T, b: &dyn Reflect) -> Result<(), Apply
     if let ReflectRef::Tuple(tuple) = b.reflect_ref() {
         for (i, value) in tuple.iter_fields().enumerate() {
             if let Some(v) = a.field_mut(i) {
-                if let Err(e) = v.try_apply(value) {
-                    return Err(e);
-                }
+                v.try_apply(value)?;
             }
         }
     } else {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -400,6 +400,12 @@ pub fn tuple_apply<T: Tuple>(a: &mut T, b: &dyn Reflect) {
     }
 }
 
+/// Tries to apply the elements of `b` to the corresponding elements of `a` and
+/// returns a Result.
+///
+/// # Errors
+///
+/// This function returns an [`ApplyError::MismatchedTypes`] if `b` is not a tuple.
 #[inline]
 pub fn tuple_try_apply<T: Tuple>(a: &mut T, b: &dyn Reflect) -> Result<(), ApplyError> {
     if let ReflectRef::Tuple(tuple) = b.reflect_ref() {

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -359,9 +359,7 @@ impl Reflect for DynamicTupleStruct {
         if let ReflectRef::TupleStruct(tuple_struct) = value.reflect_ref() {
             for (i, value) in tuple_struct.iter_fields().enumerate() {
                 if let Some(v) = self.field_mut(i) {
-                    if let Err(e) = v.try_apply(value) {
-                        return Err(e);
-                    }
+                    v.try_apply(value)?;
                 }
             }
         } else {

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -23,7 +23,7 @@ use std::any::{Any, TypeId};
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, ValueInfo};
+/// # use bevy_reflect::{ApplyError, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, TypeInfo, ValueInfo};
 /// # use bevy_reflect::utility::NonGenericTypeInfoCell;
 /// use bevy_reflect::Typed;
 ///

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -57,6 +57,7 @@ use std::any::{Any, TypeId};
 /// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
 /// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #   fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> { todo!() }
 /// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
 /// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -108,7 +108,7 @@ impl NonGenericTypeInfoCell {
 /// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
 /// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
-/// #   fn try_apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #   fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> { todo!() }
 /// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
 /// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -44,6 +44,7 @@ use std::any::{Any, TypeId};
 /// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
 /// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #   fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError> { todo!() }
 /// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
 /// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }
@@ -107,6 +108,7 @@ impl NonGenericTypeInfoCell {
 /// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
 /// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
 /// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #   fn try_apply(&mut self, value: &dyn Reflect) { todo!() }
 /// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
 /// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
 /// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -82,7 +82,7 @@ impl NonGenericTypeInfoCell {
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, UnnamedField};
+/// # use bevy_reflect::{ApplyError, Reflect, ReflectMut, ReflectOwned, ReflectRef, TupleStructInfo, Typed, TypeInfo, UnnamedField};
 /// use bevy_reflect::utility::GenericTypeInfoCell;
 ///
 /// struct Foo<T: Reflect>(T);

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -16,7 +16,7 @@ use std::any::{Any, TypeId};
 ///
 /// ```
 /// # use std::any::Any;
-/// # use bevy_reflect::{NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo};
+/// # use bevy_reflect::{ApplyError, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, StructInfo, Typed, TypeInfo};
 /// use bevy_reflect::utility::NonGenericTypeInfoCell;
 ///
 /// struct Foo {


### PR DESCRIPTION
# Objective

- Have a non panicking version of `Reflect.apply()`.
- Fixes #6182

## Solution

- I basically copied the existing code for `apply` and altered it to return a new error type `ApplyError`.

- The way it works now is that the error 'bubbles' up all the way up to the caller with an appropriate error so that the user can handle it on their end.

- Note: this 'version' of my implementation takes in a `&mut self` so It will leave data partially mutated when an error occurs. It is up to the user to handle the error and, for example, clone the data beforehand.

Definition:
```rust
fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), ApplyError>;
```

Implementation for list:
```rust
#[inline]
pub fn list_try_apply<L: List>(a: &mut L, b: &dyn Reflect) -> Result<(), ApplyError> {
    if let ReflectRef::List(list_value) = b.reflect_ref() {
        for (i, value) in list_value.iter().enumerate() {
            if i < a.len() {
                if let Some(v) = a.get_mut(i) {
                    v.try_apply(value)?;
                }
            } else {
                List::push(a, value.clone_value());
            }
        }
    } else {
        return Err(ApplyError::MismatchedTypes("list".to_string()));
    }
    Ok(())
}
```
## Changelog

- Added new function `try_apply` to all the types that implement `Reflect`.
- Added new error `ApplyError` in `reflect.rs`. (not finished, I half-assed the errors, will fix).
- Added documentation for this function in `reflect.rs` (would like some feedback on how to write this nicely).
- Added `try_apply` to the examples in `utility.rs` and `type_info.rs`.

## Migration Guide

No breaking changes

## Additional information

This is just a draft so that I can get some feedback on the implementation and thought process. 

This version of `try_apply` takes in a `&mut self` and potentially leaves the value it was called on in a partially mutated state. We've had some discussion on wether it would be preferred to take in:

- An `immutable reference` to `self` and return a `Box<dyn Reflect>` as result.
- A `mutable reference` and clone once at the top so that we can return the original untouched data to the user when an error occurs.
- A `Box<Self>` and return a `Box<dyn Reflect>`. (I tried to implement this but I haven't figured it out quite yet).
