### PR TITLE
[Merged by Bors] - Add support for Rgb9e5Ufloat textures

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -533,6 +533,7 @@ impl TextureFormatPixelInfo for TextureFormat {
             | TextureFormat::Depth32Float => 4,
 
             // special cases
+            TextureFormat::Rgb9e5Ufloat => 4,
             TextureFormat::Rgb10a2Unorm => 4,
             TextureFormat::Rg11b10Float => 4,
             TextureFormat::Depth24Plus => 3, // FIXME is this correct?
@@ -581,7 +582,8 @@ impl TextureFormatPixelInfo for TextureFormat {
             | TextureFormat::Rgba32Float => 4,
 
             // special cases
-            TextureFormat::Rgb10a2Unorm
+            TextureFormat::Rgb9e5Ufloat
+            | TextureFormat::Rgb10a2Unorm
             | TextureFormat::Rg11b10Float
             | TextureFormat::Depth32Float
             | TextureFormat::Depth24Plus


### PR DESCRIPTION
# Objective

- Support textures in `Rgb9e5Ufloat` format.

## Solution

- Add `TextureFormatPixelInfo` for `Rgb9e5Ufloat`.

Tested this with a `Rgb9e5Ufloat` encoded KTX2 texture.
