### PR TITLE
Register Hash for glam types

### DIFF
--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -6,14 +6,14 @@ use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_ref
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct IVec2 {
         x: i32,
         y: i32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct IVec3 {
         x: i32,
         y: i32,
@@ -21,7 +21,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct IVec4 {
         x: i32,
         y: i32,
@@ -31,14 +31,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct UVec2 {
         x: u32,
         y: u32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct UVec3 {
         x: u32,
         y: u32,
@@ -46,7 +46,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Hash, PartialEq, Default)]
     struct UVec4 {
         x: u32,
         y: u32,


### PR DESCRIPTION
# Objective

- fixes https://github.com/bevyengine/bevy/issues/6736

## Solution

- Register `Hash` on all of glam's reflected integer vector types.