### PR TITLE
remove pixel size and try to calculate texture sizes more correctly

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -456,15 +456,7 @@ impl FromWorld for MeshPipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
-                            image
-                                .texture_descriptor
-                                .size
-                                .bytes_per_row(image.texture_descriptor.format),
-                        )
-                        .unwrap(),
-                    ),
+                    bytes_per_row: Some(image.texture_descriptor.bytes_per_row()),
                     rows_per_image: None,
                 },
                 image.texture_descriptor.size,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -22,9 +22,7 @@ use bevy_render::{
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
-    },
+    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
     view::{ComputedVisibility, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, RenderApp, RenderStage,
 };
@@ -446,7 +444,6 @@ impl FromWorld for MeshPipeline {
                 ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
             };
 
-            let format_size = image.texture_descriptor.format.pixel_size();
             render_queue.write_texture(
                 ImageCopyTexture {
                     texture: &texture,
@@ -459,7 +456,10 @@ impl FromWorld for MeshPipeline {
                     offset: 0,
                     bytes_per_row: Some(
                         std::num::NonZeroU32::new(
-                            image.texture_descriptor.size.width * format_size as u32,
+                            image
+                                .texture_descriptor
+                                .size
+                                .bytes_per_row(image.texture_descriptor.format),
                         )
                         .unwrap(),
                     ),

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -22,7 +22,9 @@ use bevy_render::{
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
+    texture::{
+        BevyDefault, DefaultImageSampler, Extent3dDimensions, GpuImage, Image, ImageSampler,
+    },
     view::{ComputedVisibility, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, RenderApp, RenderStage,
 };

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -1,4 +1,4 @@
-use crate::texture::{Image, TextureFormatPixelInfo};
+use crate::texture::Image;
 use anyhow::Result;
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};
 use bevy_utils::BoxedFuture;
@@ -16,16 +16,12 @@ impl AssetLoader for HdrTextureLoader {
     ) -> BoxedFuture<'a, Result<()>> {
         Box::pin(async move {
             let format = TextureFormat::Rgba32Float;
-            debug_assert_eq!(
-                format.pixel_size(),
-                4 * 4,
-                "Format should have 32bit x 4 size"
-            );
 
             let decoder = image::codecs::hdr::HdrDecoder::new(bytes)?;
             let info = decoder.metadata();
             let rgb_data = decoder.read_image_hdr()?;
-            let mut rgba_data = Vec::with_capacity(rgb_data.len() * format.pixel_size());
+            let mut rgba_data =
+                Vec::with_capacity(rgb_data.len() * format.describe().block_size as usize);
 
             for rgb in rgb_data {
                 let alpha = 1.0f32;

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -457,11 +457,11 @@ impl<'a> ImageType<'a> {
 
 /// Extends Extent3d with some convenience methods to calculate some useful values related to the dimensions of a texture
 pub trait Extent3dDimensions {
-    /// calculates the bytes per row in a texture
+    /// Calculates the bytes per row in a texture
     fn bytes_per_row(&self) -> NonZeroU32;
-    /// calculates the rows in an image
+    /// Calculates the rows in an image
     fn rows_per_image(&self) -> u32;
-    /// calculates the total bytes in the data buffer for a texture
+    /// Calculates the total bytes for a texture
     fn total_bytes(&self) -> u32;
 }
 
@@ -490,7 +490,8 @@ fn rows_per_image(physical_height: u32, format: &TextureFormat) -> u32 {
     physical_height / info.block_dimensions.1 as u32
 }
 
-/// calculate the total bytes needed to hold an image with `size` and `format`
+/// Calculate the total bytes needed to hold an image with `size` and `format`. If you have a [`TextureDescriptor`]
+/// consider using [`Extent3dDimensions::total_bytes`] instead.
 pub fn total_bytes(size: &Extent3d, format: &TextureFormat) -> u32 {
     let physical_size = size.physical_size(*format);
     let bytes_per_row = u32::from(bytes_per_row(physical_size.width, format));

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -489,112 +489,11 @@ pub trait TextureFormatPixelInfo {
 impl TextureFormatPixelInfo for TextureFormat {
     #[allow(clippy::match_same_arms)]
     fn pixel_info(&self) -> PixelInfo {
-        let type_size = match self {
-            // 8bit
-            TextureFormat::R8Unorm
-            | TextureFormat::R8Snorm
-            | TextureFormat::R8Uint
-            | TextureFormat::R8Sint
-            | TextureFormat::Rg8Unorm
-            | TextureFormat::Rg8Snorm
-            | TextureFormat::Rg8Uint
-            | TextureFormat::Rg8Sint
-            | TextureFormat::Rgba8Unorm
-            | TextureFormat::Rgba8UnormSrgb
-            | TextureFormat::Rgba8Snorm
-            | TextureFormat::Rgba8Uint
-            | TextureFormat::Rgba8Sint
-            | TextureFormat::Bgra8Unorm
-            | TextureFormat::Bgra8UnormSrgb => 1,
-
-            // 16bit
-            TextureFormat::R16Uint
-            | TextureFormat::R16Sint
-            | TextureFormat::R16Float
-            | TextureFormat::R16Unorm
-            | TextureFormat::Rg16Uint
-            | TextureFormat::Rg16Sint
-            | TextureFormat::Rg16Unorm
-            | TextureFormat::Rg16Float
-            | TextureFormat::Rgba16Uint
-            | TextureFormat::Rgba16Sint
-            | TextureFormat::Rgba16Float => 2,
-
-            // 32bit
-            TextureFormat::R32Uint
-            | TextureFormat::R32Sint
-            | TextureFormat::R32Float
-            | TextureFormat::Rg32Uint
-            | TextureFormat::Rg32Sint
-            | TextureFormat::Rg32Float
-            | TextureFormat::Rgba32Uint
-            | TextureFormat::Rgba32Sint
-            | TextureFormat::Rgba32Float
-            | TextureFormat::Depth32Float => 4,
-
-            // special cases
-            TextureFormat::Rgb9e5Ufloat => 4,
-            TextureFormat::Rgb10a2Unorm => 4,
-            TextureFormat::Rg11b10Float => 4,
-            TextureFormat::Depth24Plus => 3, // FIXME is this correct?
-            TextureFormat::Depth24PlusStencil8 => 4,
-            // TODO: this is not good! this is a temporary step while porting bevy_render to direct wgpu usage
-            _ => panic!("cannot get pixel info for type"),
-        };
-
-        let components = match self {
-            TextureFormat::R8Unorm
-            | TextureFormat::R8Snorm
-            | TextureFormat::R8Uint
-            | TextureFormat::R8Sint
-            | TextureFormat::R16Uint
-            | TextureFormat::R16Sint
-            | TextureFormat::R16Unorm
-            | TextureFormat::R16Float
-            | TextureFormat::R32Uint
-            | TextureFormat::R32Sint
-            | TextureFormat::R32Float => 1,
-
-            TextureFormat::Rg8Unorm
-            | TextureFormat::Rg8Snorm
-            | TextureFormat::Rg8Uint
-            | TextureFormat::Rg8Sint
-            | TextureFormat::Rg16Uint
-            | TextureFormat::Rg16Sint
-            | TextureFormat::Rg16Unorm
-            | TextureFormat::Rg16Float
-            | TextureFormat::Rg32Uint
-            | TextureFormat::Rg32Sint
-            | TextureFormat::Rg32Float => 2,
-
-            TextureFormat::Rgba8Unorm
-            | TextureFormat::Rgba8UnormSrgb
-            | TextureFormat::Rgba8Snorm
-            | TextureFormat::Rgba8Uint
-            | TextureFormat::Rgba8Sint
-            | TextureFormat::Bgra8Unorm
-            | TextureFormat::Bgra8UnormSrgb
-            | TextureFormat::Rgba16Uint
-            | TextureFormat::Rgba16Sint
-            | TextureFormat::Rgba16Float
-            | TextureFormat::Rgba32Uint
-            | TextureFormat::Rgba32Sint
-            | TextureFormat::Rgba32Float => 4,
-
-            // special cases
-            TextureFormat::Rgb9e5Ufloat
-            | TextureFormat::Rgb10a2Unorm
-            | TextureFormat::Rg11b10Float
-            | TextureFormat::Depth32Float
-            | TextureFormat::Depth24Plus
-            | TextureFormat::Depth24PlusStencil8 => 1,
-            // TODO: this is not good! this is a temporary step while porting bevy_render to direct wgpu usage
-            _ => panic!("cannot get pixel info for type"),
-        };
+        let info = self.describe();
 
         PixelInfo {
-            type_size,
-            num_components: components,
+            type_size: info.block_size.into(),
+            num_components: info.components.into(),
         }
     }
 }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -467,34 +467,15 @@ impl Volume for Extent3d {
     }
 }
 
-/// Information about the pixel size in bytes and the number of different components.
-pub struct PixelInfo {
-    /// The size of a component of a pixel in bytes.
-    pub type_size: usize,
-    /// The amount of different components (color channels).
-    pub num_components: usize,
-}
-
 /// Extends the wgpu [`TextureFormat`] with information about the pixel.
 pub trait TextureFormatPixelInfo {
-    /// Returns the pixel information of the format.
-    fn pixel_info(&self) -> PixelInfo;
-    /// Returns the size of a pixel of the format.
-    fn pixel_size(&self) -> usize {
-        let info = self.pixel_info();
-        info.type_size * info.num_components
-    }
+    /// Returns the size in bytes of a pixel of the format.
+    fn pixel_size(&self) -> usize;
 }
 
 impl TextureFormatPixelInfo for TextureFormat {
-    #[allow(clippy::match_same_arms)]
-    fn pixel_info(&self) -> PixelInfo {
-        let info = self.describe();
-
-        PixelInfo {
-            type_size: info.block_size.into(),
-            num_components: info.components.into(),
-        }
+    fn pixel_size(&self) -> usize {
+        self.describe().block_size.into()
     }
 }
 

--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -1,4 +1,4 @@
-use crate::texture::{Image, TextureFormatPixelInfo};
+use crate::texture::Image;
 use anyhow::anyhow;
 use image::{DynamicImage, ImageBuffer};
 use wgpu::{Extent3d, TextureDimension, TextureFormat};
@@ -84,8 +84,9 @@ impl Image {
                 height = image.height();
                 format = TextureFormat::Rgba16Uint;
 
-                let mut local_data =
-                    Vec::with_capacity(width as usize * height as usize * format.pixel_size());
+                let mut local_data = Vec::with_capacity(
+                    width as usize * height as usize * format.describe().block_size as usize,
+                );
 
                 for pixel in image.into_raw().chunks_exact(3) {
                     // TODO: use the array_chunks method once stabilised
@@ -117,8 +118,9 @@ impl Image {
                 height = image.height();
                 format = TextureFormat::Rgba32Float;
 
-                let mut local_data =
-                    Vec::with_capacity(width as usize * height as usize * format.pixel_size());
+                let mut local_data = Vec::with_capacity(
+                    width as usize * height as usize * format.describe().block_size as usize,
+                );
 
                 for pixel in image.into_raw().chunks_exact(3) {
                     // TODO: use the array_chunks method once stabilised

--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -1,7 +1,7 @@
 use crate::TextureAtlas;
 use bevy_asset::Assets;
 use bevy_math::{IVec2, Rect, Vec2};
-use bevy_render::texture::{Image, TextureFormatPixelInfo};
+use bevy_render::texture::Image;
 use guillotiere::{size2, Allocation, AtlasAllocator};
 
 pub struct DynamicTextureAtlasBuilder {
@@ -67,12 +67,26 @@ impl DynamicTextureAtlasBuilder {
         allocation: Allocation,
         texture: &Image,
     ) {
+        debug_assert_eq!(
+            atlas_texture
+                .texture_descriptor
+                .format
+                .describe()
+                .block_dimensions,
+            (1, 1),
+            "Compressed textures are unsupported"
+        );
+
         let mut rect = allocation.rectangle;
         rect.max.x -= self.padding;
         rect.max.y -= self.padding;
         let atlas_width = atlas_texture.texture_descriptor.size.width as usize;
         let rect_width = rect.width() as usize;
-        let format_size = atlas_texture.texture_descriptor.format.pixel_size();
+        let format_size = atlas_texture
+            .texture_descriptor
+            .format
+            .describe()
+            .block_size as usize;
 
         for (texture_y, bound_y) in (rect.min.y..rect.max.y).map(|i| i as usize).enumerate() {
             let begin = (bound_y * atlas_width + rect.min.x as usize) * format_size;

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -14,9 +14,7 @@ use bevy_render::{
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
-    },
+    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
     view::{
         ComputedVisibility, ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
     },
@@ -218,7 +216,6 @@ impl FromWorld for Mesh2dPipeline {
                 ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
             };
 
-            let format_size = image.texture_descriptor.format.pixel_size();
             let render_queue = world.resource_mut::<RenderQueue>();
             render_queue.write_texture(
                 ImageCopyTexture {
@@ -232,7 +229,10 @@ impl FromWorld for Mesh2dPipeline {
                     offset: 0,
                     bytes_per_row: Some(
                         std::num::NonZeroU32::new(
-                            image.texture_descriptor.size.width * format_size as u32,
+                            image
+                                .texture_descriptor
+                                .size
+                                .bytes_per_row(image.texture_descriptor.format),
                         )
                         .unwrap(),
                     ),

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -229,15 +229,7 @@ impl FromWorld for Mesh2dPipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
-                            image
-                                .texture_descriptor
-                                .size
-                                .bytes_per_row(image.texture_descriptor.format),
-                        )
-                        .unwrap(),
-                    ),
+                    bytes_per_row: Some(image.texture_descriptor.bytes_per_row()),
                     rows_per_image: None,
                 },
                 image.texture_descriptor.size,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -14,7 +14,9 @@ use bevy_render::{
     render_phase::{EntityRenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
+    texture::{
+        BevyDefault, DefaultImageSampler, Extent3dDimensions, GpuImage, Image, ImageSampler,
+    },
     view::{
         ComputedVisibility, ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
     },

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -21,7 +21,9 @@ use bevy_render::{
     },
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
+    texture::{
+        BevyDefault, DefaultImageSampler, Extent3dDimensions, GpuImage, Image, ImageSampler,
+    },
     view::{
         ComputedVisibility, ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniformOffset,
         ViewUniforms, VisibleEntities,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -21,9 +21,7 @@ use bevy_render::{
     },
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
-    },
+    texture::{BevyDefault, BytesPerRow, DefaultImageSampler, GpuImage, Image, ImageSampler},
     view::{
         ComputedVisibility, ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniformOffset,
         ViewUniforms, VisibleEntities,
@@ -100,7 +98,6 @@ impl FromWorld for SpritePipeline {
                 ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
             };
 
-            let format_size = image.texture_descriptor.format.pixel_size();
             render_queue.write_texture(
                 ImageCopyTexture {
                     texture: &texture,
@@ -113,7 +110,10 @@ impl FromWorld for SpritePipeline {
                     offset: 0,
                     bytes_per_row: Some(
                         std::num::NonZeroU32::new(
-                            image.texture_descriptor.size.width * format_size as u32,
+                            image
+                                .texture_descriptor
+                                .size
+                                .bytes_per_row(image.texture_descriptor.format),
                         )
                         .unwrap(),
                     ),

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -110,15 +110,7 @@ impl FromWorld for SpritePipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(
-                        std::num::NonZeroU32::new(
-                            image
-                                .texture_descriptor
-                                .size
-                                .bytes_per_row(image.texture_descriptor.format),
-                        )
-                        .unwrap(),
-                    ),
+                    bytes_per_row: Some(image.texture_descriptor.bytes_per_row()),
                     rows_per_image: None,
                 },
                 image.texture_descriptor.size,

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -3,7 +3,7 @@ use bevy_log::{debug, error, warn};
 use bevy_math::{Rect, Vec2};
 use bevy_render::{
     render_resource::{Extent3d, TextureDimension, TextureFormat},
-    texture::{Image, TextureFormatPixelInfo},
+    texture::Image,
 };
 use bevy_utils::HashMap;
 use rectangle_pack::{
@@ -97,12 +97,26 @@ impl TextureAtlasBuilder {
         texture: &Image,
         packed_location: &PackedLocation,
     ) {
+        debug_assert_eq!(
+            atlas_texture
+                .texture_descriptor
+                .format
+                .describe()
+                .block_dimensions,
+            (1, 1),
+            "Compressed textures are unsupported"
+        );
+
         let rect_width = packed_location.width() as usize;
         let rect_height = packed_location.height() as usize;
         let rect_x = packed_location.x() as usize;
         let rect_y = packed_location.y() as usize;
         let atlas_width = atlas_texture.texture_descriptor.size.width as usize;
-        let format_size = atlas_texture.texture_descriptor.format.pixel_size();
+        let format_size = atlas_texture
+            .texture_descriptor
+            .format
+            .describe()
+            .block_size as usize;
 
         for (texture_y, bound_y) in (rect_y..rect_y + rect_height).enumerate() {
             let begin = (bound_y * atlas_width + rect_x) * format_size;
@@ -161,6 +175,16 @@ impl TextureAtlasBuilder {
         let mut rect_placements = None;
         let mut atlas_texture = Image::default();
 
+        debug_assert_eq!(
+            atlas_texture
+                .texture_descriptor
+                .format
+                .describe()
+                .block_dimensions,
+            (1, 1),
+            "Compressed textures are unsupported"
+        );
+
         while rect_placements.is_none() {
             if current_width > max_width || current_height > max_height {
                 break;
@@ -186,7 +210,8 @@ impl TextureAtlasBuilder {
                         TextureDimension::D2,
                         vec![
                             0;
-                            self.format.pixel_size() * (current_width * current_height) as usize
+                            self.format.describe().block_size as usize
+                                * (current_width * current_height) as usize
                         ],
                         self.format,
                     );


### PR DESCRIPTION
# Objective

- Rather than maintain a big match statement get the info from wgpu instead. `wgpu` already maintains a list of this info https://docs.rs/wgpu-types/0.14.0/src/wgpu_types/lib.rs.html#2359

# Solution

- more complicated alternative to https://github.com/bevyengine/bevy/pull/6820
- this mostly be considered a rebase of #4124. Though some of the details are modified.
- remove the TextureFormatPixelInfo trait. It is inaccurate to use pixel_size to calculate bytes when a texture is compressed
- create a trait to calculate the usages of pixel_size directly. These are bytes_per_row, total_bytes, and rows_per_image.
- use `format.describe().block_size` directly in situations where it is obvious that the format is uncompressed or where surrounding code assumes the texture is uncompressed.
- add some debug asserts to functions that assume the texture is uncompressed.
- note that all the internal uses of `TextureFormatPixelInfo` were on uncompressed textures. A smaller change would be to panic if in the pixel_info function if the texture is compressed and return block_size for type_size otherwise.

## Breaking Changes

`TextureFormatPixelInfo` has been removed. `PixelInfo::components` can be gotten from `texture_format.describe().components`. `PixelInfo::type_size` can be gotten from `texture_format.describe().block_size/ texture_format.describe().components`. But note this can yield incorrect results for some texture types like `Rg11b10Float`. You might prefer to use the new functions on `texture_descriptor` instead. These include `bytes_per_row`, `total_bytes` and `rows_per_image`.