### PR TITLE
Don't Fail On Non-Mappable Entities in `Children`

### DIFF
--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -23,7 +23,9 @@ pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 impl MapEntities for Children {
     fn map_entities(&mut self, entity_map: &EntityMap) -> Result<(), MapEntitiesError> {
         for entity in &mut self.0 {
-            *entity = entity_map.get(*entity)?;
+            if let Ok(new_entity) = entity_map.get(*entity) {
+                *entity = new_entity;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
# Objective

Fixes #6790

## Solution

- Don't fail when mapping entities that aren't found in the `EntityMap`.

---

I don't think this requires a changelog entry, but let me know if I'm wrong.

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
