### PR TITLE
bevy_scene: Add `SceneFilter`

### DIFF
--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -45,14 +45,13 @@ pub struct DynamicEntity {
 
 impl DynamicScene {
     /// Create a new dynamic scene from a given scene.
-    pub fn from_scene(scene: &Scene, type_registry: &AppTypeRegistry) -> Self {
-        Self::from_world(&scene.world, type_registry)
+    pub fn from_scene(scene: &Scene) -> Self {
+        Self::from_world(&scene.world)
     }
 
     /// Create a new dynamic scene from a given world.
-    pub fn from_world(world: &World, type_registry: &AppTypeRegistry) -> Self {
-        let mut builder =
-            DynamicSceneBuilder::from_world_with_type_registry(world, type_registry.clone());
+    pub fn from_world(world: &World) -> Self {
+        let mut builder = DynamicSceneBuilder::from_world(world);
 
         builder.extract_entities(world.iter_entities().map(|entity| entity.id()));
         builder.extract_resources();

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -104,6 +104,26 @@ impl<'w> DynamicSceneBuilder<'w> {
         self
     }
 
+    /// Updates the filter to allow all component types.
+    ///
+    /// This is useful for resetting the filter so that types may be selectively [denied].
+    ///
+    /// [denied]: Self::deny
+    pub fn allow_all(&mut self) -> &mut Self {
+        self.component_filter = SceneFilter::allow_all();
+        self
+    }
+
+    /// Updates the filter to deny all component types.
+    ///
+    /// This is useful for resetting the filter so that types may be selectively [allowed].
+    ///
+    /// [allowed]: Self::allow
+    pub fn deny_all(&mut self) -> &mut Self {
+        self.component_filter = SceneFilter::deny_all();
+        self
+    }
+
     /// Allows the given resource type, `T`, to be included in the generated scene.
     ///
     /// This method may be called multiple times for any number of resources.
@@ -123,6 +143,26 @@ impl<'w> DynamicSceneBuilder<'w> {
     /// If `T` has already been allowed, then it will be removed from the allowlist.
     pub fn deny_resource<T: Resource>(&mut self) -> &mut Self {
         self.resource_filter.deny::<T>();
+        self
+    }
+
+    /// Updates the filter to allow all resource types.
+    ///
+    /// This is useful for resetting the filter so that types may be selectively [denied].
+    ///
+    /// [denied]: Self::deny_resource
+    pub fn allow_all_resources(&mut self) -> &mut Self {
+        self.resource_filter = SceneFilter::allow_all();
+        self
+    }
+
+    /// Updates the filter to deny all resource types.
+    ///
+    /// This is useful for resetting the filter so that types may be selectively [allowed].
+    ///
+    /// [allowed]: Self::allow_resource
+    pub fn deny_all_resources(&mut self) -> &mut Self {
+        self.resource_filter = SceneFilter::deny_all();
         self
     }
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -84,49 +84,45 @@ impl<'w> DynamicSceneBuilder<'w> {
 
     /// Allows the given component type, `T`, to be included in the generated scene.
     ///
-    /// This method may be called for multiple components.
+    /// This method may be called multiple times for any number of components.
     ///
-    /// Please note that this method is mutually exclusive with the [`deny`](Self::deny) method.
-    /// Calling this one will replace the denylist with a new allowlist.
+    /// This is the inverse of [`deny`](Self::deny).
+    /// If `T` has already been denied, then it will be removed from the denylist.
     pub fn allow<T: Component>(&mut self) -> &mut Self {
-        self.component_filter =
-            core::mem::replace(&mut self.component_filter, SceneFilter::None).allow::<T>();
+        self.component_filter.allow::<T>();
         self
     }
 
     /// Denies the given component type, `T`, from being included in the generated scene.
     ///
-    /// This method may be called for multiple components.
+    /// This method may be called multiple times for any number of components.
     ///
-    /// Please note that this method is mutually exclusive with the [`allow`](Self::allow) method.
-    /// Calling this one will replace the allowlist with a new denylist.
+    /// This is the inverse of [`allow`](Self::allow).
+    /// If `T` has already been allowed, then it will be removed from the allowlist.
     pub fn deny<T: Component>(&mut self) -> &mut Self {
-        self.component_filter =
-            core::mem::replace(&mut self.component_filter, SceneFilter::None).deny::<T>();
+        self.component_filter.deny::<T>();
         self
     }
 
     /// Allows the given resource type, `T`, to be included in the generated scene.
     ///
-    /// This method may be called for multiple resources.
+    /// This method may be called multiple times for any number of resources.
     ///
-    /// Please note that this method is mutually exclusive with the [`deny_resource`](Self::deny_resource) method.
-    /// Calling this one will replace the denylist with a new allowlist.
+    /// This is the inverse of [`deny_resource`](Self::deny_resource).
+    /// If `T` has already been denied, then it will be removed from the denylist.
     pub fn allow_resource<T: Resource>(&mut self) -> &mut Self {
-        self.resource_filter =
-            core::mem::replace(&mut self.resource_filter, SceneFilter::None).allow::<T>();
+        self.resource_filter.allow::<T>();
         self
     }
 
     /// Denies the given resource type, `T`, from being included in the generated scene.
     ///
-    /// This method may be called for multiple resources.
+    /// This method may be called multiple times for any number of resources.
     ///
-    /// Please note that this method is mutually exclusive with the [`allow_resource`](Self::allow_resource) method.
-    /// Calling this one will replace the allowlist with a new denylist.
+    /// This is the inverse of [`allow_resource`](Self::allow_resource).
+    /// If `T` has already been allowed, then it will be removed from the allowlist.
     pub fn deny_resource<T: Resource>(&mut self) -> &mut Self {
-        self.resource_filter =
-            core::mem::replace(&mut self.resource_filter, SceneFilter::None).deny::<T>();
+        self.resource_filter.deny::<T>();
         self
     }
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -19,12 +19,16 @@ use std::collections::BTreeMap;
 /// This can be changed by [specifying a filter](DynamicSceneBuilder::with_filter) or by explicitly
 /// [allowing](DynamicSceneBuilder::allow)/[denying](DynamicSceneBuilder::deny) certain components.
 ///
+/// Extraction happens immediately and uses the filter as it exists during the time of extraction.
+///
 /// # Resource Extraction
 ///
 /// By default, all resources registered with [`ReflectResource`] type data in a world's [`AppTypeRegistry`] will be extracted.
 /// (this type data is added automatically during registration if [`Reflect`] is derived with the `#[reflect(Resource)]` attribute).
 /// This can be changed by [specifying a filter](DynamicSceneBuilder::with_resource_filter) or by explicitly
 /// [allowing](DynamicSceneBuilder::allow_resource)/[denying](DynamicSceneBuilder::deny_resource) certain resources.
+///
+/// Extraction happens immediately and uses the filter as it exists during the time of extraction.
 ///
 /// # Entity Order
 ///

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -64,8 +64,8 @@ impl<'w> DynamicSceneBuilder<'w> {
         Self {
             extracted_resources: default(),
             extracted_scene: default(),
-            component_filter: SceneFilter::None,
-            resource_filter: SceneFilter::None,
+            component_filter: SceneFilter::default(),
+            resource_filter: SceneFilter::default(),
             original_world: world,
         }
     }

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -4,6 +4,7 @@ mod bundle;
 mod dynamic_scene;
 mod dynamic_scene_builder;
 mod scene;
+mod scene_filter;
 mod scene_loader;
 mod scene_spawner;
 
@@ -14,13 +15,15 @@ pub use bundle::*;
 pub use dynamic_scene::*;
 pub use dynamic_scene_builder::*;
 pub use scene::*;
+pub use scene_filter::*;
 pub use scene_loader::*;
 pub use scene_spawner::*;
 
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        DynamicScene, DynamicSceneBuilder, DynamicSceneBundle, Scene, SceneBundle, SceneSpawner,
+        DynamicScene, DynamicSceneBuilder, DynamicSceneBundle, Scene, SceneBundle, SceneFilter,
+        SceneSpawner,
     };
 }
 

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -44,22 +44,28 @@ pub enum SceneFilter {
 impl SceneFilter {
     /// Allow the given type, `T`.
     ///
-    /// If this filter is already set as a [`SceneFilter::Denylist`],
+    /// If this filter is already set as a [`Denylist`],
     /// then the given type will be removed from the denied set.
     ///
-    /// If this filter is already set as [`SceneFilter::Unset`],
-    /// then it will be completely replaced by a new [`SceneFilter::Allowlist`].
+    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Allowlist`].
+    ///
+    /// [`Denylist`]: SceneFilter::Denylist
+    /// [`Unset`]: SceneFilter::Unset
+    /// [`Allowlist`]: SceneFilter::Allowlist
     pub fn allow<T: Any>(&mut self) -> &mut Self {
         self.allow_by_id(TypeId::of::<T>())
     }
 
     /// Allow the given type.
     ///
-    /// If this filter is already set as a [`SceneFilter::Denylist`],
+    /// If this filter is already set as a [`Denylist`],
     /// then the given type will be removed from the denied set.
     ///
-    /// If this filter is already set as [`SceneFilter::Unset`],
-    /// then it will be completely replaced by a new [`SceneFilter::Allowlist`].
+    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Allowlist`].
+    ///
+    /// [`Denylist`]: SceneFilter::Denylist
+    /// [`Unset`]: SceneFilter::Unset
+    /// [`Allowlist`]: SceneFilter::Allowlist
     pub fn allow_by_id(&mut self, type_id: TypeId) -> &mut Self {
         match self {
             Self::Unset => {
@@ -77,22 +83,28 @@ impl SceneFilter {
 
     /// Deny the given type, `T`.
     ///
-    /// If this filter is already set as an [`SceneFilter::Allowlist`],
+    /// If this filter is already set as an [`Allowlist`],
     /// then the given type will be removed from the allowed set.
     ///
-    /// If this filter is already set as [`SceneFilter::Unset`],
-    /// then it will be completely replaced by a new [`SceneFilter::Denylist`].
+    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Denylist`].
+    ///
+    /// [`Allowlist`]: SceneFilter::Allowlist
+    /// [`Unset`]: SceneFilter::Unset
+    /// [`Denylist`]: SceneFilter::Denylist
     pub fn deny<T: Any>(&mut self) -> &mut Self {
         self.deny_by_id(TypeId::of::<T>())
     }
 
     /// Deny the given type.
     ///
-    /// If this filter is already set as an [`SceneFilter::Allowlist`],
+    /// If this filter is already set as an [`Allowlist`],
     /// then the given type will be removed from the allowed set.
     ///
-    /// If this filter is already set as [`SceneFilter::Unset`],
-    /// then it will be completely replaced by a new [`SceneFilter::Denylist`].
+    /// If this filter is [`Unset`], then it will be completely replaced by a new [`Denylist`].
+    ///
+    /// [`Allowlist`]: SceneFilter::Allowlist
+    /// [`Unset`]: SceneFilter::Unset
+    /// [`Denylist`]: SceneFilter::Denylist
     pub fn deny_by_id(&mut self, type_id: TypeId) -> &mut Self {
         match self {
             Self::Unset => *self = Self::Denylist(HashSet::from([type_id])),
@@ -108,14 +120,18 @@ impl SceneFilter {
 
     /// Returns true if the given type, `T`, is allowed by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
+    /// If the filter is [`Unset`], this will always return `true`.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed<T: Any>(&self) -> bool {
         self.is_allowed_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is allowed by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
+    /// If the filter is [`Unset`], this will always return `true`.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
         match self {
             Self::Unset => true,
@@ -126,21 +142,27 @@ impl SceneFilter {
 
     /// Returns true if the given type, `T`, is denied by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return `false`.
+    /// If the filter is [`Unset`], this will always return `false`.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn is_denied<T: Any>(&self) -> bool {
         self.is_denied_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is denied by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return `false`.
+    /// If the filter is [`Unset`], this will always return `false`.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn is_denied_by_id(&self, type_id: TypeId) -> bool {
         !self.is_allowed_by_id(type_id)
     }
 
     /// Returns an iterator over the items in the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will return an empty iterator.
+    /// If the filter is [`Unset`], this will return an empty iterator.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &TypeId> + '_> {
         match self {
             Self::Unset => Box::new(core::iter::empty()),
@@ -150,7 +172,9 @@ impl SceneFilter {
 
     /// Returns the number of items in the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return a length of zero.
+    /// If the filter is [`Unset`], this will always return a length of zero.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn len(&self) -> usize {
         match self {
             Self::Unset => 0,
@@ -160,7 +184,9 @@ impl SceneFilter {
 
     /// Returns true if there are zero items in the filter.
     ///
-    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
+    /// If the filter is [`Unset`], this will always return `true`.
+    ///
+    /// [`Unset`]: SceneFilter::Unset
     pub fn is_empty(&self) -> bool {
         match self {
             Self::Unset => true,

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -15,13 +15,18 @@ use std::any::{Any, TypeId};
 pub enum SceneFilter {
     /// Represents an unset filter.
     ///
-    /// This is the equivalent of an empty [`Denylist`] or a [`Allowlist`] containing every type—
+    /// This is the equivalent of an empty [`Denylist`] or an [`Allowlist`] containing every type—
     /// essentially, all types are permissible.
+    ///
+    /// [Allowing] a type will convert this filter to an `Allowlist`.
+    /// Similarly, [denying] a type will convert this filter to a `Denylist`.
     ///
     /// [`Denylist`]: SceneFilter::Denylist
     /// [`Allowlist`]: SceneFilter::Allowlist
+    /// [Allowing]: SceneFilter::allow
+    /// [denying]: SceneFilter::deny
     #[default]
-    None,
+    Unset,
     /// Contains the set of permitted types by their [`TypeId`].
     ///
     /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
@@ -39,25 +44,25 @@ pub enum SceneFilter {
 impl SceneFilter {
     /// Allow the given type, `T`.
     ///
-    /// If this filter is already set as a [denylist](Self::Denylist),
+    /// If this filter is already set as a [`SceneFilter::Denylist`],
     /// then the given type will be removed from the denied set.
     ///
-    /// If this filter is already set as [`SceneFilter::None`],
-    /// then it will be completely replaced by a new [allowlist](Self::Allowlist).
+    /// If this filter is already set as [`SceneFilter::Unset`],
+    /// then it will be completely replaced by a new [`SceneFilter::Allowlist`].
     pub fn allow<T: Any>(&mut self) -> &mut Self {
         self.allow_by_id(TypeId::of::<T>())
     }
 
     /// Allow the given type.
     ///
-    /// If this filter is already set as a [denylist](Self::Denylist),
+    /// If this filter is already set as a [`SceneFilter::Denylist`],
     /// then the given type will be removed from the denied set.
     ///
-    /// If this filter is already set as [`SceneFilter::None`],
-    /// then it will be completely replaced by a new [allowlist](Self::Allowlist).
+    /// If this filter is already set as [`SceneFilter::Unset`],
+    /// then it will be completely replaced by a new [`SceneFilter::Allowlist`].
     pub fn allow_by_id(&mut self, type_id: TypeId) -> &mut Self {
         match self {
-            Self::None => {
+            Self::Unset => {
                 *self = Self::Allowlist(HashSet::from([type_id]));
             }
             Self::Allowlist(list) => {
@@ -72,25 +77,25 @@ impl SceneFilter {
 
     /// Deny the given type, `T`.
     ///
-    /// If this filter is already set as a [allowlist](Self::Allowlist),
+    /// If this filter is already set as an [`SceneFilter::Allowlist`],
     /// then the given type will be removed from the allowed set.
     ///
-    /// If this filter is already set as [`SceneFilter::None`],
-    /// then it will be completely replaced by a new [denylist](Self::Denylist).
+    /// If this filter is already set as [`SceneFilter::Unset`],
+    /// then it will be completely replaced by a new [`SceneFilter::Denylist`].
     pub fn deny<T: Any>(&mut self) -> &mut Self {
         self.deny_by_id(TypeId::of::<T>())
     }
 
     /// Deny the given type.
     ///
-    /// If this filter is already set as a [allowlist](Self::Allowlist),
+    /// If this filter is already set as an [`SceneFilter::Allowlist`],
     /// then the given type will be removed from the allowed set.
     ///
-    /// If this filter is already set as [`SceneFilter::None`],
-    /// then it will be completely replaced by a new [denylist](Self::Denylist).
+    /// If this filter is already set as [`SceneFilter::Unset`],
+    /// then it will be completely replaced by a new [`SceneFilter::Denylist`].
     pub fn deny_by_id(&mut self, type_id: TypeId) -> &mut Self {
         match self {
-            Self::None => *self = Self::Denylist(HashSet::from([type_id])),
+            Self::Unset => *self = Self::Denylist(HashSet::from([type_id])),
             Self::Allowlist(list) => {
                 list.remove(&type_id);
             }
@@ -103,17 +108,17 @@ impl SceneFilter {
 
     /// Returns true if the given type, `T`, is allowed by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::None`], this will always return `true`.
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
     pub fn is_allowed<T: Any>(&self) -> bool {
         self.is_allowed_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is allowed by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::None`], this will always return `true`.
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
         match self {
-            Self::None => true,
+            Self::Unset => true,
             Self::Allowlist(list) => list.contains(&type_id),
             Self::Denylist(list) => !list.contains(&type_id),
         }
@@ -121,38 +126,44 @@ impl SceneFilter {
 
     /// Returns true if the given type, `T`, is denied by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::None`], this will always return `false`.
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return `false`.
     pub fn is_denied<T: Any>(&self) -> bool {
         self.is_denied_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is denied by the filter.
     ///
-    /// If the filter is set to [`SceneFilter::None`], this will always return `false`.
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return `false`.
     pub fn is_denied_by_id(&self, type_id: TypeId) -> bool {
         !self.is_allowed_by_id(type_id)
     }
 
     /// Returns an iterator over the items in the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::Unset`], this will return an empty iterator.
     pub fn iter(&self) -> Box<dyn ExactSizeIterator<Item = &TypeId> + '_> {
         match self {
-            Self::None => Box::new(core::iter::empty()),
+            Self::Unset => Box::new(core::iter::empty()),
             Self::Allowlist(list) | Self::Denylist(list) => Box::new(list.iter()),
         }
     }
 
     /// Returns the number of items in the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return a length of zero.
     pub fn len(&self) -> usize {
         match self {
-            Self::None => 0,
+            Self::Unset => 0,
             Self::Allowlist(list) | Self::Denylist(list) => list.len(),
         }
     }
 
     /// Returns true if there are zero items in the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::Unset`], this will always return `true`.
     pub fn is_empty(&self) -> bool {
         match self {
-            Self::None => true,
+            Self::Unset => true,
             Self::Allowlist(list) | Self::Denylist(list) => list.is_empty(),
         }
     }
@@ -164,7 +175,7 @@ impl IntoIterator for SceneFilter {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            Self::None => HashSet::new().into_iter(),
+            Self::Unset => HashSet::new().into_iter(),
             Self::Allowlist(list) | Self::Denylist(list) => list.into_iter(),
         }
     }
@@ -176,11 +187,11 @@ mod tests {
 
     #[test]
     fn should_set_list_type_if_none() {
-        let mut filter = SceneFilter::None;
+        let mut filter = SceneFilter::Unset;
         filter.allow::<i32>();
         assert!(matches!(filter, SceneFilter::Allowlist(_)));
 
-        let mut filter = SceneFilter::None;
+        let mut filter = SceneFilter::Unset;
         filter.deny::<i32>();
         assert!(matches!(filter, SceneFilter::Denylist(_)));
     }

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -42,6 +42,24 @@ pub enum SceneFilter {
 }
 
 impl SceneFilter {
+    /// Creates a filter where all types are allowed.
+    ///
+    /// This is the equivalent of creating an empty [`Denylist`].
+    ///
+    /// [`Denylist`]: SceneFilter::Denylist
+    pub fn allow_all() -> Self {
+        Self::Denylist(HashSet::new())
+    }
+
+    /// Creates a filter where all types are denied.
+    ///
+    /// This is the equivalent of creating an empty [`Allowlist`].
+    ///
+    /// [`Allowlist`]: SceneFilter::Allowlist
+    pub fn deny_all() -> Self {
+        Self::Allowlist(HashSet::new())
+    }
+
     /// Allow the given type, `T`.
     ///
     /// If this filter is already set as a [`Denylist`],

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -11,6 +11,14 @@ use std::any::{Any, TypeId};
 /// [components]: bevy_ecs::prelude::Component
 /// [resources]: bevy_ecs::prelude::Resource
 pub enum SceneFilter {
+    /// Represents an unset filter.
+    ///
+    /// This is the equivalent of an empty [`Denylist`] or a [`Allowlist`] containing every type—
+    /// essentially, all types are permissible.
+    ///
+    /// [`Denylist`]: SceneFilter::Denylist
+    /// [`Allowlist`]: SceneFilter::Allowlist
+    None,
     /// Contains the set of permitted types by their [`TypeId`].
     ///
     /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
@@ -26,16 +34,6 @@ pub enum SceneFilter {
 }
 
 impl SceneFilter {
-    /// Create a new [allowlist](Self::Allowlist).
-    pub fn new_allowlist() -> Self {
-        Self::Allowlist(HashSet::new())
-    }
-
-    /// Create a new [denylist](Self::Denylist).
-    pub fn new_denylist() -> Self {
-        Self::Denylist(HashSet::new())
-    }
-
     /// Allow the given type, `T`.
     ///
     /// If this filter is already set as a [denylist](Self::Denylist),
@@ -54,7 +52,7 @@ impl SceneFilter {
                 list.insert(type_id);
                 self
             }
-            Self::Denylist(_) => Self::Allowlist(HashSet::from([type_id])),
+            Self::None | Self::Denylist(_) => Self::Allowlist(HashSet::from([type_id])),
         }
     }
 
@@ -72,7 +70,7 @@ impl SceneFilter {
     /// then it will be completely replaced by a new [denylist](Self::Denylist).
     pub fn deny_by_id(mut self, type_id: TypeId) -> Self {
         match self {
-            Self::Allowlist(_) => Self::Denylist(HashSet::from([type_id])),
+            Self::None | Self::Allowlist(_) => Self::Denylist(HashSet::from([type_id])),
             Self::Denylist(ref mut list) => {
                 list.insert(type_id);
                 self
@@ -81,25 +79,40 @@ impl SceneFilter {
     }
 
     /// Returns true if the given type, `T`, is allowed by the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::None`], this will always return `true`.
     pub fn is_allowed<T: Any>(&self) -> bool {
         self.is_allowed_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is allowed by the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::None`], this will always return `true`.
     pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
         match self {
-            SceneFilter::Allowlist(list) => list.contains(&type_id),
-            SceneFilter::Denylist(list) => !list.contains(&type_id),
+            Self::None => true,
+            Self::Allowlist(list) => list.contains(&type_id),
+            Self::Denylist(list) => !list.contains(&type_id),
         }
     }
 
     /// Returns true if the given type, `T`, is denied by the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::None`], this will always return `false`.
     pub fn is_denied<T: Any>(&self) -> bool {
         self.is_denied_by_id(TypeId::of::<T>())
     }
 
     /// Returns true if the given type is denied by the filter.
+    ///
+    /// If the filter is set to [`SceneFilter::None`], this will always return `false`.
     pub fn is_denied_by_id(&self, type_id: TypeId) -> bool {
         !self.is_allowed_by_id(type_id)
+    }
+}
+
+impl Default for SceneFilter {
+    fn default() -> Self {
+        Self::None
     }
 }

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -1,0 +1,105 @@
+use bevy_utils::HashSet;
+use std::any::{Any, TypeId};
+
+/// A filter used to control which types can be added to a [`DynamicScene`].
+///
+/// This scene filter _can_ be used more generically to represent a filter for any given type;
+/// however, note that its intended usage with `DynamicScene` only considers [components] and [resources].
+/// Adding types that are not a component or resource will have no effect when used with `DynamicScene`.
+///
+/// [`DynamicScene`]: crate::DynamicScene
+/// [components]: bevy_ecs::prelude::Component
+/// [resources]: bevy_ecs::prelude::Resource
+pub enum SceneFilter {
+    /// Contains the set of permitted types by their [`TypeId`].
+    ///
+    /// Types not contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
+    ///
+    /// [`DynamicScene`]: crate::DynamicScene
+    Allowlist(HashSet<TypeId>),
+    /// Contains the set of prohibited types by their [`TypeId`].
+    ///
+    /// Types contained within this set should not be allowed to be saved to an associated [`DynamicScene`].
+    ///
+    /// [`DynamicScene`]: crate::DynamicScene
+    Denylist(HashSet<TypeId>),
+}
+
+impl SceneFilter {
+    /// Create a new [allowlist](Self::Allowlist).
+    pub fn new_allowlist() -> Self {
+        Self::Allowlist(HashSet::new())
+    }
+
+    /// Create a new [denylist](Self::Denylist).
+    pub fn new_denylist() -> Self {
+        Self::Denylist(HashSet::new())
+    }
+
+    /// Allow the given type, `T`.
+    ///
+    /// If this filter is already set as a [denylist](Self::Denylist),
+    /// then it will be completely replaced by a new [allowlist](Self::Allowlist).
+    pub fn allow<T: Any>(self) -> Self {
+        self.allow_by_id(TypeId::of::<T>())
+    }
+
+    /// Allow the given type.
+    ///
+    /// If this filter is already set as a [denylist](Self::Denylist),
+    /// then it will be completely replaced by a new [allowlist](Self::Allowlist).
+    pub fn allow_by_id(mut self, type_id: TypeId) -> Self {
+        match self {
+            Self::Allowlist(ref mut list) => {
+                list.insert(type_id);
+                self
+            }
+            Self::Denylist(_) => Self::Allowlist(HashSet::from([type_id])),
+        }
+    }
+
+    /// Deny the given type, `T`.
+    ///
+    /// If this filter is already set as an [allowlist](Self::Allowlist),
+    /// then it will be completely replaced by a new [denylist](Self::Denylist).
+    pub fn deny<T: Any>(self) -> Self {
+        self.deny_by_id(TypeId::of::<T>())
+    }
+
+    /// Deny the given type.
+    ///
+    /// If this filter is already set as an [allowlist](Self::Allowlist),
+    /// then it will be completely replaced by a new [denylist](Self::Denylist).
+    pub fn deny_by_id(mut self, type_id: TypeId) -> Self {
+        match self {
+            Self::Allowlist(_) => Self::Denylist(HashSet::from([type_id])),
+            Self::Denylist(ref mut list) => {
+                list.insert(type_id);
+                self
+            }
+        }
+    }
+
+    /// Returns true if the given type, `T`, is allowed by the filter.
+    pub fn is_allowed<T: Any>(&self) -> bool {
+        self.is_allowed_by_id(TypeId::of::<T>())
+    }
+
+    /// Returns true if the given type is allowed by the filter.
+    pub fn is_allowed_by_id(&self, type_id: TypeId) -> bool {
+        match self {
+            SceneFilter::Allowlist(list) => list.contains(&type_id),
+            SceneFilter::Denylist(list) => !list.contains(&type_id),
+        }
+    }
+
+    /// Returns true if the given type, `T`, is denied by the filter.
+    pub fn is_denied<T: Any>(&self) -> bool {
+        self.is_denied_by_id(TypeId::of::<T>())
+    }
+
+    /// Returns true if the given type is denied by the filter.
+    pub fn is_denied_by_id(&self, type_id: TypeId) -> bool {
+        !self.is_allowed_by_id(type_id)
+    }
+}

--- a/crates/bevy_scene/src/scene_filter.rs
+++ b/crates/bevy_scene/src/scene_filter.rs
@@ -169,3 +169,55 @@ impl IntoIterator for SceneFilter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_set_list_type_if_none() {
+        let mut filter = SceneFilter::None;
+        filter.allow::<i32>();
+        assert!(matches!(filter, SceneFilter::Allowlist(_)));
+
+        let mut filter = SceneFilter::None;
+        filter.deny::<i32>();
+        assert!(matches!(filter, SceneFilter::Denylist(_)));
+    }
+
+    #[test]
+    fn should_add_to_list() {
+        let mut filter = SceneFilter::default();
+        filter.allow::<i16>();
+        filter.allow::<i32>();
+        assert_eq!(2, filter.len());
+        assert!(filter.is_allowed::<i16>());
+        assert!(filter.is_allowed::<i32>());
+
+        let mut filter = SceneFilter::default();
+        filter.deny::<i16>();
+        filter.deny::<i32>();
+        assert_eq!(2, filter.len());
+        assert!(filter.is_denied::<i16>());
+        assert!(filter.is_denied::<i32>());
+    }
+
+    #[test]
+    fn should_remove_from_list() {
+        let mut filter = SceneFilter::default();
+        filter.allow::<i16>();
+        filter.allow::<i32>();
+        filter.deny::<i32>();
+        assert_eq!(1, filter.len());
+        assert!(filter.is_allowed::<i16>());
+        assert!(!filter.is_allowed::<i32>());
+
+        let mut filter = SceneFilter::default();
+        filter.deny::<i16>();
+        filter.deny::<i32>();
+        filter.allow::<i32>();
+        assert_eq!(1, filter.len());
+        assert!(filter.is_denied::<i16>());
+        assert!(!filter.is_denied::<i32>());
+    }
+}

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -630,7 +630,7 @@ mod tests {
 
         let registry = world.resource::<AppTypeRegistry>();
 
-        let scene = DynamicScene::from_world(&world, registry);
+        let scene = DynamicScene::from_world(&world);
 
         let serialized = scene
             .serialize_ron(&world.resource::<AppTypeRegistry>().0)
@@ -680,7 +680,7 @@ mod tests {
 
         let registry = world.resource::<AppTypeRegistry>();
 
-        let scene = DynamicScene::from_world(&world, registry);
+        let scene = DynamicScene::from_world(&world);
 
         let scene_serializer = SceneSerializer::new(&scene, &registry.0);
         let serialized_scene = postcard::to_allocvec(&scene_serializer).unwrap();
@@ -718,7 +718,7 @@ mod tests {
 
         let registry = world.resource::<AppTypeRegistry>();
 
-        let scene = DynamicScene::from_world(&world, registry);
+        let scene = DynamicScene::from_world(&world);
 
         let scene_serializer = SceneSerializer::new(&scene, &registry.0);
         let mut buf = Vec::new();
@@ -761,7 +761,7 @@ mod tests {
 
         let registry = world.resource::<AppTypeRegistry>();
 
-        let scene = DynamicScene::from_world(&world, registry);
+        let scene = DynamicScene::from_world(&world);
 
         let scene_serializer = SceneSerializer::new(&scene, &registry.0);
         let serialized_scene = bincode::serialize(&scene_serializer).unwrap();
@@ -835,8 +835,7 @@ mod tests {
         #[should_panic(expected = "entity count did not match")]
         fn should_panic_when_entity_count_not_eq() {
             let mut world = create_world();
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_a = DynamicScene::from_world(&world, registry);
+            let scene_a = DynamicScene::from_world(&world);
 
             world.spawn(MyComponent {
                 foo: [1, 2, 3],
@@ -844,8 +843,7 @@ mod tests {
                 baz: MyEnum::Unit,
             });
 
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_b = DynamicScene::from_world(&world, registry);
+            let scene_b = DynamicScene::from_world(&world);
 
             assert_scene_eq(&scene_a, &scene_b);
         }
@@ -863,8 +861,7 @@ mod tests {
                 })
                 .id();
 
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_a = DynamicScene::from_world(&world, registry);
+            let scene_a = DynamicScene::from_world(&world);
 
             world.entity_mut(entity).insert(MyComponent {
                 foo: [3, 2, 1],
@@ -872,8 +869,7 @@ mod tests {
                 baz: MyEnum::Unit,
             });
 
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_b = DynamicScene::from_world(&world, registry);
+            let scene_b = DynamicScene::from_world(&world);
 
             assert_scene_eq(&scene_a, &scene_b);
         }
@@ -891,13 +887,11 @@ mod tests {
                 })
                 .id();
 
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_a = DynamicScene::from_world(&world, registry);
+            let scene_a = DynamicScene::from_world(&world);
 
             world.entity_mut(entity).remove::<MyComponent>();
 
-            let registry = world.resource::<AppTypeRegistry>();
-            let scene_b = DynamicScene::from_world(&world, registry);
+            let scene_b = DynamicScene::from_world(&world);
 
             assert_scene_eq(&scene_a, &scene_b);
         }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -100,9 +100,18 @@ fn log_system(
 }
 
 fn save_scene_system(world: &mut World) {
-    // Scenes can be created from any ECS World. You can either create a new one for the scene or
-    // use the current World.
+    // Scenes can be created from any ECS World.
+    // You can either create a new one for the scene or use the current World.
+    // For demonstration purposes, we'll create a new one.
     let mut scene_world = World::new();
+
+    // The `TypeRegistry` resource contains information about all registered types (including components).
+    // This is used to construct scenes, so we'll want to ensure that our previous type registrations
+    // exist in this new scene world as well.
+    // To do this, we can simply clone the `AppTypeRegistry` resource.
+    let type_registry = world.resource::<AppTypeRegistry>().clone();
+    scene_world.insert_resource(type_registry);
+
     let mut component_b = ComponentB::from_world(world);
     component_b.value = "hello".to_string();
     scene_world.spawn((
@@ -113,12 +122,11 @@ fn save_scene_system(world: &mut World) {
     scene_world.spawn(ComponentA { x: 3.0, y: 4.0 });
     scene_world.insert_resource(ResourceA { score: 1 });
 
-    // The TypeRegistry resource contains information about all registered types (including
-    // components). This is used to construct scenes.
-    let type_registry = world.resource::<AppTypeRegistry>();
-    let scene = DynamicScene::from_world(&scene_world, type_registry);
+    // With our sample world ready to go, we can now create our scene:
+    let scene = DynamicScene::from_world(&scene_world);
 
     // Scenes can be serialized like this:
+    let type_registry = world.resource::<AppTypeRegistry>();
     let serialized_scene = scene.serialize_ron(type_registry).unwrap();
 
     // Showing the scene in the console


### PR DESCRIPTION
# Objective

Currently, `DynamicScene`s extract all components listed in the given (or the world's) type registry. This acts as a quasi-filter of sorts. However, it can be troublesome to use effectively and lacks decent control.

For example, say you need to serialize only the following component over the network:

```rust
#[derive(Reflect, Component, Default)]
#[reflect(Component)]
struct NPC {
  name: Option<String>
}
```

To do this, you'd need to:
1. Create a new `AppTypeRegistry`
2. Register `NPC`
3. Register `Option<String>`

If we skip Step 3, then the entire scene might fail to serialize as `Option<String>` requires registration.

Not only is this annoying and easy to forget, but it can leave users with an impossible task: serializing a third-party type that contains private types. 

Generally, the third-party crate will register their private types within a plugin so the user doesn't need to do it themselves. However, this means we are now unable to serialize _just_ that type— we're forced to allow everything!

## Solution

Add the `SceneFilter` enum for filtering components to extract.

This filter can be used to optionally allow or deny entire sets of components/resources. With the `DynamicSceneBuilder`, users have more control over how their `DynamicScene`s are built.

To only serialize a subset of components, use the `allow` method:
```rust
let scene = builder
  .allow::<ComponentA>()
  .allow::<ComponentB>()
  .extract_entity(entity)
  .build();
```

To serialize everything _but_ a subset of components, use the `deny` method:
```rust
let scene = builder
  .deny::<ComponentA>()
  .deny::<ComponentB>()
  .extract_entity(entity)
  .build();
```

Or create a custom filter:
```rust
let components = HashSet::from([type_id]);

let filter = SceneFilter::Allowlist(components);
// let filter = SceneFilter::Denylist(components);

let scene = builder
  .with_filter(Some(filter))
  .extract_entity(entity)
  .build();
```

Similar operations exist for resources:

<details>
<summary>View Resource Methods</summary>

To only serialize a subset of resources, use the `allow_resource` method:
```rust
let scene = builder
  .allow_resource::<ResourceA>()
  .extract_resources()
  .build();
```

To serialize everything _but_ a subset of resources, use the `deny_resource` method:
```rust
let scene = builder
  .deny_resource::<ResourceA>()
  .extract_resources()
  .build();
```

Or create a custom filter:
```rust
let resources = HashSet::from([type_id]);

let filter = SceneFilter::Allowlist(resources);
// let filter = SceneFilter::Denylist(resources);

let scene = builder
  .with_resource_filter(Some(filter))
  .extract_resources()
  .build();
```

</details>

### Open Questions

- [x] ~~`allow` and `deny` are mutually exclusive. Currently, they overwrite each other. Should this instead be a panic?~~ Took @soqb's suggestion and made it so that the opposing method simply removes that type from the list.
- [x] ~~`DynamicSceneBuilder` extracts entity data as soon as `extract_entity`/`extract_entities` is called. Should this behavior instead be moved to the `build` method to prevent ordering mixups (e.g. `.allow::<Foo>().extract_entity(entity)` vs `.extract_entity(entity).allow::<Foo>()`)? The tradeoff would be iterating over the given entities twice: once at extraction and again at build.~~ Based on the feedback from @Testare it sounds like it might be better to just keep the current functionality (if anything we can open a separate PR that adds deferred methods for extraction, so the choice/performance hit is up to the user).
  - [ ] An alternative might be to remove the filter from `DynamicSceneBuilder` and have it as a separate parameter to the extraction methods (either in the existing ones or as added `extract_entity_with_filter`-type methods). Is this preferable?
- [x] ~~Should we include constructors that include common types to allow/deny? For example, a `SceneFilter::standard_allowlist` that includes things like `Parent` and `Children`?~~ Consensus suggests we should. I may split this out into a followup PR, though.
- [x] ~~Should we add the ability to remove types from the filter regardless of whether an allowlist or denylist (e.g. `filter.remove::<Foo>()`)?~~ See the first list item
- [x] ~~Should `SceneFilter` be an enum? Would it make more sense as a struct that contains an `is_denylist` boolean?~~ With the added `SceneFilter::None` state (replacing the need to wrap in an `Option` or rely on an empty `Denylist`), it seems an enum is better suited now 
- [x] ~~Bikeshed: Do we like the naming convention? Should we instead use `include`/`exclude` terminology?~~ Sounds like we're sticking with `allow`/`deny`!
- [x] ~~Does this feature need a new example? Do we simply include it in the existing one (maybe even as a comment?)? Should this be done in a followup PR instead?~~ Example will be added in a followup PR

### Followup Tasks

- [ ] Add a dedicated `SceneFilter` example
- [ ] Possibly add default types to the filter (e.g. deny things like `ComputedVisibility`, allow `Parent`, etc)

---

## Changelog

- Added the `SceneFilter` enum for filtering components and resources when building a `DynamicScene`
- Added methods:
  - `DynamicSceneBuilder::with_filter`
  - `DynamicSceneBuilder::allow`
  - `DynamicSceneBuilder::deny`
  - `DynamicSceneBuilder::allow_all`
  - `DynamicSceneBuilder::deny_all`
  - `DynamicSceneBuilder::with_resource_filter`
  - `DynamicSceneBuilder::allow_resource`
  - `DynamicSceneBuilder::deny_resource`
  - `DynamicSceneBuilder::allow_all_resources`
  - `DynamicSceneBuilder::deny_all_resources`
- Removed methods:
  - `DynamicSceneBuilder::from_world_with_type_registry`
- `DynamicScene::from_scene` and `DynamicScene::from_world` no longer require an `AppTypeRegistry` reference

## Migration Guide

- `DynamicScene::from_scene` and `DynamicScene::from_world` no longer require an `AppTypeRegistry` reference:
  ```rust
  // OLD
  let registry = world.resource::<AppTypeRegistry>();
  let dynamic_scene = DynamicScene::from_world(&world, registry);
  // let dynamic_scene = DynamicScene::from_scene(&scene, registry);
  
  // NEW
  let dynamic_scene = DynamicScene::from_world(&world);
  // let dynamic_scene = DynamicScene::from_scene(&scene);
  ```

- Removed `DynamicSceneBuilder::from_world_with_type_registry`. Now the registry is automatically taken from the given world:
  ```rust
  // OLD
  let registry = world.resource::<AppTypeRegistry>();
  let builder = DynamicSceneBuilder::from_world_with_type_registry(&world, registry);
  
  // NEW
  let builder = DynamicSceneBuilder::from_world(&world);
  ```
