### PR TITLE
[Merged by Bors] - Remove `TextError::ExceedMaxTextAtlases(usize)` variant

### DIFF
--- a/crates/bevy_text/src/error.rs
+++ b/crates/bevy_text/src/error.rs
@@ -7,7 +7,4 @@ pub enum TextError {
     NoSuchFont,
     #[error("failed to add glyph to newly-created atlas {0:?}")]
     FailedToAddGlyph(GlyphId),
-    // TODO this is not used. Remove it.
-    #[error("exceeded {0:?} available TextAltases for font. This can be caused by using an excessive number of font sizes or ui scaling. If you are changing font sizes or ui scaling dynamically consider using Transform::scale to modify the size. If you need more font sizes modify TextSettings.max_font_atlases." )]
-    ExceedMaxTextAtlases(usize),
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -207,8 +207,7 @@ pub fn update_text2d_layout(
                     // queue for further processing
                     queue.insert(entity);
                 }
-                Err(e @ TextError::FailedToAddGlyph(_))
-                | Err(e @ TextError::ExceedMaxTextAtlases(_)) => {
+                Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(info) => {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -135,8 +135,7 @@ pub fn text_system(
                     // queue for further processing
                     new_queue.push(entity);
                 }
-                Err(e @ TextError::FailedToAddGlyph(_))
-                | Err(e @ TextError::ExceedMaxTextAtlases(_)) => {
+                Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(info) => {


### PR DESCRIPTION
# Objective

Fixes #6756

## Solution

Removes the variant wherever it's used