### PR TITLE
[Merged by Bors] - Fix hot reloading for read_asset_bytes

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -422,7 +422,7 @@ impl AssetServer {
         }
 
         self.asset_io()
-            .watch_path_for_changes(asset_path.path())
+            .watch_path_for_changes(asset_path.path(), None)
             .unwrap();
         self.create_assets_in_load_context(&mut load_context);
         Ok(asset_path_id)

--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -51,7 +51,11 @@ impl AssetIo for AndroidAssetIo {
         Ok(Box::new(std::iter::empty::<PathBuf>()))
     }
 
-    fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {
+    fn watch_path_for_changes(
+        &self,
+        _to_watch: &Path,
+        _to_reload: Option<PathBuf>,
+    ) -> Result<(), AssetIoError> {
         Ok(())
     }
 

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -66,7 +66,19 @@ pub trait AssetIo: Downcast + Send + Sync + 'static {
     fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError>;
 
     /// Tells the asset I/O to watch for changes recursively at the provided path.
-    fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError>;
+    ///
+    /// No-op if `watch_for_changes` hasn't been called yet.
+    /// Otherwise triggers a reload each time `to_watch` changes.
+    /// In most cases the asset found at the watched path should be changed,
+    /// but when an asset depends on data at another path, the asset's path
+    /// is provided in `to_reload`.
+    /// Note that there may be a many-to-many correspondence between
+    /// `to_watch` and `to_reload` paths.
+    fn watch_path_for_changes(
+        &self,
+        to_watch: &Path,
+        to_reload: Option<PathBuf>,
+    ) -> Result<(), AssetIoError>;
 
     /// Enables change tracking in this asset I/O.
     fn watch_for_changes(&self) -> Result<(), AssetIoError>;

--- a/crates/bevy_asset/src/io/wasm_asset_io.rs
+++ b/crates/bevy_asset/src/io/wasm_asset_io.rs
@@ -56,7 +56,11 @@ impl AssetIo for WasmAssetIo {
         Ok(Box::new(std::iter::empty::<PathBuf>()))
     }
 
-    fn watch_path_for_changes(&self, _path: &Path) -> Result<(), AssetIoError> {
+    fn watch_path_for_changes(
+        &self,
+        _to_watch: &Path,
+        _to_reload: Option<PathBuf>,
+    ) -> Result<(), AssetIoError> {
         Ok(())
     }
 

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -174,6 +174,8 @@ impl<'a> LoadContext<'a> {
     /// Reads the contents of the file at the specified path through the [`AssetIo`] associated
     /// with this context.
     pub async fn read_asset_bytes<P: AsRef<Path>>(&self, path: P) -> Result<Vec<u8>, AssetIoError> {
+        self.asset_io
+            .watch_path_for_changes(path.as_ref(), Some(self.path.to_owned()))?;
         self.asset_io.load_path(path.as_ref()).await
     }
 

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -18,7 +18,7 @@ struct CustomAssetIo(Box<dyn AssetIo>);
 
 impl AssetIo for CustomAssetIo {
     fn load_path<'a>(&'a self, path: &'a Path) -> BoxedFuture<'a, Result<Vec<u8>, AssetIoError>> {
-        info!("load_path({:?})", path);
+        info!("load_path({path:?})");
         self.0.load_path(path)
     }
 
@@ -26,13 +26,17 @@ impl AssetIo for CustomAssetIo {
         &self,
         path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
-        info!("read_directory({:?})", path);
+        info!("read_directory({path:?})");
         self.0.read_directory(path)
     }
 
-    fn watch_path_for_changes(&self, path: &Path) -> Result<(), AssetIoError> {
-        info!("watch_path_for_changes({:?})", path);
-        self.0.watch_path_for_changes(path)
+    fn watch_path_for_changes(
+        &self,
+        to_watch: &Path,
+        to_reload: PathBuf,
+    ) -> Result<(), AssetIoError> {
+        info!("watch_path_for_changes({to_watch:?}, {to_reload:?})");
+        self.0.watch_path_for_changes(to_watch, to_reload)
     }
 
     fn watch_for_changes(&self) -> Result<(), AssetIoError> {
@@ -41,7 +45,7 @@ impl AssetIo for CustomAssetIo {
     }
 
     fn get_metadata(&self, path: &Path) -> Result<Metadata, AssetIoError> {
-        info!("get_metadata({:?})", path);
+        info!("get_metadata({path:?})");
         self.0.get_metadata(path)
     }
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -33,7 +33,7 @@ impl AssetIo for CustomAssetIo {
     fn watch_path_for_changes(
         &self,
         to_watch: &Path,
-        to_reload: PathBuf,
+        to_reload: Option<PathBuf>,
     ) -> Result<(), AssetIoError> {
         info!("watch_path_for_changes({to_watch:?}, {to_reload:?})");
         self.0.watch_path_for_changes(to_watch, to_reload)


### PR DESCRIPTION
# Objective

Fixes #6780

## Solution

- record the asset path of each watched file
- call `AssetIo::watch_for_changes` in `LoadContext::read_asset_bytes`

---

## Changelog

### Fixed
- fixed hot reloading for `LoadContext::read_asset_bytes`

### Changed
- `AssetIo::watch_path_for_changes` allows watched path and path to reload to differ

## Migration Guide
- for custom `AssetIo`s, differentiate paths to watch and asset paths to reload as a consequence