### PR TITLE
[Merged by Bors] - Remove APIs deprecated in 0.9

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -99,7 +99,7 @@ pub(crate) struct SpawnBundleStatus;
 impl BundleComponentStatus for SpawnBundleStatus {
     #[inline]
     unsafe fn get_status(&self, _index: usize) -> ComponentStatus {
-        // Components added during a spawn_bundle call are always treated as added
+        // Components added during a spawn call are always treated as added
         ComponentStatus::Added
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1129,7 +1129,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_bundle() {
+    fn remove() {
         let mut world = World::default();
         world.spawn((A(1), B(1), TableStored("1")));
         let e2 = world.spawn((A(2), B(2), TableStored("2"))).id();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -387,7 +387,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// This method is equivalent to iterating `bundles_iter`,
     /// calling [`get_or_spawn`](Self::get_or_spawn) for each bundle,
-    /// and passing it to [`insert_bundle`](EntityCommands::insert_bundle),
+    /// and passing it to [`insert`](EntityCommands::insert),
     /// but it is faster due to memory pre-allocation.
     ///
     /// # Note

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -243,16 +243,6 @@ impl<'w, 's> Commands<'w, 's> {
         e
     }
 
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `spawn` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn spawn_bundle<'a, T: Bundle>(&'a mut self, bundle: T) -> EntityCommands<'w, 's, 'a> {
-        let mut e = self.spawn_empty();
-        e.insert(bundle);
-        e
-    }
-
     /// Returns the [`EntityCommands`] for the requested [`Entity`].
     ///
     /// # Panics
@@ -620,14 +610,6 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         self
     }
 
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `insert` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn insert_bundle(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.insert(bundle)
-    }
-
     /// Removes a [`Bundle`] of components from the entity.
     ///
     /// See [`EntityMut::remove`](crate::world::EntityMut::remove) for more
@@ -675,17 +657,6 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
             phantom: PhantomData,
         });
         self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `remove` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn remove_bundle<T>(&mut self) -> &mut Self
-    where
-        T: Bundle,
-    {
-        self.remove::<T>()
     }
 
     /// Despawns the entity.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -229,14 +229,6 @@ impl<'w> EntityMut<'w> {
             })
     }
 
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `insert` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn insert_bundle<T: Bundle>(&mut self, bundle: T) -> &mut Self {
-        self.insert(bundle)
-    }
-
     /// Adds a [`Bundle`] of components to the entity.
     ///
     /// This will overwrite any previous value(s) of the same component type.
@@ -260,14 +252,6 @@ impl<'w> EntityMut<'w> {
         }
 
         self
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `remove` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn remove_bundle<T: Bundle>(&mut self) -> Option<T> {
-        self.remove::<T>()
     }
 
     // TODO: move to BundleInfo
@@ -396,14 +380,6 @@ impl<'w> EntityMut<'w> {
         *self_location = new_location;
         // SAFETY: The entity is valid and has been moved to the new location already.
         entities.set(entity.index(), new_location);
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `remove_intersection` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn remove_bundle_intersection<T: Bundle>(&mut self) {
-        self.remove_intersection::<T>();
     }
 
     // TODO: move to BundleInfo

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -220,15 +220,6 @@ pub struct ChildBuilder<'w, 's, 'a> {
 
 impl<'w, 's, 'a> ChildBuilder<'w, 's, 'a> {
     /// Spawns an entity with the given bundle and inserts it into the children defined by the [`ChildBuilder`]
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `spawn` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    pub fn spawn_bundle(&mut self, bundle: impl Bundle) -> EntityCommands<'w, 's, '_> {
-        self.spawn(bundle)
-    }
-
-    /// Spawns an entity with the given bundle and inserts it into the children defined by the [`ChildBuilder`]
     pub fn spawn(&mut self, bundle: impl Bundle) -> EntityCommands<'w, 's, '_> {
         let e = self.commands.spawn(bundle);
         self.push_children.children.push(e.id());
@@ -409,15 +400,6 @@ impl<'w> WorldChildBuilder<'w> {
             });
         }
         self.world.entity_mut(entity)
-    }
-
-    #[deprecated(
-        since = "0.9.0",
-        note = "Use `spawn` instead, which now accepts bundles, components, and tuples of bundles and components."
-    )]
-    /// Spawns an entity with the given bundle and inserts it into the children defined by the [`WorldChildBuilder`]
-    pub fn spawn_bundle(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> EntityMut<'_> {
-        self.spawn(bundle)
     }
 
     /// Spawns an [`Entity`] with no components and inserts it into the children defined by the [`WorldChildBuilder`] which adds the [`Parent`] component to it.

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -277,7 +277,7 @@ pub trait BuildChildren {
     ///
     ///     parent_commands.insert(SomethingElse);
     ///     commands.entity(child_id).with_children(|parent| {
-    ///         parent.spawn_bundle(MoreStuff);
+    ///         parent.spawn(MoreStuff);
     ///     });
     /// # }
     /// ```


### PR DESCRIPTION
# Objective
These functions were deprecated in 0.9. They should be removed in 0.10.

## Solution
Remove them.