### PR TITLE
[Merged by Bors] - try to fix run-examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-examples:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: figure out why latest fails
     timeout-minutes: 30
     steps:
       - name: Install Bevy dependencies

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -91,7 +91,7 @@ jobs:
           done
 
   run-examples-on-wasm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04 # TODO: figure out why this fails on latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Objective

- run examples is failing with `xvfb-run: error: Xvfb failed to start`

## Solution

- rollback ubuntu version for run-examples to 20.04. latest is 22.04

## Notes

- this is just a quick fix and someone should probably get it working on 22.04. I'll make an issue for that if this gets merged.