### PR TITLE
Cherry pick "bevy_reflect: Register missing reflected types for `bevy_render` (#6725)"

### DIFF
--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -7,12 +7,7 @@ pub use camera::*;
 pub use camera_driver_node::*;
 pub use projection::*;
 
-use crate::{
-    primitives::Aabb,
-    render_graph::RenderGraph,
-    view::{ComputedVisibility, RenderLayers, Visibility, VisibleEntities},
-    RenderApp, RenderStage,
-};
+use crate::{render_graph::RenderGraph, RenderApp, RenderStage};
 use bevy_app::{App, Plugin};
 
 #[derive(Default)]
@@ -23,14 +18,10 @@ impl Plugin for CameraPlugin {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
             .register_type::<Option<Viewport>>()
-            .register_type::<Visibility>()
-            .register_type::<ComputedVisibility>()
-            .register_type::<VisibleEntities>()
             .register_type::<WindowOrigin>()
             .register_type::<ScalingMode>()
-            .register_type::<Aabb>()
             .register_type::<CameraRenderGraph>()
-            .register_type::<RenderLayers>()
+            .register_type::<RenderTarget>()
             .add_plugin(CameraProjectionPlugin::<Projection>::default())
             .add_plugin(CameraProjectionPlugin::<OrthographicProjection>::default())
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -14,6 +14,7 @@ pub struct GlobalsPlugin;
 
 impl Plugin for GlobalsPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<GlobalsUniform>();
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<GlobalsBuffer>()

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -38,14 +38,11 @@ pub mod prelude {
 
 use globals::GlobalsPlugin;
 pub use once_cell;
-use prelude::ComputedVisibility;
 
 use crate::{
     camera::CameraPlugin,
-    color::Color,
     mesh::MeshPlugin,
-    primitives::{CubemapFrusta, Frustum},
-    render_graph::RenderGraph,
+    prelude::ComputedVisibility,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
     view::{ViewPlugin, WindowRenderPlugin},
@@ -138,8 +135,7 @@ impl Plugin for RenderPlugin {
         app.add_asset::<Shader>()
             .add_debug_asset::<Shader>()
             .init_asset_loader::<ShaderLoader>()
-            .init_debug_asset_loader::<ShaderLoader>()
-            .register_type::<Color>();
+            .init_debug_asset_loader::<ShaderLoader>();
 
         if let Some(backends) = options.backends {
             let windows = app.world.resource_mut::<bevy_window::Windows>();
@@ -167,9 +163,7 @@ impl Plugin for RenderPlugin {
                 .insert_resource(queue.clone())
                 .insert_resource(adapter_info.clone())
                 .insert_resource(render_adapter.clone())
-                .init_resource::<ScratchMainWorld>()
-                .register_type::<Frustum>()
-                .register_type::<CubemapFrusta>();
+                .init_resource::<ScratchMainWorld>();
 
             let pipeline_cache = PipelineCache::new(device.clone());
             let asset_server = app.world.resource::<AssetServer>().clone();
@@ -204,7 +198,7 @@ impl Plugin for RenderPlugin {
                         .with_system(render_system.at_end()),
                 )
                 .add_stage(RenderStage::Cleanup, SystemStage::parallel())
-                .init_resource::<RenderGraph>()
+                .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(RenderInstance(instance))
                 .insert_resource(device)
                 .insert_resource(queue)
@@ -335,6 +329,11 @@ impl Plugin for RenderPlugin {
             .add_plugin(MeshPlugin)
             .add_plugin(GlobalsPlugin)
             .add_plugin(FrameCountPlugin);
+
+        app.register_type::<color::Color>()
+            .register_type::<primitives::Aabb>()
+            .register_type::<primitives::CubemapFrusta>()
+            .register_type::<primitives::Frustum>();
     }
 }
 

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -8,6 +8,7 @@ pub use mesh::*;
 use crate::render_asset::RenderAssetPlugin;
 use bevy_app::{App, Plugin};
 use bevy_asset::AddAsset;
+use bevy_ecs::entity::Entity;
 
 /// Adds the [`Mesh`] as an asset and makes sure that they are extracted and prepared for the GPU.
 pub struct MeshPlugin;
@@ -17,6 +18,7 @@ impl Plugin for MeshPlugin {
         app.add_asset::<Mesh>()
             .add_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_type::<skinning::SkinnedMesh>()
+            .register_type::<Vec<Entity>>()
             .add_plugin(RenderAssetPlugin::<Mesh>::default());
     }
 }

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -86,6 +86,7 @@ impl Plugin for ImagePlugin {
         app.add_plugin(RenderAssetPlugin::<Image>::with_prepare_asset_label(
             PrepareAssetLabel::PreAssetPrepare,
         ))
+        .register_type::<Image>()
         .add_asset::<Image>()
         .register_asset_reflect::<Image>();
         app.world

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -31,7 +31,11 @@ pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Msaa>()
+        app.register_type::<ComputedVisibility>()
+            .register_type::<Msaa>()
+            .register_type::<RenderLayers>()
+            .register_type::<Visibility>()
+            .register_type::<VisibleEntities>()
             .init_resource::<Msaa>()
             // NOTE: windows.is_changed() handles cases where a window was resized
             .add_plugin(ExtractResourcePlugin::<Msaa>::default())


### PR DESCRIPTION
This had merge conflicts with the 0.9.1 release branch, so this had to be merged manually. Creating a PR for visibility + a final review.