### PR TITLE
Point/Spot light docs

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -41,9 +41,9 @@ use crate::{
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct PointLight {
-    /// Color of the point light.
+    /// Color of the light emitted.
     pub color: Color,
-    /// Intensity of the point light, in lumens.
+    /// Amount/strength of light emitted, in lumens.
     pub intensity: f32,
     /// How far light extends from the surface (TODO: or center?) of the point light.
     pub range: f32,
@@ -98,9 +98,15 @@ impl Default for PointLightShadowMap {
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct SpotLight {
+    /// Color of the light emitted.
     pub color: Color,
+    /// Amount/strength of light emitted, in lumens.
     pub intensity: f32,
+    /// How far light extends from the surface (TODO: or center?) of the spot light.
     pub range: f32,
+    /// The size (radius) of the spot light itself.
+    ///
+    /// A radius of 0.0 (the default) is a point with no measureable size, while a radius of 1.0 is a unit sphere, etc.
     pub radius: f32,
     pub shadows_enabled: bool,
     pub shadow_depth_bias: f32,

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -41,9 +41,15 @@ use crate::{
 #[derive(Component, Debug, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 pub struct PointLight {
+    /// Color of the point light.
     pub color: Color,
+    /// Intensity of the point light, in lumens.
     pub intensity: f32,
+    /// How far light extends from the surface (TODO: or center?) of the point light.
     pub range: f32,
+    /// The size (radius) of the point light itself.
+    ///
+    /// A radius of 0.0 (the default) is a point with no measureable size, while a radius of 1.0 is a unit sphere, etc.
     pub radius: f32,
     pub shadows_enabled: bool,
     pub shadow_depth_bias: f32,


### PR DESCRIPTION
Documents some fields of PointLight and SpotLight.

I'm unsure whether range is measured from the surface of the point/spot light, or always from the center regardless of its radius. 

I'm also unsure what units range and radius are in (meters?), and how to document the rest of the fields.