### PR TITLE
[Merged by Bors] - Replace `World::read_change_ticks` with `World::change_ticks` within `bevy_ecs` crate

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -279,12 +279,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             let change_tick = world.change_tick();
-            self.get_unchecked_manual(
-                world,
-                entity,
-                world.last_change_tick(),
-                change_tick,
-            )
+            self.get_unchecked_manual(world, entity, world.last_change_tick(), change_tick)
         }
     }
 
@@ -338,12 +333,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // and world has been validated via update_archetypes
         unsafe {
             let change_tick = world.change_tick();
-            self.get_many_unchecked_manual(
-                world,
-                entities,
-                world.last_change_tick(),
-                change_tick,
-            )
+            self.get_many_unchecked_manual(world, entities, world.last_change_tick(), change_tick)
         }
     }
 
@@ -618,11 +608,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         unsafe {
             self.update_archetypes(world);
             let change_tick = world.change_tick();
-            self.iter_combinations_unchecked_manual(
-                world,
-                world.last_change_tick(),
-                change_tick,
-            )
+            self.iter_combinations_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
 
@@ -672,12 +658,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: Query has unique world access.
         unsafe {
             let change_tick = world.change_tick();
-            self.iter_many_unchecked_manual(
-                entities,
-                world,
-                world.last_change_tick(),
-                change_tick,
-            )
+            self.iter_many_unchecked_manual(entities, world, world.last_change_tick(), change_tick)
         }
     }
 
@@ -806,12 +787,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         unsafe {
             self.update_archetypes(world);
             let change_tick = world.change_tick();
-            self.for_each_unchecked_manual(
-                world,
-                func,
-                world.last_change_tick(),
-                change_tick,
-            );
+            self.for_each_unchecked_manual(world, func, world.last_change_tick(), change_tick);
         }
     }
 
@@ -1205,11 +1181,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             let change_tick = world.change_tick();
-            self.get_single_unchecked_manual(
-                world,
-                world.last_change_tick(),
-                change_tick,
-            )
+            self.get_single_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -276,11 +276,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         entity: Entity,
     ) -> Result<Q::Item<'w>, QueryEntityError> {
         self.update_archetypes(world);
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
-        unsafe {
-            let change_tick = world.change_tick();
-            self.get_unchecked_manual(world, entity, world.last_change_tick(), change_tick)
-        }
+        unsafe { self.get_unchecked_manual(world, entity, world.last_change_tick(), change_tick) }
     }
 
     /// Returns the query results for the given array of [`Entity`].
@@ -329,10 +327,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ) -> Result<[Q::Item<'w>; N], QueryEntityError> {
         self.update_archetypes(world);
 
+        let change_tick = world.change_tick();
         // SAFETY: method requires exclusive world access
         // and world has been validated via update_archetypes
         unsafe {
-            let change_tick = world.change_tick();
             self.get_many_unchecked_manual(world, entities, world.last_change_tick(), change_tick)
         }
     }
@@ -517,10 +515,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Returns an [`Iterator`] over the query results for the given [`World`].
     #[inline]
     pub fn iter_mut<'w, 's>(&'s mut self, world: &'w mut World) -> QueryIter<'w, 's, Q, F> {
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            let change_tick = world.change_tick();
             self.iter_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
@@ -604,10 +602,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         &'s mut self,
         world: &'w mut World,
     ) -> QueryCombinationIter<'w, 's, Q, F, K> {
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            let change_tick = world.change_tick();
             self.iter_combinations_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
@@ -655,9 +653,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         EntityList::Item: Borrow<Entity>,
     {
         self.update_archetypes(world);
+        let change_tick = world.change_tick();
         // SAFETY: Query has unique world access.
         unsafe {
-            let change_tick = world.change_tick();
             self.iter_many_unchecked_manual(entities, world, world.last_change_tick(), change_tick)
         }
     }
@@ -783,10 +781,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// `iter_mut()` method, but cannot be chained like a normal [`Iterator`].
     #[inline]
     pub fn for_each_mut<'w, FN: FnMut(Q::Item<'w>)>(&mut self, world: &'w mut World, func: FN) {
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            let change_tick = world.change_tick();
             self.for_each_unchecked_manual(world, func, world.last_change_tick(), change_tick);
         }
     }
@@ -855,10 +853,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         batch_size: usize,
         func: FN,
     ) {
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            let change_tick = world.change_tick();
             self.par_for_each_unchecked_manual(
                 world,
                 batch_size,
@@ -1178,11 +1176,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ) -> Result<Q::Item<'w>, QuerySingleError> {
         self.update_archetypes(world);
 
+        let change_tick = world.change_tick();
         // SAFETY: query has unique world access
-        unsafe {
-            let change_tick = world.change_tick();
-            self.get_single_unchecked_manual(world, world.last_change_tick(), change_tick)
-        }
+        unsafe { self.get_single_unchecked_manual(world, world.last_change_tick(), change_tick) }
     }
 
     /// Returns a query result when there is exactly one entity matching the query.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -278,11 +278,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         self.update_archetypes(world);
         // SAFETY: query has unique world access
         unsafe {
+            let change_tick = world.change_tick();
             self.get_unchecked_manual(
                 world,
                 entity,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             )
         }
     }
@@ -336,11 +337,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: method requires exclusive world access
         // and world has been validated via update_archetypes
         unsafe {
+            let change_tick = world.change_tick();
             self.get_many_unchecked_manual(
                 world,
                 entities,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             )
         }
     }
@@ -528,7 +530,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
-            self.iter_unchecked_manual(world, world.last_change_tick(), world.read_change_tick())
+            let change_tick = world.change_tick();
+            self.iter_unchecked_manual(world, world.last_change_tick(), change_tick)
         }
     }
 
@@ -614,10 +617,11 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
+            let change_tick = world.change_tick();
             self.iter_combinations_unchecked_manual(
                 world,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             )
         }
     }
@@ -667,11 +671,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         self.update_archetypes(world);
         // SAFETY: Query has unique world access.
         unsafe {
+            let change_tick = world.change_tick();
             self.iter_many_unchecked_manual(
                 entities,
                 world,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             )
         }
     }
@@ -800,11 +805,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
+            let change_tick = world.change_tick();
             self.for_each_unchecked_manual(
                 world,
                 func,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             );
         }
     }
@@ -876,12 +882,13 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // SAFETY: query has unique world access
         unsafe {
             self.update_archetypes(world);
+            let change_tick = world.change_tick();
             self.par_for_each_unchecked_manual(
                 world,
                 batch_size,
                 func,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             );
         }
     }
@@ -1197,10 +1204,11 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
         // SAFETY: query has unique world access
         unsafe {
+            let change_tick = world.change_tick();
             self.get_single_unchecked_manual(
                 world,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             )
         }
     }
@@ -1293,7 +1301,7 @@ mod tests {
 
         // These don't matter for the test
         let last_change_tick = world.last_change_tick();
-        let change_tick = world.read_change_tick();
+        let change_tick = world.change_tick();
 
         // It's best to test get_many_unchecked_manual directly,
         // as it is shared and unsafe

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -927,11 +927,7 @@ pub(crate) unsafe fn get_mut_by_id(
     get_component_and_ticks(world, component_id, entity, location).map(|(value, ticks)| {
         MutUntyped {
             value: value.assert_unique(),
-            ticks: Ticks::from_tick_cells(
-                ticks,
-                world.last_change_tick(),
-                change_tick,
-            ),
+            ticks: Ticks::from_tick_cells(ticks, world.last_change_tick(), change_tick),
         }
     })
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -922,6 +922,7 @@ pub(crate) unsafe fn get_mut_by_id(
     location: EntityLocation,
     component_id: ComponentId,
 ) -> Option<MutUntyped> {
+    let change_tick = world.change_tick();
     // SAFETY: world access is unique, entity location and component_id required to be valid
     get_component_and_ticks(world, component_id, entity, location).map(|(value, ticks)| {
         MutUntyped {
@@ -929,7 +930,7 @@ pub(crate) unsafe fn get_mut_by_id(
             ticks: Ticks::from_tick_cells(
                 ticks,
                 world.last_change_tick(),
-                world.read_change_tick(),
+                change_tick,
             ),
         }
     })

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1448,13 +1448,15 @@ impl World {
             self.validate_non_send_access_untyped(info.name());
         }
 
+        let change_tick = self.change_tick();
+
         let (ptr, ticks) = self.get_resource_with_ticks(component_id)?;
 
         // SAFETY: This function has exclusive access to the world so nothing aliases `ticks`.
         // - index is in-bounds because the column is initialized and non-empty
         // - no other reference to the ticks of the same row can exist at the same time
         let ticks = unsafe {
-            Ticks::from_tick_cells(ticks, self.last_change_tick(), self.read_change_tick())
+            Ticks::from_tick_cells(ticks, self.last_change_tick(), change_tick)
         };
 
         Some(MutUntyped {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1455,9 +1455,7 @@ impl World {
         // SAFETY: This function has exclusive access to the world so nothing aliases `ticks`.
         // - index is in-bounds because the column is initialized and non-empty
         // - no other reference to the ticks of the same row can exist at the same time
-        let ticks = unsafe {
-            Ticks::from_tick_cells(ticks, self.last_change_tick(), change_tick)
-        };
+        let ticks = unsafe { Ticks::from_tick_cells(ticks, self.last_change_tick(), change_tick) };
 
         Some(MutUntyped {
             // SAFETY: This function has exclusive access to the world so nothing aliases `ptr`.


### PR DESCRIPTION
# Objective

- Fixes #6812.

## Solution

- Replaced `World::read_change_ticks` with `World::change_ticks` within `bevy_ecs` crate in places where `World` references were mutable.

---