### PR TITLE
[Merged by Bors] - text aspect ratio bug fix

### DIFF
--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -249,12 +249,7 @@ pub fn flex_node_system(
         for (entity, style, calculated_size) in &query {
             // TODO: remove node from old hierarchy if its root has changed
             if let Some(calculated_size) = calculated_size {
-                flex_surface.upsert_leaf(
-                    entity,
-                    style,
-                    *calculated_size,
-                    scaling_factor,
-                );
+                flex_surface.upsert_leaf(entity, style, *calculated_size, scaling_factor);
             } else {
                 flex_surface.upsert_node(entity, style, scaling_factor);
             }
@@ -262,22 +257,13 @@ pub fn flex_node_system(
     }
 
     if scale_factor_events.iter().next_back().is_some() || ui_scale.is_changed() {
-        update_changed(
-            &mut flex_surface,
-            scale_factor,
-            full_node_query,
-        );
+        update_changed(&mut flex_surface, scale_factor, full_node_query);
     } else {
         update_changed(&mut flex_surface, scale_factor, node_query);
     }
 
     for (entity, style, calculated_size) in &changed_size_query {
-        flex_surface.upsert_leaf(
-            entity,
-            style,
-            *calculated_size,
-            scale_factor,
-        );
+        flex_surface.upsert_leaf(entity, style, *calculated_size, scale_factor);
     }
 
     // clean up removed nodes

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -1,6 +1,6 @@
 mod convert;
 
-use crate::{CalculatedSize, Node, Style, UiScale, UiImage};
+use crate::{CalculatedSize, Node, Style, UiImage, UiScale};
 use bevy_ecs::{
     entity::Entity,
     event::EventReader,
@@ -252,7 +252,13 @@ pub fn flex_node_system(
         for (entity, style, calculated_size) in &query {
             // TODO: remove node from old hierarchy if its root has changed
             if let Some(calculated_size) = calculated_size {
-                flex_surface.upsert_leaf(entity, style, *calculated_size, scaling_factor, image_query.contains(entity));
+                flex_surface.upsert_leaf(
+                    entity,
+                    style,
+                    *calculated_size,
+                    scaling_factor,
+                    image_query.contains(entity),
+                );
             } else {
                 flex_surface.upsert_node(entity, style, scaling_factor);
             }
@@ -260,13 +266,24 @@ pub fn flex_node_system(
     }
 
     if scale_factor_events.iter().next_back().is_some() || ui_scale.is_changed() {
-        update_changed(&mut flex_surface, scale_factor, full_node_query, &image_query);
+        update_changed(
+            &mut flex_surface,
+            scale_factor,
+            full_node_query,
+            &image_query,
+        );
     } else {
         update_changed(&mut flex_surface, scale_factor, node_query, &image_query);
     }
 
     for (entity, style, calculated_size) in &changed_size_query {
-        flex_surface.upsert_leaf(entity, style, *calculated_size, scale_factor, image_query.contains(entity));
+        flex_surface.upsert_leaf(
+            entity,
+            style,
+            *calculated_size,
+            scale_factor,
+            image_query.contains(entity),
+        );
     }
 
     // clean up removed nodes

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -435,7 +435,7 @@ pub struct CalculatedSize {
     /// The size of the node
     pub size: Size,
     /// Whether to attempt to preserve the aspect ratio when determing the layout for this item
-    pub preserve_aspect_ratio: bool
+    pub preserve_aspect_ratio: bool,
 }
 
 /// The background color of the node

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -434,6 +434,8 @@ pub enum FlexWrap {
 pub struct CalculatedSize {
     /// The size of the node
     pub size: Size,
+    /// Whether to preserve the aspect ratio of this item
+    pub preserve_aspect_ratio: bool
 }
 
 /// The background color of the node

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -434,7 +434,7 @@ pub enum FlexWrap {
 pub struct CalculatedSize {
     /// The size of the node
     pub size: Size,
-    /// Whether to preserve the aspect ratio of this item
+    /// Whether to attempt to preserve the aspect ratio when determing the layout for this item
     pub preserve_aspect_ratio: bool
 }
 

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -21,6 +21,7 @@ pub fn update_image_calculated_size_system(
             // Update only if size has changed to avoid needless layout calculations
             if size != calculated_size.size {
                 calculated_size.size = size;
+                calculated_size.preserve_aspect_ratio = true;
             }
         }
     }


### PR DESCRIPTION
## Objective 

Bevy UI uses a `MeasureFunc` that preserves the aspect ratio of text, not just images. This means that the extent of flex-items containing text may be calculated incorrectly depending on the ratio of the text size compared to the size of its containing node.

Fixes #6748 
Related to #6724

with Bevy 0.9:

![Capture_cols_0 9](https://user-images.githubusercontent.com/27962798/205435999-386d3400-fe9b-475a-aab1-18e61c4c074f.PNG)

with this PR (accurately matching the behavior of Flexbox):

![Capture_fixed](https://user-images.githubusercontent.com/27962798/205436005-6bafbcc2-cd87-4eb7-b5c6-9dbcb30fc795.PNG)

## Solution
Only perform the aspect ratio calculations if the uinode contains an image.

## Changelog
* Added a field `preserve_aspect_ratio` to `CalculatedSize`
* The `MeasureFunc` only preserves the aspect ratio when `preserve_aspect_ratio` is true.
* `update_image_calculated_size_system` sets `preserve_aspect_ratio` to true for nodes with images.
