### PR TITLE
[Merged by Bors] - Add reflection support for VecDeque 

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -332,7 +332,7 @@ impl_reflect_for_veclike!(Vec<T>, Vec::push, Vec::pop, [T]);
 impl_reflect_for_veclike!(
     VecDeque<T>,
     VecDeque::push_back,
-    VecDeque::pop_front,
+    VecDeque::pop_back,
     VecDeque::<T>
 );
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -15,8 +15,8 @@ use bevy_utils::{HashMap, HashSet};
 use std::{
     any::Any,
     borrow::Cow,
-    ffi::OsString,
     collections::VecDeque,
+    ffi::OsString,
     hash::{Hash, Hasher},
     num::{
         NonZeroI128, NonZeroI16, NonZeroI32, NonZeroI64, NonZeroI8, NonZeroIsize, NonZeroU128,
@@ -347,6 +347,13 @@ impl<T: FromReflect> Array for VecDeque<T> {
             index: 0,
         }
     }
+
+    #[inline]
+    fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
+        self.into_iter()
+            .map(|value| Box::new(value) as Box<dyn Reflect>)
+            .collect()
+    }
 }
 
 impl<T: FromReflect> List for VecDeque<T> {
@@ -361,6 +368,11 @@ impl<T: FromReflect> List for VecDeque<T> {
         });
         VecDeque::push_back(self, value);
     }
+
+    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
+        self.pop_front()
+            .map(|value| Box::new(value) as Box<dyn Reflect>)
+    }
 }
 
 impl<T: FromReflect> Reflect for VecDeque<T> {
@@ -374,6 +386,14 @@ impl<T: FromReflect> Reflect for VecDeque<T> {
 
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::List(self)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -178,298 +178,163 @@ impl_from_reflect_value!(NonZeroU16);
 impl_from_reflect_value!(NonZeroU8);
 impl_from_reflect_value!(NonZeroI8);
 
-impl<T: FromReflect> Array for Vec<T> {
-    #[inline]
-    fn get(&self, index: usize) -> Option<&dyn Reflect> {
-        <[T]>::get(self, index).map(|value| value as &dyn Reflect)
-    }
-
-    #[inline]
-    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
-        <[T]>::get_mut(self, index).map(|value| value as &mut dyn Reflect)
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        <[T]>::len(self)
-    }
-
-    #[inline]
-    fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
-    }
-
-    #[inline]
-    fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
-        self.into_iter()
-            .map(|value| Box::new(value) as Box<dyn Reflect>)
-            .collect()
-    }
-}
-
-impl<T: FromReflect> List for Vec<T> {
-    fn push(&mut self, value: Box<dyn Reflect>) {
-        let value = value.take::<T>().unwrap_or_else(|value| {
-            T::from_reflect(&*value).unwrap_or_else(|| {
-                panic!(
-                    "Attempted to push invalid value of type {}.",
-                    value.type_name()
-                )
-            })
-        });
-        Vec::push(self, value);
-    }
-
-    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
-        self.pop().map(|value| Box::new(value) as Box<dyn Reflect>)
-    }
-}
-
-impl<T: FromReflect> Reflect for Vec<T> {
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    fn get_type_info(&self) -> &'static TypeInfo {
-        <Self as Typed>::type_info()
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn apply(&mut self, value: &dyn Reflect) {
-        crate::list_apply(self, value);
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::List(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::List(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::List(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(List::clone_dynamic(self))
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        crate::array_hash(self)
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        crate::list_partial_eq(self, value)
-    }
-}
-
-impl<T: FromReflect> Typed for Vec<T> {
-    fn type_info() -> &'static TypeInfo {
-        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T>()))
-    }
-}
-
-impl<T: FromReflect> GetTypeRegistration for Vec<T> {
-    fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Vec<T>>();
-        registration.insert::<ReflectFromPtr>(FromType::<Vec<T>>::from_type());
-        registration
-    }
-}
-
-impl<T: FromReflect> FromReflect for Vec<T> {
-    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
-            let mut new_list = Self::with_capacity(ref_list.len());
-            for field in ref_list.iter() {
-                new_list.push(T::from_reflect(field)?);
+macro_rules! impl_reflect_for_veclike {
+    ($ty:ty, $push:expr, $pop:expr, $sub:ty) => {
+        impl<T: FromReflect> Array for $ty {
+            #[inline]
+            fn get(&self, index: usize) -> Option<&dyn Reflect> {
+                <$sub>::get(self, index).map(|value| value as &dyn Reflect)
             }
-            Some(new_list)
-        } else {
-            None
-        }
-    }
-}
 
-impl<T: FromReflect> Array for VecDeque<T> {
-    #[inline]
-    fn get(&self, index: usize) -> Option<&dyn Reflect> {
-        VecDeque::get(self, index).map(|value| value as &dyn Reflect)
-    }
-
-    #[inline]
-    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
-        VecDeque::get_mut(self, index).map(|value| value as &mut dyn Reflect)
-    }
-
-    #[inline]
-    fn len(&self) -> usize {
-        VecDeque::len(self)
-    }
-
-    #[inline]
-    fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
-    }
-
-    #[inline]
-    fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
-        self.into_iter()
-            .map(|value| Box::new(value) as Box<dyn Reflect>)
-            .collect()
-    }
-}
-
-impl<T: FromReflect> List for VecDeque<T> {
-    fn push(&mut self, value: Box<dyn Reflect>) {
-        let value = value.take::<T>().unwrap_or_else(|value| {
-            T::from_reflect(&*value).unwrap_or_else(|| {
-                panic!(
-                    "Attempted to push invalid value of type {}.",
-                    value.type_name()
-                )
-            })
-        });
-        VecDeque::push_back(self, value);
-    }
-
-    fn pop(&mut self) -> Option<Box<dyn Reflect>> {
-        self.pop_front()
-            .map(|value| Box::new(value) as Box<dyn Reflect>)
-    }
-}
-
-impl<T: FromReflect> Reflect for VecDeque<T> {
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    fn get_type_info(&self) -> &'static TypeInfo {
-        <Self as Typed>::type_info()
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::List(self)
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn apply(&mut self, value: &dyn Reflect) {
-        crate::list_apply(self, value);
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::List(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::List(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(List::clone_dynamic(self))
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        crate::array_hash(self)
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        crate::list_partial_eq(self, value)
-    }
-}
-
-impl<T: FromReflect> Typed for VecDeque<T> {
-    fn type_info() -> &'static TypeInfo {
-        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T>()))
-    }
-}
-
-impl<T: FromReflect> GetTypeRegistration for VecDeque<T> {
-    fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<VecDeque<T>>();
-        registration.insert::<ReflectFromPtr>(FromType::<VecDeque<T>>::from_type());
-        registration
-    }
-}
-
-impl<T: FromReflect> FromReflect for VecDeque<T> {
-    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
-            let mut new_list = Self::with_capacity(ref_list.len());
-            for field in ref_list.iter() {
-                new_list.push_back(T::from_reflect(field)?);
+            #[inline]
+            fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+                <$sub>::get_mut(self, index).map(|value| value as &mut dyn Reflect)
             }
-            Some(new_list)
-        } else {
-            None
+
+            #[inline]
+            fn len(&self) -> usize {
+                <$sub>::len(self)
+            }
+
+            #[inline]
+            fn iter(&self) -> ArrayIter {
+                ArrayIter {
+                    array: self,
+                    index: 0,
+                }
+            }
+
+            #[inline]
+            fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
+                self.into_iter()
+                    .map(|value| Box::new(value) as Box<dyn Reflect>)
+                    .collect()
+            }
         }
-    }
+
+        impl<T: FromReflect> List for $ty {
+            fn push(&mut self, value: Box<dyn Reflect>) {
+                let value = value.take::<T>().unwrap_or_else(|value| {
+                    T::from_reflect(&*value).unwrap_or_else(|| {
+                        panic!(
+                            "Attempted to push invalid value of type {}.",
+                            value.type_name()
+                        )
+                    })
+                });
+                $push(self, value);
+            }
+
+            fn pop(&mut self) -> Option<Box<dyn Reflect>> {
+                $pop(self).map(|value| Box::new(value) as Box<dyn Reflect>)
+            }
+        }
+
+        impl<T: FromReflect> Reflect for $ty {
+            fn type_name(&self) -> &str {
+                std::any::type_name::<Self>()
+            }
+
+            fn get_type_info(&self) -> &'static TypeInfo {
+                <Self as Typed>::type_info()
+            }
+
+            fn into_any(self: Box<Self>) -> Box<dyn Any> {
+                self
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+                self
+            }
+
+            fn as_reflect(&self) -> &dyn Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+                self
+            }
+
+            fn apply(&mut self, value: &dyn Reflect) {
+                crate::list_apply(self, value);
+            }
+
+            fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+                *self = value.take()?;
+                Ok(())
+            }
+
+            fn reflect_ref(&self) -> ReflectRef {
+                ReflectRef::List(self)
+            }
+
+            fn reflect_mut(&mut self) -> ReflectMut {
+                ReflectMut::List(self)
+            }
+
+            fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+                ReflectOwned::List(self)
+            }
+
+            fn clone_value(&self) -> Box<dyn Reflect> {
+                Box::new(List::clone_dynamic(self))
+            }
+
+            fn reflect_hash(&self) -> Option<u64> {
+                crate::array_hash(self)
+            }
+
+            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+                crate::list_partial_eq(self, value)
+            }
+        }
+
+        impl<T: FromReflect> Typed for $ty {
+            fn type_info() -> &'static TypeInfo {
+                static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+                CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T>()))
+            }
+        }
+
+        impl<T: FromReflect> GetTypeRegistration for $ty {
+            fn get_type_registration() -> TypeRegistration {
+                let mut registration = TypeRegistration::of::<Vec<T>>();
+                registration.insert::<ReflectFromPtr>(FromType::<Vec<T>>::from_type());
+                registration
+            }
+        }
+
+        impl<T: FromReflect> FromReflect for $ty {
+            fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+                if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
+                    let mut new_list = Self::with_capacity(ref_list.len());
+                    for field in ref_list.iter() {
+                        $push(&mut new_list, T::from_reflect(field)?);
+                    }
+                    Some(new_list)
+                } else {
+                    None
+                }
+            }
+        }
+    };
 }
+
+impl_reflect_for_veclike!(Vec<T>, Vec::push, Vec::pop, [T]);
+impl_reflect_for_veclike!(
+    VecDeque<T>,
+    VecDeque::push_back,
+    VecDeque::pop_front,
+    VecDeque::<T>
+);
 
 impl<K: FromReflect + Eq + Hash, V: FromReflect> Map for HashMap<K, V> {
     fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {


### PR DESCRIPTION
# Objective
This is an adoption of #5792. Fixes #5791.

## Solution
Implemented all the required reflection traits for `VecDeque`, taking from `Vec`'s impls.

---

## Changelog
Added: `std::collections::VecDeque` now implements `Reflect` and all relevant traits.