### PR TITLE
Added ARRAY_TEXTURES support to shaders.

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -14,13 +14,13 @@ fn fragment(
     @builtin(front_facing) is_front: bool,
     mesh: MeshVertexOutput,
 ) -> @location(0) vec4<f32> {
-    let layer = i32(mesh.world_position.x) & 0x3;
+    let texture_layer = i32(mesh.world_position.x) & 0x3;
 
     // Prepare a 'processed' StandardMaterial by sampling all textures to resolve
     // the material members
     var pbr_input: fns::PbrInput = fns::pbr_input_new();
 
-    pbr_input.material.base_color = textureSample(my_array_texture, my_array_texture_sampler, mesh.uv, layer);
+    pbr_input.material.base_color = textureSample(my_array_texture, my_array_texture_sampler, mesh.uv, texture_layer);
 #ifdef VERTEX_COLORS
     pbr_input.material.base_color = pbr_input.material.base_color * mesh.color;
 #endif

--- a/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
@@ -15,4 +15,7 @@ struct MeshVertexOutput {
     #ifdef VERTEX_COLORS
     @location(4) color: vec4<f32>,
     #endif
+    #ifdef ARRAY_TEXTURES
+    @location(5) texture_layer: i32,
+    #endif
 }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -45,6 +45,9 @@ fn fragment(
             // parallax mapping algorithm easier to understand and reason
             // about.
             -Vt,
+            #ifdef ARRAY_TEXTURES
+                in.texture_layer
+            #endif
         );
     }
 #endif
@@ -55,7 +58,11 @@ fn fragment(
 #endif
 #ifdef VERTEX_UVS
     if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u) {
-        output_color = output_color * textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, uv, view.mip_bias);
+        output_color = output_color * textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, uv,
+        #ifdef ARRAY_TEXTURES
+            in.texture_layer,
+        #endif
+        view.mip_bias);
     }
 #endif
 
@@ -74,7 +81,11 @@ fn fragment(
         var emissive: vec4<f32> = pbr_bindings::material.emissive;
 #ifdef VERTEX_UVS
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_EMISSIVE_TEXTURE_BIT) != 0u) {
-            emissive = vec4<f32>(emissive.rgb * textureSampleBias(pbr_bindings::emissive_texture, pbr_bindings::emissive_sampler, uv, view.mip_bias).rgb, 1.0);
+            emissive = vec4<f32>(emissive.rgb * textureSampleBias(pbr_bindings::emissive_texture, pbr_bindings::emissive_sampler, uv,
+            #ifdef ARRAY_TEXTURES
+                in.texture_layer,
+            #endif
+            view.mip_bias).rgb, 1.0);
         }
 #endif
         pbr_input.material.emissive = emissive;
@@ -83,7 +94,11 @@ fn fragment(
         var perceptual_roughness: f32 = pbr_bindings::material.perceptual_roughness;
 #ifdef VERTEX_UVS
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_METALLIC_ROUGHNESS_TEXTURE_BIT) != 0u) {
-            let metallic_roughness = textureSampleBias(pbr_bindings::metallic_roughness_texture, pbr_bindings::metallic_roughness_sampler, uv, view.mip_bias);
+            let metallic_roughness = textureSampleBias(pbr_bindings::metallic_roughness_texture, pbr_bindings::metallic_roughness_sampler, uv,
+            #ifdef ARRAY_TEXTURES
+                in.texture_layer,
+            #endif
+            view.mip_bias);
             // Sampling from GLTF standard channels for now
             metallic = metallic * metallic_roughness.b;
             perceptual_roughness = perceptual_roughness * metallic_roughness.g;
@@ -96,7 +111,11 @@ fn fragment(
         var occlusion: vec3<f32> = vec3(1.0);
 #ifdef VERTEX_UVS
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_OCCLUSION_TEXTURE_BIT) != 0u) {
-            occlusion = vec3(textureSampleBias(pbr_bindings::occlusion_texture, pbr_bindings::occlusion_sampler, uv, view.mip_bias).r);
+            occlusion = vec3(textureSampleBias(pbr_bindings::occlusion_texture, pbr_bindings::occlusion_sampler, uv, 
+            #ifdef ARRAY_TEXTURES
+                in.texture_layer,
+            #endif
+            view.mip_bias).r);
         }
 #endif
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
@@ -132,6 +151,9 @@ fn fragment(
             uv,
 #endif
             view.mip_bias,
+#ifdef ARRAY_TEXTURES
+            in.texture_layer,
+#endif
         );
 #endif
 

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -4,6 +4,8 @@
 
 @group(1) @binding(0)
 var<uniform> material: StandardMaterial;
+
+#ifndef ARRAY_TEXTURES
 @group(1) @binding(1)
 var base_color_texture: texture_2d<f32>;
 @group(1) @binding(2)
@@ -28,3 +30,29 @@ var normal_map_sampler: sampler;
 var depth_map_texture: texture_2d<f32>;
 @group(1) @binding(12)
 var depth_map_sampler: sampler;
+#else
+@group(1) @binding(1)
+var base_color_texture: texture_2d_array<f32>;
+@group(1) @binding(2)
+var base_color_sampler: sampler;
+@group(1) @binding(3)
+var emissive_texture: texture_2d_array<f32>;
+@group(1) @binding(4)
+var emissive_sampler: sampler;
+@group(1) @binding(5)
+var metallic_roughness_texture: texture_2d_array<f32>;
+@group(1) @binding(6)
+var metallic_roughness_sampler: sampler;
+@group(1) @binding(7)
+var occlusion_texture: texture_2d_array<f32>;
+@group(1) @binding(8)
+var occlusion_sampler: sampler;
+@group(1) @binding(9)
+var normal_map_texture: texture_2d_array<f32>;
+@group(1) @binding(10)
+var normal_map_sampler: sampler;
+@group(1) @binding(11)
+var depth_map_texture: texture_2d_array<f32>;
+@group(1) @binding(12)
+var depth_map_sampler: sampler;
+#endif

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -71,6 +71,9 @@ fn apply_normal_mapping(
     uv: vec2<f32>,
 #endif
     mip_bias: f32,
+#ifdef ARRAY_TEXTURES
+    texture_layer: i32,
+#endif
 ) -> vec3<f32> {
     // NOTE: The mikktspace method of normal mapping explicitly requires that the world normal NOT
     // be re-normalized in the fragment shader. This is primarily to match the way mikktspace
@@ -95,7 +98,11 @@ fn apply_normal_mapping(
 #ifdef VERTEX_UVS
 #ifdef STANDARDMATERIAL_NORMAL_MAP
     // Nt is the tangent-space normal.
-    var Nt = textureSampleBias(pbr_bindings::normal_map_texture, pbr_bindings::normal_map_sampler, uv, mip_bias).rgb;
+    var Nt = textureSampleBias(pbr_bindings::normal_map_texture, pbr_bindings::normal_map_sampler, uv,
+    #ifdef ARRAY_TEXTURES
+        texture_layer,
+    #endif
+    mip_bias).rgb;
     if (standard_material_flags & pbr_types::STANDARD_MATERIAL_FLAGS_TWO_COMPONENT_NORMAL_MAP) != 0u {
         // Only use the xy components and derive z for 2-component normal maps.
         Nt = vec3<f32>(Nt.rg * 2.0 - 1.0, 0.0);


### PR DESCRIPTION
# Objective

I and some other people in the Bevy Discord group use texture arrays. We've had to re-implement all of the pbr functionality to support this, and any change upstream breaks our code.

## Solution

I have added macros that add in/swap out the few lines of code needed to support array textures.
The user still needs to implement a custom material as I haven't added any form of "StandardArrayTextureMaterial". Adding one on top of this isn't hard, but the macro `#[derive(AsBindGroup)]` needs to be fixed. It [tries to set a fallback](https://github.com/bevyengine/bevy/blob/main/crates/bevy_render/macros/src/as_bind_group.rs#L212) texture when one is set to none, and because that fallback texture is not an array texture, wgpu will fail it at validation. My workaround is to set my own fallback textures, rather than using None.

I would fix this myself but I've never written a Proc macro before and I figured I'd see if the shader changes are acceptable before going down that rabbit hole.

---

## Changelog

If you create a custom material, you can add "ARRAY_TEXTURES" to your shader_defs to enable array texture support in the shaders. All textures become array textures and a "texture_layer" variable is added to the `mesh_vertex_output`.

## Migration Guide

Standard shaders still work as expected. No migration is needed.
