### PR TITLE
[Merged by Bors] - Avoid triggering change detection for inputs

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,6 +1,9 @@
 use crate::{Axis, Input};
 use bevy_ecs::event::{EventReader, EventWriter};
-use bevy_ecs::system::{Res, ResMut, Resource};
+use bevy_ecs::{
+    change_detection::DetectChanges,
+    system::{Res, ResMut, Resource},
+};
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 use bevy_utils::{tracing::info, HashMap};
 use thiserror::Error;

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1160,7 +1160,7 @@ pub fn gamepad_event_system(
     mut events: EventWriter<GamepadEvent>,
     settings: Res<GamepadSettings>,
 ) {
-    button_input.clear();
+    button_input.bypass_change_detection().clear();
     for event in raw_events.iter() {
         match &event.event_type {
             GamepadEventType::Connected(_) => {

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -34,6 +34,13 @@ use bevy_ecs::schedule::State;
 /// * Call the [`Input::press`] method for each press event.
 /// * Call the [`Input::release`] method for each release event.
 /// * Call the [`Input::clear`] method at each frame start, before processing events.
+///
+/// Note: Calling `clear` from a [`ResMut`] will tricgger change detection.
+/// It may be preferable to use [`DetectChanges::bypass_change_detection`]
+/// to avoid causing the resource to always be marked as changed.
+///
+///[`ResMut`]: bevy_ecs::system::ResMut
+///[`DetectChanges::bypass_change_detection`]: bevy_ecs::change_detection::DetectChanges::bypass_change_detection
 #[derive(Debug, Clone, Resource, Reflect)]
 #[reflect(Default)]
 pub struct Input<T: Copy + Eq + Hash + Send + Sync + 'static> {
@@ -147,11 +154,6 @@ where
     pub fn clear(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
-    }
-
-    /// Checks if there is nothing activated currently.
-    pub(crate) fn is_empty(&self) -> bool {
-        self.just_pressed.is_empty() && self.just_released.is_empty()
     }
 
     /// An iterator visiting every pressed input in arbitrary order.

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -35,7 +35,7 @@ use bevy_ecs::schedule::State;
 /// * Call the [`Input::release`] method for each release event.
 /// * Call the [`Input::clear`] method at each frame start, before processing events.
 ///
-/// Note: Calling `clear` from a [`ResMut`] will tricgger change detection.
+/// Note: Calling `clear` from a [`ResMut`] will trigger change detection.
 /// It may be preferable to use [`DetectChanges::bypass_change_detection`]
 /// to avoid causing the resource to always be marked as changed.
 ///

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -149,6 +149,11 @@ where
         self.just_released.clear();
     }
 
+    /// Checks if there is nothing activated currently.
+    pub(crate) fn is_empty(&self) -> bool {
+        self.just_pressed.is_empty() && self.just_released.is_empty()
+    }
+
     /// An iterator visiting every pressed input in arbitrary order.
     pub fn get_pressed(&self) -> impl ExactSizeIterator<Item = &T> {
         self.pressed.iter()

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,5 +1,5 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{event::EventReader, system::ResMut};
+use bevy_ecs::{change_detection::DetectChanges, event::EventReader, system::ResMut};
 use bevy_reflect::{FromReflect, Reflect};
 
 #[cfg(feature = "serialize")]

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -42,12 +42,8 @@ pub fn keyboard_input_system(
     mut keyboard_input_events: EventReader<KeyboardInput>,
 ) {
     // Avoid clearing if it's not empty to ensure change detection is not triggered.
-    if !scan_input.is_empty() {
-        scan_input.clear();
-    }
-    if !key_input.is_empty() {
-        key_input.clear();
-    }
+    scan_input.bypass_change_detection().clear();
+    key_input.bypass_change_detection().clear();
     for event in keyboard_input_events.iter() {
         let KeyboardInput {
             scan_code, state, ..

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -41,8 +41,12 @@ pub fn keyboard_input_system(
     mut key_input: ResMut<Input<KeyCode>>,
     mut keyboard_input_events: EventReader<KeyboardInput>,
 ) {
-    scan_input.clear();
-    key_input.clear();
+    if !scan_input.is_empty() {
+        scan_input.clear();
+    }
+    if !key_input.is_empty() {
+        key_input.clear();
+    }
     for event in keyboard_input_events.iter() {
         let KeyboardInput {
             scan_code, state, ..

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -41,6 +41,7 @@ pub fn keyboard_input_system(
     mut key_input: ResMut<Input<KeyCode>>,
     mut keyboard_input_events: EventReader<KeyboardInput>,
 ) {
+    // Avoid clearing if it's not empty to ensure change detection is not triggered.
     if !scan_input.is_empty() {
         scan_input.clear();
     }

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,5 +1,5 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{event::EventReader, system::ResMut};
+use bevy_ecs::{change_detection::DetectChanges, event::EventReader, system::ResMut};
 use bevy_math::Vec2;
 use bevy_reflect::{FromReflect, Reflect};
 

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -132,7 +132,7 @@ pub fn mouse_button_input_system(
     mut mouse_button_input: ResMut<Input<MouseButton>>,
     mut mouse_button_input_events: EventReader<MouseButtonInput>,
 ) {
-    mouse_button_input.clear();
+    mouse_button_input.bypass_change_detection().clear();
     for event in mouse_button_input_events.iter() {
         match event.state {
             ButtonState::Pressed => mouse_button_input.press(event.button),


### PR DESCRIPTION
# Objective
Fix #5292.

## Solution
Avoid derefencing when clearing to ensure that change detection is not triggered when there is nothing to clear.