### PR TITLE
[Merged by Bors] - add rust-version for MSRV and CI job to check

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -17,6 +17,7 @@ status = [
     "build-without-default-features (bevy)",
     "build-without-default-features (bevy_ecs)",
     "build-without-default-features (bevy_reflect)",
+    "msrv",
 ]
 
 use_squash_merge = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,3 +274,29 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Run cargo udeps
         run: cargo udeps
+
+  msrv:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-msrv-${{ hashFiles('**/Cargo.toml') }}
+      - name: get MSRV
+        run: |
+          msrv=`cargo metadata --no-deps --format-version 1 | jq --raw-output '.packages[] | select(.name=="bevy") | .rust_version'`
+          echo "MSRV=$msrv" >> $GITHUB_ENV
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.MSRV }}
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Run cargo check
+        run: cargo check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
-rust-version = "1.65.0"
+rust-version = "1.66.0"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
+rust-version = "1.65.0"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]


### PR DESCRIPTION
# Objective

- Fixes #6777, fixes #2998, replaces #5518
- Help avoid confusing error message when using an older version of Rust

## Solution

- Add the `rust-version` field to `Cargo.toml`
- Add a CI job checking the MSRV
- Add the job to bors

