### PR TITLE
Make font atlas grayscale (v2)

### DIFF
--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -49,6 +49,11 @@ var sprite_sampler: sampler;
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = textureSample(sprite_texture, sprite_sampler, in.uv);
+
+#ifdef TEXT
+    color = vec4(color.r);
+#endif
+
 #ifdef COLORED
     color = in.color * color;
 #endif

--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -37,9 +37,9 @@ impl Font {
             TextureDimension::D2,
             alpha
                 .iter()
-                .flat_map(|a| vec![255, 255, 255, (*a * 255.0) as u8])
+                .flat_map(|a| vec![(*a * 255.0) as u8])
                 .collect::<Vec<u8>>(),
-            TextureFormat::Rgba8UnormSrgb,
+            TextureFormat::R8Unorm,
         )
     }
 }

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -58,8 +58,8 @@ impl FontAtlas {
                 depth_or_array_layers: 1,
             },
             TextureDimension::D2,
-            &[0, 0, 0, 0],
-            TextureFormat::Rgba8UnormSrgb,
+            &[0],
+            TextureFormat::R8Unorm,
         ));
         let texture_atlas = TextureAtlas::new_empty(atlas_texture, size);
         Self {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -138,6 +138,7 @@ pub fn extract_text2d_sprite(
                 flip_x: false,
                 flip_y: false,
                 anchor: Anchor::Center.as_vec(),
+                text: true,
             });
         }
     }

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -62,6 +62,7 @@ impl FromWorld for UiPipeline {
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub hdr: bool,
+    pub text: bool,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -79,7 +80,12 @@ impl SpecializedRenderPipeline for UiPipeline {
                 VertexFormat::Float32x4,
             ],
         );
-        let shader_defs = Vec::new();
+
+        let mut shader_defs = Vec::new();
+
+        if key.text {
+            shader_defs.push("TEXT".into());
+        }
 
         RenderPipelineDescriptor {
             vertex: VertexState {

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -39,6 +39,12 @@ var sprite_sampler: sampler;
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = textureSample(sprite_texture, sprite_sampler, in.uv);
-    color = in.color * color;
+
+    #ifdef TEXT
+        color = in.color * color.r;
+    #else
+        color = in.color * color;
+    #endif
+
     return color;
 }


### PR DESCRIPTION
Alternative of https://github.com/bevyengine/bevy/pull/6708

# Objective

Making font atlas a grayscale texture.

## Solution

The same pipeline was used to draw both text and sprite, which makes using a grayscale font atlas impossible. This PR creates new pipelines (UI and 2D) dedicated for text drawing.