### PR TITLE
[Merged by Bors] - Sprite sheet example: specify animation indices

### DIFF
--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -11,23 +11,30 @@ fn main() {
         .run();
 }
 
+#[derive(Component)]
+struct AnimationIndices {
+    first: usize,
+    last: usize,
+}
+
 #[derive(Component, Deref, DerefMut)]
 struct AnimationTimer(Timer);
 
 fn animate_sprite(
     time: Res<Time>,
-    texture_atlases: Res<Assets<TextureAtlas>>,
     mut query: Query<(
+        &AnimationIndices,
         &mut AnimationTimer,
         &mut TextureAtlasSprite,
-        &Handle<TextureAtlas>,
     )>,
 ) {
-    for (mut timer, mut sprite, texture_atlas_handle) in &mut query {
+    for (indices, mut timer, mut sprite) in &mut query {
         timer.tick(time.delta());
         if timer.just_finished() {
-            let texture_atlas = texture_atlases.get(texture_atlas_handle).unwrap();
-            sprite.index = (sprite.index + 1) % texture_atlas.textures.len();
+            sprite.index = match sprite.index == indices.last {
+                true => indices.first,
+                false => sprite.index + 1,
+            };
         }
     }
 }
@@ -48,6 +55,7 @@ fn setup(
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..default()
         },
+        AnimationIndices { first: 1, last: 6 },
         AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
     ));
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -49,6 +49,7 @@ fn setup(
     let texture_atlas =
         TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1, None, None);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
+    // Use only the subset of sprites in the sheet that make up the run animation
     let animation_indices = AnimationIndices { first: 1, last: 6 };
     commands.spawn(Camera2dBundle::default());
     commands.spawn((

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -52,6 +52,7 @@ fn setup(
     commands.spawn((
         SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
+            sprite: TextureAtlasSprite::new(1),
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..default()
         },

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -31,9 +31,10 @@ fn animate_sprite(
     for (indices, mut timer, mut sprite) in &mut query {
         timer.tick(time.delta());
         if timer.just_finished() {
-            sprite.index = match sprite.index == indices.last {
-                true => indices.first,
-                false => sprite.index + 1,
+            sprite.index = if sprite.index == indices.last {
+                indices.first
+            } else {
+                sprite.index + 1
             };
         }
     }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -49,15 +49,16 @@ fn setup(
     let texture_atlas =
         TextureAtlas::from_grid(texture_handle, Vec2::new(24.0, 24.0), 7, 1, None, None);
     let texture_atlas_handle = texture_atlases.add(texture_atlas);
+    let animation_indices = AnimationIndices { first: 1, last: 6 };
     commands.spawn(Camera2dBundle::default());
     commands.spawn((
         SpriteSheetBundle {
             texture_atlas: texture_atlas_handle,
-            sprite: TextureAtlasSprite::new(1),
+            sprite: TextureAtlasSprite::new(animation_indices.first),
             transform: Transform::from_scale(Vec3::splat(6.0)),
             ..default()
         },
-        AnimationIndices { first: 1, last: 6 },
+        animation_indices,
         AnimationTimer(Timer::from_seconds(0.1, TimerMode::Repeating)),
     ));
 }


### PR DESCRIPTION
# Objective

- Make running animation fluid skipping 'idle' frame.

## Solution

- Loop through the specified indices instead of through the whole sprite sheet.

The example is correct, is just the feeling that the animation loop is not seamless.

Based on the solution suggested by @mockersf in #5429.