### PR TITLE
[Merged by Bors] - unpin miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly-2022-11-28
+  NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
   build:


### PR DESCRIPTION
# Objective

- https://github.com/rust-lang/miri/pull/2713 was merged into miri. See if this fixes miri for bevy.