### PR TITLE
[Merged by Bors] - Document options for !Sync types for Component and Resources

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -127,7 +127,12 @@ use std::{
 /// struct NotSync {
 ///    counter: RefCell<usize>,
 /// }
+/// ```
 ///
+/// ```
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::system::Resource;
+/// # use bevy_utils::synccell::SyncCell;
 /// // This will compile.
 /// #[derive(Component)]
 /// struct ActuallySync {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -117,22 +117,22 @@ use std::{
 /// having mutable access (`&mut T` only, never `&T`), but makes it safe to reference across multiple
 /// threads.
 ///
+/// This will fail to compile since `RefCell` is `!Sync`.
 /// ```compile_fail
 /// # use std::cell::RefCell;
 /// # use bevy_ecs::component::Component;
-/// use bevy_utils::synccell::SyncCell;
-///
-/// // This will fail to compile since RefCell is !Sync.
 /// #[derive(Component)]
 /// struct NotSync {
 ///    counter: RefCell<usize>,
 /// }
 /// ```
 ///
+/// This will compile since the `RefCell` is wrapped with `SyncCell`.
 /// ```
 /// # use std::cell::RefCell;
-/// # use bevy_ecs::system::Resource;
-/// # use bevy_utils::synccell::SyncCell;
+/// # use bevy_ecs::component::Component;
+/// use bevy_utils::synccell::SyncCell;
+///
 /// // This will compile.
 /// #[derive(Component)]
 /// struct ActuallySync {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -110,6 +110,33 @@ use std::{
 ///
 /// [orphan rule]: https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type
 /// [newtype pattern]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types
+///
+/// # `!Sync` Components
+/// A `!Sync` type cannot implement `Component`. However, it is possible to wrap a `Send` but not `Sync`
+/// type in [`SyncCell`] or the currently unstable [`Exclusive`] to make it `Sync`. This forces only
+/// having mutable access (`&mut T` only, never `&T`), but makes it safe to reference across multiple
+/// threads.
+///
+/// ```compile_fail
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::component::Component;
+/// use bevy_utils::synccell::SyncCell;
+///
+/// // This will fail to compile since RefCell is !Sync.
+/// #[derive(Component)]
+/// struct NotSync {
+///    counter: RefCell<usize>,
+/// }
+///
+/// // This will compile.
+/// #[derive(Component)]
+/// struct ActuallySync {
+///    counter: SyncCell<RefCell<usize>>,
+/// }
+/// ```
+///
+/// [`SyncCell`]: bevy_utils::synccell::SyncCell
+/// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
 pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -96,23 +96,23 @@ use std::{
 /// having mutable access (`&mut T` only, never `&T`), but makes it safe to reference across multiple
 /// threads.
 ///
+/// This will fail to compile since `RefCell` is `!Sync`.
 /// ```compile_fail
 /// # use std::cell::RefCell;
 /// # use bevy_ecs::system::Resource;
-/// use bevy_utils::synccell::SyncCell;
 ///
-/// // This will fail to compile since RefCell is !Sync.
 /// #[derive(Resource)]
 /// struct NotSync {
 ///    counter: RefCell<usize>,
 /// }
 /// ```
 ///
+/// This will compile since the `RefCell` is wrapped with `SyncCell`.
 /// ```
 /// # use std::cell::RefCell;
 /// # use bevy_ecs::system::Resource;
-/// # use bevy_utils::synccell::SyncCell;
-/// // This will compile.
+/// use bevy_utils::synccell::SyncCell;
+///
 /// #[derive(Resource)]
 /// struct ActuallySync {
 ///    counter: SyncCell<RefCell<usize>>,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -110,7 +110,12 @@ use std::{
 /// struct NotSync {
 ///    counter: RefCell<usize>,
 /// }
+/// ```
 ///
+/// ```
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::system::Resource;
+/// # use bevy_utils::synccell::SyncCell;
 /// // This will compile.
 /// #[derive(Resource)]
 /// struct ActuallySync {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -93,6 +93,33 @@ use std::{
 ///
 /// This will most commonly occur when working with `SystemParam`s generically, as the requirement
 /// has not been proven to the compiler.
+///
+/// # `!Sync` Resources
+/// A `!Sync` type cannot implement `Resource`. However, it is possible to wrap a `Send` but not `Sync`
+/// type in [`SyncCell`] or the currently unstable [`Exclusive`] to make it `Sync`. This forces only
+/// having mutable access (`&mut T` only, never `&T`), but makes it safe to reference across multiple
+/// threads.
+///
+/// ```compile_fail
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::system::Resource;
+/// use bevy_utils::synccell::SyncCell;
+///
+/// // This will fail to compile since RefCell is !Sync.
+/// #[derive(Resource)]
+/// struct NotSync {
+///    counter: RefCell<usize>,
+/// }
+///
+/// // This will compile.
+/// #[derive(Resource)]
+/// struct ActuallySync {
+///    counter: SyncCell<RefCell<usize>>,
+/// }
+/// ```
+///
+/// [`SyncCell`]: bevy_utils::synccell::SyncCell
+/// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
 pub trait SystemParam: Sized {
     type Fetch: for<'w, 's> SystemParamFetch<'w, 's>;
 }


### PR DESCRIPTION
# Objective
It's not clear to users how to handle `!Sync` types as components and resources in the absence of engine level support for them. 

## Solution
Added a section to `Component`'s and `Resource`'s type level docs on available options for making a type `Sync` when it holds `!Sync` fields, linking `bevy_utils::synccell::SyncCell` and the currently unstable `std::sync::Exclusive`.

Also added a compile_fail doctest that illustrates how to apply `SyncCell`. These will break when/if #6572 gets merged, at which point these docs should be updated.