### PR TITLE
[Merged by Bors] - Simplify trait hierarchy for `SystemParam`

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -241,7 +241,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
             // SAFETY: All parameters are constrained to ReadOnlyState, so World is only read
 
             unsafe impl<'w, 's, #(#param,)*> ReadOnlySystemParam for ParamSet<'w, 's, (#(#param,)*)>
-            where #(#param: SystemParam + ReadOnlySystemParam,)*
+            where #(#param: ReadOnlySystemParam,)*
             { }
 
             // SAFETY: Relevant parameter ComponentId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -216,7 +216,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
         let fn_name = Ident::new(&format!("p{i}"), Span::call_site());
         let index = Index::from(i);
         param_fn_muts.push(quote! {
-            pub fn #fn_name<'a>(&'a mut self) -> <#param::State as SystemParamState>::Item::<'a, 'a> {
+            pub fn #fn_name<'a>(&'a mut self) -> SystemParamItem<'a, 'a, #param> {
                 // SAFETY: systems run without conflicts with other systems.
                 // Conflicting params in ParamSet are not accessible at the same time
                 // ParamSets are guaranteed to not conflict with other SystemParams

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -238,10 +238,10 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                 type State = ParamSetState<(#(#param::State,)*)>;
             }
 
-            // SAFETY: All parameters are constrained to ReadOnlyFetch, so World is only read
+            // SAFETY: All parameters are constrained to ReadOnlyState, so World is only read
 
-            unsafe impl<#(#param_state: SystemParamState,)*> ReadOnlySystemParamFetch for ParamSetState<(#(#param_state,)*)>
-            where #(#param_state: ReadOnlySystemParamFetch,)*
+            unsafe impl<#(#param_state: SystemParamState,)*> ReadOnlySystemParamState for ParamSetState<(#(#param_state,)*)>
+            where #(#param_state: ReadOnlySystemParamState,)*
             { }
 
             // SAFETY: Relevant parameter ComponentId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts
@@ -466,8 +466,8 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 }
             }
 
-            // Safety: The `ParamState` is `ReadOnlySystemParamFetch`, so this can only read from the `World`
-            unsafe impl<TSystemParamState: #path::system::SystemParamState + #path::system::ReadOnlySystemParamFetch, #punctuated_generics> #path::system::ReadOnlySystemParamFetch for FetchState <TSystemParamState, #punctuated_generic_idents> #where_clause {}
+            // Safety: The `ParamState` is `ReadOnlySystemParamState`, so this can only read from the `World`
+            unsafe impl<TSystemParamState: #path::system::SystemParamState + #path::system::ReadOnlySystemParamState, #punctuated_generics> #path::system::ReadOnlySystemParamState for FetchState <TSystemParamState, #punctuated_generic_idents> #where_clause {}
         };
     })
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -209,19 +209,19 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
     let mut tokens = TokenStream::new();
     let max_params = 8;
     let params = get_idents(|i| format!("P{i}"), max_params);
-    let params_fetch = get_idents(|i| format!("PF{i}"), max_params);
+    let params_state = get_idents(|i| format!("PF{i}"), max_params);
     let metas = get_idents(|i| format!("m{i}"), max_params);
     let mut param_fn_muts = Vec::new();
     for (i, param) in params.iter().enumerate() {
         let fn_name = Ident::new(&format!("p{i}"), Span::call_site());
         let index = Index::from(i);
         param_fn_muts.push(quote! {
-            pub fn #fn_name<'a>(&'a mut self) -> <#param::Fetch as SystemParamFetch<'a, 'a>>::Item {
+            pub fn #fn_name<'a>(&'a mut self) -> <#param::State as SystemParamState>::Item::<'a, 'a> {
                 // SAFETY: systems run without conflicts with other systems.
                 // Conflicting params in ParamSet are not accessible at the same time
                 // ParamSets are guaranteed to not conflict with other SystemParams
                 unsafe {
-                    <#param::Fetch as SystemParamFetch<'a, 'a>>::get_param(&mut self.param_states.#index, &self.system_meta, self.world, self.change_tick)
+                    <#param::State as SystemParamState>::get_param(&mut self.param_states.#index, &self.system_meta, self.world, self.change_tick)
                 }
             }
         });
@@ -229,34 +229,36 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
 
     for param_count in 1..=max_params {
         let param = &params[0..param_count];
-        let param_fetch = &params_fetch[0..param_count];
+        let param_state = &params_state[0..param_count];
         let meta = &metas[0..param_count];
         let param_fn_mut = &param_fn_muts[0..param_count];
         tokens.extend(TokenStream::from(quote! {
             impl<'w, 's, #(#param: SystemParam,)*> SystemParam for ParamSet<'w, 's, (#(#param,)*)>
             {
-                type Fetch = ParamSetState<(#(#param::Fetch,)*)>;
+                type State = ParamSetState<(#(#param::State,)*)>;
             }
 
             // SAFETY: All parameters are constrained to ReadOnlyFetch, so World is only read
 
-            unsafe impl<#(#param_fetch: for<'w1, 's1> SystemParamFetch<'w1, 's1>,)*> ReadOnlySystemParamFetch for ParamSetState<(#(#param_fetch,)*)>
-            where #(#param_fetch: ReadOnlySystemParamFetch,)*
+            unsafe impl<#(#param_state: SystemParamState,)*> ReadOnlySystemParamFetch for ParamSetState<(#(#param_state,)*)>
+            where #(#param_state: ReadOnlySystemParamFetch,)*
             { }
 
             // SAFETY: Relevant parameter ComponentId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts
             // with any prior access, a panic will occur.
 
-            unsafe impl<#(#param_fetch: for<'w1, 's1> SystemParamFetch<'w1, 's1>,)*> SystemParamState for ParamSetState<(#(#param_fetch,)*)>
+            unsafe impl<#(#param_state: SystemParamState,)*> SystemParamState for ParamSetState<(#(#param_state,)*)>
             {
+                type Item<'w, 's> = ParamSet<'w, 's, (#(<#param_state as SystemParamState>::Item::<'w, 's>,)*)>;
+
                 fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
                     #(
                         // Pretend to add each param to the system alone, see if it conflicts
                         let mut #meta = system_meta.clone();
                         #meta.component_access_set.clear();
                         #meta.archetype_component_access.clear();
-                        #param_fetch::init(world, &mut #meta);
-                        let #param = #param_fetch::init(world, &mut system_meta.clone());
+                        #param_state::init(world, &mut #meta);
+                        let #param = #param_state::init(world, &mut system_meta.clone());
                     )*
                     #(
                         system_meta
@@ -279,21 +281,14 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                 fn apply(&mut self, world: &mut World) {
                     self.0.apply(world)
                 }
-            }
-
-
-
-            impl<'w, 's, #(#param_fetch: for<'w1, 's1> SystemParamFetch<'w1, 's1>,)*> SystemParamFetch<'w, 's> for ParamSetState<(#(#param_fetch,)*)>
-            {
-                type Item = ParamSet<'w, 's, (#(<#param_fetch as SystemParamFetch<'w, 's>>::Item,)*)>;
 
                 #[inline]
-                unsafe fn get_param(
+                unsafe fn get_param<'w, 's>(
                     state: &'s mut Self,
                     system_meta: &SystemMeta,
                     world: &'w World,
                     change_tick: u32,
-                ) -> Self::Item {
+                ) -> Self::Item<'w, 's> {
                     ParamSet {
                         param_states: &mut state.0,
                         system_meta: system_meta.clone(),

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -5,9 +5,8 @@ use crate::{
     query::Access,
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamFetch,
-        ExclusiveSystemParamItem, ExclusiveSystemParamState, IntoSystem, System, SystemMeta,
-        SystemTypeIdLabel,
+        check_system_change_tick, AsSystemLabel, ExclusiveSystemParam, ExclusiveSystemParamItem,
+        ExclusiveSystemParamState, IntoSystem, System, SystemMeta, SystemTypeIdLabel,
     },
     world::{World, WorldId},
 };
@@ -25,7 +24,7 @@ where
     Param: ExclusiveSystemParam,
 {
     func: F,
-    param_state: Option<Param::Fetch>,
+    param_state: Option<Param::State>,
     system_meta: SystemMeta,
     world_id: Option<WorldId>,
     // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
@@ -95,7 +94,7 @@ where
         let saved_last_tick = world.last_change_tick;
         world.last_change_tick = self.system_meta.last_change_tick;
 
-        let params = <Param as ExclusiveSystemParam>::Fetch::get_param(
+        let params = <Param as ExclusiveSystemParam>::State::get_param(
             self.param_state.as_mut().expect(PARAM_MESSAGE),
             &self.system_meta,
         );
@@ -130,7 +129,7 @@ where
     fn initialize(&mut self, world: &mut World) {
         self.world_id = Some(world.id());
         self.system_meta.last_change_tick = world.change_tick().wrapping_sub(MAX_CHANGE_AGE);
-        self.param_state = Some(<Param::Fetch as ExclusiveSystemParamState>::init(
+        self.param_state = Some(<Param::State as ExclusiveSystemParamState>::init(
             world,
             &mut self.system_meta,
         ));

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -15,10 +15,8 @@ pub type ExclusiveSystemParamItem<'s, P> =
     <<P as ExclusiveSystemParam>::State as ExclusiveSystemParamState>::Item<'s>;
 
 /// The state of a [`SystemParam`].
-pub trait ExclusiveSystemParamState: Send + Sync {
-    type Item<'s>: ExclusiveSystemParam<State = Self>
-    where
-        Self: 's;
+pub trait ExclusiveSystemParamState: Send + Sync + 'static {
+    type Item<'s>: ExclusiveSystemParam<State = Self>;
 
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self;
     #[inline]
@@ -88,7 +86,7 @@ macro_rules! impl_exclusive_system_param_tuple {
         #[allow(unused_variables)]
         #[allow(non_snake_case)]
         impl<$($param: ExclusiveSystemParamState),*> ExclusiveSystemParamState for ($($param,)*) {
-            type Item<'s> = ($($param::Item<'s>,)*) where Self: 's;
+            type Item<'s> = ($($param::Item<'s>,)*);
 
             #[inline]
             fn init(_world: &mut World, _system_meta: &mut SystemMeta) -> Self {

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -8,111 +8,88 @@ use bevy_ecs_macros::all_tuples;
 use bevy_utils::synccell::SyncCell;
 
 pub trait ExclusiveSystemParam: Sized {
-    type Fetch: for<'s> ExclusiveSystemParamFetch<'s>;
+    type State: ExclusiveSystemParamState;
 }
 
 pub type ExclusiveSystemParamItem<'s, P> =
-    <<P as ExclusiveSystemParam>::Fetch as ExclusiveSystemParamFetch<'s>>::Item;
+    <<P as ExclusiveSystemParam>::State as ExclusiveSystemParamState>::Item<'s>;
 
 /// The state of a [`SystemParam`].
 pub trait ExclusiveSystemParamState: Send + Sync {
+    type Item<'s>: ExclusiveSystemParam<State = Self>
+    where
+        Self: 's;
+
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self;
     #[inline]
     fn apply(&mut self, _world: &mut World) {}
-}
 
-pub trait ExclusiveSystemParamFetch<'state>: ExclusiveSystemParamState {
-    type Item: ExclusiveSystemParam<Fetch = Self>;
-    fn get_param(state: &'state mut Self, system_meta: &SystemMeta) -> Self::Item;
+    fn get_param<'s>(state: &'s mut Self, system_meta: &SystemMeta) -> Self::Item<'s>;
 }
 
 impl<'a, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParam
     for &'a mut QueryState<Q, F>
 {
-    type Fetch = QueryState<Q, F>;
-}
-
-impl<'s, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParamFetch<'s>
-    for QueryState<Q, F>
-{
-    type Item = &'s mut QueryState<Q, F>;
-
-    fn get_param(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item {
-        state
-    }
+    type State = QueryState<Q, F>;
 }
 
 impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParamState
     for QueryState<Q, F>
 {
+    type Item<'s> = &'s mut QueryState<Q, F>;
+
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {
         QueryState::new(world)
     }
-}
 
-impl<'a, P: SystemParam + 'static> ExclusiveSystemParam for &'a mut SystemState<P> {
-    type Fetch = SystemState<P>;
-}
-
-impl<'s, P: SystemParam + 'static> ExclusiveSystemParamFetch<'s> for SystemState<P> {
-    type Item = &'s mut SystemState<P>;
-
-    fn get_param(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item {
+    fn get_param<'s>(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item<'s> {
         state
     }
 }
 
+impl<'a, P: SystemParam + 'static> ExclusiveSystemParam for &'a mut SystemState<P> {
+    type State = SystemState<P>;
+}
+
 impl<P: SystemParam> ExclusiveSystemParamState for SystemState<P> {
+    type Item<'s> = &'s mut SystemState<P>;
+
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {
         SystemState::new(world)
+    }
+
+    fn get_param<'s>(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item<'s> {
+        state
     }
 }
 
 impl<'s, T: FromWorld + Send + Sync + 'static> ExclusiveSystemParam for Local<'s, T> {
-    type Fetch = LocalState<T>;
-}
-
-impl<'s, T: FromWorld + Send + Sync + 'static> ExclusiveSystemParamFetch<'s> for LocalState<T> {
-    type Item = Local<'s, T>;
-
-    fn get_param(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item {
-        Local(state.0.get())
-    }
+    type State = LocalState<T>;
 }
 
 impl<T: FromWorld + Send + Sync> ExclusiveSystemParamState for LocalState<T> {
+    type Item<'s> = Local<'s, T>;
+
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {
         Self(SyncCell::new(T::from_world(world)))
+    }
+
+    fn get_param<'s>(state: &'s mut Self, _system_meta: &SystemMeta) -> Self::Item<'s> {
+        Local(state.0.get())
     }
 }
 
 macro_rules! impl_exclusive_system_param_tuple {
     ($($param: ident),*) => {
         impl<$($param: ExclusiveSystemParam),*> ExclusiveSystemParam for ($($param,)*) {
-            type Fetch = ($($param::Fetch,)*);
+            type State = ($($param::State,)*);
         }
 
         #[allow(unused_variables)]
         #[allow(non_snake_case)]
-        impl<'s, $($param: ExclusiveSystemParamFetch<'s>),*> ExclusiveSystemParamFetch<'s> for ($($param,)*) {
-            type Item = ($($param::Item,)*);
-
-            #[inline]
-            #[allow(clippy::unused_unit)]
-            fn get_param(
-                state: &'s mut Self,
-                system_meta: &SystemMeta,
-            ) -> Self::Item {
-
-                let ($($param,)*) = state;
-                ($($param::get_param($param, system_meta),)*)
-            }
-        }
-
-        // SAFETY: implementors of each `ExclusiveSystemParamState` in the tuple have validated their impls
-        #[allow(clippy::undocumented_unsafe_blocks)] // false positive by clippy
-        #[allow(non_snake_case)]
         impl<$($param: ExclusiveSystemParamState),*> ExclusiveSystemParamState for ($($param,)*) {
+            type Item<'s> = ($($param::Item<'s>,)*) where Self: 's;
+
             #[inline]
             fn init(_world: &mut World, _system_meta: &mut SystemMeta) -> Self {
                 (($($param::init(_world, _system_meta),)*))
@@ -123,7 +100,19 @@ macro_rules! impl_exclusive_system_param_tuple {
                 let ($($param,)*) = self;
                 $($param.apply(_world);)*
             }
+
+            #[inline]
+            #[allow(clippy::unused_unit)]
+            fn get_param<'s>(
+                state: &'s mut Self,
+                system_meta: &SystemMeta,
+            ) -> Self::Item<'s> {
+
+                let ($($param,)*) = state;
+                ($($param::get_param($param, system_meta),)*)
+            }
         }
+
     };
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -6,7 +6,7 @@ use crate::{
     query::{Access, FilteredAccessSet},
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, ReadOnlySystemParamState, System, SystemParam, SystemParamItem,
+        check_system_change_tick, ReadOnlySystemParam, System, SystemParam, SystemParamItem,
         SystemParamState,
     },
     world::{World, WorldId},
@@ -162,7 +162,7 @@ impl<Param: SystemParam> SystemState<Param> {
     #[inline]
     pub fn get<'w, 's>(&'s mut self, world: &'w World) -> SystemParamItem<'w, 's, Param>
     where
-        Param::State: ReadOnlySystemParamState,
+        Param: ReadOnlySystemParam,
     {
         self.validate_world_and_update_archetypes(world);
         // SAFETY: Param is read-only and doesn't allow mutable access to World. It also matches the World this SystemState was created with.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -6,7 +6,7 @@ use crate::{
     query::{Access, FilteredAccessSet},
     schedule::{SystemLabel, SystemLabelId},
     system::{
-        check_system_change_tick, ReadOnlySystemParamFetch, System, SystemParam, SystemParamItem,
+        check_system_change_tick, ReadOnlySystemParamState, System, SystemParam, SystemParamItem,
         SystemParamState,
     },
     world::{World, WorldId},
@@ -165,7 +165,7 @@ impl<Param: SystemParam> SystemState<Param> {
         world: &'w World,
     ) -> <Param::State as SystemParamState>::Item<'w, 's>
     where
-        Param::State: ReadOnlySystemParamFetch,
+        Param::State: ReadOnlySystemParamState,
     {
         self.validate_world_and_update_archetypes(world);
         // SAFETY: Param is read-only and doesn't allow mutable access to World. It also matches the World this SystemState was created with.

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -127,7 +127,7 @@ pub unsafe trait SystemParamState: Send + Sync + 'static {
 ///
 /// # Safety
 /// This must only be implemented for [`SystemParam`] impls that exclusively read the World passed in to [`SystemParamState::get_param`]
-pub unsafe trait ReadOnlySystemParam {}
+pub unsafe trait ReadOnlySystemParam: SystemParam {}
 
 impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParam
     for Query<'w, 's, Q, F>
@@ -136,8 +136,8 @@ impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPar
 }
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
-unsafe impl<'w, 's, Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParam
-    for Query<'w, 's, Q, F>
+unsafe impl<'w, 's, Q: ReadOnlyWorldQuery + 'static, F: ReadOnlyWorldQuery + 'static>
+    ReadOnlySystemParam for Query<'w, 's, Q, F>
 {
 }
 
@@ -1555,7 +1555,7 @@ impl<'w, 's, P: SystemParam> StaticSystemParam<'w, 's, P> {
 pub struct StaticSystemParamState<S, P>(S, PhantomData<fn() -> P>);
 
 // SAFETY: This doesn't add any more reads, and the delegated fetch confirms it
-unsafe impl<'w, 's, P: SystemParam + ReadOnlySystemParam> ReadOnlySystemParam
+unsafe impl<'w, 's, P: ReadOnlySystemParam + 'static> ReadOnlySystemParam
     for StaticSystemParam<'w, 's, P>
 {
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1555,7 +1555,10 @@ impl<'w, 's, P: SystemParam> StaticSystemParam<'w, 's, P> {
 pub struct StaticSystemParamState<S, P>(S, PhantomData<fn() -> P>);
 
 // SAFETY: This doesn't add any more reads, and the delegated fetch confirms it
-unsafe impl<S, P: ReadOnlySystemParam> ReadOnlySystemParam for StaticSystemParamState<S, P> {}
+unsafe impl<'w, 's, P: SystemParam + ReadOnlySystemParam> ReadOnlySystemParam
+    for StaticSystemParam<'w, 's, P>
+{
+}
 
 impl<'world, 'state, P: SystemParam + 'static> SystemParam
     for StaticSystemParam<'world, 'state, P>

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -123,11 +123,11 @@ pub unsafe trait SystemParamState: Send + Sync + 'static {
     ) -> Self::Item<'world, 'state>;
 }
 
-/// A [`SystemParamState`] that only reads a given [`World`].
+/// A [`SystemParam`] that only reads a given [`World`].
 ///
 /// # Safety
-/// This must only be implemented for [`SystemParamState`] impls that exclusively read the World passed in to [`SystemParamState::get_param`]
-pub unsafe trait ReadOnlySystemParamState {}
+/// This must only be implemented for [`SystemParam`] impls that exclusively read the World passed in to [`SystemParamState::get_param`]
+pub unsafe trait ReadOnlySystemParam {}
 
 impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParam
     for Query<'w, 's, Q, F>
@@ -136,8 +136,8 @@ impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPar
 }
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
-unsafe impl<Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParamState
-    for QueryState<Q, F>
+unsafe impl<'w, 's, Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParam
+    for Query<'w, 's, Q, F>
 {
 }
 
@@ -270,7 +270,7 @@ pub struct Res<'w, T: Resource> {
 }
 
 // SAFETY: Res only reads a single World resource
-unsafe impl<T: Resource> ReadOnlySystemParamState for ResState<T> {}
+unsafe impl<'w, T: Resource> ReadOnlySystemParam for Res<'w, T> {}
 
 impl<'w, T: Resource> Debug for Res<'w, T>
 where
@@ -427,7 +427,7 @@ impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
 }
 
 // SAFETY: Only reads a single World resource
-unsafe impl<T: Resource> ReadOnlySystemParamState for OptionResState<T> {}
+unsafe impl<'a, T: Resource> ReadOnlySystemParam for Option<Res<'a, T>> {}
 
 // SAFETY: this impl defers to `ResState`, which initializes
 // and validates the correct world access
@@ -573,7 +573,7 @@ impl<'w, 's> SystemParam for Commands<'w, 's> {
 }
 
 // SAFETY: Commands only accesses internal state
-unsafe impl ReadOnlySystemParamState for CommandQueue {}
+unsafe impl<'w, 's> ReadOnlySystemParam for Commands<'w, 's> {}
 
 // SAFETY: only local state is accessed
 unsafe impl SystemParamState for CommandQueue {
@@ -599,7 +599,7 @@ unsafe impl SystemParamState for CommandQueue {
 }
 
 /// SAFETY: only reads world
-unsafe impl ReadOnlySystemParamState for WorldState {}
+unsafe impl<'w> ReadOnlySystemParam for &'w World {}
 
 /// The [`SystemParamState`] of [`&World`](crate::world::World).
 #[doc(hidden)]
@@ -695,7 +695,7 @@ unsafe impl SystemParamState for WorldState {
 pub struct Local<'a, T: FromWorld + Send + 'static>(pub(crate) &'a mut T);
 
 // SAFETY: Local only accesses internal state
-unsafe impl<T: Send + 'static> ReadOnlySystemParamState for LocalState<T> {}
+unsafe impl<'a, T: FromWorld + Send + 'static> ReadOnlySystemParam for Local<'a, T> {}
 
 impl<'a, T: FromWorld + Send + Sync + 'static> Debug for Local<'a, T>
 where
@@ -830,7 +830,7 @@ impl<'a, T: Component> IntoIterator for &'a RemovedComponents<'a, T> {
 }
 
 // SAFETY: Only reads World components
-unsafe impl<T: Component> ReadOnlySystemParamState for RemovedComponentsState<T> {}
+unsafe impl<'a, T: Component> ReadOnlySystemParam for RemovedComponents<'a, T> {}
 
 /// The [`SystemParamState`] of [`RemovedComponents<T>`].
 #[doc(hidden)]
@@ -890,7 +890,7 @@ pub struct NonSend<'w, T: 'static> {
 }
 
 // SAFETY: Only reads a single World non-send resource
-unsafe impl<T> ReadOnlySystemParamState for NonSendState<T> {}
+unsafe impl<'w, T> ReadOnlySystemParam for NonSend<'w, T> {}
 
 impl<'w, T> Debug for NonSend<'w, T>
 where
@@ -1015,7 +1015,7 @@ impl<'w, T: 'static> SystemParam for Option<NonSend<'w, T>> {
 }
 
 // SAFETY: Only reads a single non-send resource
-unsafe impl<T: 'static> ReadOnlySystemParamState for OptionNonSendState<T> {}
+unsafe impl<'w, T: 'static> ReadOnlySystemParam for Option<NonSend<'w, T>> {}
 
 // SAFETY: this impl defers to `NonSendState`, which initializes
 // and validates the correct world access
@@ -1155,7 +1155,7 @@ impl<'a> SystemParam for &'a Archetypes {
 }
 
 // SAFETY: Only reads World archetypes
-unsafe impl ReadOnlySystemParamState for ArchetypesState {}
+unsafe impl<'a> ReadOnlySystemParam for &'a Archetypes {}
 
 /// The [`SystemParamState`] of [`Archetypes`].
 #[doc(hidden)]
@@ -1185,7 +1185,7 @@ impl<'a> SystemParam for &'a Components {
 }
 
 // SAFETY: Only reads World components
-unsafe impl ReadOnlySystemParamState for ComponentsState {}
+unsafe impl<'a> ReadOnlySystemParam for &'a Components {}
 
 /// The [`SystemParamState`] of [`Components`].
 #[doc(hidden)]
@@ -1215,7 +1215,7 @@ impl<'a> SystemParam for &'a Entities {
 }
 
 // SAFETY: Only reads World entities
-unsafe impl ReadOnlySystemParamState for EntitiesState {}
+unsafe impl<'a> ReadOnlySystemParam for &'a Entities {}
 
 /// The [`SystemParamState`] of [`Entities`].
 #[doc(hidden)]
@@ -1245,7 +1245,7 @@ impl<'a> SystemParam for &'a Bundles {
 }
 
 // SAFETY: Only reads World bundles
-unsafe impl ReadOnlySystemParamState for BundlesState {}
+unsafe impl<'a> ReadOnlySystemParam for &'a Bundles {}
 
 /// The [`SystemParamState`] of [`Bundles`].
 #[doc(hidden)]
@@ -1300,7 +1300,7 @@ impl SystemChangeTick {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl ReadOnlySystemParamState for SystemChangeTickState {}
+unsafe impl ReadOnlySystemParam for SystemChangeTick {}
 
 impl SystemParam for SystemChangeTick {
     type State = SystemChangeTickState;
@@ -1383,7 +1383,7 @@ impl<'s> SystemParam for SystemName<'s> {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl ReadOnlySystemParamState for SystemNameState {}
+unsafe impl<'s> ReadOnlySystemParam for SystemName<'s> {}
 
 /// The [`SystemParamState`] of [`SystemName`].
 #[doc(hidden)]
@@ -1420,8 +1420,8 @@ macro_rules! impl_system_param_tuple {
             type State = ($($param::State,)*);
         }
 
-        // SAFETY: tuple consists only of ReadOnlySystemParamStates
-        unsafe impl<$($param: ReadOnlySystemParamState),*> ReadOnlySystemParamState for ($($param,)*) {}
+        // SAFETY: tuple consists only of ReadOnlySystemParams
+        unsafe impl<$($param: ReadOnlySystemParam),*> ReadOnlySystemParam for ($($param,)*) {}
 
 
         // SAFETY: implementors of each `SystemParamState` in the tuple have validated their impls
@@ -1555,10 +1555,7 @@ impl<'w, 's, P: SystemParam> StaticSystemParam<'w, 's, P> {
 pub struct StaticSystemParamState<S, P>(S, PhantomData<fn() -> P>);
 
 // SAFETY: This doesn't add any more reads, and the delegated fetch confirms it
-unsafe impl<S: ReadOnlySystemParamState, P> ReadOnlySystemParamState
-    for StaticSystemParamState<S, P>
-{
-}
+unsafe impl<S, P: ReadOnlySystemParam> ReadOnlySystemParam for StaticSystemParamState<S, P> {}
 
 impl<'world, 'state, P: SystemParam + 'static> SystemParam
     for StaticSystemParam<'world, 'state, P>

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -123,11 +123,11 @@ pub unsafe trait SystemParamState: Send + Sync + 'static {
     ) -> Self::Item<'world, 'state>;
 }
 
-/// A [`SystemParamFetch`] that only reads a given [`World`].
+/// A [`SystemParamState`] that only reads a given [`World`].
 ///
 /// # Safety
 /// This must only be implemented for [`SystemParamState`] impls that exclusively read the World passed in to [`SystemParamState::get_param`]
-pub unsafe trait ReadOnlySystemParamFetch {}
+pub unsafe trait ReadOnlySystemParamState {}
 
 impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParam
     for Query<'w, 's, Q, F>
@@ -136,7 +136,7 @@ impl<'w, 's, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPar
 }
 
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
-unsafe impl<Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParamFetch
+unsafe impl<Q: ReadOnlyWorldQuery, F: ReadOnlyWorldQuery> ReadOnlySystemParamState
     for QueryState<Q, F>
 {
 }
@@ -270,7 +270,7 @@ pub struct Res<'w, T: Resource> {
 }
 
 // SAFETY: Res only reads a single World resource
-unsafe impl<T: Resource> ReadOnlySystemParamFetch for ResState<T> {}
+unsafe impl<T: Resource> ReadOnlySystemParamState for ResState<T> {}
 
 impl<'w, T: Resource> Debug for Res<'w, T>
 where
@@ -427,7 +427,7 @@ impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
 }
 
 // SAFETY: Only reads a single World resource
-unsafe impl<T: Resource> ReadOnlySystemParamFetch for OptionResState<T> {}
+unsafe impl<T: Resource> ReadOnlySystemParamState for OptionResState<T> {}
 
 // SAFETY: this impl defers to `ResState`, which initializes
 // and validates the correct world access
@@ -573,7 +573,7 @@ impl<'w, 's> SystemParam for Commands<'w, 's> {
 }
 
 // SAFETY: Commands only accesses internal state
-unsafe impl ReadOnlySystemParamFetch for CommandQueue {}
+unsafe impl ReadOnlySystemParamState for CommandQueue {}
 
 // SAFETY: only local state is accessed
 unsafe impl SystemParamState for CommandQueue {
@@ -599,7 +599,7 @@ unsafe impl SystemParamState for CommandQueue {
 }
 
 /// SAFETY: only reads world
-unsafe impl ReadOnlySystemParamFetch for WorldState {}
+unsafe impl ReadOnlySystemParamState for WorldState {}
 
 /// The [`SystemParamState`] of [`&World`](crate::world::World).
 #[doc(hidden)]
@@ -695,7 +695,7 @@ unsafe impl SystemParamState for WorldState {
 pub struct Local<'a, T: FromWorld + Send + 'static>(pub(crate) &'a mut T);
 
 // SAFETY: Local only accesses internal state
-unsafe impl<T: Send + 'static> ReadOnlySystemParamFetch for LocalState<T> {}
+unsafe impl<T: Send + 'static> ReadOnlySystemParamState for LocalState<T> {}
 
 impl<'a, T: FromWorld + Send + Sync + 'static> Debug for Local<'a, T>
 where
@@ -830,7 +830,7 @@ impl<'a, T: Component> IntoIterator for &'a RemovedComponents<'a, T> {
 }
 
 // SAFETY: Only reads World components
-unsafe impl<T: Component> ReadOnlySystemParamFetch for RemovedComponentsState<T> {}
+unsafe impl<T: Component> ReadOnlySystemParamState for RemovedComponentsState<T> {}
 
 /// The [`SystemParamState`] of [`RemovedComponents<T>`].
 #[doc(hidden)]
@@ -890,7 +890,7 @@ pub struct NonSend<'w, T: 'static> {
 }
 
 // SAFETY: Only reads a single World non-send resource
-unsafe impl<T> ReadOnlySystemParamFetch for NonSendState<T> {}
+unsafe impl<T> ReadOnlySystemParamState for NonSendState<T> {}
 
 impl<'w, T> Debug for NonSend<'w, T>
 where
@@ -1015,7 +1015,7 @@ impl<'w, T: 'static> SystemParam for Option<NonSend<'w, T>> {
 }
 
 // SAFETY: Only reads a single non-send resource
-unsafe impl<T: 'static> ReadOnlySystemParamFetch for OptionNonSendState<T> {}
+unsafe impl<T: 'static> ReadOnlySystemParamState for OptionNonSendState<T> {}
 
 // SAFETY: this impl defers to `NonSendState`, which initializes
 // and validates the correct world access
@@ -1155,7 +1155,7 @@ impl<'a> SystemParam for &'a Archetypes {
 }
 
 // SAFETY: Only reads World archetypes
-unsafe impl ReadOnlySystemParamFetch for ArchetypesState {}
+unsafe impl ReadOnlySystemParamState for ArchetypesState {}
 
 /// The [`SystemParamState`] of [`Archetypes`].
 #[doc(hidden)]
@@ -1185,7 +1185,7 @@ impl<'a> SystemParam for &'a Components {
 }
 
 // SAFETY: Only reads World components
-unsafe impl ReadOnlySystemParamFetch for ComponentsState {}
+unsafe impl ReadOnlySystemParamState for ComponentsState {}
 
 /// The [`SystemParamState`] of [`Components`].
 #[doc(hidden)]
@@ -1215,7 +1215,7 @@ impl<'a> SystemParam for &'a Entities {
 }
 
 // SAFETY: Only reads World entities
-unsafe impl ReadOnlySystemParamFetch for EntitiesState {}
+unsafe impl ReadOnlySystemParamState for EntitiesState {}
 
 /// The [`SystemParamState`] of [`Entities`].
 #[doc(hidden)]
@@ -1245,7 +1245,7 @@ impl<'a> SystemParam for &'a Bundles {
 }
 
 // SAFETY: Only reads World bundles
-unsafe impl ReadOnlySystemParamFetch for BundlesState {}
+unsafe impl ReadOnlySystemParamState for BundlesState {}
 
 /// The [`SystemParamState`] of [`Bundles`].
 #[doc(hidden)]
@@ -1300,7 +1300,7 @@ impl SystemChangeTick {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl ReadOnlySystemParamFetch for SystemChangeTickState {}
+unsafe impl ReadOnlySystemParamState for SystemChangeTickState {}
 
 impl SystemParam for SystemChangeTick {
     type State = SystemChangeTickState;
@@ -1383,7 +1383,7 @@ impl<'s> SystemParam for SystemName<'s> {
 }
 
 // SAFETY: Only reads internal system state
-unsafe impl ReadOnlySystemParamFetch for SystemNameState {}
+unsafe impl ReadOnlySystemParamState for SystemNameState {}
 
 /// The [`SystemParamState`] of [`SystemName`].
 #[doc(hidden)]
@@ -1420,8 +1420,8 @@ macro_rules! impl_system_param_tuple {
             type State = ($($param::State,)*);
         }
 
-        // SAFETY: tuple consists only of ReadOnlySystemParamFetches
-        unsafe impl<$($param: ReadOnlySystemParamFetch),*> ReadOnlySystemParamFetch for ($($param,)*) {}
+        // SAFETY: tuple consists only of ReadOnlySystemParamStates
+        unsafe impl<$($param: ReadOnlySystemParamState),*> ReadOnlySystemParamState for ($($param,)*) {}
 
 
         // SAFETY: implementors of each `SystemParamState` in the tuple have validated their impls
@@ -1556,7 +1556,7 @@ impl<'w, 's, P: SystemParam> StaticSystemParam<'w, 's, P> {
 pub struct StaticSystemParamState<S, P>(S, PhantomData<fn() -> P>);
 
 // SAFETY: This doesn't add any more reads, and the delegated fetch confirms it
-unsafe impl<S: ReadOnlySystemParamFetch, P> ReadOnlySystemParamFetch
+unsafe impl<S: ReadOnlySystemParamState, P> ReadOnlySystemParamState
     for StaticSystemParamState<S, P>
 {
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -72,7 +72,7 @@ use std::{
 ///
 /// ```text
 /// expected ... [ParamType]
-/// found associated type `<<[ParamType] as SystemParam>::Fetch as SystemParamFetch<'_, '_>>::Item`
+/// found associated type `<<[ParamType] as SystemParam>::State as SystemParamState>::Item<'_, '_>`
 /// ```
 /// where `[ParamType]` is the type of one of your fields.
 /// To solve this error, you can wrap the field of type `[ParamType]` with [`StaticSystemParam`]
@@ -81,7 +81,7 @@ use std::{
 /// ## Details
 ///
 /// The derive macro requires that the [`SystemParam`] implementation of
-/// each field `F`'s [`Fetch`](`SystemParam::Fetch`)'s [`Item`](`SystemParamFetch::Item`) is itself `F`
+/// each field `F`'s [`State`](`SystemParam::State`)'s [`Item`](`SystemParamState::Item`) is itself `F`
 /// (ignoring lifetimes for simplicity).
 /// This assumption is due to type inference reasons, so that the derived [`SystemParam`] can be
 /// used as an argument to a function system.
@@ -100,7 +100,7 @@ pub type SystemParamItem<'w, 's, P> = <<P as SystemParam>::State as SystemParamS
 /// # Safety
 ///
 /// It is the implementor's responsibility to ensure `system_meta` is populated with the _exact_
-/// [`World`] access used by the [`SystemParamState`] (and associated [`SystemParamFetch`]).
+/// [`World`] access used by the [`SystemParamState`].
 /// Additionally, it is the implementor's responsibility to ensure there is no
 /// conflicting access across all [`SystemParam`]'s.
 pub unsafe trait SystemParamState: Send + Sync + 'static {
@@ -1478,7 +1478,7 @@ pub mod lifetimeless {
 /// A helper for using system parameters in generic contexts
 ///
 /// This type is a [`SystemParam`] adapter which always has
-/// `Self::Fetch::Item == Self` (ignoring lifetimes for brevity),
+/// `Self::State::Item == Self` (ignoring lifetimes for brevity),
 /// no matter the argument [`SystemParam`] (`P`) (other than
 /// that `P` must be `'static`)
 ///
@@ -1517,7 +1517,7 @@ pub mod lifetimeless {
 /// fn do_thing_generically<T: SystemParam + 'static>(t: T) {}
 ///
 /// #[derive(SystemParam)]
-/// struct GenericParam<'w,'s, T: SystemParam> {
+/// struct GenericParam<'w, 's, T: SystemParam> {
 ///     field: T,
 ///     #[system_param(ignore)]
 ///     // Use the lifetimes in this type, or they will be unbound.

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use bevy_ecs::system::{ReadOnlySystemParamState, SystemParam, SystemState};
+use bevy_ecs::system::{ReadOnlySystemParam, SystemParam, SystemState};
 
 #[derive(Component)]
 struct Foo;
@@ -20,6 +20,6 @@ fn main() {
 
 fn assert_readonly<P: SystemParam>()
 where
-    <P as SystemParam>::State: ReadOnlySystemParamState,
+    P: ReadOnlySystemParam,
 {
 }

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
@@ -18,7 +18,7 @@ fn main() {
     assert_readonly::<Mutable>();
 }
 
-fn assert_readonly<P: SystemParam>()
+fn assert_readonly<P>()
 where
     P: ReadOnlySystemParam,
 {

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::prelude::*;
-use bevy_ecs::system::{ReadOnlySystemParamFetch, SystemParam, SystemState};
+use bevy_ecs::system::{ReadOnlySystemParamState, SystemParam, SystemState};
 
 #[derive(Component)]
 struct Foo;
@@ -20,6 +20,6 @@ fn main() {
 
 fn assert_readonly<P: SystemParam>()
 where
-    <P as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+    <P as SystemParam>::State: ReadOnlySystemParamState,
 {
 }

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -1,8 +1,8 @@
 warning: unused import: `SystemState`
  --> tests/ui/system_param_derive_readonly.rs:2:58
   |
-2 | use bevy_ecs::system::{ReadOnlySystemParamState, SystemParam, SystemState};
-  |                                                               ^^^^^^^^^^^
+2 | use bevy_ecs::system::{ReadOnlySystemParam, SystemParam, SystemState};
+  |                                                          ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
 
@@ -23,9 +23,9 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
              (F0, F1, F2, F3, F4, F5, F6)
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
-   = note: required for `QueryState<&'static mut Foo>` to implement `ReadOnlySystemParamState`
-   = note: 2 redundant requirements hidden
-   = note: required for `FetchState<(QueryState<&'static mut Foo>,)>` to implement `ReadOnlySystemParamState`
+   = note: required for `bevy_ecs::system::Query<'_, '_, &'static mut Foo>` to implement `ReadOnlySystemParam`
+   = note: 1 redundant requirement hidden
+   = note: required for `Mutable<'_, '_>` to implement `ReadOnlySystemParam`
 note: required by a bound in `assert_readonly`
   --> tests/ui/system_param_derive_readonly.rs:23:8
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -29,7 +29,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
 note: required by a bound in `assert_readonly`
   --> tests/ui/system_param_derive_readonly.rs:23:8
    |
-21 | fn assert_readonly<P: SystemParam>()
+21 | fn assert_readonly<P>()
    |    --------------- required by a bound in this
 22 | where
 23 |     P: ReadOnlySystemParam,

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -1,5 +1,5 @@
 warning: unused import: `SystemState`
- --> tests/ui/system_param_derive_readonly.rs:2:63
+ --> tests/ui/system_param_derive_readonly.rs:2:58
   |
 2 | use bevy_ecs::system::{ReadOnlySystemParamState, SystemParam, SystemState};
   |                                                               ^^^^^^^^^^^
@@ -27,7 +27,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
    = note: 2 redundant requirements hidden
    = note: required for `FetchState<(QueryState<&'static mut Foo>,)>` to implement `ReadOnlySystemParamState`
 note: required by a bound in `assert_readonly`
-  --> tests/ui/system_param_derive_readonly.rs:23:32
+  --> tests/ui/system_param_derive_readonly.rs:23:8
    |
 21 | fn assert_readonly<P: SystemParam>()
    |    --------------- required by a bound in this

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -32,5 +32,5 @@ note: required by a bound in `assert_readonly`
 21 | fn assert_readonly<P: SystemParam>()
    |    --------------- required by a bound in this
 22 | where
-23 |     <P as SystemParam>::State: ReadOnlySystemParamState,
-   |                                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_readonly`
+23 |     P: ReadOnlySystemParam,
+   |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_readonly`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -1,7 +1,7 @@
 warning: unused import: `SystemState`
  --> tests/ui/system_param_derive_readonly.rs:2:63
   |
-2 | use bevy_ecs::system::{ReadOnlySystemParamFetch, SystemParam, SystemState};
+2 | use bevy_ecs::system::{ReadOnlySystemParamState, SystemParam, SystemState};
   |                                                               ^^^^^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
@@ -23,14 +23,14 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
              (F0, F1, F2, F3, F4, F5, F6)
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
-   = note: required for `QueryState<&'static mut Foo>` to implement `ReadOnlySystemParamFetch`
+   = note: required for `QueryState<&'static mut Foo>` to implement `ReadOnlySystemParamState`
    = note: 2 redundant requirements hidden
-   = note: required for `FetchState<(QueryState<&'static mut Foo>,)>` to implement `ReadOnlySystemParamFetch`
+   = note: required for `FetchState<(QueryState<&'static mut Foo>,)>` to implement `ReadOnlySystemParamState`
 note: required by a bound in `assert_readonly`
   --> tests/ui/system_param_derive_readonly.rs:23:32
    |
 21 | fn assert_readonly<P: SystemParam>()
    |    --------------- required by a bound in this
 22 | where
-23 |     <P as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+23 |     <P as SystemParam>::State: ReadOnlySystemParamState,
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_readonly`

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -44,14 +44,14 @@ use std::ops::{Deref, DerefMut};
 /// [Window]: bevy_window::Window
 pub struct Extract<'w, 's, P>
 where
-    P: SystemParam + ReadOnlySystemParam + 'static,
+    P: ReadOnlySystemParam + 'static,
 {
     item: SystemParamItem<'w, 's, P>,
 }
 
 impl<'w, 's, P> SystemParam for Extract<'w, 's, P>
 where
-    P: SystemParam + ReadOnlySystemParam,
+    P: ReadOnlySystemParam,
 {
     type State = ExtractState<P>;
 }
@@ -66,7 +66,7 @@ pub struct ExtractState<P: SystemParam + 'static> {
 // which is initialized in init()
 unsafe impl<P: SystemParam + 'static> SystemParamState for ExtractState<P>
 where
-    P: SystemParam + ReadOnlySystemParam + 'static,
+    P: ReadOnlySystemParam + 'static,
 {
     type Item<'w, 's> = Extract<'w, 's, P>;
 

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -2,8 +2,8 @@ use crate::MainWorld;
 use bevy_ecs::{
     prelude::*,
     system::{
-        ReadOnlySystemParamState, ResState, SystemMeta, SystemParam, SystemParamItem,
-        SystemParamState, SystemState,
+        ReadOnlySystemParam, ResState, SystemMeta, SystemParam, SystemParamItem, SystemParamState,
+        SystemState,
     },
 };
 use std::ops::{Deref, DerefMut};
@@ -42,16 +42,16 @@ use std::ops::{Deref, DerefMut};
 ///
 /// [`RenderStage::Extract`]: crate::RenderStage::Extract
 /// [Window]: bevy_window::Window
-pub struct Extract<'w, 's, P: SystemParam + 'static>
+pub struct Extract<'w, 's, P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: SystemParam + ReadOnlySystemParam + 'static,
 {
     item: SystemParamItem<'w, 's, P>,
 }
 
-impl<'w, 's, P: SystemParam> SystemParam for Extract<'w, 's, P>
+impl<'w, 's, P> SystemParam for Extract<'w, 's, P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: SystemParam + ReadOnlySystemParam,
 {
     type State = ExtractState<P>;
 }
@@ -66,7 +66,7 @@ pub struct ExtractState<P: SystemParam + 'static> {
 // which is initialized in init()
 unsafe impl<P: SystemParam + 'static> SystemParamState for ExtractState<P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: SystemParam + ReadOnlySystemParam + 'static,
 {
     type Item<'w, 's> = Extract<'w, 's, P>;
 
@@ -97,7 +97,7 @@ where
 
 impl<'w, 's, P: SystemParam> Deref for Extract<'w, 's, P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: ReadOnlySystemParam,
 {
     type Target = SystemParamItem<'w, 's, P>;
 
@@ -109,7 +109,7 @@ where
 
 impl<'w, 's, P: SystemParam> DerefMut for Extract<'w, 's, P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: ReadOnlySystemParam,
 {
     #[inline]
     fn deref_mut(&mut self) -> &mut Self::Target {
@@ -119,7 +119,7 @@ where
 
 impl<'a, 'w, 's, P: SystemParam> IntoIterator for &'a Extract<'w, 's, P>
 where
-    P::State: ReadOnlySystemParamState,
+    P: ReadOnlySystemParam,
     &'a SystemParamItem<'w, 's, P>: IntoIterator,
 {
     type Item = <&'a SystemParamItem<'w, 's, P> as IntoIterator>::Item;

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -46,7 +46,7 @@ pub struct Extract<'w, 's, P: SystemParam + 'static>
 where
     P::State: ReadOnlySystemParamState,
 {
-    item: <P::State as SystemParamState>::Item<'w, 's>,
+    item: SystemParamItem<'w, 's, P>,
 }
 
 impl<'w, 's, P: SystemParam> SystemParam for Extract<'w, 's, P>
@@ -99,7 +99,7 @@ impl<'w, 's, P: SystemParam> Deref for Extract<'w, 's, P>
 where
     P::State: ReadOnlySystemParamState,
 {
-    type Target = <P::State as SystemParamState>::Item<'w, 's>;
+    type Target = SystemParamItem<'w, 's, P>;
 
     #[inline]
     fn deref(&self) -> &Self::Target {

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     all_tuples,
     entity::Entity,
     system::{
-        lifetimeless::SRes, ReadOnlySystemParamState, Resource, SystemParam, SystemParamItem,
+        lifetimeless::SRes, ReadOnlySystemParam, Resource, SystemParam, SystemParamItem,
         SystemState,
     },
     world::World,
@@ -325,7 +325,7 @@ impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C> {
 
 impl<P: PhaseItem, C: RenderCommand<P> + Send + Sync + 'static> Draw<P> for RenderCommandState<P, C>
 where
-    <C::Param as SystemParam>::State: ReadOnlySystemParamState,
+    C::Param: ReadOnlySystemParam,
 {
     /// Prepares the ECS parameters for the wrapped [`RenderCommand`] and then renders it.
     fn draw<'w>(
@@ -348,7 +348,7 @@ pub trait AddRenderCommand {
         &mut self,
     ) -> &mut Self
     where
-        <C::Param as SystemParam>::State: ReadOnlySystemParamState;
+        C::Param: ReadOnlySystemParam;
 }
 
 impl AddRenderCommand for App {
@@ -356,7 +356,7 @@ impl AddRenderCommand for App {
         &mut self,
     ) -> &mut Self
     where
-        <C::Param as SystemParam>::State: ReadOnlySystemParamState,
+        C::Param: ReadOnlySystemParam,
     {
         let draw_function = RenderCommandState::<P, C>::new(&mut self.world);
         let draw_functions = self

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     all_tuples,
     entity::Entity,
     system::{
-        lifetimeless::SRes, ReadOnlySystemParamFetch, Resource, SystemParam, SystemParamItem,
+        lifetimeless::SRes, ReadOnlySystemParamState, Resource, SystemParam, SystemParamItem,
         SystemState,
     },
     world::World,
@@ -325,7 +325,7 @@ impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C> {
 
 impl<P: PhaseItem, C: RenderCommand<P> + Send + Sync + 'static> Draw<P> for RenderCommandState<P, C>
 where
-    <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+    <C::Param as SystemParam>::State: ReadOnlySystemParamState,
 {
     /// Prepares the ECS parameters for the wrapped [`RenderCommand`] and then renders it.
     fn draw<'w>(
@@ -348,7 +348,7 @@ pub trait AddRenderCommand {
         &mut self,
     ) -> &mut Self
     where
-        <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch;
+        <C::Param as SystemParam>::State: ReadOnlySystemParamState;
 }
 
 impl AddRenderCommand for App {
@@ -356,7 +356,7 @@ impl AddRenderCommand for App {
         &mut self,
     ) -> &mut Self
     where
-        <C::Param as SystemParam>::Fetch: ReadOnlySystemParamFetch,
+        <C::Param as SystemParam>::State: ReadOnlySystemParamState,
     {
         let draw_function = RenderCommandState::<P, C>::new(&mut self.world);
         let draw_functions = self


### PR DESCRIPTION
# Objective

* Implementing a custom `SystemParam` by hand requires implementing three traits -- four if it is read-only.
* The trait `SystemParamFetch<'w, 's>` is a workaround from before we had generic associated types, and is no longer necessary.

## Solution

* Combine the trait `SystemParamFetch` with `SystemParamState`.
    * I decided to remove the `Fetch` name and keep the `State` name, since the former was consistently conflated with the latter.
* Replace the trait `ReadOnlySystemParamFetch` with `ReadOnlySystemParam`, which simplifies trait bounds in generic code.

---

## Changelog

- Removed the trait `SystemParamFetch`, moving its functionality to `SystemParamState`.
- Replaced the trait `ReadOnlySystemParamFetch` with `ReadOnlySystemParam`.

## Migration Guide

The trait `SystemParamFetch` has been removed, and its functionality has been transferred to `SystemParamState`.

```rust
// Before
impl SystemParamState for MyParamState {
    fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self { ... }
}
impl<'w, 's> SystemParamFetch<'w, 's> for MyParamState {
    type Item = MyParam<'w, 's>;
    fn get_param(...) -> Self::Item;
}

// After
impl SystemParamState for MyParamState {
    type Item<'w, 's> = MyParam<'w, 's>; // Generic associated types!
    fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self { ... }
    fn get_param<'w, 's>(...) -> Self::Item<'w, 's>;
}
```

The trait `ReadOnlySystemParamFetch` has been replaced with `ReadOnlySystemParam`.

```rust
// Before
unsafe impl ReadOnlySystemParamFetch for MyParamState {}

// After
unsafe impl<'w, 's> ReadOnlySystemParam for MyParam<'w, 's> {}
```