### PR TITLE
[Merged by Bors] - Lift the 16-field limit from the `SystemParam` derive

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -359,18 +359,16 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         })
         .collect::<Vec<(&Field, SystemParamFieldAttributes)>>();
     let mut fields = Vec::new();
-    let mut field_indices = Vec::new();
     let mut field_types = Vec::new();
     let mut ignored_fields = Vec::new();
     let mut ignored_field_types = Vec::new();
-    for (i, (field, attrs)) in field_attributes.iter().enumerate() {
+    for (field, attrs) in &field_attributes {
         if attrs.ignore {
             ignored_fields.push(field.ident.as_ref().unwrap());
             ignored_field_types.push(&field.ty);
         } else {
             fields.push(field.ident.as_ref().unwrap());
             field_types.push(&field.ty);
-            field_indices.push(Index::from(i));
         }
     }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -415,10 +415,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     }));
 
     let mut tuple_types: Vec<_> = field_types.iter().map(|x| quote! { #x }).collect();
-    let field_local_names: Vec<_> = (0..field_types.len())
-        .map(|x| format_ident!("f{x}"))
-        .collect();
-    let mut tuple_patterns: Vec<_> = field_local_names.iter().map(|x| quote! { #x }).collect();
+    let mut tuple_patterns: Vec<_> = fields.iter().map(|x| quote! { #x }).collect();
 
     // If the number of fields exceeds the 16-parameter limit,
     // fold the fields into tuples of tuples until we are below the limit.
@@ -482,7 +479,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 ) -> Self::Item {
                     let (#(#tuple_patterns,)*) = #path::system::SystemParamFetch::get_param(&mut state.state, system_meta, world, change_tick,);
                     #struct_name {
-                        #(#fields: #field_local_names,)*
+                        #(#fields,)*
                         #(#ignored_fields: <#ignored_field_types>::default(),)*
                     }
                 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -480,11 +480,9 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     world: &'w #path::world::World,
                     change_tick: u32,
                 ) -> Self::Item {
-                    let (#(#tuple_patterns,)*) = &mut state.state;
+                    let (#(#tuple_patterns,)*) = #path::system::SystemParamFetch::get_param(&mut state.state, system_meta, world, change_tick,);
                     #struct_name {
-                        #(#fields: <<#field_types as #path::system::SystemParam>::Fetch as #path::system::SystemParamFetch>::get_param(
-                            #field_local_names, system_meta, world, change_tick,
-                        ),)*
+                        #(#fields: #field_local_names,)*
                         #(#ignored_fields: <#ignored_field_types>::default(),)*
                     }
                 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1689,7 +1689,7 @@ mod tests {
     fn long_system(_param: LongParam) {
         crate::system::assert_is_system(long_system);
     }
-    
+
     #[derive(SystemParam)]
     pub struct UnitParam;
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1677,4 +1677,33 @@ mod tests {
 
     #[derive(SystemParam)]
     pub struct UnitParam {}
+
+    #[derive(Resource)]
+    pub struct R<const I: usize>;
+
+    #[derive(SystemParam)]
+    pub struct LongParam<'w> {
+        _r0: Res<'w, R<0>>,
+        _r1: Res<'w, R<1>>,
+        _r2: Res<'w, R<2>>,
+        _r3: Res<'w, R<3>>,
+        _r4: Res<'w, R<4>>,
+        _r5: Res<'w, R<5>>,
+        _r6: Res<'w, R<6>>,
+        _r7: Res<'w, R<7>>,
+        _r8: Res<'w, R<8>>,
+        _r9: Res<'w, R<9>>,
+        _r10: Res<'w, R<10>>,
+        _r11: Res<'w, R<11>>,
+        _r12: Res<'w, R<12>>,
+        _r13: Res<'w, R<13>>,
+        _r14: Res<'w, R<14>>,
+        _r15: Res<'w, R<15>>,
+        _r16: Res<'w, R<16>>,
+    }
+
+    #[allow(dead_code)]
+    fn long_system(_param: LongParam) {
+        crate::system::assert_is_system(long_system);
+    }
 }


### PR DESCRIPTION
# Objective

* The `SystemParam` derive internally uses tuples, which means it is constrained by the 16-field limit on `all_tuples`.
    * The error message if you exceed this limit is abysmal.
* Supercedes #5965 -- this does the same thing, but is simpler.

## Solution

If any tuples have more than 16 fields, they are folded into tuples of tuples until they are under the 16-field limit.