### PR TITLE
[Merged by Bors] - Updated docs for ``List`` Trait in ``bevy_reflect``

### DIFF
--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -11,11 +11,14 @@ use crate::{
 ///
 /// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
 /// it's internal size to grow.
+///
+/// This trait expects index 0 to contain the _first_ or _front_ element.
+/// The _last_ or _back_ element refers to the element with the largest index.
 pub trait List: Reflect + Array {
-    /// Appends an element to the list.
+    /// Appends an element to the _back_ of the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
-    /// Removes the last element from the list (highest index in the array) and returns it, or [`None`] if it is empty.
+    /// Removes the _last_ element from the list and returns it, or [`None`] if it is empty.
     fn pop(&mut self) -> Option<Box<dyn Reflect>>;
 
     /// Clones the list, producing a [`DynamicList`].

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -12,8 +12,9 @@ use crate::{
 /// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
 /// it's internal size to grow.
 ///
-/// This trait expects index 0 to contain the _first_ or _front_ element.
-/// The _last_ or _back_ element refers to the element with the largest index.
+/// **Attention manual implementors**: 
+/// * This trait expects index 0 to contain the _first_ or _front_ element.
+/// * The _last_ or _back_ element must refer to the element with the largest index.
 pub trait List: Reflect + Array {
     /// Appends an element to the _back_ of the list.
     fn push(&mut self, value: Box<dyn Reflect>);

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -12,14 +12,14 @@ use crate::{
 /// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
 /// it's internal size to grow.
 ///
-/// **Attention manual implementors**:
-/// * This trait expects index 0 to contain the _first_ or _front_ element.
-/// * The _last_ or _back_ element must refer to the element with the largest index.
+/// This trait expects index 0 to contain the _front_ element.
+/// The _back_ element must refer to the element with the largest index.
+/// These two rules above should be upheld by manual implementors.
 pub trait List: Reflect + Array {
     /// Appends an element to the _back_ of the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
-    /// Removes the _last_ element from the list and returns it, or [`None`] if it is empty.
+    /// Removes the _back_ element from the list and returns it, or [`None`] if it is empty.
     fn pop(&mut self) -> Option<Box<dyn Reflect>>;
 
     /// Clones the list, producing a [`DynamicList`].

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -12,7 +12,7 @@ use crate::{
 /// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
 /// it's internal size to grow.
 ///
-/// **Attention manual implementors**: 
+/// **Attention manual implementors**:
 /// * This trait expects index 0 to contain the _first_ or _front_ element.
 /// * The _last_ or _back_ element must refer to the element with the largest index.
 pub trait List: Reflect + Array {


### PR DESCRIPTION
# Objective

Fixes #6866.

## Solution

Docs now should describe what the _front_, _first_, _back_, and _last_ elements are for an implementor of the `bevy::reflect::list::List` Trait. Further, the docs should describe how `bevy::reflect::list::List::push` and `bevy::reflect::list::List::pop` should act on these elements.
