### PR TITLE
[Merged by Bors] - ci: Use Ubuntu 22.04 runner for run-examples, run-examples-on-wasm jobs 

### DIFF
--- a/.github/start-wasm-example/package-lock.json
+++ b/.github/start-wasm-example/package-lock.json
@@ -12,16 +12,17 @@
         "dotenv": "^16.0.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.22.1"
+        "@playwright/test": "^1.28.1"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.1.tgz",
-      "integrity": "sha512-8ouMBUboYslHom41W8bnSEn0TwlAMHhCACwOZeuiAgzukj7KobpZ+UBwrGE0jJ0UblJbKAQNRHXL+z7sDSkb6g==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "dev": true,
       "dependencies": {
-        "playwright-core": "1.22.1"
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -29,6 +30,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@types/node": {
+      "version": "18.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
+      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "dev": true
     },
     "node_modules/dotenv": {
       "version": "16.0.1",
@@ -39,9 +46,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.1.tgz",
-      "integrity": "sha512-H+ZUVYnceWNXrRf3oxTEKAr81QzFsCKu5Fp//fEjQvqgKkfA1iX3E9DBrPJpPNOrgVzcE+IqeI0fDmYJe6Ynnw==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -53,13 +60,20 @@
   },
   "dependencies": {
     "@playwright/test": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.22.1.tgz",
-      "integrity": "sha512-8ouMBUboYslHom41W8bnSEn0TwlAMHhCACwOZeuiAgzukj7KobpZ+UBwrGE0jJ0UblJbKAQNRHXL+z7sDSkb6g==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+      "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
       "dev": true,
       "requires": {
-        "playwright-core": "1.22.1"
+        "@types/node": "*",
+        "playwright-core": "1.28.1"
       }
+    },
+    "@types/node": {
+      "version": "18.11.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.11.tgz",
+      "integrity": "sha512-KJ021B1nlQUBLopzZmPBVuGU9un7WJd/W4ya7Ih02B4Uwky5Nja0yGYav2EfYIk0RR2Q9oVhf60S2XR1BCWJ2g==",
+      "dev": true
     },
     "dotenv": {
       "version": "16.0.1",
@@ -67,9 +81,9 @@
       "integrity": "sha512-1K6hR6wtk2FviQ4kEiSjFiH5rpzEVi8WW0x96aztHVMhEspNpc4DVOUTEHtEva5VThQ8IaBX1Pe4gSzpVVUsKQ=="
     },
     "playwright-core": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.22.1.tgz",
-      "integrity": "sha512-H+ZUVYnceWNXrRf3oxTEKAr81QzFsCKu5Fp//fEjQvqgKkfA1iX3E9DBrPJpPNOrgVzcE+IqeI0fDmYJe6Ynnw==",
+      "version": "1.28.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+      "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
       "dev": true
     }
   }

--- a/.github/start-wasm-example/package.json
+++ b/.github/start-wasm-example/package.json
@@ -8,7 +8,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.22.1"
+    "@playwright/test": "^1.28.1"
   },
   "dependencies": {
     "dotenv": "^16.0.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
           #GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   run-examples:
-    runs-on: ubuntu-20.04 # TODO: figure out why latest fails
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Install Bevy dependencies

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -91,7 +91,7 @@ jobs:
           done
 
   run-examples-on-wasm:
-    runs-on: ubuntu-20.04 # TODO: figure out why this fails on latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
# Objective

- The `run-examples-on-wasm` job fails on Ubuntu 22.04, when it was previously working on Ubuntu 20.04. Playwright 1.22.1 (the version currently pinned by us) fails trying to install system dependencies that were renamed between Ubuntu 20.04 and 22.04.
- The `run-examples` job previously failed on Ubuntu 22.04 with errors consistent with those listed in [this upstream mesa bug](https://gitlab.freedesktop.org/mesa/mesa/-/issues/7819).
- Fixes #6832

## Solution

- Upgrade `playwright` to the latest [v1.28.1](https://github.com/microsoft/playwright/releases/tag/v1.28.1) release. Ubuntu 22.04 support was [added](https://github.com/microsoft/playwright/pull/14588) in [v1.23.0](https://github.com/microsoft/playwright/releases/tag/v1.23.0). The [test now passes on 22.04](https://github.com/oliviacrain/bevy/actions/runs/3633583112/jobs/6130757397), and the output screenshots are unchanged from previous job outputs.
- Use `ubuntu-latest` for the `run-examples` job. No other modifications necessary. The [PPA we pull mesa from](https://launchpad.net/~oibaf/+archive/ubuntu/graphics-drivers) rebuilt the package for 22.04 with the [upstream fix](https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/20145/diffs?commit_id=b3d1ae19f2f4d93cf0a5f45a598149ac4e8e05aa).