### PR TITLE
[Merged by Bors] - run clear trackers on render world

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -107,9 +107,7 @@ impl Default for App {
         #[cfg(feature = "bevy_reflect")]
         app.init_resource::<AppTypeRegistry>();
 
-        app.add_default_stages()
-            .add_event::<AppExit>()
-            .add_system_to_stage(CoreStage::Last, World::clear_trackers);
+        app.add_default_stages().add_event::<AppExit>();
 
         #[cfg(feature = "bevy_ci_testing")]
         {
@@ -150,6 +148,7 @@ impl App {
         #[cfg(feature = "trace")]
         let _bevy_frame_update_span = info_span!("frame").entered();
         self.schedule.run(&mut self.world);
+        self.world.clear_trackers();
 
         for sub_app in self.sub_apps.values_mut() {
             (sub_app.runner)(&mut self.world, &mut sub_app.app);

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -148,12 +148,13 @@ impl App {
         #[cfg(feature = "trace")]
         let _bevy_frame_update_span = info_span!("frame").entered();
         self.schedule.run(&mut self.world);
-        self.world.clear_trackers();
 
         for sub_app in self.sub_apps.values_mut() {
             (sub_app.runner)(&mut self.world, &mut sub_app.app);
             sub_app.app.world.clear_trackers();
         }
+
+        self.world.clear_trackers();
     }
 
     /// Starts the application by calling the app's [runner function](Self::set_runner).

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -150,8 +150,10 @@ impl App {
         #[cfg(feature = "trace")]
         let _bevy_frame_update_span = info_span!("frame").entered();
         self.schedule.run(&mut self.world);
+
         for sub_app in self.sub_apps.values_mut() {
             (sub_app.runner)(&mut self.world, &mut sub_app.app);
+            sub_app.app.world.clear_trackers();
         }
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -804,6 +804,8 @@ impl<'w, 's, T: FromWorld + Send + 'static> SystemParamFetch<'w, 's> for LocalSt
 /// and will need to be manually flushed using [`World::clear_trackers`]
 ///
 /// For users of `bevy` and `bevy_app`, this is automatically done in `bevy_app::App::update`.
+/// For the main world, [`World::clear_trackers`] is run after the main schedule is run and after
+/// `SubApp`'s have run.
 ///
 /// # Examples
 ///

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -803,10 +803,7 @@ impl<'w, 's, T: FromWorld + Send + 'static> SystemParamFetch<'w, 's> for LocalSt
 /// note that the `RemovedComponents` list will not be automatically cleared for you,
 /// and will need to be manually flushed using [`World::clear_trackers`]
 ///
-/// For users of `bevy` itself, this is automatically done in a system added by `MinimalPlugins`
-/// or `DefaultPlugins` at the end of each pass of the game loop during the `CoreStage::Last`
-/// stage. As such `RemovedComponents` systems should be scheduled after the stage where
-/// removal occurs but before `CoreStage::Last`.
+/// For users of `bevy` itself, this is automatically done in `bevy_app::App::update`.
 ///
 /// # Examples
 ///

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -803,7 +803,7 @@ impl<'w, 's, T: FromWorld + Send + 'static> SystemParamFetch<'w, 's> for LocalSt
 /// note that the `RemovedComponents` list will not be automatically cleared for you,
 /// and will need to be manually flushed using [`World::clear_trackers`]
 ///
-/// For users of `bevy` itself, this is automatically done in `bevy_app::App::update`.
+/// For users of `bevy` and `bevy_app`, this is automatically done in `bevy_app::App::update`.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/6417

## Solution

- clear_trackers was not being called on the render world. This causes the removed components vecs to continuously grow. This PR adds clear trackers to the end of RenderStage::Cleanup

## Migration Guide

The call to `clear_trackers` in `App` has been moved from the schedule to App::update for the main world and calls to `clear_trackers` have been added for sub_apps in the same function. This was due to needing stronger guarantees. If clear_trackers isn't called on a world it can lead to memory leaks in `RemovedComponents`. 