### PR TITLE
[Merged by Bors] - ShaderDefVal: add an `UInt` option

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -321,9 +321,9 @@ impl SpecializedMeshPipeline for ShadowPipeline {
 
         let mut bind_group_layout = vec![self.view_layout.clone()];
         let mut shader_defs = Vec::new();
-        shader_defs.push(ShaderDefVal::Int(
+        shader_defs.push(ShaderDefVal::UInt(
             "MAX_DIRECTIONAL_LIGHTS".to_string(),
-            MAX_DIRECTIONAL_LIGHTS as i32,
+            MAX_DIRECTIONAL_LIGHTS as u32,
         ));
 
         if layout.contains(Mesh::ATTRIBUTE_JOINT_INDEX)

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -590,9 +590,9 @@ impl SpecializedMeshPipeline for MeshPipeline {
             vertex_attributes.push(Mesh::ATTRIBUTE_NORMAL.at_shader_location(1));
         }
 
-        shader_defs.push(ShaderDefVal::Int(
+        shader_defs.push(ShaderDefVal::UInt(
             "MAX_DIRECTIONAL_LIGHTS".to_string(),
-            MAX_DIRECTIONAL_LIGHTS as i32,
+            MAX_DIRECTIONAL_LIGHTS as u32,
         ));
 
         if layout.contains(Mesh::ATTRIBUTE_UV_0) {

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -123,6 +123,7 @@ struct ShaderCache {
 pub enum ShaderDefVal {
     Bool(String, bool),
     Int(String, i32),
+    UInt(String, u32),
 }
 
 impl From<&str> for ShaderDefVal {
@@ -134,6 +135,16 @@ impl From<&str> for ShaderDefVal {
 impl From<String> for ShaderDefVal {
     fn from(key: String) -> Self {
         ShaderDefVal::Bool(key, true)
+    }
+}
+
+impl ShaderDefVal {
+    pub fn value_as_string(&self) -> String {
+        match self {
+            ShaderDefVal::Bool(_, def) => def.to_string(),
+            ShaderDefVal::Int(_, def) => def.to_string(),
+            ShaderDefVal::UInt(_, def) => def.to_string(),
+        }
     }
 }
 
@@ -176,9 +187,9 @@ impl ShaderCache {
                     shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
                 }
 
-                shader_defs.push(ShaderDefVal::Int(
+                shader_defs.push(ShaderDefVal::UInt(
                     String::from("AVAILABLE_STORAGE_BUFFER_BINDINGS"),
-                    render_device.limits().max_storage_buffers_per_shader_stage as i32,
+                    render_device.limits().max_storage_buffers_per_shader_stage,
                 ));
 
                 debug!(


### PR DESCRIPTION
# Objective

- Fixes #6841 
- In some case, the number of maximum storage buffers is `u32::MAX` which doesn't fit in a `i32`

## Solution

- Add an option to have a `u32` in a `ShaderDefVal`
