### PR TITLE
Added examples for async client/server files

### DIFF
--- a/examples/async_tasks/async_client.rs
+++ b/examples/async_tasks/async_client.rs
@@ -1,0 +1,118 @@
+/*
+    async_client - a very basic example of how to use the async_source_external_thread 
+    example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
+    to implement a server/client model. This is the client, which will start up, send an initial packet to the server,
+    spawn a thread that listens for incoming connections and parses incoming connections and passes them into the
+    crossbeam_channel. Another system reads from that channel and writes to the Bevy event queue, which is then read from 
+    and parsed to, in this case, spawn a rectangle.
+
+*/
+
+
+use std::io::prelude::*;
+use std::thread;
+use std::net::{TcpStream, TcpListener};
+use bevy::{prelude::*, sprite::MaterialMesh2dBundle,tasks::{AsyncComputeTaskPool, Task},};
+use crossbeam_channel::{bounded, Receiver};
+
+#[derive(Component)]
+struct ComputeSpawn(Task<SpriteBundle>);
+
+#[derive(Resource, Deref)]
+struct StreamRec(Receiver<String>);
+struct StreamEvent(String);
+
+// Initially connect to the server
+fn connect(){
+    let mut stream = TcpStream::connect("127.0.0.1:7878").unwrap();
+    stream.write(b"yeet");
+}
+
+// A separate function to parse string input
+fn handleStream(mut stream : TcpStream) -> String{
+    let mut buffer = String::new();
+    stream.read_to_string(&mut buffer);
+    println!("Received {}",buffer);
+    if buffer == "spawn"{
+       "spawn".to_string() 
+
+    }else{
+        "".to_string()
+    }
+
+}
+// The function that actually polls the events queue and, if it finds the "spawn" 
+// command in the event reader queue, will actually spawn the rectangle
+fn spawner(mut commands : Commands,
+           mut reader : EventReader<StreamEvent>){
+    let events : Vec<_> = reader.iter().collect();
+    for event in events{
+        println!("Pulled from event system: {}",event.0);
+        if event.0 == "spawn"{
+            let rect = SpriteBundle {
+                sprite: Sprite {
+                    color: Color::rgb(0.25, 0.25, 0.75),
+                    custom_size: Some(Vec2::new(50.0, 100.0)),
+                    ..default()
+                },
+                ..default()
+            };
+            commands.spawn(rect); 
+        }
+
+    }
+
+}
+
+// Basically, this bridges from the channel comms to the Bevy App.
+// This function reads from the channel reader and adds events to the 
+// App Events queue (which is read by the spawner() function)
+fn readstream(receiver: Res<StreamRec>, mut events: EventWriter<StreamEvent>){
+    for from_str in receiver.try_iter(){
+        println!("Received an event from the StreamReceiver: {:?}",from_str);
+        events.send(StreamEvent(from_str));
+    }
+}
+// Spawns a camera and then spawns a thread that listens on the :8080 port 
+// for any and all connections. If it receives the connection, it passes
+// the stream to the handleStream() function, which parses it and returns
+// a stream that is then added to the channel reader, which is polled by 
+// readstream(), which adds the event to the Bevy events queue
+fn setup(mut commands : Commands){
+    commands.spawn(Camera2dBundle::default());
+    let listener = TcpListener::bind("127.0.0.1:8080").unwrap();
+    println!("In listener...");
+    connect(); 
+    let (tx, rx) = bounded::<String>(10);
+    std::thread::spawn(move || loop {
+        println!("In thread...");
+        for stream in listener.incoming(){
+            println!("Received stream!");
+            match stream {
+                Ok(stream) => {
+                    
+                    let res = handleStream(stream);
+                    println!("Received {} from handleStream",res);
+                    tx.send(res);
+                }
+                Err(e) => {}
+
+            }
+
+        }
+    });
+    commands.insert_resource(StreamRec(rx));
+     
+}
+
+
+fn main() {
+    App::new()
+        // This is important: StreamEvent needs to be on the App object to start receiving events
+        .add_event::<StreamEvent>()
+        .add_plugins(DefaultPlugins)
+        .add_startup_system(setup)
+        .add_system(readstream)
+        .add_system(spawner)
+        .run()
+}

--- a/examples/async_tasks/async_client.rs
+++ b/examples/async_tasks/async_client.rs
@@ -1,12 +1,9 @@
-/*
-    async_client - a very basic example of how to use the async_source_external_thread 
-    example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
-    to implement a server/client model. This is the client, which will start up, send an initial packet to the server,
-    spawn a thread that listens for incoming connections and parses incoming connections and passes them into the
-    crossbeam_channel. Another system reads from that channel and writes to the Bevy event queue, which is then read from 
-    and parsed to, in this case, spawn a rectangle.
-
-*/
+//! async_client - a very basic example of how to use the async_source_external_thread 
+//! example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
+//! to implement a server/client model. This is the client, which will start up, send an initial packet to the server,
+//! spawn a thread that listens for incoming connections and parses incoming connections and passes them into the
+//! crossbeam_channel. Another system reads from that channel and writes to the Bevy event queue, which is then read from 
+//! and parsed to, in this case, spawn a rectangle.
 
 
 use std::io::prelude::*;

--- a/examples/async_tasks/async_server.rs
+++ b/examples/async_tasks/async_server.rs
@@ -1,0 +1,64 @@
+/*
+    async_server - a very basic example of how to use the async_source_external_thread 
+    example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
+    to implement a server/client model. This server example creates a plugin that initializes a listener that sends incoming streams
+    to a parsing function, which will parse the sent stream from the client, compare it to a hardcoded value and send a response to the 
+    client
+*/
+
+use bevy::prelude::*;
+use bevy::prelude::*;
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+use std::io::{Read, Write};
+pub struct ServerPlugin;
+
+// Sets up a listener on port 7878
+fn streamListener(){
+    println!("Server initialized!");
+    let listener = TcpListener::bind("127.0.0.1:7878").unwrap();
+
+    for stream in listener.incoming() {
+        let stream = stream.unwrap();
+        thread::spawn(|| {
+            handleStream(stream);
+        });
+        println!("Connection established!");
+    
+    }
+}
+// Parses the incoming stream and checks it against hardcoded values before sending something back
+fn handleStream(mut stream : TcpStream){
+    // With the way this is set up now, the initial ("yeet") packet essentially comes in from a (dynamic) random port.
+    // Instead of this, we want to parse out the IP and send the response back to the port the client will be listening
+    // on (:8080)
+    let addr = stream.peer_addr().unwrap().to_string(); 
+    let spl : Vec<&str>= addr.split(":").collect();
+    let ip = spl[0];
+    println!("IP: {:?}",ip);
+    // Reads the stream in to a String buffer
+    let mut buffer = String::new();
+    stream.read_to_string(&mut buffer);
+    // Checks buffer string against hardcoded value
+    if(buffer == "yeet".to_string()){
+        println!("Yeet command received");
+        // Note: will panic if the client sends the yeet packet and then kills itself before the server can connect
+        let mut stream = TcpStream::connect(ip.to_owned()+":8080").unwrap();
+        stream.write(b"spawn");
+    }
+    
+}
+impl Plugin for ServerPlugin {
+    fn build(&self, app: &mut App) {
+        // add things to your app here
+        app.add_system(streamListener);    
+    }
+    
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(ServerPlugin)
+        .run();
+}

--- a/examples/async_tasks/async_server.rs
+++ b/examples/async_tasks/async_server.rs
@@ -1,10 +1,9 @@
-/*
-    async_server - a very basic example of how to use the async_source_external_thread 
-    example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
-    to implement a server/client model. This server example creates a plugin that initializes a listener that sends incoming streams
-    to a parsing function, which will parse the sent stream from the client, compare it to a hardcoded value and send a response to the 
-    client
-*/
+//! async_server - a very basic example of how to use the async_source_external_thread 
+//! example (https://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs)
+//! to implement a server/client model. This server example creates a plugin that initializes a listener that sends incoming streams
+//! to a parsing function, which will parse the sent stream from the client, compare it to a hardcoded value and send a response to the 
+//! client
+
 
 use bevy::prelude::*;
 use bevy::prelude::*;


### PR DESCRIPTION
# Objective

I've been playing around with using raw sockets to create an asynchronous client/server methodology with Bevy. The [async_source_external_thread](ttps://github.com/bevyengine/bevy/blob/main/examples/async_tasks/external_source_external_thread.rs) example was good, but there were a few quirks that I implemented to make it work with clients/servers.

No worries if you don't find this example useful! I learned a ton from the experience and plan on implementing it into some projects in the future.

## Solution

One of the primary problems was figuring out a queue'ing/polling model. Using crossbeam_channel was a huge unlock for me, and that allowed me to essentially create a bridge between the incoming packets (whose data are pushed to the channel) and the Bevy app (which polls the Events API) by creating a system that (asynchronously) pulls from the channel (which is registered as a resource) and writes to the Events stream.

---

## Changelog

Added two files: async_client.rs and async_server.rs

