### PR TITLE
[Merged by Bors] - Fix Sparse Change Detection

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -771,7 +771,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                     .debug_checked_unwrap();
                 Mut {
                     value: component.assert_unique().deref_mut(),
-                    ticks: Ticks::from_tick_cells(ticks, fetch.change_tick, fetch.last_change_tick),
+                    ticks: Ticks::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick),
                 }
             }
         }


### PR DESCRIPTION
# Objective
#6547 accidentally broke change detection for SparseSet components by using `Ticks::from_tick_cells` with the wrong argument order.

## Solution
Use the right argument order. Add a regression test.