### PR TITLE
[Merged by Bors] - Move system_commands spans into apply_buffers

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -276,8 +276,8 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                     )*
                 }
 
-                fn apply(&mut self, world: &mut World) {
-                    self.0.apply(world)
+                fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
+                    self.0.apply(system_meta, world)
                 }
             }
 
@@ -450,8 +450,8 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     self.state.new_archetype(archetype, system_meta)
                 }
 
-                fn apply(&mut self, world: &mut #path::world::World) {
-                    self.state.apply(world)
+                fn apply(&mut self, system_meta: &#path::system::SystemMeta, world: &mut #path::world::World) {
+                    self.state.apply(system_meta, world)
                 }
             }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -229,12 +229,11 @@ impl SystemStage {
     }
 
     pub fn apply_buffers(&mut self, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _span = bevy_utils::tracing::info_span!("stage::apply_buffers")
+            .entered();
         for container in &mut self.parallel {
-            let system = container.system_mut();
-            #[cfg(feature = "trace")]
-            let _span = bevy_utils::tracing::info_span!("system_commands", name = &*system.name())
-                .entered();
-            system.apply_buffers(world);
+            container.system_mut().apply_buffers(world);
         }
     }
 
@@ -781,15 +780,7 @@ impl Stage for SystemStage {
                             .entered();
                             container.system_mut().run((), world);
                         }
-                        {
-                            #[cfg(feature = "trace")]
-                            let _system_span = bevy_utils::tracing::info_span!(
-                                "system_commands",
-                                name = &*container.name()
-                            )
-                            .entered();
-                            container.system_mut().apply_buffers(world);
-                        }
+                        container.system_mut().apply_buffers(world);
                     }
                 }
 
@@ -813,15 +804,7 @@ impl Stage for SystemStage {
                             .entered();
                             container.system_mut().run((), world);
                         }
-                        {
-                            #[cfg(feature = "trace")]
-                            let _system_span = bevy_utils::tracing::info_span!(
-                                "system_commands",
-                                name = &*container.name()
-                            )
-                            .entered();
-                            container.system_mut().apply_buffers(world);
-                        }
+                        container.system_mut().apply_buffers(world);
                     }
                 }
 
@@ -829,12 +812,6 @@ impl Stage for SystemStage {
                 if self.apply_buffers {
                     for container in &mut self.parallel {
                         if container.should_run {
-                            #[cfg(feature = "trace")]
-                            let _span = bevy_utils::tracing::info_span!(
-                                "system_commands",
-                                name = &*container.name()
-                            )
-                            .entered();
                             container.system_mut().apply_buffers(world);
                         }
                     }
@@ -852,15 +829,7 @@ impl Stage for SystemStage {
                             .entered();
                             container.system_mut().run((), world);
                         }
-                        {
-                            #[cfg(feature = "trace")]
-                            let _system_span = bevy_utils::tracing::info_span!(
-                                "system_commands",
-                                name = &*container.name()
-                            )
-                            .entered();
-                            container.system_mut().apply_buffers(world);
-                        }
+                        container.system_mut().apply_buffers(world);
                     }
                 }
 

--- a/crates/bevy_ecs/src/schedule/stage.rs
+++ b/crates/bevy_ecs/src/schedule/stage.rs
@@ -230,8 +230,7 @@ impl SystemStage {
 
     pub fn apply_buffers(&mut self, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _span = bevy_utils::tracing::info_span!("stage::apply_buffers")
-            .entered();
+        let _span = bevy_utils::tracing::info_span!("stage::apply_buffers").entered();
         for container in &mut self.parallel {
             container.system_mut().apply_buffers(world);
         }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -5,7 +5,7 @@ use thread_local::ThreadLocal;
 use crate::{
     entity::Entities,
     prelude::World,
-    system::{SystemParam, SystemParamFetch, SystemParamState},
+    system::{SystemParam, SystemParamFetch, SystemParamState, SystemMeta},
 };
 
 use super::{CommandQueue, Commands};
@@ -74,7 +74,13 @@ unsafe impl SystemParamState for ParallelCommandsState {
         Self::default()
     }
 
-    fn apply(&mut self, world: &mut World) {
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _system_span = bevy_utils::tracing::info_span!(
+            "system_commands",
+            name = _system_meta.name()
+        )
+        .entered();
         for cq in &mut self.thread_local_storage {
             cq.get_mut().apply(world);
         }

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -5,7 +5,7 @@ use thread_local::ThreadLocal;
 use crate::{
     entity::Entities,
     prelude::World,
-    system::{SystemParam, SystemParamFetch, SystemParamState, SystemMeta},
+    system::{SystemMeta, SystemParam, SystemParamFetch, SystemParamState},
 };
 
 use super::{CommandQueue, Commands};
@@ -76,11 +76,9 @@ unsafe impl SystemParamState for ParallelCommandsState {
 
     fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _system_span = bevy_utils::tracing::info_span!(
-            "system_commands",
-            name = _system_meta.name()
-        )
-        .entered();
+        let _system_span =
+            bevy_utils::tracing::info_span!("system_commands", name = _system_meta.name())
+                .entered();
         for cq in &mut self.thread_local_storage {
             cq.get_mut().apply(world);
         }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -193,8 +193,8 @@ impl<Param: SystemParam> SystemState<Param> {
     /// by a [`Commands`](`super::Commands`) parameter to the given [`World`].
     /// This function should be called manually after the values returned by [`SystemState::get`] and [`SystemState::get_mut`]
     /// are finished being used.
-    pub fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
-        self.param_state.apply(system_meta, world);
+    pub fn apply(&mut self, world: &mut World) {
+        self.param_state.apply(&self.meta, world);
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -37,7 +37,7 @@ impl SystemMeta {
         }
     }
 
-    /// Returns true if the system is [`Send`].
+    /// Returns the system's name
     #[inline]
     pub fn name(&self) -> &str {
         &self.name

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -39,6 +39,12 @@ impl SystemMeta {
 
     /// Returns true if the system is [`Send`].
     #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns true if the system is [`Send`].
+    #[inline]
     pub fn is_send(&self) -> bool {
         self.is_send
     }
@@ -187,8 +193,8 @@ impl<Param: SystemParam> SystemState<Param> {
     /// by a [`Commands`](`super::Commands`) parameter to the given [`World`].
     /// This function should be called manually after the values returned by [`SystemState::get`] and [`SystemState::get_mut`]
     /// are finished being used.
-    pub fn apply(&mut self, world: &mut World) {
-        self.param_state.apply(world);
+    pub fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
+        self.param_state.apply(system_meta, world);
     }
 
     #[inline]
@@ -422,7 +428,7 @@ where
     #[inline]
     fn apply_buffers(&mut self, world: &mut World) {
         let param_state = self.param_state.as_mut().expect(Self::PARAM_MESSAGE);
-        param_state.apply(world);
+        param_state.apply(&self.system_meta, world);
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -598,11 +598,9 @@ unsafe impl SystemParamState for CommandQueue {
 
     fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
         #[cfg(feature = "trace")]
-        let _system_span = bevy_utils::tracing::info_span!(
-            "system_commands",
-            name = _system_meta.name()
-        )
-        .entered();
+        let _system_span =
+            bevy_utils::tracing::info_span!("system_commands", name = _system_meta.name())
+                .entered();
         self.apply(world);
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -108,7 +108,8 @@ pub unsafe trait SystemParamState: Send + Sync + 'static {
     #[inline]
     fn new_archetype(&mut self, _archetype: &Archetype, _system_meta: &mut SystemMeta) {}
     #[inline]
-    fn apply(&mut self, _world: &mut World) {}
+    #[allow(unused_variables)]
+    fn apply(&mut self, system_meta: &SystemMeta, _world: &mut World) {}
 }
 
 /// A [`SystemParamFetch`] that only reads a given [`World`].
@@ -595,7 +596,13 @@ unsafe impl SystemParamState for CommandQueue {
         Default::default()
     }
 
-    fn apply(&mut self, world: &mut World) {
+    fn apply(&mut self, _system_meta: &SystemMeta, world: &mut World) {
+        #[cfg(feature = "trace")]
+        let _system_span = bevy_utils::tracing::info_span!(
+            "system_commands",
+            name = _system_meta.name()
+        )
+        .entered();
         self.apply(world);
     }
 }
@@ -1499,9 +1506,9 @@ macro_rules! impl_system_param_tuple {
             }
 
             #[inline]
-            fn apply(&mut self, _world: &mut World) {
+            fn apply(&mut self, _system_meta: &SystemMeta, _world: &mut World) {
                 let ($($param,)*) = self;
-                $($param.apply(_world);)*
+                $($param.apply(_system_meta, _world);)*
             }
         }
     };
@@ -1640,8 +1647,8 @@ unsafe impl<S: SystemParamState, P: SystemParam + 'static> SystemParamState
         self.0.new_archetype(archetype, system_meta);
     }
 
-    fn apply(&mut self, world: &mut World) {
-        self.0.apply(world);
+    fn apply(&mut self, system_meta: &SystemMeta, world: &mut World) {
+        self.0.apply(system_meta, world);
     }
 }
 


### PR DESCRIPTION
# Objective
A separate `tracing` span for running a system's commands is created, even if the system doesn't have commands. This is adding extra measuring overhead (see #4892) where it's not needed.

## Solution
Move the span into `ParallelCommandState` and `CommandQueue`'s `SystemParamState::apply`. To get the right metadata for the span, a additional `&SystemMeta` parameter was added to `SystemParamState::apply`.

---

## Changelog
Added: `SystemMeta::name`
Changed: Systems without `Commands` and  `ParallelCommands` will no longer show a "system_commands" span when profiling.
Changed: `SystemParamState::apply` now takes a `&SystemMeta` parameter in addition to the provided `&mut World`.