### PR TITLE
Reduce memory usage in Edges

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -98,7 +98,7 @@ pub(crate) enum ComponentStatus {
 
 pub(crate) struct AddBundle {
     pub archetype_id: ArchetypeId,
-    pub bundle_status: Vec<ComponentStatus>,
+    pub bundle_status: u64,
 }
 
 /// This trait is used to report the status of [`Bundle`](crate::bundle::Bundle) components
@@ -116,8 +116,11 @@ pub(crate) trait BundleComponentStatus {
 impl BundleComponentStatus for AddBundle {
     #[inline]
     unsafe fn get_status(&self, index: usize) -> ComponentStatus {
-        // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        *self.bundle_status.get_unchecked(index)
+        if self.bundle_status & (1 << index) != 0 {
+            ComponentStatus::Added
+        } else {
+            ComponentStatus::Mutated
+        }
     }
 }
 
@@ -181,7 +184,7 @@ impl Edges {
         &mut self,
         bundle_id: BundleId,
         archetype_id: ArchetypeId,
-        bundle_status: Vec<ComponentStatus>,
+        bundle_status: u64,
     ) {
         self.add_bundle.insert(
             bundle_id,


### PR DESCRIPTION
# Objective
Reduce the memory usage of `Edges`. `SparseArray<AddBundle>` is exceptionally large to be keeping on every `Archetype`.

## Solution
Reduce the memory usage of it by storing the added/mutated status of components in a bundle as a `u64` bitmask instead of as a `Vec<ComponentStatus>`.

### Alternatives
The limitation on bundle size can be possibly undesirable. Here's a few alternatives and why they aren't immediately implemented:

  - Bump it up to `u128` and support up to a hard limit of 128 instead. Not really desirable as 128-bit machines don't really exist and the support for bit testing them can be spotty at the hardware level.
  - Use a `FixedBitset` instead. This actually increases the size of `AddBundle` by one `usize` and adds other checks, which might be undesirable.
  - Automatically batch bundles into groups of 64 for insertion. This causes more archetype fragmentation.

---

## Changelog
Changed: Bundles can contain a maximum of 64 components now. Attempting to insert a bundle with more than 64 components will panic.

## Migration Guide
TODO