### PR TITLE
[Merged by Bors] - Remove `render` feature group

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,13 @@ default = [
   "bevy_gilrs",
   "bevy_scene",
   "bevy_winit",
-  "render",
+  "bevy_core_pipeline",
+  "bevy_pbr",
+  "bevy_gltf",
+  "bevy_render",
+  "bevy_sprite",
+  "bevy_text",
+  "bevy_ui",
   "png",
   "hdr",
   "vorbis",
@@ -42,17 +48,6 @@ default = [
 
 # Force dynamic linking, which improves iterative compile times
 dynamic = ["bevy_dylib"]
-
-# Rendering support
-render = [
-  "bevy_internal/bevy_core_pipeline",
-  "bevy_internal/bevy_pbr",
-  "bevy_internal/bevy_gltf",
-  "bevy_internal/bevy_render",
-  "bevy_internal/bevy_sprite",
-  "bevy_internal/bevy_text",
-  "bevy_internal/bevy_ui",
-]
 
 # Optional bevy crates
 bevy_animation = ["bevy_internal/bevy_animation"]

--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -14,7 +14,11 @@ crate-type = ["staticlib"]
 bevy = { path = "../../", features = [ 
   "bevy_audio",
   "bevy_winit",
-  "render",
+  "bevy_core_pipeline",
+  "bevy_pbr",
+  "bevy_render",
+  "bevy_text",
+  "bevy_ui",
   "vorbis",
   "filesystem_watcher"
 ], default-features = false}


### PR DESCRIPTION
# Objective

The feature doesn't have any use case in libraries or applications and many users use this feature incorrectly. See the issue for details.
Closes #5753.

## Solution

Remove it.

---

## Changelog

### Removed

- `render` feature group. 

## Migration Guide

Instead of using `render` feature group use dependencies directly. This group consisted of `bevy_core_pipeline`, `bevy_pbr`, `bevy_gltf`, `bevy_render`, `bevy_sprite`, `bevy_text` and `bevy_ui`. You probably want to check if you need all of them.

