### PR TITLE
[Merged by Bors] - Fix alpha channel in RGB32F image texture format conversion

### DIFF
--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -126,7 +126,7 @@ impl Image {
                     let r = pixel[0];
                     let g = pixel[1];
                     let b = pixel[2];
-                    let a = u16::max_value();
+                    let a = 1f32;
 
                     local_data.extend_from_slice(&r.to_ne_bytes());
                     local_data.extend_from_slice(&g.to_ne_bytes());


### PR DESCRIPTION
# Objective

The following code:

```rs
use bevy::prelude::Image;
use image::{ DynamicImage, GenericImage, Rgba };

fn main() {
    let mut dynamic_image = DynamicImage::new_rgb32f(1, 1);
    dynamic_image.put_pixel(0, 0, Rgba([1, 1, 1, 1]));
    
    let image = Image::from_dynamic(dynamic_image, false); // Panic!
    println!("{image:?}");
}
```

Can cause an assertion failed:

```
thread 'main' panicked at 'assertion failed: `(left == right)`
  left: `16`,
 right: `14`: Pixel data, size and format have to match', .../bevy_render-0.9.1/src/texture/image.rs:209:9
stack backtrace:
...
   4: core::panicking::assert_failed<usize,usize>
             at /rustc/897e37553bba8b42751c67658967889d11ecd120/library/core/src/panicking.rs:181
   5: bevy_render::texture::image::Image::new
             at .../bevy_render-0.9.1/src/texture/image.rs:209
   6: bevy_render::texture::image::Image::from_dynamic
             at .../bevy_render-0.9.1/src/texture/image_texture_conversion.rs:159
   7: bevy_test::main
             at ./src/main.rs:8
...
```

It seems to be cause by a copypasta in `crates/bevy_render/src/texture/image_texture_conversion.rs`. Let's fix it.

## Solution

```diff
  // DynamicImage::ImageRgb32F(image) => {
- let a = u16::max_value();
+ let a = 1f32;
```

This will fix the conversion.

---

## Changelog

- Fixed the alpha channel of the `image::DynamicImage::ImageRgb32F` to `bevy_render::texture::Image` conversion in `bevy_render::texture::Image::from_dynamic()`.
