### PR TITLE
[Merged by Bors] - Use `World` helper methods for sending `HierarchyEvent`s 

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1282,7 +1282,7 @@ impl World {
 
     /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.
     #[inline]
-    pub fn send_event_batch<E: crate::event::Event>(&mut self, events: impl Iterator<Item = E>) {
+    pub fn send_event_batch<E: crate::event::Event>(&mut self, events: impl IntoIterator<Item = E>) {
         match self.get_resource_mut::<crate::event::Events<E>>() {
             Some(mut events_resource) => events_resource.extend(events),
             None => bevy_utils::tracing::error!(

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -15,6 +15,7 @@ use crate::{
         Component, ComponentDescriptor, ComponentId, ComponentInfo, Components, TickCells,
     },
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
+    event::{Event, Events},
     query::{QueryState, ReadOnlyWorldQuery, WorldQuery},
     storage::{ResourceData, SparseSet, Storages},
     system::Resource,
@@ -1268,22 +1269,22 @@ impl World {
         result
     }
 
-    /// Sends an [`Event`](crate::event::Event).
+    /// Sends an [`Event`].
     #[inline]
-    pub fn send_event<E: crate::event::Event>(&mut self, event: E) {
+    pub fn send_event<E: Event>(&mut self, event: E) {
         self.send_event_batch(std::iter::once(event));
     }
 
-    /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
+    /// Sends the default value of the [`Event`] of type `E`.
     #[inline]
-    pub fn send_event_default<E: crate::event::Event + Default>(&mut self) {
+    pub fn send_event_default<E: Event + Default>(&mut self) {
         self.send_event_batch(std::iter::once(E::default()));
     }
 
-    /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.
+    /// Sends a batch of [`Event`]s from an iterator.
     #[inline]
-    pub fn send_event_batch<E: crate::event::Event>(&mut self, events: impl IntoIterator<Item = E>) {
-        match self.get_resource_mut::<crate::event::Events<E>>() {
+    pub fn send_event_batch<E: Event>(&mut self, events: impl IntoIterator<Item = E>) {
+        match self.get_resource_mut::<Events<E>>() {
             Some(mut events_resource) => events_resource.extend(events),
             None => bevy_utils::tracing::error!(
                     "Unable to send event `{}`\n\tEvent must be added to the app with `add_event()`\n\thttps://docs.rs/bevy/*/bevy/app/struct.App.html#method.add_event ",

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -2,19 +2,10 @@ use crate::{Children, HierarchyEvent, Parent};
 use bevy_ecs::{
     bundle::Bundle,
     entity::Entity,
-    event::Events,
     system::{Command, Commands, EntityCommands},
     world::{EntityMut, World},
 };
 use smallvec::SmallVec;
-
-fn push_events(world: &mut World, events: SmallVec<[HierarchyEvent; 8]>) {
-    if let Some(mut moved) = world.get_resource_mut::<Events<HierarchyEvent>>() {
-        for evt in events {
-            moved.send(evt);
-        }
-    }
-}
 
 fn push_child_unchecked(world: &mut World, parent: Entity, child: Entity) {
     let mut parent = world.entity_mut(parent);
@@ -64,7 +55,7 @@ fn update_old_parents(world: &mut World, parent: Entity, children: &[Entity]) {
             });
         }
     }
-    push_events(world, moved);
+    world.send_event_batch(moved);
 }
 
 fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
@@ -83,7 +74,7 @@ fn remove_children(parent: Entity, children: &[Entity], world: &mut World) {
             world.entity_mut(child).remove::<Parent>();
         }
     }
-    push_events(world, events);
+    world.send_event_batch(events);
 
     let mut parent = world.entity_mut(parent);
     if let Some(mut parent_children) = parent.get_mut::<Children>() {
@@ -114,19 +105,16 @@ impl Command for AddChild {
                 return;
             }
             remove_from_children(world, previous, self.child);
-            if let Some(mut events) = world.get_resource_mut::<Events<HierarchyEvent>>() {
-                events.send(HierarchyEvent::ChildMoved {
-                    child: self.child,
-                    previous_parent: previous,
-                    new_parent: self.parent,
-                });
-            }
-        } else if let Some(mut events) = world.get_resource_mut::<Events<HierarchyEvent>>() {
-            events.send(HierarchyEvent::ChildAdded {
+            world.send_event(HierarchyEvent::ChildMoved {
                 child: self.child,
-                parent: self.parent,
+                previous_parent: previous,
+                new_parent: self.parent,
             });
         }
+        world.send_event(HierarchyEvent::ChildAdded {
+            child: self.child,
+            parent: self.parent,
+        });
         let mut parent = world.entity_mut(self.parent);
         if let Some(mut children) = parent.get_mut::<Children>() {
             if !children.contains(&self.child) {
@@ -202,12 +190,10 @@ impl Command for RemoveParent {
             let parent_entity = parent.get();
             remove_from_children(world, parent_entity, self.child);
             world.entity_mut(self.child).remove::<Parent>();
-            if let Some(mut events) = world.get_resource_mut::<Events<_>>() {
-                events.send(HierarchyEvent::ChildRemoved {
-                    child: self.child,
-                    parent: parent_entity,
-                });
-            }
+            world.send_event(HierarchyEvent::ChildRemoved {
+                child: self.child,
+                parent: parent_entity,
+            });
         }
     }
 }
@@ -393,12 +379,10 @@ impl<'w> WorldChildBuilder<'w> {
     pub fn spawn(&mut self, bundle: impl Bundle + Send + Sync + 'static) -> EntityMut<'_> {
         let entity = self.world.spawn((bundle, Parent(self.parent))).id();
         push_child_unchecked(self.world, self.parent, entity);
-        if let Some(mut added) = self.world.get_resource_mut::<Events<HierarchyEvent>>() {
-            added.send(HierarchyEvent::ChildAdded {
-                child: entity,
-                parent: self.parent,
-            });
-        }
+        self.world.send_event(HierarchyEvent::ChildAdded {
+            child: entity,
+            parent: self.parent,
+        });
         self.world.entity_mut(entity)
     }
 
@@ -406,12 +390,10 @@ impl<'w> WorldChildBuilder<'w> {
     pub fn spawn_empty(&mut self) -> EntityMut<'_> {
         let entity = self.world.spawn(Parent(self.parent)).id();
         push_child_unchecked(self.world, self.parent, entity);
-        if let Some(mut added) = self.world.get_resource_mut::<Events<HierarchyEvent>>() {
-            added.send(HierarchyEvent::ChildAdded {
-                child: entity,
-                parent: self.parent,
-            });
-        }
+        self.world.send_event(HierarchyEvent::ChildAdded {
+            child: entity,
+            parent: self.parent,
+        });
         self.world.entity_mut(entity)
     }
 


### PR DESCRIPTION
A code-quality PR

Also cleans up the helper methods by just importing the `Event` type