### PR TITLE
Fallible System Parameters

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -371,7 +371,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 } else {
                     return syn::Error::new_spanned(
                         attr,
-                        "The content of `fallibility` should be a single identifier."
+                        "The content of `fallibility` should be a single identifier.",
                     )
                     .into_compile_error()
                     .into();
@@ -379,7 +379,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             } else {
                 return syn::Error::new_spanned(
                     attr,
-                    "There should only be one `fallibility` attribute."
+                    "There should only be one `fallibility` attribute.",
                 )
                 .into_compile_error()
                 .into();
@@ -400,7 +400,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         f
     };
 
-    // Read field-level attributes 
+    // Read field-level attributes
     let field_attributes = fields
         .iter()
         .map(|field| {
@@ -511,7 +511,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 
                 #returned_struct
             },
-            quote! { Self::Item<'w, 's> }
+            quote! { Self::Item<'w, 's> },
         ),
         Fallibility::Optional => (
             quote! {
@@ -521,16 +521,16 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 
                 Some(#returned_struct)
             },
-            quote! { Option<Self::Item<'w, 's>> }
-    ),
+            quote! { Option<Self::Item<'w, 's>> },
+        ),
         Fallibility::Resultful => (
             quote! {
                 #(let #fields = <<#field_types as #path::system::SystemParam<#fallible>>::State as #path::system::SystemParamState<#fallible>>::get_param(&mut state.state.#field_indices, system_meta, world, change_tick)?;)*
 
                 Ok(#returned_struct)
             },
-            quote! { Result<Self::Item<'w, 's>, &'s dyn std::error::Error> }
-        )
+            quote! { Result<Self::Item<'w, 's>, &'s dyn std::error::Error> },
+        ),
     };
 
     TokenStream::from(quote! {

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -347,7 +347,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     for attr in &ast.attrs {
         let Some(attr_ident) = attr.path.get_ident() else { continue };
         if attr_ident == FALLIBILITY_ATTRIBUTE_NAME {
-            if fallibility == None {
+            if fallibility.is_none() {
                 if let Ok(fallible_ident) =
                     attr.parse_args_with(|input: ParseStream| input.parse::<Ident>())
                 {

--- a/crates/bevy_ecs/src/system/commands/parallel_scope.rs
+++ b/crates/bevy_ecs/src/system/commands/parallel_scope.rs
@@ -5,7 +5,7 @@ use thread_local::ThreadLocal;
 use crate::{
     entity::Entities,
     prelude::World,
-    system::{SystemMeta, SystemParam, SystemParamState},
+    system::{Infallible, SystemMeta, SystemParam, SystemParamState},
 };
 
 use super::{CommandQueue, Commands};
@@ -48,12 +48,12 @@ pub struct ParallelCommands<'w, 's> {
     entities: &'w Entities,
 }
 
-impl SystemParam for ParallelCommands<'_, '_> {
+impl SystemParam<Infallible> for ParallelCommands<'_, '_> {
     type State = ParallelCommandsState;
 }
 
 // SAFETY: no component or resource access to report
-unsafe impl SystemParamState for ParallelCommandsState {
+unsafe impl SystemParamState<Infallible> for ParallelCommandsState {
     type Item<'w, 's> = ParallelCommands<'w, 's>;
 
     fn init(_: &mut World, _: &mut crate::system::SystemMeta) -> Self {

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -1,7 +1,7 @@
 use crate::{
     prelude::{FromWorld, QueryState},
     query::{ReadOnlyWorldQuery, WorldQuery},
-    system::{Local, LocalState, SystemMeta, SystemParam, SystemState},
+    system::{Infallible, Local, LocalState, SystemMeta, SystemParam, SystemState},
     world::World,
 };
 use bevy_ecs_macros::all_tuples;
@@ -45,11 +45,11 @@ impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemPa
     }
 }
 
-impl<'a, P: SystemParam + 'static> ExclusiveSystemParam for &'a mut SystemState<P> {
+impl<'a, P: SystemParam<Infallible> + 'static> ExclusiveSystemParam for &'a mut SystemState<P> {
     type State = SystemState<P>;
 }
 
-impl<P: SystemParam> ExclusiveSystemParamState for SystemState<P> {
+impl<P: SystemParam<Infallible>> ExclusiveSystemParamState for SystemState<P> {
     type Item<'s> = &'s mut SystemState<P>;
 
     fn init(world: &mut World, _system_meta: &mut SystemMeta) -> Self {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -553,7 +553,9 @@ impl<T> Copy for SystemTypeIdLabel<T> {}
 /// ```
 /// [`PipeSystem`]: crate::system::PipeSystem
 /// [`ParamSet`]: crate::system::ParamSet
-pub trait SystemParamFunction<In, Out, Param: SystemParam<Infallible>, Marker>: Send + Sync + 'static {
+pub trait SystemParamFunction<In, Out, Param: SystemParam<Infallible>, Marker>:
+    Send + Sync + 'static
+{
     fn run(&mut self, input: In, param_value: SystemParamItem<Param>) -> Out;
 }
 
@@ -617,8 +619,13 @@ pub trait AsSystemLabel<Marker> {
     fn as_system_label(&self) -> SystemLabelId;
 }
 
-impl<In, Out, Param: SystemParam<Infallible>, Marker, T: SystemParamFunction<In, Out, Param, Marker>>
-    AsSystemLabel<(In, Out, Param, Marker)> for T
+impl<
+        In,
+        Out,
+        Param: SystemParam<Infallible>,
+        Marker,
+        T: SystemParamFunction<In, Out, Param, Marker>,
+    > AsSystemLabel<(In, Out, Param, Marker)> for T
 {
     #[inline]
     fn as_system_label(&self) -> SystemLabelId {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -505,7 +505,7 @@ impl<T> Copy for SystemTypeIdLabel<T> {}
 /// use std::num::ParseIntError;
 ///
 /// use bevy_ecs::prelude::*;
-/// use bevy_ecs::system::{SystemParam, SystemParamItem};
+/// use bevy_ecs::system::{Infallible, SystemParam, SystemParamItem};
 ///
 /// // Unfortunately, we need all of these generics. `A` is the first system, with its
 /// // parameters and marker type required for coherence. `B` is the second system, and
@@ -519,8 +519,8 @@ impl<T> Copy for SystemTypeIdLabel<T> {}
 ///     // We need A and B to be systems, add those bounds
 ///     A: SystemParamFunction<AIn, Shared, AParam, AMarker>,
 ///     B: SystemParamFunction<Shared, BOut, BParam, BMarker>,
-///     AParam: SystemParam,
-///     BParam: SystemParam,
+///     AParam: SystemParam<Infallible>,
+///     BParam: SystemParam<Infallible>,
 /// {
 ///     // The type of `params` is inferred based on the return of this function above
 ///     move |In(a_in), mut params| {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1493,14 +1493,14 @@ pub mod lifetimeless {
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
-/// use bevy_ecs::system::{SystemParam, StaticSystemParam};
+/// use bevy_ecs::system::{Infallible, SystemParam, StaticSystemParam};
 /// #[derive(SystemParam)]
-/// struct GenericParam<'w,'s, T: SystemParam + 'static> {
+/// struct GenericParam<'w,'s, T: SystemParam<Infallible> + 'static> {
 ///     field: StaticSystemParam<'w, 's, T>,
 /// }
-/// fn do_thing_generically<T: SystemParam + 'static>(t: StaticSystemParam<T>) {}
+/// fn do_thing_generically<T: SystemParam<Infallible> + 'static>(t: StaticSystemParam<T>) {}
 ///
-/// fn check_always_is_system<T: SystemParam + 'static>(){
+/// fn check_always_is_system<T: SystemParam<Infallible> + 'static>(){
 ///     bevy_ecs::system::assert_is_system(do_thing_generically::<T>);
 /// }
 /// ```

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -255,9 +255,9 @@ mod sealed {
 
 /// A parameter that can be used in a [`System`](super::System).
 ///
-/// This type comes in three variants:
+/// This trait comes in three variants, where [`Infallible`] is the base variant:
 ///
-/// - [`Infallible`]: The base case, which can be used as `T`.
+/// - [`Infallible`]: Which can be used as `T`.
 /// - [`Optional`]: Which can be used as `Option<T>` or `T`.
 /// - [`Resultful`]: Which can be used as `Result<T, &dyn Error>`, `Option<T>`, or `T`.
 ///
@@ -274,6 +274,11 @@ mod sealed {
 ///
 /// ## Attributes
 ///
+/// `#[fallibility(T)]`:
+/// Can be added to the struct. `T` can be one of [`Infallible`], [`Optional`], or [`Resultful`].
+/// This requires the fields to have the same fallibility.
+/// If the attribute is not specified, the fallibility defaults to [`Infallible`].
+///
 /// `#[system_param(ignore)]`:
 /// Can be added to any field in the struct. Fields decorated with this attribute
 /// will be created with the default value upon realisation.
@@ -289,6 +294,7 @@ mod sealed {
 /// use bevy_ecs::system::SystemParam;
 ///
 /// #[derive(SystemParam)]
+/// #[fallibility(Optional)]
 /// struct MyParam<'w, Marker: 'static> {
 ///     foo: Res<'w, SomeResource>,
 ///     #[system_param(ignore)]
@@ -1848,4 +1854,10 @@ mod tests {
 
     #[derive(SystemParam)]
     pub struct UnitParam {}
+
+    #[derive(SystemParam)]
+    #[fallibility(Optional)]
+    pub struct OptionalParam<'w, T: Resource> {
+        _res: Res<'w, T>,
+    }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -759,7 +759,7 @@ impl<'a, T: Resource> SystemParam<Optional> for Res<'a, T> {
     type State = ResState<T>;
 }
 
-// SAFETY: Res ComponentI d and ArchetypeComponentId access is applied to SystemMeta. If this Res
+// SAFETY: Res ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this Res
 // conflicts with any prior access, a panic will occur.
 unsafe impl<T: Resource> SystemParamState<Optional> for ResState<T> {
     type Item<'w, 's> = Res<'w, T>;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -63,7 +63,7 @@ use std::{
 ///         }
 ///     }
 ///
-/// 	type Item<'w, 's> = MyParam<'w>;
+///     type Item<'w, 's> = MyParam<'w>;
 ///
 ///     #[inline]
 ///     unsafe fn get_param<'w, 's>(

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -236,17 +236,20 @@ pub struct Resultful;
 
 mod sealed {
     use std::error::Error;
+
+    /// Describes a [`SystemParam`](super::SystemParam)'s level of fallibility.
     pub trait Fallibility {
-        type Scope<'s, T>;
+        /// Maps `T` to some form of error-handling.
+        type Fallible<'s, T>;
     }
     impl Fallibility for super::Infallible {
-        type Scope<'s, T> = T;
+        type Fallible<'s, T> = T;
     }
     impl Fallibility for super::Optional {
-        type Scope<'s, T> = Option<T>;
+        type Fallible<'s, T> = Option<T>;
     }
     impl Fallibility for super::Resultful {
-        type Scope<'s, T> = Result<T, &'s dyn Error>;
+        type Fallible<'s, T> = Result<T, &'s dyn Error>;
     }
 }
 
@@ -518,7 +521,7 @@ pub unsafe trait SystemParamState<T: sealed::Fallibility>: Send + Sync + 'static
         system_meta: &SystemMeta,
         world: &'world World,
         change_tick: u32,
-    ) -> T::Scope<'state, Self::Item<'world, 'state>>;
+    ) -> T::Fallible<'state, Self::Item<'world, 'state>>;
 }
 
 /// A [`SystemParam`] that only reads a given [`World`].

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -31,12 +31,10 @@ use std::{
 /// # Example
 ///
 /// ```
-/// use bevy::{
-///     ecs::system::{
-///         Infallible, ResState, SystemMeta,
-///         SystemParam, SystemParamState,
-///     },
-///     prelude::*,
+/// # use bevy_ecs::prelude::*;
+/// use bevy_ecs::system::{
+///     Infallible, ResState, SystemMeta,
+///     SystemParam, SystemParamState,
 /// };
 /// # #[derive(Resource)]
 /// # struct SomeResource {
@@ -57,7 +55,7 @@ use std::{
 /// }
 ///
 /// unsafe impl SystemParamState<Infallible> for MyParamState {
-///     fn init(world: &mut World, system_meta: &mut bevy::ecs::system::SystemMeta) -> Self {
+///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
 ///         Self {
 ///             res_state: <ResState<SomeResource> as SystemParamState<Infallible>>::init(world, system_meta),
 ///         }
@@ -96,12 +94,10 @@ pub struct Infallible;
 /// # Example
 ///
 /// ```
-/// use bevy::{
-///     ecs::system::{
-///         Infallible, Optional, OptionState, ResState, SystemMeta,
-///         SystemParam, SystemParamState,
-///     },
-///     prelude::*,
+/// # use bevy_ecs::prelude::*;
+/// use bevy_ecs::system::{
+///     Infallible, Optional, OptionState, ResState, SystemMeta,
+///     SystemParam, SystemParamState,
 /// };
 /// # #[derive(Resource)]
 /// # struct SomeResource {
@@ -122,7 +118,7 @@ pub struct Infallible;
 /// }
 ///
 /// unsafe impl SystemParamState<Optional> for MyParamState {
-///     fn init(world: &mut World, system_meta: &mut bevy::ecs::system::SystemMeta) -> Self {
+///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
 ///         Self {
 ///             res_state: OptionState::init(world, system_meta),
 ///         }
@@ -163,12 +159,10 @@ pub struct Optional;
 /// # Example
 ///
 /// ```
-/// use bevy::{
-///     ecs::system::{
-///         Infallible, Resultful, OptionState, ResState, SystemMeta,
-///         SystemParam, SystemParamState,
-///     },
-///     prelude::*,
+/// # use bevy_ecs::prelude::*;
+/// use bevy_ecs::system::{
+///     Infallible, Resultful, OptionState, ResState, SystemMeta,
+///     SystemParam, SystemParamState,
 /// };
 /// use std::error::Error;
 /// # #[derive(Resource)]
@@ -190,7 +184,7 @@ pub struct Optional;
 /// }
 ///
 /// unsafe impl SystemParamState<Resultful> for MyParamState {
-///     fn init(world: &mut World, system_meta: &mut bevy::ecs::system::SystemMeta) -> Self {
+///     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
 ///         Self {
 ///             res_state: OptionState::init(world, system_meta),
 ///         }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -166,11 +166,11 @@ unsafe impl<T: SystemParamState<Optional>> SystemParamState<Infallible> for T {
     type Item<'world, 'state> = T::Item<'world, 'state>;
 
     unsafe fn get_param<'world, 'state>(
-            state: &'state mut Self,
-            system_meta: &SystemMeta,
-            world: &'world World,
-            change_tick: u32,
-        ) -> Self::Item<'world, 'state> {
+        state: &'state mut Self,
+        system_meta: &SystemMeta,
+        world: &'world World,
+        change_tick: u32,
+    ) -> Self::Item<'world, 'state> {
         T::get_param(state, system_meta, world, change_tick).unwrap_or_else(|| {
             panic!(
                 "Failed to get system param `{}`",
@@ -203,11 +203,11 @@ unsafe impl<T: SystemParamState<Optional>> SystemParamState<Infallible> for Opti
     type Item<'world, 'state> = Option<T::Item<'world, 'state>>;
 
     unsafe fn get_param<'world, 'state>(
-            state: &'state mut Self,
-            system_meta: &SystemMeta,
-            world: &'world World,
-            change_tick: u32,
-        ) -> Self::Item<'world, 'state> {
+        state: &'state mut Self,
+        system_meta: &SystemMeta,
+        world: &'world World,
+        change_tick: u32,
+    ) -> Self::Item<'world, 'state> {
         T::get_param(&mut state.0, system_meta, world, change_tick)
     }
 }
@@ -216,7 +216,7 @@ impl<T: SystemParam<Resultful>> SystemParam<Optional> for T {
     type State = T::State;
 }
 
-unsafe impl <T: SystemParamState<Resultful>> SystemParamState<Optional> for T {
+unsafe impl<T: SystemParamState<Resultful>> SystemParamState<Optional> for T {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         T::init(world, system_meta)
     }
@@ -232,11 +232,11 @@ unsafe impl <T: SystemParamState<Resultful>> SystemParamState<Optional> for T {
     type Item<'world, 'state> = T::Item<'world, 'state>;
 
     unsafe fn get_param<'world, 'state>(
-            state: &'state mut Self,
-            system_meta: &SystemMeta,
-            world: &'world World,
-            change_tick: u32,
-        ) -> Option<Self::Item<'world, 'state>> {
+        state: &'state mut Self,
+        system_meta: &SystemMeta,
+        world: &'world World,
+        change_tick: u32,
+    ) -> Option<Self::Item<'world, 'state>> {
         T::get_param(state, system_meta, world, change_tick).ok()
     }
 }
@@ -264,16 +264,17 @@ unsafe impl<T: SystemParamState<Resultful>> SystemParamState<Infallible> for Res
     type Item<'world, 'state> = Result<T::Item<'world, 'state>, Box<dyn Error>>;
 
     unsafe fn get_param<'world, 'state>(
-            state: &'state mut Self,
-            system_meta: &SystemMeta,
-            world: &'world World,
-            change_tick: u32,
-        ) -> Self::Item<'world, 'state> {
+        state: &'state mut Self,
+        system_meta: &SystemMeta,
+        world: &'world World,
+        change_tick: u32,
+    ) -> Self::Item<'world, 'state> {
         T::get_param(&mut state.0, system_meta, world, change_tick)
     }
 }
 
-pub type SystemParamItem<'w, 's, P> = <<P as SystemParam<Infallible>>::State as SystemParamState<Infallible>>::Item<'w, 's>;
+pub type SystemParamItem<'w, 's, P> =
+    <<P as SystemParam<Infallible>>::State as SystemParamState<Infallible>>::Item<'w, 's>;
 
 /// The state of a [`SystemParam`].
 ///
@@ -1568,8 +1569,8 @@ impl<'world, 'state, P: SystemParam<Infallible> + 'static> SystemParam<Infallibl
 }
 
 // SAFETY: all methods are just delegated to `S`'s `SystemParamState` implementation
-unsafe impl<S: SystemParamState<Infallible>, P: SystemParam<Infallible, State = S> + 'static> SystemParamState<Infallible>
-    for StaticSystemParamState<S, P>
+unsafe impl<S: SystemParamState<Infallible>, P: SystemParam<Infallible, State = S> + 'static>
+    SystemParamState<Infallible> for StaticSystemParamState<S, P>
 {
     type Item<'world, 'state> = StaticSystemParam<'world, 'state, P>;
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -150,6 +150,7 @@ impl<T: SystemParam<Optional>> SystemParam<Infallible> for T {
     type State = T::State;
 }
 
+// SAFETY: `SystemParamState<Optional>` must be safely implemented.
 unsafe impl<T: SystemParamState<Optional>> SystemParamState<Infallible> for T {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         T::init(world, system_meta)
@@ -187,6 +188,7 @@ impl<T: SystemParam<Optional>> SystemParam<Infallible> for Option<T> {
 #[doc(hidden)]
 pub struct OptionState<T: SystemParamState<Optional>>(T);
 
+// SAFETY: `SystemParamState<Optional>` must be safely implemented.
 unsafe impl<T: SystemParamState<Optional>> SystemParamState<Infallible> for OptionState<T> {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         Self(T::init(world, system_meta))
@@ -216,6 +218,7 @@ impl<T: SystemParam<Resultful>> SystemParam<Optional> for T {
     type State = T::State;
 }
 
+// SAFETY: `SystemParamState<Resultful>` must be safely implemented.
 unsafe impl<T: SystemParamState<Resultful>> SystemParamState<Optional> for T {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         T::init(world, system_meta)
@@ -248,6 +251,7 @@ impl<T: SystemParam<Resultful>> SystemParam<Infallible> for Result<T, Box<dyn Er
 #[doc(hidden)]
 pub struct ResultState<T: SystemParamState<Resultful>>(T);
 
+// SAFETY: `SystemParamState<Resultful>` must be safely implemented.
 unsafe impl<T: SystemParamState<Resultful>> SystemParamState<Infallible> for ResultState<T> {
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self {
         Self(T::init(world, system_meta))

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -2,8 +2,8 @@ use crate::MainWorld;
 use bevy_ecs::{
     prelude::*,
     system::{
-        ReadOnlySystemParam, ResState, SystemMeta, SystemParam, SystemParamItem, SystemParamState,
-        SystemState, Infallible
+        Infallible, ReadOnlySystemParam, ResState, SystemMeta, SystemParam, SystemParamItem,
+        SystemParamState, SystemState,
     },
 };
 use std::ops::{Deref, DerefMut};
@@ -74,7 +74,10 @@ where
         let mut main_world = world.resource_mut::<MainWorld>();
         Self {
             state: SystemState::new(&mut main_world),
-            main_world_state: <ResState<MainWorld> as SystemParamState<Infallible>>::init(world, system_meta),
+            main_world_state: <ResState<MainWorld> as SystemParamState<Infallible>>::init(
+                world,
+                system_meta,
+            ),
         }
     }
 

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -3,7 +3,7 @@ use bevy_ecs::{
     prelude::*,
     system::{
         ReadOnlySystemParam, ResState, SystemMeta, SystemParam, SystemParamItem, SystemParamState,
-        SystemState,
+        SystemState, Infallible
     },
 };
 use std::ops::{Deref, DerefMut};
@@ -49,7 +49,7 @@ where
     item: SystemParamItem<'w, 's, P>,
 }
 
-impl<'w, 's, P> SystemParam for Extract<'w, 's, P>
+impl<'w, 's, P> SystemParam<Infallible> for Extract<'w, 's, P>
 where
     P: ReadOnlySystemParam,
 {
@@ -57,14 +57,14 @@ where
 }
 
 #[doc(hidden)]
-pub struct ExtractState<P: SystemParam + 'static> {
+pub struct ExtractState<P: SystemParam<Infallible> + 'static> {
     state: SystemState<P>,
     main_world_state: ResState<MainWorld>,
 }
 
 // SAFETY: only accesses MainWorld resource with read only system params using ResState,
 // which is initialized in init()
-unsafe impl<P: SystemParam + 'static> SystemParamState for ExtractState<P>
+unsafe impl<P: SystemParam<Infallible> + 'static> SystemParamState<Infallible> for ExtractState<P>
 where
     P: ReadOnlySystemParam + 'static,
 {
@@ -74,7 +74,7 @@ where
         let mut main_world = world.resource_mut::<MainWorld>();
         Self {
             state: SystemState::new(&mut main_world),
-            main_world_state: ResState::init(world, system_meta),
+            main_world_state: <ResState<MainWorld> as SystemParamState<Infallible>>::init(world, system_meta),
         }
     }
 
@@ -84,7 +84,7 @@ where
         world: &'w World,
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
-        let main_world = ResState::<MainWorld>::get_param(
+        let main_world = <ResState<MainWorld> as SystemParamState<Infallible>>::get_param(
             &mut state.main_world_state,
             system_meta,
             world,
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<'w, 's, P: SystemParam> Deref for Extract<'w, 's, P>
+impl<'w, 's, P: SystemParam<Infallible>> Deref for Extract<'w, 's, P>
 where
     P: ReadOnlySystemParam,
 {
@@ -107,7 +107,7 @@ where
     }
 }
 
-impl<'w, 's, P: SystemParam> DerefMut for Extract<'w, 's, P>
+impl<'w, 's, P: SystemParam<Infallible>> DerefMut for Extract<'w, 's, P>
 where
     P: ReadOnlySystemParam,
 {
@@ -117,7 +117,7 @@ where
     }
 }
 
-impl<'a, 'w, 's, P: SystemParam> IntoIterator for &'a Extract<'w, 's, P>
+impl<'a, 'w, 's, P: SystemParam<Infallible>> IntoIterator for &'a Extract<'w, 's, P>
 where
     P: ReadOnlySystemParam,
     &'a SystemParamItem<'w, 's, P>: IntoIterator,

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -4,7 +4,7 @@ use bevy_asset::{Asset, AssetEvent, Assets, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::*,
-    system::{StaticSystemParam, SystemParam, SystemParamItem},
+    system::{Infallible, StaticSystemParam, SystemParam, SystemParamItem},
 };
 use bevy_utils::{HashMap, HashSet};
 use std::marker::PhantomData;
@@ -29,7 +29,7 @@ pub trait RenderAsset: Asset {
     type PreparedAsset: Send + Sync + 'static;
     /// Specifies all ECS data required by [`RenderAsset::prepare_asset`].
     /// For convenience use the [`lifetimeless`](bevy_ecs::system::lifetimeless) [`SystemParam`].
-    type Param: SystemParam;
+    type Param: SystemParam<Infallible>;
     /// Converts the asset into a [`RenderAsset::ExtractedAsset`].
     fn extract_asset(&self) -> Self::ExtractedAsset;
     /// Prepares the `extracted asset` for the GPU by transforming it into

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     entity::Entity,
     system::{
         lifetimeless::SRes, ReadOnlySystemParam, Resource, SystemParam, SystemParamItem,
-        SystemState,
+        SystemState, Infallible,
     },
     world::World,
 };
@@ -167,7 +167,7 @@ impl<P: PhaseItem> DrawFunctions<P> {
 pub trait RenderCommand<P: PhaseItem> {
     /// Specifies all ECS data required by [`RenderCommand::render`].
     /// All parameters have to be read only.
-    type Param: SystemParam + 'static;
+    type Param: SystemParam<Infallible> + 'static;
 
     /// Renders the [`PhaseItem`] by issuing draw calls via the [`TrackedRenderPass`].
     fn render<'w>(
@@ -184,7 +184,7 @@ pub enum RenderCommandResult {
 }
 
 pub trait EntityRenderCommand {
-    type Param: SystemParam + 'static;
+    type Param: SystemParam<Infallible> + 'static;
     fn render<'w>(
         view: Entity,
         item: Entity,

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -7,8 +7,8 @@ use bevy_ecs::{
     all_tuples,
     entity::Entity,
     system::{
-        lifetimeless::SRes, ReadOnlySystemParam, Resource, SystemParam, SystemParamItem,
-        SystemState, Infallible,
+        lifetimeless::SRes, Infallible, ReadOnlySystemParam, Resource, SystemParam,
+        SystemParamItem, SystemState,
     },
     world::World,
 };


### PR DESCRIPTION
# Objective

There is no way to implement `SystemParam` for `Option<T>` and `Result<T, E>` in downstream crates because of orphan rules.

## Solution

Make `SystemParam` generic for `T: Fallibility`. The sealed trait `Fallibility` describes the return value of `SystemParamState::get_param` via the generic associated type `Scope<T>`. Users can then use the marker structs `Infallible`, `Optional`, and `Resultful`, which define `Scope<T>` to be `T`, `Option<T>` and `Result<T, &dyn Error>`.

`&dyn Error` was chosen because there was no way to constrain the type parameter `E` ([this would require higher-ranked types](https://github.com/rust-lang/rfcs/issues/1481)).

The point of doing it this way instead of creating `OptionalSystemParam` and `ResultfulSystemParam` traits is that there would otherwise be significant overlap between traits as `SystemParamFetch` and `SystemParamState` get merged into `SystemParam`.

---

## Changelog

- Changed `SystemParam` to `SystemParam<T: Fallibility>`.
- Changed `SystemParamState` to `SystemParamState<T: Fallibility>`.
- Changed instances of `SystemParam` to `SystemParam<Infallible>` or `SystemParam<Optional>`, when appropriate.
- Changed instances of `SystemParamState` to `SystemParamState<Infallible>` or `SystemParamState<Optional>`, when appropriate.
- Added sealed `Fallibility` trait.
- Added `Infallible`, `Optional`, and `Resultful` markers.

## Migration Guide

- Instances of `SystemParam` and `SystemParamState` have to be changed to their respective generic type.