### PR TITLE
bevy_sprite: fail early on missing RenderPlugin

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -61,21 +61,22 @@ impl Plugin for SpritePlugin {
             .add_plugin(Mesh2dRenderPlugin)
             .add_plugin(ColorMaterialPlugin);
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ImageBindGroups>()
-                .init_resource::<SpritePipeline>()
-                .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
-                .init_resource::<SpriteMeta>()
-                .init_resource::<ExtractedSprites>()
-                .init_resource::<SpriteAssetEvents>()
-                .add_render_command::<Transparent2d, DrawSprite>()
-                .add_system_to_stage(
-                    RenderStage::Extract,
-                    render::extract_sprites.label(SpriteSystem::ExtractSprites),
-                )
-                .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
-                .add_system_to_stage(RenderStage::Queue, queue_sprites);
-        };
+        let render_app = app
+            .get_sub_app_mut(RenderApp)
+            .expect("SpritePlugin depends on RenderPlugin, but RenderPlugin not added");
+        render_app
+            .init_resource::<ImageBindGroups>()
+            .init_resource::<SpritePipeline>()
+            .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
+            .init_resource::<SpriteMeta>()
+            .init_resource::<ExtractedSprites>()
+            .init_resource::<SpriteAssetEvents>()
+            .add_render_command::<Transparent2d, DrawSprite>()
+            .add_system_to_stage(
+                RenderStage::Extract,
+                render::extract_sprites.label(SpriteSystem::ExtractSprites),
+            )
+            .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
+            .add_system_to_stage(RenderStage::Queue, queue_sprites);
     }
 }


### PR DESCRIPTION
Panic when inserting `SpritePlugin` and there is no `RenderPlugin`, panic instead of failing silently.

Didn't do this as just a error log message as bevy_sprite panics later on due to missing assets.

#69 requests a general solution to this.