### PR TITLE
[Merged by Bors] - Apply `WindowDescriptor` settings in all modes

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -63,18 +63,20 @@ impl WinitWindows {
                     window_descriptor.height as u32,
                 )),
             )),
-            _ => {
+            WindowMode::Windowed => {
                 if let Some(sf) = scale_factor_override {
                     winit_window_builder.with_inner_size(logical_size.to_physical::<f64>(sf))
                 } else {
                     winit_window_builder.with_inner_size(logical_size)
                 }
             }
+        };
+
+        winit_window_builder = winit_window_builder
             .with_resizable(window_descriptor.resizable)
             .with_decorations(window_descriptor.decorations)
             .with_transparent(window_descriptor.transparent)
-            .with_always_on_top(window_descriptor.always_on_top),
-        };
+            .with_always_on_top(window_descriptor.always_on_top);
 
         let constraints = window_descriptor.resize_constraints.check_constraints();
         let min_inner_size = LogicalSize {


### PR DESCRIPTION
# Objective
Some settings were only applied in windowed mode.
Fix the issue in #6933 

# Solution
Always apply the settings.
