### PR TITLE
[Merged by Bors] - Add `EntityMap::iter()`

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -117,4 +117,9 @@ impl EntityMap {
     pub fn is_empty(&self) -> bool {
         self.map.is_empty()
     }
+
+    /// An iterator visiting all (key, value) pairs in arbitrary order.
+    pub fn iter(&self) -> impl Iterator<Item = (Entity, Entity)> + '_ {
+        self.map.iter().map(|(from, to)| (*from, *to))
+    }
 }


### PR DESCRIPTION
# Objective

There is currently no way to iterate over key/value pairs inside an `EntityMap`, which makes the usage of this struct very awkward. I couldn't think of a good reason why the `iter()` function should not be exposed, considering the interface already exposes `keys()` and `values()`, so I made this PR.

## Solution

Implement `iter()` for `EntityMap` in terms of its inner map type.