### PR TITLE
Rename `CoreStage::First` to `CoreStage::PreStartup`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -639,7 +639,7 @@ impl App {
     /// let app = App::empty().add_default_stages();
     /// ```
     pub fn add_default_stages(&mut self) -> &mut Self {
-        self.add_stage(CoreStage::First, SystemStage::parallel())
+        self.add_stage(CoreStage::PreStartup, SystemStage::parallel())
             .add_stage(
                 StartupSchedule,
                 Schedule::default()
@@ -678,7 +678,7 @@ impl App {
     {
         if !self.world.contains_resource::<Events<T>>() {
             self.init_resource::<Events<T>>()
-                .add_system_to_stage(CoreStage::First, Events::<T>::update_system);
+                .add_system_to_stage(CoreStage::PreStartup, Events::<T>::update_system);
         }
         self
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -615,7 +615,7 @@ impl App {
     /// All the added stages, with the exception of the startup stage, run every time the
     /// schedule is invoked. The stages are the following, in order of execution:
     ///
-    /// - **First:** Runs at the very start of the schedule execution cycle, even before the
+    /// - **Pre-startup:** Runs at the very start of the schedule execution cycle, even before the
     ///   startup stage.
     /// - **Startup:** This is actually a schedule containing sub-stages. Runs only once
     ///   when the app starts.
@@ -657,7 +657,7 @@ impl App {
     /// Setup the application to manage events of type `T`.
     ///
     /// This is done by adding a [`Resource`] of type [`Events::<T>`],
-    /// and inserting an [`update_system`](Events::update_system) into [`CoreStage::First`].
+    /// and inserting an [`update_system`](Events::update_system) into [`CoreStage::PreStartup`].
     ///
     /// See [`Events`] for defining events.
     ///

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -35,7 +35,7 @@ use bevy_ecs::schedule::StageLabel;
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
 pub enum CoreStage {
     /// The [`Stage`](bevy_ecs::schedule::Stage) that runs before all other app stages.
-    First,
+    PreStartup,
     /// The [`Stage`](bevy_ecs::schedule::Stage) that runs before [`CoreStage::Update`].
     PreUpdate,
     /// The [`Stage`](bevy_ecs::schedule::Stage) responsible for doing most app logic. Systems should be registered here by default.

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -34,7 +34,8 @@ use bevy_ecs::schedule::StageLabel;
 /// The relative [`Stages`](bevy_ecs::schedule::Stage) are added by [`App::add_default_stages`].
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
 pub enum CoreStage {
-    /// The [`Stage`](bevy_ecs::schedule::Stage) that runs before all other app stages.
+    /// The [`Stage`](bevy_ecs::schedule::Stage) that runs before all other app stages, including
+    /// [`StartupStage`]s. All other `CoreStage`s run *after* startup stages complete.
     PreStartup,
     /// The [`Stage`](bevy_ecs::schedule::Stage) that runs before [`CoreStage::Update`].
     PreUpdate,

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -41,7 +41,10 @@ impl Plugin for TimePlugin {
             .register_type::<Stopwatch>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
             // in CoreStage::First
-            .add_system_to_stage(CoreStage::First, time_system.at_start().label(TimeSystem));
+            .add_system_to_stage(
+                CoreStage::PreStartup,
+                time_system.at_start().label(TimeSystem),
+            );
     }
 }
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -40,7 +40,7 @@ impl Plugin for TimePlugin {
             .register_type::<Time>()
             .register_type::<Stopwatch>()
             // time system is added as an "exclusive system" to ensure it runs before other systems
-            // in CoreStage::First
+            // in CoreStage::PreStartup
             .add_system_to_stage(
                 CoreStage::PreStartup,
                 time_system.at_start().label(TimeSystem),


### PR DESCRIPTION
# Objective

- I just learned that `CoreStage::First` runs before startup systems. This is incredibly surprising, and explains a number of frame-delay bugs I've been unable to diagnose for a very, very long time.
- I couldn't find this in the documentation, and the name of the stage label does not imply it is a special case. By their name, I expected startup systems to run before all normal stages.

## Solution

- Rename the variant to make it explicit that this is not just the first stage, but a stage that runs before the startup stages.
- Alternatively we could update the docs, but I don't think it's sufficient, as the name itself is misleading.

---

## Changelog

-  `CoreStage::First` has been renamed to `CoreStage::PreStartup` to make it clear that the stage runs before startup systems. 

## Migration Guide

- Rename all occurrences of  `CoreStage::First` to  `CoreStage::PreStartup`. The behavior of this stage is unchanged.