### PR TITLE
[Merged by Bors] - Shrink DrawFunctionId

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(target_pointer_width = "16")]
+compile_error!("bevy_render cannot safely compile for a 16-bit platform.");
+
 extern crate core;
 
 pub mod camera;

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,5 +1,5 @@
 #[cfg(target_pointer_width = "16")]
-compile_error!("bevy_render cannot safely compile for a 16-bit platform.");
+compile_error!("bevy_render cannot compile for a 16-bit platform.");
 
 extern crate core;
 

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -65,7 +65,7 @@ pub trait PhaseItem: Sized + Send + Sync + 'static {
 // TODO: make this generic?
 /// An identifier for a [`Draw`] function stored in [`DrawFunctions`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
-pub struct DrawFunctionId(usize);
+pub struct DrawFunctionId(u32);
 
 /// Stores all draw functions for the [`PhaseItem`] type.
 /// For retrieval they are associated with their [`TypeId`].
@@ -82,15 +82,15 @@ impl<P: PhaseItem> DrawFunctionsInternal<P> {
 
     /// Adds the [`Draw`] function and associates it to the type `T`
     pub fn add_with<T: 'static, D: Draw<P>>(&mut self, draw_function: D) -> DrawFunctionId {
+        let id = DrawFunctionId(self.draw_functions.len().try_into().unwrap());
         self.draw_functions.push(Box::new(draw_function));
-        let id = DrawFunctionId(self.draw_functions.len() - 1);
         self.indices.insert(TypeId::of::<T>(), id);
         id
     }
 
     /// Retrieves the [`Draw`] function corresponding to the `id` mutably.
     pub fn get_mut(&mut self, id: DrawFunctionId) -> Option<&mut dyn Draw<P>> {
-        self.draw_functions.get_mut(id.0).map(|f| &mut **f)
+        self.draw_functions.get_mut(id.0 as usize).map(|f| &mut **f)
     }
 
     /// Retrieves the id of the [`Draw`] function corresponding to their associated type `T`.


### PR DESCRIPTION
# Objective
This includes one part of #4899. The aim is to improve CPU-side rendering performance by reducing the memory footprint and bandwidth required.

## Solution
Shrink `DrawFunctionId` to `u32`. Enforce that `u32 as usize` conversions are always safe by forbidding compilation on 16-bit platforms. This shouldn't be a breaking change since #4736 disabled compilation of `bevy_ecs` on those platforms.

Shrinking `DrawFunctionId` shrinks all of the `PhaseItem` types, which is integral to sort and render phase performance.

Testing against `many_cubes`, the sort phase improved by 22% (174.21us -> 141.76us per frame).

![image](https://user-images.githubusercontent.com/3137680/207345422-a512b4cf-1680-46e0-9973-ea72494ebdfe.png)

The main opaque pass also imrproved by 9% (5.49ms -> 5.03ms)

![image](https://user-images.githubusercontent.com/3137680/207346436-cbee7209-6450-4964-b566-0b64cfa4b4ea.png)

Overall frame time improved by 5% (14.85ms -> 14.09ms)

![image](https://user-images.githubusercontent.com/3137680/207346895-9de8676b-ef37-4cb9-8445-8493f5f90003.png)

There will be a followup PR that likewise shrinks `CachedRenderPipelineId` which should yield similar results on top of these improvements.