### PR TITLE
[Merged by Bors] - Fix clippy lints and failed test with Rust 1.66

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1551,9 +1551,7 @@ mod tests {
         world_a.flush();
 
         let world_a_max_entities = world_a.entities().len();
-        world_b
-            .entities
-            .reserve_entities(world_a_max_entities as u32);
+        world_b.entities.reserve_entities(world_a_max_entities);
         world_b.entities.flush_as_invalid();
 
         let e4 = world_b.spawn(A(4)).id();

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
@@ -1,5 +1,8 @@
 error[E0499]: cannot borrow `iter` as mutable more than once at a time
- --> tests/ui/system_query_iter_many_mut_lifetime_safety.rs:9:25
-  |
-9 |     while let Some(a) = iter.fetch_next() {
-  |                         ^^^^^^^^^^^^^^^^^ `iter` was mutably borrowed here in the previous iteration of the loop
+  --> tests/ui/system_query_iter_many_mut_lifetime_safety.rs:9:25
+   |
+9  |     while let Some(a) = iter.fetch_next() {
+   |                         ^^^^^^^^^^^^^^^^^ `iter` was mutably borrowed here in the previous iteration of the loop
+10 |         // this should fail to compile
+11 |         results.push(a);
+   |         --------------- first borrow used here, in later iteration of loop

--- a/crates/bevy_render/src/mesh/shape/cylinder.rs
+++ b/crates/bevy_render/src/mesh/shape/cylinder.rs
@@ -103,7 +103,7 @@ impl From<Cylinder> for Mesh {
                 uvs.push([0.5 * (cos + 1.0), 1.0 - 0.5 * (sin + 1.0)]);
             }
 
-            for i in 1..(c.resolution as u32 - 1) {
+            for i in 1..(c.resolution - 1) {
                 indices.extend_from_slice(&[
                     offset,
                     offset + i + winding.0,

--- a/examples/tools/scene_viewer.rs
+++ b/examples/tools/scene_viewer.rs
@@ -109,7 +109,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     info!("Loading {}", scene_path);
     let (file_path, scene_index) = parse_scene(scene_path);
     commands.insert_resource(SceneHandle {
-        gltf_handle: asset_server.load(&file_path),
+        gltf_handle: asset_server.load(file_path),
         scene_index,
         #[cfg(feature = "animation")]
         animations: Vec::new(),


### PR DESCRIPTION
# Objective

[Rust 1.66](https://blog.rust-lang.org/inside-rust/2022/12/12/1.66.0-prerelease.html) is coming in a few days, and bevy doesn't build with it.

Fix that.

## Solution

Replace output from a trybuild test, and fix a few new instances of `needless_borrow` and `unnecessary_cast` that are now caught.

## Note

Due to the trybuild test, this can't be merged until 1.66 is released.