### PR TITLE
Move 'startup' Resource `WgpuSettings`  into `RenderPlugin` struct

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -43,6 +43,7 @@ use crate::{
     mesh::MeshPlugin,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
+    settings::WgpuSettings,
     view::{ViewPlugin, WindowRenderPlugin},
 };
 use bevy_app::{App, AppLabel, Plugin};
@@ -56,7 +57,9 @@ use std::{
 
 /// Contains the default Bevy rendering backend based on wgpu.
 #[derive(Default)]
-pub struct RenderPlugin;
+pub struct RenderPlugin {
+    pub wgpu_settings: WgpuSettings,
+}
 
 /// The labels of the default App rendering stages.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
@@ -124,18 +127,12 @@ pub struct RenderApp;
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderStage`](RenderStage) and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
-        let options = app
-            .world
-            .get_resource::<settings::WgpuSettings>()
-            .cloned()
-            .unwrap_or_default();
-
         app.add_asset::<Shader>()
             .add_debug_asset::<Shader>()
             .init_asset_loader::<ShaderLoader>()
             .init_debug_asset_loader::<ShaderLoader>();
 
-        if let Some(backends) = options.backends {
+        if let Some(backends) = self.wgpu_settings.backends {
             let windows = app.world.resource_mut::<bevy_window::Windows>();
             let instance = wgpu::Instance::new(backends);
 
@@ -148,13 +145,16 @@ impl Plugin for RenderPlugin {
                 });
 
             let request_adapter_options = wgpu::RequestAdapterOptions {
-                power_preference: options.power_preference,
+                power_preference: self.wgpu_settings.power_preference,
                 compatible_surface: surface.as_ref(),
                 ..Default::default()
             };
-            let (device, queue, adapter_info, render_adapter) = futures_lite::future::block_on(
-                renderer::initialize_renderer(&instance, &options, &request_adapter_options),
-            );
+            let (device, queue, adapter_info, render_adapter) =
+                futures_lite::future::block_on(renderer::initialize_renderer(
+                    &instance,
+                    &self.wgpu_settings,
+                    &request_adapter_options,
+                ));
             debug!("Configured wgpu adapter Limits: {:#?}", device.limits());
             debug!("Configured wgpu adapter Features: {:#?}", device.features());
             app.insert_resource(device.clone())

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use bevy_ecs::system::Resource;
 pub use wgpu::{Backends, Features as WgpuFeatures, Limits as WgpuLimits, PowerPreference};
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.
@@ -23,7 +22,7 @@ pub enum WgpuSettingsPriority {
 /// NOTE: If you want to use [`Backends::GL`](Backends::GL) in a native app on Windows, you must
 /// use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle). This is because wgpu requires EGL to
 /// create a GL context without a window and only ANGLE supports that.
-#[derive(Resource, Clone)]
+#[derive(Clone)]
 pub struct WgpuSettings {
     pub device_label: Option<Cow<'static, str>>,
     pub backends: Option<Backends>,

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -3,16 +3,17 @@
 use bevy::{
     pbr::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
     prelude::*,
-    render::{render_resource::WgpuFeatures, settings::WgpuSettings},
+    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
 };
 
 fn main() {
     App::new()
-        .insert_resource(WgpuSettings {
-            features: WgpuFeatures::POLYGON_MODE_LINE,
-            ..default()
-        })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(RenderPlugin {
+            wgpu_settings: WgpuSettings {
+                features: WgpuFeatures::POLYGON_MODE_LINE,
+                ..default()
+            },
+        }))
         .add_plugin(WireframePlugin)
         .add_startup_system(setup)
         .run();

--- a/examples/android/src/lib.rs
+++ b/examples/android/src/lib.rs
@@ -1,19 +1,23 @@
 use bevy::{
     prelude::*,
-    render::settings::{WgpuSettings, WgpuSettingsPriority},
+    render::{
+        settings::{WgpuSettings, WgpuSettingsPriority},
+        RenderPlugin,
+    },
 };
 
 // the `bevy_main` proc_macro generates the required android boilerplate
 #[bevy_main]
 fn main() {
     App::new()
-        // This configures the app to use the most compatible rendering settings.
-        // They help with compatibility with as many devices as possible.
-        .insert_resource(WgpuSettings {
-            priority: WgpuSettingsPriority::Compatibility,
-            ..default()
-        })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(RenderPlugin {
+            // This configures the app to use the most compatible rendering settings.
+            // They help with compatibility with as many devices as possible.
+            wgpu_settings: WgpuSettings {
+                priority: WgpuSettingsPriority::Compatibility,
+                ..default()
+            },
+        }))
         .add_startup_system(setup)
         .run();
 }

--- a/examples/app/no_renderer.rs
+++ b/examples/app/no_renderer.rs
@@ -4,14 +4,18 @@
 //!
 //! See also the `headless` example which does not display a window.
 
-use bevy::{prelude::*, render::settings::WgpuSettings};
+use bevy::{
+    prelude::*,
+    render::{settings::WgpuSettings, RenderPlugin},
+};
 
 fn main() {
     App::new()
-        .insert_resource(WgpuSettings {
-            backends: None,
-            ..default()
-        })
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(RenderPlugin {
+            wgpu_settings: WgpuSettings {
+                backends: None,
+                ..default()
+            },
+        }))
         .run();
 }


### PR DESCRIPTION
# Objective
Move the `WgpuSettings` startup resource into `RenderPlugin` struct.

## Migration Guide
```rust
// Before (0.9)
App::new()
    .insert_resource(WgpuSettings { .. })
    .add_plugins(DefaultPlugins)
// After (0.10)
App::new()
    .add_plugins(DefaultPlugins.set(RenderPlugin {
        wgpu_settings: WgpuSettings { .. },
    }))
```