### PR TITLE
assets.get can take any kind of handle

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -136,7 +136,7 @@ impl<T: Asset> Assets<T> {
     ///
     /// This is the main method for accessing asset data from an [Assets] collection. If you need
     /// mutable access to the asset, use [`get_mut`](Assets::get_mut).
-    pub fn get(&self, handle: &Handle<T>) -> Option<&T> {
+    pub fn get<H: Into<HandleId>>(&self, handle: H) -> Option<&T> {
         self.assets.get(&handle.into())
     }
 

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -137,7 +137,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
             assets_resource_type_id: TypeId::of::<Assets<A>>(),
             get: |world, handle| {
                 let assets = world.resource::<Assets<A>>();
-                let asset = assets.get(&handle.typed());
+                let asset = assets.get(handle);
                 asset.map(|asset| asset as &dyn Reflect)
             },
             get_mut: |world, handle| {


### PR DESCRIPTION
# Objective

- `assets.get` can take an `Handle<T>` or an `HandleId`

## Solution

- it's using the value as a `HandleId` anyway, so just expose it as needing the trait
