### PR TITLE
Changed Msaa to take level rather than int

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -283,7 +283,7 @@ pub fn prepare_core_3d_depth_textures(
                                 height: physical_target_size.y,
                             },
                             mip_level_count: 1,
-                            sample_count: msaa.samples,
+                            sample_count: msaa.level as u32,
                             dimension: TextureDimension::D2,
                             format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
                                                                   * bit depth for better performance */

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -283,7 +283,7 @@ pub fn prepare_core_3d_depth_textures(
                                 height: physical_target_size.y,
                             },
                             mip_level_count: 1,
-                            sample_count: msaa.level as u32,
+                            sample_count: msaa.samples(),
                             dimension: TextureDimension::D2,
                             format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
                                                                   * bit depth for better performance */

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -347,8 +347,8 @@ pub fn queue_material_meshes<M: Material>(
         let draw_alpha_mask_pbr = alpha_mask_draw_functions.read().id::<DrawMaterial<M>>();
         let draw_transparent_pbr = transparent_draw_functions.read().id::<DrawMaterial<M>>();
 
-        let mut view_key =
-            MeshPipelineKey::from_msaa_samples(msaa.samples) | MeshPipelineKey::from_hdr(view.hdr);
+        let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.level as u32)
+            | MeshPipelineKey::from_hdr(view.hdr);
 
         if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {
             if !view.hdr {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -347,7 +347,7 @@ pub fn queue_material_meshes<M: Material>(
         let draw_alpha_mask_pbr = alpha_mask_draw_functions.read().id::<DrawMaterial<M>>();
         let draw_transparent_pbr = transparent_draw_functions.read().id::<DrawMaterial<M>>();
 
-        let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.level as u32)
+        let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
             | MeshPipelineKey::from_hdr(view.hdr);
 
         if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -117,7 +117,7 @@ fn queue_wireframes(
     mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions.read().id::<DrawWireframes>();
-    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
+    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.level as u32);
     for (view, visible_entities, mut opaque_phase) in &mut views {
         let rangefinder = view.rangefinder3d();
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -117,7 +117,7 @@ fn queue_wireframes(
     mut views: Query<(&ExtractedView, &VisibleEntities, &mut RenderPhase<Opaque3d>)>,
 ) {
     let draw_custom = opaque_3d_draw_functions.read().id::<DrawWireframes>();
-    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.level as u32);
+    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
     for (view, visible_entities, mut opaque_phase) in &mut views {
         let rangefinder = view.rangefinder3d();
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
         render_resource::Shader,
         spatial_bundle::SpatialBundle,
         texture::{Image, ImagePlugin},
-        view::{ComputedVisibility, Msaa, Visibility, VisibilityBundle},
+        view::{ComputedVisibility, Msaa, MultiSampleLevel, Visibility, VisibilityBundle},
     };
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -79,6 +79,7 @@ pub struct Msaa {
 }
 
 impl Msaa {
+    #[inline]
     pub fn samples(&self) -> u32 {
         self.level as u32
     }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -66,7 +66,6 @@ impl Plugin for ViewPlugin {
 /// ```
 #[derive(Resource, Clone, ExtractResource, Reflect)]
 #[reflect(Resource)]
-#[non_exhaustive]
 pub struct Msaa {
     /// The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in
     /// smoother edges.
@@ -99,6 +98,7 @@ impl From<MultiSampleLevel> for Msaa {
 }
 
 #[derive(Clone, Copy, Reflect, PartialEq)]
+#[non_exhaustive]
 pub enum MultiSampleLevel {
     Off = 1,
     Sample4 = 4,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -60,6 +60,7 @@ impl Plugin for ViewPlugin {
 /// ```
 /// # use bevy_app::prelude::App;
 /// # use bevy_render::prelude::Msaa;
+/// # use bevy_render::prelude::MultiSampleLevel;
 /// App::new()
 ///     .insert_resource(Msaa::from(MultiSampleLevel::Sample4))
 ///     .run();

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -355,7 +355,7 @@ fn prepare_view_targets(
                                     },
                                 )
                                 .default_view,
-                            sampled: (msaa.level as u32 > 1).then(|| {
+                            sampled: (msaa.samples() > 1).then(|| {
                                 texture_cache
                                     .get(
                                         &render_device,
@@ -363,7 +363,7 @@ fn prepare_view_targets(
                                             label: Some("main_texture_sampled"),
                                             size,
                                             mip_level_count: 1,
-                                            sample_count: msaa.level as u32,
+                                            sample_count: msaa.samples(),
                                             dimension: TextureDimension::D2,
                                             format: main_texture_format,
                                             usage: TextureUsages::RENDER_ATTACHMENT,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -322,7 +322,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
     for (view, visible_entities, tonemapping, mut transparent_phase) in &mut views {
         let draw_transparent_pbr = transparent_draw_functions.read().id::<DrawMaterial2d<M>>();
 
-        let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples)
+        let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.level as u32)
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -322,7 +322,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
     for (view, visible_entities, tonemapping, mut transparent_phase) in &mut views {
         let draw_transparent_pbr = transparent_draw_functions.read().id::<DrawMaterial2d<M>>();
 
-        let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.level as u32)
+        let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -470,7 +470,7 @@ pub fn queue_sprites(
         };
     }
 
-    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.level as u32);
+    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples());
 
     if let Some(view_binding) = view_uniforms.uniforms.binding() {
         let sprite_meta = &mut sprite_meta;

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -470,7 +470,7 @@ pub fn queue_sprites(
         };
     }
 
-    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples);
+    let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.level as u32);
 
     if let Some(view_binding) = view_uniforms.uniforms.binding() {
         let sprite_meta = &mut sprite_meta;

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -329,7 +329,7 @@ pub fn queue_colored_mesh2d(
     for (visible_entities, mut transparent_phase, view) in &mut views {
         let draw_colored_mesh2d = transparent_draw_functions.read().id::<DrawColoredMesh2d>();
 
-        let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples)
+        let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.level as u32)
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         // Queue all entities visible to that view

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -329,7 +329,7 @@ pub fn queue_colored_mesh2d(
     for (visible_entities, mut transparent_phase, view) in &mut views {
         let draw_colored_mesh2d = transparent_draw_functions.read().id::<DrawColoredMesh2d>();
 
-        let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.level as u32)
+        let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         // Queue all entities visible to that view

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -1,6 +1,6 @@
 //! This examples compares MSAA (Multi-Sample Anti-Aliasing) and FXAA (Fast Approximate Anti-Aliasing).
 
-use std::{f32::consts::PI, ops::Mul};
+use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::fxaa::{Fxaa, Sensitivity},

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -1,6 +1,6 @@
 //! This examples compares MSAA (Multi-Sample Anti-Aliasing) and FXAA (Fast Approximate Anti-Aliasing).
 
-use std::f32::consts::PI;
+use std::{f32::consts::PI, ops::Mul};
 
 use bevy::{
     core_pipeline::fxaa::{Fxaa, Sensitivity},
@@ -8,13 +8,14 @@ use bevy::{
     render::{
         render_resource::{Extent3d, SamplerDescriptor, TextureDimension, TextureFormat},
         texture::ImageSampler,
+        view::MultiSampleLevel,
     },
 };
 
 fn main() {
     App::new()
-        // Disable MSAA be default
-        .insert_resource(Msaa { samples: 1 })
+        // Disable MSAA by default
+        .insert_resource(Msaa::from(MultiSampleLevel::Off))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(toggle_fxaa)
@@ -118,19 +119,20 @@ fn toggle_fxaa(keys: Res<Input<KeyCode>>, mut query: Query<&mut Fxaa>, mut msaa:
     let fxaa_ultra = keys.just_pressed(KeyCode::Key9);
     let fxaa_extreme = keys.just_pressed(KeyCode::Key0);
     let set_fxaa = set_fxaa | fxaa_low | fxaa_med | fxaa_high | fxaa_ultra | fxaa_extreme;
+
     for mut fxaa in &mut query {
         if set_msaa {
             fxaa.enabled = false;
-            msaa.samples = 4;
+            msaa.level = MultiSampleLevel::Sample4;
             info!("MSAA 4x");
         }
         if set_no_aa {
             fxaa.enabled = false;
-            msaa.samples = 1;
+            msaa.level = MultiSampleLevel::Off;
             info!("NO AA");
         }
         if set_no_aa | set_fxaa {
-            msaa.samples = 1;
+            msaa.level = MultiSampleLevel::Off;
         }
         if fxaa_low {
             fxaa.edge_threshold = Sensitivity::Low;
@@ -150,7 +152,7 @@ fn toggle_fxaa(keys: Res<Input<KeyCode>>, mut query: Query<&mut Fxaa>, mut msaa:
         }
         if set_fxaa {
             fxaa.enabled = true;
-            msaa.samples = 1;
+            msaa.level = MultiSampleLevel::Off;
             info!("FXAA {}", fxaa.edge_threshold.get_str());
         }
     }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -6,7 +6,7 @@
 //! Ultimately we plan on supporting whatever is natively supported on a given device.
 //! Check out [this issue](https://github.com/gfx-rs/wgpu/issues/1832) for more info.
 
-use bevy::{prelude::*, render::view::MultiSampleLevel};
+use bevy::prelude::*;
 
 fn main() {
     App::new()

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -6,11 +6,11 @@
 //! Ultimately we plan on supporting whatever is natively supported on a given device.
 //! Check out [this issue](https://github.com/gfx-rs/wgpu/issues/1832) for more info.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, render::view::MultiSampleLevel};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa::from(MultiSampleLevel::Off))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(cycle_msaa)
@@ -46,12 +46,12 @@ fn setup(
 
 fn cycle_msaa(input: Res<Input<KeyCode>>, mut msaa: ResMut<Msaa>) {
     if input.just_pressed(KeyCode::M) {
-        if msaa.samples == 4 {
+        if msaa.level == MultiSampleLevel::Sample4 {
             info!("Not using MSAA");
-            msaa.samples = 1;
+            msaa.level = MultiSampleLevel::Off;
         } else {
             info!("Using 4x MSAA");
-            msaa.samples = 4;
+            msaa.level = MultiSampleLevel::Sample4;
         }
     }
 }

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -2,11 +2,11 @@
 //! Shows the effects of different blend modes.
 //! The `fade_transparency` system smoothly changes the transparency over time.
 
-use bevy::prelude::*;
+use bevy::{prelude::*, render::view::MultiSampleLevel};
 
 fn main() {
     App::new()
-        .insert_resource(Msaa { samples: 4 })
+        .insert_resource(Msaa::from(MultiSampleLevel::Sample4))
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(fade_transparency)

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -111,7 +111,7 @@ fn queue_custom(
 ) {
     let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
 
-    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples);
+    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
     for (view, mut transparent_phase) in &mut views {
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);


### PR DESCRIPTION
# Objective

- Fixes #6931 

## Solution

- Msaa takes new type MultiSampleLevel rather than inter

---

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

```
let Msaa { samples: 4 } 
// is now
let Msaa::from(MultiSampleLevel::Sample4)
