### PR TITLE
[Merged by Bors] - Fix suppression of all console logs when `trace_tracy` is enabled

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -158,11 +158,10 @@ impl Plugin for LogPlugin {
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.
             #[cfg(feature = "tracing-tracy")]
-            let fmt_layer = fmt_layer.with_filter(
-                tracing_subscriber::filter::Targets::new()
-                    .with_target("bevy_render::renderer", Level::ERROR)
-                    .with_default(Level::TRACE),
-            );
+            let fmt_layer =
+                fmt_layer.with_filter(tracing_subscriber::filter::FilterFn::new(|meta| {
+                    meta.fields().field("tracy.frame_mark").is_none()
+                }));
 
             let subscriber = subscriber.with(fmt_layer);
 

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -154,9 +154,14 @@ impl Plugin for LogPlugin {
             let tracy_layer = tracing_tracy::TracyLayer::new();
 
             let fmt_layer = tracing_subscriber::fmt::Layer::default();
+
+            // bevy_render::renderer logs a `tracy.frame_mark` event every frame
+            // at Level::INFO. Formatted logs should omit it.
             #[cfg(feature = "tracing-tracy")]
             let fmt_layer = fmt_layer.with_filter(
-                tracing_subscriber::filter::Targets::new().with_target("tracy", Level::ERROR),
+                tracing_subscriber::filter::Targets::new()
+                    .with_target("bevy_render::renderer", Level::ERROR)
+                    .with_default(Level::TRACE),
             );
 
             let subscriber = subscriber.with(fmt_layer);


### PR DESCRIPTION
# Objective

Fixes #6862 (oh hey good catch @alice-i-cecile)

Bevy was failing to print events from `info!()` and friends to the console if the `trace_tracy` feature was enabled. It shouldn't be doing that.

## Solution

The problem was this per-layer filter that was added in #4320 to suppress a noisy per-frame event (which Tracy requires in order to properly close out a frame):

- The problem event's target was `"bevy_render::renderer"`, not `"tracy"`. - So, the filter wasn't specifically targeting the noisy event.
- Without a default, `tracing_subscriber::filter::Targets` will remove _everything_ that doesn't match an explicit target rule. - So, the filter _was_ silencing the noisy event, along with everything else.

This PR changes that filter to do what was probably intended in #4320: suppress ~any events more verbose than `ERROR` from `bevy_render::renderer`~ the one problematically noisy event, but allow anything else that already made it through the top-level filter_layer.

Also, adds a comment to clarify the intent of that filter, since it's otherwise a bit opaque and required some research.

---

## Changelog

Fixed a bug that hid console log messages when the `trace_tracy` feature was enabled.