### PR TITLE
[Merged by Bors] - Support tuple structs with `#[derive(SystemParam)]`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1662,5 +1662,11 @@ mod tests {
     }
 
     #[derive(SystemParam)]
-    pub struct UnitParam {}
+    pub struct UnitParam;
+
+    #[derive(SystemParam)]
+    pub struct TupleParam<'w, 's, R: Resource, L: FromWorld + Send + 'static>(
+        Res<'w, R>,
+        Local<'s, L>,
+    );
 }


### PR DESCRIPTION
# Objective

Currently, only named structs can be used with the `SystemParam` derive macro.

## Solution

Remove the restriction. Tuple structs and unit structs are now supported.

---

## Changelog

+ Added support for tuple structs and unit structs to the `SystemParam` derive macro.
