### PR TITLE
Emit SPIR-V for glsl shaders

### DIFF
--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -187,10 +187,8 @@ impl ProcessedShader {
                 }
                 ProcessedShader::Glsl(_source, _stage) => {
                     let reflection = self.reflect(features)?;
-                    // TODO: it probably makes more sense to convert this to spirv, but as of writing
-                    // this comment, naga's spirv conversion is broken
-                    let wgsl = reflection.get_wgsl()?;
-                    ShaderSource::Wgsl(wgsl.into())
+                    let spirv = reflection.get_spirv()?;
+                    ShaderSource::SpirV(spirv.into())
                 }
                 ProcessedShader::SpirV(source) => make_spirv(source),
             },


### PR DESCRIPTION
Naga's SPIR-V conversion seems to be working fine now.

There are built-ins in glsl unsupported by wgsl (for example `gl_PointSize`) so it matters that we convert glsl directly to SPIR-V without using the wgsl writer.