### PR TITLE
[Merged by Bors] - Fix UiCameraConfig doc (link to the Camera page)

### DIFF
--- a/crates/bevy_ui/src/camera_config.rs
+++ b/crates/bevy_ui/src/camera_config.rs
@@ -11,7 +11,7 @@ use bevy_render::extract_component::ExtractComponent;
 /// When a [`Camera`] doesn't have the [`UiCameraConfig`] component,
 /// it will display the UI by default.
 ///
-/// [`Camera`]: bevy_render::camera::Camera
+/// [Camera]: bevy_render::camera::Camera
 #[derive(Component, Clone)]
 pub struct UiCameraConfig {
     /// Whether to output UI to this camera view.

--- a/crates/bevy_ui/src/camera_config.rs
+++ b/crates/bevy_ui/src/camera_config.rs
@@ -11,7 +11,6 @@ use bevy_render::extract_component::ExtractComponent;
 /// When a [`Camera`] doesn't have the [`UiCameraConfig`] component,
 /// it will display the UI by default.
 ///
-/// [Camera]: bevy_render::camera::Camera
 #[derive(Component, Clone)]
 pub struct UiCameraConfig {
     /// Whether to output UI to this camera view.


### PR DESCRIPTION
The Camera link in the UiCameraConfig was not rendered properly by the documentation.

# Objective

- In the UiCameraConfig page (https://docs.rs/bevy/latest/bevy/prelude/struct.UiCameraConfig.html), a link to the Camera page (https://docs.rs/bevy/latest/bevy/render/camera/struct.Camera.html) is broken.

## Solution

- It seems that when using URL fragment specifiers, backtick should not be used. It might be an issue of rust itself. Replacing the URL fragment specifier `[`Camera`]: bevy_render::camera::Camera` with `[Camera]: bevy_render::camera::Camera` solves this.
