### PR TITLE
use `UnsafeWorldCell` internally

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -220,7 +220,7 @@ pub fn derive_world_query_impl(ast: DeriveInput) -> TokenStream {
                 }
 
                 unsafe fn init_fetch<'__w>(
-                    _world: &'__w #path::world::World,
+                    _world: #path::world::unsafe_world_cell::UnsafeWorldCell<'__w>,
                     state: &Self::State,
                     _last_change_tick: u32,
                     _change_tick: u32

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -294,7 +294,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                 unsafe fn get_param<'w, 's>(
                     state: &'s mut Self::State,
                     system_meta: &SystemMeta,
-                    world: &'w World,
+                    world: UnsafeWorldCell<'w>,
                     change_tick: u32,
                 ) -> Self::Item<'w, 's> {
                     ParamSet {
@@ -498,7 +498,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 unsafe fn get_param<'w2, 's2>(
                     state: &'s2 mut Self::State,
                     system_meta: &#path::system::SystemMeta,
-                    world: &'w2 #path::world::World,
+                    world: #path::world::unsafe_world_cell::UnsafeWorldCell<'w2>,
                     change_tick: u32,
                 ) -> Self::Item<'w2, 's2> {
                     let (#(#tuple_patterns,)*) = <

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -1,4 +1,4 @@
-use crate::world::World;
+use crate::world::unsafe_world_cell::UnsafeWorldCell;
 use bevy_tasks::ComputeTaskPool;
 use std::ops::Range;
 
@@ -79,7 +79,7 @@ impl BatchingStrategy {
 /// This struct is created by the [`Query::par_iter`](crate::system::Query::iter) and
 /// [`Query::par_iter_mut`](crate::system::Query::iter_mut) methods.
 pub struct QueryParIter<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
-    pub(crate) world: &'w World,
+    pub(crate) world: UnsafeWorldCell<'w>,
     pub(crate) state: &'s QueryState<Q, F>,
     pub(crate) batching_strategy: BatchingStrategy,
 }

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -8,7 +8,7 @@ use crate::{
     prelude::Local,
     storage::SparseSet,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam},
-    world::World,
+    world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 
 use std::{
@@ -178,9 +178,10 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
     unsafe fn get_param<'w, 's>(
         _state: &'s mut Self::State,
         _system_meta: &SystemMeta,
-        world: &'w World,
+        world: UnsafeWorldCell<'w>,
         _change_tick: u32,
     ) -> Self::Item<'w, 's> {
-        world.removed_components()
+        // SAFETY: only metadata is accessed
+        unsafe { world.world_metadata() }.removed_components()
     }
 }

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -7,7 +7,7 @@ use crate::{
         check_system_change_tick, ExclusiveSystemParam, ExclusiveSystemParamItem, In, InputMarker,
         IntoSystem, System, SystemMeta,
     },
-    world::{World, WorldId},
+    world::{unsafe_world_cell::UnsafeWorldCell, World, WorldId},
 };
 use bevy_ecs_macros::all_tuples;
 use std::{any::TypeId, borrow::Cow, marker::PhantomData};
@@ -95,7 +95,7 @@ where
     }
 
     #[inline]
-    unsafe fn run_unsafe(&mut self, _input: Self::In, _world: &World) -> Self::Out {
+    unsafe fn run_unsafe(&mut self, _input: Self::In, _world: UnsafeWorldCell<'_>) -> Self::Out {
         panic!("Cannot run exclusive systems with a shared World reference");
     }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1225,7 +1225,8 @@ mod tests {
         let world2 = World::new();
         let qstate = world1.query::<()>();
         // SAFETY: doesnt access anything
-        let query = unsafe { Query::new(&world2, &qstate, 0, 0, false) };
+        let query =
+            unsafe { Query::new(world2.as_unsafe_world_cell_readonly(), &qstate, 0, 0, false) };
         query.iter();
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -230,8 +230,8 @@ unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPara
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         // SAFETY: QueryState::new populates `component_access` which is used in `impl SystemParamState for QueryState`,
-        // so the scheduler only calls this in systems with access to every component used in the query
-        let world = unsafe { world.world() };
+        // so the scheduler only calls this in systems with access to every component used in the query,
+        // so using `world` for `state` is always allowed.
         Query::new(
             world,
             state,

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -3,7 +3,7 @@ use crate::{
     component::ComponentId,
     query::Access,
     system::{IntoSystem, System},
-    world::World,
+    world::{unsafe_world_cell::UnsafeWorldCell, World},
 };
 use std::{any::TypeId, borrow::Cow};
 
@@ -99,7 +99,7 @@ impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for PipeSystem<
         self.system_a.is_exclusive() || self.system_b.is_exclusive()
     }
 
-    unsafe fn run_unsafe(&mut self, input: Self::In, world: &World) -> Self::Out {
+    unsafe fn run_unsafe(&mut self, input: Self::In, world: UnsafeWorldCell<'_>) -> Self::Out {
         let out = self.system_a.run_unsafe(input, world);
         self.system_b.run_unsafe(out, world)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1753,6 +1753,9 @@ impl World {
 
 impl fmt::Debug for World {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // NOTE: we can not access any resources or components here
+        // as the debug impl is reused by UnsafeWorldCell
+
         f.debug_struct("World")
             .field("id", &self.id)
             .field("entity_count", &self.entities.len())

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -2,6 +2,7 @@ use crate::MainWorld;
 use bevy_ecs::{
     prelude::*,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam, SystemParamItem, SystemState},
+    world::unsafe_world_cell::UnsafeWorldCell,
 };
 use std::ops::{Deref, DerefMut};
 
@@ -75,7 +76,7 @@ where
     unsafe fn get_param<'w, 's>(
         state: &'s mut Self::State,
         system_meta: &SystemMeta,
-        world: &'w World,
+        world: UnsafeWorldCell<'w>,
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         // SAFETY:


### PR DESCRIPTION
builds on #6404 (and https://github.com/bevyengine/bevy/pull/6402)

important commits:
- https://github.com/bevyengine/bevy/commit/4f04a573740630e1da611d374d3dd4f770652cdb `System` and `ParamState`
- https://github.com/bevyengine/bevy/commit/91ef673b7f0b29ac714f9c1daef87f1f309b10f4 `QueryState`/`Query`

# Objective

- the motivation is given in https://github.com/bevyengine/bevy/pull/6404 and the issue https://github.com/bevyengine/bevy/issues/5956, but the TLDR is:
  - `&World` is sometimes used internally to mean "world that is shared with others but the access is distinct"
  - this means that you can accidentally write safe code like `get_resource` that is unsound because the `&World` doesn't actually give access
  - introducing a separate type makes this distinction more clear and self-documenting

## Solution

- use `UnsafeWorldCell` whenever we use `&World` as shared mutable
  - this is in the `System` machinery and for `Query`/`WorldQuery`

## Changelog

bevy now uses the `UnsafeWorldCell` type in places where we previously used `&World` to mean "shared mutable access, but ensured to be distinct by systems".
This means that systems and queries now get a `UnsafeWorldCell` where every method is unsafe, so you need to reason correctly about every access.

Usually this is done like
```rust
// SAFETY: must only be called with read/write access to resource A and B, and component C
unsafe fn get_unsafe_world_cell(world: UnsafeWorldCell) {
  // SAFETY: caller promises read access, no other references
  let a = world.get_resource::<A>();
}