### PR TITLE
[Merged by Bors] - Add extras field to GltfNode

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -47,8 +47,8 @@ pub struct Gltf {
     pub named_animations: HashMap<String, Handle<AnimationClip>>,
 }
 
-/// A glTF node with all of its child nodes, its [`GltfMesh`] and
-/// [`Transform`](bevy_transform::prelude::Transform).
+/// A glTF node with all of its child nodes, its [`GltfMesh`],
+/// [`Transform`](bevy_transform::prelude::Transform) and an optional [`GltfExtras`].
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "dad74750-1fd6-460f-ac51-0a7937563865"]
 pub struct GltfNode {
@@ -58,19 +58,22 @@ pub struct GltfNode {
     pub extras: Option<GltfExtras>,
 }
 
-/// A glTF mesh, which may consist of multiple [`GltfPrimitives`](GltfPrimitive).
+/// A glTF mesh, which may consist of multiple [`GltfPrimitives`](GltfPrimitive)
+/// and an optional [`GltfExtras`].
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "8ceaec9a-926a-4f29-8ee3-578a69f42315"]
 pub struct GltfMesh {
     pub primitives: Vec<GltfPrimitive>,
+    pub extras: Option<GltfExtras>,
 }
 
-/// Part of a [`GltfMesh`] that consists of a [`Mesh`] and an optional [`StandardMaterial`].
+/// Part of a [`GltfMesh`] that consists of a [`Mesh`], an optional [`StandardMaterial`] and [`GltfExtras`].
 #[derive(Debug, Clone, TypeUuid)]
 #[uuid = "cbfca302-82fd-41cb-af77-cab6b3d50af1"]
 pub struct GltfPrimitive {
     pub mesh: Handle<Mesh>,
     pub material: Option<Handle<StandardMaterial>>,
+    pub material_extras: Option<GltfExtras>,
 }
 
 #[derive(Clone, Debug, Reflect, Default, Component)]

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -55,6 +55,7 @@ pub struct GltfNode {
     pub children: Vec<GltfNode>,
     pub mesh: Option<Handle<GltfMesh>>,
     pub transform: bevy_transform::prelude::Transform,
+    pub extras: Option<GltfExtras>,
 }
 
 /// A glTF mesh, which may consist of multiple [`GltfPrimitives`](GltfPrimitive).

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -73,6 +73,7 @@ pub struct GltfMesh {
 pub struct GltfPrimitive {
     pub mesh: Handle<Mesh>,
     pub material: Option<Handle<StandardMaterial>>,
+    pub extras: Option<GltfExtras>,
     pub material_extras: Option<GltfExtras>,
 }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -368,6 +368,12 @@ async fn load_gltf<'a, 'b>(
                         scale: bevy_math::Vec3::from(scale),
                     },
                 },
+                extras: node
+                    .mesh()
+                    .and_then(|mesh| mesh.extras().as_ref())
+                    .map(|extras| super::GltfExtras {
+                        value: extras.get().to_string(),
+                    }),
             },
             node.children()
                 .map(|child| child.index())
@@ -1166,6 +1172,7 @@ mod test {
                 children: vec![],
                 mesh: None,
                 transform: bevy_transform::prelude::Transform::IDENTITY,
+                extras: None,
             }
         }
     }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -329,12 +329,20 @@ async fn load_gltf<'a, 'b>(
                     .material()
                     .index()
                     .and_then(|i| materials.get(i).cloned()),
+                material_extras: primitive.extras().as_ref().map(|extras| super::GltfExtras {
+                    value: extras.get().to_string(),
+                }),
             });
         }
 
         let handle = load_context.set_labeled_asset(
             &mesh_label(&mesh),
-            LoadedAsset::new(super::GltfMesh { primitives }),
+            LoadedAsset::new(super::GltfMesh {
+                primitives,
+                extras: mesh.extras().as_ref().map(|extras| super::GltfExtras {
+                    value: extras.get().to_string(),
+                }),
+            }),
         );
         if let Some(name) = mesh.name() {
             named_meshes.insert(name.to_string(), handle.clone());
@@ -368,12 +376,9 @@ async fn load_gltf<'a, 'b>(
                         scale: bevy_math::Vec3::from(scale),
                     },
                 },
-                extras: node
-                    .mesh()
-                    .and_then(|mesh| mesh.extras().as_ref())
-                    .map(|extras| super::GltfExtras {
-                        value: extras.get().to_string(),
-                    }),
+                extras: node.extras().as_ref().map(|extras| super::GltfExtras {
+                    value: extras.get().to_string(),
+                }),
             },
             node.children()
                 .map(|child| child.index())

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -43,7 +43,7 @@ use gltf::{
 use std::{collections::VecDeque, path::Path};
 use thiserror::Error;
 
-use crate::{Gltf, GltfNode, GltfExtras};
+use crate::{Gltf, GltfExtras, GltfNode};
 
 /// An error that occurs when loading a glTF file.
 #[derive(Error, Debug)]

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -43,7 +43,7 @@ use gltf::{
 use std::{collections::VecDeque, path::Path};
 use thiserror::Error;
 
-use crate::{Gltf, GltfNode};
+use crate::{Gltf, GltfNode, GltfExtras};
 
 /// An error that occurs when loading a glTF file.
 #[derive(Error, Debug)]
@@ -329,9 +329,8 @@ async fn load_gltf<'a, 'b>(
                     .material()
                     .index()
                     .and_then(|i| materials.get(i).cloned()),
-                material_extras: primitive.extras().as_ref().map(|extras| super::GltfExtras {
-                    value: extras.get().to_string(),
-                }),
+                extras: get_gltf_extras(primitive.extras()),
+                material_extras: get_gltf_extras(primitive.material().extras()),
             });
         }
 
@@ -339,9 +338,7 @@ async fn load_gltf<'a, 'b>(
             &mesh_label(&mesh),
             LoadedAsset::new(super::GltfMesh {
                 primitives,
-                extras: mesh.extras().as_ref().map(|extras| super::GltfExtras {
-                    value: extras.get().to_string(),
-                }),
+                extras: get_gltf_extras(mesh.extras()),
             }),
         );
         if let Some(name) = mesh.name() {
@@ -376,9 +373,7 @@ async fn load_gltf<'a, 'b>(
                         scale: bevy_math::Vec3::from(scale),
                     },
                 },
-                extras: node.extras().as_ref().map(|extras| super::GltfExtras {
-                    value: extras.get().to_string(),
-                }),
+                extras: get_gltf_extras(node.extras()),
             },
             node.children()
                 .map(|child| child.index())
@@ -553,6 +548,12 @@ async fn load_gltf<'a, 'b>(
     }));
 
     Ok(())
+}
+
+fn get_gltf_extras(extras: &gltf::json::Extras) -> Option<GltfExtras> {
+    extras.as_ref().map(|extras| super::GltfExtras {
+        value: extras.get().to_string(),
+    })
 }
 
 fn node_name(node: &Node) -> Name {


### PR DESCRIPTION
# Objective

In our project we parse `GltfNode` from `*.gltf` file, and we need extra properties information from Blender. Right now there is no way to get this properties from GltfNode (only through query when you spawn scene), so objective of this PR is to add extra properties to `GltfNode`

## Solution

Store extra properties inside `Gltf` structs

---

## Changelog

- Add pub field `extras` to `GltfNode`/`GltfMesh`/`GltfPrimitive` which store extras
- Add pub field `material_extras` to `GltfPrimitive` which store material extras