### PR TITLE
Show warning when no camera is used

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,5 +1,6 @@
 use crate::{
     camera::CameraProjection,
+    mesh::Mesh,
     prelude::Image,
     render_asset::RenderAssets,
     render_resource::TextureView,
@@ -16,6 +17,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res},
 };
+use bevy_log::warn;
 use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_reflect::FromReflect;
@@ -527,5 +529,16 @@ pub fn extract_cameras(
                 visible_entities.clone(),
             ));
         }
+    }
+}
+
+pub fn check_has_camera(
+    mesh_query: Extract<Query<&Handle<Mesh>>>,
+    camera_query: Extract<Query<&Camera>>,
+) {
+    let has_meshes = !mesh_query.is_empty();
+    let has_cameras = !camera_query.is_empty();
+    if has_meshes && !has_cameras {
+        warn!("Trying to render meshes without a camera will not show anything!");
     }
 }

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -27,6 +27,7 @@ impl Plugin for CameraPlugin {
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.add_system_to_stage(RenderStage::Extract, check_has_camera);
             render_app.add_system_to_stage(RenderStage::Extract, extract_cameras);
 
             let camera_driver_node = CameraDriverNode::new(&mut render_app.world);


### PR DESCRIPTION
# Objective
Show a warning if meshes get rendered without a camera.

Fixes #1432

## Solution
Add a system to the extract render stage that queries for all cameras and all meshes. If only meshes and no camera was found, a warning gets emitted.

What I don't like about this solution, is that the console gets spammed by the warning. Please let me know what you think.

---

## Changelog
Print a warning when trying to render meshes without a camera.

