### PR TITLE
[Merged by Bors] - Add fmt::Pointer impl for bevy_ptr::{Ptr, PtrMut, OwnedPtr}

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 #![warn(missing_docs)]
 
+use core::fmt::{self, Formatter, Pointer};
 use core::{
     cell::UnsafeCell, marker::PhantomData, mem::ManuallyDrop, num::NonZeroUsize, ptr::NonNull,
 };
@@ -92,6 +93,13 @@ macro_rules! impl_ptr {
             #[inline]
             pub unsafe fn new(inner: NonNull<u8>) -> Self {
                 Self(inner, PhantomData)
+            }
+        }
+
+        impl Pointer for $ptr<'_> {
+            #[inline]
+            fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+                Pointer::fmt(&self.0, f)
             }
         }
     };


### PR DESCRIPTION
# Objective

- `bevy_ptr::{Ptr, PtrMut, OwnedPtr}` wrap raw pointers and should be printable using pointer formatting.

## Solution

- Add a `core::fmt::Pointer` impl for `Ptr`, `PtrMut` and `OwnedPtr` based on the wrapped `NonNull` pointer.

---

## Changelog

- Added a `core::fmt::Pointer` impl to `Ptr`, `PtrMut` and `OwnedPtr`.