### PR TITLE
Make From<PathBuf> for AssetPath parse label.

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -3,6 +3,7 @@ use bevy_utils::AHasher;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
+    ffi::OsStr,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
 };

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -172,18 +172,48 @@ impl<'a> From<&'a String> for AssetPath<'a> {
 
 impl<'a> From<&'a Path> for AssetPath<'a> {
     fn from(path: &'a Path) -> Self {
-        AssetPath {
-            path: Cow::Borrowed(path),
-            label: None,
+        match path.file_name() {
+            Some(os_str) => {
+                let mut parts = os_str
+                    .to_str()
+                    .expect("File name format is not valid unicode")
+                    .splitn(2, '#');
+                path.pop();
+                path = path.join(parts.next().expect("Path must be set."));
+                let label = parts.next();
+                AssetPath {
+                    path: Cow::Borrowed(path),
+                    label: label.map(Cow::Borrowed),
+                }
+            }
+            None => AssetPath {
+                path: Cow::Borrowed(path),
+                label: None,
+            },
         }
     }
 }
 
 impl<'a> From<PathBuf> for AssetPath<'a> {
-    fn from(path: PathBuf) -> Self {
-        AssetPath {
-            path: Cow::Owned(path),
-            label: None,
+    fn from(mut path: PathBuf) -> Self {
+        match path.file_name() {
+            Some(os_str) => {
+                let mut parts = os_str
+                    .to_str()
+                    .expect("File name format is not valid unicode")
+                    .splitn(2, '#');
+                path.pop();
+                path = path.join(parts.next().expect("Path must be set."));
+                let label = parts.next().map(String::from);
+                AssetPath {
+                    path: Cow::Owned(path),
+                    label: label.map(Cow::Owned),
+                }
+            }
+            None => AssetPath {
+                path: Cow::Owned(path),
+                label: None,
+            },
         }
     }
 }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -181,8 +181,8 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
 }
 
 impl<'a> From<PathBuf> for AssetPath<'a> {
-    fn from(mut path: PathBuf) -> Self {
-        match path
+    fn from(mut path_buf: PathBuf) -> Self {
+        match path_buf
             .file_name()
             .and_then(OsStr::to_str)
             .map(ToOwned::to_owned)
@@ -193,12 +193,12 @@ impl<'a> From<PathBuf> for AssetPath<'a> {
                 path = path.join(parts.next().expect("Path must be set."));
                 let label = parts.next().map(String::from);
                 AssetPath {
-                    path: Cow::Owned(path),
+                    path: Cow::Owned(path_buf),
                     label: label.map(Cow::Owned),
                 }
             }
             None => AssetPath {
-                path: Cow::Owned(path),
+                path: Cow::Owned(path_buf),
                 label: None,
             },
         }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -184,8 +184,8 @@ impl<'a> From<PathBuf> for AssetPath<'a> {
     fn from(mut path: PathBuf) -> Self {
         match path
             .file_name()
-            .map(ToOwned::to_owned)
             .and_then(OsStr::to_str)
+            .map(ToOwned::to_owned)
         {
             Some(path) => {
                 let mut parts = path.splitn(2, '#');

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -181,7 +181,7 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
 
 impl<'a> From<PathBuf> for AssetPath<'a> {
     fn from(mut path: PathBuf) -> Self {
-        match path.file_name() {
+        match path.file_name().map(ToOwned::to_owned) {
             Some(os_str) => {
                 let mut parts = os_str
                     .to_str()

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -181,12 +181,13 @@ impl<'a> From<&'a Path> for AssetPath<'a> {
 
 impl<'a> From<PathBuf> for AssetPath<'a> {
     fn from(mut path: PathBuf) -> Self {
-        match path.file_name().map(ToOwned::to_owned) {
-            Some(os_str) => {
-                let mut parts = os_str
-                    .to_str()
-                    .expect("File name format is not valid unicode")
-                    .splitn(2, '#');
+        match path
+            .file_name()
+            .map(ToOwned::to_owned)
+            .and_then(OsStr::to_str)
+        {
+            Some(path) => {
+                let mut parts = path.splitn(2, '#');
                 path.pop();
                 path = path.join(parts.next().expect("Path must be set."));
                 let label = parts.next().map(String::from);

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -172,24 +172,9 @@ impl<'a> From<&'a String> for AssetPath<'a> {
 
 impl<'a> From<&'a Path> for AssetPath<'a> {
     fn from(path: &'a Path) -> Self {
-        match path.file_name() {
-            Some(os_str) => {
-                let mut parts = os_str
-                    .to_str()
-                    .expect("File name format is not valid unicode")
-                    .splitn(2, '#');
-                path.pop();
-                path = path.join(parts.next().expect("Path must be set."));
-                let label = parts.next();
-                AssetPath {
-                    path: Cow::Borrowed(path),
-                    label: label.map(Cow::Borrowed),
-                }
-            }
-            None => AssetPath {
-                path: Cow::Borrowed(path),
-                label: None,
-            },
+        AssetPath {
+            path: Cow::Borrowed(path),
+            label: None,
         }
     }
 }

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -189,8 +189,8 @@ impl<'a> From<PathBuf> for AssetPath<'a> {
         {
             Some(path) => {
                 let mut parts = path.splitn(2, '#');
-                path.pop();
-                path = path.join(parts.next().expect("Path must be set."));
+                path_buf.pop();
+                path = path_buf.join(parts.next().expect("Path must be set."));
                 let label = parts.next().map(String::from);
                 AssetPath {
                     path: Cow::Owned(path_buf),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -190,7 +190,7 @@ impl<'a> From<PathBuf> for AssetPath<'a> {
             Some(path) => {
                 let mut parts = path.splitn(2, '#');
                 path_buf.pop();
-                path = path_buf.join(parts.next().expect("Path must be set."));
+                path_buf.join(parts.next().expect("Path must be set."));
                 let label = parts.next().map(String::from);
                 AssetPath {
                     path: Cow::Owned(path_buf),


### PR DESCRIPTION
# Objective

When you use `Path` and `join` through `AssetServer::load`, server doesn't recognize labels.
It will be inconvenient if you have to hard code full `str` every time you load.

## Solution

Thus, as convenience purpose, modified `impl` of `From<PathBuf> for AssetPath` to parse labels.

---

## Changelog


## Migration Guide
