### PR TITLE
Require one up-to-date approval for Bors merging

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -21,3 +21,5 @@ status = [
 
 use_squash_merge = true
 block_labels = ["S-Pre-Relicense"]
+required_approvals = 1
+up_to_date_approvals = 1

--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -22,4 +22,4 @@ status = [
 use_squash_merge = true
 block_labels = ["S-Pre-Relicense"]
 required_approvals = 1
-up_to_date_approvals = 1
+up_to_date_approvals = true


### PR DESCRIPTION
# Objective

Currently it is possible for the following to happen:
1. Maintainer queues a merge with `bors r+`
2. Bors fails for some reason
3. PR author adds new arbitrary unreviewed code
4. PR author calls bors retry 

This allows arbitrary unreviewed code to be committed. In general this isn't a problem because the PR author has already indicated that they are trustworthy by getting the initial approval / not adding malicious code. But this is still a hole and we should close it.

## Solution

Configure bors to require one approval _after_ the latest commit. 
