### PR TITLE
[Merged by Bors] - Support `SystemParam` types with const generics

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -423,7 +423,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     }));
 
     let mut punctuated_generics_no_bounds = punctuated_generics.clone();
-    for g in punctuated_generics_no_bounds.iter_mut() {
+    for g in &mut punctuated_generics_no_bounds {
         match g {
             GenericParam::Type(g) => g.bounds.clear(),
             GenericParam::Lifetime(g) => g.bounds.clear(),

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -422,6 +422,15 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         _ => unreachable!(),
     }));
 
+    let mut punctuated_generics_no_bounds = punctuated_generics.clone();
+    for g in punctuated_generics_no_bounds.iter_mut() {
+        match g {
+            GenericParam::Type(g) => g.bounds.clear(),
+            GenericParam::Lifetime(g) => g.bounds.clear(),
+            GenericParam::Const(_) => {}
+        }
+    }
+
     let mut punctuated_type_generic_idents = Punctuated::<_, Token![,]>::new();
     punctuated_type_generic_idents.extend(lifetimeless_generics.iter().filter_map(|g| match g {
         GenericParam::Type(g) => Some(&g.ident),
@@ -471,7 +480,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             }
 
             #[doc(hidden)]
-            type State<'w, 's, #punctuated_generics> = FetchState<
+            type State<'w, 's, #punctuated_generics_no_bounds> = FetchState<
                 (#(<#tuple_types as #path::system::SystemParam>::State,)*),
                 #punctuated_generic_idents
             >;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1665,6 +1665,9 @@ mod tests {
     pub struct R<const I: usize>;
 
     #[derive(SystemParam)]
+    pub struct ConstGenericParam<'w, const I: usize>(Res<'w, R<I>>);
+
+    #[derive(SystemParam)]
     pub struct LongParam<'w> {
         _r0: Res<'w, R<0>>,
         _r1: Res<'w, R<1>>,


### PR DESCRIPTION
# Objective

* Currently, the `SystemParam` derive does not support types with const generic parameters.
  * If you try to use const generics, the error message is cryptic and unhelpful.
* Continuation of the work started in #6867 and #6957.

## Solution

Allow const generic parameters to be used with `#[derive(SystemParam)]`.
