### PR TITLE
[Merged by Bors] - Fix unsoundness for `propagate_recursive`

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -132,15 +132,19 @@ unsafe fn propagate_recursive(
     // If our `Children` has changed, we need to recalculate everything below us
     changed |= changed_children;
     for child in children {
-        propagate_recursive(
-            &global_matrix,
-            unsafe_transform_query,
-            parent_query,
-            children_query,
-            entity,
-            *child,
-            changed,
-        );
+        // SAFETY: The caller guarantees that `unsafe_transform_query` will not be borrowed
+        // for any children of `entity`, so it is safe to call `propagate_recursive` for each child.
+        unsafe {
+            propagate_recursive(
+                &global_matrix,
+                unsafe_transform_query,
+                parent_query,
+                children_query,
+                entity,
+                *child,
+                changed,
+            )
+        };
     }
 }
 

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -58,8 +58,8 @@ pub fn propagate_transforms(
                         entity,
                         *child,
                         changed,
-                    )
-                };
+                    );
+                }
             }
         },
     );
@@ -143,8 +143,8 @@ unsafe fn propagate_recursive(
                 entity,
                 *child,
                 changed,
-            )
-        };
+            );
+        }
     }
 }
 

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -49,7 +49,7 @@ pub fn propagate_transforms(
                 // SAFETY: Assuming the hierarchy is consistent, we can be sure that each `child` entity
                 // will be unique across each invocation of this loop body.
                 // Since this is the only place where `transform_query` gets used, `child` will not be borrowed anywhere else.
-                // Also, since `child` only has one ancestor, none of its children will be borrowed by other invocations of the loop.
+                // Also, since `child` only has one ancestor, none of its descendants will be borrowed by other invocations of the loop.
                 unsafe {
                     propagate_recursive(
                         &global_transform,

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -49,6 +49,7 @@ pub fn propagate_transforms(
                 // SAFETY: Assuming the hierarchy is consistent, we can be sure that each `child` entity
                 // will be unique across each invocation of this loop body.
                 // Since this is the only place where `transform_query` gets used, `child` will not be borrowed anywhere else.
+                // Also, since `child` only has one ancestor, none of its children will be borrowed by other invocations of the loop.
                 unsafe {
                     propagate_recursive(
                         &global_transform,

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -46,7 +46,7 @@ pub fn propagate_transforms(
             changed |= children_changed;
 
             for child in children.iter() {
-                // SAFETY: Assuming the hierarchy is consistent, we can be sure that each `child`
+                // SAFETY: Assuming the hierarchy is consistent, we can be sure that each `child` entity
                 // will be unique across each invocation of this loop body.
                 // Since this is the only place where `transform_query` gets used, `child` will not be borrowed anywhere else.
                 unsafe {

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -67,7 +67,7 @@ pub fn propagate_transforms(
 }
 
 /// # Safety
-/// `unsafe_transform_query` must not be borrowed for `entity`, nor any of its children.
+/// `unsafe_transform_query` must not be borrowed for `entity`, nor any of its descendants.
 unsafe fn propagate_recursive(
     parent: &GlobalTransform,
     unsafe_transform_query: &Query<

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -48,8 +48,8 @@ pub fn propagate_transforms(
             for child in children.iter() {
                 // SAFETY: Assuming the hierarchy is consistent, we can be sure that each `child` entity
                 // will be unique across each invocation of this loop body.
-                // Since this is the only place where `transform_query` gets used, `child` will not be borrowed anywhere else.
-                // Also, since `child` only has one ancestor, none of its descendants will be borrowed by other invocations of the loop.
+                // Since this is the only place where `transform_query` gets used, `child` will not get fetched elsewhere.
+                // Also, since `child` only has one ancestor, none of its descendants will get fetched by other invocations of the loop.
                 unsafe {
                     propagate_recursive(
                         &global_transform,
@@ -67,7 +67,7 @@ pub fn propagate_transforms(
 }
 
 /// # Safety
-/// `unsafe_transform_query` must not be borrowed for `entity`, nor any of its descendants.
+/// `unsafe_transform_query` must not have any existing fetches for `entity`, nor any of its descendants.
 unsafe fn propagate_recursive(
     parent: &GlobalTransform,
     unsafe_transform_query: &Query<
@@ -133,7 +133,7 @@ unsafe fn propagate_recursive(
     // If our `Children` has changed, we need to recalculate everything below us
     changed |= changed_children;
     for child in children {
-        // SAFETY: The caller guarantees that `unsafe_transform_query` will not be borrowed
+        // SAFETY: The caller guarantees that `unsafe_transform_query` will not be fetched
         // for any descendants of `entity`, so it is safe to call `propagate_recursive` for each child.
         unsafe {
             propagate_recursive(

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -78,7 +78,6 @@ unsafe fn propagate_recursive(
     expected_parent: Entity,
     entity: Entity,
     mut changed: bool,
-    // We use a result here to use the `?` operator. Ideally we'd use a try block instead
 ) {
     let Ok(actual_parent) = parent_query.get(entity) else {
         panic!("Propagated child for {:?} has no Parent component!", entity);

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -73,7 +73,7 @@ pub fn propagate_transforms(
 /// # Panics
 ///
 /// If `entity` or any of its descendants have a malformed hierarchy.
-/// The panic will occur propagating the transforms of any malformed entities and their descendants.
+/// The panic will occur before propagating the transforms of any malformed entities and their descendants.
 ///
 /// # Safety
 ///

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -134,7 +134,7 @@ unsafe fn propagate_recursive(
     changed |= changed_children;
     for child in children {
         // SAFETY: The caller guarantees that `unsafe_transform_query` will not be borrowed
-        // for any children of `entity`, so it is safe to call `propagate_recursive` for each child.
+        // for any descendants of `entity`, so it is safe to call `propagate_recursive` for each child.
         unsafe {
             propagate_recursive(
                 &global_matrix,


### PR DESCRIPTION
# Objective

Fix #6983.

## Solution

Mark the function `propagate_recursive` as unsafe, and specify the safety invariants through doc comments.
