### PR TITLE
[Merged by Bors] - Round out the untyped api s

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -5,7 +5,7 @@ use crate::{
     ptr::PtrMut,
     system::Resource,
 };
-use bevy_ptr::UnsafeCellDeref;
+use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -427,6 +427,20 @@ impl<'a> MutUntyped<'a> {
     #[inline]
     pub fn into_inner(self) -> PtrMut<'a> {
         self.value
+    }
+
+    /// Returns a pointer to the value without taking ownership of this smart pointer or marking it as changed.
+    ///
+    /// In order to mark the value as changed, you need to call [`set_changed`](DetectChanges::set_changed) manually.
+    #[inline]
+    pub fn as_mut(&mut self) -> PtrMut<'_> {
+        self.value.shrink()
+    }
+
+    /// Returns an immutable pointer to the value without taking ownership.
+    #[inline]
+    pub fn as_ref(&self) -> Ptr<'_> {
+        self.value.as_ref()
     }
 }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -421,20 +421,22 @@ pub struct MutUntyped<'a> {
 }
 
 impl<'a> MutUntyped<'a> {
-    /// Returns the pointer to the value, without marking it as changed.
+    /// Returns the pointer to the value, marking it as changed.
     ///
-    /// In order to mark the value as changed, you need to call [`set_changed`](DetectChanges::set_changed) manually.
+    /// In order to avoid marking the value as changed, you need to call [`bypass_change_detection`](DetectChanges::bypass_change_detection).
     #[inline]
-    pub fn into_inner(self) -> PtrMut<'a> {
+    pub fn into_inner(mut self) -> PtrMut<'a> {
+        self.set_changed();
         self.value
     }
 
-    /// Returns a pointer to the value without taking ownership of this smart pointer or marking it as changed.
+    /// Returns a pointer to the value without taking ownership of this smart pointer, marking it as changed.
     ///
-    /// In order to mark the value as changed, you need to call [`set_changed`](DetectChanges::set_changed) manually.
+    /// In order to avoid marking the value as changed, you need to call [`bypass_change_detection`](DetectChanges::bypass_change_detection).
     #[inline]
     pub fn as_mut(&mut self) -> PtrMut<'_> {
-        self.value.shrink()
+        self.set_changed();
+        self.value.reborrow()
     }
 
     /// Returns an immutable pointer to the value without taking ownership.

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -176,6 +176,20 @@ impl<'a> PtrMut<'a> {
     pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
     }
+
+    /// Gets a `PtrMut` from this with a smaller lifetime
+    #[inline]
+    pub fn shrink(&mut self) -> PtrMut<'_> {
+        // SAFE: the ptrmut we're borrowing from is assumed to be valid
+        unsafe { PtrMut::new(self.0) }
+    }
+
+    /// Gets an immutable reference from this mutable reference
+    #[inline]
+    pub fn as_ref(&self) -> Ptr<'_> {
+        // SAFE: The `PtrMut` type's guarantees about the validity of this pointer are a superset of `Ptr` s guarantees
+        unsafe { Ptr::new(self.0) }
+    }
 }
 
 impl<'a, T> From<&'a mut T> for PtrMut<'a> {
@@ -223,6 +237,20 @@ impl<'a> OwningPtr<'a> {
     #[allow(clippy::wrong_self_convention)]
     pub fn as_ptr(&self) -> *mut u8 {
         self.0.as_ptr()
+    }
+
+    /// Gets an immutable reference from this mutable reference
+    #[inline]
+    pub fn as_ref(&self) -> Ptr<'_> {
+        // SAFE: The `Owning` type's guarantees about the validity of this pointer are a superset of `Ptr` s guarantees
+        unsafe { Ptr::new(self.0) }
+    }
+
+    /// Gets an mutable reference from this
+    #[inline]
+    pub fn as_mut(&mut self) -> PtrMut<'_> {
+        // SAFE: The `Owning` type's guarantees about the validity of this pointer are a superset of `Ptr` s guarantees
+        unsafe { PtrMut::new(self.0) }
     }
 }
 

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -177,7 +177,7 @@ impl<'a> PtrMut<'a> {
         self.0.as_ptr()
     }
 
-    /// Gets a `PtrMut` from this with a smaller lifetime
+    /// Gets a `PtrMut` from this with a smaller lifetime.
     #[inline]
     pub fn reborrow(&mut self) -> PtrMut<'_> {
         // SAFE: the ptrmut we're borrowing from is assumed to be valid
@@ -239,14 +239,14 @@ impl<'a> OwningPtr<'a> {
         self.0.as_ptr()
     }
 
-    /// Gets an immutable reference from this mutable reference
+    /// Gets an immutable pointer from this owned pointer.
     #[inline]
     pub fn as_ref(&self) -> Ptr<'_> {
         // SAFE: The `Owning` type's guarantees about the validity of this pointer are a superset of `Ptr` s guarantees
         unsafe { Ptr::new(self.0) }
     }
 
-    /// Gets an mutable reference from this
+    /// Gets a mutable pointer from this owned pointer.
     #[inline]
     pub fn as_mut(&mut self) -> PtrMut<'_> {
         // SAFE: The `Owning` type's guarantees about the validity of this pointer are a superset of `Ptr` s guarantees

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -179,7 +179,7 @@ impl<'a> PtrMut<'a> {
 
     /// Gets a `PtrMut` from this with a smaller lifetime
     #[inline]
-    pub fn shrink(&mut self) -> PtrMut<'_> {
+    pub fn reborrow(&mut self) -> PtrMut<'_> {
         // SAFE: the ptrmut we're borrowing from is assumed to be valid
         unsafe { PtrMut::new(self.0) }
     }


### PR DESCRIPTION
# Objective

Bevy uses custom `Ptr` types so the rust borrow checker can help ensure lifetimes are correct, even when types aren't known. However, these types don't benefit from the automatic lifetime coercion regular rust references enjoy

## Solution

Add a couple methods to Ptr, PtrMut, and MutUntyped to allow for easy usage of these types in more complex scenarios.

## Changelog

- Added `as_mut` and `as_ref` methods to `MutUntyped`.
- Added `shrink` and `as_ref` methods to `PtrMut`.

## Migration Guide

- `MutUntyped::into_inner` now marks things as changed. 