### PR TITLE
[Merged by Bors] - Relax `Sync` bound on anonymous `Command`s

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -709,7 +709,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
 
 impl<F> Command for F
 where
-    F: FnOnce(&mut World) + Send + Sync + 'static,
+    F: FnOnce(&mut World) + Send + 'static,
 {
     fn write(self, world: &mut World) {
         self(world);


### PR DESCRIPTION
# Objective

Any closure with the signature `FnOnce(&mut World)` implicitly implements the trait `Command` due to a blanket implementation. However, this implementation unnecessarily has the `Sync` bound, which limits the types that can be used.

## Solution

Remove the bound.

---

## Changelog

- `Command` closures no longer need to implement the marker trait `std::marker::Sync`.