### PR TITLE
[Merged by Bors] - Add a const `PipeSystem` constructor

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -71,16 +71,20 @@ impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
 }
 impl<T: SparseSetIndex> Default for Access<T> {
     fn default() -> Self {
-        Self {
-            reads_all: false,
-            reads_and_writes: Default::default(),
-            writes: Default::default(),
-            marker: PhantomData,
-        }
+        Self::new()
     }
 }
 
 impl<T: SparseSetIndex> Access<T> {
+    pub const fn new() -> Self {
+        Self {
+            reads_all: false,
+            reads_and_writes: FixedBitSet::new(),
+            writes: FixedBitSet::new(),
+            marker: PhantomData,
+        }
+    }
+
     /// Increases the set capacity to the specified amount.
     ///
     /// Does nothing if `capacity` is less than or equal to the current value.

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -76,6 +76,7 @@ impl<T: SparseSetIndex> Default for Access<T> {
 }
 
 impl<T: SparseSetIndex> Access<T> {
+    /// Creates an empty [`Access`] collection.
     pub const fn new() -> Self {
         Self {
             reads_all: false,

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -55,6 +55,9 @@ pub struct PipeSystem<SystemA, SystemB> {
 }
 
 impl<SystemA, SystemB> PipeSystem<SystemA, SystemB> {
+    /// Manual constructor for creating a [`PipeSystem`].
+    /// This should only be used when [`IntoPipeSystem::pipe`] cannot be used,
+    /// such as in `const` contexts.
     pub const fn new(system_a: SystemA, system_b: SystemB, name: Cow<'static, str>) -> Self {
         Self {
             system_a,

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -54,6 +54,18 @@ pub struct PipeSystem<SystemA, SystemB> {
     archetype_component_access: Access<ArchetypeComponentId>,
 }
 
+impl<SystemA, SystemB> PipeSystem<SystemA, SystemB> {
+    pub const fn new(system_a: SystemA, system_b: SystemB, name: Cow<'static, str>) -> Self {
+        Self {
+            system_a,
+            system_b,
+            name,
+            component_access: Access::new(),
+            archetype_component_access: Access::new(),
+        }
+    }
+}
+
 impl<SystemA: System, SystemB: System<In = SystemA::Out>> System for PipeSystem<SystemA, SystemB> {
     type In = SystemA::In;
     type Out = SystemB::Out;

--- a/crates/bevy_ecs/src/system/system_piping.rs
+++ b/crates/bevy_ecs/src/system/system_piping.rs
@@ -166,13 +166,8 @@ where
     fn pipe(self, system: SystemB) -> PipeSystem<SystemA::System, SystemB::System> {
         let system_a = IntoSystem::into_system(self);
         let system_b = IntoSystem::into_system(system);
-        PipeSystem {
-            name: Cow::Owned(format!("Pipe({}, {})", system_a.name(), system_b.name())),
-            system_a,
-            system_b,
-            archetype_component_access: Default::default(),
-            component_access: Default::default(),
-        }
+        let name = format!("Pipe({}, {})", system_a.name(), system_b.name());
+        PipeSystem::new(system_a, system_b, Cow::Owned(name))
     }
 }
 


### PR DESCRIPTION
# Objective

Fix #5914.

`PipeSystem` cannot be constructed in `const` contexts.

## Solution

Add a const `PipeSystem::new` function.
