### PR TITLE
[Merged by Bors] - Update linux_dependencies.md

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -113,7 +113,7 @@ with pkgs; mkShell rec {
     llvmPackages.bintools # To use lld linker
   ];
   buildInputs = [
-    udev alsaLib vulkan-loader
+    udev alsa-lib vulkan-loader
     xlibsWrapper xorg.libXcursor xorg.libXrandr xorg.libXi # To use x11 feature
     libxkbcommon wayland # To use wayland feature
   ];


### PR DESCRIPTION
fixes alsalib dependency for NixOS
