### PR TITLE
map gilrs::Axis::Unknown to GamepadAxisType::Other

### DIFF
--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -29,7 +29,7 @@ pub fn convert_button(button: gilrs::Button) -> Option<GamepadButtonType> {
     }
 }
 
-pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxisType> {
+pub fn convert_axis(axis: gilrs::Axis, code: gilrs::ev::Code) -> Option<GamepadAxisType> {
     match axis {
         gilrs::Axis::LeftStickX => Some(GamepadAxisType::LeftStickX),
         gilrs::Axis::LeftStickY => Some(GamepadAxisType::LeftStickY),
@@ -40,6 +40,7 @@ pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxisType> {
         // The `axis_dpad_to_button` gilrs filter should filter out all DPadX and DPadY events. If
         // it doesn't then we probably need an entry added to the following repo and an update to
         // GilRs to use the updated database: https://github.com/gabomdq/SDL_GameControllerDB
-        gilrs::Axis::Unknown | gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
+        gilrs::Axis::Unknown => Some(GamepadAxisType::Other(code.into_u32() as u8)),
+        gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
     }
 }

--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -40,7 +40,7 @@ pub fn convert_axis(axis: gilrs::Axis, code: gilrs::ev::Code) -> Option<GamepadA
         // The `axis_dpad_to_button` gilrs filter should filter out all DPadX and DPadY events. If
         // it doesn't then we probably need an entry added to the following repo and an update to
         // GilRs to use the updated database: https://github.com/gabomdq/SDL_GameControllerDB
-        gilrs::Axis::Unknown => Some(GamepadAxisType::Other(code.into_u32() as u8)),
+        gilrs::Axis::Unknown => Some(GamepadAxisType::Other(code.into_u32())),
         gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
     }
 }

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -51,8 +51,8 @@ pub fn gilrs_event_system(mut gilrs: NonSendMut<Gilrs>, mut events: EventWriter<
                     ));
                 }
             }
-            EventType::AxisChanged(gilrs_axis, value, _) => {
-                if let Some(axis_type) = convert_axis(gilrs_axis) {
+            EventType::AxisChanged(gilrs_axis, value, code) => {
+                if let Some(axis_type) = convert_axis(gilrs_axis, code) {
                     events.send(GamepadEventRaw::new(
                         convert_gamepad_id(gilrs_event.id),
                         GamepadEventType::AxisChanged(axis_type, value),

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -455,7 +455,7 @@ pub enum GamepadAxisType {
     RightZ,
 
     /// Non-standard support for other axis types (i.e. HOTAS sliders, potentiometers, etc).
-    Other(u8),
+    Other(u32),
 }
 
 /// An axis of a [`Gamepad`].


### PR DESCRIPTION
# Objective

Slider doesn't map to GamepadAxisType::Other or emit events from the gamepad_input_events example.

## Solution

The GamepadAxisType::Other has an additional `u8` value, while `Unknown` is a unitary variant.
To produce a u8 we add a `code` parameter to `convert_axis_type`, which has a platform specific `into_u32`.

---

## Changelog
- `GamepadAxisEvent::Other` now gets emitted.

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- The type of the `GamepadAxisType::Other(..)`'s value has changed to u32.