### PR TITLE
[Merged by Bors] - Remove redundant bitwise OR `TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -137,7 +137,7 @@ pub async fn initialize_renderer(
     let mut features = wgpu::Features::empty();
     let mut limits = options.limits.clone();
     if matches!(options.priority, WgpuSettingsPriority::Functionality) {
-        features = adapter.features() | wgpu::Features::TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES;
+        features = adapter.features();
         if adapter_info.device_type == wgpu::DeviceType::DiscreteGpu {
             // `MAPPABLE_PRIMARY_BUFFERS` can have a significant, negative performance impact for
             // discrete GPUs due to having to transfer data across the PCI-E bus and so it


### PR DESCRIPTION
# Objective

`TEXTURE_ADAPTER_SPECIFIC_FORMAT_FEATURES`  was already included in `adapter.features()` on non-wasm target, and since it is the default value for `WgpuSettings.features`, the subsequent code will also combine into this feature:
https://github.com/bevyengine/bevy/blob/b6066c30b6cfa7bffa598d45706dbe6e46ad24fc/crates/bevy_render/src/renderer/mod.rs#L155-L156

