### PR TITLE
[Merged by Bors] - Replace `WgpuAdapterInfo` with `RenderAdapterInfo` in the documentation.

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -138,7 +138,7 @@ pub mod render {
     //! Cameras, meshes, textures, shaders, and pipelines.
     //! Use [`RenderDevice::features`](crate::render::renderer::RenderDevice::features),
     //! [`RenderDevice::limits`](crate::render::renderer::RenderDevice::limits), and the
-    //! [`WgpuAdapterInfo`](crate::render::render_resource::WgpuAdapterInfo) resource to
+    //! [`RenderAdapterInfo`](crate::render::renderer::RenderAdapterInfo) resource to
     //! get runtime information about the actual adapter, backend, features, and limits.
     pub use bevy_render::*;
 }

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -14,12 +14,12 @@ pub enum WgpuSettingsPriority {
 }
 
 /// Provides configuration for renderer initialization. Use [`RenderDevice::features`](crate::renderer::RenderDevice::features),
-/// [`RenderDevice::limits`](crate::renderer::RenderDevice::limits), and the [`WgpuAdapterInfo`](crate::render_resource::WgpuAdapterInfo)
+/// [`RenderDevice::limits`](crate::renderer::RenderDevice::limits), and the [`RenderAdapterInfo`](crate::renderer::RenderAdapterInfo)
 /// resource to get runtime information about the actual adapter, backend, features, and limits.
 /// NOTE: [`Backends::DX12`](Backends::DX12), [`Backends::METAL`](Backends::METAL), and
 /// [`Backends::VULKAN`](Backends::VULKAN) are enabled by default for non-web and the best choice
 /// is automatically selected. Web using the `webgl` feature uses [`Backends::GL`](Backends::GL).
-/// NOTE: If you want to use [`Backends::GL`](Backends::GL) in a native app on Windows, you must
+/// NOTE: If you want to use [`Backends::GL`](Backends::GL) in a native app on `Windows` and/or `macOS`, you must
 /// use [`ANGLE`](https://github.com/gfx-rs/wgpu#angle). This is because wgpu requires EGL to
 /// create a GL context without a window and only ANGLE supports that.
 #[derive(Clone)]


### PR DESCRIPTION
# Objective

Fixes #6598
In addition, macOS can also support GL backends through ANGLE.