### PR TITLE
[Merged by Bors] - bevy_reflect: Add compile fail tests for bevy_reflect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
             ~/.cargo/git/db/
             target/
             crates/bevy_ecs_compile_fail_tests/target/
+            crates/bevy_reflect_compile_fail_tests/target/
           key: ${{ runner.os }}-cargo-check-compiles-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
 
 [workspace]
-exclude = ["benches", "crates/bevy_ecs_compile_fail_tests"]
+exclude = ["benches", "crates/bevy_ecs_compile_fail_tests", "crates/bevy_reflect_compile_fail_tests"]
 members = [
   "crates/*",
   "examples/android",

--- a/crates/bevy_reflect_compile_fail_tests/Cargo.toml
+++ b/crates/bevy_reflect_compile_fail_tests/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "bevy_reflect_compile_fail_tests"
+version = "0.1.0"
+edition = "2021"
+description = "Compile fail tests for Bevy Engine's reflection system"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dev-dependencies]
+bevy_reflect = { path = "../bevy_reflect" }
+trybuild = "1.0.71"

--- a/crates/bevy_reflect_compile_fail_tests/README.md
+++ b/crates/bevy_reflect_compile_fail_tests/README.md
@@ -1,0 +1,7 @@
+# Compile fail tests for bevy_reflect
+
+This crate is separate from `bevy_reflect` and not part of the Bevy workspace in order to not fail `crater` tests for
+Bevy.
+The tests assert on the exact compiler errors and can easily fail for new Rust versions due to updated compiler errors (e.g. changes in spans).
+
+The `CI` workflow executes these tests on the stable rust toolchain (see [tools/ci](../../tools/ci/src/main.rs)).

--- a/crates/bevy_reflect_compile_fail_tests/src/lib.rs
+++ b/crates/bevy_reflect_compile_fail_tests/src/lib.rs
@@ -1,0 +1,1 @@
+// Nothing here, check out the integration tests

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive.rs
@@ -1,0 +1,6 @@
+#[test]
+fn test() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/reflect_derive/*.fail.rs");
+    t.pass("tests/reflect_derive/*.pass.rs");
+}

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.fail.rs
@@ -1,0 +1,9 @@
+use bevy_reflect::Reflect;
+
+#[derive(Reflect)]
+struct Foo<'a> {
+    #[reflect(ignore)]
+    value: &'a str,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.fail.stderr
@@ -1,0 +1,13 @@
+error[E0478]: lifetime bound not satisfied
+ --> tests/reflect_derive/lifetimes.fail.rs:3:10
+  |
+3 | #[derive(Reflect)]
+  |          ^^^^^^^
+  |
+note: lifetime parameter instantiated with the lifetime `'a` as defined here
+ --> tests/reflect_derive/lifetimes.fail.rs:4:12
+  |
+4 | struct Foo<'a> {
+  |            ^^
+  = note: but lifetime parameter must outlive the static lifetime
+  = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.pass.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/lifetimes.pass.rs
@@ -1,0 +1,10 @@
+use bevy_reflect::Reflect;
+
+// Reason: Reflection relies on `Any` which requires `'static`
+#[derive(Reflect)]
+struct Foo<'a: 'static> {
+    #[reflect(ignore)]
+    value: &'a str,
+}
+
+fn main() {}

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -88,12 +88,24 @@ fn main() {
     }
 
     if what_to_run.contains(Check::COMPILE_FAIL) {
-        // Run UI tests (they do not get executed with the workspace tests)
-        // - See crates/bevy_ecs_compile_fail_tests/README.md
-        let _subdir = sh.push_dir("crates/bevy_ecs_compile_fail_tests");
-        cmd!(sh, "cargo test --target-dir ../../target")
-            .run()
-            .expect("Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.");
+        {
+            // ECS Compile Fail Tests
+            // Run UI tests (they do not get executed with the workspace tests)
+            // - See crates/bevy_ecs_compile_fail_tests/README.md
+            let _subdir = sh.push_dir("crates/bevy_ecs_compile_fail_tests");
+            cmd!(sh, "cargo test --target-dir ../../target")
+                .run()
+                .expect("Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.");
+        }
+        {
+            // Reflect Compile Fail Tests
+            // Run tests (they do not get executed with the workspace tests)
+            // - See crates/bevy_ecs_compile_fail_tests/README.md
+            let _subdir = sh.push_dir("crates/bevy_reflect_compile_fail_tests");
+            cmd!(sh, "cargo test --target-dir ../../target")
+                .run()
+                .expect("Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.");
+        }
     }
 
     if what_to_run.contains(Check::TEST) {

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -100,7 +100,7 @@ fn main() {
         {
             // Reflect Compile Fail Tests
             // Run tests (they do not get executed with the workspace tests)
-            // - See crates/bevy_ecs_compile_fail_tests/README.md
+            // - See crates/bevy_reflect_compile_fail_tests/README.md
             let _subdir = sh.push_dir("crates/bevy_reflect_compile_fail_tests");
             cmd!(sh, "cargo test --target-dir ../../target")
                 .run()


### PR DESCRIPTION
# Objective

There isn't really a way to test that code using bevy_reflect compiles or doesn't compile for certain scenarios. This would be especially useful for macro-centric PRs like #6511 and #6042.

## Solution

Using `bevy_ecs_compile_fail_tests` as reference, added the `bevy_reflect_compile_fail_tests` crate.

Currently, this crate contains a very simple test case. This is so that we can get the basic foundation of this crate agreed upon and merged so that more tests can be added by other PRs.

### Open Questions

- [x] Should this be added to CI? (Answer: Yes)

---

## Changelog

- Added the `bevy_reflect_compile_fail_tests` crate for testing compilation errors