### PR TITLE
[Merged by Bors] - Use ```bevy``` with default features in iOS example

### DIFF
--- a/examples/ios/Cargo.toml
+++ b/examples/ios/Cargo.toml
@@ -11,14 +11,4 @@ name = "bevy_ios_example"
 crate-type = ["staticlib"]
 
 [dependencies]
-bevy = { path = "../../", features = [ 
-  "bevy_audio",
-  "bevy_winit",
-  "bevy_core_pipeline",
-  "bevy_pbr",
-  "bevy_render",
-  "bevy_text",
-  "bevy_ui",
-  "vorbis",
-  "filesystem_watcher"
-], default-features = false}
+bevy = { path = "../../" }


### PR DESCRIPTION
# Objective

I am new to Bevy. And during my development, I noticed that the `iOS` example doesn't work.
Example panics with next message: ```panicked at 'Resource requested by bevy_ui::widget::text::text_system does not exist: bevy_asset::assets::Assets```.

I have asked for help in a `discord` iOS chat and there I receive a recommendation that it is possible that some bevy features missing.

## Solution

So, I used ```bevy``` with default features.
