### PR TITLE
[Merged by Bors] - improve nix docs

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -101,29 +101,44 @@ Depending on your graphics card, you may have to install one of the following:
 sudo xbps-install -S pkgconf alsa-lib-devel libX11-devel eudev-libudev-devel
 ```
 
-## NixOS
+## [Nix](https://nixos.org)
 
 Add a `shell.nix` file to the root of the project containing:
 
 ```nix
-{ pkgs ? import <nixpkgs> {} }:
-with pkgs; mkShell rec {
+{ pkgs ? import <nixpkgs> { } }:
+
+with pkgs;
+
+mkShell rec {
   nativeBuildInputs = [
     pkg-config
-    llvmPackages.bintools # To use lld linker
   ];
   buildInputs = [
     udev alsa-lib vulkan-loader
-    xlibsWrapper xorg.libXcursor xorg.libXrandr xorg.libXi # To use x11 feature
-    libxkbcommon wayland # To use wayland feature
+    xorg.libX11 xorg.libXcursor xorg.libXi xorg.libXrandr # To use the x11 feature
+    libxkbcommon wayland # To use the wayland feature
   ];
-  LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath buildInputs;
+  LD_LIBRARY_PATH = lib.makeLibraryPath buildInputs;
 }
 ```
 
-And enter it by just running `nix-shell`. You should be able compile Bevy programs using `cargo run` within this nix-shell. You can do this in one line with `nix-shell --run "cargo run"`.
+And enter it by just running `nix-shell`.
+You should be able compile Bevy programs using `cargo run` within this nix-shell.
+You can do this in one line with `nix-shell --run "cargo run"`.
 
-Note that this template does not add Rust to the environment because there are many ways to do it. For example, to use stable Rust from nixpkgs you can add `cargo` to `nativeBuildInputs`.
+This is also possible with [Nix flakes](https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-flake.html).
+Instead of creating `shell.nix`, you just need to add the derivation (`mkShell`)
+to your `devShells` in `flake.nix`. Run `nix develop` to enter the shell and
+`nix develop -c cargo run` to run the program. See
+[Nix's documentation](https://nixos.org/manual/nix/unstable/command-ref/new-cli/nix3-develop.html)
+for more information about `devShells`.
+
+Note that this template does not add Rust to the environment because there are many ways to do it.
+For example, to use stable Rust from nixpkgs, you can add `cargo` and `rustc` to `nativeBuildInputs`.
+
+[Here](https://github.com/NixOS/nixpkgs/blob/master/pkgs/games/jumpy/default.nix)
+is an example of packaging a Bevy program in nix.
 
 ## [OpenSUSE](https://www.opensuse.org/)
 


### PR DESCRIPTION
# Objective

`xlibsWrapper` is being deprecated: https://github.com/NixOS/nixpkgs/issues/194054, this pr removes the deprecated xlibsWrapper and makes a couple more improvements

## Solution

- rename NixOS to Nix since this is not specific to NixOS
- remove usage of `xlibsWrapper`
- add instructions for nix flakes with `nix develop`
- add example of a packaged bevy program in nixpkgs
- minor cosmetic/grammatical changes