### PR TITLE
[Merged by Bors] - Separate Extract from Sub App Schedule

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -94,13 +94,13 @@ struct SubApp {
 }
 
 impl SubApp {
-    /// run the `SubApp`'s schedule
+    /// Runs the `SubApp`'s schedule.
     pub fn run(&mut self) {
         self.app.schedule.run(&mut self.app.world);
         self.app.world.clear_trackers();
     }
 
-    /// extract data from main world to sub app
+    /// Extracts data from main world to this sub-app.
     pub fn extract(&mut self, main_world: &mut World) {
         (self.extract)(main_world, &mut self.app);
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -189,6 +189,14 @@ impl App {
         if app.is_building_plugin {
             panic!("App::run() was called from within Plugin::Build(), which is not allowed.");
         }
+
+        // temporarily remove the plugin registry to run each plugin's setup function on app.
+        let mut plugin_registry = std::mem::take(&mut app.plugin_registry);
+        for plugin in &plugin_registry {
+            plugin.setup(&mut app);
+        }
+        std::mem::swap(&mut app.plugin_registry, &mut plugin_registry);
+
         let runner = std::mem::replace(&mut app.runner, Box::new(run_once));
         (runner)(app);
     }

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -16,10 +16,19 @@ use std::any::Any;
 pub trait Plugin: Downcast + Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
     fn build(&self, app: &mut App);
+
+    /// Runs after all plugins are built, but before the app runner is called.
+    /// This can be useful if you have some resource that other plugins need during their build step,
+    /// but after build you want to remove it and send it to another thread.
+    fn setup(&self, _app: &mut App) {
+        // do nothing
+    }
+
     /// Configures a name for the [`Plugin`] which is primarily used for debugging.
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
     }
+
     /// If the plugin can be meaningfully instantiated several times in an [`App`](crate::App),
     /// override this method to return `false`.
     fn is_unique(&self) -> bool {

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -361,6 +361,17 @@ impl Schedule {
             .and_then(|stage| stage.downcast_mut::<T>())
     }
 
+    /// Remove a [`Stage`] from the schedule
+    pub fn remove_stage(&mut self, stage_label: impl StageLabel) -> Option<Box<dyn Stage>> {
+        let label = stage_label.as_label();
+
+        let Some(index) = self.stage_order.iter().position(|x| *x == label) else {
+                return None;
+            };
+        self.stage_order.remove(index);
+        self.stages.remove(&label)
+    }
+
     /// Executes each [`Stage`] contained in the schedule, one at a time.
     pub fn run_once(&mut self, world: &mut World) {
         for label in &self.stage_order {

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -361,7 +361,7 @@ impl Schedule {
             .and_then(|stage| stage.downcast_mut::<T>())
     }
 
-    /// Remove a [`Stage`] from the schedule
+    /// Removes a [`Stage`] from the schedule.
     pub fn remove_stage(&mut self, stage_label: impl StageLabel) -> Option<Box<dyn Stage>> {
         let label = stage_label.as_label();
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -92,7 +92,7 @@ pub enum RenderStage {
     Cleanup,
 }
 
-/// Resource for holding the extract stage of the rendering schedule
+/// Resource for holding the extract stage of the rendering schedule.
 #[derive(Resource)]
 pub struct ExtractStage(pub SystemStage);
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -198,7 +198,10 @@ impl Plugin for RenderPlugin {
                         .with_system(PipelineCache::process_pipeline_queue_system)
                         .with_system(render_system.at_end()),
                 )
-                .add_stage(RenderStage::Cleanup, SystemStage::parallel())
+                .add_stage(
+                    RenderStage::Cleanup,
+                    SystemStage::parallel().with_system(World::clear_entities.at_end()),
+                )
                 .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(RenderInstance(instance))
                 .insert_resource(device)
@@ -247,78 +250,6 @@ impl Plugin for RenderPlugin {
 
                     // extract
                     extract(app_world, render_app);
-                }
-
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "prepare").entered();
-
-                    // prepare
-                    let prepare = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Prepare)
-                        .unwrap();
-                    prepare.run(&mut render_app.world);
-                }
-
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "queue").entered();
-
-                    // queue
-                    let queue = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Queue)
-                        .unwrap();
-                    queue.run(&mut render_app.world);
-                }
-
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "sort").entered();
-
-                    // phase sort
-                    let phase_sort = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::PhaseSort)
-                        .unwrap();
-                    phase_sort.run(&mut render_app.world);
-                }
-
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "render").entered();
-
-                    // render
-                    let render = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Render)
-                        .unwrap();
-                    render.run(&mut render_app.world);
-                }
-
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "cleanup").entered();
-
-                    // cleanup
-                    let cleanup = render_app
-                        .schedule
-                        .get_stage_mut::<SystemStage>(RenderStage::Cleanup)
-                        .unwrap();
-                    cleanup.run(&mut render_app.world);
-                }
-                {
-                    #[cfg(feature = "trace")]
-                    let _stage_span =
-                        bevy_utils::tracing::info_span!("stage", name = "clear_entities").entered();
-
-                    render_app.world.clear_entities();
                 }
             });
         }


### PR DESCRIPTION
# Objective

- This pulls out some of the changes to Plugin setup and sub apps from #6503 to make that PR easier to review.
- Separate the extract stage from running the sub app's schedule to allow for them to be run on separate threads in the future
- Fixes #6990

## Solution

- add a run method to `SubApp` that runs the schedule
- change the name of `sub_app_runner` to extract to make it clear that this function is only for extracting data between the main app and the sub app
- remove the extract stage from the sub app schedule so it can be run separately. This is done by adding a `setup` method to the `Plugin` trait that runs after all plugin build methods run. This is required to allow the extract stage to be removed from the schedule after all the plugins have added their systems to the stage. We will also need the setup method for pipelined rendering to setup the render thread. See https://github.com/bevyengine/bevy/blob/e3267965e15f14be18eec942dcaf16807144eb05/crates/bevy_render/src/pipelined_rendering.rs#L57-L98

## Changelog

- Separate SubApp Extract stage from running the sub app schedule.

## Migration Guide

### SubApp `runner` has conceptually been changed to an `extract` function.

The `runner` no longer is in charge of running the sub app schedule. It's only concern is now moving data between the main world and the sub app. The `sub_app.app.schedule` is now run for you after the provided function is called.

```rust
// before
fn main() {
    let sub_app = App::empty();
    sub_app.add_stage(MyStage, SystemStage::parallel());
    
    App::new().add_sub_app(MySubApp, sub_app, move |main_world, sub_app| {
        extract(app_world, render_app);
        render_app.app.schedule.run();
    });
}

// after
fn main() {
        let sub_app = App::empty();
    sub_app.add_stage(MyStage, SystemStage::parallel());
    
    App::new().add_sub_app(MySubApp, sub_app, move |main_world, sub_app| {
        extract(app_world, render_app);
        // schedule is automatically called for you after extract is run
    });
}
```
