### PR TITLE
[Merged by Bors] - Allow `SystemParam`s with private fields

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -533,6 +533,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 {}
             }
         }
+        // For unconditionally mutable params, we simply do not implement `ReadOnlySystemParam`.
         ParamAccess::Mutable => quote! {},
     };
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -518,7 +518,21 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 {}
             }
         }
-        ParamAccess::ReadOnly => todo!(),
+        ParamAccess::ReadOnly => {
+            quote! {
+                fn __assert_field_is_read_only_system_param<T: #path::system::ReadOnlySystemParam>() {}
+                fn __assert_each_field_is_read_only_system_param #impl_generics () #where_clause {
+                    #(
+                        __assert_field_is_read_only_system_param::<#field_types>();
+                    )*
+                }
+
+                // SAFETY: The above code will cause a compile error if each field does not implement `ReadOnlySystemParam`.
+                // Since each field is `ReadOnlySystemParam`, this can only read from the `World`
+                unsafe impl #impl_generics #path::system::ReadOnlySystemParam for #struct_name #ty_generics #where_clause
+                {}
+            }
+        }
         ParamAccess::Mutable => quote! {},
     };
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -333,13 +333,6 @@ struct SystemParamFieldAttributes {
 
 static SYSTEM_PARAM_ATTRIBUTE_NAME: &str = "system_param";
 
-#[derive(Debug)]
-enum ParamAccess {
-    Auto,
-    ReadOnly,
-    Mutable,
-}
-
 /// Implement `SystemParam` to use a struct as a parameter in a system
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
@@ -350,28 +343,6 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             .into();
     };
     let path = bevy_ecs_path();
-
-    let mut access = ParamAccess::Auto;
-    for attr in &ast.attrs {
-        let expected_attr_name = format_ident!("{SYSTEM_PARAM_ATTRIBUTE_NAME}");
-        if attr.path.get_ident() != Some(&expected_attr_name) {
-            continue;
-        }
-
-        syn::custom_keyword!(read_only);
-        syn::custom_keyword!(mutable);
-
-        attr.parse_args_with(|input: ParseStream| {
-            if input.parse::<Option<read_only>>()?.is_some() {
-                access = ParamAccess::ReadOnly;
-            }
-            if input.parse::<Option<mutable>>()?.is_some() {
-                access = ParamAccess::Mutable;
-            }
-            Ok(())
-        })
-        .expect("Invalid 'system_param' attribute format.");
-    }
 
     let field_attributes = field_definitions
         .iter()

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -333,6 +333,13 @@ struct SystemParamFieldAttributes {
 
 static SYSTEM_PARAM_ATTRIBUTE_NAME: &str = "system_param";
 
+#[derive(Debug)]
+enum ParamAccess {
+    Auto,
+    ReadOnly,
+    Mutable,
+}
+
 /// Implement `SystemParam` to use a struct as a parameter in a system
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
@@ -343,6 +350,28 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             .into();
     };
     let path = bevy_ecs_path();
+
+    let mut access = ParamAccess::Auto;
+    for attr in &ast.attrs {
+        let expected_attr_name = format_ident!("{SYSTEM_PARAM_ATTRIBUTE_NAME}");
+        if attr.path.get_ident() != Some(&expected_attr_name) {
+            continue;
+        }
+
+        syn::custom_keyword!(read_only);
+        syn::custom_keyword!(mutable);
+
+        attr.parse_args_with(|input: ParseStream| {
+            if input.parse::<Option<read_only>>()?.is_some() {
+                access = ParamAccess::ReadOnly;
+            }
+            if input.parse::<Option<mutable>>()?.is_some() {
+                access = ParamAccess::Mutable;
+            }
+            Ok(())
+        })
+        .expect("Invalid 'system_param' attribute format.");
+    }
 
     let field_attributes = field_definitions
         .iter()

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -518,21 +518,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 {}
             }
         }
-        ParamAccess::ReadOnly => {
-            quote! {
-                fn __assert_field_is_read_only_system_param<T: #path::system::ReadOnlySystemParam>() {}
-                fn __assert_each_field_is_read_only_system_param #impl_generics () #where_clause {
-                    #(
-                        __assert_field_is_read_only_system_param::<#field_types>();
-                    )*
-                }
-
-                // SAFETY: The above code will cause a compile error if each field does not implement `ReadOnlySystemParam`.
-                // Since each field is `ReadOnlySystemParam`, this can only read from the `World`
-                unsafe impl #impl_generics #path::system::ReadOnlySystemParam for #struct_name #ty_generics #where_clause
-                {}
-            }
-        }
+        ParamAccess::ReadOnly => todo!(),
         ParamAccess::Mutable => quote! {},
     };
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -496,31 +496,18 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         let end = Vec::from_iter(tuple_patterns.drain(..LIMIT));
         tuple_patterns.push(parse_quote!( (#(#end,)*) ));
     }
+    // Create a where clause for the `ReadOnlySystemParam` impl.
+    // Ensure that each field implements `ReadOnlySystemParam`.
+    let mut read_only_generics = generics.clone();
+    let read_only_where_clause = read_only_generics.make_where_clause();
+    for field_type in &field_types {
+        read_only_where_clause
+            .predicates
+            .push(syn::parse_quote!(#field_type: #path::system::ReadOnlySystemParam));
+    }
 
     let struct_name = &ast.ident;
     let state_struct_visibility = &ast.vis;
-
-    let read_only_impl = match access {
-        ParamAccess::Auto => {
-            // Create a where clause for the `ReadOnlySystemParam` impl.
-            // Ensure that each field implements `ReadOnlySystemParam`.
-            let mut read_only_generics = generics.clone();
-            let read_only_where_clause = read_only_generics.make_where_clause();
-            for field_type in &field_types {
-                read_only_where_clause
-                    .predicates
-                    .push(syn::parse_quote!(#field_type: #path::system::ReadOnlySystemParam));
-            }
-
-            quote! {
-                // Safety: Each field is `ReadOnlySystemParam`, so this can only read from the `World`
-                unsafe impl<'w, 's, #punctuated_generics> #path::system::ReadOnlySystemParam for #struct_name #ty_generics #read_only_where_clause
-                {}
-            }
-        }
-        ParamAccess::ReadOnly => todo!(),
-        ParamAccess::Mutable => quote! {},
-    };
 
     TokenStream::from(quote! {
         // We define the FetchState struct in an anonymous scope to avoid polluting the user namespace.
@@ -576,7 +563,8 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 }
             }
 
-            #read_only_impl
+            // Safety: Each field is `ReadOnlySystemParam`, so this can only read from the `World`
+            unsafe impl<'w, 's, #punctuated_generics> #path::system::ReadOnlySystemParam for #struct_name #ty_generics #read_only_where_clause {}
         };
     })
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -441,12 +441,6 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         }
     }
 
-    let mut punctuated_type_generic_idents = Punctuated::<_, Token![,]>::new();
-    punctuated_type_generic_idents.extend(lifetimeless_generics.iter().filter_map(|g| match g {
-        GenericParam::Type(g) => Some(&g.ident),
-        _ => None,
-    }));
-
     let mut punctuated_generic_idents = Punctuated::<_, Token![,]>::new();
     punctuated_generic_idents.extend(lifetimeless_generics.iter().map(|g| match g {
         GenericParam::Type(g) => &g.ident,
@@ -494,7 +488,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 state: (#(<#tuple_types as #path::system::SystemParam>::State,)*),
                 marker: std::marker::PhantomData<(
                     <#path::prelude::Query<'w, 's, ()> as #path::system::SystemParam>::State,
-                    fn()->(#punctuated_type_generic_idents)
+                    #(fn() -> #ignored_field_types,)*
                 )>,
             }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -440,7 +440,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         }
     }
 
-    let (_impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
     let lifetimeless_generics: Vec<_> = generics
         .params
@@ -527,24 +527,21 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         // The struct can still be accessed via SystemParam::State, e.g. EventReaderState can be accessed via
         // <EventReader<'static, 'static, T> as SystemParam>::State
         const _: () = {
-            impl<'w, 's, #punctuated_generics> #path::system::SystemParam for #struct_name #ty_generics #where_clause {
-                type State = State<'w, 's, #punctuated_generic_idents>;
+            impl #impl_generics #path::system::SystemParam for #struct_name #ty_generics #where_clause {
+                type State = FetchState<'static, 'static, #punctuated_generic_idents>;
             }
 
             #[doc(hidden)]
-            type State<'w, 's, #punctuated_generics_no_bounds> = FetchState<
-                (#(<#tuple_types as #path::system::SystemParam>::State,)*),
-                #punctuated_generic_idents
-            >;
-
-            #[doc(hidden)]
-            #state_struct_visibility struct FetchState <TSystemParamState, #punctuated_generics> {
-                state: TSystemParamState,
-                marker: std::marker::PhantomData<fn()->(#punctuated_type_generic_idents)>
+            #state_struct_visibility struct FetchState <'w, 's, #(#lifetimeless_generics,)*> {
+                state: (#(<#tuple_types as #path::system::SystemParam>::State,)*),
+                marker: std::marker::PhantomData<(
+                    <#path::prelude::Query<'w, 's, ()> as #path::system::SystemParam>::State,
+                    fn()->(#punctuated_type_generic_idents)
+                )>,
             }
 
-            unsafe impl<'__w, '__s, #punctuated_generics> #path::system::SystemParamState for
-                State<'__w, '__s, #punctuated_generic_idents>
+            unsafe impl<#punctuated_generics> #path::system::SystemParamState for
+                FetchState<'static, 'static, #punctuated_generic_idents>
             #where_clause {
                 type Item<'w, 's> = #struct_name #ty_generics;
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -533,7 +533,6 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 {}
             }
         }
-        // For unconditionally mutable params, we simply do not implement `ReadOnlySystemParam`.
         ParamAccess::Mutable => quote! {},
     };
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1812,10 +1812,10 @@ mod tests {
 
     #[derive(SystemParam)]
     #[system_param(read_only)]
-    pub struct EncapsulatedParam<'s, T: Send + 'static> {
-        _p: PrivateParam<'s, T>,
+    pub struct EncapsulatedParam<'s> {
+        p: PrivateParam<'s>,
     }
 
     #[derive(SystemParam)]
-    struct PrivateParam<'s, T: Send + 'static>(Local<'s, PhantomData<T>>);
+    struct PrivateParam<'s>(Local<'s, ()>);
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1811,7 +1811,6 @@ mod tests {
     );
 
     #[derive(SystemParam)]
-    #[system_param(read_only)]
     pub struct EncapsulatedParam<'s> {
         p: PrivateParam<'s>,
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -43,7 +43,7 @@ use std::{
 /// will be created with the default value upon realisation.
 /// This is most useful for `PhantomData` fields, such as markers for generic types.
 ///
-/// ### Example
+/// # Example
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
@@ -64,29 +64,6 @@ use std::{
 /// }
 ///
 /// # bevy_ecs::system::assert_is_system(my_system::<()>);
-/// ```
-///
-/// `#[system_param(read_only)]` and `#[system_param(mutable)]`:
-/// Can be placed on the struct definition to indicate whether or not the type should
-/// implement [`ReadOnlySystemParam`].
-/// In most cases you do not need to worry about either of these attributes, since derived
-/// `SystemParam`s automatically implement `ReadOnlySystemParam` if each field does.
-///
-/// However, it is necessary to manually specifify this when you need to encapsulate
-/// private fields, since the default automagic `ReadOnlySystemParam` impl publicly
-/// exposes the type of each field.
-///
-/// ### Example
-///
-/// ```
-/// # use bevy_ecs::prelude::*;
-/// # use bevy_ecs_macros::SystemParam;
-/// #[derive(Resource)]
-/// struct MyResource(u32);
-///
-/// #[derive(SystemParam)]
-/// #[system_param(mutable)] // `MyResource` gets leaked if you don't add this
-/// pub struct MyParam<'w>(ResMut<'w, MyResource>);
 /// ```
 ///
 /// # Generic `SystemParam`s

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1811,6 +1811,7 @@ mod tests {
     );
 
     #[derive(SystemParam)]
+    #[system_param(read_only)]
     pub struct EncapsulatedParam<'s> {
         p: PrivateParam<'s>,
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1809,4 +1809,12 @@ mod tests {
         Res<'w, R>,
         Local<'s, L>,
     );
+
+    #[derive(SystemParam)]
+    pub struct EncapsulatedParam<'s> {
+        p: PrivateParam<'s>,
+    }
+
+    #[derive(SystemParam)]
+    struct PrivateParam<'s>(Local<'s, ()>);
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1812,10 +1812,10 @@ mod tests {
 
     #[derive(SystemParam)]
     #[system_param(read_only)]
-    pub struct EncapsulatedParam<'s> {
-        p: PrivateParam<'s>,
+    pub struct EncapsulatedParam<'s, T: Send + 'static> {
+        _p: PrivateParam<'s, T>,
     }
 
     #[derive(SystemParam)]
-    struct PrivateParam<'s>(Local<'s, ()>);
+    struct PrivateParam<'s, T: Send + 'static>(Local<'s, PhantomData<T>>);
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -43,7 +43,7 @@ use std::{
 /// will be created with the default value upon realisation.
 /// This is most useful for `PhantomData` fields, such as markers for generic types.
 ///
-/// # Example
+/// ### Example
 ///
 /// ```
 /// # use bevy_ecs::prelude::*;
@@ -64,6 +64,29 @@ use std::{
 /// }
 ///
 /// # bevy_ecs::system::assert_is_system(my_system::<()>);
+/// ```
+///
+/// `#[system_param(read_only)]` and `#[system_param(mutable)]`:
+/// Can be placed on the struct definition to indicate whether or not the type should
+/// implement [`ReadOnlySystemParam`].
+/// In most cases you do not need to worry about either of these attributes, since derived
+/// `SystemParam`s automatically implement `ReadOnlySystemParam` if each field does.
+///
+/// However, it is necessary to manually specifify this when you need to encapsulate
+/// private fields, since the default automagic `ReadOnlySystemParam` impl publicly
+/// exposes the type of each field.
+///
+/// ### Example
+///
+/// ```
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs_macros::SystemParam;
+/// #[derive(Resource)]
+/// struct MyResource(u32);
+///
+/// #[derive(SystemParam)]
+/// #[system_param(mutable)] // `MyResource` gets leaked if you don't add this
+/// pub struct MyParam<'w>(ResMut<'w, MyResource>);
 /// ```
 ///
 /// # Generic `SystemParam`s

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1810,11 +1810,9 @@ mod tests {
         Local<'s, L>,
     );
 
-    #[derive(SystemParam)]
-    pub struct EncapsulatedParam<'s> {
-        p: PrivateParam<'s>,
-    }
+    #[derive(Resource)]
+    struct PrivateResource;
 
     #[derive(SystemParam)]
-    struct PrivateParam<'s>(Local<'s, ()>);
+    pub struct EncapsulatedParam<'w>(Res<'w, PrivateResource>);
 }


### PR DESCRIPTION
# Objective

- Fix #4200

Currently, `#[derive(SystemParam)]` publicly exposes each field type, which makes it impossible to encapsulate private fields.

## Solution

Previously, the fields were leaked because they were used as an input generic type to the macro-generated `SystemParam::State` struct. That type has been changed to store its state in a field with a specific type, instead of a generic type.

---

## Changelog

- Fixed a bug that caused `#[derive(SystemParam)]` to leak the types of private fields.
