### PR TITLE
[Merged by Bors] - Add a more familiar hex color entry

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -253,7 +253,8 @@ impl Color {
     /// ```
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {
-        let hex = hex.as_ref().replace('#', "");
+        let hex = hex.as_ref();
+        let hex = hex.strip_prefix("#").unwrap_or(hex);
 
         // RGB
         if hex.len() == 3 {

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -253,7 +253,7 @@ impl Color {
     /// ```
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {
-        let hex = hex.as_ref().replace("#", "");
+        let hex = hex.as_ref().replace('#', "");
 
         // RGB
         if hex.len() == 3 {

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -253,7 +253,7 @@ impl Color {
     /// ```
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {
-        let hex = hex.as_ref();
+        let hex = hex.as_ref().replace("#", "");
 
         // RGB
         if hex.len() == 3 {

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -250,6 +250,9 @@ impl Color {
     /// # use bevy_render::color::Color;
     /// let color = Color::hex("FF00FF").unwrap(); // fuchsia
     /// let color = Color::hex("FF00FF7F").unwrap(); // partially transparent fuchsia
+    ///
+    /// // A standard hex color notation is also available
+    /// assert_eq!(Color::hex("#FFFFFF").unwrap(), Color::rgb(1.0, 1.0, 1.0));
     /// ```
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -254,7 +254,7 @@ impl Color {
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {
         let hex = hex.as_ref();
-        let hex = hex.strip_prefix("#").unwrap_or(hex);
+        let hex = hex.strip_prefix('#').unwrap_or(hex);
 
         // RGB
         if hex.len() == 3 {

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -30,7 +30,7 @@ fn setup(
                     .unwrap(),
                 ),
                 material: materials.add(StandardMaterial {
-                    base_color: Color::hex("ffd891").unwrap(),
+                    base_color: Color::hex("#ffd891").unwrap(),
                     // vary key PBR parameters on a grid of spheres to show the effect
                     metallic: y01,
                     perceptual_roughness: x01,
@@ -51,7 +51,7 @@ fn setup(
             .unwrap(),
         ),
         material: materials.add(StandardMaterial {
-            base_color: Color::hex("ffd891").unwrap(),
+            base_color: Color::hex("#ffd891").unwrap(),
             // vary key PBR parameters on a grid of spheres to show the effect
             unlit: true,
             ..default()


### PR DESCRIPTION
# Objective

- When using `Color::hex` for the first time, I was confused by the fact that I can't specify colors using #, which is much more familiar.
- In the code editor (if there is support) there is a preview of the color, which is very convenient.
![Снимок экрана от 2022-12-30 02-54-00](https://user-images.githubusercontent.com/69102503/209990973-f6fc3bc6-08f6-4e51-a9a9-1de8a675c82d.png)

## Solution

- Allow you to enter colors like `#ff33f2` and use the `.strip_prefix` method to delete the `#` character.
