### PR TITLE
Utility to fetch the next event from an event reader

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -207,14 +207,6 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
         self.reader.len(&self.events)
     }
 
-    /// Retrieves the next event in the [`EventReader`] that has not been seen.
-    ///
-    /// Updates the [`EventReader`]'s event counter, meaning subsequent reads
-    /// will start after the fetched event, if it exists.
-    pub fn next(&mut self) -> Option<&'w E> {
-        self.reader.iter(&self.events).next()
-    }
-
     /// Determines if no events are available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::clear`].
     ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -207,6 +207,14 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
         self.reader.len(&self.events)
     }
 
+    /// Retrieves the next event in the [`EventReader`] that has not been seen.
+    ///
+    /// Updates the [`EventReader`]'s event counter, meaning subsequent reads
+    /// will start after the fetched event, if it exists.
+    pub fn next(&mut self) -> Option<&'w E> {
+        self.reader.iter(&self.events).next()
+    }
+
     /// Determines if no events are available to be read without consuming any.
     /// If you need to consume the iterator you can use [`EventReader::clear`].
     ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -211,7 +211,8 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     ///
     /// Updates the [`EventReader`]'s event counter, meaning subsequent reads
     /// will start after the fetched event, if it exists.
-    pub fn next(&mut self) -> Option<&'w E> {
+    #[allow(clippy::should_implement_trait)]
+    pub fn next(&mut self) -> Option<&E> {
         self.reader.iter(&self.events).next()
     }
 

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -8,13 +8,10 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_event::<MyEvent>()
         .add_event::<PlaySound>()
-        .add_event::<ExitGameEvent>()
         .init_resource::<EventTriggerState>()
         .add_system(event_trigger)
         .add_system(event_listener)
         .add_system(sound_player)
-        .add_system(check_exit_game)
-        .add_system(handle_exit_game.after(check_exit_game))
         .run();
 }
 
@@ -29,9 +26,6 @@ struct PlaySound;
 struct EventTriggerState {
     event_timer: Timer,
 }
-
-#[derive(Default)]
-struct ExitGameEvent;
 
 impl Default for EventTriggerState {
     fn default() -> Self {

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -8,10 +8,13 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_event::<MyEvent>()
         .add_event::<PlaySound>()
+        .add_event::<ExitGameEvent>()
         .init_resource::<EventTriggerState>()
         .add_system(event_trigger)
         .add_system(event_listener)
         .add_system(sound_player)
+        .add_system(check_exit_game)
+        .add_system(handle_exit_game.after(check_exit_game))
         .run();
 }
 
@@ -26,6 +29,9 @@ struct PlaySound;
 struct EventTriggerState {
     event_timer: Timer,
 }
+
+#[derive(Default)]
+struct ExitGameEvent;
 
 impl Default for EventTriggerState {
     fn default() -> Self {


### PR DESCRIPTION
## Overview

It's pretty common to want to fetch a single event from an event reader. For instance, if you want to trigger cleanup upon receipt of some `OnCloseEvent(data)` or `GameOverEvent(exit_status)`. There currently isn't an `EventReader<E>` function for this.

## Objective

- Make it easier to read a single event from an `EventReader<E>`. 

## Solution

- Added a function `next()` to `EventReader<E>` to fetch the next event in the event stream.
