### PR TITLE
[Merged by Bors] - asset: make HandleUntyped::id private

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -322,8 +322,7 @@ impl<T: Asset> Clone for Handle<T> {
 /// To convert back to a typed handle, use the [typed](HandleUntyped::typed) method.
 #[derive(Debug)]
 pub struct HandleUntyped {
-    /// An unique identifier to an Asset.
-    pub id: HandleId,
+    id: HandleId,
     handle_type: HandleType,
 }
 
@@ -350,6 +349,12 @@ impl HandleUntyped {
             id,
             handle_type: HandleType::Weak,
         }
+    }
+
+    /// The ID of the asset.
+    #[inline]
+    pub fn id(&self) -> HandleId {
+        self.id
     }
 
     /// Creates a weak copy of this handle.

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -34,8 +34,8 @@ fn check_textures(
     rpg_sprite_handles: ResMut<RpgSpriteHandles>,
     asset_server: Res<AssetServer>,
 ) {
-    if let LoadState::Loaded =
-        asset_server.get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id))
+    if let LoadState::Loaded = asset_server
+        .get_group_load_state(rpg_sprite_handles.handles.iter().map(|handle| handle.id()))
     {
         state.set(AppState::Finished).unwrap();
     }


### PR DESCRIPTION
# Objective

It is currently possible to break reference counting for assets by creating a strong `HandleUntyped` and then modifying the `id` field before dropping the handle. This should not be allowed.

## Solution

Change the `id` field visibility to private and add a getter instead. The same change was previously done for `Handle<T>` in #6176, but `HandleUntyped` was forgotten.

---

## Migration Guide

- Instead of directly accessing the ID of a `HandleUntyped` as `handle.id`, use the new getter `handle.id()`.
