### PR TITLE
[Merged by Bors] - Fix: CI `bench-check` command

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
         .expect("Please fix doc warnings in output above.");
     }
 
-    if what_to_run.contains(Check::COMPILE_FAIL) {
+    if what_to_run.contains(Check::BENCH_CHECK) {
         let _subdir = sh.push_dir("benches");
         // Check that benches are building
         cmd!(sh, "cargo check --benches --target-dir ../target")


### PR DESCRIPTION
# Objective

I noticed that running the following command didn't actually do anything:

```
cargo run -p ci -- bench-check
```

## Solution

Made it so that running `cargo run -p ci -- bench-check` actually runs a compile check on the `benches` directory.
