### PR TITLE
TrackedRenderPass driven RenderPhases

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -231,9 +231,10 @@ impl Node for BloomNode {
 
         {
             let view = &BloomTextures::texture_view(&textures.texture_a, 0);
-            let mut prefilter_pass =
-                TrackedRenderPass::new(render_context.command_encoder.begin_render_pass(
-                    &RenderPassDescriptor {
+            let mut prefilter_pass = TrackedRenderPass::new(
+                render_context
+                    .command_encoder
+                    .begin_render_pass(&RenderPassDescriptor {
                         label: Some("bloom_prefilter_pass"),
                         color_attachments: &[Some(RenderPassColorAttachment {
                             view,
@@ -241,8 +242,9 @@ impl Node for BloomNode {
                             ops: Operations::default(),
                         })],
                         depth_stencil_attachment: None,
-                    },
-                ));
+                    }),
+                view_entity,
+            );
             prefilter_pass.set_render_pipeline(downsampling_prefilter_pipeline);
             prefilter_pass.set_bind_group(
                 0,
@@ -257,9 +259,10 @@ impl Node for BloomNode {
 
         for mip in 1..textures.mip_count {
             let view = &BloomTextures::texture_view(&textures.texture_a, mip);
-            let mut downsampling_pass =
-                TrackedRenderPass::new(render_context.command_encoder.begin_render_pass(
-                    &RenderPassDescriptor {
+            let mut downsampling_pass = TrackedRenderPass::new(
+                render_context
+                    .command_encoder
+                    .begin_render_pass(&RenderPassDescriptor {
                         label: Some("bloom_downsampling_pass"),
                         color_attachments: &[Some(RenderPassColorAttachment {
                             view,
@@ -267,8 +270,9 @@ impl Node for BloomNode {
                             ops: Operations::default(),
                         })],
                         depth_stencil_attachment: None,
-                    },
-                ));
+                    }),
+                view_entity,
+            );
             downsampling_pass.set_render_pipeline(downsampling_pipeline);
             downsampling_pass.set_bind_group(
                 0,
@@ -283,9 +287,10 @@ impl Node for BloomNode {
 
         for mip in (1..textures.mip_count).rev() {
             let view = &BloomTextures::texture_view(&textures.texture_b, mip - 1);
-            let mut upsampling_pass =
-                TrackedRenderPass::new(render_context.command_encoder.begin_render_pass(
-                    &RenderPassDescriptor {
+            let mut upsampling_pass = TrackedRenderPass::new(
+                render_context
+                    .command_encoder
+                    .begin_render_pass(&RenderPassDescriptor {
                         label: Some("bloom_upsampling_pass"),
                         color_attachments: &[Some(RenderPassColorAttachment {
                             view,
@@ -293,8 +298,9 @@ impl Node for BloomNode {
                             ops: Operations::default(),
                         })],
                         depth_stencil_attachment: None,
-                    },
-                ));
+                    }),
+                view_entity,
+            );
             upsampling_pass.set_render_pipeline(upsampling_pipeline);
             upsampling_pass.set_bind_group(
                 0,
@@ -308,9 +314,10 @@ impl Node for BloomNode {
         }
 
         {
-            let mut upsampling_final_pass =
-                TrackedRenderPass::new(render_context.command_encoder.begin_render_pass(
-                    &RenderPassDescriptor {
+            let mut upsampling_final_pass = TrackedRenderPass::new(
+                render_context
+                    .command_encoder
+                    .begin_render_pass(&RenderPassDescriptor {
                         label: Some("bloom_upsampling_final_pass"),
                         color_attachments: &[Some(view_target.get_unsampled_color_attachment(
                             Operations {
@@ -319,8 +326,9 @@ impl Node for BloomNode {
                             },
                         ))],
                         depth_stencil_attachment: None,
-                    },
-                ));
+                    }),
+                view_entity,
+            );
             upsampling_final_pass.set_render_pipeline(upsampling_final_pipeline);
             upsampling_final_pass.set_bind_group(
                 0,

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -81,13 +81,13 @@ impl Node for MainPass2dNode {
             let render_pass = render_context
                 .command_encoder
                 .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass);
+            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
             if let Some(viewport) = camera.viewport.as_ref() {
                 render_pass.set_camera_viewport(viewport);
             }
 
-            transparent_phase.render(&mut render_pass, world, view_entity);
+            render_pass.render_phase(transparent_phase, world);
         }
 
         // WebGL2 quirk: if ending with a render pass with a custom viewport, the viewport isn't

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -12,8 +12,6 @@ use bevy_render::{
     renderer::RenderContext,
     view::{ExtractedView, ViewTarget},
 };
-#[cfg(feature = "trace")]
-use bevy_utils::tracing::info_span;
 
 pub struct MainPass2dNode {
     query: QueryState<

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -3,17 +3,14 @@ use crate::{
     core_3d::{AlphaMask3d, Camera3d, Opaque3d, Transparent3d},
 };
 use bevy_ecs::prelude::*;
-use bevy_render::render_phase::TrackedRenderPass;
 use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
-    render_phase::RenderPhase,
+    render_phase::{RenderPhase, TrackedRenderPass},
     render_resource::{LoadOp, Operations},
     renderer::RenderContext,
     view::{ExtractedView, ViewDepthTexture, ViewTarget},
 };
-#[cfg(feature = "trace")]
-use bevy_utils::tracing::info_span;
 
 pub struct MainPass3dNode {
     query: QueryState<

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -99,13 +99,13 @@ impl Node for MainPass3dNode {
             let render_pass = render_context
                 .command_encoder
                 .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass);
+            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
             if let Some(viewport) = camera.viewport.as_ref() {
                 render_pass.set_camera_viewport(viewport);
             }
 
-            opaque_phase.render(&mut render_pass, world, view_entity);
+            render_pass.render_phase(opaque_phase, world);
         }
 
         if !alpha_mask_phase.items.is_empty() {
@@ -134,13 +134,13 @@ impl Node for MainPass3dNode {
             let render_pass = render_context
                 .command_encoder
                 .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass);
+            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
             if let Some(viewport) = camera.viewport.as_ref() {
                 render_pass.set_camera_viewport(viewport);
             }
 
-            alpha_mask_phase.render(&mut render_pass, world, view_entity);
+            render_pass.render_phase(alpha_mask_phase, world);
         }
 
         if !transparent_phase.items.is_empty() {
@@ -174,13 +174,13 @@ impl Node for MainPass3dNode {
             let render_pass = render_context
                 .command_encoder
                 .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass);
+            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
             if let Some(viewport) = camera.viewport.as_ref() {
                 render_pass.set_camera_viewport(viewport);
             }
 
-            transparent_phase.render(&mut render_pass, world, view_entity);
+            render_pass.render_phase(transparent_phase, world);
         }
 
         // WebGL2 quirk: if ending with a render pass with a custom viewport, the viewport isn't

--- a/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_pass_3d_node.rs
@@ -8,7 +8,7 @@ use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::RenderPhase,
-    render_resource::{LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor},
+    render_resource::{LoadOp, Operations},
     renderer::RenderContext,
     view::{ExtractedView, ViewDepthTexture, ViewTarget},
 };
@@ -67,118 +67,89 @@ impl Node for MainPass3dNode {
         // Always run opaque pass to ensure screen is cleared
         {
             // Run the opaque pass, sorted front-to-back
-            // NOTE: Scoped to drop the mutable borrow of render_context
-            #[cfg(feature = "trace")]
-            let _main_opaque_pass_3d_span = info_span!("main_opaque_pass_3d").entered();
-            let pass_descriptor = RenderPassDescriptor {
-                label: Some("main_opaque_pass_3d"),
-                // NOTE: The opaque pass loads the color
-                // buffer as well as writing to it.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
-                    load: match camera_3d.clear_color {
-                        ClearColorConfig::Default => {
-                            LoadOp::Clear(world.resource::<ClearColor>().0.into())
-                        }
-                        ClearColorConfig::Custom(color) => LoadOp::Clear(color.into()),
-                        ClearColorConfig::None => LoadOp::Load,
-                    },
-                    store: true,
-                }))],
-                depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
-                    view: &depth.view,
-                    // NOTE: The opaque main pass loads the depth buffer and possibly overwrites it
-                    depth_ops: Some(Operations {
-                        // NOTE: 0.0 is the far plane due to bevy's use of reverse-z projections.
-                        load: camera_3d.depth_load_op.clone().into(),
-                        store: true,
-                    }),
-                    stencil_ops: None,
-                }),
+
+            // NOTE: The opaque pass loads the color buffer as well as writing to it.
+            let color_ops = Operations {
+                load: match camera_3d.clear_color {
+                    ClearColorConfig::Default => {
+                        LoadOp::Clear(world.resource::<ClearColor>().0.into())
+                    }
+                    ClearColorConfig::Custom(color) => LoadOp::Clear(color.into()),
+                    ClearColorConfig::None => LoadOp::Load,
+                },
+                store: true,
             };
 
-            let render_pass = render_context
-                .command_encoder
-                .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
+            let depth_ops = Some(Operations {
+                // NOTE: 0.0 is the far plane due to bevy's use of reverse-z projections.
+                load: camera_3d.depth_load_op.clone().into(),
+                store: true,
+            });
 
-            if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
-            }
+            let mut render_pass = TrackedRenderPass::create_for_camera(
+                render_context,
+                "main_opaque_pass_3d",
+                view_entity,
+                target,
+                color_ops,
+                Some(depth),
+                depth_ops,
+                &camera.viewport,
+            );
 
             render_pass.render_phase(opaque_phase, world);
         }
 
         if !alpha_mask_phase.items.is_empty() {
             // Run the alpha mask pass, sorted front-to-back
-            // NOTE: Scoped to drop the mutable borrow of render_context
-            #[cfg(feature = "trace")]
-            let _main_alpha_mask_pass_3d_span = info_span!("main_alpha_mask_pass_3d").entered();
-            let pass_descriptor = RenderPassDescriptor {
-                label: Some("main_alpha_mask_pass_3d"),
-                // NOTE: The alpha_mask pass loads the color buffer as well as overwriting it where appropriate.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+
+            let mut render_pass = TrackedRenderPass::create_for_camera(
+                render_context,
+                "main_alpha_mask_pass_3d",
+                view_entity,
+                target,
+                Operations {
                     load: LoadOp::Load,
                     store: true,
-                }))],
-                depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
-                    view: &depth.view,
-                    // NOTE: The alpha mask pass loads the depth buffer and possibly overwrites it
-                    depth_ops: Some(Operations {
-                        load: LoadOp::Load,
-                        store: true,
-                    }),
-                    stencil_ops: None,
+                },
+                Some(depth),
+                Some(Operations {
+                    load: LoadOp::Load,
+                    store: true,
                 }),
-            };
-
-            let render_pass = render_context
-                .command_encoder
-                .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
-
-            if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
-            }
+                &camera.viewport,
+            );
 
             render_pass.render_phase(alpha_mask_phase, world);
         }
 
         if !transparent_phase.items.is_empty() {
             // Run the transparent pass, sorted back-to-front
-            // NOTE: Scoped to drop the mutable borrow of render_context
-            #[cfg(feature = "trace")]
-            let _main_transparent_pass_3d_span = info_span!("main_transparent_pass_3d").entered();
-            let pass_descriptor = RenderPassDescriptor {
-                label: Some("main_transparent_pass_3d"),
-                // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+
+            // NOTE: For the transparent pass we load the depth buffer. There should be no
+            // need to write to it, but store is set to `true` as a workaround for issue #3776,
+            // https://github.com/bevyengine/bevy/issues/3776
+            // so that wgpu does not clear the depth buffer.
+            // As the opaque and alpha mask passes run first, opaque meshes can occlude
+            // transparent ones.
+            let depth_ops = Some(Operations {
+                load: LoadOp::Load,
+                store: true,
+            });
+
+            let mut render_pass = TrackedRenderPass::create_for_camera(
+                render_context,
+                "main_transparent_pass_3d",
+                view_entity,
+                target,
+                Operations {
                     load: LoadOp::Load,
                     store: true,
-                }))],
-                depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
-                    view: &depth.view,
-                    // NOTE: For the transparent pass we load the depth buffer. There should be no
-                    // need to write to it, but store is set to `true` as a workaround for issue #3776,
-                    // https://github.com/bevyengine/bevy/issues/3776
-                    // so that wgpu does not clear the depth buffer.
-                    // As the opaque and alpha mask passes run first, opaque meshes can occlude
-                    // transparent ones.
-                    depth_ops: Some(Operations {
-                        load: LoadOp::Load,
-                        store: true,
-                    }),
-                    stencil_ops: None,
-                }),
-            };
-
-            let render_pass = render_context
-                .command_encoder
-                .begin_render_pass(&pass_descriptor);
-            let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
-
-            if let Some(viewport) = camera.viewport.as_ref() {
-                render_pass.set_camera_viewport(viewport);
-            }
+                },
+                Some(depth),
+                depth_ops,
+                &camera.viewport,
+            );
 
             render_pass.render_phase(transparent_phase, world);
         }
@@ -187,20 +158,19 @@ impl Node for MainPass3dNode {
         // reset for the next render pass so add an empty render pass without a custom viewport
         #[cfg(feature = "webgl")]
         if camera.viewport.is_some() {
-            #[cfg(feature = "trace")]
-            let _reset_viewport_pass_3d = info_span!("reset_viewport_pass_3d").entered();
-            let pass_descriptor = RenderPassDescriptor {
-                label: Some("reset_viewport_pass_3d"),
-                color_attachments: &[Some(target.get_color_attachment(Operations {
+            let _render_pass = TrackedRenderPass::create_for_camera(
+                render_context,
+                "reset_viewport_pass_3d",
+                view_entity,
+                target,
+                Operations {
                     load: LoadOp::Load,
                     store: true,
-                }))],
-                depth_stencil_attachment: None,
-            };
-
-            render_context
-                .command_encoder
-                .begin_render_pass(&pass_descriptor);
+                },
+                None,
+                None,
+                &None,
+            );
         }
 
         Ok(())

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1786,9 +1786,9 @@ impl Node for ShadowPassNode {
                 let render_pass = render_context
                     .command_encoder
                     .begin_render_pass(&pass_descriptor);
-                let mut render_pass = TrackedRenderPass::new(render_pass);
+                let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
-                shadow_phase.render(&mut render_pass, world, view_light_entity);
+                render_pass.render_phase(shadow_phase, world);
             }
         }
 

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -29,13 +29,7 @@ pub trait Draw<P: PhaseItem>: Send + Sync + 'static {
     fn prepare(&mut self, world: &'_ World) {}
 
     /// Draws the [`PhaseItem`] by issuing draw calls via the [`TrackedRenderPass`].
-    fn draw<'w>(
-        &mut self,
-        world: &'w World,
-        pass: &mut TrackedRenderPass<'w>,
-        view: Entity,
-        item: &P,
-    );
+    fn draw<'w>(&mut self, world: &'w World, pass: &mut TrackedRenderPass<'w>, item: &P);
 }
 
 /// An item which will be drawn to the screen. A phase item should be queued up for rendering
@@ -330,15 +324,9 @@ where
     }
 
     /// Prepares the ECS parameters for the wrapped [`RenderCommand`] and then renders it.
-    fn draw<'w>(
-        &mut self,
-        world: &'w World,
-        pass: &mut TrackedRenderPass<'w>,
-        view: Entity,
-        item: &P,
-    ) {
+    fn draw<'w>(&mut self, world: &'w World, pass: &mut TrackedRenderPass<'w>, item: &P) {
         let param = self.state.get(world);
-        let view = self.view.get_manual(world, view).unwrap();
+        let view = self.view.get_manual(world, pass.view_entity).unwrap();
         let entity = self.entity.get_manual(world, item.entity()).unwrap();
         C::render(item, view, entity, param, pass);
     }

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -1,12 +1,10 @@
 mod draw;
 mod draw_state;
 
-use bevy_ecs::entity::Entity;
 pub use draw::*;
 pub use draw_state::*;
 
 use bevy_ecs::prelude::{Component, Query};
-use bevy_ecs::world::World;
 
 /// A resource to collect and sort draw requests for specific [`PhaseItems`](PhaseItem).
 #[derive(Component)]
@@ -30,22 +28,6 @@ impl<I: PhaseItem> RenderPhase<I> {
     /// Sorts all of its [`PhaseItems`](PhaseItem).
     pub fn sort(&mut self) {
         I::sort(&mut self.items);
-    }
-
-    pub fn render<'w>(
-        &self,
-        render_pass: &mut TrackedRenderPass<'w>,
-        world: &'w World,
-        view: Entity,
-    ) {
-        let draw_functions = world.resource::<DrawFunctions<I>>();
-        let mut draw_functions = draw_functions.write();
-        draw_functions.prepare(world);
-
-        for item in &self.items {
-            let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
-            draw_function.draw(world, render_pass, view, item);
-        }
     }
 }
 

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -88,9 +88,9 @@ impl Node for UiPassNode {
         let render_pass = render_context
             .command_encoder
             .begin_render_pass(&pass_descriptor);
-        let mut render_pass = TrackedRenderPass::new(render_pass);
+        let mut render_pass = TrackedRenderPass::new(render_pass, view_entity);
 
-        transparent_phase.render(&mut render_pass, world, view_entity);
+        render_pass.render_phase(transparent_phase, world);
 
         Ok(())
     }


### PR DESCRIPTION
# Objective

The current code for creating render passes and executing render phases is quite boilerplate-heavy and repetitive.

I have experimented with further improving the API, based on the proposal by @cart (posted in  https://github.com/bevyengine/bevy/pull/7043#discussion_r1060194089):

```rust
// This would create and set up a TrackedRenderPass, which would set the viewport, if it is
// configured on the camera. "pass" would need to be a wrapper over TrackedRenderPass.
let pass = camera.begin_render_pass(render_context, view_entity);
pass.render_phase(opaque_phase, world);
```

## Solution

This PR comprises two changes: 

### 1. The `RenderPhase`s are now executed directly using the `TrackedRenderPass`, with the API described above.
- Therefore, each `TrackedRenderPass` is associated with a `view_entity`.
- Additionally, this alleviates the need to pass around the `view_entity`s in the render method of `Draw` functions. Instead, they can be accessed directly from the `TrackedRenderPass` if they are needed.
```rust
old
opaque_phase.render(&mut pass, world, view_entity);

new
pass.render_phase(opaque_phase, world);
```

### 2. I have added a `TrackedRenderPass::create_for_camera` method, that sets up the render pass based on the camera view and depth target.
- This is an attempt to create a method similar to the one proposed by @cart.
```rust
let pass = camera.begin_render_pass(render_context, view_entity);
vs
let pass = TrackedRenderPass::create_for_camera(
    render_context,
    "main_alpha_mask_pass_3d",
    view_entity,
    target,
    Operations {
        load: LoadOp::Load,
        store: true,
    },
    Some(depth),
    Some(Operations {
        load: LoadOp::Load,
        store: true,
    }),
    &camera.viewport,
);
```
- This method replaces the setup for the 2d and 3d pass but is not general enough to accommodate the shadow and the UI pass as well.

I think that 1. is a good idea because from what I have gathered a `TrackedRenderPass` is always associated with a `view_entity` anyway. 

IMO, 2. is less ideal and I am interested if you have got a better idea. There are just too many different components at play that might or might not be required. I still believe that setting up the render attachments in a way that is simpler and more clear is a worthwhile goal though.

---

## Changelog
Todo

## Migration Guide
Todo
