### PR TITLE
[Merged by Bors] - Break `CorePlugin` into `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -493,7 +493,8 @@ mod tests {
         #[uuid = "44115972-f31b-46e5-be5c-2b9aece6a52f"]
         struct MyAsset;
         let mut app = App::new();
-        app.add_plugin(bevy_core::CorePlugin::default())
+        app.add_plugin(bevy_core::TaskPoolPlugin::default())
+            .add_plugin(bevy_core::CorePlugin::default())
             .add_plugin(crate::AssetPlugin::default());
         app.add_asset::<MyAsset>();
         let mut assets_before = app.world.resource_mut::<Assets<MyAsset>>();

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -494,7 +494,7 @@ mod tests {
         struct MyAsset;
         let mut app = App::new();
         app.add_plugin(bevy_core::TaskPoolPlugin::default())
-            .add_plugin(bevy_core::CorePlugin::default())
+            .add_plugin(bevy_core::TypeRegistrationPlugin::default())
             .add_plugin(crate::AssetPlugin::default());
         app.add_asset::<MyAsset>();
         let mut assets_before = app.world.resource_mut::<Assets<MyAsset>>();

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -14,7 +14,7 @@ pub use task_pool_options::*;
 pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
-    pub use crate::{CorePlugin, Name, TaskPoolOptions};
+    pub use crate::{CorePlugin, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin};
 }
 
 use bevy_app::prelude::*;
@@ -33,29 +33,14 @@ use bevy_tasks::tick_global_task_pools_on_main_thread;
 
 /// Adds core functionality to Apps.
 #[derive(Default)]
-pub struct CorePlugin {
-    /// Options for the [`TaskPool`](bevy_tasks::TaskPool) created at application start.
-    pub task_pool_options: TaskPoolOptions,
-}
+pub struct CorePlugin {}
 
 impl Plugin for CorePlugin {
     fn build(&self, app: &mut App) {
-        // Setup the default bevy task pools
-        self.task_pool_options.create_default_pools();
-
-        #[cfg(not(target_arch = "wasm32"))]
-        app.add_system_to_stage(
-            bevy_app::CoreStage::Last,
-            tick_global_task_pools_on_main_thread.at_end(),
-        );
-
         app.register_type::<Entity>().register_type::<Name>();
 
         register_rust_types(app);
         register_math_types(app);
-
-        app.init_resource::<FrameCount>();
-        app.add_system(update_frame_count);
     }
 }
 
@@ -107,11 +92,42 @@ fn register_math_types(app: &mut App) {
         .register_type::<bevy_math::Quat>();
 }
 
+/// Provides access to `TaskPools`.
+#[derive(Default)]
+pub struct TaskPoolPlugin {
+    /// Options for the [`TaskPool`](bevy_tasks::TaskPool) created at application start.
+    pub task_pool_options: TaskPoolOptions,
+}
+
+impl Plugin for TaskPoolPlugin {
+    fn build(&self, app: &mut App) {
+        // Setup the default bevy task pools
+        self.task_pool_options.create_default_pools();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        app.add_system_to_stage(
+            bevy_app::CoreStage::Last,
+            tick_global_task_pools_on_main_thread.at_end(),
+        );
+    }
+}
+
 /// Keeps a count of rendered frames since the start of the app
 ///
 /// Wraps to 0 when it reaches the maximum u32 value
 #[derive(Default, Resource, Clone, Copy)]
 pub struct FrameCount(pub u32);
+
+/// Adds frame counting functionality to Apps.
+#[derive(Default)]
+pub struct FrameCountPlugin {}
+
+impl Plugin for FrameCountPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<FrameCount>();
+        app.add_system(update_frame_count);
+    }
+}
 
 fn update_frame_count(mut frame_count: ResMut<FrameCount>) {
     frame_count.0 = frame_count.0.wrapping_add(1);
@@ -125,7 +141,9 @@ mod tests {
     #[test]
     fn runs_spawn_local_tasks() {
         let mut app = App::new();
+        app.add_plugin(TaskPoolPlugin::default());
         app.add_plugin(CorePlugin::default());
+        app.add_plugin(FrameCountPlugin::default());
 
         let (async_tx, async_rx) = crossbeam_channel::unbounded();
         AsyncComputeTaskPool::get()
@@ -158,7 +176,9 @@ mod tests {
     #[test]
     fn frame_counter_update() {
         let mut app = App::new();
+        app.add_plugin(TaskPoolPlugin::default());
         app.add_plugin(CorePlugin::default());
+        app.add_plugin(FrameCountPlugin::default());
         app.update();
 
         let frame_count = app.world.resource::<FrameCount>();

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -14,7 +14,9 @@ pub use task_pool_options::*;
 pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
-    pub use crate::{CorePlugin, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin};
+    pub use crate::{
+        FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
+    };
 }
 
 use bevy_app::prelude::*;
@@ -31,11 +33,11 @@ use bevy_ecs::schedule::IntoSystemDescriptor;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
 
-/// Adds core functionality to Apps.
+/// Registration of default types to the `TypeRegistry` reesource.
 #[derive(Default)]
-pub struct CorePlugin {}
+pub struct TypeRegistrationPlugin;
 
-impl Plugin for CorePlugin {
+impl Plugin for TypeRegistrationPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Entity>().register_type::<Name>();
 
@@ -92,7 +94,7 @@ fn register_math_types(app: &mut App) {
         .register_type::<bevy_math::Quat>();
 }
 
-/// Provides access to `TaskPools`.
+/// Setup of default task pools: `AsyncComputeTaskPool`, `ComputeTaskPool`, `IoTaskPool`.
 #[derive(Default)]
 pub struct TaskPoolPlugin {
     /// Options for the [`TaskPool`](bevy_tasks::TaskPool) created at application start.
@@ -120,7 +122,7 @@ pub struct FrameCount(pub u32);
 
 /// Adds frame counting functionality to Apps.
 #[derive(Default)]
-pub struct FrameCountPlugin {}
+pub struct FrameCountPlugin;
 
 impl Plugin for FrameCountPlugin {
     fn build(&self, app: &mut App) {
@@ -142,8 +144,7 @@ mod tests {
     fn runs_spawn_local_tasks() {
         let mut app = App::new();
         app.add_plugin(TaskPoolPlugin::default());
-        app.add_plugin(CorePlugin::default());
-        app.add_plugin(FrameCountPlugin::default());
+        app.add_plugin(TypeRegistrationPlugin::default());
 
         let (async_tx, async_rx) = crossbeam_channel::unbounded();
         AsyncComputeTaskPool::get()
@@ -177,7 +178,7 @@ mod tests {
     fn frame_counter_update() {
         let mut app = App::new();
         app.add_plugin(TaskPoolPlugin::default());
-        app.add_plugin(CorePlugin::default());
+        app.add_plugin(TypeRegistrationPlugin::default());
         app.add_plugin(FrameCountPlugin::default());
         app.update();
 

--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -32,7 +32,7 @@ impl TaskPoolThreadAssignmentPolicy {
 }
 
 /// Helper for configuring and creating the default task pools. For end-users who want full control,
-/// set up [`CorePlugin`](super::CorePlugin)
+/// set up [`TaskPoolPlugin`](super::TaskPoolPlugin)
 #[derive(Clone, Resource)]
 pub struct TaskPoolOptions {
     /// If the number of physical cores is less than min_total_threads, force using

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -3,7 +3,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// This plugin group will add all the default plugins:
 /// * [`LogPlugin`](crate::log::LogPlugin)
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
-/// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)
 /// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
 /// * [`TimePlugin`](crate::time::TimePlugin)
 /// * [`TransformPlugin`](crate::transform::TransformPlugin)
@@ -32,7 +32,7 @@ impl PluginGroup for DefaultPlugins {
         group = group
             .add(bevy_log::LogPlugin::default())
             .add(bevy_core::TaskPoolPlugin::default())
-            .add(bevy_core::CorePlugin::default())
+            .add(bevy_core::TypeRegistrationPlugin::default())
             .add(bevy_core::FrameCountPlugin::default())
             .add(bevy_time::TimePlugin::default())
             .add(bevy_transform::TransformPlugin::default())
@@ -123,7 +123,7 @@ impl PluginGroup for DefaultPlugins {
 
 /// Minimal plugin group that will add the following plugins:
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
-/// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)
 /// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
 /// * [`TimePlugin`](crate::time::TimePlugin)
 /// * [`ScheduleRunnerPlugin`](crate::app::ScheduleRunnerPlugin)
@@ -135,7 +135,7 @@ impl PluginGroup for MinimalPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(bevy_core::TaskPoolPlugin::default())
-            .add(bevy_core::CorePlugin::default())
+            .add(bevy_core::TypeRegistrationPlugin::default())
             .add(bevy_core::FrameCountPlugin::default())
             .add(bevy_time::TimePlugin::default())
             .add(bevy_app::ScheduleRunnerPlugin::default())

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -2,7 +2,9 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 
 /// This plugin group will add all the default plugins:
 /// * [`LogPlugin`](crate::log::LogPlugin)
+/// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
 /// * [`TimePlugin`](crate::time::TimePlugin)
 /// * [`TransformPlugin`](crate::transform::TransformPlugin)
 /// * [`HierarchyPlugin`](crate::hierarchy::HierarchyPlugin)
@@ -29,7 +31,9 @@ impl PluginGroup for DefaultPlugins {
         let mut group = PluginGroupBuilder::start::<Self>();
         group = group
             .add(bevy_log::LogPlugin::default())
+            .add(bevy_core::TaskPoolPlugin::default())
             .add(bevy_core::CorePlugin::default())
+            .add(bevy_core::FrameCountPlugin::default())
             .add(bevy_time::TimePlugin::default())
             .add(bevy_transform::TransformPlugin::default())
             .add(bevy_hierarchy::HierarchyPlugin::default())
@@ -118,7 +122,9 @@ impl PluginGroup for DefaultPlugins {
 }
 
 /// Minimal plugin group that will add the following plugins:
+/// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`CorePlugin`](crate::core::CorePlugin)
+/// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
 /// * [`TimePlugin`](crate::time::TimePlugin)
 /// * [`ScheduleRunnerPlugin`](crate::app::ScheduleRunnerPlugin)
 ///
@@ -128,7 +134,9 @@ pub struct MinimalPlugins;
 impl PluginGroup for MinimalPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
+            .add(bevy_core::TaskPoolPlugin::default())
             .add(bevy_core::CorePlugin::default())
+            .add(bevy_core::FrameCountPlugin::default())
             .add(bevy_time::TimePlugin::default())
             .add(bevy_app::ScheduleRunnerPlugin::default())
     }

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(CorePlugin {
+        .add_plugins(DefaultPlugins.set(TaskPoolPlugin {
             task_pool_options: TaskPoolOptions::with_num_threads(4),
         }))
         .run();


### PR DESCRIPTION
# Objective

- Fixes #7081.

## Solution

- Moved functionality from kitchen sink plugin `CorePlugin` to separate plugins, `TaskPoolPlugin`, `TypeRegistrationPlugin`, `FrameCountPlugin`.  `TaskPoolOptions` resource should now be used with `TaskPoolPlugin`.

## Changelog

Minimal changes made (code kept in `bevy_core/lib.rs`).

## Migration Guide

- `CorePlugin` broken into separate plugins.  If not using `DefaultPlugins` or `MinimalPlugins` `PluginGroup`s, the replacement for `CorePlugin` is now to add `TaskPoolPlugin`, `TypeRegistrationPlugin`, and `FrameCountPlugin` to the app.

## Notes

- Consistent with Bevy goal "modularity over deep integration" but the functionality of `TypeRegistrationPlugin` and `FrameCountPlugin` is weak (the code has to go somewhere, though!).
- No additional tests written.