### PR TITLE
Improve or-with disjoint checks

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -27,6 +27,7 @@ fixedbitset = "0.4.2"
 rustc-hash = "1.1"
 downcast-rs = "1.2"
 serde = { version = "1", features = ["derive"] }
+smallvec = "1.6"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -27,7 +27,6 @@ fixedbitset = "0.4.2"
 rustc-hash = "1.1"
 downcast-rs = "1.2"
 serde = { version = "1", features = ["derive"] }
-smallvec = "1.6"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -272,8 +272,8 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 
     /// Adds a `With` filter: corresponds to a conjunction (AND) operation.
     ///
-    /// For example, in case we have `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances,
-    /// adding `AND With<C>` gets expanded into `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
+    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+    /// Adding `AND With<C>` via this method transforms it into the equivalent of  `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
     pub fn and_with(&mut self, index: T) {
         let index = index.sparse_set_index();
         for filter in &mut self.filter_sets {
@@ -284,8 +284,8 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 
     /// Adds a `Without` filter: corresponds to a conjunction (AND) operation.
     ///
-    /// For example, in case we have `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances,
-    /// adding `AND Without<C>` gets expanded into `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
+    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+    /// Adding `AND Without<C>` via this method transforms it into the equivalent of  `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
     pub fn and_without(&mut self, index: T) {
         let index = index.sparse_set_index();
         for filter in &mut self.filter_sets {
@@ -315,7 +315,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 
         // If the access instances are incompatible, we want to check that whether filters can
         // guarantee that queries are disjoint.
-        // Since the `filter_sets` array represents a DNF formula ("ORs of ANDs"),
+        // Since the `filter_sets` array represents a Disjunctive Normal Form formula ("ORs of ANDs"),
         // we need to make sure that each filter set (ANDs) rule out every filter set from the `other` instance.
         //
         // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -403,6 +403,11 @@ impl<T: SparseSetIndex> Default for AccessFilters<T> {
 
 impl<T: SparseSetIndex> AccessFilters<T> {
     fn is_ruled_out_by(&self, other: &Self) -> bool {
+        // Although not technically complete, we don't consider the case when `AccessFilters`'s
+        // `without` bitset contradicts its own `with` bitset (e.g. `(With<A>, Without<A>)`).
+        // Such query would be considered compatible with any other query, but as it's almost
+        // always an error, we ignore this case instead of treating such query as compatible
+        // with others.
         !self.with.is_disjoint(&other.without) || !self.without.is_disjoint(&other.with)
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -355,7 +355,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 }
 
 // A struct to express something like `Or<(With<A>, With<B>)>`.
-// Filters like `(With<A>, Or<(With<B>, With<C>)>` are expanded into `Or<(With<(A, B)>, With<(B, C)>)>`.
+// Filters like `(With<A>, Or<(With<B>, With<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, With<C>))>`.
 #[derive(Clone, Eq, PartialEq)]
 struct ExpandedOrWithAccesses {
     arr: SmallVec<[FixedBitSet; 8]>,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1293,7 +1293,7 @@ macro_rules! impl_anytuple_fetch {
                     if _not_first {
                         let mut intermediate = _access.clone();
                         $name::update_component_access($name, &mut intermediate);
-                        _intersected_access.extend_intersect_filter(&intermediate);
+                        _intersected_access.append_or(&intermediate);
                         _intersected_access.extend_access(&intermediate);
                     } else {
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1275,34 +1275,21 @@ macro_rules! impl_anytuple_fetch {
             fn update_component_access(state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {
                 let ($($name,)*) = state;
 
-                // We do not unconditionally add `$name`'s `with`/`without` accesses to `_access`
-                // as this would be unsound. For example the following two queries should conflict:
-                // - Query<(AnyOf<(&A, ())>, &mut B)>
-                // - Query<&mut B, Without<A>>
-                //
-                // If we were to unconditionally add `$name`'s `with`/`without` accesses then `AnyOf<(&A, ())>`
-                // would have a `With<A>` access which is incorrect as this `WorldQuery` will match entities that
-                // do not have the `A` component. This is the same logic as the `Or<...>: WorldQuery` impl.
-                //
-                // The correct thing to do here is to only add a `with`/`without` access to `_access` if all
-                // `$name` params have that `with`/`without` access. More jargony put- we add the intersection
-                // of all `with`/`without` accesses of the `$name` params to `_access`.
-                let mut _intersected_access = _access.clone();
+                let mut _new_access = _access.clone();
                 let mut _not_first = false;
                 $(
                     if _not_first {
                         let mut intermediate = _access.clone();
                         $name::update_component_access($name, &mut intermediate);
-                        _intersected_access.append_or(&intermediate);
-                        _intersected_access.extend_access(&intermediate);
+                        _new_access.append_or(&intermediate);
+                        _new_access.extend_access(&intermediate);
                     } else {
-
-                        $name::update_component_access($name, &mut _intersected_access);
+                        $name::update_component_access($name, &mut _new_access);
                         _not_first = true;
                     }
                 )*
 
-                *_access = _intersected_access;
+                *_access = _new_access;
             }
 
             fn update_archetype_component_access(state: &Self::State, _archetype: &Archetype, _access: &mut Access<ArchetypeComponentId>) {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -85,7 +85,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     #[inline]
     fn update_component_access(&id: &ComponentId, access: &mut FilteredAccess<ComponentId>) {
-        access.add_with(id);
+        access.and_with(id);
     }
 
     #[inline]
@@ -181,7 +181,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     #[inline]
     fn update_component_access(&id: &ComponentId, access: &mut FilteredAccess<ComponentId>) {
-        access.add_without(id);
+        access.and_without(id);
     }
 
     #[inline]
@@ -354,7 +354,7 @@ macro_rules! impl_query_filter_tuple {
                     if _not_first {
                         let mut intermediate = access.clone();
                         $filter::update_component_access($filter, &mut intermediate);
-                        _intersected_access.extend_intersect_filter(&intermediate);
+                        _intersected_access.append_or(&intermediate);
                         _intersected_access.extend_access(&intermediate);
                     } else {
                         $filter::update_component_access($filter, &mut _intersected_access);

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -336,33 +336,21 @@ macro_rules! impl_query_filter_tuple {
             fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>) {
                 let ($($filter,)*) = state;
 
-                // We do not unconditionally add `$filter`'s `with`/`without` accesses to `access`
-                // as this would be unsound. For example the following two queries should conflict:
-                // - Query<&mut B, Or<(With<A>, ())>>
-                // - Query<&mut B, Without<A>>
-                //
-                // If we were to unconditionally add `$name`'s `with`/`without` accesses then `Or<(With<A>, ())>`
-                // would have a `With<A>` access which is incorrect as this `WorldQuery` will match entities that
-                // do not have the `A` component. This is the same logic as the `AnyOf<...>: WorldQuery` impl.
-                //
-                // The correct thing to do here is to only add a `with`/`without` access to `_access` if all
-                // `$filter` params have that `with`/`without` access. More jargony put- we add the intersection
-                // of all `with`/`without` accesses of the `$filter` params to `access`.
-                let mut _intersected_access = access.clone();
+                let mut _new_access = access.clone();
                 let mut _not_first = false;
                 $(
                     if _not_first {
                         let mut intermediate = access.clone();
                         $filter::update_component_access($filter, &mut intermediate);
-                        _intersected_access.append_or(&intermediate);
-                        _intersected_access.extend_access(&intermediate);
+                        _new_access.append_or(&intermediate);
+                        _new_access.extend_access(&intermediate);
                     } else {
-                        $filter::update_component_access($filter, &mut _intersected_access);
+                        $filter::update_component_access($filter, &mut _new_access);
                         _not_first = true;
                     }
                 )*
 
-                *access = _intersected_access;
+                *access = _new_access;
             }
 
             fn update_archetype_component_access(state: &Self::State, archetype: &Archetype, access: &mut Access<ArchetypeComponentId>) {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -547,6 +547,41 @@ mod tests {
     }
 
     #[test]
+    #[should_panic = "error[B0001]"]
+    fn or_expanded_nested_or_with_and_disjoint_without() {
+        fn sys(
+            _: Query<&mut D, Or<(Or<(With<A>, With<B>)>, Or<(With<A>, With<C>)>)>>,
+            _: Query<&mut D, Without<A>>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    fn or_expanded_nested_with_and_common_nested_without() {
+        fn sys(
+            _: Query<&mut D, Or<((With<A>, With<B>), (With<B>, With<C>))>>,
+            _: Query<&mut D, Or<(Without<A>, Without<B>)>>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn or_expanded_nested_with_and_disjoint_nested_without() {
+        fn sys(
+            _: Query<&mut D, Or<(With<A>, With<B>)>>,
+            _: Query<&mut D, Or<(Without<A>, Without<B>)>>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
     fn or_doesnt_remove_unrelated_filter_with() {
         fn sys(_: Query<&mut B, (Or<(With<A>, With<B>)>, With<A>)>, _: Query<&mut B, Without<A>>) {}
         let mut world = World::default();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -484,6 +484,13 @@ mod tests {
     }
 
     #[test]
+    fn any_of_and_without() {
+        fn sys(_: Query<(AnyOf<(&A, &B)>, &mut C)>, _: Query<&mut C, (Without<A>, Without<B>)>) {}
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
     #[should_panic = "error[B0001]"]
     fn or_has_no_filter_with() {
         fn sys(_: Query<&mut B, Or<(With<A>, With<B>)>>, _: Query<&mut B, Without<A>>) {}
@@ -503,6 +510,36 @@ mod tests {
         fn sys(
             _: Query<&mut C, Or<(With<A>, With<B>)>>,
             _: Query<&mut C, (Without<A>, Without<B>)>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    fn or_expanded_with_and_without_common() {
+        fn sys(_: Query<&mut D, (With<A>, Or<(With<B>, With<C>)>)>, _: Query<&mut D, Without<A>>) {}
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    fn or_expanded_nested_with_and_without_common() {
+        fn sys(
+            _: Query<&mut E, (Or<((With<B>, With<C>), (With<C>, With<D>))>, With<A>)>,
+            _: Query<&mut E, (Without<B>, Without<D>)>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn or_expanded_nested_with_and_disjoint_without() {
+        fn sys(
+            _: Query<&mut E, (Or<((With<B>, With<C>), (With<C>, With<D>))>, With<A>)>,
+            _: Query<&mut E, Without<D>>,
         ) {
         }
         let mut world = World::default();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -499,6 +499,17 @@ mod tests {
     }
 
     #[test]
+    fn or_has_filter_with() {
+        fn sys(
+            _: Query<&mut C, Or<(With<A>, With<B>)>>,
+            _: Query<&mut C, (Without<A>, Without<B>)>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
     fn or_doesnt_remove_unrelated_filter_with() {
         fn sys(_: Query<&mut B, (Or<(With<A>, With<B>)>, With<A>)>, _: Query<&mut B, Without<A>>) {}
         let mut world = World::default();

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -562,6 +562,43 @@ mod tests {
     fn or_expanded_nested_with_and_common_nested_without() {
         fn sys(
             _: Query<&mut D, Or<((With<A>, With<B>), (With<B>, With<C>))>>,
+            _: Query<&mut D, Or<(Without<D>, Without<B>)>>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    fn or_with_without_and_compatible_with_without() {
+        // TODO: atm, it doesn't fail, even though the current implementation is believed
+        //  not to support this case, need to investigate.
+        fn sys(
+            _: Query<&mut C, Or<(With<A>, Without<B>)>>,
+            _: Query<&mut C, (With<B>, Without<A>)>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn with_and_disjoint_or_empty_without() {
+        fn sys(
+            _: Query<&mut B, With<A>>,
+            _: Query<&mut B, Or<((), Without<A>)>>,
+        ) {
+        }
+        let mut world = World::default();
+        run_system(&mut world, sys);
+    }
+
+    #[test]
+    #[should_panic = "error[B0001]"]
+    fn or_expanded_with_and_disjoint_nested_without() {
+        fn sys(
+            _: Query<&mut D, Or<(With<A>, With<B>)>>,
             _: Query<&mut D, Or<(Without<A>, Without<B>)>>,
         ) {
         }
@@ -573,7 +610,7 @@ mod tests {
     #[should_panic = "error[B0001]"]
     fn or_expanded_nested_with_and_disjoint_nested_without() {
         fn sys(
-            _: Query<&mut D, Or<(With<A>, With<B>)>>,
+            _: Query<&mut D, Or<((With<A>, With<B>), (With<B>, With<C>))>>,
             _: Query<&mut D, Or<(Without<A>, Without<B>)>>,
         ) {
         }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -571,8 +571,6 @@ mod tests {
 
     #[test]
     fn or_with_without_and_compatible_with_without() {
-        // TODO: atm, it doesn't fail, even though the current implementation is believed
-        //  not to support this case, need to investigate.
         fn sys(
             _: Query<&mut C, Or<(With<A>, Without<B>)>>,
             _: Query<&mut C, (With<B>, Without<A>)>,
@@ -585,11 +583,7 @@ mod tests {
     #[test]
     #[should_panic = "error[B0001]"]
     fn with_and_disjoint_or_empty_without() {
-        fn sys(
-            _: Query<&mut B, With<A>>,
-            _: Query<&mut B, Or<((), Without<A>)>>,
-        ) {
-        }
+        fn sys(_: Query<&mut B, With<A>>, _: Query<&mut B, Or<((), Without<A>)>>) {}
         let mut world = World::default();
         run_system(&mut world, sys);
     }


### PR DESCRIPTION
# Objective

This PR attempts to improve query compatibility checks in scenarios involving `Or` filters.

Currently, for the following two disjoint queries, Bevy will throw a panic:

```
fn sys(_: Query<&mut C, Or<(With<A>, With<B>)>>, _: Query<&mut C, (Without<A>, Without<B>)>) {}
``` 

This PR addresses this particular scenario.

## Solution

`FilteredAccess::with` now stores a vector of `AccessFilters` (representing a pair of `with` and `without` bitsets), where each member represents an `Or` "variant".
Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expected to be expanded into `A * B + A * !C`.

When calculating whether queries are compatible, every `AccessFilters` of a query is tested for incompatibility with every `AccessFilters` of another query.

---

## Changelog

- Improved system and query data access compatibility checks in scenarios involving `Or` filters
