### PR TITLE
[Merged by Bors] - Thread executor for running tasks on specific threads.

### DIFF
--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -22,6 +22,11 @@ mod usages;
 pub use usages::tick_global_task_pools_on_main_thread;
 pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 
+#[cfg(not(target_arch = "wasm32"))]
+mod thread_executor;
+#[cfg(not(target_arch = "wasm32"))]
+pub use thread_executor::ThreadExecutor;
+
 mod iter;
 pub use iter::ParallelIterator;
 

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -25,7 +25,7 @@ pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 #[cfg(not(target_arch = "wasm32"))]
 mod thread_executor;
 #[cfg(not(target_arch = "wasm32"))]
-pub use thread_executor::ThreadExecutor;
+pub use thread_executor::{ThreadExecutor, ThreadExecutorSpawner, ThreadExecutorTicker};
 
 mod iter;
 pub use iter::ParallelIterator;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -25,7 +25,7 @@ pub use usages::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool};
 #[cfg(not(target_arch = "wasm32"))]
 mod thread_executor;
 #[cfg(not(target_arch = "wasm32"))]
-pub use thread_executor::{ThreadExecutor, ThreadExecutorSpawner, ThreadExecutorTicker};
+pub use thread_executor::{ThreadExecutor, ThreadExecutorTicker};
 
 mod iter;
 pub use iter::ParallelIterator;

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -11,7 +11,7 @@ use concurrent_queue::ConcurrentQueue;
 use futures_lite::{future, pin, FutureExt};
 
 use crate::{
-    thread_executor::{ThreadExecutor, ThreadSpawner},
+    thread_executor::{ThreadExecutor, ThreadExecutorSpawner},
     Task,
 };
 
@@ -284,7 +284,8 @@ impl TaskPool {
             let executor: &async_executor::Executor = &self.executor;
             let executor: &'env async_executor::Executor = unsafe { mem::transmute(executor) };
             let thread_spawner = thread_executor.spawner();
-            let thread_spawner: ThreadSpawner<'env> = unsafe { mem::transmute(thread_spawner) };
+            let thread_spawner: ThreadExecutorSpawner<'env> =
+                unsafe { mem::transmute(thread_spawner) };
             let spawned: ConcurrentQueue<FallibleTask<T>> = ConcurrentQueue::unbounded();
             let spawned_ref: &'env ConcurrentQueue<FallibleTask<T>> =
                 unsafe { mem::transmute(&spawned) };
@@ -401,7 +402,7 @@ impl Drop for TaskPool {
 #[derive(Debug)]
 pub struct Scope<'scope, 'env: 'scope, T> {
     executor: &'scope async_executor::Executor<'scope>,
-    thread_spawner: ThreadSpawner<'scope>,
+    thread_spawner: ThreadExecutorSpawner<'scope>,
     spawned: &'scope ConcurrentQueue<FallibleTask<T>>,
     // make `Scope` invariant over 'scope and 'env
     scope: PhantomData<&'scope mut &'scope ()>,

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -10,7 +10,10 @@ use async_task::FallibleTask;
 use concurrent_queue::ConcurrentQueue;
 use futures_lite::{future, pin, FutureExt};
 
-use crate::Task;
+use crate::{
+    thread_executor::{ThreadExecutor, ThreadSpawner},
+    Task,
+};
 
 struct CallOnDrop(Option<Arc<dyn Fn() + Send + Sync + 'static>>);
 
@@ -108,6 +111,7 @@ pub struct TaskPool {
 impl TaskPool {
     thread_local! {
         static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = async_executor::LocalExecutor::new();
+        static THREAD_EXECUTOR: ThreadExecutor = ThreadExecutor::new();
     }
 
     /// Create a `TaskPool` with the default configuration.
@@ -271,59 +275,61 @@ impl TaskPool {
         F: for<'scope> FnOnce(&'scope Scope<'scope, 'env, T>),
         T: Send + 'static,
     {
-        // SAFETY: This safety comment applies to all references transmuted to 'env.
-        // Any futures spawned with these references need to return before this function completes.
-        // This is guaranteed because we drive all the futures spawned onto the Scope
-        // to completion in this function. However, rust has no way of knowing this so we
-        // transmute the lifetimes to 'env here to appease the compiler as it is unable to validate safety.
-        let executor: &async_executor::Executor = &self.executor;
-        let executor: &'env async_executor::Executor = unsafe { mem::transmute(executor) };
-        let task_scope_executor = &async_executor::Executor::default();
-        let task_scope_executor: &'env async_executor::Executor =
-            unsafe { mem::transmute(task_scope_executor) };
-        let spawned: ConcurrentQueue<FallibleTask<T>> = ConcurrentQueue::unbounded();
-        let spawned_ref: &'env ConcurrentQueue<FallibleTask<T>> =
-            unsafe { mem::transmute(&spawned) };
+        Self::THREAD_EXECUTOR.with(|thread_executor| {
+            // SAFETY: This safety comment applies to all references transmuted to 'env.
+            // Any futures spawned with these references need to return before this function completes.
+            // This is guaranteed because we drive all the futures spawned onto the Scope
+            // to completion in this function. However, rust has no way of knowing this so we
+            // transmute the lifetimes to 'env here to appease the compiler as it is unable to validate safety.
+            let executor: &async_executor::Executor = &self.executor;
+            let executor: &'env async_executor::Executor = unsafe { mem::transmute(executor) };
+            let thread_spawner = thread_executor.spawner();
+            let thread_spawner: ThreadSpawner<'env> = unsafe { mem::transmute(thread_spawner) };
+            let spawned: ConcurrentQueue<FallibleTask<T>> = ConcurrentQueue::unbounded();
+            let spawned_ref: &'env ConcurrentQueue<FallibleTask<T>> =
+                unsafe { mem::transmute(&spawned) };
 
-        let scope = Scope {
-            executor,
-            task_scope_executor,
-            spawned: spawned_ref,
-            scope: PhantomData,
-            env: PhantomData,
-        };
-
-        let scope_ref: &'env Scope<'_, 'env, T> = unsafe { mem::transmute(&scope) };
-
-        f(scope_ref);
-
-        if spawned.is_empty() {
-            Vec::new()
-        } else {
-            let get_results = async {
-                let mut results = Vec::with_capacity(spawned_ref.len());
-                while let Ok(task) = spawned_ref.pop() {
-                    results.push(task.await.unwrap());
-                }
-
-                results
+            let scope = Scope {
+                executor,
+                thread_spawner,
+                spawned: spawned_ref,
+                scope: PhantomData,
+                env: PhantomData,
             };
 
-            // Pin the futures on the stack.
-            pin!(get_results);
+            let scope_ref: &'env Scope<'_, 'env, T> = unsafe { mem::transmute(&scope) };
 
-            loop {
-                if let Some(result) = future::block_on(future::poll_once(&mut get_results)) {
-                    break result;
+            f(scope_ref);
+
+            if spawned.is_empty() {
+                Vec::new()
+            } else {
+                let get_results = async {
+                    let mut results = Vec::with_capacity(spawned_ref.len());
+                    while let Ok(task) = spawned_ref.pop() {
+                        results.push(task.await.unwrap());
+                    }
+
+                    results
                 };
 
-                std::panic::catch_unwind(|| {
-                    executor.try_tick();
-                    task_scope_executor.try_tick();
-                })
-                .ok();
+                // Pin the futures on the stack.
+                pin!(get_results);
+
+                let thread_ticker = thread_executor.ticker().unwrap();
+                loop {
+                    if let Some(result) = future::block_on(future::poll_once(&mut get_results)) {
+                        break result;
+                    };
+
+                    std::panic::catch_unwind(|| {
+                        executor.try_tick();
+                        thread_ticker.try_tick();
+                    })
+                    .ok();
+                }
             }
-        }
+        })
     }
 
     /// Spawns a static future onto the thread pool. The returned Task is a future. It can also be
@@ -395,7 +401,7 @@ impl Drop for TaskPool {
 #[derive(Debug)]
 pub struct Scope<'scope, 'env: 'scope, T> {
     executor: &'scope async_executor::Executor<'scope>,
-    task_scope_executor: &'scope async_executor::Executor<'scope>,
+    thread_spawner: ThreadSpawner<'scope>,
     spawned: &'scope ConcurrentQueue<FallibleTask<T>>,
     // make `Scope` invariant over 'scope and 'env
     scope: PhantomData<&'scope mut &'scope ()>,
@@ -425,7 +431,7 @@ impl<'scope, 'env, T: Send + 'scope> Scope<'scope, 'env, T> {
     ///
     /// For more information, see [`TaskPool::scope`].
     pub fn spawn_on_scope<Fut: Future<Output = T> + 'scope + Send>(&self, f: Fut) {
-        let task = self.task_scope_executor.spawn(f).fallible();
+        let task = self.thread_spawner.spawn(f).fallible();
         // ConcurrentQueue only errors when closed or full, but we never
         // close and use an unbounded queue, so it is safe to unwrap
         self.spawned.push(task).unwrap();

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -60,18 +60,18 @@ impl Default for ThreadExecutor {
 }
 
 impl ThreadExecutor {
-    /// create a new `[ThreadExecutor]`
+    /// create a new [`ThreadExecutor`]
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Gets the `[ThreadSpawner]` for the thread executor.
+    /// Gets the [`ThreadExecutorSpawner`] for the thread executor.
     /// Use this to spawn tasks that run on the thread this was instantiated on.
     pub fn spawner(&self) -> ThreadExecutorSpawner<'static> {
         ThreadExecutorSpawner(self.executor.clone())
     }
 
-    /// Gets the `[ThreadTicker]` for this executor.
+    /// Gets the [`ThreadExecutorTicker`] for this executor.
     /// Use this to tick the executor.
     /// It only returns the ticker if it's on the thread the executor was created on
     /// and returns `None` otherwise.

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -44,7 +44,6 @@ use futures_lite::Future;
 /// thread_ticker.try_tick();
 /// assert_eq!(count.load(Ordering::Relaxed), 1);
 /// ```
-///
 #[derive(Debug, Clone)]
 pub struct ThreadExecutor {
     executor: Arc<Executor<'static>>,
@@ -67,7 +66,7 @@ impl ThreadExecutor {
     }
 
     /// Gets the `[ThreadSpawner]` for the thread executor.
-    /// Use this to spawn tasks that run on the thread this was instatiated on.
+    /// Use this to spawn tasks that run on the thread this was instantiated on.
     pub fn spawner(&self) -> ThreadSpawner<'static> {
         ThreadSpawner(self.executor.clone())
     }
@@ -88,7 +87,7 @@ impl ThreadExecutor {
 }
 
 /// Used to spawn on the [`ThreadExecutor`]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ThreadSpawner<'a>(Arc<Executor<'a>>);
 impl<'a> ThreadSpawner<'a> {
     /// Spawn a task on the thread executor

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -1,0 +1,103 @@
+use std::{
+    marker::PhantomData,
+    sync::Arc,
+    thread::{self, ThreadId},
+};
+
+use async_executor::{Executor, Task};
+use futures_lite::Future;
+
+/// An executor that can only be ticked on the thread it was instantiated on.
+#[derive(Debug)]
+pub struct ThreadExecutor {
+    executor: Arc<Executor<'static>>,
+    thread_id: ThreadId,
+}
+
+impl Default for ThreadExecutor {
+    fn default() -> Self {
+        Self {
+            executor: Arc::new(Executor::new()),
+            thread_id: thread::current().id(),
+        }
+    }
+}
+
+impl ThreadExecutor {
+    /// createa a new `[ThreadExecutor]`
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Gets the `[ThreadSpawner]` for the thread executor.
+    /// Use this to spawn tasks that run on the thread this was instatiated on.
+    pub fn spawner(&self) -> ThreadSpawner<'static> {
+        ThreadSpawner(self.executor.clone())
+    }
+
+    /// Gets the `[ThreadTicker]` for this executor.
+    /// Use this to tick the executor.
+    /// It only returns the ticker if it's on the thread the executor was created on
+    /// and returns `None` otherwise.
+    pub fn ticker(&self) -> Option<ThreadTicker> {
+        if thread::current().id() == self.thread_id {
+            return Some(ThreadTicker {
+                executor: self.executor.clone(),
+                _marker: PhantomData::default(),
+            });
+        }
+        None
+    }
+}
+
+/// Used to spawn on the [`ThreadExecutor`]
+#[derive(Debug)]
+pub struct ThreadSpawner<'a>(Arc<Executor<'a>>);
+impl<'a> ThreadSpawner<'a> {
+    /// Spawn a task on the main thread
+    pub fn spawn<T: Send + 'a>(&self, future: impl Future<Output = T> + Send + 'a) -> Task<T> {
+        self.0.spawn(future)
+    }
+}
+
+/// Used to tick the [`ThreadExecutor`]
+#[derive(Debug)]
+pub struct ThreadTicker {
+    executor: Arc<Executor<'static>>,
+    // make type not send or sync
+    _marker: PhantomData<*const ()>,
+}
+impl ThreadTicker {
+    /// Tick the main thread executor.
+    /// This needs to be called manually on the thread if it is not being used with
+    /// a `[TaskPool::scope]`.
+    pub fn tick(&self) -> impl Future<Output = ()> + '_ {
+        self.executor.tick()
+    }
+
+    /// Synchronously try to tick a task on the executor.
+    /// Returns false if if does not find a task to tick.
+    pub fn try_tick(&self) -> bool {
+        self.executor.try_tick()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_ticker() {
+        let executor = Arc::new(ThreadExecutor::new());
+        let ticker = executor.ticker();
+        assert!(ticker.is_some());
+
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let ticker = executor.ticker();
+                assert!(ticker.is_none());
+            });
+        });
+    }
+}


### PR DESCRIPTION
# Objective

- Spawn tasks from other threads onto an async executor, but limit those tasks to run on a specific thread.
- This is a continuation of trying to break up some of the changes in pipelined rendering.
- Eventually this will be used to allow `NonSend` systems to run on the main thread in pipelined rendering #6503 and also to solve #6552.
- For this specific PR this allows for us to store a thread executor in a thread local, rather than recreating a scope executor for every scope which should save on a little work.

## Solution

- We create a Executor that does a runtime check for what thread it's on before creating a !Send ticker. The ticker is the only way for the executor to make progress.

---

## Changelog

- create a ThreadExecutor that can only be ticked on one thread.