### PR TITLE
[Merged by Bors] - Fix doc comment "Turbo" -> "Extreme"

### DIFF
--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -47,7 +47,8 @@ pub struct Fxaa {
 
     /// Use lower sensitivity for a sharper, faster, result.
     /// Use higher sensitivity for a slower, smoother, result.
-    /// Ultra and Extreme settings can result in significant smearing and loss of detail.
+    /// [Ultra](`Sensitivity::Ultra`) and [Extreme](`Sensitivity::Extreme`)
+    /// settings can result in significant smearing and loss of detail.
 
     /// The minimum amount of local contrast required to apply algorithm.
     pub edge_threshold: Sensitivity,

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -47,7 +47,7 @@ pub struct Fxaa {
 
     /// Use lower sensitivity for a sharper, faster, result.
     /// Use higher sensitivity for a slower, smoother, result.
-    /// Ultra and Turbo settings can result in significant smearing and loss of detail.
+    /// Ultra and Extreme settings can result in significant smearing and loss of detail.
 
     /// The minimum amount of local contrast required to apply algorithm.
     pub edge_threshold: Sensitivity,


### PR DESCRIPTION
# Objective
Doc comment mentions turbo which is a sensitivity that doesn't exist.

## Solution

Change the comment to "Extreme" which does exist

