### PR TITLE
Add an opt-in warning on missed events

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -13,9 +13,13 @@ use accesskit::{NodeBuilder, NodeId};
 use bevy_app::Plugin;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
-    prelude::{Component, Entity},
+    prelude::{Component, Entity, Event},
     system::Resource,
 };
+
+/// Wrapper struct for [`accesskit::ActionRequest`]. Required to allow it to be used as an `Event`.
+#[derive(Event, Deref, DerefMut)]
+pub struct ActionRequest(pub accesskit::ActionRequest);
 
 /// Resource that tracks whether an assistive technology has requested
 /// accessibility information.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1009,7 +1009,7 @@ fn run_once(mut app: App) {
 /// If you don't require access to other components or resources, consider implementing the [`Drop`]
 /// trait on components/resources for code that runs on exit. That saves you from worrying about
 /// system schedule ordering, and is idiomatic Rust.
-#[derive(Debug, Clone, Default)]
+#[derive(Event, Debug, Clone, Default)]
 pub struct AppExit;
 
 #[cfg(test)]

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -570,6 +570,7 @@ impl App {
     /// # use bevy_app::prelude::*;
     /// # use bevy_ecs::prelude::*;
     /// #
+    /// # #[derive(Event)]
     /// # struct MyEvent;
     /// # let mut app = App::new();
     /// #

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 ///
 /// Events sent via the [`Assets`] struct will always be sent with a _Weak_ handle, because the
 /// asset may not exist by the time the event is handled.
+#[derive(Event)]
 pub enum AssetEvent<T: Asset> {
     #[allow(missing_docs)]
     Created { handle: Handle<T> },

--- a/crates/bevy_ecs/README.md
+++ b/crates/bevy_ecs/README.md
@@ -286,6 +286,7 @@ Events offer a communication channel between one or more systems. Events can be 
 ```rust
 use bevy_ecs::prelude::*;
 
+#[derive(Event)]
 struct MyEvent {
     message: String,
 }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -30,6 +30,7 @@ fn main() {
 }
 
 // This is our event that we will send and receive in systems
+#[derive(Event)]
 struct MyEvent {
     pub message: String,
     pub random_value: f32,

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -4,6 +4,24 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Ident, Path, Result};
 
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+    let bevy_ecs_path: Path = crate::bevy_ecs_path();
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Send + Sync + 'static });
+
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
+        }
+    })
+}
+
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -4,24 +4,6 @@ use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{quote, ToTokens};
 use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Ident, Path, Result};
 
-pub fn derive_event(input: TokenStream) -> TokenStream {
-    let mut ast = parse_macro_input!(input as DeriveInput);
-    let bevy_ecs_path: Path = crate::bevy_ecs_path();
-
-    ast.generics
-        .make_where_clause()
-        .predicates
-        .push(parse_quote! { Self: Send + Sync + 'static });
-
-    let struct_name = &ast.ident;
-    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
-
-    TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
-        }
-    })
-}
-
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);
     let bevy_ecs_path: Path = crate::bevy_ecs_path();

--- a/crates/bevy_ecs/macros/src/event.rs
+++ b/crates/bevy_ecs/macros/src/event.rs
@@ -1,0 +1,107 @@
+use bevy_macro_utils::{get_lit_str, Symbol};
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{parse_macro_input, parse_quote, DeriveInput, Error, Path, Result};
+
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+    let bevy_ecs_path: Path = crate::bevy_ecs_path();
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Send + Sync + 'static });
+
+    let attrs = match parse_event_attr(&ast) {
+        Ok(attrs) => attrs,
+        Err(e) => return e.into_compile_error().into(),
+    };
+
+    let missed = attrs.missed;
+
+    let warn_missed = match missed {
+        Missed::Ignore => quote! { const WARN_MISSED: bool = false; },
+        Missed::DebugWarn => quote! {
+            #[cfg(debug_assertions)]
+            const WARN_MISSED: bool = true;
+            #[cfg(not(debug_assertions))]
+            const WARN_MISSED: bool = false;
+        },
+        Missed::Warn => quote! { const WARN_MISSED:bool = true; },
+    };
+
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_ecs_path::event::Event for #struct_name #type_generics #where_clause {
+            #warn_missed
+        }
+    })
+}
+
+struct Attrs {
+    missed: Missed,
+}
+
+enum Missed {
+    Ignore,
+    DebugWarn,
+    Warn,
+}
+
+pub const EVENT: Symbol = Symbol("event");
+pub const MISSED: Symbol = Symbol("missed");
+
+const IGNORE: &str = "ignore";
+const DEBUG_WARN: &str = "debug_warn";
+const WARN: &str = "warn";
+
+fn parse_event_attr(ast: &DeriveInput) -> Result<Attrs> {
+    let meta_items = bevy_macro_utils::parse_attrs(ast, EVENT)?;
+
+    let mut attrs = Attrs {
+        missed: Missed::DebugWarn,
+    };
+
+    for meta in meta_items {
+        use syn::{
+            Meta::NameValue,
+            NestedMeta::{Lit, Meta},
+        };
+        match meta {
+            Meta(NameValue(m)) if m.path == MISSED => {
+                attrs.missed = match get_lit_str(MISSED, &m.lit)?.value().as_str() {
+                    IGNORE => Missed::Ignore,
+                    DEBUG_WARN => Missed::DebugWarn,
+                    WARN => Missed::Warn,
+                    e => {
+                        return Err(Error::new_spanned(
+                            m.lit,
+                            format!(
+                                "Invalid missed event behaviour `{e}`, expected '{IGNORE}', '{DEBUG_WARN}', or '{WARN}'.",
+                            ),
+                        ))
+                    }
+                }
+            }
+            Meta(meta_item) => {
+                return Err(Error::new_spanned(
+                    meta_item.path(),
+                    format!(
+                        "unknown event attribute `{}`",
+                        meta_item.path().into_token_stream()
+                    ),
+                ));
+            }
+            Lit(lit) => {
+                return Err(Error::new_spanned(
+                    lit,
+                    "unexpected literal in event attribute",
+                ))
+            }
+        }
+    }
+
+    Ok(attrs)
+}

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -1,6 +1,7 @@
 extern crate proc_macro;
 
 mod component;
+mod event;
 mod fetch;
 mod set;
 mod states;
@@ -482,9 +483,9 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::default().get_path("bevy_ecs")
 }
 
-#[proc_macro_derive(Event)]
+#[proc_macro_derive(Event, attributes(event))]
 pub fn derive_event(input: TokenStream) -> TokenStream {
-    component::derive_event(input)
+    event::derive_event(input)
 }
 
 #[proc_macro_derive(Resource)]

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -482,6 +482,11 @@ pub(crate) fn bevy_ecs_path() -> syn::Path {
     BevyManifest::default().get_path("bevy_ecs")
 }
 
+#[proc_macro_derive(Event)]
+pub fn derive_event(input: TokenStream) -> TokenStream {
+    component::derive_event(input)
+}
+
 #[proc_macro_derive(Resource)]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -77,8 +77,9 @@ struct EventInstance<E: Event> {
 ///
 /// # Example
 /// ```
-/// use bevy_ecs::event::Events;
+/// use bevy_ecs::event::{Event, Events};
 ///
+/// #[derive(Event)]
 /// struct MyEvent {
 ///     value: usize
 /// }
@@ -216,6 +217,8 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
+    /// #
+    /// #[derive(Event)]
     /// struct CollisionEvent;
     ///
     /// fn play_collision_sound(mut events: EventReader<CollisionEvent>) {
@@ -257,6 +260,7 @@ impl<'a, 'w, 's, E: Event> IntoIterator for &'a mut EventReader<'w, 's, E> {
 /// ```
 /// # use bevy_ecs::prelude::*;
 ///
+/// #[derive(Event)]
 /// pub struct MyEvent; // Custom event type.
 /// fn my_system(mut writer: EventWriter<MyEvent>) {
 ///     writer.send(MyEvent);
@@ -273,7 +277,7 @@ impl<'a, 'w, 's, E: Event> IntoIterator for &'a mut EventReader<'w, 's, E> {
 ///
 /// ```
 /// # use bevy_ecs::{prelude::*, event::Events};
-///
+/// # #[derive(Event)]
 /// # pub struct MyEvent;
 /// fn send_untyped(mut commands: Commands) {
 ///     // Send an event of a specific type without having to declare that

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -671,7 +671,7 @@ mod tests {
 
     use super::*;
 
-    #[derive(Copy, Clone, PartialEq, Eq, Debug)]
+    #[derive(Event, Copy, Clone, PartialEq, Eq, Debug)]
     struct TestEvent {
         i: usize,
     }
@@ -774,7 +774,7 @@ mod tests {
         reader.iter(events).cloned().collect::<Vec<E>>()
     }
 
-    #[derive(PartialEq, Eq, Debug)]
+    #[derive(Event, PartialEq, Eq, Debug)]
     struct E(usize);
 
     fn events_clear_and_read_impl(clear_func: impl FnOnce(&mut Events<E>)) {
@@ -981,7 +981,7 @@ mod tests {
         assert!(last.is_none(), "EventReader should be empty");
     }
 
-    #[derive(Clone, PartialEq, Debug, Default)]
+    #[derive(Event, Clone, PartialEq, Debug, Default)]
     struct EmptyTestEvent;
 
     #[test]

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -10,7 +10,6 @@ use std::{fmt, hash::Hash, iter::Chain, marker::PhantomData, slice::Iter};
 ///
 /// Events must be thread-safe.
 pub trait Event: Send + Sync + 'static {}
-impl<T> Event for T where T: Send + Sync + 'static {}
 
 /// An `EventId` uniquely identifies an event.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -5,6 +5,7 @@ use crate::system::{Local, Res, ResMut, Resource, SystemParam};
 use bevy_utils::tracing::trace;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, hash::Hash, iter::Chain, marker::PhantomData, slice::Iter};
+pub use bevy_ecs_macros::Event;
 /// A type that can be stored in an [`Events<E>`] resource
 /// You can conveniently access events using the [`EventReader`] and [`EventWriter`] system parameter.
 ///

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -2,10 +2,10 @@
 
 use crate as bevy_ecs;
 use crate::system::{Local, Res, ResMut, Resource, SystemParam};
+pub use bevy_ecs_macros::Event;
 use bevy_utils::tracing::trace;
 use std::ops::{Deref, DerefMut};
 use std::{fmt, hash::Hash, iter::Chain, marker::PhantomData, slice::Iter};
-pub use bevy_ecs_macros::Event;
 /// A type that can be stored in an [`Events<E>`] resource
 /// You can conveniently access events using the [`EventReader`] and [`EventWriter`] system parameter.
 ///

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -4,7 +4,7 @@ use crate::{
     self as bevy_ecs,
     component::{Component, ComponentId, ComponentIdFor},
     entity::Entity,
-    event::{EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader},
+    event::{Event, EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader},
     prelude::Local,
     storage::SparseSet,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam},
@@ -21,7 +21,7 @@ use std::{
 
 /// Wrapper around [`Entity`] for [`RemovedComponents`].
 /// Internally, `RemovedComponents` uses these as an `Events<RemovedComponentEntity>`.
-#[derive(Debug, Clone)]
+#[derive(Event, Debug, Clone)]
 pub struct RemovedComponentEntity(Entity);
 
 impl From<RemovedComponentEntity> for Entity {

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -4,7 +4,9 @@ use crate::{
     self as bevy_ecs,
     component::{Component, ComponentId, ComponentIdFor},
     entity::Entity,
-    event::{Event, EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader},
+    event::{
+        Event, EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader,
+    },
     prelude::Local,
     storage::SparseSet,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam},

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -86,6 +86,7 @@ impl SystemMeta {
 /// use bevy_ecs::{system::SystemState};
 /// use bevy_ecs::event::Events;
 ///
+/// #[derive(Event)]
 /// struct MyEvent;
 /// #[derive(Resource)]
 /// struct MyResource(u32);
@@ -118,6 +119,7 @@ impl SystemMeta {
 /// use bevy_ecs::{system::SystemState};
 /// use bevy_ecs::event::Events;
 ///
+/// #[derive(Event)]
 /// struct MyEvent;
 /// #[derive(Resource)]
 /// struct CachedSystemState {

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -340,6 +340,7 @@ fn assert_component_access_compatibility(
 /// ```
 /// # use bevy_ecs::prelude::*;
 /// #
+/// # #[derive(Event)]
 /// # struct MyEvent;
 /// # impl MyEvent {
 /// #   pub fn new() -> Self { Self }

--- a/crates/bevy_hierarchy/src/events.rs
+++ b/crates/bevy_hierarchy/src/events.rs
@@ -1,9 +1,9 @@
-use bevy_ecs::prelude::Entity;
+use bevy_ecs::{event::Event, prelude::Entity};
 
 /// An [`Event`] that is fired whenever there is a change in the world's hierarchy.
 ///
 /// [`Event`]: bevy_ecs::event::Event
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Event, Debug, Clone, PartialEq, Eq)]
 pub enum HierarchyEvent {
     /// Fired whenever an [`Entity`] is added as a child to a parent.
     ChildAdded {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,5 +1,5 @@
 use crate::{Axis, Input};
-use bevy_ecs::event::{EventReader, EventWriter};
+use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     system::{Res, ResMut, Resource},
@@ -1037,7 +1037,7 @@ pub enum GamepadConnection {
 
 /// A Gamepad connection event. Created when a connection to a gamepad
 /// is established and when a gamepad is disconnected.
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -1068,7 +1068,7 @@ impl GamepadConnectionEvent {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -1093,7 +1093,7 @@ impl GamepadAxisChangedEvent {
 
 /// Gamepad event for when the "value" (amount of pressure) on the button
 /// changes by an amount larger than the threshold defined in [`GamepadSettings`].
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -1156,7 +1156,7 @@ pub fn gamepad_button_event_system(
 /// This event type is used over the [`GamepadConnectionEvent`],
 /// [`GamepadButtonChangedEvent`] and [`GamepadAxisChangedEvent`] when
 /// the in-frame relative ordering of events is important.
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,5 +1,9 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{change_detection::DetectChangesMut, event::EventReader, system::ResMut};
+use bevy_ecs::{
+    change_detection::DetectChangesMut,
+    event::{Event, EventReader},
+    system::ResMut,
+};
 use bevy_reflect::{FromReflect, Reflect};
 
 #[cfg(feature = "serialize")]
@@ -14,7 +18,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,5 +1,9 @@
 use crate::{ButtonState, Input};
-use bevy_ecs::{change_detection::DetectChangesMut, event::EventReader, system::ResMut};
+use bevy_ecs::{
+    change_detection::DetectChangesMut,
+    event::{Event, EventReader},
+    system::ResMut,
+};
 use bevy_math::Vec2;
 use bevy_reflect::{FromReflect, Reflect};
 
@@ -14,7 +18,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -65,7 +69,7 @@ pub enum MouseButton {
 /// However, the event data does not make it possible to distinguish which device it is referring to.
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -106,7 +110,7 @@ pub enum MouseScrollUnit {
 /// A mouse wheel event.
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::event::EventReader;
+use bevy_ecs::event::{Event, EventReader};
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_math::Vec2;
 use bevy_reflect::{FromReflect, Reflect};
@@ -30,7 +30,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// This event is the translated version of the `WindowEvent::Touch` from the `winit` crate.
 /// It is available to the end user and can be used for game logic.
-#[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use bevy_ecs::entity::Entity;
+use bevy_ecs::event::Event;
 use bevy_math::{IVec2, Vec2};
 use bevy_reflect::{FromReflect, Reflect};
 
@@ -8,7 +9,7 @@ use bevy_reflect::{FromReflect, Reflect};
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// A window event that is sent whenever a window's logical size has changed.
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -27,7 +28,7 @@ pub struct WindowResized {
 // TODO: This would redraw all windows ? If yes, update docs to reflect this
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -39,7 +40,7 @@ pub struct RequestRedraw;
 /// An event that is sent whenever a new window is created.
 ///
 /// To create a new window, spawn an entity with a [`crate::Window`] on it.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -61,7 +62,7 @@ pub struct WindowCreated {
 ///
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -75,7 +76,7 @@ pub struct WindowCloseRequested {
 
 /// An event that is sent whenever a window is closed. This will be sent when
 /// the window entity loses its `Window` component or is despawned.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -98,7 +99,7 @@ pub struct WindowClosed {
 ///
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -113,7 +114,7 @@ pub struct CursorMoved {
 }
 
 /// An event that is sent whenever the user's cursor enters a window.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -126,7 +127,7 @@ pub struct CursorEntered {
 }
 
 /// An event that is sent whenever the user's cursor leaves a window.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -139,7 +140,7 @@ pub struct CursorLeft {
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -158,7 +159,7 @@ pub struct ReceivedCharacter {
 /// This event is the translated version of the `WindowEvent::Ime` from the `winit` crate.
 ///
 /// It is only sent if IME was enabled on the window with [`Window::ime_enabled`](crate::window::Window::ime_enabled).
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -200,7 +201,7 @@ pub enum Ime {
 }
 
 /// An event that indicates a window has received or lost focus.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -215,7 +216,7 @@ pub struct WindowFocused {
 }
 
 /// An event that indicates a window's scale factor has changed.
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -230,7 +231,7 @@ pub struct WindowScaleFactorChanged {
 }
 
 /// An event that indicates a window's OS-reported scale factor has changed.
-#[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -245,7 +246,7 @@ pub struct WindowBackendScaleFactorChanged {
 }
 
 /// Events related to files being dragged and dropped on a window.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
@@ -277,7 +278,7 @@ pub enum FileDragAndDrop {
 }
 
 /// An event that is sent when a window is repositioned in physical pixels.
-#[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use accesskit_winit::Adapter;
+use bevy_a11y::ActionRequest as ActionRequestWrapper;
 use bevy_a11y::{
     accesskit::{ActionHandler, ActionRequest, NodeBuilder, NodeClassSet, Role, TreeUpdate},
     AccessKitEntityExt, AccessibilityNode, AccessibilityRequested, Focus,
@@ -71,11 +72,14 @@ fn window_closed(
     }
 }
 
-fn poll_receivers(handlers: Res<WinitActionHandlers>, mut actions: EventWriter<ActionRequest>) {
+fn poll_receivers(
+    handlers: Res<WinitActionHandlers>,
+    mut actions: EventWriter<ActionRequestWrapper>,
+) {
     for (_id, handler) in handlers.iter() {
         let mut handler = handler.lock().unwrap();
         while let Some(event) = handler.pop_front() {
-            actions.send(event);
+            actions.send(ActionRequestWrapper(event));
         }
     }
 }
@@ -162,7 +166,7 @@ impl Plugin for AccessibilityPlugin {
     fn build(&self, app: &mut App) {
         app.init_non_send_resource::<AccessKitAdapters>()
             .init_resource::<WinitActionHandlers>()
-            .add_event::<ActionRequest>()
+            .add_event::<ActionRequestWrapper>()
             .add_system(handle_window_focus)
             .add_system(window_closed)
             .add_system(poll_receivers)

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -19,6 +19,8 @@ fn main() {
 
 #[derive(Resource, Deref)]
 struct StreamReceiver(Receiver<u32>);
+
+#[derive(Event)]
 struct StreamEvent(u32);
 
 #[derive(Resource, Deref)]

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -15,11 +15,12 @@ fn main() {
         .run();
 }
 
+#[derive(Event)]
 struct MyEvent {
     pub message: String,
 }
 
-#[derive(Default)]
+#[derive(Event, Default)]
 struct PlaySound;
 
 #[derive(Resource)]

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -88,7 +88,7 @@ struct Velocity(Vec2);
 #[derive(Component)]
 struct Collider;
 
-#[derive(Default)]
+#[derive(Event, Default)]
 struct CollisionEvent;
 
 #[derive(Component)]

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -6,6 +6,7 @@ struct Enemy {
     score_value: u32,
 }
 
+#[derive(Event)]
 struct EnemyDied(u32);
 
 #[derive(Resource)]


### PR DESCRIPTION
# Objective
Add an opt-in warning for events that get missed. Addresses #7089. Based on (and requires) #7086.

## Solution

Add an associated const on the `Event` trait, which is set with an additional attribute macro. Only emit the warning of that associated const is true.

I believe this should have no performance impact for events that do not enable the warning, as the branch should be trivially optimized out. 

## Notes

Should this be inverted i.e. warn by default, add `#[event(ignore_missed)]`? Should the attribute be formatted in a different way? I did not add the warning to any engine events, although some should probably have them (AssetEvent comes to mind).

This implementation only allows for the warning to be enabled/disabled when the event is declared. Events sent by third-party plugins that are intended to be handled by the user are required to make a call on whether or an event must be handled, which can differ depending on the application. 

I added the documentation for the attribute to `Events`, as that is where most of the documentation around events currently resides. Should this go on `Event` instead?

---

## Changelog

### Added
Users can add the `#[event(warn_missed)]` attribute to emit a warning if that event is not handled.