### PR TITLE
[Merged by Bors] - Add `TypeRegistrationDeserializer` and remove `BorrowedStr`

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -29,7 +29,7 @@ downcast-rs = "1.2"
 parking_lot = "0.12.1"
 thiserror = "1.0"
 once_cell = "1.11"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
 glam = { version = "0.22", features = ["serde"], optional = true }
 

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -1,7 +1,10 @@
 use crate::{DynamicEntity, DynamicScene};
 use anyhow::Result;
 use bevy_reflect::serde::{TypedReflectDeserializer, TypedReflectSerializer};
-use bevy_reflect::{serde::UntypedReflectDeserializer, Reflect, TypeRegistry, TypeRegistryArc};
+use bevy_reflect::{
+    serde::{TypeRegistrationDeserializer, UntypedReflectDeserializer},
+    Reflect, TypeRegistry, TypeRegistryArc,
+};
 use bevy_utils::HashSet;
 use serde::ser::SerializeMap;
 use serde::{
@@ -9,7 +12,6 @@ use serde::{
     ser::SerializeStruct,
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::borrow::Cow;
 use std::fmt::Formatter;
 
 pub const SCENE_STRUCT: &str = "Scene";
@@ -353,15 +355,16 @@ impl<'a, 'de> Visitor<'de> for ComponentVisitor<'a> {
     {
         let mut added = HashSet::new();
         let mut components = Vec::new();
-        while let Some(BorrowableCowStr(key)) = map.next_key()? {
-            if !added.insert(key.clone()) {
-                return Err(Error::custom(format!("duplicate component: `{key}`")));
+        while let Some(registration) =
+            map.next_key_seed(TypeRegistrationDeserializer::new(self.registry))?
+        {
+            if !added.insert(registration.type_id()) {
+                return Err(Error::custom(format_args!(
+                    "duplicate component: `{}`",
+                    registration.type_name()
+                )));
             }
 
-            let registration = self
-                .registry
-                .get_with_name(&key)
-                .ok_or_else(|| Error::custom(format!("no registration found for `{key}`")))?;
             components.push(
                 map.next_value_seed(TypedReflectDeserializer::new(registration, self.registry))?,
             );
@@ -384,13 +387,6 @@ impl<'a, 'de> Visitor<'de> for ComponentVisitor<'a> {
         Ok(dynamic_properties)
     }
 }
-
-/// Helper struct for deserializing strings without allocating (when possible).
-///
-/// Based on [this comment](https://github.com/bevyengine/bevy/pull/6894#discussion_r1045069010).
-#[derive(Deserialize)]
-#[serde(transparent)]
-struct BorrowableCowStr<'a>(#[serde(borrow)] Cow<'a, str>);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Objective

This a follow-up to #6894, see https://github.com/bevyengine/bevy/pull/6894#discussion_r1045203113

The goal is to avoid cloning any string when getting a `&TypeRegistration` corresponding to a string which is being deserialized. As a bonus code duplication is also reduced.

## Solution

The manual deserialization of a string and lookup into the type registry has been moved into a separate `TypeRegistrationDeserializer` type, which implements `DeserializeSeed` with a `Visitor` that accepts any string with `visit_str`, even ones that may not live longer than that function call.
`BorrowedStr` has been removed since it's no longer used.

---

## Changelog

- The type `TypeRegistrationDeserializer` has been added, which simplifies getting a `&TypeRegistration` while deserializing a string.
