### PR TITLE
Aggressively use let-else and combinators to reduce indentation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -263,11 +263,8 @@ fn verify_no_ancestor_player(
         if maybe_player.is_some() {
             return false;
         }
-        if let Some(parent) = parent {
-            current = parent.get();
-        } else {
-            return true;
-        }
+        let Some(parent) = parent else { return true };
+        current = parent.get();
     }
 }
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -174,18 +174,17 @@ impl PluginGroupBuilder {
     /// Panics if one of the plugin in the group was already added to the application.
     pub fn finish(mut self, app: &mut App) {
         for ty in &self.order {
-            if let Some(entry) = self.plugins.remove(ty) {
-                if entry.enabled {
-                    debug!("added plugin: {}", entry.plugin.name());
-                    if let Err(AppError::DuplicatePlugin { plugin_name }) =
-                        app.add_boxed_plugin(entry.plugin)
-                    {
-                        panic!(
-                            "Error adding plugin {} in group {}: plugin was already added in application",
-                            plugin_name,
-                            self.group_name
-                        );
-                    }
+            let Some(entry) = self.plugins.remove(ty) else { continue };
+            if entry.enabled {
+                debug!("added plugin: {}", entry.plugin.name());
+                if let Err(AppError::DuplicatePlugin { plugin_name }) =
+                    app.add_boxed_plugin(entry.plugin)
+                {
+                    panic!(
+                        "Error adding plugin {} in group {}: plugin was already added in application",
+                        plugin_name,
+                        self.group_name
+                    );
                 }
             }
         }

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -117,9 +117,8 @@ impl Plugin for ScheduleRunnerPlugin {
                     #[cfg(not(target_arch = "wasm32"))]
                     {
                         while let Ok(delay) = tick(&mut app, wait) {
-                            if let Some(delay) = delay {
-                                std::thread::sleep(delay);
-                            }
+                            let Some(delay) = delay else { continue };
+                            std::thread::sleep(delay);
                         }
                     }
 

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -512,20 +512,17 @@ impl AssetServer {
             let asset_sources = self.server.asset_sources.read();
             let asset_lifecycles = self.server.asset_lifecycles.read();
             for potential_free in potential_frees.drain(..) {
-                if let Some(&0) = ref_counts.get(&potential_free) {
-                    let type_uuid = match potential_free {
-                        HandleId::Id(type_uuid, _) => Some(type_uuid),
-                        HandleId::AssetPathId(id) => asset_sources
-                            .get(&id.source_path_id())
-                            .and_then(|source_info| source_info.get_asset_type(id.label_id())),
-                    };
+                let Some(&0) = ref_counts.get(&potential_free) else { continue };
+                let type_uuid = match potential_free {
+                    HandleId::Id(type_uuid, _) => Some(type_uuid),
+                    HandleId::AssetPathId(id) => asset_sources
+                        .get(&id.source_path_id())
+                        .and_then(|source_info| source_info.get_asset_type(id.label_id())),
+                };
 
-                    if let Some(type_uuid) = type_uuid {
-                        if let Some(asset_lifecycle) = asset_lifecycles.get(&type_uuid) {
-                            asset_lifecycle.free_asset(potential_free);
-                        }
-                    }
-                }
+                let Some(type_uuid) = type_uuid else { continue } ;
+                let Some(asset_lifecycle) = asset_lifecycles.get(&type_uuid) else { continue };
+                asset_lifecycle.free_asset(potential_free);
             }
         }
     }

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -103,11 +103,9 @@ pub(crate) fn sync_debug_assets<T: Asset + Clone>(
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
             AssetEvent::Removed { .. } => continue,
         };
-        if let Some(handle) = handle_map.handles.get(debug_handle) {
-            if let Some(debug_asset) = debug_assets.get(debug_handle) {
-                assets.set_untracked(handle, debug_asset.clone());
-            }
-        }
+        let Some(handle) = handle_map.handles.get(debug_handle) else { continue };
+        let Some(debug_asset) = debug_assets.get(debug_handle) else { continue };
+        assets.set_untracked(handle, debug_asset.clone());
     }
 }
 

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -63,17 +63,17 @@ impl FileAssetIo {
     /// If the `CARGO_MANIFEST_DIR` environment variable is set, then its value will be used
     /// instead. It's set by cargo when running with `cargo run`.
     pub fn get_base_path() -> PathBuf {
-        if let Ok(manifest_dir) = env::var("CARGO_MANIFEST_DIR") {
-            PathBuf::from(manifest_dir)
-        } else {
-            env::current_exe()
-                .map(|path| {
-                    path.parent()
-                        .map(|exe_parent_path| exe_parent_path.to_owned())
-                        .unwrap()
-                })
-                .unwrap()
-        }
+        env::var("CARGO_MANIFEST_DIR")
+            .map(|manifest_dir| PathBuf::from(manifest_dir))
+            .unwrap_or_else(|_| {
+                env::current_exe()
+                    .map(|path| {
+                        path.parent()
+                            .map(|exe_parent_path| exe_parent_path.to_owned())
+                            .unwrap()
+                    })
+                    .unwrap()
+            })
     }
 
     /// Returns the root directory where assets are loaded from.

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -235,20 +235,19 @@ impl_downcast!(AssetLifecycle);
 
 impl<T: AssetDynamic> AssetLifecycle for AssetLifecycleChannel<T> {
     fn create_asset(&self, id: HandleId, asset: Box<dyn AssetDynamic>, version: usize) {
-        if let Ok(asset) = asset.downcast::<T>() {
-            self.sender
-                .send(AssetLifecycleEvent::Create(AssetResult {
-                    asset,
-                    id,
-                    version,
-                }))
-                .unwrap();
-        } else {
+        let asset = asset.downcast::<T>().unwrap_or_else(|_| {
             panic!(
                 "Failed to downcast asset to {}.",
                 std::any::type_name::<T>()
-            );
-        }
+            )
+        });
+        self.sender
+            .send(AssetLifecycleEvent::Create(AssetResult {
+                asset,
+                id,
+                version,
+            }))
+            .unwrap();
     }
 
     fn free_asset(&self, id: HandleId) {

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -100,9 +100,8 @@ pub fn play_queued_audio_system<Source: Asset + Decodable>(
     mut audio: ResMut<Audio<Source>>,
     mut sinks: ResMut<Assets<AudioSink>>,
 ) {
-    if let Some(audio_sources) = audio_sources {
-        audio_output.try_play_queued(&*audio_sources, &mut *audio, &mut sinks);
-    };
+    let Some(audio_sources) = audio_sources else { return };
+    audio_output.try_play_queued(&*audio_sources, &mut *audio, &mut sinks);
 }
 
 /// Asset controlling the playback of a sound

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -53,13 +53,10 @@ impl Node for MainPass2dNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
-        let (camera, transparent_phase, target, camera_2d) =
-            if let Ok(result) = self.query.get_manual(world, view_entity) {
-                result
-            } else {
-                // no target
-                return Ok(());
-            };
+        let Ok((camera, transparent_phase, target, camera_2d)) = self.query.get_manual(world, view_entity) else {
+            // no target
+            return Ok(());
+        };
         {
             #[cfg(feature = "trace")]
             let _main_pass_2d = info_span!("main_pass_2d").entered();

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -263,33 +263,32 @@ pub fn prepare_core_3d_depth_textures(
 ) {
     let mut textures = HashMap::default();
     for (entity, camera) in &views_3d {
-        if let Some(physical_target_size) = camera.physical_target_size {
-            let cached_texture = textures
-                .entry(camera.target.clone())
-                .or_insert_with(|| {
-                    texture_cache.get(
-                        &render_device,
-                        TextureDescriptor {
-                            label: Some("view_depth_texture"),
-                            size: Extent3d {
-                                depth_or_array_layers: 1,
-                                width: physical_target_size.x,
-                                height: physical_target_size.y,
-                            },
-                            mip_level_count: 1,
-                            sample_count: msaa.samples,
-                            dimension: TextureDimension::D2,
-                            format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
-                                                                  * bit depth for better performance */
-                            usage: TextureUsages::RENDER_ATTACHMENT,
+        let Some(physical_target_size) = camera.physical_target_size else { continue };
+        let cached_texture = textures
+            .entry(camera.target.clone())
+            .or_insert_with(|| {
+                texture_cache.get(
+                    &render_device,
+                    TextureDescriptor {
+                        label: Some("view_depth_texture"),
+                        size: Extent3d {
+                            depth_or_array_layers: 1,
+                            width: physical_target_size.x,
+                            height: physical_target_size.y,
                         },
-                    )
-                })
-                .clone();
-            commands.entity(entity).insert(ViewDepthTexture {
-                texture: cached_texture.texture,
-                view: cached_texture.default_view,
-            });
-        }
+                        mip_level_count: 1,
+                        sample_count: msaa.samples,
+                        dimension: TextureDimension::D2,
+                        format: TextureFormat::Depth32Float, /* PERF: vulkan docs recommend using 24
+                                                              * bit depth for better performance */
+                        usage: TextureUsages::RENDER_ATTACHMENT,
+                    },
+                )
+            })
+            .clone();
+        commands.entity(entity).insert(ViewDepthTexture {
+            texture: cached_texture.texture,
+            view: cached_texture.default_view,
+        });
     }
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -41,12 +41,11 @@ impl Plugin for TonemappingPlugin {
 
         app.add_plugin(ExtractComponentPlugin::<Tonemapping>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<TonemappingPipeline>()
-                .init_resource::<SpecializedRenderPipelines<TonemappingPipeline>>()
-                .add_system_to_stage(RenderStage::Queue, queue_view_tonemapping_pipelines);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<TonemappingPipeline>()
+            .init_resource::<SpecializedRenderPipelines<TonemappingPipeline>>()
+            .add_system_to_stage(RenderStage::Queue, queue_view_tonemapping_pipelines);
     }
 }
 

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -25,12 +25,11 @@ impl Plugin for UpscalingPlugin {
             Shader::from_wgsl
         );
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<UpscalingPipeline>()
-                .init_resource::<SpecializedRenderPipelines<UpscalingPipeline>>()
-                .add_system_to_stage(RenderStage::Queue, queue_view_upscaling_pipelines);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<UpscalingPipeline>()
+            .init_resource::<SpecializedRenderPipelines<UpscalingPipeline>>()
+            .add_system_to_stage(RenderStage::Queue, queue_view_upscaling_pipelines);
     }
 }
 

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -169,10 +169,8 @@ impl Diagnostic {
             return None;
         }
 
-        if let Some(newest) = self.history.back() {
-            if let Some(oldest) = self.history.front() {
-                return Some(newest.time.duration_since(oldest.time));
-            }
+        if let (Some(newest), Some(oldest)) = (self.history.back(), self.history.front()) {
+            return Some(newest.time.duration_since(oldest.time));
         }
 
         None

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -53,31 +53,30 @@ impl LogDiagnosticsPlugin {
     }
 
     fn log_diagnostic(diagnostic: &Diagnostic) {
-        if let Some(value) = diagnostic.smoothed() {
-            if diagnostic.get_max_history_length() > 1 {
-                if let Some(average) = diagnostic.average() {
-                    info!(
-                        target: "bevy diagnostic",
-                        // Suffix is only used for 's' or 'ms' currently,
-                        // so we reserve two columns for it; however,
-                        // Do not reserve columns for the suffix in the average
-                        // The ) hugging the value is more aesthetically pleasing
-                        "{name:<name_width$}: {value:>11.6}{suffix:2} (avg {average:>.6}{suffix:})",
-                        name = diagnostic.name,
-                        suffix = diagnostic.suffix,
-                        name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
-                    );
-                    return;
-                }
+        let Some(value) = diagnostic.smoothed() else { return };
+        if diagnostic.get_max_history_length() > 1 {
+            if let Some(average) = diagnostic.average() {
+                info!(
+                    target: "bevy diagnostic",
+                    // Suffix is only used for 's' or 'ms' currently,
+                    // so we reserve two columns for it; however,
+                    // Do not reserve columns for the suffix in the average
+                    // The ) hugging the value is more aesthetically pleasing
+                    "{name:<name_width$}: {value:>11.6}{suffix:2} (avg {average:>.6}{suffix:})",
+                    name = diagnostic.name,
+                    suffix = diagnostic.suffix,
+                    name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+                );
+                return;
             }
-            info!(
-                target: "bevy diagnostic",
-                "{name:<name_width$}: {value:>.6}{suffix:}",
-                name = diagnostic.name,
-                suffix = diagnostic.suffix,
-                name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
-            );
         }
+        info!(
+            target: "bevy diagnostic",
+            "{name:<name_width$}: {value:>.6}{suffix:}",
+            name = diagnostic.name,
+            suffix = diagnostic.suffix,
+            name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+        );
     }
 
     fn log_diagnostics_system(

--- a/crates/bevy_ecs/src/schedule/run_criteria.rs
+++ b/crates/bevy_ecs/src/schedule/run_criteria.rs
@@ -81,17 +81,14 @@ impl BoxedRunCriteria {
     }
 
     pub(crate) fn should_run(&mut self, world: &mut World) -> ShouldRun {
-        if let Some(ref mut run_criteria) = self.criteria_system {
-            if !self.initialized {
-                run_criteria.initialize(world);
-                self.initialized = true;
-            }
-            let should_run = run_criteria.run((), world);
-            run_criteria.apply_buffers(world);
-            should_run
-        } else {
-            ShouldRun::Yes
+        let Some(ref mut run_criteria) = self.criteria_system else { return ShouldRun::Yes };
+        if !self.initialized {
+            run_criteria.initialize(world);
+            self.initialized = true;
         }
+        let should_run = run_criteria.run((), world);
+        run_criteria.apply_buffers(world);
+        should_run
     }
 }
 
@@ -153,11 +150,10 @@ impl GraphNode for RunCriteriaContainer {
     }
 
     fn labels(&self) -> &[RunCriteriaLabelId] {
-        if let Some(ref label) = self.label {
-            std::slice::from_ref(label)
-        } else {
-            &[]
-        }
+        self.label
+            .as_ref()
+            .map(|label| std::slice::from_ref(label))
+            .unwrap_or(&[])
     }
 
     fn before(&self) -> &[RunCriteriaLabelId] {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -914,11 +914,11 @@ where
     T: Bundle + 'static,
 {
     fn write(self, world: &mut World) {
-        if let Some(mut entity) = world.get_entity_mut(self.entity) {
-            entity.insert(self.bundle);
-        } else {
-            panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", std::any::type_name::<T>(), self.entity);
-        }
+        world.get_entity_mut(self.entity)
+            .unwrap_or_else(|| {
+                panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", std::any::type_name::<T>(), self.entity);
+            })
+            .insert(self.bundle);
     }
 }
 
@@ -933,11 +933,10 @@ where
     T: Bundle,
 {
     fn write(self, world: &mut World) {
-        if let Some(mut entity_mut) = world.get_entity_mut(self.entity) {
-            // remove intersection to gracefully handle components that were removed before running
-            // this command
-            entity_mut.remove_intersection::<T>();
-        }
+        let Some(mut entity_mut) = world.get_entity_mut(self.entity) else { return };
+        // remove intersection to gracefully handle components that were removed before running
+        // this command
+        entity_mut.remove_intersection::<T>();
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -609,11 +609,10 @@ impl<'w> EntityMut<'w> {
             };
         };
 
-        if let Some(moved_entity) = moved_entity {
-            let moved_location = world.entities.get(moved_entity).unwrap();
-            world.archetypes[moved_location.archetype_id]
-                .set_entity_table_row(moved_location.archetype_row, table_row);
-        }
+        let Some(moved_entity) = moved_entity else { return };
+        let moved_location = world.entities.get(moved_entity).unwrap();
+        world.archetypes[moved_location.archetype_id]
+            .set_entity_table_row(moved_location.archetype_row, table_row);
     }
 
     #[inline]
@@ -905,11 +904,11 @@ unsafe fn get_ticks_with_type(
 }
 
 fn contains_component_with_type(world: &World, type_id: TypeId, location: EntityLocation) -> bool {
-    if let Some(component_id) = world.components.get_id(type_id) {
-        contains_component_with_id(world, component_id, location)
-    } else {
-        false
-    }
+    world
+        .components
+        .get_id(type_id)
+        .map(|component_id| contains_component_with_id(world, component_id, location))
+        .unwrap_or(false)
 }
 
 fn contains_component_with_id(
@@ -950,7 +949,6 @@ unsafe fn remove_bundle_from_archetype(
         }
     };
     let result = if let Some(result) = remove_bundle_result {
-        // this Bundle removal result is cached. just return that!
         result
     } else {
         let mut next_table_components;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -739,11 +739,10 @@ impl World {
     /// Returns an iterator of entities that had components of type `T` removed
     /// since the last call to [`World::clear_trackers`].
     pub fn removed<T: Component>(&self) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
-        if let Some(component_id) = self.components.get_id(TypeId::of::<T>()) {
-            self.removed_with_id(component_id)
-        } else {
-            [].iter().cloned()
-        }
+        self.components
+            .get_id(TypeId::of::<T>())
+            .map(|component_id| self.removed_with_id(component_id))
+            .unwrap_or([].iter().cloned())
     }
 
     /// Returns an iterator of entities that had components with the given `component_id` removed
@@ -752,11 +751,10 @@ impl World {
         &self,
         component_id: ComponentId,
     ) -> std::iter::Cloned<std::slice::Iter<'_, Entity>> {
-        if let Some(removed) = self.removed_components.get(component_id) {
-            removed.iter().cloned()
-        } else {
-            [].iter().cloned()
-        }
+        self.removed_components
+            .get(component_id)
+            .map(|removed| removed.iter().cloned())
+            .unwrap_or([].iter().cloned())
     }
 
     /// Inserts a new resource with standard starting values.

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -47,10 +47,9 @@ fn despawn_with_children_recursive_inner(world: &mut World, entity: Entity) {
 }
 
 fn despawn_children(world: &mut World, entity: Entity) {
-    if let Some(mut children) = world.get_mut::<Children>(entity) {
-        for e in std::mem::take(&mut children.0) {
-            despawn_with_children_recursive_inner(world, e);
-        }
+    let Some(mut children) = world.get_mut::<Children>(entity) else { return };
+    for e in std::mem::take(&mut children.0) {
+        despawn_with_children_recursive_inner(world, e);
     }
 }
 

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -58,19 +58,16 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
         let mut new_debug_record = StringRecorder::new();
         attrs.record(&mut new_debug_record);
 
-        if let Some(span_ref) = ctx.span(id) {
-            span_ref
-                .extensions_mut()
-                .insert::<StringRecorder>(new_debug_record);
-        }
+        let Some(span_ref) = ctx.span(id) else { return };
+        span_ref
+            .extensions_mut()
+            .insert::<StringRecorder>(new_debug_record);
     }
 
     fn on_record(&self, id: &Id, values: &Record<'_>, ctx: Context<'_, S>) {
-        if let Some(span_ref) = ctx.span(id) {
-            if let Some(debug_record) = span_ref.extensions_mut().get_mut::<StringRecorder>() {
-                values.record(debug_record);
-            }
-        }
+        let Some(span_ref) = ctx.span(id) else { return };
+        let Some(debug_record) = span_ref.extensions_mut().get_mut::<StringRecorder>() else { return };
+        values.record(debug_record);
     }
 
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -164,22 +164,21 @@ where
     fn build(&self, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible());
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Transparent3d, DrawMaterial<M>>()
-                .add_render_command::<Opaque3d, DrawMaterial<M>>()
-                .add_render_command::<AlphaMask3d, DrawMaterial<M>>()
-                .init_resource::<MaterialPipeline<M>>()
-                .init_resource::<ExtractedMaterials<M>>()
-                .init_resource::<RenderMaterials<M>>()
-                .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
-                .add_system_to_stage(RenderStage::Extract, extract_materials::<M>)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_materials::<M>.after(PrepareAssetLabel::PreAssetPrepare),
-                )
-                .add_system_to_stage(RenderStage::Queue, queue_material_meshes::<M>);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .add_render_command::<Transparent3d, DrawMaterial<M>>()
+            .add_render_command::<Opaque3d, DrawMaterial<M>>()
+            .add_render_command::<AlphaMask3d, DrawMaterial<M>>()
+            .init_resource::<MaterialPipeline<M>>()
+            .init_resource::<ExtractedMaterials<M>>()
+            .init_resource::<RenderMaterials<M>>()
+            .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
+            .add_system_to_stage(RenderStage::Extract, extract_materials::<M>)
+            .add_system_to_stage(
+                RenderStage::Prepare,
+                prepare_materials::<M>.after(PrepareAssetLabel::PreAssetPrepare),
+            )
+            .add_system_to_stage(RenderStage::Queue, queue_material_meshes::<M>);
     }
 }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -94,16 +94,15 @@ impl Plugin for MeshRenderPlugin {
 
         app.add_plugin(UniformComponentPlugin::<MeshUniform>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<MeshPipeline>()
-                .init_resource::<SkinnedMeshUniform>()
-                .add_system_to_stage(RenderStage::Extract, extract_meshes)
-                .add_system_to_stage(RenderStage::Extract, extract_skinned_meshes)
-                .add_system_to_stage(RenderStage::Prepare, prepare_skinned_meshes)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh_bind_group)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh_view_bind_groups);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<MeshPipeline>()
+            .init_resource::<SkinnedMeshUniform>()
+            .add_system_to_stage(RenderStage::Extract, extract_meshes)
+            .add_system_to_stage(RenderStage::Extract, extract_skinned_meshes)
+            .add_system_to_stage(RenderStage::Prepare, prepare_skinned_meshes)
+            .add_system_to_stage(RenderStage::Queue, queue_mesh_bind_group)
+            .add_system_to_stage(RenderStage::Queue, queue_mesh_view_bind_groups);
     }
 }
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -41,14 +41,13 @@ impl Plugin for WireframePlugin {
             .init_resource::<WireframeConfig>()
             .add_plugin(ExtractResourcePlugin::<WireframeConfig>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Opaque3d, DrawWireframes>()
-                .init_resource::<WireframePipeline>()
-                .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
-                .add_system_to_stage(RenderStage::Extract, extract_wireframes)
-                .add_system_to_stage(RenderStage::Queue, queue_wireframes);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .add_render_command::<Opaque3d, DrawWireframes>()
+            .init_resource::<WireframePipeline>()
+            .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
+            .add_system_to_stage(RenderStage::Extract, extract_wireframes)
+            .add_system_to_stage(RenderStage::Queue, queue_wireframes);
     }
 }
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -124,29 +124,28 @@ fn queue_wireframes(
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let add_render_phase =
             |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
-                if let Some(mesh) = render_meshes.get(mesh_handle) {
-                    let key = view_key
-                        | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                    let pipeline_id = pipelines.specialize(
-                        &mut pipeline_cache,
-                        &wireframe_pipeline,
-                        key,
-                        &mesh.layout,
-                    );
-                    let pipeline_id = match pipeline_id {
-                        Ok(id) => id,
-                        Err(err) => {
-                            error!("{}", err);
-                            return;
-                        }
-                    };
-                    opaque_phase.add(Opaque3d {
-                        entity,
-                        pipeline: pipeline_id,
-                        draw_function: draw_custom,
-                        distance: rangefinder.distance(&mesh_uniform.transform),
-                    });
-                }
+                let Some(mesh) = render_meshes.get(mesh_handle) else { return };
+                let key =
+                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                let pipeline_id = pipelines.specialize(
+                    &mut pipeline_cache,
+                    &wireframe_pipeline,
+                    key,
+                    &mesh.layout,
+                );
+                let pipeline_id = match pipeline_id {
+                    Ok(id) => id,
+                    Err(err) => {
+                        error!("{}", err);
+                        return;
+                    }
+                };
+                opaque_phase.add(Opaque3d {
+                    entity,
+                    pipeline: pipeline_id,
+                    draw_function: draw_custom,
+                    distance: rangefinder.distance(&mesh_uniform.transform),
+                });
             };
 
         if wireframe_config.global {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/documentation.rs
@@ -69,10 +69,9 @@ impl Documentation {
 
 impl ToTokens for Documentation {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        if let Some(doc) = self.doc_string() {
-            quote!(#FQOption::Some(#doc)).to_tokens(tokens);
-        } else {
-            quote!(#FQOption::None).to_tokens(tokens);
+        match self.doc_string() {
+            Some(doc) => quote!(#FQOption::Some(#doc)).to_tokens(tokens),
+            None => quote!(#FQOption::None).to_tokens(tokens),
         }
     }
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -79,12 +79,11 @@ pub(crate) fn parse_field_attrs(attrs: &[Attribute]) -> Result<ReflectFieldAttr,
         .filter(|a| a.path.is_ident(REFLECT_ATTRIBUTE_NAME));
     for attr in attrs {
         let meta = attr.parse_meta()?;
-        if let Err(err) = parse_meta(&mut args, &meta) {
-            if let Some(ref mut error) = errors {
-                error.combine(err);
-            } else {
-                errors = Some(err);
-            }
+        let Err(err) = parse_meta(&mut args, &meta) else { continue };
+        if let Some(ref mut error) = errors {
+            error.combine(err);
+        } else {
+            errors = Some(err);
         }
     }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -961,12 +961,11 @@ impl Reflect for Cow<'static, str> {
     }
 
     fn apply(&mut self, value: &dyn Reflect) {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
-        } else {
-            panic!("Value is not a {}.", std::any::type_name::<Self>());
-        }
+        *self = value
+            .as_any()
+            .downcast_ref::<Self>()
+            .unwrap_or_else(|| panic!("Value is not a {}.", std::any::type_name::<Self>()))
+            .clone();
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
@@ -998,12 +997,11 @@ impl Reflect for Cow<'static, str> {
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
-        } else {
-            Some(false)
-        }
+        value
+            .as_any()
+            .downcast_ref::<Self>()
+            .map(|value| std::cmp::PartialEq::eq(self, value))
+            .or(Some(false))
     }
 }
 
@@ -1069,12 +1067,10 @@ impl Reflect for &'static Path {
     }
 
     fn apply(&mut self, value: &dyn Reflect) {
-        let value = value.as_any();
-        if let Some(&value) = value.downcast_ref::<Self>() {
-            *self = value;
-        } else {
-            panic!("Value is not a {}.", std::any::type_name::<Self>());
-        }
+        *self = value
+            .as_any()
+            .downcast_ref::<Self>()
+            .unwrap_or_else(|| panic!("Value is not a {}.", std::any::type_name::<Self>()));
     }
 
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
@@ -1106,12 +1102,11 @@ impl Reflect for &'static Path {
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            Some(std::cmp::PartialEq::eq(self, value))
-        } else {
-            Some(false)
-        }
+        value
+            .as_any()
+            .downcast_ref::<Self>()
+            .map(|value| std::cmp::PartialEq::eq(self, value))
+            .or(Some(false))
     }
 }
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -110,42 +110,40 @@ impl GetPath for dyn Reflect {
             let current_index = index;
             match token {
                 Token::Dot => {
-                    if let Some(Token::Ident(value)) = next_token(path, &mut index) {
-                        current = read_field(current, value, current_index)?;
-                    } else {
+                    let Some(Token::Ident(value)) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedIdent {
                             index: current_index,
                         });
-                    }
+                    };
+                    current = read_field(current, value, current_index)?;
                 }
                 Token::OpenBracket => {
-                    if let Some(Token::Ident(value)) = next_token(path, &mut index) {
-                        match current.reflect_ref() {
-                            ReflectRef::List(reflect_list) => {
-                                current = read_array_entry(reflect_list, value, current_index)?;
-                            }
-                            ReflectRef::Array(reflect_arr) => {
-                                current = read_array_entry(reflect_arr, value, current_index)?;
-                            }
-                            _ => {
-                                return Err(ReflectPathError::ExpectedList {
-                                    index: current_index,
-                                })
-                            }
-                        }
-                    } else {
+                    let Some(Token::Ident(value)) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedIdent {
                             index: current_index,
                         });
+                    };
+
+                    match current.reflect_ref() {
+                        ReflectRef::List(reflect_list) => {
+                            current = read_array_entry(reflect_list, value, current_index)?;
+                        }
+                        ReflectRef::Array(reflect_arr) => {
+                            current = read_array_entry(reflect_arr, value, current_index)?;
+                        }
+                        _ => {
+                            return Err(ReflectPathError::ExpectedList {
+                                index: current_index,
+                            })
+                        }
                     }
 
-                    if let Some(Token::CloseBracket) = next_token(path, &mut index) {
-                    } else {
+                    let Some(Token::CloseBracket) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedToken {
                             index: current_index,
                             token: "]",
                         });
-                    }
+                    };
                 }
                 Token::CloseBracket => {
                     return Err(ReflectPathError::UnexpectedToken {
@@ -172,42 +170,40 @@ impl GetPath for dyn Reflect {
             let current_index = index;
             match token {
                 Token::Dot => {
-                    if let Some(Token::Ident(value)) = next_token(path, &mut index) {
-                        current = read_field_mut(current, value, current_index)?;
-                    } else {
+                    let Some(Token::Ident(value)) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedIdent {
                             index: current_index,
                         });
-                    }
+                    };
+                    current = read_field_mut(current, value, current_index)?;
                 }
                 Token::OpenBracket => {
-                    if let Some(Token::Ident(value)) = next_token(path, &mut index) {
-                        match current.reflect_mut() {
-                            ReflectMut::List(reflect_list) => {
-                                current = read_array_entry_mut(reflect_list, value, current_index)?;
-                            }
-                            ReflectMut::Array(reflect_arr) => {
-                                current = read_array_entry_mut(reflect_arr, value, current_index)?;
-                            }
-                            _ => {
-                                return Err(ReflectPathError::ExpectedStruct {
-                                    index: current_index,
-                                })
-                            }
-                        }
-                    } else {
+                    let Some(Token::Ident(value)) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedIdent {
                             index: current_index,
                         });
+                    };
+
+                    match current.reflect_mut() {
+                        ReflectMut::List(reflect_list) => {
+                            current = read_array_entry_mut(reflect_list, value, current_index)?;
+                        }
+                        ReflectMut::Array(reflect_arr) => {
+                            current = read_array_entry_mut(reflect_arr, value, current_index)?;
+                        }
+                        _ => {
+                            return Err(ReflectPathError::ExpectedStruct {
+                                index: current_index,
+                            })
+                        }
                     }
 
-                    if let Some(Token::CloseBracket) = next_token(path, &mut index) {
-                    } else {
+                    let Some(Token::CloseBracket) = next_token(path, &mut index) else {
                         return Err(ReflectPathError::ExpectedToken {
                             index: current_index,
                             token: "]",
                         });
-                    }
+                    };
                 }
                 Token::CloseBracket => {
                     return Err(ReflectPathError::UnexpectedToken {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -339,8 +339,7 @@ impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
 
         // Handle both Value case and types that have a custom `ReflectDeserialize`
         if let Some(deserialize_reflect) = self.registration.data::<ReflectDeserialize>() {
-            let value = deserialize_reflect.deserialize(deserializer)?;
-            return Ok(value);
+            return Ok(deserialize_reflect.deserialize(deserializer)?);
         }
 
         match self.registration.type_info() {

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -339,7 +339,7 @@ impl<'a, 'de> DeserializeSeed<'de> for TypedReflectDeserializer<'a> {
 
         // Handle both Value case and types that have a custom `ReflectDeserialize`
         if let Some(deserialize_reflect) = self.registration.data::<ReflectDeserialize>() {
-            return Ok(deserialize_reflect.deserialize(deserializer)?);
+            return deserialize_reflect.deserialize(deserializer);
         }
 
         match self.registration.type_info() {

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -329,11 +329,9 @@ impl Struct for DynamicStruct {
 
     #[inline]
     fn field_mut(&mut self, name: &str) -> Option<&mut dyn Reflect> {
-        if let Some(index) = self.field_indices.get(name) {
-            Some(&mut *self.fields[*index])
-        } else {
-            None
-        }
+        self.field_indices
+            .get(name)
+            .map(|index| &mut *self.fields[*index])
     }
 
     #[inline]
@@ -443,9 +441,8 @@ impl Reflect for DynamicStruct {
         if let ReflectRef::Struct(struct_value) = value.reflect_ref() {
             for (i, value) in struct_value.iter_fields().enumerate() {
                 let name = struct_value.name_at(i).unwrap();
-                if let Some(v) = self.field_mut(name) {
-                    v.apply(value);
-                }
+                let Some(v) = self.field_mut(name) else { continue };
+                v.apply(value);
             }
         } else {
             panic!("Attempted to apply non-struct type to struct type.");

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -345,9 +345,8 @@ impl Reflect for DynamicTupleStruct {
     fn apply(&mut self, value: &dyn Reflect) {
         if let ReflectRef::TupleStruct(tuple_struct) = value.reflect_ref() {
             for (i, value) in tuple_struct.iter_fields().enumerate() {
-                if let Some(v) = self.field_mut(i) {
-                    v.apply(value);
-                }
+                let Some(v) = self.field_mut(i) else { continue };
+                v.apply(value);
             }
         } else {
             panic!("Attempted to apply non-TupleStruct type to TupleStruct type.");

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -51,13 +51,11 @@ impl Node for CameraDriverNode {
                 }
             }
             previous_order_target = Some(new_order_target);
-            if let Ok((_, camera)) = self.cameras.get_manual(world, entity) {
-                if let RenderTarget::Window(id) = camera.target {
-                    camera_windows.insert(id);
-                }
-                graph
-                    .run_sub_graph(camera.render_graph.clone(), vec![SlotValue::Entity(entity)])?;
+            let Ok((_, camera)) = self.cameras.get_manual(world, entity) else { continue };
+            if let RenderTarget::Window(id) = camera.target {
+                camera_windows.insert(id);
             }
+            graph.run_sub_graph(camera.render_graph.clone(), vec![SlotValue::Entity(entity)])?;
         }
 
         if !ambiguities.is_empty() {

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -26,12 +26,11 @@ impl Plugin for CameraPlugin {
             .add_plugin(CameraProjectionPlugin::<OrthographicProjection>::default())
             .add_plugin(CameraProjectionPlugin::<PerspectiveProjection>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(RenderStage::Extract, extract_cameras);
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app.add_system_to_stage(RenderStage::Extract, extract_cameras);
 
-            let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
-            let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
-            render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);
-        }
+        let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
+        let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
+        render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);
     }
 }

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -78,11 +78,10 @@ impl<C> Default for UniformComponentPlugin<C> {
 
 impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .insert_resource(ComponentUniforms::<C>::default())
-                .add_system_to_stage(RenderStage::Prepare, prepare_uniform_components::<C>);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .insert_resource(ComponentUniforms::<C>::default())
+            .add_system_to_stage(RenderStage::Prepare, prepare_uniform_components::<C>);
     }
 }
 
@@ -176,13 +175,11 @@ impl<C, F> ExtractComponentPlugin<C, F> {
 
 impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            if self.only_extract_visible {
-                render_app
-                    .add_system_to_stage(RenderStage::Extract, extract_visible_components::<C>);
-            } else {
-                render_app.add_system_to_stage(RenderStage::Extract, extract_components::<C>);
-            }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        if self.only_extract_visible {
+            render_app.add_system_to_stage(RenderStage::Extract, extract_visible_components::<C>);
+        } else {
+            render_app.add_system_to_stage(RenderStage::Extract, extract_components::<C>);
         }
     }
 }

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -33,9 +33,8 @@ impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
 
 impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app.add_system_to_stage(RenderStage::Extract, extract_resource::<R>);
     }
 }
 

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -46,11 +46,7 @@ pub fn extract_resource<R: ExtractResource>(
     target_resource: Option<ResMut<R>>,
     #[cfg(debug_assertions)] mut has_warned_on_remove: Local<bool>,
 ) {
-    if let Some(mut target_resource) = target_resource {
-        if main_resource.is_changed() {
-            *target_resource = R::extract_resource(&main_resource);
-        }
-    } else {
+    let Some(mut target_resource) = target_resource else {
         #[cfg(debug_assertions)]
         if !main_resource.is_added() && !*has_warned_on_remove {
             *has_warned_on_remove = true;
@@ -61,5 +57,9 @@ pub fn extract_resource<R: ExtractResource>(
             );
         }
         commands.insert_resource(R::extract_resource(&main_resource));
+        return;
+    };
+    if main_resource.is_changed() {
+        *target_resource = R::extract_resource(&main_resource);
     }
 }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -15,14 +15,13 @@ pub struct GlobalsPlugin;
 impl Plugin for GlobalsPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<GlobalsUniform>();
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<GlobalsBuffer>()
-                .init_resource::<Time>()
-                .add_system_to_stage(RenderStage::Extract, extract_frame_count)
-                .add_system_to_stage(RenderStage::Extract, extract_time)
-                .add_system_to_stage(RenderStage::Prepare, prepare_globals_buffer);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<GlobalsBuffer>()
+            .init_resource::<Time>()
+            .add_system_to_stage(RenderStage::Extract, extract_frame_count)
+            .add_system_to_stage(RenderStage::Extract, extract_time)
+            .add_system_to_stage(RenderStage::Prepare, prepare_globals_buffer);
     }
 }
 

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -464,24 +464,22 @@ impl InnerMeshVertexBufferLayout {
     ) -> Result<VertexBufferLayout, MissingVertexAttributeError> {
         let mut attributes = Vec::with_capacity(attribute_descriptors.len());
         for attribute_descriptor in attribute_descriptors {
-            if let Some(index) = self
+            let Some(index) = self
                 .attribute_ids
                 .iter()
-                .position(|id| *id == attribute_descriptor.id)
-            {
-                let layout_attribute = &self.layout.attributes[index];
-                attributes.push(VertexAttribute {
-                    format: layout_attribute.format,
-                    offset: layout_attribute.offset,
-                    shader_location: attribute_descriptor.shader_location,
-                });
-            } else {
+                .position(|id| *id == attribute_descriptor.id) else {
                 return Err(MissingVertexAttributeError {
                     id: attribute_descriptor.id,
                     name: attribute_descriptor.name,
                     pipeline_type: None,
                 });
-            }
+            };
+            let layout_attribute = &self.layout.attributes[index];
+            attributes.push(VertexAttribute {
+                format: layout_attribute.format,
+                offset: layout_attribute.offset,
+                shader_location: attribute_descriptor.shader_location,
+            });
         }
 
         Ok(VertexBufferLayout {

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -78,26 +78,25 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            let prepare_asset_system = prepare_assets::<A>.label(self.prepare_asset_label.clone());
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let prepare_asset_system = prepare_assets::<A>.label(self.prepare_asset_label.clone());
 
-            let prepare_asset_system = match self.prepare_asset_label {
-                PrepareAssetLabel::PreAssetPrepare => prepare_asset_system,
-                PrepareAssetLabel::AssetPrepare => {
-                    prepare_asset_system.after(PrepareAssetLabel::PreAssetPrepare)
-                }
-                PrepareAssetLabel::PostAssetPrepare => {
-                    prepare_asset_system.after(PrepareAssetLabel::AssetPrepare)
-                }
-            };
+        let prepare_asset_system = match self.prepare_asset_label {
+            PrepareAssetLabel::PreAssetPrepare => prepare_asset_system,
+            PrepareAssetLabel::AssetPrepare => {
+                prepare_asset_system.after(PrepareAssetLabel::PreAssetPrepare)
+            }
+            PrepareAssetLabel::PostAssetPrepare => {
+                prepare_asset_system.after(PrepareAssetLabel::AssetPrepare)
+            }
+        };
 
-            render_app
-                .init_resource::<ExtractedAssets<A>>()
-                .init_resource::<RenderAssets<A>>()
-                .init_resource::<PrepareNextFrameAssets<A>>()
-                .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
-                .add_system_to_stage(RenderStage::Prepare, prepare_asset_system);
-        }
+        render_app
+            .init_resource::<ExtractedAssets<A>>()
+            .init_resource::<RenderAssets<A>>()
+            .init_resource::<PrepareNextFrameAssets<A>>()
+            .add_system_to_stage(RenderStage::Extract, extract_render_asset::<A>)
+            .add_system_to_stage(RenderStage::Prepare, prepare_asset_system);
     }
 }
 

--- a/crates/bevy_render/src/render_graph/context.rs
+++ b/crates/bevy_render/src/render_graph/context.rs
@@ -171,21 +171,20 @@ impl<'a> RenderGraphContext<'a> {
             .ok_or_else(|| RunSubGraphError::MissingSubGraph(name.clone()))?;
         if let Some(input_node) = sub_graph.get_input_node() {
             for (i, input_slot) in input_node.input_slots.iter().enumerate() {
-                if let Some(input_value) = inputs.get(i) {
-                    if input_slot.slot_type != input_value.slot_type() {
-                        return Err(RunSubGraphError::MismatchedInputSlotType {
-                            graph_name: name,
-                            slot_index: i,
-                            actual: input_value.slot_type(),
-                            expected: input_slot.slot_type,
-                            label: input_slot.name.clone().into(),
-                        });
-                    }
-                } else {
+                let Some(input_value) = inputs.get(i) else {
                     return Err(RunSubGraphError::MissingInput {
                         slot_index: i,
                         slot_name: input_slot.name.clone(),
                         graph_name: name,
+                    });
+                };
+                if input_slot.slot_type != input_value.slot_type() {
+                    return Err(RunSubGraphError::MismatchedInputSlotType {
+                        graph_name: name,
+                        slot_index: i,
+                        actual: input_value.slot_type(),
+                        expected: input_slot.slot_type,
+                        label: input_slot.name.clone().into(),
                     });
                 }
             }

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -491,12 +491,11 @@ impl RenderGraph {
     pub fn has_edge(&self, edge: &Edge) -> bool {
         let output_node_state = self.get_node_state(edge.get_output_node());
         let input_node_state = self.get_node_state(edge.get_input_node());
-        if let Ok(output_node_state) = output_node_state {
-            if output_node_state.edges.output_edges().contains(edge) {
-                if let Ok(input_node_state) = input_node_state {
-                    if input_node_state.edges.input_edges().contains(edge) {
-                        return true;
-                    }
+        let Ok(output_node_state) = output_node_state else { return false };
+        if output_node_state.edges.output_edges().contains(edge) {
+            if let Ok(input_node_state) = input_node_state {
+                if input_node_state.edges.input_edges().contains(edge) {
+                    return true;
                 }
             }
         }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -40,11 +40,12 @@ impl DrawState {
         bind_group: BindGroupId,
         dynamic_indices: &[u32],
     ) -> bool {
-        if let Some(current_bind_group) = self.bind_groups.get(index) {
-            current_bind_group.0 == Some(bind_group) && dynamic_indices == current_bind_group.1
-        } else {
-            false
-        }
+        self.bind_groups
+            .get(index)
+            .map(|current_bind_group| {
+                current_bind_group.0 == Some(bind_group) && dynamic_indices == current_bind_group.1
+            })
+            .unwrap_or(false)
     }
 
     pub fn set_vertex_buffer(&mut self, index: usize, buffer: BufferId, offset: u64) {
@@ -55,11 +56,10 @@ impl DrawState {
     }
 
     pub fn is_vertex_buffer_set(&self, index: usize, buffer: BufferId, offset: u64) -> bool {
-        if let Some(current) = self.vertex_buffers.get(index) {
-            *current == Some((buffer, offset))
-        } else {
-            false
-        }
+        self.vertex_buffers
+            .get(index)
+            .map(|current| *current == Some((buffer, offset)))
+            .unwrap_or(false)
     }
 
     pub fn set_index_buffer(&mut self, buffer: BufferId, offset: u64, index_format: IndexFormat) {

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -58,21 +58,20 @@ impl<I: BatchedPhaseItem> RenderPhase<I> {
         self.items.reserve(items.len());
 
         // Start the first batch from the first item
-        if let Some(mut current_batch) = items.next() {
-            // Batch following items until we find an incompatible item
-            for next_item in items {
-                if matches!(
-                    current_batch.add_to_batch(&next_item),
-                    BatchResult::IncompatibleItems
-                ) {
-                    // Store the completed batch, and start a new one from the incompatible item
-                    self.items.push(current_batch);
-                    current_batch = next_item;
-                }
+        let Some(mut current_batch) = items.next() else { return };
+        // Batch following items until we find an incompatible item
+        for next_item in items {
+            if matches!(
+                current_batch.add_to_batch(&next_item),
+                BatchResult::IncompatibleItems
+            ) {
+                // Store the completed batch, and start a new one from the incompatible item
+                self.items.push(current_batch);
+                current_batch = next_item;
             }
-            // Store the last batch
-            self.items.push(current_batch);
         }
+        // Store the last batch
+        self.items.push(current_batch);
     }
 }
 

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -124,11 +124,10 @@ impl<T: Pod> BufferVec<T> {
             return;
         }
         self.reserve(self.values.len(), device);
-        if let Some(buffer) = &self.buffer {
-            let range = 0..self.item_size * self.values.len();
-            let bytes: &[u8] = cast_slice(&self.values);
-            queue.write_buffer(buffer, 0, &bytes[range]);
-        }
+        let Some(buffer) = &self.buffer else { return };
+        let range = 0..self.item_size * self.values.len();
+        let bytes: &[u8] = cast_slice(&self.values);
+        queue.write_buffer(buffer, 0, &bytes[range]);
     }
 
     pub fn truncate(&mut self, len: usize) {

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -536,21 +536,19 @@ impl ShaderProcessor {
                     let mut line_with_defs = line.to_string();
                     for capture in self.def_regex.captures_iter(line) {
                         let def = capture.get(1).unwrap();
-                        if let Some(def) = shader_defs_unique.get(def.as_str()) {
-                            line_with_defs = self
-                                .def_regex
-                                .replace(&line_with_defs, def.value_as_string())
-                                .to_string();
-                        }
+                        let Some(def) = shader_defs_unique.get(def.as_str()) else { continue };
+                        line_with_defs = self
+                            .def_regex
+                            .replace(&line_with_defs, def.value_as_string())
+                            .to_string();
                     }
                     for capture in self.def_regex_delimited.captures_iter(line) {
                         let def = capture.get(1).unwrap();
-                        if let Some(def) = shader_defs_unique.get(def.as_str()) {
-                            line_with_defs = self
-                                .def_regex_delimited
-                                .replace(&line_with_defs, def.value_as_string())
-                                .to_string();
-                        }
+                        let Some(def) = shader_defs_unique.get(def.as_str()) else  { continue };
+                        line_with_defs = self
+                            .def_regex_delimited
+                            .replace(&line_with_defs, def.value_as_string())
+                            .to_string();
                     }
                     final_string.push_str(&line_with_defs);
                     final_string.push('\n');

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -101,23 +101,22 @@ impl RenderGraphRunner {
         if let Some(input_node) = graph.get_input_node() {
             let mut input_values: SmallVec<[SlotValue; 4]> = SmallVec::new();
             for (i, input_slot) in input_node.input_slots.iter().enumerate() {
-                if let Some(input_value) = inputs.get(i) {
-                    if input_slot.slot_type != input_value.slot_type() {
-                        return Err(RenderGraphRunnerError::MismatchedInputSlotType {
-                            slot_index: i,
-                            actual: input_value.slot_type(),
-                            expected: input_slot.slot_type,
-                            label: input_slot.name.clone().into(),
-                        });
-                    }
-                    input_values.push(input_value.clone());
-                } else {
+                let Some(input_value) = inputs.get(i) else {
                     return Err(RenderGraphRunnerError::MissingInput {
                         slot_index: i,
                         slot_name: input_slot.name.clone(),
                         graph_name: graph_name.clone(),
                     });
+                };
+                if input_slot.slot_type != input_value.slot_type() {
+                    return Err(RenderGraphRunnerError::MismatchedInputSlotType {
+                        slot_index: i,
+                        actual: input_value.slot_type(),
+                        expected: input_slot.slot_type,
+                        label: input_slot.name.clone().into(),
+                    });
                 }
+                input_values.push(input_value.clone());
             }
 
             node_outputs.insert(input_node.id, input_values);
@@ -204,16 +203,15 @@ impl RenderGraphRunner {
 
             let mut values: SmallVec<[SlotValue; 4]> = SmallVec::new();
             for (i, output) in outputs.into_iter().enumerate() {
-                if let Some(value) = output {
-                    values.push(value);
-                } else {
+                let Some(value) = output else {
                     let empty_slot = node_state.output_slots.get_slot(i).unwrap();
                     return Err(RenderGraphRunnerError::EmptyNodeOutputSlot {
                         type_name: node_state.type_name,
                         slot_index: i,
                         slot_name: empty_slot.name.clone(),
                     });
-                }
+                };
+                values.push(value);
             }
             node_outputs.insert(node_state.id, values);
 

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -62,11 +62,9 @@ pub fn render_system(world: &mut World) {
 
         let mut windows = world.resource_mut::<ExtractedWindows>();
         for window in windows.values_mut() {
-            if let Some(texture_view) = window.swap_chain_texture.take() {
-                if let Some(surface_texture) = texture_view.take_surface_texture() {
-                    surface_texture.present();
-                }
-            }
+            let Some(texture_view) = window.swap_chain_texture.take() else { continue };
+            let Some(surface_texture) = texture_view.take_surface_texture() else { continue };
+            surface_texture.present();
         }
 
         #[cfg(feature = "tracing-tracy")]

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -93,17 +93,16 @@ impl Plugin for ImagePlugin {
             .resource_mut::<Assets<Image>>()
             .set_untracked(DEFAULT_IMAGE_HANDLE, Image::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            let default_sampler = {
-                let device = render_app.world.resource::<RenderDevice>();
-                device.create_sampler(&self.default_sampler.clone())
-            };
-            render_app
-                .insert_resource(DefaultImageSampler(default_sampler))
-                .init_resource::<TextureCache>()
-                .init_resource::<FallbackImage>()
-                .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let default_sampler = {
+            let device = render_app.world.resource::<RenderDevice>();
+            device.create_sampler(&self.default_sampler.clone())
+        };
+        render_app
+            .insert_resource(DefaultImageSampler(default_sampler))
+            .init_resource::<TextureCache>()
+            .init_resource::<FallbackImage>()
+            .add_system_to_stage(RenderStage::Cleanup, update_texture_cache_system);
     }
 }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -42,15 +42,14 @@ impl Plugin for ViewPlugin {
             .add_plugin(ExtractResourcePlugin::<Msaa>::default())
             .add_plugin(VisibilityPlugin);
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ViewUniforms>()
-                .add_system_to_stage(RenderStage::Prepare, prepare_view_uniforms)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_view_targets.after(WindowSystem::Prepare),
-                );
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<ViewUniforms>()
+            .add_system_to_stage(RenderStage::Prepare, prepare_view_uniforms)
+            .add_system_to_stage(
+                RenderStage::Prepare,
+                prepare_view_targets.after(WindowSystem::Prepare),
+            );
     }
 }
 

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -268,11 +268,9 @@ pub fn calculate_bounds(
     without_aabb: Query<(Entity, &Handle<Mesh>), (Without<Aabb>, Without<NoFrustumCulling>)>,
 ) {
     for (entity, mesh_handle) in &without_aabb {
-        if let Some(mesh) = meshes.get(mesh_handle) {
-            if let Some(aabb) = mesh.compute_aabb() {
-                commands.entity(entity).insert(aabb);
-            }
-        }
+        let Some(mesh) = meshes.get(mesh_handle) else { continue };
+        let Some(aabb) = mesh.compute_aabb() else { continue };
+        commands.entity(entity).insert(aabb);
     }
 }
 
@@ -308,16 +306,15 @@ fn visibility_propagate_system(
         // reset "view" visibility here ... if this entity should be drawn a future system should set this to true
         computed_visibility
             .reset(visibility == Visibility::Inherited || visibility == Visibility::Visible);
-        if let Some(children) = children {
-            for child in children.iter() {
-                let _ = propagate_recursive(
-                    computed_visibility.is_visible_in_hierarchy(),
-                    &mut visibility_query,
-                    &children_query,
-                    *child,
-                    entity,
-                );
-            }
+        let Some(children) = children else { continue };
+        for child in children.iter() {
+            let _ = propagate_recursive(
+                computed_visibility.is_visible_in_hierarchy(),
+                &mut visibility_query,
+                &children_query,
+                *child,
+                entity,
+            );
         }
     }
 }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -25,17 +25,16 @@ pub enum WindowSystem {
 
 impl Plugin for WindowRenderPlugin {
     fn build(&self, app: &mut App) {
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ExtractedWindows>()
-                .init_resource::<WindowSurfaces>()
-                .init_resource::<NonSendMarker>()
-                .add_system_to_stage(RenderStage::Extract, extract_windows)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_windows.label(WindowSystem::Prepare),
-                );
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<ExtractedWindows>()
+            .init_resource::<WindowSurfaces>()
+            .init_resource::<NonSendMarker>()
+            .add_system_to_stage(RenderStage::Extract, extract_windows)
+            .add_system_to_stage(
+                RenderStage::Prepare,
+                prepare_windows.label(WindowSystem::Prepare),
+            );
     }
 }
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -125,18 +125,15 @@ impl<'w> DynamicSceneBuilder<'w> {
             };
 
             for component_id in self.original_world.entity(entity).archetype().components() {
-                let reflect_component = self
+                let Some(reflect_component) = self
                     .original_world
                     .components()
                     .get_info(component_id)
                     .and_then(|info| type_registry.get(info.type_id().unwrap()))
-                    .and_then(|registration| registration.data::<ReflectComponent>());
+                    .and_then(|registration| registration.data::<ReflectComponent>()) else { continue };
 
-                if let Some(reflect_component) = reflect_component {
-                    if let Some(component) = reflect_component.reflect(self.original_world, entity)
-                    {
-                        entry.components.push(component.clone_value());
-                    }
+                if let Some(component) = reflect_component.reflect(self.original_world, entity) {
+                    entry.components.push(component.clone_value());
                 }
             }
             self.extracted_scene.insert(index, entry);

--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -26,16 +26,12 @@ impl DynamicTextureAtlasBuilder {
         let allocation = self.atlas_allocator.allocate(size2(
             texture.texture_descriptor.size.width as i32 + self.padding,
             texture.texture_descriptor.size.height as i32 + self.padding,
-        ));
-        if let Some(allocation) = allocation {
-            let atlas_texture = textures.get_mut(&texture_atlas.texture).unwrap();
-            self.place_texture(atlas_texture, allocation, texture);
-            let mut rect: Rect = to_rect(allocation.rectangle);
-            rect.max -= self.padding as f32;
-            Some(texture_atlas.add_texture(rect))
-        } else {
-            None
-        }
+        ))?;
+        let atlas_texture = textures.get_mut(&texture_atlas.texture).unwrap();
+        self.place_texture(atlas_texture, allocation, texture);
+        let mut rect: Rect = to_rect(allocation.rectangle);
+        rect.max -= self.padding as f32;
+        Some(texture_atlas.add_texture(rect))
     }
 
     // fn resize(

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -61,21 +61,20 @@ impl Plugin for SpritePlugin {
             .add_plugin(Mesh2dRenderPlugin)
             .add_plugin(ColorMaterialPlugin);
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<ImageBindGroups>()
-                .init_resource::<SpritePipeline>()
-                .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
-                .init_resource::<SpriteMeta>()
-                .init_resource::<ExtractedSprites>()
-                .init_resource::<SpriteAssetEvents>()
-                .add_render_command::<Transparent2d, DrawSprite>()
-                .add_system_to_stage(
-                    RenderStage::Extract,
-                    render::extract_sprites.label(SpriteSystem::ExtractSprites),
-                )
-                .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
-                .add_system_to_stage(RenderStage::Queue, queue_sprites);
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<ImageBindGroups>()
+            .init_resource::<SpritePipeline>()
+            .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
+            .init_resource::<SpriteMeta>()
+            .init_resource::<ExtractedSprites>()
+            .init_resource::<SpriteAssetEvents>()
+            .add_render_command::<Transparent2d, DrawSprite>()
+            .add_system_to_stage(
+                RenderStage::Extract,
+                render::extract_sprites.label(SpriteSystem::ExtractSprites),
+            )
+            .add_system_to_stage(RenderStage::Extract, render::extract_sprite_events)
+            .add_system_to_stage(RenderStage::Queue, queue_sprites);
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -153,20 +153,19 @@ where
     fn build(&self, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible());
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
-                .init_resource::<Material2dPipeline<M>>()
-                .init_resource::<ExtractedMaterials2d<M>>()
-                .init_resource::<RenderMaterials2d<M>>()
-                .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .add_system_to_stage(RenderStage::Extract, extract_materials_2d::<M>)
-                .add_system_to_stage(
-                    RenderStage::Prepare,
-                    prepare_materials_2d::<M>.after(PrepareAssetLabel::PreAssetPrepare),
-                )
-                .add_system_to_stage(RenderStage::Queue, queue_material2d_meshes::<M>);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
+            .init_resource::<Material2dPipeline<M>>()
+            .init_resource::<ExtractedMaterials2d<M>>()
+            .init_resource::<RenderMaterials2d<M>>()
+            .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
+            .add_system_to_stage(RenderStage::Extract, extract_materials_2d::<M>)
+            .add_system_to_stage(
+                RenderStage::Prepare,
+                prepare_materials_2d::<M>.after(PrepareAssetLabel::PreAssetPrepare),
+            )
+            .add_system_to_stage(RenderStage::Queue, queue_material2d_meshes::<M>);
     }
 }
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -342,48 +342,44 @@ pub fn queue_material2d_meshes<M: Material2d>(
         }
 
         for visible_entity in &visible_entities.entities {
-            if let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) =
-                material2d_meshes.get(*visible_entity)
-            {
-                if let Some(material2d) = render_materials.get(material2d_handle) {
-                    if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
-                        let mesh_key = view_key
-                            | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) =
+            material2d_meshes.get(*visible_entity) else { continue };
+            let Some(material2d) = render_materials.get(material2d_handle) else { continue };
+            let Some(mesh) = render_meshes.get(&mesh2d_handle.0) else { continue };
+            let mesh_key =
+                view_key | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
 
-                        let pipeline_id = pipelines.specialize(
-                            &mut pipeline_cache,
-                            &material2d_pipeline,
-                            Material2dKey {
-                                mesh_key,
-                                bind_group_data: material2d.key.clone(),
-                            },
-                            &mesh.layout,
-                        );
+            let pipeline_id = pipelines.specialize(
+                &mut pipeline_cache,
+                &material2d_pipeline,
+                Material2dKey {
+                    mesh_key,
+                    bind_group_data: material2d.key.clone(),
+                },
+                &mesh.layout,
+            );
 
-                        let pipeline_id = match pipeline_id {
-                            Ok(id) => id,
-                            Err(err) => {
-                                error!("{}", err);
-                                continue;
-                            }
-                        };
-
-                        let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                        transparent_phase.add(Transparent2d {
-                            entity: *visible_entity,
-                            draw_function: draw_transparent_pbr,
-                            pipeline: pipeline_id,
-                            // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                            // lowest sort key and getting closer should increase. As we have
-                            // -z in front of the camera, the largest distance is -far with values increasing toward the
-                            // camera. As such we can just use mesh_z as the distance
-                            sort_key: FloatOrd(mesh_z),
-                            // This material is not batched
-                            batch_range: None,
-                        });
-                    }
+            let pipeline_id = match pipeline_id {
+                Ok(id) => id,
+                Err(err) => {
+                    error!("{}", err);
+                    continue;
                 }
-            }
+            };
+
+            let mesh_z = mesh2d_uniform.transform.w_axis.z;
+            transparent_phase.add(Transparent2d {
+                entity: *visible_entity,
+                draw_function: draw_transparent_pbr,
+                pipeline: pipeline_id,
+                // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
+                // lowest sort key and getting closer should increase. As we have
+                // -z in front of the camera, the largest distance is -far with values increasing toward the
+                // camera. As such we can just use mesh_z as the distance
+                sort_key: FloatOrd(mesh_z),
+                // This material is not batched
+                batch_range: None,
+            });
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -441,18 +441,17 @@ pub fn queue_mesh2d_bind_group(
     render_device: Res<RenderDevice>,
     mesh2d_uniforms: Res<ComponentUniforms<Mesh2dUniform>>,
 ) {
-    if let Some(binding) = mesh2d_uniforms.uniforms().binding() {
-        commands.insert_resource(Mesh2dBindGroup {
-            value: render_device.create_bind_group(&BindGroupDescriptor {
-                entries: &[BindGroupEntry {
-                    binding: 0,
-                    resource: binding,
-                }],
-                label: Some("mesh2d_bind_group"),
-                layout: &mesh2d_pipeline.mesh_layout,
-            }),
-        });
-    }
+    let Some(binding) = mesh2d_uniforms.uniforms().binding() else { return };
+    commands.insert_resource(Mesh2dBindGroup {
+        value: render_device.create_bind_group(&BindGroupDescriptor {
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: binding,
+            }],
+            label: Some("mesh2d_bind_group"),
+            layout: &mesh2d_pipeline.mesh_layout,
+        }),
+    });
 }
 
 #[derive(Component)]

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -98,14 +98,13 @@ impl Plugin for Mesh2dRenderPlugin {
 
         app.add_plugin(UniformComponentPlugin::<Mesh2dUniform>::default());
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app
-                .init_resource::<Mesh2dPipeline>()
-                .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
-                .add_system_to_stage(RenderStage::Extract, extract_mesh2d)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh2d_bind_group)
-                .add_system_to_stage(RenderStage::Queue, queue_mesh2d_view_bind_groups);
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app
+            .init_resource::<Mesh2dPipeline>()
+            .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
+            .add_system_to_stage(RenderStage::Extract, extract_mesh2d)
+            .add_system_to_stage(RenderStage::Queue, queue_mesh2d_bind_group)
+            .add_system_to_stage(RenderStage::Queue, queue_mesh2d_view_bind_groups);
     }
 }
 

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -93,15 +93,13 @@ impl FontAtlas {
         texture: &Image,
     ) -> bool {
         let texture_atlas = texture_atlases.get_mut(&self.texture_atlas).unwrap();
-        if let Some(index) =
-            self.dynamic_texture_atlas_builder
-                .add_texture(texture_atlas, textures, texture)
-        {
-            self.glyph_to_atlas_index
-                .insert((glyph_id, subpixel_offset), index);
-            true
-        } else {
-            false
-        }
+        self.dynamic_texture_atlas_builder
+            .add_texture(texture_atlas, textures, texture)
+            .map(|index| {
+                self.glyph_to_atlas_index
+                    .insert((glyph_id, subpixel_offset), index);
+                true
+            })
+            .unwrap_or(false)
     }
 }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -95,11 +95,10 @@ impl Plugin for TextPlugin {
                     .ambiguous_with(CameraUpdateSystem),
             );
 
-        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
-            render_app.add_system_to_stage(
-                RenderStage::Extract,
-                extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
-            );
-        }
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        render_app.add_system_to_stage(
+            RenderStage::Extract,
+            extract_text2d_sprite.after(SpriteSystem::ExtractSprites),
+        );
     }
 }

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -208,16 +208,15 @@ impl System for FixedTimestep {
             self.state.clone(),
         )));
         self.internal_system.initialize(world);
-        if let Some(ref label) = self.state.label {
-            let mut fixed_timesteps = world.resource_mut::<FixedTimesteps>();
-            fixed_timesteps.fixed_timesteps.insert(
-                label.clone(),
-                FixedTimestepState {
-                    accumulator: 0.0,
-                    step: self.state.step,
-                },
-            );
-        }
+        let Some(ref label) = self.state.label else { return };
+        let mut fixed_timesteps = world.resource_mut::<FixedTimesteps>();
+        fixed_timesteps.fixed_timesteps.insert(
+            label.clone(),
+            FixedTimestepState {
+                accumulator: 0.0,
+                step: self.state.step,
+            },
+        );
     }
 
     fn update_archetype_component_access(&mut self, world: &World) {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -114,10 +114,9 @@ pub fn ui_focus_system(
         mouse_button_input.just_released(MouseButton::Left) || touches_input.any_just_released();
     if mouse_released {
         for node in node_query.iter_mut() {
-            if let Some(mut interaction) = node.interaction {
-                if *interaction == Interaction::Clicked {
-                    *interaction = Interaction::None;
-                }
+            let Some(mut interaction) = node.interaction else { continue };
+            if *interaction == Interaction::Clicked {
+                *interaction = Interaction::None;
             }
         }
     }
@@ -239,11 +238,10 @@ pub fn ui_focus_system(
     // `moused_over_nodes` after the previous loop is exited.
     let mut iter = node_query.iter_many_mut(moused_over_nodes);
     while let Some(node) = iter.fetch_next() {
-        if let Some(mut interaction) = node.interaction {
-            // don't reset clicked nodes because they're handled separately
-            if *interaction != Interaction::Clicked {
-                interaction.set_if_neq(Interaction::None);
-            }
+        let Some(mut interaction) = node.interaction else { continue };
+        // don't reset clicked nodes because they're handled separately
+        if *interaction != Interaction::Clicked {
+            interaction.set_if_neq(Interaction::None);
         }
     }
 }

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -64,9 +64,8 @@ fn update_clipping(
         }
     };
 
-    if let Ok(children) = children_query.get(entity) {
-        for child in children.iter().cloned() {
-            update_clipping(commands, children_query, node_query, child, children_clip);
-        }
+    let Ok(children) = children_query.get(entity) else { return };
+    for child in children.iter().cloned() {
+        update_clipping(commands, children_query, node_query, child, children_clip);
     }
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -13,16 +13,15 @@ pub fn update_image_calculated_size_system(
     mut query: Query<(&mut CalculatedSize, &UiImage), Without<Text>>,
 ) {
     for (mut calculated_size, image) in &mut query {
-        if let Some(texture) = textures.get(&image.texture) {
-            let size = Size {
-                width: Val::Px(texture.texture_descriptor.size.width as f32),
-                height: Val::Px(texture.texture_descriptor.size.height as f32),
-            };
-            // Update only if size has changed to avoid needless layout calculations
-            if size != calculated_size.size {
-                calculated_size.size = size;
-                calculated_size.preserve_aspect_ratio = true;
-            }
+        let Some(texture) = textures.get(&image.texture) else { continue };
+        let size = Size {
+            width: Val::Px(texture.texture_descriptor.size.width as f32),
+            height: Val::Px(texture.texture_descriptor.size.height as f32),
+        };
+        // Update only if size has changed to avoid needless layout calculations
+        if size != calculated_size.size {
+            calculated_size.size = size;
+            calculated_size.preserve_aspect_ratio = true;
         }
     }
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -71,11 +71,10 @@ pub fn text_system(
 ) {
     // TODO: This should support window-independent scale settings.
     // See https://github.com/bevyengine/bevy/issues/5621
-    let scale_factor = if let Some(window) = windows.get_primary() {
-        window.scale_factor() * ui_scale.scale
-    } else {
-        ui_scale.scale
-    };
+    let scale_factor = windows
+        .get_primary()
+        .map(|window| window.scale_factor() * ui_scale.scale)
+        .unwrap_or(ui_scale.scale);
 
     let inv_scale_factor = 1. / scale_factor;
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -100,53 +100,52 @@ pub fn text_system(
     let mut new_queue = Vec::new();
     let mut query = text_queries.p2();
     for entity in queued_text.entities.drain(..) {
-        if let Ok((text, style, mut calculated_size, text_layout_info)) = query.get_mut(entity) {
-            let node_size = Vec2::new(
-                text_constraint(
-                    style.min_size.width,
-                    style.size.width,
-                    style.max_size.width,
-                    scale_factor,
-                ),
-                text_constraint(
-                    style.min_size.height,
-                    style.size.height,
-                    style.max_size.height,
-                    scale_factor,
-                ),
-            );
-
-            match text_pipeline.queue_text(
-                &fonts,
-                &text.sections,
+        let Ok((text, style, mut calculated_size, text_layout_info)) = query.get_mut(entity) else { continue };
+        let node_size = Vec2::new(
+            text_constraint(
+                style.min_size.width,
+                style.size.width,
+                style.max_size.width,
                 scale_factor,
-                text.alignment,
-                node_size,
-                &mut font_atlas_set_storage,
-                &mut texture_atlases,
-                &mut textures,
-                text_settings.as_ref(),
-                &mut font_atlas_warning,
-                YAxisOrientation::TopToBottom,
-            ) {
-                Err(TextError::NoSuchFont) => {
-                    // There was an error processing the text layout, let's add this entity to the
-                    // queue for further processing
-                    new_queue.push(entity);
-                }
-                Err(e @ TextError::FailedToAddGlyph(_)) => {
-                    panic!("Fatal error when processing text: {e}.");
-                }
-                Ok(info) => {
-                    calculated_size.size = Size {
-                        width: Val::Px(scale_value(info.size.x, inv_scale_factor)),
-                        height: Val::Px(scale_value(info.size.y, inv_scale_factor)),
-                    };
-                    match text_layout_info {
-                        Some(mut t) => *t = info,
-                        None => {
-                            commands.entity(entity).insert(info);
-                        }
+            ),
+            text_constraint(
+                style.min_size.height,
+                style.size.height,
+                style.max_size.height,
+                scale_factor,
+            ),
+        );
+
+        match text_pipeline.queue_text(
+            &fonts,
+            &text.sections,
+            scale_factor,
+            text.alignment,
+            node_size,
+            &mut font_atlas_set_storage,
+            &mut texture_atlases,
+            &mut textures,
+            text_settings.as_ref(),
+            &mut font_atlas_warning,
+            YAxisOrientation::TopToBottom,
+        ) {
+            Err(TextError::NoSuchFont) => {
+                // There was an error processing the text layout, let's add this entity to the
+                // queue for further processing
+                new_queue.push(entity);
+            }
+            Err(e @ TextError::FailedToAddGlyph(_)) => {
+                panic!("Fatal error when processing text: {e}.");
+            }
+            Ok(info) => {
+                calculated_size.size = Size {
+                    width: Val::Px(scale_value(info.size.x, inv_scale_factor)),
+                    height: Val::Px(scale_value(info.size.y, inv_scale_factor)),
+                };
+                match text_layout_info {
+                    Some(mut t) => *t = info,
+                    None => {
+                        commands.entity(entity).insert(info);
                     }
                 }
             }

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -27,10 +27,11 @@ where
     }
 
     fn dyn_eq(&self, other: &dyn DynEq) -> bool {
-        if let Some(other) = other.as_any().downcast_ref::<T>() {
-            return self == other;
-        }
-        false
+        other
+            .as_any()
+            .downcast_ref::<T>()
+            .map(|other| self == other)
+            .unwrap_or(false)
     }
 }
 

--- a/crates/bevy_window/src/windows.rs
+++ b/crates/bevy_window/src/windows.rs
@@ -65,11 +65,9 @@ impl Windows {
 
     /// Returns the scale factor for the [`Window`] of `id`, or `1.0` if the window does not exist.
     pub fn scale_factor(&self, id: WindowId) -> f64 {
-        if let Some(window) = self.get(id) {
-            window.scale_factor()
-        } else {
-            1.0
-        }
+        self.get(id)
+            .map(|window| window.scale_factor())
+            .unwrap_or(1.0)
     }
 
     /// An iterator over all registered [`Window`]s.

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -334,29 +334,27 @@ pub fn queue_colored_mesh2d(
 
         // Queue all entities visible to that view
         for visible_entity in &visible_entities.entities {
-            if let Ok((mesh2d_handle, mesh2d_uniform)) = colored_mesh2d.get(*visible_entity) {
-                // Get our specialized pipeline
-                let mut mesh2d_key = mesh_key;
-                if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
-                    mesh2d_key |=
-                        Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                }
-
-                let pipeline_id =
-                    pipelines.specialize(&mut pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
-
-                let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                transparent_phase.add(Transparent2d {
-                    entity: *visible_entity,
-                    draw_function: draw_colored_mesh2d,
-                    pipeline: pipeline_id,
-                    // The 2d render items are sorted according to their z value before rendering,
-                    // in order to get correct transparency
-                    sort_key: FloatOrd(mesh_z),
-                    // This material is not batched
-                    batch_range: None,
-                });
+            let Ok((mesh2d_handle, mesh2d_uniform)) = colored_mesh2d.get(*visible_entity) else { continue };
+            // Get our specialized pipeline
+            let mut mesh2d_key = mesh_key;
+            if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
+                mesh2d_key |= Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
             }
+
+            let pipeline_id =
+                pipelines.specialize(&mut pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
+
+            let mesh_z = mesh2d_uniform.transform.w_axis.z;
+            transparent_phase.add(Transparent2d {
+                entity: *visible_entity,
+                draw_function: draw_colored_mesh2d,
+                pipeline: pipeline_id,
+                // The 2d render items are sorted according to their z value before rendering,
+                // in order to get correct transparency
+                sort_key: FloatOrd(mesh_z),
+                // This material is not batched
+                batch_range: None,
+            });
         }
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -343,76 +343,75 @@ pub fn camera_controller(
 ) {
     let dt = time.delta_seconds();
 
-    if let Ok((mut transform, mut options)) = query.get_single_mut() {
-        if !options.initialized {
-            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
-            options.yaw = yaw;
-            options.pitch = pitch;
-            options.initialized = true;
-        }
-        if !options.enabled {
-            return;
-        }
+    let Ok((mut transform, mut options)) = query.get_single_mut() else { return };
+    if !options.initialized {
+        let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
+        options.yaw = yaw;
+        options.pitch = pitch;
+        options.initialized = true;
+    }
+    if !options.enabled {
+        return;
+    }
 
-        // Handle key input
-        let mut axis_input = Vec3::ZERO;
-        if key_input.pressed(options.key_forward) {
-            axis_input.z += 1.0;
-        }
-        if key_input.pressed(options.key_back) {
-            axis_input.z -= 1.0;
-        }
-        if key_input.pressed(options.key_right) {
-            axis_input.x += 1.0;
-        }
-        if key_input.pressed(options.key_left) {
-            axis_input.x -= 1.0;
-        }
-        if key_input.pressed(options.key_up) {
-            axis_input.y += 1.0;
-        }
-        if key_input.pressed(options.key_down) {
-            axis_input.y -= 1.0;
-        }
-        if key_input.just_pressed(options.keyboard_key_enable_mouse) {
-            *move_toggled = !*move_toggled;
-        }
+    // Handle key input
+    let mut axis_input = Vec3::ZERO;
+    if key_input.pressed(options.key_forward) {
+        axis_input.z += 1.0;
+    }
+    if key_input.pressed(options.key_back) {
+        axis_input.z -= 1.0;
+    }
+    if key_input.pressed(options.key_right) {
+        axis_input.x += 1.0;
+    }
+    if key_input.pressed(options.key_left) {
+        axis_input.x -= 1.0;
+    }
+    if key_input.pressed(options.key_up) {
+        axis_input.y += 1.0;
+    }
+    if key_input.pressed(options.key_down) {
+        axis_input.y -= 1.0;
+    }
+    if key_input.just_pressed(options.keyboard_key_enable_mouse) {
+        *move_toggled = !*move_toggled;
+    }
 
-        // Apply movement update
-        if axis_input != Vec3::ZERO {
-            let max_speed = if key_input.pressed(options.key_run) {
-                options.run_speed
-            } else {
-                options.walk_speed
-            };
-            options.velocity = axis_input.normalize() * max_speed;
+    // Apply movement update
+    if axis_input != Vec3::ZERO {
+        let max_speed = if key_input.pressed(options.key_run) {
+            options.run_speed
         } else {
-            let friction = options.friction.clamp(0.0, 1.0);
-            options.velocity *= 1.0 - friction;
-            if options.velocity.length_squared() < 1e-6 {
-                options.velocity = Vec3::ZERO;
-            }
+            options.walk_speed
+        };
+        options.velocity = axis_input.normalize() * max_speed;
+    } else {
+        let friction = options.friction.clamp(0.0, 1.0);
+        options.velocity *= 1.0 - friction;
+        if options.velocity.length_squared() < 1e-6 {
+            options.velocity = Vec3::ZERO;
         }
-        let forward = transform.forward();
-        let right = transform.right();
-        transform.translation += options.velocity.x * dt * right
-            + options.velocity.y * dt * Vec3::Y
-            + options.velocity.z * dt * forward;
+    }
+    let forward = transform.forward();
+    let right = transform.right();
+    transform.translation += options.velocity.x * dt * right
+        + options.velocity.y * dt * Vec3::Y
+        + options.velocity.z * dt * forward;
 
-        // Handle mouse input
-        let mut mouse_delta = Vec2::ZERO;
-        if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            for mouse_event in mouse_events.iter() {
-                mouse_delta += mouse_event.delta;
-            }
+    // Handle mouse input
+    let mut mouse_delta = Vec2::ZERO;
+    if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
+        for mouse_event in mouse_events.iter() {
+            mouse_delta += mouse_event.delta;
         }
+    }
 
-        if mouse_delta != Vec2::ZERO {
-            // Apply look update
-            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-PI / 2., PI / 2.);
-            options.yaw -= mouse_delta.x * options.sensitivity * dt;
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
-        }
+    if mouse_delta != Vec2::ZERO {
+        // Apply look update
+        options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+            .clamp(-PI / 2., PI / 2.);
+        options.yaw -= mouse_delta.x * options.sensitivity * dt;
+        transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -168,10 +168,9 @@ fn asset_loaded(
         // spawn cube
         let mut updated = false;
         for handle in cubes.iter() {
-            if let Some(material) = cubemap_materials.get_mut(handle) {
-                updated = true;
-                material.base_color_texture = Some(cubemap.image_handle.clone_weak());
-            }
+            let Some(material) = cubemap_materials.get_mut(handle) else { continue };
+            updated = true;
+            material.base_color_texture = Some(cubemap.image_handle.clone_weak());
         }
         if !updated {
             commands.spawn(MaterialMeshBundle::<CubemapMaterial> {

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -52,14 +52,13 @@ fn move_scene_entities(
     for moved_scene_entity in &moved_scene {
         let mut offset = 0.;
         for entity in children.iter_descendants(moved_scene_entity) {
-            if let Ok(mut transform) = transforms.get_mut(entity) {
-                transform.translation = Vec3::new(
-                    offset * time.elapsed_seconds().sin() / 20.,
-                    0.,
-                    time.elapsed_seconds().cos() / 20.,
-                );
-                offset += 1.0;
-            }
+            let Ok(mut transform) = transforms.get_mut(entity) else { continue };
+            transform.translation = Vec3::new(
+                offset * time.elapsed_seconds().sin() / 20.,
+                0.,
+                time.elapsed_seconds().cos() / 20.,
+            );
+            offset += 1.0;
         }
     }
 }

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -76,12 +76,12 @@ fn setup_scene_once_loaded(
     mut player: Query<&mut AnimationPlayer>,
     mut done: Local<bool>,
 ) {
-    if !*done {
-        if let Ok(mut player) = player.get_single_mut() {
-            player.play(animations.0[0].clone_weak()).repeat();
-            *done = true;
-        }
+    if *done {
+        return;
     }
+    let Ok(mut player) = player.get_single_mut() else { return };
+    player.play(animations.0[0].clone_weak()).repeat();
+    *done = true;
 }
 
 fn keyboard_animation_control(
@@ -90,40 +90,39 @@ fn keyboard_animation_control(
     animations: Res<Animations>,
     mut current_animation: Local<usize>,
 ) {
-    if let Ok(mut player) = animation_player.get_single_mut() {
-        if keyboard_input.just_pressed(KeyCode::Space) {
-            if player.is_paused() {
-                player.resume();
-            } else {
-                player.pause();
-            }
+    let Ok(mut player) = animation_player.get_single_mut() else { return };
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        if player.is_paused() {
+            player.resume();
+        } else {
+            player.pause();
         }
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Up) {
-            let speed = player.speed();
-            player.set_speed(speed * 1.2);
-        }
+    if keyboard_input.just_pressed(KeyCode::Up) {
+        let speed = player.speed();
+        player.set_speed(speed * 1.2);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Down) {
-            let speed = player.speed();
-            player.set_speed(speed * 0.8);
-        }
+    if keyboard_input.just_pressed(KeyCode::Down) {
+        let speed = player.speed();
+        player.set_speed(speed * 0.8);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Left) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed - 0.1);
-        }
+    if keyboard_input.just_pressed(KeyCode::Left) {
+        let elapsed = player.elapsed();
+        player.set_elapsed(elapsed - 0.1);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Right) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed + 0.1);
-        }
+    if keyboard_input.just_pressed(KeyCode::Right) {
+        let elapsed = player.elapsed();
+        player.set_elapsed(elapsed + 0.1);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Return) {
-            *current_animation = (*current_animation + 1) % animations.0.len();
-            player
-                .play(animations.0[*current_animation].clone_weak())
-                .repeat();
-        }
+    if keyboard_input.just_pressed(KeyCode::Return) {
+        *current_animation = (*current_animation + 1) % animations.0.len();
+        player
+            .play(animations.0[*current_animation].clone_weak())
+            .repeat();
     }
 }

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -88,18 +88,17 @@ fn handle_tasks(
     box_material_handle: Res<BoxMaterialHandle>,
 ) {
     for (entity, mut task) in &mut transform_tasks {
-        if let Some(transform) = future::block_on(future::poll_once(&mut task.0)) {
-            // Add our new PbrBundle of components to our tagged entity
-            commands.entity(entity).insert(PbrBundle {
-                mesh: box_mesh_handle.clone(),
-                material: box_material_handle.clone(),
-                transform,
-                ..default()
-            });
+        let Some(transform) = future::block_on(future::poll_once(&mut task.0)) else { continue };
+        // Add our new PbrBundle of components to our tagged entity
+        commands.entity(entity).insert(PbrBundle {
+            mesh: box_mesh_handle.clone(),
+            material: box_material_handle.clone(),
+            transform,
+            ..default()
+        });
 
-            // Task is complete, so remove task component from entity
-            commands.entity(entity).remove::<ComputeTransform>();
-        }
+        // Task is complete, so remove task component from entity
+        commands.entity(entity).remove::<ComputeTransform>();
     }
 }
 

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -53,11 +53,10 @@ fn volume(
     audio_sinks: Res<Assets<AudioSink>>,
     music_controller: Res<MusicController>,
 ) {
-    if let Some(sink) = audio_sinks.get(&music_controller.0) {
-        if keyboard_input.just_pressed(KeyCode::Plus) {
-            sink.set_volume(sink.volume() + 0.1);
-        } else if keyboard_input.just_pressed(KeyCode::Minus) {
-            sink.set_volume(sink.volume() - 0.1);
-        }
+    let Some(sink) = audio_sinks.get(&music_controller.0) else { return };
+    if keyboard_input.just_pressed(KeyCode::Plus) {
+        sink.set_volume(sink.volume() + 0.1);
+    } else if keyboard_input.just_pressed(KeyCode::Minus) {
+        sink.set_volume(sink.volume() - 0.1);
     }
 }

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -54,9 +54,7 @@ fn remove_component(
 fn react_on_removal(removed: RemovedComponents<MyComponent>, mut query: Query<&mut Sprite>) {
     // `RemovedComponents<T>::iter()` returns an interator with the `Entity`s that had their
     // `Component` `T` (in this case `MyComponent`) removed at some point earlier during the frame.
-    for entity in removed.iter() {
-        if let Ok(mut sprite) = query.get_mut(entity) {
-            sprite.color.set_r(0.0);
-        }
+    for mut sprite in query.iter_many_mut(&removed) {
+        sprite.color.set_r(0.0);
     }
 }

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -353,13 +353,11 @@ fn spawn_bonus(
 
 // let the cake turn on itself
 fn rotate_bonus(game: Res<Game>, time: Res<Time>, mut transforms: Query<&mut Transform>) {
-    if let Some(entity) = game.bonus.entity {
-        if let Ok(mut cake_transform) = transforms.get_mut(entity) {
-            cake_transform.rotate_y(time.delta_seconds());
-            cake_transform.scale =
-                Vec3::splat(1.0 + (game.score as f32 / 10.0 * time.elapsed_seconds().sin()).abs());
-        }
-    }
+    let Some(entity) = game.bonus.entity else { return } ;
+    let Ok(mut cake_transform) = transforms.get_mut(entity) else { return };
+    cake_transform.rotate_y(time.delta_seconds());
+    cake_transform.scale =
+        Vec3::splat(1.0 + (game.score as f32 / 10.0 * time.elapsed_seconds().sin()).abs());
 }
 
 // update the score displayed during the game

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -360,45 +360,43 @@ fn check_for_collisions(
 
     // check collision with walls
     for (collider_entity, transform, maybe_brick) in &collider_query {
-        let collision = collide(
+        let Some(collision) = collide(
             ball_transform.translation,
             ball_size,
             transform.translation,
             transform.scale.truncate(),
-        );
-        if let Some(collision) = collision {
-            // Sends a collision event so that other systems can react to the collision
-            collision_events.send_default();
+        ) else { continue };
+        // Sends a collision event so that other systems can react to the collision
+        collision_events.send_default();
 
-            // Bricks should be despawned and increment the scoreboard on collision
-            if maybe_brick.is_some() {
-                scoreboard.score += 1;
-                commands.entity(collider_entity).despawn();
-            }
+        // Bricks should be despawned and increment the scoreboard on collision
+        if maybe_brick.is_some() {
+            scoreboard.score += 1;
+            commands.entity(collider_entity).despawn();
+        }
 
-            // reflect the ball when it collides
-            let mut reflect_x = false;
-            let mut reflect_y = false;
+        // reflect the ball when it collides
+        let mut reflect_x = false;
+        let mut reflect_y = false;
 
-            // only reflect if the ball's velocity is going in the opposite direction of the
-            // collision
-            match collision {
-                Collision::Left => reflect_x = ball_velocity.x > 0.0,
-                Collision::Right => reflect_x = ball_velocity.x < 0.0,
-                Collision::Top => reflect_y = ball_velocity.y < 0.0,
-                Collision::Bottom => reflect_y = ball_velocity.y > 0.0,
-                Collision::Inside => { /* do nothing */ }
-            }
+        // only reflect if the ball's velocity is going in the opposite direction of the
+        // collision
+        match collision {
+            Collision::Left => reflect_x = ball_velocity.x > 0.0,
+            Collision::Right => reflect_x = ball_velocity.x < 0.0,
+            Collision::Top => reflect_y = ball_velocity.y < 0.0,
+            Collision::Bottom => reflect_y = ball_velocity.y > 0.0,
+            Collision::Inside => { /* do nothing */ }
+        }
 
-            // reflect velocity on the x-axis if we hit something on the x-axis
-            if reflect_x {
-                ball_velocity.x = -ball_velocity.x;
-            }
+        // reflect velocity on the x-axis if we hit something on the x-axis
+        if reflect_x {
+            ball_velocity.x = -ball_velocity.x;
+        }
 
-            // reflect velocity on the y-axis if we hit something on the y-axis
-            if reflect_y {
-                ball_velocity.y = -ball_velocity.y;
-            }
+        // reflect velocity on the y-axis if we hit something on the y-axis
+        if reflect_y {
+            ball_velocity.y = -ball_velocity.y;
         }
     }
 }

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -117,19 +117,17 @@ fn queue_custom(
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
         for (entity, mesh_uniform, mesh_handle) in &material_meshes {
-            if let Some(mesh) = meshes.get(mesh_handle) {
-                let key =
-                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline = pipelines
-                    .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
-                    .unwrap();
-                transparent_phase.add(Transparent3d {
-                    entity,
-                    pipeline,
-                    draw_function: draw_custom,
-                    distance: rangefinder.distance(&mesh_uniform.transform),
-                });
-            }
+            let Some(mesh) = meshes.get(mesh_handle) else { continue };
+            let key = view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let pipeline = pipelines
+                .specialize(&mut pipeline_cache, &custom_pipeline, key, &mesh.layout)
+                .unwrap();
+            transparent_phase.add(Transparent3d {
+                entity,
+                pipeline,
+                draw_function: draw_custom,
+                distance: rangefinder.distance(&mesh_uniform.transform),
+            });
         }
     }
 }

--- a/examples/tools/scene_viewer/camera_controller_plugin.rs
+++ b/examples/tools/scene_viewer/camera_controller_plugin.rs
@@ -107,82 +107,81 @@ fn camera_controller(
     let window = windows.primary_mut();
     let dt = time.delta_seconds();
 
-    if let Ok((mut transform, mut options)) = query.get_single_mut() {
-        if !options.initialized {
-            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
-            options.yaw = yaw;
-            options.pitch = pitch;
-            options.initialized = true;
-        }
-        if !options.enabled {
-            return;
-        }
+    let Ok((mut transform, mut options)) = query.get_single_mut() else { return };
+    if !options.initialized {
+        let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
+        options.yaw = yaw;
+        options.pitch = pitch;
+        options.initialized = true;
+    }
+    if !options.enabled {
+        return;
+    }
 
-        // Handle key input
-        let mut axis_input = Vec3::ZERO;
-        if key_input.pressed(options.key_forward) {
-            axis_input.z += 1.0;
-        }
-        if key_input.pressed(options.key_back) {
-            axis_input.z -= 1.0;
-        }
-        if key_input.pressed(options.key_right) {
-            axis_input.x += 1.0;
-        }
-        if key_input.pressed(options.key_left) {
-            axis_input.x -= 1.0;
-        }
-        if key_input.pressed(options.key_up) {
-            axis_input.y += 1.0;
-        }
-        if key_input.pressed(options.key_down) {
-            axis_input.y -= 1.0;
-        }
-        if key_input.just_pressed(options.keyboard_key_enable_mouse) {
-            *move_toggled = !*move_toggled;
-        }
+    // Handle key input
+    let mut axis_input = Vec3::ZERO;
+    if key_input.pressed(options.key_forward) {
+        axis_input.z += 1.0;
+    }
+    if key_input.pressed(options.key_back) {
+        axis_input.z -= 1.0;
+    }
+    if key_input.pressed(options.key_right) {
+        axis_input.x += 1.0;
+    }
+    if key_input.pressed(options.key_left) {
+        axis_input.x -= 1.0;
+    }
+    if key_input.pressed(options.key_up) {
+        axis_input.y += 1.0;
+    }
+    if key_input.pressed(options.key_down) {
+        axis_input.y -= 1.0;
+    }
+    if key_input.just_pressed(options.keyboard_key_enable_mouse) {
+        *move_toggled = !*move_toggled;
+    }
 
-        // Apply movement update
-        if axis_input != Vec3::ZERO {
-            let max_speed = if key_input.pressed(options.key_run) {
-                options.run_speed
-            } else {
-                options.walk_speed
-            };
-            options.velocity = axis_input.normalize() * max_speed;
+    // Apply movement update
+    if axis_input != Vec3::ZERO {
+        let max_speed = if key_input.pressed(options.key_run) {
+            options.run_speed
         } else {
-            let friction = options.friction.clamp(0.0, 1.0);
-            options.velocity *= 1.0 - friction;
-            if options.velocity.length_squared() < 1e-6 {
-                options.velocity = Vec3::ZERO;
-            }
+            options.walk_speed
+        };
+        options.velocity = axis_input.normalize() * max_speed;
+    } else {
+        let friction = options.friction.clamp(0.0, 1.0);
+        options.velocity *= 1.0 - friction;
+        if options.velocity.length_squared() < 1e-6 {
+            options.velocity = Vec3::ZERO;
         }
-        let forward = transform.forward();
-        let right = transform.right();
-        transform.translation += options.velocity.x * dt * right
-            + options.velocity.y * dt * Vec3::Y
-            + options.velocity.z * dt * forward;
+    }
+    let forward = transform.forward();
+    let right = transform.right();
+    transform.translation += options.velocity.x * dt * right
+        + options.velocity.y * dt * Vec3::Y
+        + options.velocity.z * dt * forward;
 
-        // Handle mouse input
-        let mut mouse_delta = Vec2::ZERO;
-        if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            window.set_cursor_grab_mode(CursorGrabMode::Locked);
-            window.set_cursor_visibility(false);
+    // Handle mouse input
+    let mut mouse_delta = Vec2::ZERO;
+    if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
+        window.set_cursor_grab_mode(CursorGrabMode::Locked);
+        window.set_cursor_visibility(false);
 
-            for mouse_event in mouse_events.iter() {
-                mouse_delta += mouse_event.delta;
-            }
-        } else {
-            window.set_cursor_grab_mode(CursorGrabMode::None);
-            window.set_cursor_visibility(true);
+        for mouse_event in mouse_events.iter() {
+            mouse_delta += mouse_event.delta;
         }
+    } else {
+        window.set_cursor_grab_mode(CursorGrabMode::None);
+        window.set_cursor_visibility(true);
+    }
 
-        if mouse_delta != Vec2::ZERO {
-            // Apply look update
-            options.pitch = (options.pitch - mouse_delta.y * RADIANS_PER_DOT * options.sensitivity)
-                .clamp(-PI / 2., PI / 2.);
-            options.yaw -= mouse_delta.x * RADIANS_PER_DOT * options.sensitivity;
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
-        }
+    if mouse_delta != Vec2::ZERO {
+        // Apply look update
+        options.pitch = (options.pitch - mouse_delta.y * RADIANS_PER_DOT * options.sensitivity)
+            .clamp(-PI / 2., PI / 2.);
+        options.yaw -= mouse_delta.x * RADIANS_PER_DOT * options.sensitivity;
+        transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
     }
 }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -149,14 +149,13 @@ fn start_animation(
     mut done: Local<bool>,
     scene_handle: Res<SceneHandle>,
 ) {
-    if !*done {
-        if let Ok(mut player) = player.get_single_mut() {
-            if let Some(animation) = scene_handle.animations.first() {
-                player.play(animation.clone_weak()).repeat();
-                *done = true;
-            }
-        }
-    }
+    if *done {
+        return;
+    };
+    let Ok(mut player) = player.get_single_mut() else { return };
+    let Some(animation) = scene_handle.animations.first() else { return };
+    player.play(animation.clone_weak()).repeat();
+    *done = true;
 }
 
 #[cfg(feature = "animation")]

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -170,30 +170,30 @@ fn keyboard_animation_control(
         return;
     }
 
-    if let Ok(mut player) = animation_player.get_single_mut() {
-        if keyboard_input.just_pressed(KeyCode::Space) {
-            if player.is_paused() {
-                player.resume();
-            } else {
-                player.pause();
-            }
-        }
+    let Ok(mut player) = animation_player.get_single_mut() else { return };
 
-        if *changing {
-            // change the animation the frame after return was pressed
-            *current_animation = (*current_animation + 1) % scene_handle.animations.len();
-            player
-                .play(scene_handle.animations[*current_animation].clone_weak())
-                .repeat();
-            *changing = false;
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        if player.is_paused() {
+            player.resume();
+        } else {
+            player.pause();
         }
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Return) {
-            // delay the animation change for one frame
-            *changing = true;
-            // set the current animation to its start and pause it to reset to its starting state
-            player.set_elapsed(0.0).pause();
-        }
+    if *changing {
+        // change the animation the frame after return was pressed
+        *current_animation = (*current_animation + 1) % scene_handle.animations.len();
+        player
+            .play(scene_handle.animations[*current_animation].clone_weak())
+            .repeat();
+        *changing = false;
+    }
+
+    if keyboard_input.just_pressed(KeyCode::Return) {
+        // delay the animation change for one frame
+        *changing = true;
+        // set the current animation to its start and pause it to reset to its starting state
+        player.set_elapsed(0.0).pause();
     }
 }
 

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -37,31 +37,29 @@ fn atlas_render_system(
     font_atlas_sets: Res<Assets<FontAtlasSet>>,
     texture_atlases: Res<Assets<TextureAtlas>>,
 ) {
-    if let Some(set) = font_atlas_sets.get(&state.handle.cast_weak::<FontAtlasSet>()) {
-        if let Some((_size, font_atlas)) = set.iter().next() {
-            let x_offset = state.atlas_count as f32;
-            if state.atlas_count == font_atlas.len() as u32 {
-                return;
-            }
-            let texture_atlas = texture_atlases
-                .get(&font_atlas[state.atlas_count as usize].texture_atlas)
-                .unwrap();
-            state.atlas_count += 1;
-            commands.spawn(ImageBundle {
-                image: texture_atlas.texture.clone().into(),
-                style: Style {
-                    position_type: PositionType::Absolute,
-                    position: UiRect {
-                        top: Val::Px(0.0),
-                        left: Val::Px(512.0 * x_offset),
-                        ..default()
-                    },
-                    ..default()
-                },
-                ..default()
-            });
-        }
+    let Some(set) = font_atlas_sets.get(&state.handle.cast_weak::<FontAtlasSet>()) else { return };
+    let Some((_size, font_atlas)) = set.iter().next() else { return };
+    let x_offset = state.atlas_count as f32;
+    if state.atlas_count == font_atlas.len() as u32 {
+        return;
     }
+    let texture_atlas = texture_atlases
+        .get(&font_atlas[state.atlas_count as usize].texture_atlas)
+        .unwrap();
+    state.atlas_count += 1;
+    commands.spawn(ImageBundle {
+        image: texture_atlas.texture.clone().into(),
+        style: Style {
+            position_type: PositionType::Absolute,
+            position: UiRect {
+                top: Val::Px(0.0),
+                left: Val::Px(512.0 * x_offset),
+                ..default()
+            },
+            ..default()
+        },
+        ..default()
+    });
 }
 
 fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Query<&mut Text>) {

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -92,11 +92,9 @@ fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText
 
 fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
-        if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
-            if let Some(value) = fps.smoothed() {
-                // Update the value of the second section
-                text.sections[1].value = format!("{value:.2}");
-            }
-        }
+        let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) else { continue };
+        let Some(value) = fps.smoothed() else { continue };
+        // Update the value of the second section
+        text.sections[1].value = format!("{value:.2}");
     }
 }

--- a/tools/spancmp/src/main.rs
+++ b/tools/spancmp/src/main.rs
@@ -102,11 +102,9 @@ fn filter_by_threshold(span_stats: &SpanStats, threshold: f32) -> bool {
 }
 
 fn filter_by_pattern(name: &str, pattern: Option<&Regex>) -> bool {
-    if let Some(pattern) = pattern {
-        pattern.is_match(name)
-    } else {
-        true
-    }
+    pattern
+        .map(|pattern| pattern.is_match(name))
+        .unwrap_or(true)
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
# Objective
Improve the code quality of Bevy. The heavy use of `if let X = ...`  results in a relentless push to the right as we nest more and more layers inward. This PR aims to reduce that.

## Solution
Use `let-else` over `if let X = ...` where possible to reduce heavy indentation, as well as use `Option` and `Result` combinators.

This PR seemingly has a huge change, but most of these are indentation changes and no logic in the code has been changed.