### PR TITLE
[Merged by Bors] - Fix a miscompilation with `#[derive(SystemParam)]`

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -484,7 +484,8 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             }
 
             #[doc(hidden)]
-            #state_struct_visibility struct FetchState <'w, 's, #(#lifetimeless_generics,)*> {
+            #state_struct_visibility struct FetchState <'w, 's, #(#lifetimeless_generics,)*>
+            #where_clause {
                 state: (#(<#tuple_types as #path::system::SystemParam>::State,)*),
                 marker: std::marker::PhantomData<(
                     <#path::prelude::Query<'w, 's, ()> as #path::system::SystemParam>::State,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1815,4 +1815,13 @@ mod tests {
 
     #[derive(SystemParam)]
     pub struct EncapsulatedParam<'w>(Res<'w, PrivateResource>);
+
+    // regression test for https://github.com/bevyengine/bevy/issues/7103.
+    #[derive(SystemParam)]
+    pub struct WhereParam<'w, 's, Q>
+    where
+        Q: 'static + WorldQuery,
+    {
+        _q: Query<'w, 's, Q, ()>,
+    }
 }


### PR DESCRIPTION
# Objective

- Fix #7103.
- The issue is caused because I forgot to add a where clause to a generated struct in #7056.

## Solution

- Add the where clause.
