### PR TITLE
Rename bevy_reflect Array to Sequence

### DIFF
--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -3,11 +3,12 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    Array, ArrayIter, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Reflect,
-    ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed,
+    FromReflect, FromType, GetTypeRegistration, List, ListInfo, Reflect, ReflectFromPtr,
+    ReflectMut, ReflectOwned, ReflectRef, Sequence, SequenceIter, TypeInfo, TypeRegistration,
+    Typed,
 };
 
-impl<T: smallvec::Array + Send + Sync + 'static> Array for SmallVec<T>
+impl<T: smallvec::Array + Send + Sync + 'static> Sequence for SmallVec<T>
 where
     T::Item: FromReflect,
 {
@@ -31,9 +32,9 @@ where
         <SmallVec<T>>::len(self)
     }
 
-    fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
+    fn iter(&self) -> SequenceIter {
+        SequenceIter {
+            sequence: self,
             index: 0,
         }
     }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,12 +1,12 @@
 #![doc = include_str!("../README.md")]
 
-mod array;
 mod fields;
 mod from_reflect;
 mod list;
 mod map;
 mod path;
 mod reflect;
+mod sequence;
 mod struct_trait;
 mod tuple;
 mod tuple_struct;
@@ -45,7 +45,6 @@ pub mod prelude {
     };
 }
 
-pub use array::*;
 pub use enums::*;
 pub use fields::*;
 pub use from_reflect::*;
@@ -54,6 +53,7 @@ pub use list::*;
 pub use map::*;
 pub use path::*;
 pub use reflect::*;
+pub use sequence::*;
 pub use struct_trait::*;
 pub use tuple::*;
 pub use tuple_struct::*;
@@ -432,8 +432,8 @@ mod tests {
         });
         foo_patch.insert("g", composite);
 
-        let array = DynamicArray::from_vec(vec![2u32, 2u32]);
-        foo_patch.insert("h", array);
+        let sequence = DynamicSequence::from_vec(vec![2u32, 2u32]);
+        foo_patch.insert("h", sequence);
 
         foo.apply(&foo_patch);
 
@@ -570,8 +570,8 @@ mod tests {
 
     #[test]
     fn should_drain_fields() {
-        let array_value: Box<dyn Array> = Box::new([123_i32, 321_i32]);
-        let fields = array_value.drain();
+        let sequence_value: Box<dyn Sequence> = Box::new([123_i32, 321_i32]);
+        let fields = sequence_value.drain();
         assert!(fields[0].reflect_partial_eq(&123_i32).unwrap_or_default());
         assert!(fields[1].reflect_partial_eq(&321_i32).unwrap_or_default());
 
@@ -610,9 +610,9 @@ mod tests {
         let dyn_list = List::clone_dynamic(&list);
         assert_eq!(dyn_list.type_name(), std::any::type_name::<Vec<usize>>());
 
-        let array = [b'0'; 4];
-        let dyn_array = Array::clone_dynamic(&array);
-        assert_eq!(dyn_array.type_name(), std::any::type_name::<[u8; 4]>());
+        let sequence = [b'0'; 4];
+        let dyn_sequence = Sequence::clone_dynamic(&sequence);
+        assert_eq!(dyn_sequence.type_name(), std::any::type_name::<[u8; 4]>());
 
         let map = HashMap::<usize, String>::default();
         let dyn_map = map.clone_dynamic();
@@ -810,7 +810,7 @@ mod tests {
         type MyArray = [usize; 3];
 
         let info = MyArray::type_info();
-        if let TypeInfo::Array(info) = info {
+        if let TypeInfo::Sequence(info) = info {
             assert!(info.is::<MyArray>());
             assert!(info.item_is::<usize>());
             assert_eq!(std::any::type_name::<MyArray>(), info.type_name());
@@ -1064,7 +1064,7 @@ mod tests {
         struct Test {
             value: usize,
             list: Vec<String>,
-            array: [f32; 3],
+            sequence: [f32; 3],
             map: HashMap<i32, f32>,
             a_struct: SomeStruct,
             a_tuple_struct: SomeTupleStruct,
@@ -1107,7 +1107,7 @@ mod tests {
         let test = Test {
             value: 123,
             list: vec![String::from("A"), String::from("B"), String::from("C")],
-            array: [1.0, 2.0, 3.0],
+            sequence: [1.0, 2.0, 3.0],
             map,
             a_struct: SomeStruct {
                 foo: String::from("A Struct!"),
@@ -1129,7 +1129,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
         "B",
         "C",
     ],
-    array: [
+    sequence: [
         1.0,
         2.0,
         3.0,

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -3,19 +3,19 @@ use std::fmt::{Debug, Formatter};
 
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
-    Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectOwned,
-    ReflectRef, TypeInfo, Typed,
+    DynamicInfo, DynamicSequence, FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef,
+    Sequence, SequenceIter, TypeInfo, Typed,
 };
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
 ///
-/// This is a sub-trait of [`Array`] as it implements a [`push`](List::push) function, allowing
+/// This is a sub-trait of [`Sequence`] as it implements a [`push`](List::push) function, allowing
 /// it's internal size to grow.
 ///
 /// This trait expects index 0 to contain the _front_ element.
 /// The _back_ element must refer to the element with the largest index.
 /// These two rules above should be upheld by manual implementors.
-pub trait List: Reflect + Array {
+pub trait List: Reflect + Sequence {
     /// Appends an element to the _back_ of the list.
     fn push(&mut self, value: Box<dyn Reflect>);
 
@@ -137,7 +137,7 @@ impl DynamicList {
     }
 }
 
-impl Array for DynamicList {
+impl Sequence for DynamicList {
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         self.values.get(index).map(|value| &**value)
     }
@@ -150,9 +150,9 @@ impl Array for DynamicList {
         self.values.len()
     }
 
-    fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
+    fn iter(&self) -> SequenceIter {
+        SequenceIter {
+            sequence: self,
             index: 0,
         }
     }
@@ -161,8 +161,8 @@ impl Array for DynamicList {
         self.values
     }
 
-    fn clone_dynamic(&self) -> DynamicArray {
-        DynamicArray {
+    fn clone_dynamic(&self) -> DynamicSequence {
+        DynamicSequence {
             name: self.name.clone(),
             values: self
                 .values
@@ -267,7 +267,7 @@ impl Reflect for DynamicList {
 
     #[inline]
     fn reflect_hash(&self) -> Option<u64> {
-        crate::array_hash(self)
+        crate::sequence_hash(self)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -1,7 +1,7 @@
 use crate::{
-    array_debug, enum_debug, list_debug, map_debug, serde::Serializable, struct_debug, tuple_debug,
-    tuple_struct_debug, Array, Enum, List, Map, Struct, Tuple, TupleStruct, TypeInfo, Typed,
-    ValueInfo,
+    enum_debug, list_debug, map_debug, sequence_debug, serde::Serializable, struct_debug,
+    tuple_debug, tuple_struct_debug, Enum, List, Map, Sequence, Struct, Tuple, TupleStruct,
+    TypeInfo, Typed, ValueInfo,
 };
 use std::{
     any::{self, Any, TypeId},
@@ -22,7 +22,7 @@ pub enum ReflectRef<'a> {
     TupleStruct(&'a dyn TupleStruct),
     Tuple(&'a dyn Tuple),
     List(&'a dyn List),
-    Array(&'a dyn Array),
+    Sequence(&'a dyn Sequence),
     Map(&'a dyn Map),
     Enum(&'a dyn Enum),
     Value(&'a dyn Reflect),
@@ -39,7 +39,7 @@ pub enum ReflectMut<'a> {
     TupleStruct(&'a mut dyn TupleStruct),
     Tuple(&'a mut dyn Tuple),
     List(&'a mut dyn List),
-    Array(&'a mut dyn Array),
+    Sequence(&'a mut dyn Sequence),
     Map(&'a mut dyn Map),
     Enum(&'a mut dyn Enum),
     Value(&'a mut dyn Reflect),
@@ -56,7 +56,7 @@ pub enum ReflectOwned {
     TupleStruct(Box<dyn TupleStruct>),
     Tuple(Box<dyn Tuple>),
     List(Box<dyn List>),
-    Array(Box<dyn Array>),
+    Sequence(Box<dyn Sequence>),
     Map(Box<dyn Map>),
     Enum(Box<dyn Enum>),
     Value(Box<dyn Reflect>),
@@ -64,7 +64,7 @@ pub enum ReflectOwned {
 
 /// A reflected Rust type.
 ///
-/// Methods for working with particular kinds of Rust type are available using the [`Array`], [`List`],
+/// Methods for working with particular kinds of Rust type are available using the [`Sequence`], [`List`],
 /// [`Map`], [`Tuple`], [`TupleStruct`], [`Struct`], and [`Enum`] subtraits.
 ///
 /// When using `#[derive(Reflect)]` on a struct, tuple struct or enum, the suitable subtrait for that
@@ -115,7 +115,7 @@ pub trait Reflect: Any + Send + Sync {
     ///   the variant of `value`. The corresponding fields of that variant are
     ///   applied from `value` onto `self`. Fields which are not present in both
     ///   values are ignored.
-    /// - If `T` is a [`List`] or [`Array`], then each element of `value` is applied
+    /// - If `T` is a [`List`] or [`Sequence`], then each element of `value` is applied
     ///   to the corresponding element of `self`. Up to `self.len()` items are applied,
     ///   and excess elements in `value` are appended to `self`.
     /// - If `T` is a [`Map`], then for each key in `value`, the associated
@@ -200,7 +200,7 @@ pub trait Reflect: Any + Send + Sync {
             ReflectRef::TupleStruct(dyn_tuple_struct) => tuple_struct_debug(dyn_tuple_struct, f),
             ReflectRef::Tuple(dyn_tuple) => tuple_debug(dyn_tuple, f),
             ReflectRef::List(dyn_list) => list_debug(dyn_list, f),
-            ReflectRef::Array(dyn_array) => array_debug(dyn_array, f),
+            ReflectRef::Sequence(dyn_sequence) => sequence_debug(dyn_sequence, f),
             ReflectRef::Map(dyn_map) => map_debug(dyn_map, f),
             ReflectRef::Enum(dyn_enum) => enum_debug(dyn_enum, f),
             _ => write!(f, "Reflect({})", self.type_name()),

--- a/crates/bevy_reflect/src/sequence.rs
+++ b/crates/bevy_reflect/src/sequence.rs
@@ -8,17 +8,17 @@ use std::{
     hash::{Hash, Hasher},
 };
 
-/// A static-sized array of [`Reflect`] items.
+/// A static-sized sequence of [`Reflect`] items.
 ///
-/// This corresponds to types like `[T; N]` (arrays).
+/// This corresponds to types like `[T; N]` (sequences).
 ///
-/// Currently, this only supports arrays of up to 32 items. It can technically
+/// Currently, this only supports sequences of up to 32 items. It can technically
 /// contain more than 32, but the blanket [`GetTypeRegistration`] is only
 /// implemented up to the 32 item limit due to a [limitation] on `Deserialize`.
 ///
 /// [`GetTypeRegistration`]: crate::GetTypeRegistration
 /// [limitation]: https://github.com/serde-rs/serde/issues/1937
-pub trait Array: Reflect {
+pub trait Sequence: Reflect {
     /// Returns a reference to the element at `index`, or `None` if out of bounds.
     fn get(&self, index: usize) -> Option<&dyn Reflect>;
     /// Returns a mutable reference to the element at `index`, or `None` if out of bounds.
@@ -30,21 +30,21 @@ pub trait Array: Reflect {
         self.len() == 0
     }
     /// Returns an iterator over the collection.
-    fn iter(&self) -> ArrayIter;
-    /// Drain the elements of this array to get a vector of owned values.
+    fn iter(&self) -> SequenceIter;
+    /// Drain the elements of this sequence to get a vector of owned values.
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>>;
 
-    fn clone_dynamic(&self) -> DynamicArray {
-        DynamicArray {
+    fn clone_dynamic(&self) -> DynamicSequence {
+        DynamicSequence {
             name: self.type_name().to_string(),
             values: self.iter().map(|value| value.clone_value()).collect(),
         }
     }
 }
 
-/// A container for compile-time array info.
+/// A container for compile-time sequence info.
 #[derive(Clone, Debug)]
-pub struct ArrayInfo {
+pub struct SequenceInfo {
     type_name: &'static str,
     type_id: TypeId,
     item_type_name: &'static str,
@@ -54,17 +54,17 @@ pub struct ArrayInfo {
     docs: Option<&'static str>,
 }
 
-impl ArrayInfo {
-    /// Create a new [`ArrayInfo`].
+impl SequenceInfo {
+    /// Create a new [`SequenceInfo`].
     ///
     /// # Arguments
     ///
-    /// * `capacity`: The maximum capacity of the underlying array.
+    /// * `capacity`: The maximum capacity of the underlying sequence.
     ///
-    pub fn new<TArray: Array, TItem: Reflect>(capacity: usize) -> Self {
+    pub fn new<TSequence: Sequence, TItem: Reflect>(capacity: usize) -> Self {
         Self {
-            type_name: std::any::type_name::<TArray>(),
-            type_id: TypeId::of::<TArray>(),
+            type_name: std::any::type_name::<TSequence>(),
+            type_id: TypeId::of::<TSequence>(),
             item_type_name: std::any::type_name::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             capacity,
@@ -73,52 +73,52 @@ impl ArrayInfo {
         }
     }
 
-    /// Sets the docstring for this array.
+    /// Sets the docstring for this sequence.
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
     }
 
-    /// The compile-time capacity of the array.
+    /// The compile-time capacity of the sequence.
     pub fn capacity(&self) -> usize {
         self.capacity
     }
 
-    /// The [type name] of the array.
+    /// The [type name] of the sequence.
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
         self.type_name
     }
 
-    /// The [`TypeId`] of the array.
+    /// The [`TypeId`] of the sequence.
     pub fn type_id(&self) -> TypeId {
         self.type_id
     }
 
-    /// Check if the given type matches the array type.
+    /// Check if the given type matches the sequence type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The [type name] of the array item.
+    /// The [type name] of the sequence item.
     ///
     /// [type name]: std::any::type_name
     pub fn item_type_name(&self) -> &'static str {
         self.item_type_name
     }
 
-    /// The [`TypeId`] of the array item.
+    /// The [`TypeId`] of the sequence item.
     pub fn item_type_id(&self) -> TypeId {
         self.item_type_id
     }
 
-    /// Check if the given type matches the array item type.
+    /// Check if the given type matches the sequence item type.
     pub fn item_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.item_type_id
     }
 
-    /// The docstring of this array, if any.
+    /// The docstring of this sequence, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
@@ -127,20 +127,20 @@ impl ArrayInfo {
 
 /// A fixed-size list of reflected values.
 ///
-/// This differs from [`DynamicList`] in that the size of the [`DynamicArray`]
+/// This differs from [`DynamicList`] in that the size of the [`DynamicSequence`]
 /// is constant, whereas a [`DynamicList`] can have items added and removed.
 ///
-/// This isn't to say that a [`DynamicArray`] is immutable— its items
+/// This isn't to say that a [`DynamicSequence`] is immutable— its items
 /// can be mutated— just that the _number_ of items cannot change.
 ///
 /// [`DynamicList`]: crate::DynamicList
 #[derive(Debug)]
-pub struct DynamicArray {
+pub struct DynamicSequence {
     pub(crate) name: String,
     pub(crate) values: Box<[Box<dyn Reflect>]>,
 }
 
-impl DynamicArray {
+impl DynamicSequence {
     #[inline]
     pub fn new(values: Box<[Box<dyn Reflect>]>) -> Self {
         Self {
@@ -171,7 +171,7 @@ impl DynamicArray {
     }
 }
 
-impl Reflect for DynamicArray {
+impl Reflect for DynamicSequence {
     #[inline]
     fn type_name(&self) -> &str {
         self.name.as_str()
@@ -213,7 +213,7 @@ impl Reflect for DynamicArray {
     }
 
     fn apply(&mut self, value: &dyn Reflect) {
-        array_apply(self, value);
+        sequence_apply(self, value);
     }
 
     #[inline]
@@ -224,17 +224,17 @@ impl Reflect for DynamicArray {
 
     #[inline]
     fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Array(self)
+        ReflectRef::Sequence(self)
     }
 
     #[inline]
     fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Array(self)
+        ReflectMut::Sequence(self)
     }
 
     #[inline]
     fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Array(self)
+        ReflectOwned::Sequence(self)
     }
 
     #[inline]
@@ -244,15 +244,15 @@ impl Reflect for DynamicArray {
 
     #[inline]
     fn reflect_hash(&self) -> Option<u64> {
-        array_hash(self)
+        sequence_hash(self)
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        array_partial_eq(self, value)
+        sequence_partial_eq(self, value)
     }
 }
 
-impl Array for DynamicArray {
+impl Sequence for DynamicSequence {
     #[inline]
     fn get(&self, index: usize) -> Option<&dyn Reflect> {
         self.values.get(index).map(|value| &**value)
@@ -269,9 +269,9 @@ impl Array for DynamicArray {
     }
 
     #[inline]
-    fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
+    fn iter(&self) -> SequenceIter {
+        SequenceIter {
+            sequence: self,
             index: 0,
         }
     }
@@ -282,8 +282,8 @@ impl Array for DynamicArray {
     }
 
     #[inline]
-    fn clone_dynamic(&self) -> DynamicArray {
-        DynamicArray {
+    fn clone_dynamic(&self) -> DynamicSequence {
+        DynamicSequence {
             name: self.name.clone(),
             values: self
                 .values
@@ -294,81 +294,81 @@ impl Array for DynamicArray {
     }
 }
 
-impl Typed for DynamicArray {
+impl Typed for DynamicSequence {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
         CELL.get_or_set(|| TypeInfo::Dynamic(DynamicInfo::new::<Self>()))
     }
 }
 
-/// An iterator over an [`Array`].
-pub struct ArrayIter<'a> {
-    pub(crate) array: &'a dyn Array,
+/// An iterator over a [`Sequence`].
+pub struct SequenceIter<'a> {
+    pub(crate) sequence: &'a dyn Sequence,
     pub(crate) index: usize,
 }
 
-impl<'a> Iterator for ArrayIter<'a> {
+impl<'a> Iterator for SequenceIter<'a> {
     type Item = &'a dyn Reflect;
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        let value = self.array.get(self.index);
+        let value = self.sequence.get(self.index);
         self.index += 1;
         value
     }
 
     #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
-        let size = self.array.len();
+        let size = self.sequence.len();
         (size, Some(size))
     }
 }
 
-impl<'a> ExactSizeIterator for ArrayIter<'a> {}
+impl<'a> ExactSizeIterator for SequenceIter<'a> {}
 
-/// Returns the `u64` hash of the given [array](Array).
+/// Returns the `u64` hash of the given [sequence](Sequence).
 #[inline]
-pub fn array_hash<A: Array>(array: &A) -> Option<u64> {
+pub fn sequence_hash<S: Sequence>(sequence: &S) -> Option<u64> {
     let mut hasher = crate::ReflectHasher::default();
-    std::any::Any::type_id(array).hash(&mut hasher);
-    array.len().hash(&mut hasher);
-    for value in array.iter() {
+    std::any::Any::type_id(sequence).hash(&mut hasher);
+    sequence.len().hash(&mut hasher);
+    for value in sequence.iter() {
         hasher.write_u64(value.reflect_hash()?);
     }
     Some(hasher.finish())
 }
 
-/// Applies the reflected [array](Array) data to the given [array](Array).
+/// Applies the reflected [sequence](Sequence) data to the given [sequence](Sequence).
 ///
 /// # Panics
 ///
-/// * Panics if the two arrays have differing lengths.
-/// * Panics if the reflected value is not a [valid array](ReflectRef::Array).
+/// * Panics if the two sequences have differing lengths.
+/// * Panics if the reflected value is not a [valid sequence](ReflectRef::Sequence).
 ///
 #[inline]
-pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
-    if let ReflectRef::Array(reflect_array) = reflect.reflect_ref() {
-        if array.len() != reflect_array.len() {
-            panic!("Attempted to apply different sized `Array` types.");
+pub fn sequence_apply<S: Sequence>(sequence: &mut S, reflect: &dyn Reflect) {
+    if let ReflectRef::Sequence(reflect_sequence) = reflect.reflect_ref() {
+        if sequence.len() != reflect_sequence.len() {
+            panic!("Attempted to apply different sized `Sequence` types.");
         }
-        for (i, value) in reflect_array.iter().enumerate() {
-            let v = array.get_mut(i).unwrap();
+        for (i, value) in reflect_sequence.iter().enumerate() {
+            let v = sequence.get_mut(i).unwrap();
             v.apply(value);
         }
     } else {
-        panic!("Attempted to apply a non-`Array` type to an `Array` type.");
+        panic!("Attempted to apply a non-`Sequence` type to an `Sequence` type.");
     }
 }
 
-/// Compares two [arrays](Array) (one concrete and one reflected) to see if they
+/// Compares two [sequences](Sequence) (one concrete and one reflected) to see if they
 /// are equal.
 ///
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
-pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bool> {
+pub fn sequence_partial_eq<S: Sequence>(sequence: &S, reflect: &dyn Reflect) -> Option<bool> {
     match reflect.reflect_ref() {
-        ReflectRef::Array(reflect_array) if reflect_array.len() == array.len() => {
-            for (a, b) in array.iter().zip(reflect_array.iter()) {
+        ReflectRef::Sequence(reflect_sequence) if reflect_sequence.len() == sequence.len() => {
+            for (a, b) in sequence.iter().zip(reflect_sequence.iter()) {
                 let eq_result = a.reflect_partial_eq(b);
                 if let failed @ (Some(false) | None) = eq_result {
                     return failed;
@@ -381,14 +381,14 @@ pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bo
     Some(true)
 }
 
-/// The default debug formatter for [`Array`] types.
+/// The default debug formatter for [`Sequence`] types.
 ///
 /// # Example
 /// ```
 /// use bevy_reflect::Reflect;
 ///
-/// let my_array: &dyn Reflect = &[1, 2, 3];
-/// println!("{:#?}", my_array);
+/// let my_sequence: &dyn Reflect = &[1, 2, 3];
+/// println!("{:#?}", my_sequence);
 ///
 /// // Output:
 ///
@@ -399,9 +399,12 @@ pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bo
 /// // ]
 /// ```
 #[inline]
-pub fn array_debug(dyn_array: &dyn Array, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+pub fn sequence_debug(
+    dyn_sequence: &dyn Sequence,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
     let mut debug = f.debug_list();
-    for item in dyn_array.iter() {
+    for item in dyn_sequence.iter() {
         debug.entry(&item as &dyn Debug);
     }
     debug.finish()

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
+    Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Sequence, Struct, Tuple, TupleStruct,
     TypeInfo, TypeRegistry, VariantInfo, VariantType,
 };
 use serde::ser::{
@@ -141,8 +141,8 @@ impl<'a> Serialize for TypedReflectSerializer<'a> {
                 registry: self.registry,
             }
             .serialize(serializer),
-            ReflectRef::Array(value) => ArraySerializer {
-                array: value,
+            ReflectRef::Sequence(value) => SequenceSerializer {
+                sequence: value,
                 registry: self.registry,
             }
             .serialize(serializer),
@@ -448,18 +448,18 @@ impl<'a> Serialize for ListSerializer<'a> {
     }
 }
 
-pub struct ArraySerializer<'a> {
-    pub array: &'a dyn Array,
+pub struct SequenceSerializer<'a> {
+    pub sequence: &'a dyn Sequence,
     pub registry: &'a TypeRegistry,
 }
 
-impl<'a> Serialize for ArraySerializer<'a> {
+impl<'a> Serialize for SequenceSerializer<'a> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_tuple(self.array.len())?;
-        for value in self.array.iter() {
+        let mut state = serializer.serialize_tuple(self.sequence.len())?;
+        for value in self.sequence.iter() {
             state.serialize_element(&TypedReflectSerializer::new(value, self.registry))?;
         }
         state.end()
@@ -484,7 +484,7 @@ mod tests {
         option_value_complex: Option<SomeStruct>,
         tuple_value: (f32, usize),
         list_value: Vec<i32>,
-        array_value: [i32; 5],
+        sequence_value: [i32; 5],
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
         tuple_struct_value: SomeTupleStruct,
@@ -583,7 +583,7 @@ mod tests {
             option_value_complex: Some(SomeStruct { foo: 123 }),
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
+            sequence_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
             tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
@@ -629,7 +629,7 @@ mod tests {
             1,
             2,
         ],
-        array_value: (-2, -1, 0, 1, 2),
+        sequence_value: (-2, -1, 0, 1, 2),
         map_value: {
             64: 32,
         },
@@ -783,7 +783,7 @@ mod tests {
             option_value_complex: Some(SomeStruct { foo: 123 }),
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
+            sequence_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
             tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
@@ -841,7 +841,7 @@ mod tests {
             option_value_complex: Some(SomeStruct { foo: 123 }),
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
+            sequence_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
             tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ArrayInfo, EnumInfo, ListInfo, MapInfo, Reflect, StructInfo, TupleInfo, TupleStructInfo,
+    EnumInfo, ListInfo, MapInfo, Reflect, SequenceInfo, StructInfo, TupleInfo, TupleStructInfo,
 };
 use std::any::{Any, TypeId};
 
@@ -101,7 +101,7 @@ pub enum TypeInfo {
     TupleStruct(TupleStructInfo),
     Tuple(TupleInfo),
     List(ListInfo),
-    Array(ArrayInfo),
+    Sequence(SequenceInfo),
     Map(MapInfo),
     Enum(EnumInfo),
     Value(ValueInfo),
@@ -119,7 +119,7 @@ impl TypeInfo {
             Self::TupleStruct(info) => info.type_id(),
             Self::Tuple(info) => info.type_id(),
             Self::List(info) => info.type_id(),
-            Self::Array(info) => info.type_id(),
+            Self::Sequence(info) => info.type_id(),
             Self::Map(info) => info.type_id(),
             Self::Enum(info) => info.type_id(),
             Self::Value(info) => info.type_id(),
@@ -136,7 +136,7 @@ impl TypeInfo {
             Self::TupleStruct(info) => info.type_name(),
             Self::Tuple(info) => info.type_name(),
             Self::List(info) => info.type_name(),
-            Self::Array(info) => info.type_name(),
+            Self::Sequence(info) => info.type_name(),
             Self::Map(info) => info.type_name(),
             Self::Enum(info) => info.type_name(),
             Self::Value(info) => info.type_name(),
@@ -157,7 +157,7 @@ impl TypeInfo {
             Self::TupleStruct(info) => info.docs(),
             Self::Tuple(info) => info.docs(),
             Self::List(info) => info.docs(),
-            Self::Array(info) => info.docs(),
+            Self::Sequence(info) => info.docs(),
             Self::Map(info) => info.docs(),
             Self::Enum(info) => info.docs(),
             Self::Value(info) => info.docs(),

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -97,10 +97,10 @@ fn setup() {
         // This exposes "list" operations on your type, such as insertion. `List` is automatically
         // implemented for relevant core types like Vec<T>.
         ReflectRef::List(_) => {}
-        // `Array` is a special trait that can be manually implemented (instead of deriving Reflect).
-        // This exposes "array" operations on your type, such as indexing. `Array`
+        // `Sequence` is a special trait that can be manually implemented (instead of deriving Reflect).
+        // This exposes "Sequence" operations on your type, such as indexing. `Sequence`
         // is automatically implemented for relevant core types like [T; N].
-        ReflectRef::Array(_) => {}
+        ReflectRef::Sequence(_) => {}
         // `Map` is a special trait that can be manually implemented (instead of deriving Reflect).
         // This exposes "map" operations on your type, such as getting / inserting by key.
         // Map is automatically implemented for relevant core types like HashMap<K, V>


### PR DESCRIPTION
Renamed bevy_reflect Array to Sequence and all associated types, traits and functions.
Fixed accompanying documentation, tests and examples.

# Objective
Fixes #7059 

## Solution
Renamed Array to Sequence and made sure it is propagated where needed.

---

## Changelog
### Changed
bevy_reflect::Array to bevy_reflect::Sequence
