### PR TITLE
[Merged by Bors] - bevy_render: Run calculate_bounds in the end-of-update exclusive systems

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -189,7 +189,6 @@ impl Plugin for PbrPlugin {
                 check_light_mesh_visibility
                     .label(SimulationLightSystems::CheckLightVisibility)
                     .after(TransformSystem::TransformPropagate)
-                    .after(VisibilitySystems::CalculateBounds)
                     .after(SimulationLightSystems::UpdateLightFrusta)
                     // NOTE: This MUST be scheduled AFTER the core renderer visibility check
                     // because that resets entity ComputedVisibility for the first view

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -212,7 +212,7 @@ impl Plugin for VisibilityPlugin {
 
         app.add_system_to_stage(
             CoreStage::PostUpdate,
-            calculate_bounds.label(CalculateBounds),
+            calculate_bounds.label(CalculateBounds).before_commands(),
         )
         .add_system_to_stage(
             CoreStage::PostUpdate,
@@ -252,7 +252,6 @@ impl Plugin for VisibilityPlugin {
             CoreStage::PostUpdate,
             check_visibility
                 .label(CheckVisibility)
-                .after(CalculateBounds)
                 .after(UpdateOrthographicFrusta)
                 .after(UpdatePerspectiveFrusta)
                 .after(UpdateProjectionFrusta)


### PR DESCRIPTION
# Objective

- Avoid slower than necessary first frame after spawning many entities due to them not having `Aabb`s and so being marked visible
  - Avoids unnecessarily large system and VRAM allocations as a consequence

## Solution

- I noticed when debugging the `many_cubes` stress test in Xcode that the `MeshUniform` binding was much larger than it needed to be. I realised that this was because initially, all mesh entities are marked as being visible because they don't have `Aabb`s because `calculate_bounds` is being run in `PostUpdate` and there are no system commands applications before executing the visibility check systems that need the `Aabb`s. The solution then is to run the `calculate_bounds` system just before the previous system commands are applied which is at the end of the `Update` stage.