### PR TITLE
fix identation in `Typed` exmaple

### DIFF
--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -28,40 +28,40 @@ use std::any::{Any, TypeId};
 /// use bevy_reflect::Typed;
 ///
 /// struct MyStruct {
-///   foo: usize,
-///   bar: (f32, f32)
+///     foo: usize,
+///     bar: (f32, f32)
 /// }
 ///
 /// impl Typed for MyStruct {
-///   fn type_info() -> &'static TypeInfo {
-///     static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
-///     CELL.get_or_set(|| {
-///       let fields = [
-///         NamedField::new::<usize >("foo"),
-///         NamedField::new::<(f32, f32) >("bar"),
-///       ];
-///       let info = StructInfo::new::<Self>("MyStruct", &fields);
-///       TypeInfo::Struct(info)
-///     })
-///   }
+///     fn type_info() -> &'static TypeInfo {
+///         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
+///         CELL.get_or_set(|| {
+///             let fields = [
+///                 NamedField::new::<usize >("foo"),
+///                 NamedField::new::<(f32, f32) >("bar"),
+///             ];
+///             let info = StructInfo::new::<Self>("MyStruct", &fields);
+///             TypeInfo::Struct(info)
+///         })
+///     }
 /// }
 ///
 /// #
 /// # impl Reflect for MyStruct {
-/// #   fn type_name(&self) -> &str { todo!() }
-/// #   fn get_type_info(&self) -> &'static TypeInfo { todo!() }
-/// #   fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
-/// #   fn as_any(&self) -> &dyn Any { todo!() }
-/// #   fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
-/// #   fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
-/// #   fn as_reflect(&self) -> &dyn Reflect { todo!() }
-/// #   fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
-/// #   fn apply(&mut self, value: &dyn Reflect) { todo!() }
-/// #   fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
-/// #   fn reflect_ref(&self) -> ReflectRef { todo!() }
-/// #   fn reflect_mut(&mut self) -> ReflectMut { todo!() }
-/// #   fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
-/// #   fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
+/// #     fn type_name(&self) -> &str { todo!() }
+/// #     fn get_type_info(&self) -> &'static TypeInfo { todo!() }
+/// #     fn into_any(self: Box<Self>) -> Box<dyn Any> { todo!() }
+/// #     fn as_any(&self) -> &dyn Any { todo!() }
+/// #     fn as_any_mut(&mut self) -> &mut dyn Any { todo!() }
+/// #     fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> { todo!() }
+/// #     fn as_reflect(&self) -> &dyn Reflect { todo!() }
+/// #     fn as_reflect_mut(&mut self) -> &mut dyn Reflect { todo!() }
+/// #     fn apply(&mut self, value: &dyn Reflect) { todo!() }
+/// #     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> { todo!() }
+/// #     fn reflect_ref(&self) -> ReflectRef { todo!() }
+/// #     fn reflect_mut(&mut self) -> ReflectMut { todo!() }
+/// #     fn reflect_owned(self: Box<Self>) -> ReflectOwned { todo!() }
+/// #     fn clone_value(&self) -> Box<dyn Reflect> { todo!() }
 /// # }
 /// ```
 ///


### PR DESCRIPTION
# Objective

- Fixes indentation in a [`bevy_reflect::Typed` example](https://github.com/bevyengine/bevy/blob/main/crates/bevy_reflect/src/type_info.rs#L24,L66)

## Solution

- Switch from 2 to 4 spaces.