### PR TITLE
[Merged by Bors] - Expose transform propagate systems

### DIFF
--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -28,8 +28,8 @@ use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
-/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
-/// for complete transform propagation
+/// Third party plugins should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// to control when transforms are propagated from parents to children.
 ///
 /// # Examples
 ///

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -28,6 +28,9 @@ use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 /// update the [`Transform`] of an entity in this stage or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 ///
+/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// for complete transform propagation
+///
 /// # Examples
 ///
 /// - [`transform`]

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -5,8 +5,6 @@
 /// The basic components of the transform crate
 pub mod components;
 mod systems;
-pub use crate::systems::propagate_transforms;
-pub use crate::systems::sync_simple_transforms;
 
 #[doc(hidden)]
 pub mod prelude {
@@ -79,6 +77,13 @@ impl From<Transform> for TransformBundle {
 pub enum TransformSystem {
     /// Propagates changes in transform to children's [`GlobalTransform`](crate::components::GlobalTransform)
     TransformPropagate,
+}
+
+/// Transform propagation system set for third party plugins use
+pub fn transform_propagate_system_set() -> SystemSet {
+    SystemSet::new()
+        .with_system(systems::sync_simple_transforms)
+        .with_system(systems::propagate_transforms)
 }
 
 /// The base plugin for handling [`Transform`] components

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod components;
 mod systems;
 pub use crate::systems::propagate_transforms;
+pub use crate::systems::sync_simple_transforms;
 
 #[doc(hidden)]
 pub mod prelude {

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -5,6 +5,7 @@
 /// The basic components of the transform crate
 pub mod components;
 mod systems;
+pub use crate::systems::propagate_transforms;
 
 #[doc(hidden)]
 pub mod prelude {

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -3,6 +3,9 @@ use bevy_ecs::prelude::{Changed, Entity, Query, With, Without};
 use bevy_hierarchy::{Children, Parent};
 
 /// Update [`GlobalTransform`] component of entities that aren't in the hierarchy
+///
+/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// for complete transform propagation
 pub fn sync_simple_transforms(
     mut query: Query<
         (&Transform, &mut GlobalTransform),
@@ -16,6 +19,9 @@ pub fn sync_simple_transforms(
 
 /// Update [`GlobalTransform`] component of entities based on entity hierarchy and
 /// [`Transform`] component.
+///
+/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// for complete transform propagation
 pub fn propagate_transforms(
     mut root_query: Query<
         (

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -4,8 +4,8 @@ use bevy_hierarchy::{Children, Parent};
 
 /// Update [`GlobalTransform`] component of entities that aren't in the hierarchy
 ///
-/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
-/// for complete transform propagation
+/// Third party plugins should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// to propagate transforms correctly.
 pub fn sync_simple_transforms(
     mut query: Query<
         (&Transform, &mut GlobalTransform),
@@ -20,8 +20,8 @@ pub fn sync_simple_transforms(
 /// Update [`GlobalTransform`] component of entities based on entity hierarchy and
 /// [`Transform`] component.
 ///
-/// Third party plugin should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
-/// for complete transform propagation
+/// Third party plugins should use [`transform_propagate_system_set`](crate::transform_propagate_system_set)
+/// to propagate transforms correctly.
 pub fn propagate_transforms(
     mut root_query: Query<
         (


### PR DESCRIPTION
# Objective

- I tried to create a fork of bevy_rapier to track latest bevy main branch. But bevy_rapier depends on bevy internal `propagate_transforms` system (see https://github.com/dimforge/bevy_rapier/blob/master/src/plugin/plugin.rs#L64).
- `propagate_transforms` system was changed to private in https://github.com/bevyengine/bevy/pull/4775.

I don't know if it's reasonable that making `propagate_transforms` public. I also created an issue to bevy_rapier https://github.com/dimforge/bevy_rapier/issues/307 to see how offical team will solve this issue.

## Solution

- make `propagate_transforms` system public.