### PR TITLE
[Merged by Bors] - Change default FocusPolicy to Pass

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -164,9 +164,7 @@ pub fn ui_focus_system(
                         // Reset their interaction to None to avoid strange stuck state
                         if let Some(mut interaction) = node.interaction {
                             // We cannot simply set the interaction to None, as that will trigger change detection repeatedly
-                            if *interaction != Interaction::None {
-                                *interaction = Interaction::None;
-                            }
+                            interaction.set_if_neq(Interaction::None);
                         }
 
                         return None;

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -63,7 +63,7 @@ pub enum FocusPolicy {
 }
 
 impl FocusPolicy {
-    const DEFAULT: Self = Self::Block;
+    const DEFAULT: Self = Self::Pass;
 }
 
 impl Default for FocusPolicy {

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -96,7 +96,7 @@ pub struct ImageBundle {
 }
 
 /// A UI node that is text
-#[derive(Bundle, Clone, Debug)]
+#[derive(Bundle, Clone, Debug, Default)]
 pub struct TextBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -157,23 +157,6 @@ impl TextBundle {
     pub const fn with_style(mut self, style: Style) -> Self {
         self.style = style;
         self
-    }
-}
-
-impl Default for TextBundle {
-    fn default() -> Self {
-        TextBundle {
-            focus_policy: FocusPolicy::Pass,
-            text: Default::default(),
-            node: Default::default(),
-            calculated_size: Default::default(),
-            style: Default::default(),
-            transform: Default::default(),
-            global_transform: Default::default(),
-            visibility: Default::default(),
-            computed_visibility: Default::default(),
-            z_index: Default::default(),
-        }
     }
 }
 

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -161,7 +161,7 @@ impl TextBundle {
 }
 
 /// A UI node that is a button
-#[derive(Bundle, Clone, Debug, Default)]
+#[derive(Bundle, Clone, Debug)]
 pub struct ButtonBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -195,4 +195,23 @@ pub struct ButtonBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+}
+
+impl Default for ButtonBundle {
+    fn default() -> Self {
+        Self {
+            focus_policy: FocusPolicy::Block,
+            node: Default::default(),
+            button: Default::default(),
+            style: Default::default(),
+            interaction: Default::default(),
+            background_color: Default::default(),
+            image: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            computed_visibility: Default::default(),
+            z_index: Default::default(),
+        }
+    }
 }


### PR DESCRIPTION
# Objective

- While building UI, it makes more sense for most nodes to have a `FocusPolicy` of `Pass`, so that user interaction can correctly bubble
- Only `ButtonBundle` blocks by default

This change means that for someone adding children to a button, it's not needed to change the focus policy of those children to `Pass` for the button to continue to work.

---

## Changelog

- `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`

## Migration Guide

- `FocusPolicy` default has changed from `FocusPolicy::Block` to `FocusPolicy::Pass`
