### PR TITLE
[Merged by Bors] - add helper for macro to get either bevy::x or bevy_x depending on how it was imported

### DIFF
--- a/crates/bevy_encase_derive/src/lib.rs
+++ b/crates/bevy_encase_derive/src/lib.rs
@@ -1,23 +1,12 @@
 use bevy_macro_utils::BevyManifest;
 use encase_derive_impl::{implement, syn};
 
-const BEVY: &str = "bevy";
-const BEVY_RENDER: &str = "bevy_render";
 const ENCASE: &str = "encase";
 
 fn bevy_encase_path() -> syn::Path {
     let bevy_manifest = BevyManifest::default();
     bevy_manifest
-        .maybe_get_path(BEVY)
-        .map(|bevy_path| {
-            let mut segments = bevy_path.segments;
-            segments.push(BevyManifest::parse_str("render"));
-            syn::Path {
-                leading_colon: None,
-                segments,
-            }
-        })
-        .or_else(|| bevy_manifest.maybe_get_path(BEVY_RENDER))
+        .get_subcrate("render")
         .map(|bevy_render_path| {
             let mut segments = bevy_render_path.segments;
             segments.push(BevyManifest::parse_str("render_resource"));

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -32,12 +32,11 @@ impl Default for BevyManifest {
         }
     }
 }
+const BEVY: &str = "bevy";
+const BEVY_INTERNAL: &str = "bevy_internal";
 
 impl BevyManifest {
     pub fn maybe_get_path(&self, name: &str) -> Option<syn::Path> {
-        const BEVY: &str = "bevy";
-        const BEVY_INTERNAL: &str = "bevy_internal";
-
         fn dep_package(dep: &Value) -> Option<&str> {
             if dep.as_str().is_some() {
                 None
@@ -102,6 +101,19 @@ impl BevyManifest {
 
     pub fn parse_str<T: syn::parse::Parse>(path: &str) -> T {
         syn::parse(path.parse::<TokenStream>().unwrap()).unwrap()
+    }
+
+    pub fn get_subcrate(&self, subcrate: &str) -> Option<syn::Path> {
+        self.maybe_get_path(BEVY)
+            .map(|bevy_path| {
+                let mut segments = bevy_path.segments;
+                segments.push(BevyManifest::parse_str(subcrate));
+                syn::Path {
+                    leading_colon: None,
+                    segments,
+                }
+            })
+            .or_else(|| self.maybe_get_path(&format!("bevy_{subcrate}")))
     }
 }
 


### PR DESCRIPTION
# Objective

- It can be useful for third party crates to work independently on how bevy is imported

## Solution

- Expose an helper to get a subcrate path for macros
