### PR TITLE
[Merged by Bors] - gate an import used only for a debug assert

### DIFF
--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
 use bevy_ecs::change_detection::DetectChanges;
+#[cfg(debug_assertions)]
 use bevy_ecs::system::Local;
 use bevy_ecs::system::{Commands, Res, ResMut, Resource};
 pub use bevy_render_macros::ExtractResource;


### PR DESCRIPTION
# Objective

- There is a warning when building in release:
```
warning: unused import: `bevy_ecs::system::Local`
 --> crates/bevy_render/src/extract_resource.rs:5:5
  |
5 | use bevy_ecs::system::Local;
  |     ^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```
- It's used https://github.com/bevyengine/bevy/blob/59751d6e33d94eff6e1fc20c9ae155974b3860b1/crates/bevy_render/src/extract_resource.rs#L47
- Fix it

## Solution

- Gate the import
- repeat of #5320