### PR TITLE
Make `MonitorSelection` argument optional for `Window::set_position`

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -386,9 +386,9 @@ pub enum WindowCommand {
     SetMinimized {
         minimized: bool,
     },
-    /// Set the window's position on the selected monitor.
+    /// Set the window's position. Optionally relative to a monitor.
     SetPosition {
-        monitor_selection: MonitorSelection,
+        monitor_selection: Option<MonitorSelection>,
         position: IVec2,
     },
     /// Sets the position of the window to be in the center of the selected monitor.
@@ -545,6 +545,7 @@ impl Window {
     pub fn position(&self) -> Option<IVec2> {
         self.position
     }
+    
     /// Set whether or not the window is maximized.
     #[inline]
     pub fn set_maximized(&mut self, maximized: bool) {
@@ -563,7 +564,7 @@ impl Window {
             .push(WindowCommand::SetMinimized { minimized });
     }
 
-    /// Sets the `position` of the window on the selected `monitor` in physical pixels.
+    /// Set the window's position in physical pixels. Optionally relative to a monitor.
     ///
     /// This automatically un-maximizes the window if it's maximized.
     ///
@@ -574,7 +575,7 @@ impl Window {
     /// - Web: Sets the top-left coordinates relative to the viewport.
     /// - Android / Wayland: Unsupported.
     #[inline]
-    pub fn set_position(&mut self, monitor: MonitorSelection, position: IVec2) {
+    pub fn set_position(&mut self, monitor: Option<MonitorSelection>, position: IVec2) {
         self.command_queue.push(WindowCommand::SetPosition {
             monitor_selection: monitor,
             position,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -386,7 +386,7 @@ pub enum WindowCommand {
     SetMinimized {
         minimized: bool,
     },
-    /// Set the window's position. Optionally relative to a monitor.
+    /// Set the window's position, optionally relative to a monitor.
     SetPosition {
         monitor_selection: Option<MonitorSelection>,
         position: IVec2,
@@ -564,7 +564,7 @@ impl Window {
             .push(WindowCommand::SetMinimized { minimized });
     }
 
-    /// Set the window's position in physical pixels. Optionally relative to a monitor.
+    /// Set the window's position in physical pixels, optionally relative to a monitor.
     ///
     /// This automatically un-maximizes the window if it's maximized.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -545,7 +545,7 @@ impl Window {
     pub fn position(&self) -> Option<IVec2> {
         self.position
     }
-    
+
     /// Set whether or not the window is maximized.
     #[inline]
     pub fn set_maximized(&mut self, maximized: bool) {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -178,18 +178,23 @@ fn change_window(
                     let window = winit_windows.get_window(id).unwrap();
 
                     use bevy_window::MonitorSelection::*;
-                    let maybe_monitor = match monitor_selection {
-                        Current => window.current_monitor(),
-                        Primary => window.primary_monitor(),
-                        Index(i) => window.available_monitors().nth(i),
-                    };
-                    if let Some(monitor) = maybe_monitor {
-                        let monitor_position = DVec2::from(<(_, _)>::from(monitor.position()));
-                        let position = monitor_position + position.as_dvec2();
+                    if let Some(monitor_selection) = monitor_selection {
+                        let maybe_monitor = match monitor_selection {
+                            Current => window.current_monitor(),
+                            Primary => window.primary_monitor(),
+                            Index(i) => window.available_monitors().nth(i),
+                        };
+                        if let Some(monitor) = maybe_monitor {
+                            let monitor_position = DVec2::from(<(_, _)>::from(monitor.position()));
+                            let position = monitor_position + position.as_dvec2();
 
-                        window.set_outer_position(LogicalPosition::new(position.x, position.y));
+                            window
+                                .set_outer_position(PhysicalPosition::new(position.x, position.y));
+                        } else {
+                            warn!("Couldn't get monitor selected with: {monitor_selection:?}");
+                        }
                     } else {
-                        warn!("Couldn't get monitor selected with: {monitor_selection:?}");
+                        window.set_outer_position(PhysicalPosition::new(position.x, position.y));
                     }
                 }
                 bevy_window::WindowCommand::Center(monitor_selection) => {


### PR DESCRIPTION
# Objective
Allow passing `None` as argument for `monitor` to `Window::set_position`.
Passing `None` makes the method behave as it did before Bevy 0.9 where it sets the position relative to the desktop origin (wherever that may be). This matches what is returned by `Window::position`.

Fixes #6993

## Migration Guide
```rust
// Before (0.9)
window.set_position(monitor, position);
// After (0.10)
window.set_position(Some(monitor), position);
```