### PR TITLE
Make `move_sprite` both more general and more illustrative.

### DIFF
--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -34,8 +34,9 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 /// Update everything that has both a velocity *and* a transform.
 fn update_moveables(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform)>) {
-    for (v, mut trf) in &mut query {
-        trf.translation += Vec3::from((v.0 * time.delta_seconds(), 0.));
+    let delta = time.delta_seconds();
+    for (velocity, mut transform) in &mut query {
+        transform.translation += velocity.0.extend(0.0) * delta;
     }
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(update_moveables)
-        .add_system(update_birds)
+        .add_system(update_birds.before(update_moveables))
         .run();
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -12,7 +12,7 @@ fn main() {
 }
 
 /// A component for any moving entity.
-#[derive(Component)]
+#[derive(Component, Deref, DerefMut)]
 struct Velocity(Vec2);
 
 /// A marker component for our particular sprite.
@@ -36,7 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 fn apply_velocity(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform)>) {
     let delta = time.delta_seconds();
     for (velocity, mut transform) in &mut query {
-        transform.translation += velocity.0.extend(0.0) * delta;
+        transform.translation += velocity.extend(0.) * delta;
     }
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -6,12 +6,12 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(update_moveables)
-        .add_system(update_birds.before(update_moveables))
+        .add_system(update_bird_velocity)
+        .add_system(apply_velocity.after(update_bird_velocity))
         .run();
 }
 
-/// A component for any sprite that might move.
+/// A component for any moving entity.
 #[derive(Component)]
 struct Velocity(Vec2);
 
@@ -32,8 +32,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     ));
 }
 
-/// Update everything that has both a velocity *and* a transform.
-fn update_moveables(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform)>) {
+/// Update all moving entities: those with a velocity and a transform.
+fn apply_velocity(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform)>) {
     let delta = time.delta_seconds();
     for (velocity, mut transform) in &mut query {
         transform.translation += velocity.0.extend(0.0) * delta;
@@ -46,10 +46,10 @@ fn update_moveables(time: Res<Time>, mut query: Query<(&Velocity, &mut Transform
 /// component reuse is one of the core tenets of Entity Component Systems (ECS).
 ///
 /// This system uses a filter – `With<Bird>` – to restrict updates to bird sprites, only.
-fn update_birds(mut query: Query<(&mut Velocity, &Transform), With<Bird>>) {
-    for (mut v, trf) in &mut query {
-        if trf.translation.y.abs() > 200. {
-            v.0 *= -1.;
+fn update_bird_velocity(mut query: Query<(&mut Velocity, &Transform), With<Bird>>) {
+    for (mut velocity, transform) in &mut query {
+        if transform.translation.y.abs() > 200. {
+            velocity.0 *= -1.;
         }
     }
 }


### PR DESCRIPTION
# Objective

Discussion: https://discord.com/channels/691052431525675048/743559241461399582/1063153669920526376

This example is important because it is far simpler than the breakout and ECS-guide examples and thus likely to be encountered by newcomers to *Bevy*. Furthermore, unlike the breakout example which uses a `1/60`-second time-step, this example demonstrates movement with truly continuous time.

The previous version of this code has some shortcomings. Primarily, the `Direction` component is an `enum` and is mutated by the `sprite_movement(…)` system, suggesting that its reason for existence is as the mutable state required to implement the up-and-down movement rules.

Its purpose as a *marker* component is subtle and that represents a missed opportunity as well as producing an unintended pitfall for newcomers who might copy this examples code and remove that component – perhaps implementing movement with periodic functions like `sin()`.

## Solution

The revised example implements identical behaviour but places the emphasis on two key lessons for the reader:

1. How one might use a system to smoothly update the translation of sprites, moving them over time.
2. That components are widely re-used – particularly, Transform – and so queries must be well defined and marker components have their place.

Additionally, the style has been made more appropriate for the domain. For example, the movement update is now just `translation += v × dt`.
