### PR TITLE
[Merged by Bors] - Improve safety for `BlobVec::replace_unchecked`

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -174,6 +174,8 @@ impl BlobVec {
 
             // Transfer ownership of the old value out of the vector, so it can be dropped.
             // SAFETY:
+            // - `dst` was obtained from a `PtrMut` in this vector, which ensures it is non-null,
+            //   well-aligned for the underlying type, and has proper provenance.
             // - The storage location will get overwritten with `value` later, which ensures
             //   that the element will not get observed or double dropped later.
             // - If a panic occurs, `self.len` will remain `0`, which ensures a double-drop

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -165,7 +165,7 @@ impl BlobVec {
 
         // Transfer ownership of the old value out of the vector, so it can be dropped.
         // SAFETY:
-        // * The caller has promized that `index` fits in this vector.
+        // * The caller ensures that `index` fits in this vector.
         // * The storage location will get overwritten with `value` later, which ensures
         //   that the element will not get observed or double dropped later.
         // * If a panic occurs, `self.len` will remain `0`, which ensures a double-drop

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -169,10 +169,10 @@ impl BlobVec {
 
             // Transfer ownership of the old value out of the vector, so it can be dropped.
             // SAFETY:
-            // * The caller ensures that `index` fits in this vector.
-            // * The storage location will get overwritten with `value` later, which ensures
+            // - The caller ensures that `index` fits in this vector.
+            // - The storage location will get overwritten with `value` later, which ensures
             //   that the element will not get observed or double dropped later.
-            // * If a panic occurs, `self.len` will remain `0`, which ensures a double-drop
+            // - If a panic occurs, `self.len` will remain `0`, which ensures a double-drop
             //   does not occur. Instead, all elements will be forgotten.
             let old_value = self.get_ptr_mut().byte_add(index * size).promote();
             dst = old_value.as_ptr();

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -190,7 +190,7 @@ impl BlobVec {
         // SAFETY:
         // - `src` and `dst` were obtained from `OwningPtr`s, which ensures they are
         //   valid for both reads and writes.
-        // - The data behind `src` will only be dropped if the above branch panics,
+        // - The value behind `src` will only be dropped if the above branch panics,
         //   so it must still be initialized and it is safe to transfer ownership into the vector.
         // - `src` and `dst` were obtained from different memory locations,
         //   both of which we have exclusive access to, so they are guaranteed not to overlap.

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -195,7 +195,7 @@ impl BlobVec {
             self.len = old_len;
         }
 
-        // Copy the new value into the vector, overwriting the previous value which has been moved.
+        // Copy the new value into the vector, overwriting the previous value.
         // SAFETY:
         // - `src` and `dst` were obtained from `OwningPtr`s, which ensures they are
         //   valid for both reads and writes.

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -179,9 +179,9 @@ impl BlobVec {
             // This closusure will run in case `drop()` panics, which is similar to
             // the `try ... catch` construct in languages like C++.
             // This ensures that `value` does not get forgotten in case of a panic.
-            let on_unwind = OnDrop::new(|| (drop)(value));
+            let on_unwind = OnDrop::new(|| drop(value));
 
-            (drop)(old_value);
+            drop(old_value);
 
             // If the above code does not panic, make sure that `value` doesn't get dropped.
             core::mem::forget(on_unwind);

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -180,9 +180,8 @@ impl BlobVec {
             //   does not occur. Instead, all elements will be forgotten.
             let old_value = OwningPtr::new(dst);
 
-            // This closure will run in case `drop()` panics, which is similar to
-            // the `try ... catch` construct in languages like C++.
-            // This ensures that `value` does not get forgotten in case of a panic.
+            // This closure will run in case `drop()` panics,
+            // which ensures that `value` does not get forgotten.
             let on_unwind = OnDrop::new(|| drop(value));
 
             drop(old_value);

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -186,6 +186,13 @@ impl BlobVec {
             core::mem::forget(on_unwind);
         }
         // Copy the new value into the vector, overwriting the previous value which has been moved.
+        // SAFETY:
+        // - `src_addr` and `dst_addr` were obtained from `OwningPtr`s, which ensures they are
+        //   valid for both reads and writes.
+        // - The data behind `src_addr` will only be dropped if the above branch panics,
+        //   so it must still be initialized and it is safe to transfer ownership into the vector.
+        // - `src_addr` and `dst_addr` were obtained from different memory locations,
+        //   both of which we have exclusive access to, so they are guaranteed not to overlap.
         std::ptr::copy_nonoverlapping::<u8>(src_addr, dst_addr, self.item_layout.size());
 
         // Now that each entry in the vector is fully initialized again, restore its length.

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -170,6 +170,8 @@ impl BlobVec {
             // Transfer ownership of the old value out of the vector, so it can be dropped.
             // SAFETY:
             // - The caller ensures that `index` fits in this vector.
+            // - `size` must be a multiple of the erased type's alignment,
+            //   so adding a multiple of `size` will preserve alignment.
             // - The storage location will get overwritten with `value` later, which ensures
             //   that the element will not get observed or double dropped later.
             // - If a panic occurs, `self.len` will remain `0`, which ensures a double-drop

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -162,8 +162,9 @@ impl BlobVec {
         let src = value.as_ptr();
 
         if let Some(drop) = self.drop {
-            // Temporarily set the length to zero, so that uninitialized bytes won't
-            // get observed in case a panic causes this function to exit early.
+            // Temporarily set the length to zero, so that if `drop` panics the caller
+            // will not be left with a `BlobVec` containing a dropped element within
+            // its initialized range.
             let old_len = self.len;
             self.len = 0;
 
@@ -179,7 +180,7 @@ impl BlobVec {
             let old_value = self.get_ptr_mut().byte_add(index * size).promote();
             dst = old_value.as_ptr();
 
-            // This closusure will run in case `drop()` panics, which is similar to
+            // This closure will run in case `drop()` panics, which is similar to
             // the `try ... catch` construct in languages like C++.
             // This ensures that `value` does not get forgotten in case of a panic.
             let on_unwind = OnDrop::new(|| drop(value));

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -193,8 +193,7 @@ impl BlobVec {
             // Make the vector's contents observable again, since panics are no longer possible.
             self.len = old_len;
         } else {
-            // SAFETY:
-            // - The caller ensures that `index` fits in this vector.
+            // SAFETY: The caller ensures that `index` fits in this vector.
             dst = self.get_ptr_mut().as_ptr().add(index * size);
         }
 

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -172,8 +172,8 @@ impl BlobVec {
         //   does not occur. Instead, all elements will be forgotten.
         let old_value = self.get_ptr_mut().byte_add(index * size).promote();
 
-        let dst_addr = old_value.as_ptr();
-        let src_addr = value.as_ptr();
+        let dst = old_value.as_ptr();
+        let src = value.as_ptr();
 
         if let Some(drop) = drop {
             // This closusure will run in case `drop()` panics, which is similar to
@@ -188,13 +188,13 @@ impl BlobVec {
         }
         // Copy the new value into the vector, overwriting the previous value which has been moved.
         // SAFETY:
-        // - `src_addr` and `dst_addr` were obtained from `OwningPtr`s, which ensures they are
+        // - `src` and `dst` were obtained from `OwningPtr`s, which ensures they are
         //   valid for both reads and writes.
-        // - The data behind `src_addr` will only be dropped if the above branch panics,
+        // - The data behind `src` will only be dropped if the above branch panics,
         //   so it must still be initialized and it is safe to transfer ownership into the vector.
-        // - `src_addr` and `dst_addr` were obtained from different memory locations,
+        // - `src` and `dst` were obtained from different memory locations,
         //   both of which we have exclusive access to, so they are guaranteed not to overlap.
-        std::ptr::copy_nonoverlapping::<u8>(src_addr, dst_addr, size);
+        std::ptr::copy_nonoverlapping::<u8>(src, dst, size);
 
         // Now that each entry in the vector is fully initialized again, restore its length.
         self.len = old_len;

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -78,6 +78,12 @@ macro_rules! impl_ptr {
             }
         }
 
+        impl<'a, A: IsAligned> From<$ptr<'a, A>> for NonNull<u8> {
+            fn from(ptr: $ptr<'a, A>) -> Self {
+                ptr.0
+            }
+        }
+
         impl<A: IsAligned> $ptr<'_, A> {
             /// Calculates the offset from a pointer.
             /// As the pointer is type-erased, there is no size information available. The provided

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -238,6 +238,10 @@ impl<K: Hash + Eq + PartialEq + Clone, V> PreHashMapExt<K, V> for PreHashMap<K, 
 /// A type which calls a function when dropped.
 /// This can be used to ensure that cleanup code is run even in case of a panic.
 ///
+/// Note that this only works for panics that [unwind](https://doc.rust-lang.org/nomicon/unwinding.html)
+/// -- any code within `OnDrop` will be skipped if a panic does not unwind.
+/// In most cases, this will just work.
+///
 /// # Examples
 ///
 /// ```

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -237,6 +237,34 @@ impl<K: Hash + Eq + PartialEq + Clone, V> PreHashMapExt<K, V> for PreHashMap<K, 
 
 /// A type which calls a function when dropped.
 /// This can be used to ensure that cleanup code is run even in case of a panic.
+///
+/// # Examples
+///
+/// ```
+/// # use bevy_utils::OnDrop;
+/// # fn test_panic(do_panic: bool, log: impl FnOnce(&str)) {
+/// // This will print a message when the variable `_catch` gets dropped,
+/// // even if a panic occurs before we reach the end of this scope.
+/// // This is similar to a `try ... catch` block in languages such as C++.
+/// let _catch = OnDrop::new(|| log("Oops, a panic occured and this function didn't complete!"));
+///
+/// // Some code that may panic...
+/// // ...
+/// # if do_panic { panic!() }
+///
+/// // Make sure the message only gets printed if a panic occurs.
+/// // If we remove this line, then the message will be printed regardless of whether a panic occurs
+/// // -- similar to a `try ... finally` block.
+/// std::mem::forget(_catch);
+/// # }
+/// #
+/// # test_panic(false, |_| unreachable!());
+/// # let mut did_log = false;
+/// # std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+/// #   test_panic(true, |_| did_log = true);
+/// # }));
+/// # assert!(did_log);
+/// ```
 pub struct OnDrop<F: FnOnce()> {
     callback: ManuallyDrop<F>,
 }


### PR DESCRIPTION
# Objective

- The function `BlobVec::replace_unchecked` has informal use of safety comments.
- This function does strange things with `OwningPtr` in order to get around the borrow checker.

## Solution

- Put safety comments in front of each unsafe operation. Describe the specific invariants of each operation and how they apply here.
- Added a guard type `OnDrop`, which is used to simplify ownership transfer in case of a panic.

---

## Changelog

+ Added the guard type `bevy_utils::OnDrop`.
+ Added conversions from `Ptr`, `PtrMut`, and `OwningPtr` to `NonNull<u8>`.