### PR TITLE
[Merged by Bors] - Implement `ReadOnlySystemParam` for `Extract<>`

### DIFF
--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -53,7 +53,7 @@ pub struct ExtractState<P: SystemParam + 'static> {
 }
 
 // SAFETY: The only `World` access is read-only.
-unsafe impl<P> ReadOnlySystemParam<P> for Extract<'_, '_, P> where P: ReadOnlySystemParam {}
+unsafe impl<P> ReadOnlySystemParam for Extract<'_, '_, P> where P: ReadOnlySystemParam {}
 
 // SAFETY: The only `World` access is properly registered by `Res<MainWorld>::init_state`.
 unsafe impl<P> SystemParam for Extract<'_, '_, P>

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -52,7 +52,7 @@ pub struct ExtractState<P: SystemParam + 'static> {
     main_world_state: <Res<'static, MainWorld> as SystemParam>::State,
 }
 
-// SAFETY: The only `World` access is read-only.
+// SAFETY: The only `World` access (`Res<MainWorld>`) is read-only.
 unsafe impl<P> ReadOnlySystemParam for Extract<'_, '_, P> where P: ReadOnlySystemParam {}
 
 // SAFETY: The only `World` access is properly registered by `Res<MainWorld>::init_state`.

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -52,8 +52,10 @@ pub struct ExtractState<P: SystemParam + 'static> {
     main_world_state: <Res<'static, MainWorld> as SystemParam>::State,
 }
 
-// SAFETY: only accesses MainWorld resource with read only system params using Res,
-// which is initialized in init()
+// SAFETY: The only `World` access is read-only.
+unsafe impl<P> ReadOnlySystemParam<P> for Extract<'_, '_, P> where P: ReadOnlySystemParam {}
+
+// SAFETY: The only `World` access is properly registered by `Res<MainWorld>::init_state`.
 unsafe impl<P> SystemParam for Extract<'_, '_, P>
 where
     P: ReadOnlySystemParam,


### PR DESCRIPTION
# Objective

- `Extract` does not implement `ReadOnlySystemParam` even though it should.
- Noticed by @hymm on discord: https://discord.com/channels/691052431525675048/749335865876021248/1063535818267963543

## Solution

Implement the trait.
