### PR TITLE
implement ReadOnlySystemParam for Extract

### DIFF
--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -46,6 +46,11 @@ where
     item: SystemParamItem<'w, 's, P>,
 }
 
+unsafe impl<'w, 's, P> ReadOnlySystemParam for Extract<'w, 's, P> where
+    P: ReadOnlySystemParam + 'static
+{
+}
+
 #[doc(hidden)]
 pub struct ExtractState<P: SystemParam + 'static> {
     state: SystemState<P>,


### PR DESCRIPTION
# Objective

- the `Extract` param did not implement ReadOnlySystemParam even though it's generic parameter requires it.

## Solution

- impl it

---

## Changelog

- impl ReadOnlySystemParam for the Extract SystemParam