### PR TITLE
[Merged by Bors] - Convenience method for entity naming

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -15,8 +15,7 @@ pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
     pub use crate::{
-        DebugNameQueryExt, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin,
-        TypeRegistrationPlugin,
+        DebugName, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
     };
 }
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -15,7 +15,8 @@ pub mod prelude {
     //! The Bevy Core Prelude.
     #[doc(hidden)]
     pub use crate::{
-        FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin, TypeRegistrationPlugin,
+        DebugNameQueryExt, FrameCountPlugin, Name, TaskPoolOptions, TaskPoolPlugin,
+        TypeRegistrationPlugin,
     };
 }
 

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,9 +1,5 @@
 use bevy_ecs::{
-    component::Component,
-    entity::Entity,
-    prelude::Query,
-    query::{ReadOnlyWorldQuery, WorldQuery},
-    reflect::ReflectComponent,
+    component::Component, entity::Entity, query::WorldQuery, reflect::ReflectComponent,
 };
 use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
@@ -82,24 +78,21 @@ impl std::fmt::Display for Name {
     }
 }
 
-/// An extension trait for [`Query`] for more user friendly debug information about an entity.
-pub trait DebugNameQueryExt<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
-    /// Give the [`Name`] of an entity if it has one, otherwise return the [`Entity`].
-    fn debug_name(&'w self, entity: Entity) -> Box<dyn std::fmt::Debug + 'w>
-    where
-        Q::ReadOnly: WorldQuery<Item<'w> = &'w Name>;
+/// Convenient query for giving a human friendly name to an entity.
+#[derive(WorldQuery)]
+pub struct DebugName {
+    /// A [`Name`] that the entity might have that is displayed if available.
+    pub name: Option<&'static Name>,
+    /// The unique identifier of the entity as a fallback.
+    pub entity: Entity,
 }
 
-impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> DebugNameQueryExt<'w, 's, Q, F>
-    for Query<'w, 's, Q, F>
-{
-    fn debug_name(&'w self, entity: Entity) -> Box<dyn std::fmt::Debug + 'w>
-    where
-        Q::ReadOnly: WorldQuery<Item<'w> = &'w Name>,
-    {
-        match self.get(entity).ok() {
-            Some(name) => Box::new(name.as_str()),
-            None => Box::new(entity),
+impl std::fmt::Debug for DebugName {
+    #[inline(always)]
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self.name {
+            Some(name) => std::fmt::Debug::fmt(&name, f),
+            None => std::fmt::Debug::fmt(&self.entity, f),
         }
     }
 }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -91,7 +91,7 @@ impl std::fmt::Debug for DebugName {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
-            Some(name) => std::fmt::Debug::fmt(&name, f),
+            Some(name) => write!(f, "{:?} ({:?})", &name, &self.entity),
             None => std::fmt::Debug::fmt(&self.entity, f),
         }
     }

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -82,11 +82,9 @@ impl std::fmt::Display for Name {
     }
 }
 
-/// An extension trait for [`Query`] that attempts to give a user friendly
-/// name for an entity if available.
+/// An extension trait for [`Query`] for more user friendly debug information about an entity.
 pub trait DebugNameQueryExt<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
-    /// Give the name of an entity if it has one, otherwise use the entity id
-    /// as the name.
+    /// Give the [`Name`] of an entity if it has one, otherwise return the [`Entity`].
     fn debug_name(&'w self, entity: Entity) -> Box<dyn std::fmt::Debug + 'w>
     where
         Q::ReadOnly: WorldQuery<Item<'w> = &'w Name>;

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -79,7 +79,7 @@ impl std::fmt::Display for Name {
 }
 
 /// Convenient query for giving a human friendly name to an entity.
-/// 
+///
 /// ```rust
 /// # use bevy_core::prelude::*;
 /// # use bevy_ecs::prelude::*;

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -79,6 +79,21 @@ impl std::fmt::Display for Name {
 }
 
 /// Convenient query for giving a human friendly name to an entity.
+/// 
+/// ```rust
+/// # use bevy_core::prelude::*;
+/// # use bevy_ecs::prelude::*;
+/// # #[derive(Component)] pub struct Score(f32);
+/// fn increment_score(mut scores: Query<(DebugName, &mut Score)>) {
+///     for (name, mut score) in &mut scores {
+///         score.0 += 1.0;
+///         if score.0.is_nan() {
+///             bevy_utils::tracing::error!("Score for {:?} is invalid", name);
+///         }
+///     }
+/// }
+/// # bevy_ecs::system::assert_is_system(increment_score);
+/// ```
 #[derive(WorldQuery)]
 pub struct DebugName {
     /// A [`Name`] that the entity might have that is displayed if available.
@@ -87,7 +102,7 @@ pub struct DebugName {
     pub entity: Entity,
 }
 
-impl std::fmt::Debug for DebugName {
+impl<'a> std::fmt::Debug for DebugNameItem<'a> {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -1,4 +1,10 @@
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    prelude::Query,
+    query::{ReadOnlyWorldQuery, WorldQuery},
+    reflect::ReflectComponent,
+};
 use bevy_reflect::Reflect;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect};
 use bevy_utils::AHasher;
@@ -73,6 +79,30 @@ impl std::fmt::Display for Name {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         std::fmt::Display::fmt(&self.name, f)
+    }
+}
+
+/// An extension trait for [`Query`] that attempts to give a user friendly
+/// name for an entity if available.
+pub trait DebugNameQueryExt<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> {
+    /// Give the name of an entity if it has one, otherwise use the entity id
+    /// as the name.
+    fn debug_name(&'w self, entity: Entity) -> Box<dyn std::fmt::Debug + 'w>
+    where
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Name>;
+}
+
+impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> DebugNameQueryExt<'w, 's, Q, F>
+    for Query<'w, 's, Q, F>
+{
+    fn debug_name(&'w self, entity: Entity) -> Box<dyn std::fmt::Debug + 'w>
+    where
+        Q::ReadOnly: WorldQuery<Item<'w> = &'w Name>,
+    {
+        match self.get(entity).ok() {
+            Some(name) => Box::new(name.as_str()),
+            None => Box::new(entity),
+        }
     }
 }
 


### PR DESCRIPTION
# Objective
- Trying to make it easier to have a more user friendly debugging name for when you want to print out an entity.

## Solution
- Add a new `WorldQuery` struct `DebugName` to format the `Name` if the entity has one, otherwise formats the `Entity` id.
This means we can do this and get more descriptive errors without much more effort:
```rust
fn my_system(moving: Query<(DebugName, &mut Position, &Velocity)>) {
    for (name, mut position, velocity) in &mut moving {
        position += velocity; 
        if position.is_nan() {
            error!("{:?} has an invalid position state", name);
        }
    }
}
```

---

## Changelog
- Added `DebugName` world query for more human friendly debug names of entities.