### PR TITLE
Merge CachedRenderPipelinePhaseItem and PhaseItem

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -26,8 +26,8 @@ use bevy_render::{
     extract_component::ExtractComponentPlugin,
     render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
     render_phase::{
-        batch_phase_system, sort_phase_system, BatchedPhaseItem, CachedRenderPipelinePhaseItem,
-        DrawFunctionId, DrawFunctions, PhaseItem, RenderPhase,
+        batch_phase_system, sort_phase_system, BatchedPhaseItem, DrawFunctionId, DrawFunctions,
+        PhaseItem, RenderPhase,
     },
     render_resource::CachedRenderPipelineId,
     Extract, ExtractSchedule, RenderApp, RenderSet,
@@ -107,7 +107,7 @@ impl Plugin for Core2dPlugin {
 pub struct Transparent2d {
     pub sort_key: FloatOrd,
     pub entity: Entity,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
     /// Range in the vertex buffer of this item
     pub batch_range: Option<Range<u32>>,
@@ -132,15 +132,13 @@ impl PhaseItem for Transparent2d {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         items.sort_by_key(|item| item.sort_key());
-    }
-}
-
-impl CachedRenderPipelinePhaseItem for Transparent2d {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
     }
 }
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -29,10 +29,7 @@ use bevy_render::{
     extract_component::ExtractComponentPlugin,
     prelude::Msaa,
     render_graph::{EmptyNode, RenderGraph, SlotInfo, SlotType},
-    render_phase::{
-        sort_phase_system, CachedRenderPipelinePhaseItem, DrawFunctionId, DrawFunctions, PhaseItem,
-        RenderPhase,
-    },
+    render_phase::{sort_phase_system, DrawFunctionId, DrawFunctions, PhaseItem, RenderPhase},
     render_resource::{
         CachedRenderPipelineId, Extent3d, TextureDescriptor, TextureDimension, TextureFormat,
         TextureUsages,
@@ -130,7 +127,7 @@ impl Plugin for Core3dPlugin {
 
 pub struct Opaque3d {
     pub distance: f32,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub entity: Entity,
     pub draw_function: DrawFunctionId,
 }
@@ -155,22 +152,20 @@ impl PhaseItem for Opaque3d {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
         radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 
-impl CachedRenderPipelinePhaseItem for Opaque3d {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
-    }
-}
-
 pub struct AlphaMask3d {
     pub distance: f32,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub entity: Entity,
     pub draw_function: DrawFunctionId,
 }
@@ -195,22 +190,20 @@ impl PhaseItem for AlphaMask3d {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
         radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 
-impl CachedRenderPipelinePhaseItem for AlphaMask3d {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
-    }
-}
-
 pub struct Transparent3d {
     pub distance: f32,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub entity: Entity,
     pub draw_function: DrawFunctionId,
 }
@@ -235,15 +228,13 @@ impl PhaseItem for Transparent3d {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         radsort::sort_by_key(items, |item| item.distance);
-    }
-}
-
-impl CachedRenderPipelinePhaseItem for Transparent3d {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
     }
 }
 

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -31,7 +31,7 @@ use std::cmp::Reverse;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
-    render_phase::{CachedRenderPipelinePhaseItem, DrawFunctionId, PhaseItem},
+    render_phase::{DrawFunctionId, PhaseItem},
     render_resource::{CachedRenderPipelineId, Extent3d, TextureFormat},
     texture::CachedTexture,
 };
@@ -96,16 +96,14 @@ impl PhaseItem for Opaque3dPrepass {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
         radsort::sort_by_key(items, |item| -item.distance);
-    }
-}
-
-impl CachedRenderPipelinePhaseItem for Opaque3dPrepass {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline_id
     }
 }
 
@@ -141,15 +139,13 @@ impl PhaseItem for AlphaMask3dPrepass {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         // Key negated to match reversed SortKey ordering
         radsort::sort_by_key(items, |item| -item.distance);
-    }
-}
-
-impl CachedRenderPipelinePhaseItem for AlphaMask3dPrepass {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline_id
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -459,7 +459,7 @@ pub fn queue_material_meshes<M: Material>(
                             opaque_phase.add(Opaque3d {
                                 entity: *visible_entity,
                                 draw_function: draw_opaque_pbr,
-                                pipeline: pipeline_id,
+                                pipeline_id,
                                 distance,
                             });
                         }
@@ -467,7 +467,7 @@ pub fn queue_material_meshes<M: Material>(
                             alpha_mask_phase.add(AlphaMask3d {
                                 entity: *visible_entity,
                                 draw_function: draw_alpha_mask_pbr,
-                                pipeline: pipeline_id,
+                                pipeline_id,
                                 distance,
                             });
                         }
@@ -478,7 +478,7 @@ pub fn queue_material_meshes<M: Material>(
                             transparent_phase.add(Transparent3d {
                                 entity: *visible_entity,
                                 draw_function: draw_transparent_pbr,
-                                pipeline: pipeline_id,
+                                pipeline_id,
                                 distance,
                             });
                         }

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -19,8 +19,8 @@ use bevy_render::{
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{
-        CachedRenderPipelinePhaseItem, DrawFunctionId, DrawFunctions, PhaseItem, RenderCommand,
-        RenderCommandResult, RenderPhase, SetItemPipeline, TrackedRenderPass,
+        DrawFunctionId, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult, RenderPhase,
+        SetItemPipeline, TrackedRenderPass,
     },
     render_resource::*,
     renderer::{RenderContext, RenderDevice, RenderQueue},
@@ -1762,7 +1762,7 @@ pub fn queue_shadows(
 
                         shadow_phase.add(Shadow {
                             draw_function: draw_shadow_mesh,
-                            pipeline: pipeline_id,
+                            pipeline_id,
                             entity,
                             distance: 0.0, // TODO: sort back-to-front
                         });
@@ -1776,7 +1776,7 @@ pub fn queue_shadows(
 pub struct Shadow {
     pub distance: f32,
     pub entity: Entity,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 
@@ -1799,15 +1799,13 @@ impl PhaseItem for Shadow {
     }
 
     #[inline]
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
+    }
+
+    #[inline]
     fn sort(items: &mut [Self]) {
         radsort::sort_by_key(items, |item| item.distance);
-    }
-}
-
-impl CachedRenderPipelinePhaseItem for Shadow {
-    #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
     }
 }
 

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -136,7 +136,7 @@ fn queue_wireframes(
                     };
                     opaque_phase.add(Opaque3d {
                         entity,
-                        pipeline: pipeline_id,
+                        pipeline_id,
                         draw_function: draw_custom,
                         distance: rangefinder.distance(&mesh_uniform.transform),
                     });

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -383,7 +383,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                         transparent_phase.add(Transparent2d {
                             entity: *visible_entity,
                             draw_function: draw_transparent_pbr,
-                            pipeline: pipeline_id,
+                            pipeline_id,
                             // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
                             // lowest sort key and getting closer should increase. As we have
                             // -z in front of the camera, the largest distance is -far with values increasing toward the

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -527,12 +527,12 @@ pub fn queue_sprites(
                     }
                 }
             }
-            let pipeline = pipelines.specialize(
+            let pipeline_id = pipelines.specialize(
                 &pipeline_cache,
                 &sprite_pipeline,
                 view_key | SpritePipelineKey::from_colored(false),
             );
-            let colored_pipeline = pipelines.specialize(
+            let colored_pipeline_id = pipelines.specialize(
                 &pipeline_cache,
                 &sprite_pipeline,
                 view_key | SpritePipelineKey::from_colored(true),
@@ -654,7 +654,7 @@ pub fn queue_sprites(
 
                     transparent_phase.add(Transparent2d {
                         draw_function: draw_sprite_function,
-                        pipeline: colored_pipeline,
+                        pipeline_id: colored_pipeline_id,
                         entity: current_batch_entity,
                         sort_key,
                         batch_range: Some(item_start..item_end),
@@ -672,7 +672,7 @@ pub fn queue_sprites(
 
                     transparent_phase.add(Transparent2d {
                         draw_function: draw_sprite_function,
-                        pipeline,
+                        pipeline_id,
                         entity: current_batch_entity,
                         sort_key,
                         batch_range: Some(item_start..item_end),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -584,7 +584,7 @@ pub fn queue_uinodes(
         }));
         let draw_ui_function = draw_functions.read().id::<DrawUi>();
         for (view, mut transparent_phase) in &mut views {
-            let pipeline = pipelines.specialize(
+            let pipeline_id = pipelines.specialize(
                 &pipeline_cache,
                 &ui_pipeline,
                 UiPipelineKey { hdr: view.hdr },
@@ -612,7 +612,7 @@ pub fn queue_uinodes(
                     });
                 transparent_phase.add(TransparentUi {
                     draw_function: draw_ui_function,
-                    pipeline,
+                    pipeline_id,
                     entity,
                     sort_key: FloatOrd(batch.z),
                 });

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -94,7 +94,7 @@ impl Node for UiPassNode {
 pub struct TransparentUi {
     pub sort_key: FloatOrd,
     pub entity: Entity,
-    pub pipeline: CachedRenderPipelineId,
+    pub pipeline_id: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
 }
 
@@ -115,12 +115,10 @@ impl PhaseItem for TransparentUi {
     fn draw_function(&self) -> DrawFunctionId {
         self.draw_function
     }
-}
 
-impl CachedRenderPipelinePhaseItem for TransparentUi {
     #[inline]
-    fn cached_pipeline(&self) -> CachedRenderPipelineId {
-        self.pipeline
+    fn pipeline_id(&self) -> CachedRenderPipelineId {
+        self.pipeline_id
     }
 }
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -349,7 +349,7 @@ pub fn queue_colored_mesh2d(
                 transparent_phase.add(Transparent2d {
                     entity: *visible_entity,
                     draw_function: draw_colored_mesh2d,
-                    pipeline: pipeline_id,
+                    pipeline_id,
                     // The 2d render items are sorted according to their z value before rendering,
                     // in order to get correct transparency
                     sort_key: FloatOrd(mesh_z),

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -120,12 +120,12 @@ fn queue_custom(
             if let Some(mesh) = meshes.get(mesh_handle) {
                 let key =
                     view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline = pipelines
+                let pipeline_id = pipelines
                     .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                     .unwrap();
                 transparent_phase.add(Transparent3d {
                     entity,
-                    pipeline,
+                    pipeline_id,
                     draw_function: draw_custom,
                     distance: rangefinder.distance(&mesh_uniform.transform),
                 });


### PR DESCRIPTION
# Objective

- Fixes #7159

See the reasons for this PR in the issue mentioned above.
I am still not sure whether this covers all use cases. 
Let me know if you find a reason to let them stay separated.

## Solution

- removes `CachedRenderPipelinePhaseItem` and adds its method `render_pipeline`  to `PhaseItem` instead

---

## Changelog

- removed `CachedRenderPipelinePhaseItem`
- added `pipeline_id` method to `PhaseItem` replacing `CachedRenderPipelinePhaseItem::render_pipeline`
- renamed the field `pipeline` to `pipeline_id` on the types `Transparent2d`, `Opaque3d`, `AlphaMask3d`, `Transparent3d`, and `Shadow`

## Migration Guide

- change the occurrences of the `pipeline` field on the phase items: `Transparent2d`, `Opaque3d`, `AlphaMask3d`, `Transparent3d`, and `Shadow` to `pipeline_id`
- instead of separately implementing `CachedRenderPipelinePhaseItem` for your phase items, now use the `PhaseItem::pipeline_id` method