### PR TITLE
Add sheduled security checks

### DIFF
--- a/.github/workflows/rustsec.yml
+++ b/.github/workflows/rustsec.yml
@@ -1,0 +1,14 @@
+name: cargo-audit
+
+on:
+  shedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rustsec/audit-check@v0.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Objective

CI should automatically check if some deps are mentioned in https://rustsec.org database. Not only for unmaintained crates but also potential segfaults with threading and so on.

## Solution

- Added sheduled checks with `cargo audit`, it will run every day at midnight and automatically open security related issues
