### PR TITLE
[Merged by Bors] - Use Bevy People links in The Bevy Organization Doc

### DIFF
--- a/docs/the_bevy_organization.md
+++ b/docs/the_bevy_organization.md
@@ -35,7 +35,7 @@ To make it easy to reach consensus, hold a high quality bar, and synchronize vis
 
 If you are interested in a Maintainer role and believe you meet these criteria, reach out to one of our Project Leads or Maintainers. One month after every Bevy release Maintainers and Project Leads will evaluate the need for new roles, review candidates, and vote. Bringing in a new Maintainer requires unanimous support from all Project Leads and Maintainers.
 
-Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of maintainers. 
+Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of maintainers.
 
 ## Subject Matter Expert (SME)
 
@@ -53,7 +53,7 @@ To make it easy to reach consensus, hold a high quality bar, and synchronize vis
 
 If you are interested in a SME role and believe you meet these criteria, reach out to one of our Project Leads or Maintainers. One month after every Bevy release Maintainers and Project Leads will evaluate the need for new roles, review candidates, and vote. Bringing in a new SME requires the support of the Project Leads and half of the Maintainers (however unanimous support is preferred).
 
-Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of SMEs. 
+Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of SMEs.
 
 ## Bevy Org Member / Triage Team
 

--- a/docs/the_bevy_organization.md
+++ b/docs/the_bevy_organization.md
@@ -35,11 +35,7 @@ To make it easy to reach consensus, hold a high quality bar, and synchronize vis
 
 If you are interested in a Maintainer role and believe you meet these criteria, reach out to one of our Project Leads or Maintainers. One month after every Bevy release Maintainers and Project Leads will evaluate the need for new roles, review candidates, and vote. Bringing in a new Maintainer requires unanimous support from all Project Leads and Maintainers.
 
-Our current Maintainers:
-
-* Alice Cecile (@alice-i-cecile)
-* François Mockers (@mockersf)
-* Rob Swain (@superdump)
+Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of maintainers. 
 
 ## Subject Matter Expert (SME)
 
@@ -57,9 +53,7 @@ To make it easy to reach consensus, hold a high quality bar, and synchronize vis
 
 If you are interested in a SME role and believe you meet these criteria, reach out to one of our Project Leads or Maintainers. One month after every Bevy release Maintainers and Project Leads will evaluate the need for new roles, review candidates, and vote. Bringing in a new SME requires the support of the Project Leads and half of the Maintainers (however unanimous support is preferred).
 
-Our current Subject Matter Experts:
-
-(Finalizing this list now)
+Check out the [Bevy People](https://bevyengine.org/community/people/#the-bevy-organization) page for the current list of SMEs. 
 
 ## Bevy Org Member / Triage Team
 


### PR DESCRIPTION
Bevy People should be considered the source of truth for Bevy Organization roles. This replaces inline lists of maintainers and SMEs with links to Bevy People.