### PR TITLE
Move AmbientLight to a component, instead of a resource.

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -43,7 +43,6 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::CameraUpdateSystem,
-    extract_resource::ExtractResourcePlugin,
     prelude::Color,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -148,12 +148,6 @@ impl Plugin for PbrPlugin {
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                add_ambient_lights
-                    .at_start()
-                    .label(SimulationLightSystems::AddAmbientLights),
-            )
-            .add_system_to_stage(
-                CoreStage::PostUpdate,
                 assign_lights_to_clusters
                     .label(SimulationLightSystems::AssignLightsToClusters)
                     .after(TransformSystem::TransformPropagate)
@@ -219,10 +213,6 @@ impl Plugin for PbrPlugin {
             .add_system_to_stage(
                 RenderStage::Extract,
                 render::extract_clusters.label(RenderLightSystems::ExtractClusters),
-            )
-            .add_system_to_stage(
-                RenderStage::Extract,
-                render::extract_ambient_light.label(RenderLightSystems::ExtractAmbientLights),
             )
             .add_system_to_stage(
                 RenderStage::Extract,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -43,12 +43,13 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::CameraUpdateSystem,
+    extract_component::ExtractComponentPlugin,
     prelude::Color,
     render_graph::RenderGraph,
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
     render_resource::{Shader, SpecializedMeshPipelines},
     view::VisibilitySystems,
-    RenderApp, RenderStage, extract_component::ExtractComponentPlugin,
+    RenderApp, RenderStage,
 };
 use bevy_transform::TransformSystem;
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -136,11 +136,9 @@ impl Plugin for PbrPlugin {
             .register_type::<PointLightShadowMap>()
             .add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
-            .init_resource::<AmbientLight>()
             .init_resource::<GlobalVisiblePointLights>()
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()
-            .add_plugin(ExtractResourcePlugin::<AmbientLight>::default())
             .add_system_to_stage(
                 CoreStage::PostUpdate,
                 // NOTE: Clusters need to have been added before update_clusters is run so
@@ -148,6 +146,12 @@ impl Plugin for PbrPlugin {
                 add_clusters
                     .at_start()
                     .label(SimulationLightSystems::AddClusters),
+            )
+            .add_system_to_stage(
+                CoreStage::PostUpdate,
+                add_ambient_lights
+                    .at_start()
+                    .label(SimulationLightSystems::AddAmbientLights),
             )
             .add_system_to_stage(
                 CoreStage::PostUpdate,
@@ -216,6 +220,10 @@ impl Plugin for PbrPlugin {
             .add_system_to_stage(
                 RenderStage::Extract,
                 render::extract_clusters.label(RenderLightSystems::ExtractClusters),
+            )
+            .add_system_to_stage(
+                RenderStage::Extract,
+                render::extract_ambient_light.label(RenderLightSystems::ExtractAmbientLights),
             )
             .add_system_to_stage(
                 RenderStage::Extract,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -48,7 +48,7 @@ use bevy_render::{
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions},
     render_resource::{Shader, SpecializedMeshPipelines},
     view::VisibilitySystems,
-    RenderApp, RenderStage,
+    RenderApp, RenderStage, extract_component::ExtractComponentPlugin,
 };
 use bevy_transform::TransformSystem;
 
@@ -135,6 +135,7 @@ impl Plugin for PbrPlugin {
             .register_type::<PointLightShadowMap>()
             .add_plugin(MeshRenderPlugin)
             .add_plugin(MaterialPlugin::<StandardMaterial>::default())
+            .add_plugin(ExtractComponentPlugin::<AmbientLight>::default())
             .init_resource::<GlobalVisiblePointLights>()
             .init_resource::<DirectionalLightShadowMap>()
             .init_resource::<PointLightShadowMap>()

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -6,10 +6,11 @@ use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, CameraProjection, OrthographicProjection},
     color::Color,
+    extract_component::ExtractComponent,
     primitives::{Aabb, CubemapFrusta, Frustum, Plane, Sphere},
     render_resource::BufferBindingType,
     renderer::RenderDevice,
-    view::{ComputedVisibility, RenderLayers, VisibleEntities}, extract_component::ExtractComponent,
+    view::{ComputedVisibility, RenderLayers, VisibleEntities},
 };
 use bevy_transform::{components::GlobalTransform, prelude::Transform};
 use bevy_utils::tracing::warn;
@@ -285,7 +286,7 @@ impl ExtractComponent for AmbientLight {
     type Out = Self;
 
     fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::Query>) -> Option<Self::Out> {
-        Some(item.clone())
+        Some(*item)
     }
 }
 

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -263,8 +263,8 @@ impl Default for DirectionalLightShadowMap {
 }
 
 /// An ambient light, which lights the entire scene equally.
-#[derive(Resource, Clone, Debug, ExtractResource, Reflect)]
-#[reflect(Resource)]
+#[derive(Component, Debug, Clone, Copy, Reflect)]
+#[reflect(Component, Default)]
 pub struct AmbientLight {
     pub color: Color,
     /// A direct scale factor multiplied with `color` before being passed to the shader.
@@ -280,6 +280,17 @@ impl Default for AmbientLight {
     }
 }
 
+pub fn add_ambient_lights(
+    mut commands: Commands,
+    cameras: Query<Entity, With<Camera>>,
+) {
+    for entity in &cameras {
+        commands
+            .entity(entity)
+            .insert(AmbientLight::default());
+    }
+}
+
 /// Add this component to make a [`Mesh`](bevy_render::mesh::Mesh) not cast shadows.
 #[derive(Component, Reflect, Default)]
 #[reflect(Component, Default)]
@@ -292,6 +303,7 @@ pub struct NotShadowReceiver;
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemLabel)]
 pub enum SimulationLightSystems {
     AddClusters,
+    AddAmbientLights,
     AssignLightsToClusters,
     UpdateLightFrusta,
     CheckLightVisibility,

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     primitives::{Aabb, CubemapFrusta, Frustum, Plane, Sphere},
     render_resource::BufferBindingType,
     renderer::RenderDevice,
-    view::{ComputedVisibility, RenderLayers, VisibleEntities},
+    view::{ComputedVisibility, RenderLayers, VisibleEntities}, extract_component::ExtractComponent,
 };
 use bevy_transform::{components::GlobalTransform, prelude::Transform};
 use bevy_utils::tracing::warn;
@@ -276,6 +276,16 @@ impl Default for AmbientLight {
             color: Color::rgb(1.0, 1.0, 1.0),
             brightness: 0.05,
         }
+    }
+}
+
+impl ExtractComponent for AmbientLight {
+    type Query = &'static Self;
+    type Filter = With<Camera>;
+    type Out = Self;
+
+    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::Query>) -> Option<Self::Out> {
+        Some(item.clone())
     }
 }
 

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -6,7 +6,6 @@ use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, CameraProjection, OrthographicProjection},
     color::Color,
-    extract_resource::ExtractResource,
     primitives::{Aabb, CubemapFrusta, Frustum, Plane, Sphere},
     render_resource::BufferBindingType,
     renderer::RenderDevice,
@@ -280,14 +279,9 @@ impl Default for AmbientLight {
     }
 }
 
-pub fn add_ambient_lights(
-    mut commands: Commands,
-    cameras: Query<Entity, With<Camera>>,
-) {
+pub fn add_ambient_lights(mut commands: Commands, cameras: Query<Entity, With<Camera>>) {
     for entity in &cameras {
-        commands
-            .entity(entity)
-            .insert(AmbientLight::default());
+        commands.entity(entity).insert(AmbientLight::default());
     }
 }
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -389,11 +389,12 @@ pub fn extract_ambient_light(
     views: Extract<Query<(Entity, &AmbientLight), With<Camera>>>,
 ) {
     for (entity, ambient_light) in &views {
-        commands.get_or_spawn(entity).insert((
-            ExtractedAmbientLight {
-                ambient_color: Vec4::from_slice(&ambient_light.color.as_linear_rgba_f32()) * ambient_light.brightness,
-            },
-        ));
+        commands
+            .get_or_spawn(entity)
+            .insert((ExtractedAmbientLight {
+                ambient_color: Vec4::from_slice(&ambient_light.color.as_linear_rgba_f32())
+                    * ambient_light.brightness,
+            },));
     }
 }
 
@@ -782,7 +783,12 @@ pub fn prepare_lights(
     mut global_light_meta: ResMut<GlobalLightMeta>,
     mut light_meta: ResMut<LightMeta>,
     views: Query<
-        (Entity, &ExtractedView, &ExtractedClusterConfig, &ExtractedAmbientLight),
+        (
+            Entity,
+            &ExtractedView,
+            &ExtractedClusterConfig,
+            &ExtractedAmbientLight,
+        ),
         With<RenderPhase<Transparent3d>>,
     >,
     point_light_shadow_map: Res<PointLightShadowMap>,
@@ -1047,7 +1053,6 @@ pub fn prepare_lights(
             clusters.dimensions.z as f32,
             is_orthographic,
         );
-
 
         let n_clusters = clusters.dimensions.x * clusters.dimensions.y * clusters.dimensions.z;
         let gpu_lights = GpuLights {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res},
 };
-use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3};
+use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3, Vec4};
 use bevy_reflect::prelude::*;
 use bevy_reflect::FromReflect;
 use bevy_transform::components::GlobalTransform;
@@ -478,6 +478,11 @@ pub struct ExtractedCamera {
     pub viewport: Option<Viewport>,
     pub render_graph: Cow<'static, str>,
     pub order: isize,
+}
+
+#[derive(Component, Debug)]
+pub struct ExtractedCameraLighting {
+    pub ambient_color: Vec4,
 }
 
 pub fn extract_cameras(

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -16,7 +16,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res},
 };
-use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3, Vec4};
+use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_reflect::FromReflect;
 use bevy_transform::components::GlobalTransform;
@@ -478,11 +478,6 @@ pub struct ExtractedCamera {
     pub viewport: Option<Viewport>,
     pub render_graph: Cow<'static, str>,
     pub order: isize,
-}
-
-#[derive(Component, Debug)]
-pub struct ExtractedCameraLighting {
-    pub ambient_color: Vec4,
 }
 
 pub fn extract_cameras(

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -91,12 +91,6 @@ fn setup(
         Movable,
     ));
 
-    // ambient light
-    commands.insert_resource(AmbientLight {
-        color: Color::ORANGE_RED,
-        brightness: 0.02,
-    });
-
     // red point light
     commands
         .spawn(PointLightBundle {
@@ -211,10 +205,16 @@ fn setup(
     });
 
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::ORANGE_RED,
+            brightness: 0.02,
+        },
+    ));
 }
 
 fn animate_light_direction(

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -6,10 +6,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(AmbientLight {
-            color: Color::WHITE,
-            brightness: 1.0 / 5.0f32,
-        })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(animate_light_direction)
@@ -17,10 +13,17 @@ fn main() {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.7, 0.7, 1.0).looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(0.7, 0.7, 1.0)
+                .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::WHITE,
+            brightness: 1.0 / 5.0f32,
+        },
+    ));
     const HALF_SIZE: f32 = 1.0;
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -80,16 +80,15 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
+        // ambient light
+        // NOTE: The ambient light is used to scale how bright the environment map is so with a bright
+        // environment map, use an appropriate colour and brightness to match
+        AmbientLight {
+            color: Color::rgb_u8(210, 220, 240),
+            brightness: 1.0,
+        },
         CameraController::default(),
     ));
-
-    // ambient light
-    // NOTE: The ambient light is used to scale how bright the environment map is so with a bright
-    // environment map, use an appropriate colour and brightness to match
-    commands.insert_resource(AmbientLight {
-        color: Color::rgb_u8(210, 220, 240),
-        brightness: 1.0,
-    });
 
     commands.insert_resource(Cubemap {
         is_loaded: false,

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -58,12 +58,6 @@ fn setup(
         ));
     }
 
-    // ambient light
-    commands.insert_resource(AmbientLight {
-        color: Color::rgb(0.0, 1.0, 1.0),
-        brightness: 0.14,
-    });
-
     for x in 0..4 {
         for z in 0..4 {
             let x = x as f32 - 2.0;
@@ -117,10 +111,16 @@ fn setup(
     }
 
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-4.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-4.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::rgb(0.0, 1.0, 1.0),
+            brightness: 0.14,
+        },
+    ));
 }
 
 fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)>) {

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -8,10 +8,6 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            color: Color::WHITE,
-            brightness: 1.0,
-        })
         .add_startup_system(setup)
         .add_system(setup_scene_once_loaded)
         .add_system(keyboard_animation_control)
@@ -35,11 +31,17 @@ fn setup(
     ]));
 
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(100.0, 100.0, 150.0)
-            .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(100.0, 100.0, 150.0)
+                .looking_at(Vec3::new(0.0, 20.0, 0.0), Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::WHITE,
+            brightness: 1.0,
+        },
+    ));
 
     // Plane
     commands.spawn(PbrBundle {

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -7,10 +7,6 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            color: Color::WHITE,
-            brightness: 1.0,
-        })
         .add_startup_system(setup)
         .run();
 }
@@ -22,10 +18,16 @@ fn setup(
     mut animations: ResMut<Assets<AnimationClip>>,
 ) {
     // Camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::WHITE,
+            brightness: 1.0,
+        },
+    ));
 
     // The animation API uses the `Name` component to target entities
     let planet = Name::new("planet");

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -16,13 +16,22 @@ use rand::Rng;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            brightness: 1.0,
-            ..default()
-        })
         .add_startup_system(setup)
+        .add_startup_system(setup_camera)
         .add_system(joint_animation)
         .run();
+}
+
+fn setup_camera(mut commands: Commands, cameras: Query<Entity, With<Camera>>) {
+    for entity in cameras.iter() {
+        commands
+            .entity(entity)
+            // add an `Enemy` component to the entity
+            .insert(AmbientLight {
+                brightness: 1.0,
+                ..Default::default()
+            });
+    }
 }
 
 /// Used to mark a joint to be animated in the [`joint_animation`] system.

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -8,10 +8,6 @@ use bevy::{pbr::AmbientLight, prelude::*, render::mesh::skinning::SkinnedMesh};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            brightness: 1.0,
-            ..default()
-        })
         .add_startup_system(setup)
         .add_system(joint_animation)
         .run();
@@ -19,10 +15,16 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Create a camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            brightness: 1.0,
+            ..Default::default()
+        },
+    ));
 
     // Spawn the first scene in `models/SimpleSkin/SimpleSkin.gltf`
     commands.spawn(SceneBundle {

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -11,10 +11,6 @@ const DELTA_TIME: f64 = 0.01;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            brightness: 0.03,
-            ..default()
-        })
         .add_startup_system(generate_bodies)
         .add_stage_after(
             CoreStage::Update,
@@ -148,10 +144,16 @@ fn generate_bodies(
                 ..default()
             });
         });
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 10.5, -30.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 10.5, -30.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            brightness: 0.03,
+            ..default()
+        },
+    ));
 }
 
 fn interact_bodies(mut query: Query<(&Mass, &GlobalTransform, &mut Acceleration)>) {

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -36,10 +36,6 @@ fn main() {
             speed: 2.0,
             moving: true,
         })
-        .insert_resource(AmbientLight {
-            color: Color::WHITE,
-            brightness: 1.0,
-        })
         .add_startup_system(setup)
         .add_system(setup_scene_once_loaded)
         .add_system(keyboard_animation_control)
@@ -152,11 +148,17 @@ fn setup(
         radius * 0.5 * zoom,
         radius * 1.5 * zoom,
     );
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_translation(translation)
-            .looking_at(0.2 * Vec3::new(translation.x, 0.0, translation.z), Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_translation(translation)
+                .looking_at(0.2 * Vec3::new(translation.x, 0.0, translation.z), Vec3::Y),
+            ..default()
+        },
+        AmbientLight {
+            color: Color::WHITE,
+            brightness: 1.0,
+        },
+    ));
 
     // Plane
     commands.spawn(PbrBundle {

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -19,11 +19,7 @@ use scene_viewer_plugin::{SceneHandle, SceneViewerPlugin};
 
 fn main() {
     let mut app = App::new();
-    app.insert_resource(AmbientLight {
-        color: Color::WHITE,
-        brightness: 1.0 / 5.0f32,
-    })
-    .add_plugins(
+    app.add_plugins(
         DefaultPlugins
             .set(WindowPlugin {
                 window: WindowDescriptor {
@@ -125,6 +121,10 @@ fn setup_scene_after_load(
                     ..default()
                 },
                 ..default()
+            },
+            AmbientLight {
+                color: Color::WHITE,
+                brightness: 1.0 / 5.0f32,
             },
             camera_controller,
         ));


### PR DESCRIPTION
# Objective

Fixes #7193

## Solution

- Changed `AmbientLight` from a `Resource` to a `Component`. 
- The `PbrPlugin` adds a default `AmbientLight` to each camera in `PostUpdate`. I suspect this doesn't make much sense and should be configurable somewhere else? Not sure. If this would live somewhere else, that would also get rid of `SimulationLightSystems::AddAmbientLights` which seems misplaced.
- The component is extracted in  `ReanderStage::Extract`. Currently the data is put into a dedicated `ExtractedAmbientLights` struct. This should probably be a more general `ExtractedCameraConfig` struct or similar, thoughts?

---

## Changelog

- Ambient lights can now be configured on a per camera basis.

## Migration Guide

Previously setting up an `AmbientLight` looked something like this:

```rust
fn main() {
  App::new()
    ...
    .add_startup_system(setup)
    .insert_resource(AmbientLight {
        color: Color::WHITE,
        brightness: 1.0,
    })
    ...
    .run();
}

fn setup(mut commands: Commands) {
  commands.spawn((
        Camera3dBundle {
            ..default()
        },
        ...,
    ));
}
```

With `AmbientLight` as a per camera component the code needs to be transformed into:

```rust
fn main() {
  App::new()
      ...
      .add_startup_system(setup)
      ...
      .run();
}

fn setup(mut commands: Commands) {
  commands.spawn((
      Camera3dBundle {
          ..default()
      },
      AmbientLight {
          color: Color::WHITE,
          brightness: 1.0,
      },
      ...,
  ));
}
```

`AmbientLight` can be directly added to the camera entity as a component
