### PR TITLE
[Merged by Bors] - Update milestone section in `contributing.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issu
 * Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
 * Would have higher user impact and are almost ready to be merged/fixed.
 
-There are also two priority labels: [`P-Critical`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-Critical) and [`P-High`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-High) that can be used to find issues and PRs that need to be resolved urgently. 
+There are also two priority labels: [`P-Critical`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-Critical) and [`P-High`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-High) that can be used to find issues and PRs that need to be resolved urgently.
 
 ## Making changes to Bevy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,7 @@ Here are some useful pull request queries:
 ### Prioritizing PRs and issues
 
 We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issues and PRs that:
+
 * Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
 * Would have higher user impact and are almost ready to be merged/fixed.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issu
 * Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
 * Would have higher user impact and are almost ready to be merged/fixed.
 
-There are also two priority labels: `P-Critical` and `P-High` that can be used to find issues and PRs that need to be resolved urgently. 
+There are also two priority labels: [`P-Critical`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-Critical) and [`P-High`](https://github.com/bevyengine/bevy/issues?q=is%3Aopen+is%3Aissue+label%3AP-High) that can be used to find issues and PRs that need to be resolved urgently. 
 
 ## Making changes to Bevy
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,8 +111,8 @@ Here are some useful pull request queries:
 ### Prioritizing PRs and issues
 
 We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issues and PRs that:
-- Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
-- Would have higher user impact and are almost ready to be merged/fixed.
+* Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
+* Would have higher user impact and are almost ready to be merged/fixed.
 
 There are also two priority labels: `P-Critical` and `P-High` that can be used to find issues and PRs that need to be resolved urgently. 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,9 +108,13 @@ Here are some useful pull request queries:
 * [Uncontroversial pull requests which have been reviewed and are ready for maintainers to merge](https://github.com/bevyengine/bevy/pulls?q=is%3Aopen+is%3Apr+label%3AS-Ready-For-Final-Review+-label%3AS-Controversial+-label%3AS-Blocked+-label%3AS-Adopt-Me+)
 * [Controversial pull requests which have been reviewed and are ready for final input from a Project Lead or SME](https://github.com/bevyengine/bevy/pulls?q=is%3Aopen+is%3Apr+label%3AS-Ready-For-Final-Review+label%3AS-Controversial+)
 
-### Preparing Releases
+### Prioritizing PRs and issues
 
-We track issues and pull requests that must be included in releases using [Milestones](https://github.com/bevyengine/bevy/milestones).
+We use [Milestones](https://github.com/bevyengine/bevy/milestones) to track issues and PRs that:
+- Need to be merged/fixed before the next release. This is generally for extremely bad bugs i.e. UB or important functionality being broken.
+- Would have higher user impact and are almost ready to be merged/fixed.
+
+There are also two priority labels: `P-Critical` and `P-High` that can be used to find issues and PRs that need to be resolved urgently. 
 
 ## Making changes to Bevy
 


### PR DESCRIPTION
Current info is not up to date as we are now using a train release model and frequently end up with PRs and issues in the milestone that are not resolved before release. As the release milestone is now mostly used for prioritizing what work gets done I updated this section to be about prioritizing PRs/issues instead of preparing releases.