### PR TITLE
[Merged by Bors] - Add safety comments to usages of `byte_add` (`Ptr`, `PtrMut`, `OwningPtr`)

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -212,6 +212,8 @@ impl BlobVec {
     #[must_use = "The returned pointer should be used to dropped the removed element"]
     pub unsafe fn swap_remove_and_forget_unchecked(&mut self, index: usize) -> OwningPtr<'_> {
         debug_assert!(index < self.len());
+        // Since `index` must be strictly less than `self.len` and `index` is at least zero,
+        // `self.len` must be at least one. Thus, this cannot underflow.
         let new_len = self.len - 1;
         let size = self.item_layout.size();
         if index != new_len {

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -327,6 +327,8 @@ impl BlobVec {
                 // * `size` is a multiple of the erased type's alignment,
                 //   so adding a multiple of `size` will preserve alignment.
                 // * The item is left unreachable so it can be safely promoted to an `OwningPtr`.
+                // NOTE: `self.get_unchecked_mut(i)` cannot be used here, since the `debug_assert`
+                // would get panic due to `self.len` being set to 0.
                 let item = unsafe { self.get_ptr_mut().byte_add(i * size).promote() };
                 // SAFETY: `item` was obtained from this `BlobVec`, so its underlying type must match `drop`.
                 unsafe { drop(item) };

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -223,8 +223,10 @@ impl BlobVec {
         }
         self.len = new_len;
         // Cannot use get_unchecked here as this is technically out of bounds after changing len.
-        // SAFETY: `size` is a multiple of the erased type's alignment,
-        // so adding a multiple of `size` will preserve alignment.
+        // SAFETY:
+        // - `new_len` is less than the old len, so it must fit in this vector's allocation.
+        // - `size` is a multiple of the erased type's alignment,
+        //   so adding a multiple of `size` will preserve alignment.
         self.get_ptr_mut().byte_add(new_len * size).promote()
     }
 
@@ -267,8 +269,11 @@ impl BlobVec {
     pub unsafe fn get_unchecked(&self, index: usize) -> Ptr<'_> {
         debug_assert!(index < self.len());
         let size = self.item_layout.size();
-        // SAFETY: `size` is a multiple of the erased type's alignment,
-        // so adding a multiple of `size` will preserve alignment.
+        // SAFETY:
+        // - The caller ensures that `index` fits in this vector,
+        //   so this operation will not overflow the original allocation.
+        // - `size` is a multiple of the erased type's alignment,
+        //  so adding a multiple of `size` will preserve alignment.
         self.get_ptr().byte_add(index * size)
     }
 
@@ -278,8 +283,11 @@ impl BlobVec {
     pub unsafe fn get_unchecked_mut(&mut self, index: usize) -> PtrMut<'_> {
         debug_assert!(index < self.len());
         let size = self.item_layout.size();
-        // SAFETY: `size` is a multiple of the erased type's alignment,
-        // so adding a multiple of `size` will preserve alignment.
+        // SAFETY:
+        // - The caller ensures that `index` fits in this vector,
+        //   so this operation will not overflow the original allocation.
+        // - `size` is a multiple of the erased type's alignment,
+        //  so adding a multiple of `size` will preserve alignment.
         self.get_ptr_mut().byte_add(index * size)
     }
 

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -330,7 +330,7 @@ impl BlobVec {
                 //   so adding a multiple of `size` will preserve alignment.
                 // * The item is left unreachable so it can be safely promoted to an `OwningPtr`.
                 // NOTE: `self.get_unchecked_mut(i)` cannot be used here, since the `debug_assert`
-                // would get panic due to `self.len` being set to 0.
+                // would panic due to `self.len` being set to 0.
                 let item = unsafe { self.get_ptr_mut().byte_add(i * size).promote() };
                 // SAFETY: `item` was obtained from this `BlobVec`, so its underlying type must match `drop`.
                 unsafe { drop(item) };


### PR DESCRIPTION
# Objective

The usages of the unsafe function `byte_add` are not properly documented.

Follow-up to #7151.

## Solution

Add safety comments to each call-site.
