### PR TITLE
[Merged by Bors] - Make `EntityRef::new` unsafe

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -747,7 +747,7 @@ impl EntityMeta {
 // SAFETY:
 // This type must not contain any pointers at any level, and be safe to fully fill with u8::MAX.
 /// A location of an entity in an archetype.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct EntityLocation {
     /// The ID of the [`Archetype`] the [`Entity`] belongs to.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -24,7 +24,10 @@ pub struct EntityRef<'w> {
 impl<'w> EntityRef<'w> {
     /// # Safety
     ///
-    /// Entity and location _must_ be valid for the provided world.
+    ///  - `entity` must be valid for `world`: the generation should match that of the entity at the same index.
+    ///  - `location` must be sourced from `world`'s `Entities` and must exactly match the location for `entity`
+    ///
+    ///  The above is trivially satisfied if `location` was sourced from `world.entities().get(entity)`.
     #[inline]
     pub(crate) unsafe fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
         debug_assert!(world.entities().contains(entity));
@@ -215,7 +218,10 @@ pub struct EntityMut<'w> {
 impl<'w> EntityMut<'w> {
     /// # Safety
     ///
-    /// Entity and location _must_ be valid for the provided world.
+    ///  - `entity` must be valid for `world`: the generation should match that of the entity at the same index.
+    ///  - `location` must be sourced from `world`'s `Entities` and must exactly match the location for `entity`
+    ///
+    ///  The above is trivially satisfied if `location` was sourced from `world.entities().get(entity)`.
     #[inline]
     pub(crate) unsafe fn new(
         world: &'w mut World,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -27,6 +27,8 @@ impl<'w> EntityRef<'w> {
     /// Entity and location _must_ be valid for the provided world.
     #[inline]
     pub(crate) unsafe fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
+        debug_assert!(world.entities().contains(entity));
+
         Self {
             world,
             entity,
@@ -219,6 +221,8 @@ impl<'w> EntityMut<'w> {
         entity: Entity,
         location: EntityLocation,
     ) -> Self {
+        debug_assert!(world.entities().contains(entity));
+
         EntityMut {
             world,
             entity,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -31,7 +31,7 @@ impl<'w> EntityRef<'w> {
     #[inline]
     pub(crate) unsafe fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
         debug_assert!(world.entities().contains(entity));
-        debug_assert_eq!(world.entities().get(entity.index()), Some(location));
+        debug_assert_eq!(world.entities().get(entity), Some(location));
 
         Self {
             world,
@@ -229,7 +229,7 @@ impl<'w> EntityMut<'w> {
         location: EntityLocation,
     ) -> Self {
         debug_assert!(world.entities().contains(entity));
-        debug_assert_eq!(world.entities().get(entity.index()), Some(location));
+        debug_assert_eq!(world.entities().get(entity), Some(location));
 
         EntityMut {
             world,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -22,8 +22,11 @@ pub struct EntityRef<'w> {
 }
 
 impl<'w> EntityRef<'w> {
+    /// # Safety
+    ///
+    /// Entity and location _must_ be valid for the provided world.
     #[inline]
-    pub(crate) fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
+    pub(crate) unsafe fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
         Self {
             world,
             entity,
@@ -193,7 +196,9 @@ impl<'w> EntityRef<'w> {
 
 impl<'w> From<EntityMut<'w>> for EntityRef<'w> {
     fn from(entity_mut: EntityMut<'w>) -> EntityRef<'w> {
-        EntityRef::new(entity_mut.world, entity_mut.entity, entity_mut.location)
+        // SAFETY: the safety invariants on EntityMut and EntityRef are identical
+        // and EntityMut is promised to be valid by construction.
+        unsafe { EntityRef::new(entity_mut.world, entity_mut.entity, entity_mut.location) }
     }
 }
 
@@ -206,7 +211,8 @@ pub struct EntityMut<'w> {
 
 impl<'w> EntityMut<'w> {
     /// # Safety
-    /// entity and location _must_ be valid
+    ///
+    /// Entity and location _must_ be valid for the provided world.
     #[inline]
     pub(crate) unsafe fn new(
         world: &'w mut World,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -28,6 +28,7 @@ impl<'w> EntityRef<'w> {
     #[inline]
     pub(crate) unsafe fn new(world: &'w World, entity: Entity, location: EntityLocation) -> Self {
         debug_assert!(world.entities().contains(entity));
+        debug_assert_eq!(world.entities().get(entity.index()), Some(location));
 
         Self {
             world,
@@ -222,6 +223,7 @@ impl<'w> EntityMut<'w> {
         location: EntityLocation,
     ) -> Self {
         debug_assert!(world.entities().contains(entity));
+        debug_assert_eq!(world.entities().get(entity.index()), Some(location));
 
         EntityMut {
             world,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -334,13 +334,16 @@ impl World {
                 .iter()
                 .enumerate()
                 .map(|(archetype_row, archetype_entity)| {
+                    let entity = archetype_entity.entity();
                     let location = EntityLocation {
                         archetype_id: archetype.id(),
                         archetype_row: ArchetypeRow::new(archetype_row),
                         table_id: archetype.table_id(),
                         table_row: archetype_entity.table_row(),
                     };
-                    EntityRef::new(self, archetype_entity.entity(), location)
+
+                    // SAFETY: entity exists and location is validly constructed above
+                    unsafe { EntityRef::new(self, entity, location) }
                 })
         })
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -317,7 +317,12 @@ impl World {
     #[inline]
     pub fn get_entity(&self, entity: Entity) -> Option<EntityRef> {
         let location = self.entities.get(entity)?;
-        Some(EntityRef::new(self, entity, location))
+        // SAFETY: if the Entity is invalid, the function returns early.
+        // Additionally, Entities::get(entity) returns the correct EntityLocation if the entity exists
+        unsafe {
+            let entity_ref = EntityRef::new(self, entity, location);
+            Some(entity_ref)
+        }
     }
 
     /// Returns an [`Entity`] iterator of current entities.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -318,11 +318,9 @@ impl World {
     pub fn get_entity(&self, entity: Entity) -> Option<EntityRef> {
         let location = self.entities.get(entity)?;
         // SAFETY: if the Entity is invalid, the function returns early.
-        // Additionally, Entities::get(entity) returns the correct EntityLocation if the entity exists
-        unsafe {
-            let entity_ref = EntityRef::new(self, entity, location);
-            Some(entity_ref)
-        }
+        // Additionally, Entities::get(entity) returns the correct EntityLocation if the entity exists.
+        let entity_ref = unsafe { EntityRef::new(self, entity, location) };
+        Some(entity_ref)
     }
 
     /// Returns an [`Entity`] iterator of current entities.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -342,7 +342,7 @@ impl World {
                         table_row: archetype_entity.table_row(),
                     };
 
-                    // SAFETY: entity exists and location is validly constructed above
+                    // SAFETY: entity exists and location accurately specifies the archetype where the entity is stored
                     unsafe { EntityRef::new(self, entity, location) }
                 })
         })


### PR DESCRIPTION
# Objective

- We rely on the construction of `EntityRef` to be valid elsewhere in unsafe code. This construction is not checked (for performance reasons), and thus this private method must be unsafe.
- Fixes #7218.

## Solution

- Make the method unsafe.
- Add safety docs.
- Improve safety docs slightly for the sibling `EntityMut::new`.
- Add debug asserts to start to verify these assumptions in debug mode.


## Context for reviewers

I attempted to verify the `EntityLocation` more thoroughly, but this turned out to be more work than expected. I've spun that off into #7221 as a result.