### PR TITLE
Disable trace level tracing by default via a Cargo feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,21 +30,22 @@ default = [
   "animation",
   "bevy_asset",
   "bevy_audio",
-  "bevy_gilrs",
-  "bevy_scene",
-  "bevy_winit",
   "bevy_core_pipeline",
-  "bevy_pbr",
+  "bevy_gilrs",
   "bevy_gltf",
+  "bevy_pbr",
   "bevy_render",
+  "bevy_scene",
   "bevy_sprite",
   "bevy_text",
   "bevy_ui",
-  "png",
+  "bevy_winit",
+  "filesystem_watcher",
   "hdr",
+  "png",
+  "release_max_level_debug",
   "vorbis",
   "x11",
-  "filesystem_watcher",
 ]
 
 # Force dynamic linking, which improves iterative compile times
@@ -118,6 +119,11 @@ debug_asset_server = ["bevy_internal/debug_asset_server"]
 
 # Enable animation support, and glTF animation loading
 animation = ["bevy_internal/animation"]
+
+# Statically disables trace level at compile time.
+# The overhead of checking of even checking that trace level is enabled at runtime
+# can be significant in tight inner loops.
+release_max_level_debug = ["bevy_internal/release_max_level_debug"]
 
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.9.0", default-features = false, optional = true }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -23,6 +23,7 @@ trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
+release_max_level_debug = ["bevy_utils/release_max_level_debug"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 hdr = ["bevy_render/hdr"]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -62,6 +62,8 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 ///
 /// Log level can also be changed using the `RUST_LOG` environment variable.
 /// For example, using `RUST_LOG=wgpu=error,bevy_render=info,bevy_ecs=trace cargo run ..`
+/// Note that the default Bevy Cargo feature `release_max_level_debug` will statically
+/// disable trace level logging to reduce overhead in release mode.
 ///
 /// It has the same syntax as the field [`LogPlugin::filter`], see [`EnvFilter`].
 /// If you define the `RUST_LOG` environment variable, the [`LogPlugin`] settings

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features] 
+release_max_level_debug = ["tracing/release_max_level_debug"]
+
 [dependencies]
 ahash = "0.7.0"
 tracing = { version = "0.1", default-features = false, features = ["std"] }


### PR DESCRIPTION
# Objective

- Reduce significant overhead that was observed with trace-level logging in rendering, even when log level was INFO. This was observed especially in `TrackedRenderPass` which is called repeatedly in the tight inner loops of the renderer.

Using `set_bind_group` as an example, out of ~200ms spent on the function, ~140ms we spent checking if tracing is enabled at the trace level. 

![image](https://user-images.githubusercontent.com/1222141/212628328-ef877477-aab6-4c12-aa1a-f271698d8230.png)

## Solution

- Introduce a new default bevy cargo feature `release_max_level_debug` that statically disables trace-level tracing, thereby eliminating trace-related overhead.

Tracy capture using
```
cargo build --release --features bevy/trace_tracy  --example many_cubes
```
this = baseline
external = this PR

show a reduction in the median time for `main_opaque_pass_3d` rendering from 9.06ms -> 4.44ms, i.e. ~2X speedup.

![Screenshot 2023-01-15 235750](https://user-images.githubusercontent.com/1222141/212628725-1f80acaa-f2e1-4f82-9c92-4c484d4487c4.png)


---

## Changelog

- By default, in release mode trace-level tracing is statically disabled.

## Migration Guide

- In release builds, Bevy now statically disables trace-level tracing to improve performance. This means trace! logs will no longer appear regardless of the specified log level. To re-enable them in release builds, exclude the default features of bevy and include them manually, leaving out `release_max_level_debug`.
