### PR TITLE
[Merged by Bors] - Document usage of SRes::into_inner on the RenderCommand trait

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -390,6 +390,9 @@ impl<'w, T: Resource> Res<'w, T> {
         }
     }
 
+    /// Due to lifetime limitations of the `Deref` trait, this method can be used to obtain a
+    /// reference of the [`Resource`] with a lifetime bound to `'w` instead of the lifetime of the
+    /// struct itself.
     pub fn into_inner(self) -> &'w T {
         self.value
     }

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -159,6 +159,12 @@ impl<P: PhaseItem> DrawFunctions<P> {
 pub trait RenderCommand<P: PhaseItem> {
     /// Specifies the general ECS data (e.g. resources) required by [`RenderCommand::render`].
     ///
+    /// Due to lifetime limitations of the `Deref` trait,
+    /// [`SRes::into_inner`](bevy_ecs::system::lifetimeless::SRes::into_inner) must be called on
+    /// each [`SRes`](bevy_ecs::system::lifetimeless::SRes) reference in the
+    /// [`RenderCommand::render`] method, instead of being automatically dereferenced as is the
+    /// case in normal `systems`.
+    ///
     /// All parameters have to be read only.
     type Param: SystemParam + 'static;
     /// Specifies the ECS data of the view entity required by [`RenderCommand::render`].

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -159,13 +159,15 @@ impl<P: PhaseItem> DrawFunctions<P> {
 pub trait RenderCommand<P: PhaseItem> {
     /// Specifies the general ECS data (e.g. resources) required by [`RenderCommand::render`].
     ///
-    /// Due to lifetime limitations of the `Deref` trait,
-    /// [`SRes::into_inner`](bevy_ecs::system::lifetimeless::SRes::into_inner) must be called on
-    /// each [`SRes`](bevy_ecs::system::lifetimeless::SRes) reference in the
+    /// When fetching resources, note that, due to lifetime limitations of the `Deref` trait,
+    /// [`SRes::into_inner`] must be called on each [`SRes`] reference in the
     /// [`RenderCommand::render`] method, instead of being automatically dereferenced as is the
     /// case in normal `systems`.
     ///
     /// All parameters have to be read only.
+    ///
+    /// [`SRes`]: bevy_ecs::system::lifetimeless::SRes
+    /// [`SRes::into_inner`]: bevy_ecs::system::lifetimeless::SRes::into_inner
     type Param: SystemParam + 'static;
     /// Specifies the ECS data of the view entity required by [`RenderCommand::render`].
     ///


### PR DESCRIPTION
# Objective

- Fixes: #7187

Since avoiding the `SRes::into_inner` call does not seem to be possible, this PR tries to at least document its usage.
I am not sure if I explained the lifetime issue correctly, please let me know if something is incorrect.

## Solution

- Add information about the `SRes::into_inner` usage on both `RenderCommand` and `Res` 
