### PR TITLE
[Merged by Bors] - Docs: DefaultPlugins vs. MinimalPlugins and ScheduleRunnerPlugin

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -62,12 +62,15 @@ impl ScheduleRunnerSettings {
 /// Configures an [`App`] to run its [`Schedule`](bevy_ecs::schedule::Schedule) according to a given
 /// [`RunMode`].
 ///
-/// [`ScheduleRunnerPlugin`] is included in the [`MinimalPlugins`](bevy_internal::MinimalPlugins) plugin group.
+/// [`ScheduleRunnerPlugin`] is included in the
+/// [`MinimalPlugins`](https://docs.rs/bevy/latest/bevy/struct.MinimalPlugins.html) plugin group.
 ///
-/// [`ScheduleRunnerPlugin`] is *not* included in the [`DefaultPlugins`](bevy_internal::DefaultPlugins) plugin
-/// group which assumes that the [`Schedule`](bevy_ecs::schedule::Schedule) will be executed by other means:
-/// typically, the `winit` event loop (see [`WinitPlugin`](bevy_winit::WinitPlugin)) executes the
-/// [`Schedule`](bevy_ecs::schedule::Schedule) rendering [`ScheduleRunnerPlugin`] unnecessary.
+/// [`ScheduleRunnerPlugin`] is *not* included in the
+/// [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html) plugin group
+/// which assumes that the [`Schedule`](bevy_ecs::schedule::Schedule) will be executed by other means:
+/// typically, the `winit` event loop
+/// (see [`WinitPlugin`](https://docs.rs/bevy/latest/bevy/winit/struct.WinitPlugin.html))
+/// executes the schedule making [`ScheduleRunnerPlugin`] unnecessary.
 #[derive(Default)]
 pub struct ScheduleRunnerPlugin;
 

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -62,16 +62,12 @@ impl ScheduleRunnerSettings {
 /// Configures an [`App`] to run its [`Schedule`](bevy_ecs::schedule::Schedule) according to a given
 /// [`RunMode`].
 ///
-/// [`ScheduleRunnerPlugin`] is the only plugin that is included in the group of *minimal* *Bevy* plugins
-/// ([`MinimalPlugins`](bevy_internal::MinimalPlugins)) but excluded from [`DefaultPlugins`](bevy_internal::DefaultPlugins).
+/// [`ScheduleRunnerPlugin`] is included in the [`MinimalPlugins`](bevy_internal::MinimalPlugins) plugin group.
 ///
-/// Whereas windowed applications are usually driven by some kind of *event loop* or *message loop* –
-/// *Bevy's* being no exception, employing that provided by `winit` (see [`WinitPlugin`](bevy_winit::WinitPlugin))
-/// by default – *headless* programs and other, minimal cases require a schedule runner such as this.
-/// [`ScheduleRunnerPlugin`] is not required by apps that use the [`DefaultPlugins`](bevy_internal::DefaultPlugins)
-/// group because they typically include a *window* and presentation components.
-///
-/// See also: the [*Bevy* *headless* example](https://github.com/bevyengine/bevy/blob/main/examples/app/headless.rs)
+/// [`ScheduleRunnerPlugin`] is *not* included in the [`DefaultPlugins`](bevy_internal::DefaultPlugins) plugin
+/// group which assumes that the [`Schedule`](bevy_ecs::schedule::Schedule) will be executed by other means:
+/// typically, the `winit` event loop (see [`WinitPlugin`](bevy_winit::WinitPlugin)) executes the
+/// [`Schedule`](bevy_ecs::schedule::Schedule) rendering [`ScheduleRunnerPlugin`] unnecessary.
 #[derive(Default)]
 pub struct ScheduleRunnerPlugin;
 

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -61,6 +61,17 @@ impl ScheduleRunnerSettings {
 
 /// Configures an [`App`] to run its [`Schedule`](bevy_ecs::schedule::Schedule) according to a given
 /// [`RunMode`].
+///
+/// [`ScheduleRunnerPlugin`] is the only plugin that is included in the group of *minimal* *Bevy* plugins
+/// ([`MinimalPlugins`](bevy_internal::MinimalPlugins)) but excluded from [`DefaultPlugins`](bevy_internal::DefaultPlugins).
+///
+/// Whereas windowed applications are usually driven by some kind of *event loop* or *message loop* –
+/// *Bevy's* being no exception, employing that provided by `winit` (see [`WinitPlugin`](bevy_winit::WinitPlugin))
+/// by default – *headless* programs and other, minimal cases require a schedule runner such as this.
+/// [`ScheduleRunnerPlugin`] is not required by apps that use the [`DefaultPlugins`](bevy_internal::DefaultPlugins)
+/// group because they typically include a *window* and presentation components.
+///
+/// See also: the [*Bevy* *headless* example](https://github.com/bevyengine/bevy/blob/main/examples/app/headless.rs)
 #[derive(Default)]
 pub struct ScheduleRunnerPlugin;
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -1,6 +1,6 @@
 use bevy_app::{PluginGroup, PluginGroupBuilder};
 
-/// This plugin group will add all the default plugins:
+/// This plugin group will add all the default plugins for a *Bevy* application:
 /// * [`LogPlugin`](crate::log::LogPlugin)
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)
@@ -23,7 +23,10 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// * [`GltfPlugin`](crate::gltf::GltfPlugin) - with feature `bevy_gltf`
 /// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit`
 ///
-/// See also [`MinimalPlugins`] for a slimmed down option
+/// [`DefaultPlugins`] represents the group of plugins typically required to build
+/// a *Bevy* application which includes a *window* and presentation components.
+///
+/// For *headless* cases – without a *window* or presentation, see [`MinimalPlugins`].
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {
@@ -121,14 +124,21 @@ impl PluginGroup for DefaultPlugins {
     }
 }
 
-/// Minimal plugin group that will add the following plugins:
+/// This plugin group will add all the minimal plugins for a *Bevy* application:
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)
 /// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
 /// * [`TimePlugin`](crate::time::TimePlugin)
 /// * [`ScheduleRunnerPlugin`](crate::app::ScheduleRunnerPlugin)
 ///
-/// See also [`DefaultPlugins`] for a more complete set of plugins
+/// This group of plugins is intended for use for minimal, *headless* programs –
+/// see the [*Bevy* *headless* example](https://github.com/bevyengine/bevy/blob/main/examples/app/headless.rs)
+/// – and includes a [schedule runner (`ScheduleRunnerPlugin`)](crate::app::ScheduleRunnerPlugin)
+/// to provide functionality that would normally be driven by an *event loop*
+/// or *message loop*.
+///
+/// For a more complete set of plugins intended for use in applications that include window
+/// and presentation components, see [`DefaultPlugins`].
 pub struct MinimalPlugins;
 
 impl PluginGroup for MinimalPlugins {

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -23,9 +23,12 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// * [`GltfPlugin`](crate::gltf::GltfPlugin) - with feature `bevy_gltf`
 /// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit`
 ///
-/// [`DefaultPlugins`] represents the group of plugins typically required to build
-/// a *Bevy* application which includes a *window* and presentation components.
+/// [`DefaultPlugins`] obeys *Cargo* *feature* flags. Users may exert control over this plugin group
+/// by disabling `default-features` in their `Cargo.toml` and enabling only those features
+/// that they wish to use.
 ///
+/// [`DefaultPlugins`] contains all the plugins typically required to build
+/// a *Bevy* application which includes a *window* and presentation components.
 /// For *headless* cases – without a *window* or presentation, see [`MinimalPlugins`].
 pub struct DefaultPlugins;
 
@@ -124,7 +127,7 @@ impl PluginGroup for DefaultPlugins {
     }
 }
 
-/// This plugin group will add all the minimal plugins for a *Bevy* application:
+/// This plugin group will add the minimal plugins for a *Bevy* application:
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)
 /// * [`FrameCountPlugin`](crate::core::FrameCountPlugin)
@@ -134,11 +137,11 @@ impl PluginGroup for DefaultPlugins {
 /// This group of plugins is intended for use for minimal, *headless* programs –
 /// see the [*Bevy* *headless* example](https://github.com/bevyengine/bevy/blob/main/examples/app/headless.rs)
 /// – and includes a [schedule runner (`ScheduleRunnerPlugin`)](crate::app::ScheduleRunnerPlugin)
-/// to provide functionality that would normally be driven by an *event loop*
-/// or *message loop*.
+/// to provide functionality that would otherwise be driven by a windowed application's
+/// *event loop* or *message loop*.
 ///
-/// For a more complete set of plugins intended for use in applications that include window
-/// and presentation components, see [`DefaultPlugins`].
+/// Windowed applications that wish to use a reduced set of plugins should consider the
+/// [`DefaultPlugins`] plugin group which can be controlled with *Cargo* *feature* flags.
 pub struct MinimalPlugins;
 
 impl PluginGroup for MinimalPlugins {


### PR DESCRIPTION
# Objective

The naming of the two plugin groups `DefaultPlugins` and `MinimalPlugins` suggests that one is a super-set of the other but this is not the case. Instead, the two plugin groups are intended for very different purposes.

Closes: https://github.com/bevyengine/bevy/issues/7173

## Solution

This merge request adds doc. comments that compensate for this and try save the user from confusion.

1. `DefaultPlugins` and `MinimalPlugins` intentions are described.
2. A strong emphasis on embracing `DefaultPlugins` as a whole but controlling what it contains with *Cargo* *features* is added – this is because the ordering in `DefaultPlugins` appears to be important so preventing users with "minimalist" foibles (That's Me!) from recreating the code seems worthwhile.
3. Notes are added explaining the confusing fact that `MinimalPlugins` contains `ScheduleRunnerPlugin` (which is very "important"-sounding) but `DefaultPlugins` does not.
