### PR TITLE
[Merged by Bors] - Fix axis settings constructor

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -659,21 +659,19 @@ impl AxisSettings {
         livezone_upperbound: f32,
         threshold: f32,
     ) -> Result<AxisSettings, AxisSettingsError> {
-        let within = |value, lower: f32, upper: f32| (lower..=upper).contains(&value);
-
-        if !within(livezone_lowerbound, -1.0, 0.0) {
+        if !(-1.0..=0.0).contains(&livezone_lowerbound) {
             Err(AxisSettingsError::LiveZoneLowerBoundOutOfRange(
                 livezone_lowerbound,
             ))
-        } else if !within(deadzone_lowerbound, -1.0, 0.0) {
+        } else if !(-1.0..=0.0).contains(&deadzone_lowerbound) {
             Err(AxisSettingsError::DeadZoneLowerBoundOutOfRange(
                 deadzone_lowerbound,
             ))
-        } else if !within(deadzone_upperbound, 0.0, 1.0) {
+        } else if !(0.0..=1.0).contains(&deadzone_upperbound) {
             Err(AxisSettingsError::DeadZoneUpperBoundOutOfRange(
                 deadzone_upperbound,
             ))
-        } else if !within(livezone_upperbound, 0.0, 1.0) {
+        } else if !(0.0..=1.0).contains(&livezone_upperbound) {
             Err(AxisSettingsError::LiveZoneUpperBoundOutOfRange(
                 livezone_upperbound,
             ))
@@ -691,7 +689,7 @@ impl AxisSettings {
                     deadzone_upperbound,
                 },
             )
-        } else if !within(threshold, 0.0, 2.0) {
+        } else if !(0.0..=2.0).contains(&threshold) {
             Err(AxisSettingsError::Threshold(threshold))
         } else {
             Ok(Self {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -611,26 +611,6 @@ impl Default for AxisSettings {
 }
 
 impl AxisSettings {
-    /// Same as [`Self::new`], but the bounds are defined as gap from extremities.
-    ///
-    /// The default [`AxisSettings`] would be `AxisSettings::new_symmetric(0.05, 0.01)`.
-    ///
-    /// The arguments must follow those rules otherwise this returns an `Err`:
-    /// + `0.0 <= zone_size <= 0.5`
-    /// + `0.0 <= threshold <= 2.0`
-    pub fn new_symmetric(
-        zone_size: f32,
-        threshold: f32,
-    ) -> Result<AxisSettings, AxisSettingsError> {
-        Self::new(
-            -1.0 + zone_size,
-            -zone_size,
-            zone_size,
-            1.0 - zone_size,
-            threshold,
-        )
-    }
-
     /// Creates a new [`AxisSettings`] instance.
     ///
     /// # Arguments

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -583,7 +583,7 @@ impl ButtonSettings {
 /// Otherwise, values will not be rounded.
 ///
 /// The valid range is `[-1.0, 1.0]`.
-#[derive(Debug, Clone, Reflect, FromReflect)]
+#[derive(Debug, Clone, Reflect, FromReflect, PartialEq)]
 #[reflect(Debug, Default)]
 pub struct AxisSettings {
     /// Values that are higher than `livezone_upperbound` will be rounded up to -1.0.
@@ -1512,6 +1512,16 @@ mod tests {
     #[test]
     fn test_try_out_of_range_axis_settings() {
         let mut axis_settings = AxisSettings::default();
+        assert_eq!(
+            AxisSettings::new(-0.95, -0.05, 0.05, 0.95, 0.001),
+            Ok(AxisSettings {
+                livezone_lowerbound: -0.95,
+                deadzone_lowerbound: -0.05,
+                deadzone_upperbound: 0.05,
+                livezone_upperbound: 0.95,
+                threshold: 0.001,
+            })
+        );
         assert_eq!(
             Err(AxisSettingsError::LiveZoneLowerBoundOutOfRange(-2.0)),
             axis_settings.try_set_livezone_lowerbound(-2.0)


### PR DESCRIPTION
# Objective

Currently, the `AxisSettings::new` function is unusable due to
an implementation quirk. It only allows `AxisSettings` where
the bounds that are supposed to be positive are negative!

## Solution

- We fix the bound check
- We add a test to make sure the method is usable


Seems like the error slipped through because of the relatively
verbose code style. With all those `if/else`, very long names,
range syntax, the bound check is actually hard to spot. I first
refactored a lot of code, but I left out the refactor because the
fix should be integrated independently.

---

## Changelog

- Fix `AxisSettings::new` only accepting invalid bounds