### PR TITLE
Fix incorrect behavior of `just_pressed` and `just_released` in `Input<GamepadButton>`

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1116,7 +1116,7 @@ impl GamepadButtonChangedEvent {
     }
 }
 
-/// Uses [`GamepadAxisChangedEvent`]s to update update the relevant `Input` and `Axis` values.
+/// Uses [`GamepadAxisChangedEvent`]s to update the relevant `Input` and `Axis` values.
 pub fn gamepad_axis_event_system(
     mut gamepad_axis: ResMut<Axis<GamepadAxis>>,
     mut axis_events: EventReader<GamepadAxisChangedEvent>,
@@ -1127,7 +1127,7 @@ pub fn gamepad_axis_event_system(
     }
 }
 
-/// Uses [`GamepadButtonChangedEvent`]s to update update the relevant `Input` and `Axis` values.
+/// Uses [`GamepadButtonChangedEvent`]s to update the relevant `Input` and `Axis` values.
 pub fn gamepad_button_event_system(
     mut button_events: EventReader<GamepadButtonChangedEvent>,
     mut button_input: ResMut<Input<GamepadButton>>,

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -992,7 +992,6 @@ pub fn gamepad_connection_system(
     mut button_axis: ResMut<Axis<GamepadButton>>,
     mut button_input: ResMut<Input<GamepadButton>>,
 ) {
-    button_input.bypass_change_detection().clear();
     for connection_event in connection_events.iter() {
         let gamepad = connection_event.gamepad;
 
@@ -1119,11 +1118,9 @@ impl GamepadButtonChangedEvent {
 
 /// Uses [`GamepadAxisChangedEvent`]s to update update the relevant `Input` and `Axis` values.
 pub fn gamepad_axis_event_system(
-    mut button_input: ResMut<Input<GamepadButton>>,
     mut gamepad_axis: ResMut<Axis<GamepadAxis>>,
     mut axis_events: EventReader<GamepadAxisChangedEvent>,
 ) {
-    button_input.bypass_change_detection().clear();
     for axis_event in axis_events.iter() {
         let axis = GamepadAxis::new(axis_event.gamepad, axis_event.axis_type);
         gamepad_axis.set(axis, axis_event.value);
@@ -1137,7 +1134,6 @@ pub fn gamepad_button_event_system(
     mut button_axis: ResMut<Axis<GamepadButton>>,
     settings: Res<GamepadSettings>,
 ) {
-    button_input.bypass_change_detection().clear();
     for button_event in button_events.iter() {
         let button = GamepadButton::new(button_event.gamepad, button_event.button_type);
         let value = button_event.value;
@@ -1197,7 +1193,9 @@ pub fn gamepad_event_system(
     mut connection_events: EventWriter<GamepadConnectionEvent>,
     mut button_events: EventWriter<GamepadButtonChangedEvent>,
     mut axis_events: EventWriter<GamepadAxisChangedEvent>,
+    mut button_input: ResMut<Input<GamepadButton>>,
 ) {
+    button_input.bypass_change_detection().clear();
     for gamepad_event in gamepad_events.iter() {
         match gamepad_event {
             GamepadEvent::Connection(connection_event) => {


### PR DESCRIPTION
# Objective

- Fixes a bug where `just_pressed` and `just_released` in `Input<GamepadButton>` might behave incorrectly due calling `clear` 3 times in a single frame through these three different systems: `gamepad_button_event_system`, `gamepad_axis_event_system` and `gamepad_connection_system` in any order

## Solution

- Call `clear` only once and before all the above three systems, i.e. in `gamepad_event_system`