### PR TITLE
Add `Interaction::Released` (Detect the release of a UIButton)

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{
     change_detection::DetectChangesMut,
     entity::Entity,
     prelude::Component,
-    query::WorldQuery,
+    query::{WorldQuery, Changed},
     reflect::ReflectComponent,
     system::{Local, Query, Res},
 };
@@ -156,7 +156,7 @@ pub fn ui_focus_system(
                 if *interaction == Interaction::Clicked {
                     *interaction = Interaction::Released;
                     // Queue it up for reset next frame
-                    state.entities_to_reset.push(node.entity);
+                    // state.entities_to_reset.push(node.entity);
                 }
             }
         }
@@ -298,4 +298,14 @@ pub fn ui_focus_system(
             }
         }
     }
+}
+
+/// Resets any Released interactions back to None
+pub(crate) fn reset_released_interaction(mut interactions: Query<&mut Interaction>) {
+    for mut interaction in &mut interactions {
+        if *interaction == Interaction::Released {
+            *interaction == Interaction::None;
+        }
+    }
+
 }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -37,6 +37,8 @@ use smallvec::SmallVec;
 pub enum Interaction {
     /// The node has been clicked
     Clicked,
+    /// The node has been released from
+    Released,
     /// The node has been hovered over
     Hovered,
     /// Nothing has happened
@@ -147,11 +149,14 @@ pub fn ui_focus_system(
 
     let mouse_released =
         mouse_button_input.just_released(MouseButton::Left) || touches_input.any_just_released();
+    // If mouse was released this frame, then set nodes that was clicked to released instead
     if mouse_released {
         for node in node_query.iter_mut() {
             if let Some(mut interaction) = node.interaction {
                 if *interaction == Interaction::Clicked {
-                    *interaction = Interaction::None;
+                    *interaction = Interaction::Released;
+                    // Queue it up for reset next frame
+                    state.entities_to_reset.push(node.entity);
                 }
             }
         }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -108,6 +108,7 @@ impl Plugin for UiPlugin {
                 CoreStage::PreUpdate,
                 ui_focus_system.label(UiSystem::Focus).after(InputSystem),
             )
+            .add_system_to_stage(CoreStage::Last, reset_released_interaction)
             // add these stages to front because these must run before transform update systems
             .add_system_to_stage(
                 CoreStage::PostUpdate,

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
-        .insert_resource(WinitSettings::desktop_app())
+        // .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)
         .add_system(button_system)
         .run();
@@ -36,10 +36,15 @@ fn button_system(
                 *color = HOVERED_BUTTON.into();
             }
             Interaction::None => {
-                text.sections[0].value = "Button".to_string();
+                text.sections[0].value = "None".to_string();
                 *color = NORMAL_BUTTON.into();
             }
+            Interaction::Released => {
+                text.sections[0].value = "Released".to_string();
+                *color = Color::RED.into();
+            },
         }
+        info!("Button is in : {:?} state", *interaction);
     }
 }
 


### PR DESCRIPTION
# Objective

Fix #5769

## Solution

Change to `Interaction::Released` instead of `Interaction::None` for 1 frame as the button is released.

---

## Changelog

## Added
- `Interaction` now be considered `Interaction::Released` for 1 frame when the user has released interaction on the button.

## Feedback Wanted / Unresolved Questions

This solution relies on the ui_focus system running for 1 more frame after the interaction has been released, meaning that it does not work currently work when using the "DesktopMode" winit setting that only runs systems when user-input has occurred. It will be stuck in "Released" state until some new input is provided by the user.

Any ideas as to how that can be solved?