### PR TITLE
[Merged by Bors] - Add a missing impl of `ReadOnlySystemParam` for `Option<NonSend<>>`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -985,6 +985,9 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
     }
 }
 
+// SAFETY: Only reads a single World non-send resource
+unsafe impl<T: 'static> ReadOnlySystemParam for Option<NonSend<'_, T>> {}
+
 // SAFETY: this impl defers to `NonSend`, which initializes and validates the correct world access.
 unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
     type State = ComponentId;


### PR DESCRIPTION
# Objective

The trait `ReadOnlySystemParam` is not implemented for `Option<NonSend<>>`, even though it should be.

Follow-up to #7243. This fixes another mistake made in #6919.

## Solution

Add the missing impl.
