### PR TITLE
[Merged by Bors] - fix load_internal_binary_asset with debug_asset_server

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -417,7 +417,7 @@ macro_rules! load_internal_asset {
             let mut debug_app = $app
                 .world
                 .non_send_resource_mut::<$crate::debug_asset_server::DebugAssetApp>();
-            $crate::debug_asset_server::register_handle_with_loader(
+            $crate::debug_asset_server::register_handle_with_loader::<_, &'static str>(
                 $loader,
                 &mut debug_app,
                 $handle,
@@ -455,7 +455,7 @@ macro_rules! load_internal_binary_asset {
             let mut debug_app = $app
                 .world
                 .non_send_resource_mut::<$crate::debug_asset_server::DebugAssetApp>();
-            $crate::debug_asset_server::register_handle_with_loader(
+            $crate::debug_asset_server::register_handle_with_loader::<_, &'static [u8]>(
                 $loader,
                 &mut debug_app,
                 $handle,

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -116,8 +116,8 @@ pub(crate) fn sync_debug_assets<T: Asset + Clone>(
 ///
 /// If this feels a bit odd ... that's because it is. This was built to improve the UX of the
 /// `load_internal_asset` macro.
-pub fn register_handle_with_loader<A: Asset>(
-    _loader: fn(&'static str) -> A,
+pub fn register_handle_with_loader<A: Asset, T>(
+    _loader: fn(T) -> A,
     app: &mut DebugAssetApp,
     handle: HandleUntyped,
     file_path: &str,


### PR DESCRIPTION
# Objective

- Enabling the `debug_asset_server` feature doesn't compile when using it with `load_internal_binary_asset!()`. The issue is because it assumes the loader takes an `&'static str` as a parameter, but binary assets loader expect `&'static [u8]`.

## Solution

- Add a generic type for the loader and use a different type in `load_internal_asset` and `load_internal_binary_asset`
