### PR TITLE
One-shot systems as `Command`s -- allow commands to use `SystemParam`s

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -306,7 +306,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                 }
             }
 
-            impl<'_w, '_s, #(#param: CommandParam,)*> CommandParam for ParamSet<'_w, '_s, (#(#param,)*)>
+            impl<'_w, '_s, #(#param: CommandSystemParam,)*> CommandSystemParam for ParamSet<'_w, '_s, (#(#param,)*)>
             {}
 
             impl<'w, 's, #(#param: SystemParam,)*> ParamSet<'w, 's, (#(#param,)*)>
@@ -461,14 +461,14 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             .push(syn::parse_quote!(#field_type: #path::system::ReadOnlySystemParam));
     }
 
-    // Create a where clause for the `CommandParam` impl.
-    // Ensure that each field implements `CommandParam`.
+    // Create a where clause for the `CommandSystemParam` impl.
+    // Ensure that each field implements `CommandSystemParam`.
     let mut command_param_generics = generics.clone();
     let command_param_where_clause = command_param_generics.make_where_clause();
     for field_type in &field_types {
         command_param_where_clause
             .predicates
-            .push(syn::parse_quote!(#field_type: #path::system::CommandParam));
+            .push(syn::parse_quote!(#field_type: #path::system::CommandSystemParam));
     }
 
     let struct_name = &ast.ident;
@@ -527,7 +527,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             // Safety: Each field is `ReadOnlySystemParam`, so this can only read from the `World`
             unsafe impl<'w, 's, #punctuated_generics> #path::system::ReadOnlySystemParam for #struct_name #ty_generics #read_only_where_clause {}
 
-            impl<'w, 's, #punctuated_generics> #path::system::CommandParam for #struct_name #ty_generics #command_param_where_clause {}
+            impl<'w, 's, #punctuated_generics> #path::system::CommandSystemParam for #struct_name #ty_generics #command_param_where_clause {}
         };
     })
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -304,6 +304,9 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                 }
             }
 
+            impl<'_w, '_s, #(#param: CommandParam,)*> CommandParam for ParamSet<'_w, '_s, (#(#param,)*)>
+            {}
+
             impl<'w, 's, #(#param: SystemParam,)*> ParamSet<'w, 's, (#(#param,)*)>
             {
                 #(#param_fn_mut)*

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -11,8 +11,9 @@ use bevy_utils::tracing::{error, info};
 pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
+pub use system_command::CommandParam;
 
-use super::{Resource, SystemParam};
+use super::Resource;
 
 /// A [`World`] mutation.
 ///
@@ -44,8 +45,6 @@ use super::{Resource, SystemParam};
 pub trait Command: Send + 'static {
     fn write(self, world: &mut World);
 }
-
-pub trait CommandParam: SystemParam {}
 
 pub trait IntoCommand<Marker> {
     type Command: Command;

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -11,7 +11,7 @@ pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
 
-use super::Resource;
+use super::{Resource, SystemParam};
 
 /// A [`World`] mutation.
 ///
@@ -43,6 +43,8 @@ use super::Resource;
 pub trait Command: Send + 'static {
     fn write(self, world: &mut World);
 }
+
+pub trait CommandParam: SystemParam {}
 
 /// A [`Command`] queue to perform impactful changes to the [`World`].
 ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1,5 +1,6 @@
 mod command_queue;
 mod parallel_scope;
+mod system_command;
 
 use crate::{
     bundle::Bundle,
@@ -11,7 +12,7 @@ pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
 
-use super::{IntoSystem, Resource, SystemParam};
+use super::{Resource, SystemParam};
 
 /// A [`World`] mutation.
 ///
@@ -55,18 +56,6 @@ impl<T: Command> IntoCommand<()> for T {
     type Command = Self;
     fn into_command(self) -> Self::Command {
         self
-    }
-}
-
-pub struct IsSystemCommand;
-
-impl<Marker, T: IntoSystem<(), (), Marker>> IntoCommand<(IsSystemCommand, Marker)> for T
-where
-    T::System: Command,
-{
-    type Command = T::System;
-    fn into_command(self) -> Self::Command {
-        IntoSystem::into_system(self)
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -48,13 +48,13 @@ pub trait Command: Send + 'static {
 
 pub trait IntoCommand<Marker> {
     type Command: Command;
-    fn into_command(self) -> Self::Command;
+    fn into_command(this: Self) -> Self::Command;
 }
 
 impl<T: Command> IntoCommand<()> for T {
     type Command = Self;
-    fn into_command(self) -> Self::Command {
-        self
+    fn into_command(this: Self) -> Self::Command {
+        this
     }
 }
 
@@ -537,7 +537,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # bevy_ecs::system::assert_is_system(add_twenty_five_to_counter_system);
     /// ```
     pub fn add<Marker, C: IntoCommand<Marker>>(&mut self, command: C) {
-        self.queue.push(command.into_command());
+        self.queue.push(IntoCommand::into_command(command));
     }
 }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -11,7 +11,7 @@ use bevy_utils::tracing::{error, info};
 pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
-pub use system_command::CommandParam;
+pub use system_command::CommandSystemParam;
 
 use super::Resource;
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1018,6 +1018,7 @@ mod tests {
     use crate::{
         self as bevy_ecs,
         component::Component,
+        event::{EventWriter, Events},
         system::{CommandQueue, Commands, Resource},
         world::World,
     };
@@ -1171,5 +1172,24 @@ mod tests {
         queue.apply(&mut world);
         assert!(!world.contains_resource::<W<i32>>());
         assert!(world.contains_resource::<W<f64>>());
+    }
+
+    #[test]
+    fn system_commands() {
+        struct E;
+
+        let mut world = World::new();
+        world.init_resource::<Events<E>>();
+
+        let mut command_queue = CommandQueue::default();
+
+        let mut commands = Commands::new(&mut command_queue, &world);
+        commands.add(|mut events: EventWriter<E>| {
+            events.send(E);
+        });
+
+        command_queue.apply(&mut world);
+
+        assert!(!world.resource::<Events<E>>().is_empty());
     }
 }

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -28,8 +28,7 @@ where
 {
     func: F,
     system_meta: SystemMeta,
-    // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
-    marker: PhantomData<fn() -> (Param, Marker)>,
+    marker: PhantomData<fn(Param) -> Marker>,
 }
 
 impl<Param, Marker, F> IntoCommand<(IsSystemCommand, Param, Marker)> for F

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -1,0 +1,15 @@
+use crate::system::IntoSystem;
+
+use super::{Command, IntoCommand};
+
+pub struct IsSystemCommand;
+
+impl<Marker, T: IntoSystem<(), (), Marker>> IntoCommand<(IsSystemCommand, Marker)> for T
+where
+    T::System: Command,
+{
+    type Command = T::System;
+    fn into_command(self) -> Self::Command {
+        IntoSystem::into_system(self)
+    }
+}

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use super::{Command, IntoCommand};
 
-pub trait CommandParam: SystemParam {}
+pub trait CommandSystemParam: SystemParam {}
 
 impl<Marker, T: IntoSystem<(), (), Marker>> IntoCommand<(IsSystemCommand, Marker)> for T
 where
@@ -24,7 +24,7 @@ pub struct IsSystemCommand;
 
 pub struct SystemCommand<Param, Marker, F>
 where
-    Param: CommandParam,
+    Param: CommandSystemParam,
 {
     func: F,
     system_meta: SystemMeta,
@@ -33,7 +33,7 @@ where
 
 impl<Param, Marker, F> IntoCommand<(IsSystemCommand, Param, Marker)> for F
 where
-    Param: CommandParam + 'static,
+    Param: CommandSystemParam + 'static,
     Marker: 'static,
     F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
 {
@@ -49,7 +49,7 @@ where
 
 impl<Param, Marker, F> Command for SystemCommand<Param, Marker, F>
 where
-    Param: CommandParam + 'static,
+    Param: CommandSystemParam + 'static,
     Marker: 'static,
     F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
 {

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -1,9 +1,11 @@
-use crate::system::{IntoSystem, SystemParam};
+use std::marker::PhantomData;
+
+use crate::{
+    prelude::World,
+    system::{IntoSystem, SystemMeta, SystemParam, SystemParamFunction},
+};
 
 use super::{Command, IntoCommand};
-
-#[doc(hidden)]
-pub struct IsSystemCommand;
 
 pub trait CommandParam: SystemParam {}
 
@@ -14,5 +16,52 @@ where
     type Command = T::System;
     fn into_command(this: Self) -> Self::Command {
         IntoSystem::into_system(this)
+    }
+}
+
+#[doc(hidden)]
+pub struct IsSystemCommand;
+
+pub struct SystemCommand<Param, Marker, F>
+where
+    Param: CommandParam,
+{
+    func: F,
+    system_meta: SystemMeta,
+    // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
+    marker: PhantomData<fn() -> (Param, Marker)>,
+}
+
+impl<Param, Marker, F> IntoCommand<(IsSystemCommand, Param, Marker)> for F
+where
+    Param: CommandParam + 'static,
+    Marker: 'static,
+    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
+{
+    type Command = SystemCommand<Param, Marker, F>;
+    fn into_command(func: Self) -> Self::Command {
+        SystemCommand {
+            func,
+            system_meta: SystemMeta::new::<F>(),
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<Param, Marker, F> Command for SystemCommand<Param, Marker, F>
+where
+    Param: CommandParam + 'static,
+    Marker: 'static,
+    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
+{
+    fn write(mut self, world: &mut World) {
+        let change_tick = world.change_tick();
+
+        let mut param_state = Param::init_state(world, &mut self.system_meta);
+        let params =
+            // SAFETY: We have exclusive world access.
+            unsafe { Param::get_param(&mut param_state, &self.system_meta, world, change_tick) };
+        self.func.run((), params);
+        Param::apply(&mut param_state, &self.system_meta, world);
     }
 }

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -1,9 +1,11 @@
-use crate::system::IntoSystem;
+use crate::system::{IntoSystem, SystemParam};
 
 use super::{Command, IntoCommand};
 
 #[doc(hidden)]
 pub struct IsSystemCommand;
+
+pub trait CommandParam: SystemParam {}
 
 impl<Marker, T: IntoSystem<(), (), Marker>> IntoCommand<(IsSystemCommand, Marker)> for T
 where

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -27,7 +27,6 @@ where
     Param: CommandSystemParam,
 {
     func: F,
-    system_meta: SystemMeta,
     marker: PhantomData<fn(Param) -> Marker>,
 }
 
@@ -41,7 +40,6 @@ where
     fn into_command(func: Self) -> Self::Command {
         SystemCommand {
             func,
-            system_meta: SystemMeta::new::<F>(),
             marker: PhantomData,
         }
     }
@@ -56,11 +54,12 @@ where
     fn write(mut self, world: &mut World) {
         let change_tick = world.change_tick();
 
-        let mut param_state = Param::init_state(world, &mut self.system_meta);
+        let mut system_meta = SystemMeta::new::<F>();
+        let mut param_state = Param::init_state(world, &mut system_meta);
         let params =
             // SAFETY: We have exclusive world access.
-            unsafe { Param::get_param(&mut param_state, &self.system_meta, world, change_tick) };
+            unsafe { Param::get_param(&mut param_state, &system_meta, world, change_tick) };
         self.func.run((), params);
-        Param::apply(&mut param_state, &self.system_meta, world);
+        Param::apply(&mut param_state, &system_meta, world);
     }
 }

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -35,7 +35,7 @@ impl<Param, Marker, F> IntoCommand<(IsSystemCommand, Param, Marker)> for F
 where
     Param: CommandSystemParam + 'static,
     Marker: 'static,
-    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
+    F: SystemParamFunction<(), (), Param, Marker>,
 {
     type Command = SystemCommand<Param, Marker, F>;
     fn into_command(func: Self) -> Self::Command {
@@ -51,7 +51,7 @@ impl<Param, Marker, F> Command for SystemCommand<Param, Marker, F>
 where
     Param: CommandSystemParam + 'static,
     Marker: 'static,
-    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
+    F: SystemParamFunction<(), (), Param, Marker>,
 {
     fn write(mut self, world: &mut World) {
         let change_tick = world.change_tick();

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -12,7 +12,7 @@ where
     T::System: Command,
 {
     type Command = T::System;
-    fn into_command(self) -> Self::Command {
-        IntoSystem::into_system(self)
+    fn into_command(this: Self) -> Self::Command {
+        IntoSystem::into_system(this)
     }
 }

--- a/crates/bevy_ecs/src/system/commands/system_command.rs
+++ b/crates/bevy_ecs/src/system/commands/system_command.rs
@@ -2,6 +2,7 @@ use crate::system::IntoSystem;
 
 use super::{Command, IntoCommand};
 
+#[doc(hidden)]
 pub struct IsSystemCommand;
 
 impl<Marker, T: IntoSystem<(), (), Marker>> IntoCommand<(IsSystemCommand, Marker)> for T

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -5,7 +5,10 @@ use crate::{
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
     schedule::{SystemLabel, SystemLabelId},
-    system::{check_system_change_tick, ReadOnlySystemParam, System, SystemParam, SystemParamItem},
+    system::{
+        check_system_change_tick, Command, CommandParam, ReadOnlySystemParam, System, SystemParam,
+        SystemParamItem,
+    },
     world::{World, WorldId},
 };
 use bevy_ecs_macros::all_tuples;
@@ -455,6 +458,19 @@ where
     }
     fn default_labels(&self) -> Vec<SystemLabelId> {
         vec![self.func.as_system_label().as_label()]
+    }
+}
+
+impl<Param, Marker, F> Command for FunctionSystem<(), (), Param, Marker, F>
+where
+    Param: CommandParam + 'static,
+    Marker: 'static,
+    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
+{
+    fn write(mut self, world: &mut World) {
+        self.initialize(world);
+        self.run((), world);
+        self.apply_buffers(world);
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -5,10 +5,7 @@ use crate::{
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
     schedule::{SystemLabel, SystemLabelId},
-    system::{
-        check_system_change_tick, Command, CommandParam, ReadOnlySystemParam, System, SystemParam,
-        SystemParamItem,
-    },
+    system::{check_system_change_tick, ReadOnlySystemParam, System, SystemParam, SystemParamItem},
     world::{World, WorldId},
 };
 use bevy_ecs_macros::all_tuples;
@@ -458,19 +455,6 @@ where
     }
     fn default_labels(&self) -> Vec<SystemLabelId> {
         vec![self.func.as_system_label().as_label()]
-    }
-}
-
-impl<Param, Marker, F> Command for FunctionSystem<(), (), Param, Marker, F>
-where
-    Param: CommandParam + 'static,
-    Marker: 'static,
-    F: SystemParamFunction<(), (), Param, Marker> + Send + Sync + 'static,
-{
-    fn write(mut self, world: &mut World) {
-        self.initialize(world);
-        self.run((), world);
-        self.apply_buffers(world);
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -8,7 +8,7 @@ use crate::{
     query::{
         Access, FilteredAccess, FilteredAccessSet, QueryState, ReadOnlyWorldQuery, WorldQuery,
     },
-    system::{CommandParam, CommandQueue, Commands, Query, SystemMeta},
+    system::{CommandQueue, CommandSystemParam, Commands, Query, SystemMeta},
     world::{FromWorld, World},
 };
 pub use bevy_ecs_macros::Resource;
@@ -233,7 +233,7 @@ unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemPara
     }
 }
 
-impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> CommandParam
+impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> CommandSystemParam
     for Query<'_, '_, Q, F>
 {
 }
@@ -468,7 +468,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
     }
 }
 
-impl<T: Resource> CommandParam for Res<'_, T> {}
+impl<T: Resource> CommandSystemParam for Res<'_, T> {}
 
 // SAFETY: Only reads a single World resource
 unsafe impl<'a, T: Resource> ReadOnlySystemParam for Option<Res<'a, T>> {}
@@ -503,7 +503,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
     }
 }
 
-impl<T: Resource> CommandParam for Option<Res<'_, T>> {}
+impl<T: Resource> CommandSystemParam for Option<Res<'_, T>> {}
 
 // SAFETY: Res ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this Res
 // conflicts with any prior access, a panic will occur.
@@ -565,7 +565,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
     }
 }
 
-impl<T: Resource> CommandParam for ResMut<'_, T> {}
+impl<T: Resource> CommandSystemParam for ResMut<'_, T> {}
 
 // SAFETY: this impl defers to `ResMut`, which initializes and validates the correct world access.
 unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
@@ -597,7 +597,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
     }
 }
 
-impl<T: Resource> CommandParam for Option<ResMut<'_, T>> {}
+impl<T: Resource> CommandSystemParam for Option<ResMut<'_, T>> {}
 
 // SAFETY: Commands only accesses internal state
 unsafe impl<'w, 's> ReadOnlySystemParam for Commands<'w, 's> {}
@@ -672,7 +672,7 @@ unsafe impl SystemParam for &'_ World {
     }
 }
 
-impl CommandParam for &World {}
+impl CommandSystemParam for &World {}
 
 /// A system local [`SystemParam`].
 ///
@@ -1130,7 +1130,7 @@ unsafe impl<'a> SystemParam for &'a Archetypes {
     }
 }
 
-impl CommandParam for &Archetypes {}
+impl CommandSystemParam for &Archetypes {}
 
 // SAFETY: Only reads World components
 unsafe impl<'a> ReadOnlySystemParam for &'a Components {}
@@ -1153,7 +1153,7 @@ unsafe impl<'a> SystemParam for &'a Components {
     }
 }
 
-impl CommandParam for &Components {}
+impl CommandSystemParam for &Components {}
 
 // SAFETY: Only reads World entities
 unsafe impl<'a> ReadOnlySystemParam for &'a Entities {}
@@ -1176,7 +1176,7 @@ unsafe impl<'a> SystemParam for &'a Entities {
     }
 }
 
-impl CommandParam for &Entities {}
+impl CommandSystemParam for &Entities {}
 
 // SAFETY: Only reads World bundles
 unsafe impl<'a> ReadOnlySystemParam for &'a Bundles {}
@@ -1199,7 +1199,7 @@ unsafe impl<'a> SystemParam for &'a Bundles {
     }
 }
 
-impl CommandParam for &Bundles {}
+impl CommandSystemParam for &Bundles {}
 
 /// A [`SystemParam`] that reads the previous and current change ticks of the system.
 ///
@@ -1366,7 +1366,7 @@ macro_rules! impl_system_param_tuple {
         }
 
         #[allow(non_snake_case)]
-        impl<$($param: CommandParam),*> CommandParam for ($($param,)*) {}
+        impl<$($param: CommandSystemParam),*> CommandSystemParam for ($($param,)*) {}
     };
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1000,8 +1000,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
     }
 }
 
-impl<T: 'static> CommandParam for NonSend<'_, T> {}
-
 // SAFETY: this impl defers to `NonSend`, which initializes and validates the correct world access.
 unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
     type State = ComponentId;
@@ -1028,8 +1026,6 @@ unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
             })
     }
 }
-
-impl<T: 'static> CommandParam for Option<NonSend<'_, T>> {}
 
 // SAFETY: NonSendMut ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this
 // NonSendMut conflicts with any prior access, a panic will occur.
@@ -1088,8 +1084,6 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
     }
 }
 
-impl<T: 'static> CommandParam for NonSendMut<'_, T> {}
-
 // SAFETY: this impl defers to `NonSendMut`, which initializes and validates the correct world access.
 unsafe impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
     type State = ComponentId;
@@ -1114,8 +1108,6 @@ unsafe impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
             })
     }
 }
-
-impl<T: 'static> CommandParam for Option<NonSendMut<'_, T>> {}
 
 // SAFETY: Only reads World archetypes
 unsafe impl<'a> ReadOnlySystemParam for &'a Archetypes {}

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1175,6 +1175,7 @@ unsafe impl<'a> SystemParam for &'a Entities {
         world.entities()
     }
 }
+
 impl CommandParam for &Entities {}
 
 // SAFETY: Only reads World bundles


### PR DESCRIPTION
# Objective

Fixes #2192.

Currently, anonymous one-shot commands can be defined as a closure accepting `&mut World`. Working with exclusive world access is quite cumbersome, and is usually only necessary if a command makes changes to a world's archetypes. In cases where a command simply needs to access and mutate world data, it is much more ergonomic to do so via `SystemParam`s such as `ResMut<>` or `Query`.

## Solution

* Add the trait `CommandSystemParam`, which is a subset of `SystemParam` that excludes types that don't make sense for one-shot systems, such as `Local<>` or `Commands`.
* Any systems consisting of `CommandSystemParam`s may be used as a command.

### Example

```rust
// One-shot systems are run by calling `Commands::add`.
commands.add(|main_character: Res<MainCharacter>,
              mut characters: Query<&mut Character>| {
    let main_character = characters.get_mut(main_character.id()).unwrap();
    main_character.do_thing();
});
```

---

TODO: Docs. I'd like to see the response to this PR before putting in the effort to write full documentation.

TODO: Look into storing "command systems" in a registry resource, to avoid duplicate initialization code. This will require benchmarking.

## Changelog

TODO

## Migration Guide

TODO
