### PR TITLE
[Merged by Bors] - AudioOutput is actually a normal resource now, not a non-send resource

### DIFF
--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -72,7 +72,7 @@ impl AddAudioSource for App {
     {
         self.add_asset::<T>()
             .init_resource::<Audio<T>>()
-            .init_non_send_resource::<AudioOutput<T>>()
+            .init_resource::<AudioOutput<T>>()
             .add_system_to_stage(CoreStage::PostUpdate, play_queued_audio_system::<T>)
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #7260

## Solution

- #6649 used `init_non_send_resource` for `AudioOutput`, but this is before #6436 was merged.
- Use `init_resource` instead.
