### PR TITLE
[Merged by Bors] - min version of fixedbitset was changed

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -23,7 +23,7 @@ bevy_ecs_macros = { path = "macros", version = "0.9.0" }
 async-channel = "1.4"
 event-listener = "2.5"
 thread_local = "1.1.4"
-fixedbitset = "0.4"
+fixedbitset = "0.4.2"
 fxhash = "0.2"
 downcast-rs = "1.2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
# Objective

- schedule v3 is using is_clear which was added in 0.4.2, so bump the version