### PR TITLE
[Merged by Bors] - Added `resource_id` and changed `init_resource` and `init_non_send_resource` to return `ComponentId`

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -498,11 +498,37 @@ impl Components {
         self.get_id(TypeId::of::<T>())
     }
 
+    /// Type-erased equivalent of [`Components::resource_id`].
     #[inline]
     pub fn get_resource_id(&self, type_id: TypeId) -> Option<ComponentId> {
         self.resource_indices
             .get(&type_id)
             .map(|index| ComponentId(*index))
+    }
+
+    /// Returns the [`ComponentId`] of the given [`Resource`] type `T`.
+    /// 
+    /// The returned `ComponentId` is specific to the `Components instance`
+    /// it was retrieved from and should not be used with another `Components`
+    /// instance.
+    ///
+    /// Returns [`None`] if the `Resource` type has not
+    /// yet been initialized using [`Components::init_resource`].
+    ///
+    /// ```rust
+    /// use bevy_ecs::prelude::*;
+    ///
+    /// let mut world = World::new();
+    ///
+    /// #[derive(Resource)]
+    /// struct ResourceA;
+    ///
+    /// let resource_a_id = world.init_resource::<ResourceA>();
+    ///
+    /// assert_eq!(resource_a_id, world.components().resource_id::<ResourceA>().unwrap())
+    /// ```
+    pub fn resource_id<T: Resource>(&self) -> Option<ComponentId> {
+        self.get_resource_id(TypeId::of::<T>())
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -508,7 +508,7 @@ impl Components {
 
     /// Returns the [`ComponentId`] of the given [`Resource`] type `T`.
     ///
-    /// The returned `ComponentId` is specific to the `Components instance`
+    /// The returned `ComponentId` is specific to the `Components` instance
     /// it was retrieved from and should not be used with another `Components`
     /// instance.
     ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -520,7 +520,7 @@ impl Components {
     ///
     /// let mut world = World::new();
     ///
-    /// #[derive(Resource)]
+    /// #[derive(Resource, Default)]
     /// struct ResourceA;
     ///
     /// let resource_a_id = world.init_resource::<ResourceA>();

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -527,6 +527,7 @@ impl Components {
     ///
     /// assert_eq!(resource_a_id, world.components().resource_id::<ResourceA>().unwrap())
     /// ```
+    #[inline]
     pub fn resource_id<T: Resource>(&self) -> Option<ComponentId> {
         self.get_resource_id(TypeId::of::<T>())
     }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -507,7 +507,7 @@ impl Components {
     }
 
     /// Returns the [`ComponentId`] of the given [`Resource`] type `T`.
-    /// 
+    ///
     /// The returned `ComponentId` is specific to the `Components instance`
     /// it was retrieved from and should not be used with another `Components`
     /// instance.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -769,12 +769,12 @@ impl World {
         }
     }
 
-    /// Inserts a new resource with standard starting values.
+    /// Initializes a new resource and returns the [`ComponentId`] created for it.
     ///
     /// If the resource already exists, nothing happens.
     ///
     /// The value given by the [`FromWorld::from_world`] method will be used.
-    /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
+    /// Note that any resource with the [`Default`] trait automatically implements [`FromWorld`],
     /// and those default values will be here instead.
     #[inline]
     pub fn init_resource<R: Resource + FromWorld>(&mut self) -> ComponentId {
@@ -812,7 +812,7 @@ impl World {
         });
     }
 
-    /// Inserts a new non-send resource with standard starting values.
+    /// Initializes a new non-send resource and returns the [`ComponentId`] created for it.
     ///
     /// If the resource already exists, nothing happens.
     ///
@@ -824,7 +824,7 @@ impl World {
     ///
     /// Panics if called from a thread other than the main thread.
     #[inline]
-    pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) {
+    pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> ComponentId {
         let component_id = self.components.init_non_send::<R>();
         if self
             .storages
@@ -840,6 +840,7 @@ impl World {
                 }
             });
         }
+        component_id
     }
 
     /// Inserts a new non-send resource with the given `value`.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -777,7 +777,7 @@ impl World {
     /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
     /// and those default values will be here instead.
     #[inline]
-    pub fn init_resource<R: Resource + FromWorld>(&mut self) {
+    pub fn init_resource<R: Resource + FromWorld>(&mut self) -> ComponentId {
         let component_id = self.components.init_resource::<R>();
         if self
             .storages
@@ -793,6 +793,7 @@ impl World {
                 }
             });
         }
+        component_id
     }
 
     /// Inserts a new resource with the given `value`.


### PR DESCRIPTION
# Objective

- `Components::resource_id` doesn't exist. Like `Components::component_id` but for resources.

## Solution

- Created `Components::resource_id` and added some docs.

---

## Changelog

- Added `Components::resource_id`.
- Changed `World::init_resource` to return the generated `ComponentId`.
- Changed `World::init_non_send_resource` to return the generated `ComponentId`.
