### PR TITLE
revert stage changed for window closing

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -93,16 +93,16 @@ impl Plugin for WindowPlugin {
 
         match self.exit_condition {
             ExitCondition::OnPrimaryClosed => {
-                app.add_system(exit_on_primary_closed);
+                app.add_system_to_stage(CoreStage::PostUpdate, exit_on_primary_closed);
             }
             ExitCondition::OnAllClosed => {
-                app.add_system(exit_on_all_closed);
+                app.add_system_to_stage(CoreStage::PostUpdate, exit_on_all_closed);
             }
             ExitCondition::DontExit => {}
         }
 
         if self.close_when_requested {
-            app.add_system_to_stage(CoreStage::First, close_when_requested);
+            app.add_system(close_when_requested);
         }
 
         // Register event types


### PR DESCRIPTION
# Objective

- Fix #7287 

## Solution

- Revert stage changed in windows as entities PR for window closing systems

how it was before:
https://github.com/bevyengine/bevy/blob/f0c504947ce653068a424979faf226c1e990818d/crates/bevy_window/src/lib.rs#L92-L100

