### PR TITLE
[Merged by Bors] - Allow not preventing default event behaviors on wasm

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -158,6 +158,13 @@ pub struct Window {
     ///
     /// This value has no effect on non-web platforms.
     pub fit_canvas_to_parent: bool,
+    /// Whether or not to stop events from propagating out of the canvas element
+    ///
+    /// This will prevent common browser hotkeys like F5, F12, Ctrl+R, tab, etc.
+    /// from performing their default behavior while the bevy app has focus.
+    ///
+    /// This value has no effect on non-web platforms.
+    pub prevent_default_event_handling: bool,
     /// Stores internal state that isn't directly accessible.
     pub internal: InternalWindowState,
 }
@@ -180,6 +187,7 @@ impl Default for Window {
             focused: true,
             always_on_top: false,
             fit_canvas_to_parent: false,
+            prevent_default_event_handling: true,
             canvas: None,
         }
     }

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -160,7 +160,7 @@ pub struct Window {
     pub fit_canvas_to_parent: bool,
     /// Whether or not to stop events from propagating out of the canvas element
     ///
-    /// This will prevent common browser hotkeys like F5, F12, Ctrl+R, tab, etc.
+    ///  When `true`, this will prevent common browser hotkeys like F5, F12, Ctrl+R, tab, etc.
     /// from performing their default behavior while the bevy app has focus.
     ///
     /// This value has no effect on non-web platforms.

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -110,6 +110,9 @@ impl WinitWindows {
                     panic!("Cannot find element: {}.", selector);
                 }
             }
+
+            winit_window_builder = winit_window_builder
+                .with_prevent_default(window.prevent_default_event_handling)
         }
 
         let winit_window = winit_window_builder.build(event_loop).unwrap();

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -111,8 +111,8 @@ impl WinitWindows {
                 }
             }
 
-            winit_window_builder = winit_window_builder
-                .with_prevent_default(window.prevent_default_event_handling)
+            winit_window_builder =
+                winit_window_builder.with_prevent_default(window.prevent_default_event_handling)
         }
 
         let winit_window = winit_window_builder.build(event_loop).unwrap();

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -16,6 +16,8 @@ fn main() {
                 present_mode: PresentMode::AutoVsync,
                 // Tells wasm to resize the window according to the available canvas
                 fit_canvas_to_parent: true,
+                // Tells wasm not to override default event handling, like F5, Ctrl+R etc.
+                prevent_default_event_handling: false,
                 ..default()
             }),
             ..default()


### PR DESCRIPTION
# Objective

On wasm, bevy applications currently prevent any of the normal browser hotkeys from working normally (Ctrl+R, F12, F5, Ctrl+F5, tab, etc.).

Some of those events you may want to override, perhaps you can hold the tab key for showing in-game stats?

However, if you want to make a well-behaved game, you probably don't want to needlessly prevent that behavior unless you have a good reason.

Secondary motivation: Also, consider the workaround presented here to get audio working: https://developer.chrome.com/blog/web-audio-autoplay/#moving-forward ; It won't work (for keydown events) if we stop event propagation.

## Solution

- Winit has a field that allows it to not stop event propagation, expose it on the window settings to allow the user to choose the desired behavior. Default to `true` for backwards compatibility.

---

## Changelog

- Added `Window::prevent_default_event_handling` . This allows bevy apps to not override default browser behavior on hotkeys like F5, F12, Ctrl+R etc.
