### PR TITLE
[Merged by Bors] - Use `Time` `resource` instead of `Extract`ing `Time`

### DIFF
--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -8,7 +8,7 @@ use bevy::{
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
-    render::{camera::ScalingMode, Extract, RenderApp, RenderStage},
+    render::{camera::ScalingMode, RenderApp, RenderStage},
     window::{PresentMode, WindowPlugin},
 };
 use rand::{thread_rng, Rng};
@@ -156,15 +156,13 @@ impl Plugin for LogVisibleLights {
             Err(_) => return,
         };
 
-        render_app
-            .add_system_to_stage(RenderStage::Extract, extract_time)
-            .add_system_to_stage(RenderStage::Prepare, print_visible_light_count);
+        render_app.add_system_to_stage(RenderStage::Prepare, print_visible_light_count);
     }
 }
 
 // System for printing the number of meshes on every tick of the timer
 fn print_visible_light_count(
-    time: Res<ExtractedTime>,
+    time: Res<Time>,
     mut timer: Local<PrintingTimer>,
     visible: Query<&ExtractedPointLight>,
     global_light_meta: Res<GlobalLightMeta>,
@@ -178,13 +176,6 @@ fn print_visible_light_count(
             global_light_meta.entity_to_index.len()
         );
     }
-}
-
-#[derive(Resource, Deref, DerefMut)]
-pub struct ExtractedTime(Time);
-
-fn extract_time(mut commands: Commands, time: Extract<Res<Time>>) {
-    commands.insert_resource(ExtractedTime(time.clone()));
 }
 
 struct PrintingTimer(Timer);


### PR DESCRIPTION
# Objective

- "Fixes #7308".

## Solution

- Use the `Time` `Resource` instead of `Extract<Res<Time>>`
