### PR TITLE
reflect: improve container attributes

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -32,7 +32,7 @@ use serde::{Deserialize, Serialize};
     Reflect,
     FromReflect,
 )]
-#[reflect_value(Serialize, Deserialize, PartialEq, Hash)]
+#[reflect_value(partial_eq, hash, Serialize, Deserialize)]
 pub enum HandleId {
     /// A handle id of a loaded asset.
     Id(Uuid, u64),

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -68,21 +68,21 @@ impl<'a> AssetPath<'a> {
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(partial_eq, hash, Serialize, Deserialize)]
 pub struct AssetPathId(SourcePathId, LabelId);
 
 /// An unique identifier to the source path of an asset.
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(partial_eq, hash, Serialize, Deserialize)]
 pub struct SourcePathId(u64);
 
 /// An unique identifier to a sub-asset label.
 #[derive(
     Debug, Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize, Deserialize, Reflect,
 )]
-#[reflect_value(PartialEq, Hash, Serialize, Deserialize)]
+#[reflect_value(partial_eq, hash, Serialize, Deserialize)]
 pub struct LabelId(u64);
 
 impl<'a> From<&'a Path> for SourcePathId {

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -401,7 +401,7 @@ impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {
     }
 }
 
-impl_reflect_value!(Entity(Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Entity(hash, partial_eq, Serialize, Deserialize));
 impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 /// [`HierarchyQueryExt`]: crate::query_extension::HierarchyQueryExt
 /// [`Query`]: bevy_ecs::system::Query
 #[derive(Component, Debug, Eq, PartialEq, Reflect)]
-#[reflect(Component, MapEntities, PartialEq)]
+#[reflect(partial_eq, Component, MapEntities)]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -72,7 +72,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The `ID` of a gamepad is fixed until the gamepad disconnects or the app is restarted.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -92,7 +92,7 @@ impl Gamepad {
 
 /// Metadata associated with a `Gamepad`.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -153,7 +153,7 @@ impl Gamepads {
 /// which in turn is used to create the [`Input<GamepadButton>`] or
 /// [`Axis<GamepadButton>`] `bevy` resources.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -218,7 +218,7 @@ pub enum GamepadButtonType {
 ///
 /// The gamepad button resources are updated inside of the [`gamepad_button_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -260,7 +260,7 @@ impl GamepadButton {
 /// [`GamepadAxisChangedEvent`]. It is also used in the [`GamepadAxis`]
 /// which in turn is used to create the [`Axis<GamepadAxis>`] `bevy` resource.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -296,7 +296,7 @@ pub enum GamepadAxisType {
 ///
 /// The gamepad axes resources are updated inside of the [`gamepad_axis_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -341,7 +341,7 @@ impl GamepadAxis {
 /// should register as a [`GamepadEvent`]. Events that don't meet the change thresholds defined in [`GamepadSettings`]
 /// will not register. To modify these settings, mutate the corresponding resource.
 #[derive(Resource, Default, Debug, Reflect, FromReflect)]
-#[reflect(Debug, Default)]
+#[reflect(debug, Default)]
 pub struct GamepadSettings {
     /// The default button settings.
     pub default_button_settings: ButtonSettings,
@@ -424,7 +424,7 @@ impl GamepadSettings {
 ///
 /// Allowed values: `0.0 <= ``release_threshold`` <= ``press_threshold`` <= 1.0`
 #[derive(Debug, Clone, Reflect, FromReflect)]
-#[reflect(Debug, Default)]
+#[reflect(debug, Default)]
 pub struct ButtonSettings {
     press_threshold: f32,
     release_threshold: f32,
@@ -584,7 +584,7 @@ impl ButtonSettings {
 ///
 /// The valid range is `[-1.0, 1.0]`.
 #[derive(Debug, Clone, Reflect, FromReflect, PartialEq)]
-#[reflect(Debug, Default)]
+#[reflect(debug, Default)]
 pub struct AxisSettings {
     /// Values that are higher than `livezone_upperbound` will be rounded up to -1.0.
     livezone_upperbound: f32,
@@ -915,7 +915,7 @@ impl AxisSettings {
 ///
 /// The current value of a button is received through the [`GamepadButtonChangedEvent`].
 #[derive(Debug, Clone, Reflect, FromReflect)]
-#[reflect(Debug, Default)]
+#[reflect(debug, Default)]
 pub struct ButtonAxisSettings {
     /// The high value at which to apply rounding.
     pub high: f32,
@@ -1024,7 +1024,7 @@ pub fn gamepad_connection_system(
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1038,7 +1038,7 @@ pub enum GamepadConnection {
 /// A Gamepad connection event. Created when a connection to a gamepad
 /// is established and when a gamepad is disconnected.
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1069,7 +1069,7 @@ impl GamepadConnectionEvent {
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1094,7 +1094,7 @@ impl GamepadAxisChangedEvent {
 /// Gamepad event for when the "value" (amount of pressure) on the button
 /// changes by an amount larger than the threshold defined in [`GamepadSettings`].
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1157,7 +1157,7 @@ pub fn gamepad_button_event_system(
 /// [`GamepadButtonChangedEvent`] and [`GamepadAxisChangedEvent`] when
 /// the in-frame relative ordering of events is important.
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -15,7 +15,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -72,7 +72,7 @@ pub fn keyboard_input_system(
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -439,7 +439,7 @@ pub enum KeyCode {
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -132,7 +132,7 @@ impl Plugin for InputPlugin {
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -15,7 +15,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -39,7 +39,7 @@ pub struct MouseButtonInput {
 ///
 /// The resource is updated inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system).
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -66,7 +66,7 @@ pub enum MouseButton {
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -84,7 +84,7 @@ pub struct MouseMotion {
 /// The value of the event can either be interpreted as the amount of lines or the amount of pixels
 /// to scroll.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -107,7 +107,7 @@ pub enum MouseScrollUnit {
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -31,7 +31,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// This event is the translated version of the `WindowEvent::Touch` from the `winit` crate.
 /// It is available to the end user and can be used for game logic.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -53,7 +53,7 @@ pub struct TouchInput {
 
 /// A force description of a [`Touch`](crate::touch::Touch) input.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -99,7 +99,7 @@ pub enum ForceTouch {
 /// or that a finger has moved. There is also a cancelled phase that indicates that
 /// the system cancelled the tracking of the finger.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect, FromReflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(debug, hash, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -5,7 +5,7 @@ use bevy_reflect::{FromReflect, Reflect};
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
 #[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
-#[reflect(Component, Default, Debug)]
+#[reflect(debug, Component, Default)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -19,7 +19,7 @@ use bevy_render::{
 #[uuid = "7494888b-c082-457b-aacf-517228cc0c22"]
 #[bind_group_data(StandardMaterialKey)]
 #[uniform(0, StandardMaterialUniform)]
-#[reflect(Default, Debug)]
+#[reflect(debug, Default)]
 pub struct StandardMaterial {
     /// The color of the surface of the material before lighting.
     ///

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -13,7 +13,7 @@ use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::token::Comma;
-use syn::{Meta, NestedMeta, Path, Lit, parse_str};
+use syn::{parse_str, Lit, Meta, NestedMeta, Path};
 
 // The "special" idents that are used internally for reflection.
 // Received via attributes like `#[reflect(partial_eq, hash, ...)]`
@@ -136,7 +136,12 @@ impl ReflectTraits {
                         // Track the span where the trait is implemented for future errors
                         let span = lit.span();
                         let trait_func_ident = TraitImpl::Custom(path, span);
-                        match name_value.path.get_ident().map(ToString::to_string).as_deref() {
+                        match name_value
+                            .path
+                            .get_ident()
+                            .map(ToString::to_string)
+                            .as_deref()
+                        {
                             Some(DEBUG_ATTR) => {
                                 traits.debug = traits.debug.merge(trait_func_ident)?;
                             }
@@ -147,11 +152,14 @@ impl ReflectTraits {
                                 traits.hash = traits.hash.merge(trait_func_ident)?;
                             }
                             _ => {
-                                return Err(syn::Error::new(span, "custom path literals can only be used for \"special\" idents."))
+                                return Err(syn::Error::new(
+                                    span,
+                                    "custom path literals can only be used for \"special\" idents.",
+                                ))
                             }
                         }
                     }
-                },
+                }
                 // Handles `#[reflect( hash, Default, ... )]`
                 NestedMeta::Meta(Meta::Path(path)) => {
                     // Track the span where the trait is implemented for future errors

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -43,7 +43,9 @@ impl TraitLikeImpl {
     /// Otherwise, an error is returned if neither value is [`TraitLikeImpl::NotImplemented`].
     pub fn merge(self, other: TraitLikeImpl) -> Result<TraitLikeImpl, syn::Error> {
         match (self, other) {
-            (TraitLikeImpl::NotImplemented, value) | (value, TraitLikeImpl::NotImplemented) => Ok(value),
+            (TraitLikeImpl::NotImplemented, value) | (value, TraitLikeImpl::NotImplemented) => {
+                Ok(value)
+            }
             (_, TraitLikeImpl::Implemented(span) | TraitLikeImpl::Custom(_, span)) => {
                 Err(syn::Error::new(span, "conflicting type data registration"))
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -137,7 +137,10 @@ enum ReflectMode {
 }
 
 impl<'a> ReflectDerive<'a> {
-    pub fn from_input(input: &'a DeriveInput, impl_source: ReflectImplSource) -> Result<Self, syn::Error> {
+    pub fn from_input(
+        input: &'a DeriveInput,
+        impl_source: ReflectImplSource,
+    ) -> Result<Self, syn::Error> {
         let mut traits = ReflectTraits::default();
         // Should indicate whether `#[reflect_value]` was used
         let mut reflect_mode = None;
@@ -288,7 +291,12 @@ impl<'a> ReflectDerive<'a> {
 }
 
 impl<'a> ReflectMeta<'a> {
-    pub fn new(type_name: &'a Ident, generics: &'a Generics, traits: ReflectTraits, impl_source: ReflectImplSource) -> Self {
+    pub fn new(
+        type_name: &'a Ident,
+        generics: &'a Generics,
+        traits: ReflectTraits,
+        impl_source: ReflectImplSource,
+    ) -> Self {
         Self {
             traits,
             type_name,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -17,6 +17,14 @@ pub(crate) enum ReflectDerive<'a> {
     Value(ReflectMeta<'a>),
 }
 
+/// The context of the implementation.
+#[derive(Clone, Copy)]
+pub(crate) enum ReflectImplSource {
+    Derive,
+    ImplStruct,
+    ImplValue,
+}
+
 /// Metadata present on all reflected types, including name, generics, and attributes.
 ///
 /// # Example
@@ -25,7 +33,7 @@ pub(crate) enum ReflectDerive<'a> {
 /// #[derive(Reflect)]
 /// //                          traits
 /// //        |----------------------------------------|
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// #[reflect(partial_eq, Serialize, Deserialize, Default)]
 /// //            type_name       generics
 /// //     |-------------------||----------|
 /// struct ThingThatImReflecting<T1, T2, T3> {/* ... */}
@@ -39,6 +47,8 @@ pub(crate) struct ReflectMeta<'a> {
     generics: &'a Generics,
     /// A cached instance of the path to the `bevy_reflect` crate.
     bevy_reflect_path: Path,
+    /// In what context the type is being reflected.
+    impl_source: ReflectImplSource,
     /// The documentation for this type, if any
     #[cfg(feature = "documentation")]
     docs: crate::documentation::Documentation,
@@ -50,7 +60,7 @@ pub(crate) struct ReflectMeta<'a> {
 ///
 /// ```ignore
 /// #[derive(Reflect)]
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// #[reflect(partial_eq, Serialize, Deserialize, Default)]
 /// struct ThingThatImReflecting<T1, T2, T3> {
 ///     x: T1, // |
 ///     y: T2, // |- fields
@@ -69,7 +79,7 @@ pub(crate) struct ReflectStruct<'a> {
 ///
 /// ```ignore
 /// #[derive(Reflect)]
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// #[reflect(partial_eq, Serialize, Deserialize, Default)]
 /// enum ThingThatImReflecting<T1, T2, T3> {
 ///     A(T1),                  // |
 ///     B,                      // |- variants
@@ -127,7 +137,7 @@ enum ReflectMode {
 }
 
 impl<'a> ReflectDerive<'a> {
-    pub fn from_input(input: &'a DeriveInput) -> Result<Self, syn::Error> {
+    pub fn from_input(input: &'a DeriveInput, impl_source: ReflectImplSource) -> Result<Self, syn::Error> {
         let mut traits = ReflectTraits::default();
         // Should indicate whether `#[reflect_value]` was used
         let mut reflect_mode = None;
@@ -181,7 +191,7 @@ impl<'a> ReflectDerive<'a> {
             }
         }
 
-        let meta = ReflectMeta::new(&input.ident, &input.generics, traits);
+        let meta = ReflectMeta::new(&input.ident, &input.generics, traits, impl_source);
 
         #[cfg(feature = "documentation")]
         let meta = meta.with_docs(doc);
@@ -278,11 +288,12 @@ impl<'a> ReflectDerive<'a> {
 }
 
 impl<'a> ReflectMeta<'a> {
-    pub fn new(type_name: &'a Ident, generics: &'a Generics, traits: ReflectTraits) -> Self {
+    pub fn new(type_name: &'a Ident, generics: &'a Generics, traits: ReflectTraits, impl_source: ReflectImplSource) -> Self {
         Self {
             traits,
             type_name,
             generics,
+            impl_source,
             bevy_reflect_path: utility::get_bevy_reflect_path(),
             #[cfg(feature = "documentation")]
             docs: Default::default(),
@@ -310,6 +321,11 @@ impl<'a> ReflectMeta<'a> {
         self.generics
     }
 
+    /// In what context the type is being reflected.
+    pub fn impl_source(&self) -> ReflectImplSource {
+        self.impl_source
+    }
+
     /// The cached `bevy_reflect` path.
     pub fn bevy_reflect_path(&self) -> &Path {
         &self.bevy_reflect_path
@@ -320,7 +336,7 @@ impl<'a> ReflectMeta<'a> {
         crate::registration::impl_get_type_registration(
             self.type_name,
             &self.bevy_reflect_path,
-            self.traits.idents(),
+            self.traits.paths(),
             self.generics,
             None,
         )
@@ -356,7 +372,7 @@ impl<'a> ReflectStruct<'a> {
         crate::registration::impl_get_type_registration(
             self.meta.type_name(),
             reflect_path,
-            self.meta.traits().idents(),
+            self.meta.traits().paths(),
             self.meta.generics(),
             Some(&self.serialization_denylist),
         )

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -91,7 +91,7 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
 
     let MemberValuePair(ignored_members, ignored_values) =
         get_ignored_fields(reflect_struct, is_tuple);
-    
+
     let constructor = match reflect_struct.meta().impl_source() {
         ReflectImplSource::ImplStruct => {
             quote!(
@@ -107,9 +107,8 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
                 )*
                 #FQOption::Some(__this)
             )
-        },
+        }
         _ => {
-
             quote!(
                 #FQOption::Some(
                     Self {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -94,7 +94,7 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
 
     let constructor = match reflect_struct.meta().impl_source() {
         ReflectImplSource::ImplStruct => {
-            quote!(
+            quote! {
                 // This is necessary for `impl_reflect_struct` on types like `Vec4`
                 // because on some targets field access is implemented using `Deref(Mut)`.
                 let mut __this: Self = #FQDefault::default();
@@ -106,17 +106,17 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
                     __this.#ignored_members = #ignored_values;
                 )*
                 #FQOption::Some(__this)
-            )
+            }
         }
         _ => {
-            quote!(
+            quote! {
                 #FQOption::Some(
                     Self {
                         #(#active_members: #active_values()?,)*
                         #(#ignored_members: #ignored_values,)*
                     }
                 )
-            )
+            }
         }
     };
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -1,5 +1,4 @@
-use crate::container_attributes::REFLECT_DEFAULT;
-use crate::derive_data::ReflectEnum;
+use crate::derive_data::{ReflectEnum, ReflectImplSource};
 use crate::enum_utility::{get_variant_constructors, EnumVariantConstructors};
 use crate::field_attributes::DefaultBehavior;
 use crate::fq_std::{FQAny, FQClone, FQDefault, FQOption};
@@ -75,8 +74,6 @@ impl MemberValuePair {
 }
 
 fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> TokenStream {
-    let fqoption = FQOption.into_token_stream();
-
     let struct_name = reflect_struct.meta().type_name();
     let generics = reflect_struct.meta().generics();
     let bevy_reflect_path = reflect_struct.meta().bevy_reflect_path();
@@ -92,29 +89,36 @@ fn impl_struct_internal(reflect_struct: &ReflectStruct, is_tuple: bool) -> Token
     let MemberValuePair(active_members, active_values) =
         get_active_fields(reflect_struct, &ref_struct, &ref_struct_type, is_tuple);
 
-    let constructor = if reflect_struct.meta().traits().contains(REFLECT_DEFAULT) {
-        quote!(
-            let mut __this: Self = #FQDefault::default();
-            #(
-                if let #fqoption::Some(__field) = #active_values() {
-                    // Iff field exists -> use its value
-                    __this.#active_members = __field;
-                }
-            )*
-            #FQOption::Some(__this)
-        )
-    } else {
-        let MemberValuePair(ignored_members, ignored_values) =
-            get_ignored_fields(reflect_struct, is_tuple);
-
-        quote!(
-            #FQOption::Some(
-                Self {
-                    #(#active_members: #active_values()?,)*
-                    #(#ignored_members: #ignored_values,)*
-                }
+    let MemberValuePair(ignored_members, ignored_values) =
+        get_ignored_fields(reflect_struct, is_tuple);
+    
+    let constructor = match reflect_struct.meta().impl_source() {
+        ReflectImplSource::ImplStruct => {
+            quote!(
+                // This is necessary for `impl_reflect_struct` on types like `Vec4`
+                // because on some targets field access is implemented using `Deref(Mut)`.
+                let mut __this: Self = #FQDefault::default();
+                #(
+                    // Early-return if an active field is not present.
+                    __this.#active_members = #active_values()?;
+                )*
+                #(
+                    __this.#ignored_members = #ignored_values;
+                )*
+                #FQOption::Some(__this)
             )
-        )
+        },
+        _ => {
+
+            quote!(
+                #FQOption::Some(
+                    Self {
+                        #(#active_members: #active_values()?,)*
+                        #(#ignored_members: #ignored_values,)*
+                    }
+                )
+            )
+        }
     };
 
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -121,11 +121,6 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
 /// which have greater functionality. The type being reflected must be in scope, as you cannot
 /// qualify it in the macro as e.g. `bevy::prelude::Vec3`.
 ///
-/// It may be necessary to add `#[reflect(Default)]` for some types, specifically non-constructible
-/// foreign types. Without `Default` reflected for such types, you will usually get an arcane
-/// error message and fail to compile. If the type does not implement `Default`, it may not
-/// be possible to reflect without extending the macro.
-///
 /// # Example
 /// Implementing `Reflect` for `bevy::prelude::Vec3` as a struct type:
 /// ```ignore

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -103,7 +103,7 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
         &def.type_name,
         &def.generics,
         def.traits.unwrap_or_default(),
-        ReflectImplSource::ImplValue
+        ReflectImplSource::ImplValue,
     );
 
     #[cfg(feature = "documentation")]

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -30,6 +30,7 @@ mod type_uuid;
 mod utility;
 
 use crate::derive_data::{ReflectDerive, ReflectMeta, ReflectStruct};
+use derive_data::ReflectImplSource;
 use proc_macro::TokenStream;
 use quote::quote;
 use reflect_value::ReflectValueDef;
@@ -43,7 +44,7 @@ pub(crate) static REFLECT_VALUE_ATTRIBUTE_NAME: &str = "reflect_value";
 pub fn derive_reflect(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
-    let derive_data = match ReflectDerive::from_input(&ast) {
+    let derive_data = match ReflectDerive::from_input(&ast, ReflectImplSource::Derive) {
         Ok(data) => data,
         Err(err) => return err.into_compile_error().into(),
     };
@@ -69,7 +70,7 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
 pub fn derive_from_reflect(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
 
-    let derive_data = match ReflectDerive::from_input(&ast) {
+    let derive_data = match ReflectDerive::from_input(&ast, ReflectImplSource::Derive) {
         Ok(data) => data,
         Err(err) => return err.into_compile_error().into(),
     };
@@ -102,6 +103,7 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
         &def.type_name,
         &def.generics,
         def.traits.unwrap_or_default(),
+        ReflectImplSource::ImplValue
     );
 
     #[cfg(feature = "documentation")]
@@ -130,7 +132,7 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
 /// use bevy::prelude::Vec3;
 ///
 /// impl_reflect_struct!(
-///    #[reflect(PartialEq, Serialize, Deserialize, Default)]
+///    #[reflect(partial_eq, Serialize, Deserialize, Default)]
 ///    struct Vec3 {
 ///        x: f32,
 ///        y: f32,
@@ -141,7 +143,7 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn impl_reflect_struct(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
-    let derive_data = match ReflectDerive::from_input(&ast) {
+    let derive_data = match ReflectDerive::from_input(&ast, ReflectImplSource::ImplStruct) {
         Ok(data) => data,
         Err(err) => return err.into_compile_error().into(),
     };
@@ -183,5 +185,6 @@ pub fn impl_from_reflect_value(input: TokenStream) -> TokenStream {
         &def.type_name,
         &def.generics,
         def.traits.unwrap_or_default(),
+        ReflectImplSource::ImplValue,
     ))
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/registration.rs
@@ -9,7 +9,7 @@ use syn::{Generics, Path};
 pub(crate) fn impl_get_type_registration(
     type_name: &Ident,
     bevy_reflect_path: &Path,
-    registration_data: &[Ident],
+    registration_data: &[Path],
     generics: &Generics,
     serialization_denylist: Option<&BitSet<u32>>,
 ) -> proc_macro2::TokenStream {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -2,7 +2,7 @@ use crate::fq_std::{FQBox, FQClone, FQOption, FQResult};
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse::Parse, parse_macro_input, Attribute, ItemTrait, Token, Path};
+use syn::{parse::Parse, parse_macro_input, Attribute, ItemTrait, Path, Token};
 
 pub(crate) struct TraitInfo {
     item_trait: ItemTrait,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -2,7 +2,7 @@ use crate::fq_std::{FQBox, FQClone, FQOption, FQResult};
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse::Parse, parse_macro_input, Attribute, ItemTrait, Token};
+use syn::{parse::Parse, parse_macro_input, Attribute, ItemTrait, Token, Path};
 
 pub(crate) struct TraitInfo {
     item_trait: ItemTrait,
@@ -31,7 +31,7 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
     let item_trait = &trait_info.item_trait;
     let trait_ident = &item_trait.ident;
     let trait_vis = &item_trait.vis;
-    let reflect_trait_ident = crate::utility::get_reflect_ident(&item_trait.ident.to_string());
+    let reflect_trait_ident = crate::utility::into_reflected_path(Path::from(trait_ident.clone()));
     let bevy_reflect_path = BevyManifest::default().get_path("bevy_reflect");
 
     let struct_doc = format!(

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -4,7 +4,7 @@ use crate::field_attributes::ReflectIgnoreBehavior;
 use bevy_macro_utils::BevyManifest;
 use bit_set::BitSet;
 use proc_macro2::Ident;
-use syn::{Member, Path, spanned::Spanned};
+use syn::{spanned::Spanned, Member, Path};
 
 /// Returns the correct path for `bevy_reflect`.
 pub(crate) fn get_bevy_reflect_path() -> Path {
@@ -21,7 +21,10 @@ pub(crate) fn get_bevy_reflect_path() -> Path {
 /// ```
 pub(crate) fn into_reflected_path(mut path: Path) -> Path {
     let last = path.segments.last_mut().unwrap();
-    let ident = Ident::new(&format!("Reflect{name}", name = last.ident.to_string()), last.span());
+    let ident = Ident::new(
+        &format!("Reflect{name}", name = last.ident.to_string()),
+        last.span(),
+    );
     last.ident = ident;
     path
 }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -3,8 +3,8 @@
 use crate::field_attributes::ReflectIgnoreBehavior;
 use bevy_macro_utils::BevyManifest;
 use bit_set::BitSet;
-use proc_macro2::{Ident, Span};
-use syn::{Member, Path};
+use proc_macro2::Ident;
+use syn::{Member, Path, spanned::Spanned};
 
 /// Returns the correct path for `bevy_reflect`.
 pub(crate) fn get_bevy_reflect_path() -> Path {
@@ -19,9 +19,11 @@ pub(crate) fn get_bevy_reflect_path() -> Path {
 /// let reflected: Ident = get_reflect_ident("Hash");
 /// assert_eq!("ReflectHash", reflected.to_string());
 /// ```
-pub(crate) fn get_reflect_ident(name: &str) -> Ident {
-    let reflected = format!("Reflect{name}");
-    Ident::new(&reflected, Span::call_site())
+pub(crate) fn into_reflected_path(mut path: Path) -> Path {
+    let last = path.segments.last_mut().unwrap();
+    let ident = Ident::new(&format!("Reflect{name}", name = last.ident.to_string()), last.span());
+    last.ident = ident;
+    path
 }
 
 /// Helper struct used to process an iterator of `Result<Vec<T>, syn::Error>`,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -11,20 +11,17 @@ pub(crate) fn get_bevy_reflect_path() -> Path {
     BevyManifest::get_path_direct("bevy_reflect")
 }
 
-/// Returns the "reflected" ident for a given string.
+/// Returns the "reflected" path for a given path.
 ///
 /// # Example
 ///
 /// ```ignore
-/// let reflected: Ident = get_reflect_ident("Hash");
-/// assert_eq!("ReflectHash", reflected.to_string());
+/// let path: Path = parse_str("my_crate::MyTrait");
+/// let reflected = into_reflect_path(path); // == "my_crate::ReflectMyTrait"
 /// ```
 pub(crate) fn into_reflected_path(mut path: Path) -> Path {
     let last = path.segments.last_mut().unwrap();
-    let ident = Ident::new(
-        &format!("Reflect{name}", name = last.ident.to_string()),
-        last.span(),
-    );
+    let ident = Ident::new(&format!("Reflect{name}", name = last.ident), last.span());
     last.ident = ident;
     path
 }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -5,14 +5,14 @@ use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_struct, impl_ref
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct IVec2 {
         x: i32,
         y: i32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct IVec3 {
         x: i32,
         y: i32,
@@ -20,7 +20,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct IVec4 {
         x: i32,
         y: i32,
@@ -30,14 +30,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct UVec2 {
         x: u32,
         y: u32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct UVec3 {
         x: u32,
         y: u32,
@@ -45,7 +45,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(debug, hash, partial_eq, Default)]
     struct UVec4 {
         x: u32,
         y: u32,
@@ -55,14 +55,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Vec2 {
         x: f32,
         y: f32,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Vec3 {
         x: f32,
         y: f32,
@@ -70,7 +70,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Vec3A {
         x: f32,
         y: f32,
@@ -78,7 +78,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Vec4 {
         x: f32,
         y: f32,
@@ -88,14 +88,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct BVec2 {
         x: bool,
         y: bool,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct BVec3 {
         x: bool,
         y: bool,
@@ -103,7 +103,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct BVec4 {
         x: bool,
         y: bool,
@@ -113,14 +113,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DVec2 {
         x: f64,
         y: f64,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DVec3 {
         x: f64,
         y: f64,
@@ -128,7 +128,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DVec4 {
         x: f64,
         y: f64,
@@ -138,14 +138,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Mat2 {
         x_axis: Vec2,
         y_axis: Vec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Mat3 {
         x_axis: Vec3,
         y_axis: Vec3,
@@ -153,7 +153,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Mat3A {
         x_axis: Vec3A,
         y_axis: Vec3A,
@@ -161,7 +161,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Mat4 {
         x_axis: Vec4,
         y_axis: Vec4,
@@ -171,14 +171,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DMat2 {
         x_axis: DVec2,
         y_axis: DVec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DMat3 {
         x_axis: DVec3,
         y_axis: DVec3,
@@ -186,7 +186,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DMat4 {
         x_axis: DVec4,
         y_axis: DVec4,
@@ -196,14 +196,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Affine2 {
         matrix2: Mat2,
         translation: Vec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct Affine3A {
         matrix3: Mat3A,
         translation: Vec3A,
@@ -211,14 +211,14 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DAffine2 {
         matrix2: DMat2,
         translation: DVec2,
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(debug, partial_eq, Default)]
     struct DAffine3 {
         matrix3: DMat3,
         translation: DVec3,
@@ -229,12 +229,12 @@ impl_reflect_struct!(
 // mechanisms for read-only fields. I doubt those mechanisms would be added,
 // so for now quaternions will remain as values. They are represented identically
 // to Vec4 and DVec4, so you may use those instead and convert between.
-impl_reflect_value!(Quat(Debug, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(DQuat(Debug, PartialEq, Serialize, Deserialize, Default));
+impl_reflect_value!(Quat(debug, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(DQuat(debug, partial_eq, Serialize, Deserialize, Default));
 
 impl_from_reflect_value!(Quat);
 impl_from_reflect_value!(DQuat);
 
-impl_reflect_value!(EulerRot(Debug, Default));
-impl_reflect_value!(BVec3A(Debug, Default));
-impl_reflect_value!(BVec4A(Debug, Default));
+impl_reflect_value!(EulerRot(debug, Default));
+impl_reflect_value!(BVec3A(debug, Default));
+impl_reflect_value!(BVec4A(debug, Default));

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -5,7 +5,7 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(debug, partial_eq, Serialize, Deserialize, Default)]
     struct Rect {
         min: Vec2,
         max: Vec2,

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -27,75 +27,75 @@ use std::{
 };
 
 impl_reflect_value!(bool(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
 impl_reflect_value!(char(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
-impl_reflect_value!(u8(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(u16(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(u32(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(u64(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
+impl_reflect_value!(u8(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(u16(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(u32(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(u64(debug, hash, partial_eq, Serialize, Deserialize, Default));
 impl_reflect_value!(u128(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
 impl_reflect_value!(usize(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
-impl_reflect_value!(i8(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(i16(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(i32(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(i64(Debug, Hash, PartialEq, Serialize, Deserialize, Default));
+impl_reflect_value!(i8(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(i16(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(i32(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(i64(debug, hash, partial_eq, Serialize, Deserialize, Default));
 impl_reflect_value!(i128(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
 impl_reflect_value!(isize(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
-impl_reflect_value!(f32(Debug, PartialEq, Serialize, Deserialize, Default));
-impl_reflect_value!(f64(Debug, PartialEq, Serialize, Deserialize, Default));
+impl_reflect_value!(f32(debug, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(f64(debug, partial_eq, Serialize, Deserialize, Default));
 impl_reflect_value!(String(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
 impl_reflect_value!(PathBuf(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
@@ -109,33 +109,33 @@ impl_reflect_value!(RangeTo<T: Clone + Send + Sync + 'static>());
 impl_reflect_value!(RangeToInclusive<T: Clone + Send + Sync + 'static>());
 impl_reflect_value!(RangeFull());
 impl_reflect_value!(Duration(
-    Debug,
-    Hash,
-    PartialEq,
+    debug,
+    hash,
+    partial_eq,
     Serialize,
     Deserialize,
     Default
 ));
-impl_reflect_value!(Instant(Debug, Hash, PartialEq));
-impl_reflect_value!(NonZeroI128(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroU128(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroIsize(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroUsize(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroI64(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroU64(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroU32(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroI32(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroI16(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroU16(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroU8(Debug, Hash, PartialEq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroI8(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(Instant(debug, hash, partial_eq));
+impl_reflect_value!(NonZeroI128(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroU128(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroIsize(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroUsize(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroI64(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroU64(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroU32(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroI32(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroI16(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroU16(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroU8(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroI8(debug, hash, partial_eq, Serialize, Deserialize));
 
 // `Serialize` and `Deserialize` only for platforms supported by serde:
 // https://github.com/serde-rs/serde/blob/3ffb86fc70efd3d329519e2dddfa306cc04f167c/serde/src/de/impls.rs#L1732
 #[cfg(any(unix, windows))]
-impl_reflect_value!(OsString(Debug, Hash, PartialEq, Serialize, Deserialize));
+impl_reflect_value!(OsString(debug, hash, partial_eq, Serialize, Deserialize));
 #[cfg(not(any(unix, windows)))]
-impl_reflect_value!(OsString(Debug, Hash, PartialEq));
+impl_reflect_value!(OsString(debug, hash, partial_eq));
 
 impl_from_reflect_value!(bool);
 impl_from_reflect_value!(char);

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -43,9 +43,30 @@ impl_reflect_value!(char(
     Default
 ));
 impl_reflect_value!(u8(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(u16(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(u32(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(u64(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(u16(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
+impl_reflect_value!(u32(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
+impl_reflect_value!(u64(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
 impl_reflect_value!(u128(
     debug,
     hash,
@@ -63,9 +84,30 @@ impl_reflect_value!(usize(
     Default
 ));
 impl_reflect_value!(i8(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(i16(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(i32(debug, hash, partial_eq, Serialize, Deserialize, Default));
-impl_reflect_value!(i64(debug, hash, partial_eq, Serialize, Deserialize, Default));
+impl_reflect_value!(i16(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
+impl_reflect_value!(i32(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
+impl_reflect_value!(i64(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize,
+    Default
+));
 impl_reflect_value!(i128(
     debug,
     hash,
@@ -119,8 +161,20 @@ impl_reflect_value!(Duration(
 impl_reflect_value!(Instant(debug, hash, partial_eq));
 impl_reflect_value!(NonZeroI128(debug, hash, partial_eq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU128(debug, hash, partial_eq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroIsize(debug, hash, partial_eq, Serialize, Deserialize));
-impl_reflect_value!(NonZeroUsize(debug, hash, partial_eq, Serialize, Deserialize));
+impl_reflect_value!(NonZeroIsize(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize
+));
+impl_reflect_value!(NonZeroUsize(
+    debug,
+    hash,
+    partial_eq,
+    Serialize,
+    Deserialize
+));
 impl_reflect_value!(NonZeroI64(debug, hash, partial_eq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU64(debug, hash, partial_eq, Serialize, Deserialize));
 impl_reflect_value!(NonZeroU32(debug, hash, partial_eq, Serialize, Deserialize));

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -161,7 +161,7 @@ mod tests {
     #[test]
     fn reflect_map() {
         #[derive(Reflect, Hash)]
-        #[reflect(Hash)]
+        #[reflect(hash)]
         struct Foo {
             a: u32,
             b: String,
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn reflect_complex_patch() {
         #[derive(Reflect, Eq, PartialEq, Debug, FromReflect)]
-        #[reflect(PartialEq)]
+        #[reflect(partial_eq)]
         struct Foo {
             a: u32,
             #[reflect(ignore)]
@@ -360,7 +360,7 @@ mod tests {
         }
 
         #[derive(Reflect, Eq, PartialEq, Clone, Debug, FromReflect)]
-        #[reflect(PartialEq)]
+        #[reflect(partial_eq)]
         struct Bar {
             x: u32,
         }
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn reflect_take() {
         #[derive(Reflect, Debug, PartialEq)]
-        #[reflect(PartialEq)]
+        #[reflect(partial_eq)]
         struct Bar {
             x: u32,
         }
@@ -1093,7 +1093,7 @@ mod tests {
         struct SomeTupleStruct(String);
 
         #[derive(Reflect)]
-        #[reflect(Debug)]
+        #[reflect(debug)]
         struct CustomDebug;
         impl Debug for CustomDebug {
             fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -1159,8 +1159,8 @@ bevy_reflect::tests::should_reflect_debug::Test {
     #[test]
     fn multiple_reflect_lists() {
         #[derive(Hash, PartialEq, Reflect)]
-        #[reflect(Debug, Hash)]
-        #[reflect(PartialEq)]
+        #[reflect(debug, hash)]
+        #[reflect(partial_eq)]
         struct Foo(i32);
 
         impl Debug for Foo {
@@ -1180,8 +1180,7 @@ bevy_reflect::tests::should_reflect_debug::Test {
     #[test]
     fn multiple_reflect_value_lists() {
         #[derive(Clone, Hash, PartialEq, Reflect)]
-        #[reflect_value(Debug, Hash)]
-        #[reflect_value(PartialEq)]
+        #[reflect_value(debug, hash, partial_eq)]
         struct Foo(i32);
 
         impl Debug for Foo {

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -19,7 +19,7 @@ mod tests {
     #[test]
     fn test_serialization_struct() {
         #[derive(Debug, Reflect, PartialEq)]
-        #[reflect(PartialEq)]
+        #[reflect(partial_eq)]
         struct TestStruct {
             a: i32,
             #[reflect(ignore)]
@@ -61,7 +61,7 @@ mod tests {
     #[test]
     fn test_serialization_tuple_struct() {
         #[derive(Debug, Reflect, PartialEq)]
-        #[reflect(PartialEq)]
+        #[reflect(partial_eq)]
         struct TestStruct(
             i32,
             #[reflect(ignore)] i32,

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -10,7 +10,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum Color {
     /// sRGBA color
     Rgba {

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -21,7 +21,7 @@ pub type Layer = u8;
 ///
 /// Entities without this component belong to layer `0`.
 #[derive(Component, Copy, Clone, Reflect, PartialEq, Eq, PartialOrd, Ord)]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default, partial_eq)]
 pub struct RenderLayers(LayerMask);
 
 impl std::fmt::Debug for RenderLayers {

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -40,7 +40,7 @@ impl Plugin for ColorMaterialPlugin {
 
 /// A [2d material](Material2d) that renders [2d meshes](crate::Mesh2dHandle) with a texture tinted by a uniform color
 #[derive(AsBindGroup, Reflect, FromReflect, Debug, Clone, TypeUuid)]
-#[reflect(Default, Debug)]
+#[reflect(debug, Default)]
 #[uuid = "e228a544-e3ca-4e1e-bb9d-4d8bc1ad8c19"]
 #[uniform(0, ColorMaterialUniform)]
 pub struct ColorMaterial {

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -11,7 +11,7 @@ use bevy_utils::HashMap;
 /// [Example usage loading sprite sheet.](https://github.com/bevyengine/bevy/blob/latest/examples/2d/texture_atlas.rs)
 #[derive(Reflect, FromReflect, Debug, Clone, TypeUuid)]
 #[uuid = "7233c597-ccfa-411f-bd59-9af349432ada"]
-#[reflect(Debug)]
+#[reflect(debug)]
 pub struct TextureAtlas {
     /// The handle to the texture in which the sprites are stored
     pub texture: Handle<Image>,

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -38,7 +38,7 @@ use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect, FromReflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(partial_eq, Component, Default)]
 pub struct GlobalTransform(Affine3A);
 
 macro_rules! impl_local_axis {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -36,7 +36,7 @@ use std::ops::Mul;
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect, FromReflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default, partial_eq)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
     ///

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -33,7 +33,7 @@ use smallvec::SmallVec;
 /// Note that you can also control the visibility of a node using the [`Display`](crate::ui_node::Display) property,
 /// which fully collapses it during layout calculations.
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(partial_eq, Component, Serialize, Deserialize)]
 pub enum Interaction {
     /// The node has been clicked
     Clicked,
@@ -71,7 +71,7 @@ impl Default for Interaction {
     Serialize,
     Deserialize,
 )]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(partial_eq, Component, Serialize, Deserialize)]
 pub struct RelativeCursorPosition {
     /// Cursor position relative to size and position of the Node.
     pub normalized: Option<Vec2>,
@@ -88,7 +88,7 @@ impl RelativeCursorPosition {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(partial_eq, Component, Serialize, Deserialize)]
 pub enum FocusPolicy {
     /// Blocks interaction
     Block,

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -120,7 +120,7 @@ use std::ops::{Div, DivAssign, Mul, MulAssign};
 /// };
 /// ```
 #[derive(Copy, Clone, PartialEq, Debug, Reflect)]
-#[reflect(PartialEq)]
+#[reflect(partial_eq)]
 pub struct UiRect {
     /// The value corresponding to the left side of the UI rect.
     pub left: Val,
@@ -330,7 +330,7 @@ impl Default for UiRect {
 ///
 /// It is commonly used to define the size of a text or UI element.
 #[derive(Copy, Clone, PartialEq, Debug, Reflect)]
-#[reflect(PartialEq)]
+#[reflect(partial_eq)]
 pub struct Size {
     /// The width of the 2-dimensional area.
     pub width: Val,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -42,7 +42,7 @@ impl Default for Node {
 
 /// An enum that describes possible types of value in flexbox layout options
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum Val {
     /// No value defined
     Undefined,
@@ -211,7 +211,7 @@ impl Val {
 ///
 /// It uses the [Flexbox](https://cssreference.io/flexbox/) system.
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(partial_eq, Component, Default)]
 pub struct Style {
     /// Whether to arrange this node and its children with flexbox layout
     ///
@@ -299,7 +299,7 @@ impl Default for Style {
 
 /// How items are aligned according to the cross axis
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum AlignItems {
     /// Items are aligned at the start
     FlexStart,
@@ -325,7 +325,7 @@ impl Default for AlignItems {
 
 /// Works like [`AlignItems`] but applies only to a single item
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
     Auto,
@@ -355,7 +355,7 @@ impl Default for AlignSelf {
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum AlignContent {
     /// Each line moves towards the start of the cross axis
     FlexStart,
@@ -387,7 +387,7 @@ impl Default for AlignContent {
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node
     Inherit,
@@ -411,7 +411,7 @@ impl Default for Direction {
 ///
 /// Part of the [`Style`] component.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum Display {
     /// Use Flexbox layout model to determine the position of this [`Node`].
     Flex,
@@ -434,7 +434,7 @@ impl Default for Display {
 
 /// Defines how flexbox items are ordered within a flexbox
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis
     Row,
@@ -458,7 +458,7 @@ impl Default for FlexDirection {
 
 /// Defines how items are aligned according to the main axis
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum JustifyContent {
     /// Pushed towards the start
     FlexStart,
@@ -486,7 +486,7 @@ impl Default for JustifyContent {
 
 /// Whether to show or hide overflowing items
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum Overflow {
     /// Show overflowing items
     Visible,
@@ -506,7 +506,7 @@ impl Default for Overflow {
 
 /// The strategy used to position this node
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value
     Relative,
@@ -528,7 +528,7 @@ impl Default for PositionType {
 
 /// Defines if flexbox items appear on a single line or on multiple lines
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(partial_eq, Serialize, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed
     NoWrap,

--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -14,7 +14,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(debug, partial_eq, Default)]
 pub enum CursorIcon {
     /// The platform-dependent default cursor.
     #[default]

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -9,7 +9,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
 /// A window event that is sent whenever a window's logical size has changed.
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -28,7 +28,7 @@ pub struct WindowResized {
 /// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
 /// there have been no window events.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -40,7 +40,7 @@ pub struct RequestRedraw;
 ///
 /// To create a new window, spawn an entity with a [`crate::Window`] on it.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -62,7 +62,7 @@ pub struct WindowCreated {
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -76,7 +76,7 @@ pub struct WindowCloseRequested {
 /// An event that is sent whenever a window is closed. This will be sent when
 /// the window entity loses its `Window` component or is despawned.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -99,7 +99,7 @@ pub struct WindowClosed {
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -114,7 +114,7 @@ pub struct CursorMoved {
 
 /// An event that is sent whenever the user's cursor enters a window.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -127,7 +127,7 @@ pub struct CursorEntered {
 
 /// An event that is sent whenever the user's cursor leaves a window.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -140,7 +140,7 @@ pub struct CursorLeft {
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -155,7 +155,7 @@ pub struct ReceivedCharacter {
 
 /// An event that indicates a window has received or lost focus.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -170,7 +170,7 @@ pub struct WindowFocused {
 
 /// An event that indicates a window's scale factor has changed.
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -185,7 +185,7 @@ pub struct WindowScaleFactorChanged {
 
 /// An event that indicates a window's OS-reported scale factor has changed.
 #[derive(Debug, Clone, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -200,7 +200,7 @@ pub struct WindowBackendScaleFactorChanged {
 
 /// Events related to files being dragged and dropped on a window.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -232,7 +232,7 @@ pub enum FileDragAndDrop {
 
 /// An event that is sent when a window is repositioned in physical pixels.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -270,7 +270,7 @@ impl Window {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(debug, partial_eq, Default)]
 pub struct WindowResizeConstraints {
     /// The minimum width the window can have.
     pub min_width: f32,
@@ -337,7 +337,7 @@ impl WindowResizeConstraints {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, Default)]
+#[reflect(debug, Default)]
 pub struct Cursor {
     /// Get the current [`CursorIcon`] while inside the window.
     pub icon: CursorIcon,
@@ -393,7 +393,7 @@ impl Default for Cursor {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 pub enum WindowPosition {
     /// Position will be set by the window manager
     #[default]
@@ -444,7 +444,7 @@ impl WindowPosition {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(debug, partial_eq, Default)]
 pub struct WindowResolution {
     physical_width: u32,
     physical_height: u32,
@@ -608,7 +608,7 @@ impl From<bevy_math::DVec2> for WindowResolution {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(debug, partial_eq, Default)]
 pub enum CursorGrabMode {
     /// The cursor can freely leave the window.
     #[default]
@@ -626,7 +626,7 @@ pub enum CursorGrabMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(debug, partial_eq, Default)]
 pub struct InternalWindowState {
     /// If this is true then next frame we will ask to minimize the window.
     minimize_request: Option<bool>,
@@ -653,7 +653,7 @@ impl InternalWindowState {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 pub enum MonitorSelection {
     /// Uses current monitor of the window.
     ///
@@ -684,7 +684,7 @@ pub enum MonitorSelection {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Hash)]
+#[reflect(debug, partial_eq, hash)]
 #[doc(alias = "vsync")]
 pub enum PresentMode {
     /// Chooses FifoRelaxed -> Fifo based on availability.
@@ -724,7 +724,7 @@ pub enum PresentMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Hash)]
+#[reflect(debug, partial_eq, hash)]
 pub enum CompositeAlphaMode {
     /// Chooses either `Opaque` or `Inherit` automatically, depending on the
     /// `alpha_mode` that the current surface can support.
@@ -759,7 +759,7 @@ pub enum CompositeAlphaMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(debug, partial_eq)]
 pub enum WindowMode {
     /// Creates a window that uses the given size.
     #[default]

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -45,7 +45,7 @@ pub enum D {
 /// `Reflect::serializable()`. You can force these implementations to use the actual trait
 /// implementations (instead of their defaults) like this:
 #[derive(Reflect, Hash, Serialize, PartialEq, Eq)]
-#[reflect(Hash, Serialize, PartialEq)]
+#[reflect(hash, partial_eq, Serialize)]
 pub struct E {
     x: usize,
 }
@@ -56,7 +56,7 @@ pub struct E {
 /// the `PartialEq`, `Serialize`, and `Deserialize` traits on `reflect_value` types to ensure
 /// that these values behave as expected when nested underneath Reflect-ed structs.
 #[derive(Reflect, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[reflect_value(PartialEq, Serialize, Deserialize)]
+#[reflect_value(partial_eq, Serialize, Deserialize)]
 pub enum F {
     X,
     Y,


### PR DESCRIPTION
# Objective

- Remove confusion around `#[reflect(Debug, PartialEq, Hash, Default)]`.
- Allow specifying paths like `#[reflect(my_crate::foo::MyTrait)]`.

## Solution

- Remove the [special casing](https://github.com/bevyengine/bevy/blob/cb4e8c832c0ee33ea0b28a6f79971955643055fb/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs#L95) around `#[reflect(Default)]`.
- Change the syntax to `#[reflect(debug, partial_eq, hash)]` to make obvious the distinction between normal and "special" idents.
  - `#[reflect(Hash(my_hash_fn))]` is now `#[reflect(hash = "my_hash_fn")]`.
- Implement parsing for paths in `#[reflect]` attributes.

---

## Changelog

- Replaced `#[reflect(Debug, PartialEq, Hash, Default)]` syntax with `#[reflect(debug, partial_eq, hash)]` syntax.

## Migration Guide

- Replaced `#[reflect(Debug, PartialEq, Hash, Default)]` syntax with `#[reflect(debug, partial_eq, hash)]` syntax.
- Derived `FromReflect::from_reflect` implementations no longer can create a value from a partial set of fields if it implements default. All fields are required.