### PR TITLE
[Merged by Bors] - bevy_reflect: Pre-parsed paths

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1274,9 +1274,15 @@ bevy_reflect::tests::should_reflect_debug::Test {
         fn vec3_path_access() {
             let mut v = vec3(1.0, 2.0, 3.0);
 
-            assert_eq!(*v.path("x").unwrap().downcast_ref::<f32>().unwrap(), 1.0);
+            assert_eq!(
+                *v.reflect_path("x").unwrap().downcast_ref::<f32>().unwrap(),
+                1.0
+            );
 
-            *v.path_mut("y").unwrap().downcast_mut::<f32>().unwrap() = 6.0;
+            *v.reflect_path_mut("y")
+                .unwrap()
+                .downcast_mut::<f32>()
+                .unwrap() = 6.0;
 
             assert_eq!(v.y, 6.0);
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -54,7 +54,8 @@ pub enum ReflectPathError<'a> {
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
 ///   but can be much more fragile as code and string paths must be kept in sync since
-///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
+///   the order of fields could be easily changed. Storing these paths in persistent
+///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -161,7 +161,8 @@ impl FieldPath {
         Ok(Self(parts.into_boxed_slice()))
     }
 
-    /// Gets a read-only reference of given field.
+    /// Gets a read-only reference to a given field.
+    ///
     /// Returns an error if the path is invalid for the provided type.
     pub fn field<'r, 'p>(
         &'p self,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -164,9 +164,9 @@ impl FieldPath {
     /// Returns an error if the path is invalid for the provided type.
     pub fn field<'r, 'p>(
         &'p self,
-        root: &'r impl Reflect,
+        root: &'r dyn Reflect,
     ) -> Result<&'r dyn Reflect, ReflectPathError<'p>> {
-        let mut current: &dyn Reflect = root;
+        let mut current = root;
         for (access, current_index) in self.0.iter() {
             current = access.to_ref().read_field(current, *current_index)?;
         }
@@ -177,9 +177,9 @@ impl FieldPath {
     /// Returns an error if the path is invalid for the provided type.
     pub fn field_mut<'r, 'p>(
         &'p mut self,
-        root: &'r mut impl Reflect,
+        root: &'r mut dyn Reflect,
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
-        let mut current: &mut dyn Reflect = root;
+        let mut current = root;
         for (access, current_index) in self.0.iter() {
             current = access.to_ref().read_field_mut(current, *current_index)?;
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -141,7 +141,7 @@ impl GetPath for dyn Reflect {
 pub struct FieldPath(Box<[(Access, usize)]>);
 
 impl FieldPath {
-    pub fn parse<'a>(string: &'a str) -> Result<Self, ReflectPathError<'a>> {
+    pub fn parse(string: &str) -> Result<Self, ReflectPathError<'_>> {
         let mut parts = Vec::new();
         for (access, idx) in PathParser::new(string) {
             parts.push((access?.to_owned(), idx));
@@ -182,7 +182,7 @@ enum Access {
 impl Access {
     fn to_ref(&self) -> AccessRef<'_> {
         match self {
-            Self::Field(value) => AccessRef::Field(&value),
+            Self::Field(value) => AccessRef::Field(value),
             Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
             Self::ListIndex(value) => AccessRef::ListIndex(*value),
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::num::ParseIntError;
 
 use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
@@ -179,6 +180,37 @@ impl FieldPath {
             current = access.to_ref().read_field_mut(current, *current_index)?;
         }
         Ok(current)
+    }
+}
+
+impl fmt::Display for FieldPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (idx, (access, _)) in self.0.iter().enumerate() {
+            match access {
+                Access::Field(field) => {
+                    if idx != 0 {
+                        f.write_str(".")?;
+                    }
+                    f.write_str(field.as_str())?;
+                }
+                Access::FieldIndex(index) => {
+                    f.write_str("#")?;
+                    index.fmt(f)?;
+                }
+                Access::TupleIndex(index) => {
+                    if idx != 0 {
+                        f.write_str(".")?;
+                    }
+                    index.fmt(f)?;
+                }
+                Access::ListIndex(index) => {
+                    f.write_str("[")?;
+                    index.fmt(f)?;
+                    f.write_str("]")?;
+                }
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -175,7 +175,8 @@ impl FieldPath {
         Ok(current)
     }
 
-    /// Gets a mutable reference of given field.
+    /// Gets a mutable reference to a given field.
+    ///
     /// Returns an error if the path is invalid for the provided type.
     pub fn field_mut<'r, 'p>(
         &'p mut self,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -471,19 +471,19 @@ impl<'a> PathParser<'a> {
         }
 
         match self.path[self.index..].chars().next().unwrap() {
-            '.' => {
+            Token::DOT => {
                 self.index += 1;
                 return Some(Token::Dot);
             }
-            '#' => {
+            Token::CROSSHATCH => {
                 self.index += 1;
                 return Some(Token::CrossHatch);
             }
-            '[' => {
+            Token::OPEN_BRACKET => {
                 self.index += 1;
                 return Some(Token::OpenBracket);
             }
-            ']' => {
+            Token::CLOSE_BRACKET => {
                 self.index += 1;
                 return Some(Token::CloseBracket);
             }
@@ -493,7 +493,7 @@ impl<'a> PathParser<'a> {
         // we can assume we are parsing an ident now
         for (char_index, character) in self.path[self.index..].chars().enumerate() {
             match character {
-                '.' | '#' | '[' | ']' => {
+                Token::DOT | Token::CROSSHATCH | Token::OPEN_BRACKET | Token::CLOSE_BRACKET => {
                     let ident = Token::Ident(&self.path[self.index..self.index + char_index]);
                     self.index += char_index;
                     return Some(ident);
@@ -542,7 +542,7 @@ impl<'a> PathParser<'a> {
                 if !matches!(self.next_token(), Some(Token::CloseBracket)) {
                     return Err(ReflectPathError::ExpectedToken {
                         index: current_index,
-                        token: "]",
+                        token: Token::OPEN_BRACKET_STR,
                     });
                 }
 
@@ -550,7 +550,7 @@ impl<'a> PathParser<'a> {
             }
             Token::CloseBracket => Err(ReflectPathError::UnexpectedToken {
                 index: current_index,
-                token: "]",
+                token: Token::CLOSE_BRACKET_STR,
             }),
             Token::Ident(value) => value
                 .parse::<usize>()
@@ -576,6 +576,15 @@ enum Token<'a> {
     OpenBracket,
     CloseBracket,
     Ident(&'a str),
+}
+
+impl<'a> Token<'a> {
+    const DOT: char = '.';
+    const CROSSHATCH: char = '#';
+    const OPEN_BRACKET: char = '[';
+    const CLOSE_BRACKET: char = ']';
+    const OPEN_BRACKET_STR: &'static str = "[";
+    const CLOSE_BRACKET_STR: &'static str = "]";
 }
 
 #[cfg(test)]

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -448,12 +448,9 @@ impl<'a> Iterator for PathParser<'a> {
     type Item = (Result<AccessRef<'a>, ReflectPathError<'a>>, usize);
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(token) = self.next_token() {
-            let index = self.index;
-            Some((self.token_to_access(token), index))
-        } else {
-            None
-        }
+        let token = self.next_token()?;
+        let index = self.index;
+        Some((self.token_to_access(token), index))
     }
 }
 

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -218,24 +218,24 @@ impl fmt::Display for FieldPath {
             match access {
                 Access::Field(field) => {
                     if idx != 0 {
-                        f.write_str(".")?;
+                        Token::DOT.fmt(f)?;
                     }
                     f.write_str(field.as_str())?;
                 }
                 Access::FieldIndex(index) => {
-                    f.write_str("#")?;
+                    Token::CROSSHATCH.fmt(f)?;
                     index.fmt(f)?;
                 }
                 Access::TupleIndex(index) => {
                     if idx != 0 {
-                        f.write_str(".")?;
+                        Token::DOT.fmt(f)?;
                     }
                     index.fmt(f)?;
                 }
                 Access::ListIndex(index) => {
-                    f.write_str("[")?;
+                    Token::OPEN_BRACKET.fmt(f)?;
                     index.fmt(f)?;
-                    f.write_str("]")?;
+                    Token::CLOSE_BRACKET.fmt(f)?;
                 }
             }
         }

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -245,7 +245,7 @@ impl fmt::Display for FieldPath {
 
 /// A singular owned field access within a path. Can be applied
 /// to a `dyn Reflect` to get a reference to the targetted field.
-/// 
+///
 /// A path is composed of multiple accesses in sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 enum Access {
@@ -268,7 +268,7 @@ impl Access {
 
 /// A singular borrowed field access within a path. Can be applied
 /// to a `dyn Reflect` to get a reference to the targetted field.
-/// 
+///
 /// Does not own the backing store it's sourced from. For an owned
 /// version, you can convert one to an [`Access`].
 #[derive(Debug)]
@@ -614,6 +614,7 @@ mod tests {
         unit_variant: F,
         tuple_variant: F,
         struct_variant: F,
+        array: [i32; 3],
     }
 
     #[derive(Reflect)]
@@ -707,6 +708,7 @@ mod tests {
             unit_variant: F::Unit,
             tuple_variant: F::Tuple(123, 321),
             struct_variant: F::Struct { value: 'm' },
+            array: [86, 75, 309],
         };
 
         let b = FieldPath::parse("w").unwrap();
@@ -720,6 +722,7 @@ mod tests {
         let j = FieldPath::parse("tuple_variant.1").unwrap();
         let k = FieldPath::parse("struct_variant.value").unwrap();
         let l = FieldPath::parse("struct_variant#0").unwrap();
+        let m = FieldPath::parse("array[2]").unwrap();
 
         for _ in 0..30 {
             assert_eq!(*b.get_field::<usize>(&a).unwrap(), 1);
@@ -733,6 +736,7 @@ mod tests {
             assert_eq!(*j.get_field::<u32>(&a).unwrap(), 321);
             assert_eq!(*k.get_field::<char>(&a).unwrap(), 'm');
             assert_eq!(*l.get_field::<char>(&a).unwrap(), 'm');
+            assert_eq!(*m.get_field::<i32>(&a).unwrap(), 309);
         }
     }
 
@@ -791,6 +795,7 @@ mod tests {
             unit_variant: F::Unit,
             tuple_variant: F::Tuple(123, 321),
             struct_variant: F::Struct { value: 'm' },
+            array: [86, 75, 309],
         };
 
         assert_eq!(*a.get_path::<usize>("w").unwrap(), 1);
@@ -805,6 +810,8 @@ mod tests {
         assert_eq!(*a.get_path::<u32>("tuple_variant.1").unwrap(), 321);
         assert_eq!(*a.get_path::<char>("struct_variant.value").unwrap(), 'm');
         assert_eq!(*a.get_path::<char>("struct_variant#0").unwrap(), 'm');
+
+        assert_eq!(*a.get_path::<i32>("array[2]").unwrap(), 309);
 
         *a.get_path_mut::<f32>("y[1].baz").unwrap() = 3.0;
         assert_eq!(a.y[1].baz, 3.0);

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -53,8 +53,8 @@ pub enum ReflectPathError<'a> {
 /// - [`List`] items are accessed with brackets: `[0]`
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
-///   but can be much more fragile to keeping code and string paths in sync. Storing
-///   these paths in persistent storage (i.e. game assets) is strongly discouraged.
+///   but can be much more fragile to keeping code and string paths in sync since
+///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -145,6 +145,8 @@ impl GetPath for dyn Reflect {
     }
 }
 
+// This stores an access and a start index for the identity. The index is only really
+// used for errors.
 /// A path to a field within a type. Can be used like [`GetPath`] functions to get
 /// references to the inner fields of a type.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
@@ -241,6 +243,10 @@ impl fmt::Display for FieldPath {
     }
 }
 
+/// A singular owned field access within a path. Can be applied
+/// to a `dyn Reflect` to get a reference to the targetted field.
+/// 
+/// A path is composed of multiple accesses in sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 enum Access {
     Field(String),
@@ -260,6 +266,11 @@ impl Access {
     }
 }
 
+/// A singular borrowed field access within a path. Can be applied
+/// to a `dyn Reflect` to get a reference to the targetted field.
+/// 
+/// Does not own the backing store it's sourced from. For an owned
+/// version, you can convert one to an [`Access`].
 #[derive(Debug)]
 enum AccessRef<'a> {
     Field(&'a str),

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -51,6 +51,10 @@ pub enum ReflectPathError<'a> {
 /// - [`Struct`] items are accessed with a dot and a field name: `.field_name`
 /// - [`TupleStruct`] and [`Tuple`] items are accessed with a dot and a number: `.0`
 /// - [`List`] items are accessed with brackets: `[0]`
+/// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
+///   the first field. This can speed up fetches at runtime (no string matching)
+///   but can be much more fragile to keeping code and string paths in sync. Storing
+///   these paths in persistent storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,
 /// the initial '.' may be omitted.

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -185,6 +185,26 @@ impl FieldPath {
         }
         Ok(current)
     }
+
+    pub fn get_field<'r, 'p, T: Reflect>(
+        &'p self,
+        root: &'r dyn Reflect,
+    ) -> Result<&'r T, ReflectPathError<'p>> {
+        self.field(root).and_then(|p| {
+            p.downcast_ref::<T>()
+                .ok_or(ReflectPathError::InvalidDowncast)
+        })
+    }
+
+    pub fn get_field_mut<'r, 'p, T: Reflect>(
+        &'p mut self,
+        root: &'r mut dyn Reflect,
+    ) -> Result<&'r mut T, ReflectPathError<'p>> {
+        self.field_mut(root).and_then(|p| {
+            p.downcast_mut::<T>()
+                .ok_or(ReflectPathError::InvalidDowncast)
+        })
+    }
 }
 
 impl fmt::Display for FieldPath {
@@ -558,9 +578,140 @@ enum Token<'a> {
 #[cfg(test)]
 #[allow(clippy::float_cmp, clippy::approx_constant)]
 mod tests {
-    use super::GetPath;
+    use super::*;
     use crate as bevy_reflect;
     use crate::*;
+
+    #[derive(Reflect)]
+    struct A {
+        w: usize,
+        x: B,
+        y: Vec<C>,
+        z: D,
+        unit_variant: F,
+        tuple_variant: F,
+        struct_variant: F,
+    }
+
+    #[derive(Reflect)]
+    struct B {
+        foo: usize,
+        bar: C,
+    }
+
+    #[derive(Reflect, FromReflect)]
+    struct C {
+        baz: f32,
+    }
+
+    #[derive(Reflect)]
+    struct D(E);
+
+    #[derive(Reflect)]
+    struct E(f32, usize);
+
+    #[derive(Reflect, FromReflect, PartialEq, Debug)]
+    enum F {
+        Unit,
+        Tuple(u32, u32),
+        Struct { value: char },
+    }
+
+    #[test]
+    fn field_path_parse() {
+        assert_eq!(
+            &*FieldPath::parse("w").unwrap().0,
+            &[(Access::Field("w".to_string()), 1)]
+        );
+        assert_eq!(
+            &*FieldPath::parse("x.foo").unwrap().0,
+            &[
+                (Access::Field("x".to_string()), 1),
+                (Access::Field("foo".to_string()), 2)
+            ]
+        );
+        assert_eq!(
+            &*FieldPath::parse("x.bar.baz").unwrap().0,
+            &[
+                (Access::Field("x".to_string()), 1),
+                (Access::Field("bar".to_string()), 2),
+                (Access::Field("baz".to_string()), 6)
+            ]
+        );
+        assert_eq!(
+            &*FieldPath::parse("y[1].baz").unwrap().0,
+            &[
+                (Access::Field("y".to_string()), 1),
+                (Access::ListIndex(1), 2),
+                (Access::Field("baz".to_string()), 5)
+            ]
+        );
+        assert_eq!(
+            &*FieldPath::parse("z.0.1").unwrap().0,
+            &[
+                (Access::Field("z".to_string()), 1),
+                (Access::TupleIndex(0), 2),
+                (Access::TupleIndex(1), 4),
+            ]
+        );
+        assert_eq!(
+            &*FieldPath::parse("x#0").unwrap().0,
+            &[
+                (Access::Field("x".to_string()), 1),
+                (Access::FieldIndex(0), 2),
+            ]
+        );
+        assert_eq!(
+            &*FieldPath::parse("x#0#1").unwrap().0,
+            &[
+                (Access::Field("x".to_string()), 1),
+                (Access::FieldIndex(0), 2),
+                (Access::FieldIndex(1), 4)
+            ]
+        );
+    }
+
+    #[test]
+    fn field_path_get_field() {
+        let a = A {
+            w: 1,
+            x: B {
+                foo: 10,
+                bar: C { baz: 3.14 },
+            },
+            y: vec![C { baz: 1.0 }, C { baz: 2.0 }],
+            z: D(E(10.0, 42)),
+            unit_variant: F::Unit,
+            tuple_variant: F::Tuple(123, 321),
+            struct_variant: F::Struct { value: 'm' },
+        };
+
+        let b = FieldPath::parse("w").unwrap();
+        let c = FieldPath::parse("x.foo").unwrap();
+        let d = FieldPath::parse("x.bar.baz").unwrap();
+        let e = FieldPath::parse("y[1].baz").unwrap();
+        let f = FieldPath::parse("z.0.1").unwrap();
+        let g = FieldPath::parse("x#0").unwrap();
+        let h = FieldPath::parse("x#1#0").unwrap();
+        let i = FieldPath::parse("unit_variant").unwrap();
+        let j = FieldPath::parse("tuple_variant.1").unwrap();
+        let k = FieldPath::parse("struct_variant.value").unwrap();
+        let l = FieldPath::parse("struct_variant#0").unwrap();
+
+        for _ in 0..30 {
+            assert_eq!(*b.get_field::<usize>(&a).unwrap(), 1);
+            assert_eq!(*c.get_field::<usize>(&a).unwrap(), 10);
+            assert_eq!(*d.get_field::<f32>(&a).unwrap(), 3.14);
+            assert_eq!(*e.get_field::<f32>(&a).unwrap(), 2.0);
+            assert_eq!(*f.get_field::<usize>(&a).unwrap(), 42);
+            assert_eq!(*g.get_field::<usize>(&a).unwrap(), 10);
+            assert_eq!(*h.get_field::<f32>(&a).unwrap(), 3.14);
+            assert_eq!(*i.get_field::<F>(&a).unwrap(), F::Unit);
+            assert_eq!(*j.get_field::<u32>(&a).unwrap(), 321);
+            assert_eq!(*k.get_field::<char>(&a).unwrap(), 'm');
+            assert_eq!(*l.get_field::<char>(&a).unwrap(), 'm');
+        }
+    }
 
     #[test]
     fn reflect_array_behaves_like_list() {
@@ -606,41 +757,6 @@ mod tests {
 
     #[test]
     fn reflect_path() {
-        #[derive(Reflect)]
-        struct A {
-            w: usize,
-            x: B,
-            y: Vec<C>,
-            z: D,
-            unit_variant: F,
-            tuple_variant: F,
-            struct_variant: F,
-        }
-
-        #[derive(Reflect)]
-        struct B {
-            foo: usize,
-            bar: C,
-        }
-
-        #[derive(Reflect, FromReflect)]
-        struct C {
-            baz: f32,
-        }
-
-        #[derive(Reflect)]
-        struct D(E);
-
-        #[derive(Reflect)]
-        struct E(f32, usize);
-
-        #[derive(Reflect, FromReflect, PartialEq, Debug)]
-        enum F {
-            Unit,
-            Tuple(u32, u32),
-            Struct { value: char },
-        }
-
         let mut a = A {
             w: 1,
             x: B {
@@ -665,6 +781,7 @@ mod tests {
         assert_eq!(*a.get_path::<F>("unit_variant").unwrap(), F::Unit);
         assert_eq!(*a.get_path::<u32>("tuple_variant.1").unwrap(), 321);
         assert_eq!(*a.get_path::<char>("struct_variant.value").unwrap(), 'm');
+        assert_eq!(*a.get_path::<char>("struct_variant#0").unwrap(), 'm');
 
         *a.get_path_mut::<f32>("y[1].baz").unwrap() = 3.0;
         assert_eq!(a.y[1].baz, 3.0);

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -623,6 +623,8 @@ mod tests {
         assert_eq!(*a.get_path::<f32>("x.bar.baz").unwrap(), 3.14);
         assert_eq!(*a.get_path::<f32>("y[1].baz").unwrap(), 2.0);
         assert_eq!(*a.get_path::<usize>("z.0.1").unwrap(), 42);
+        assert_eq!(*a.get_path::<usize>("x#0").unwrap(), 10);
+        assert_eq!(*a.get_path::<f32>("x#1#0").unwrap(), 3.14);
 
         assert_eq!(*a.get_path::<F>("unit_variant").unwrap(), F::Unit);
         assert_eq!(*a.get_path::<u32>("tuple_variant.1").unwrap(), 321);

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -53,7 +53,7 @@ pub enum ReflectPathError<'a> {
 /// - [`List`] items are accessed with brackets: `[0]`
 /// - Field indexes within [`Struct`] can also be optionally used instead: `#0` for
 ///   the first field. This can speed up fetches at runtime (no string matching)
-///   but can be much more fragile to keeping code and string paths in sync since
+///   but can be much more fragile as code and string paths must be kept in sync since
 ///   the order of fields could be easily changed. Storing these paths in persistent ///   storage (i.e. game assets) is strongly discouraged.
 ///
 /// If the initial path element is a field of a struct, tuple struct, or tuple,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -406,7 +406,7 @@ impl<'a> PathParser<'a> {
                 if let Some(Token::Ident(value)) = self.next_token() {
                     value
                         .parse::<usize>()
-                        .map(|idx| AccessRef::TupleIndex(idx))
+                        .map(AccessRef::TupleIndex)
                         .or(Ok(AccessRef::Field(value)))
                 } else {
                     Err(ReflectPathError::ExpectedIdent {
@@ -438,7 +438,7 @@ impl<'a> PathParser<'a> {
             }),
             Token::Ident(value) => value
                 .parse::<usize>()
-                .map(|idx| AccessRef::TupleIndex(idx))
+                .map(AccessRef::TupleIndex)
                 .or(Ok(AccessRef::Field(value))),
         }
     }


### PR DESCRIPTION
# Objective

> ℹ️ **This is an adoption of #4081 by @james7132**

Fixes #4080.

Provide a way to pre-parse reflection paths so as to avoid having to parse at each call to `GetPath::path` (or similar method).

## Solution

Adds the `ParsedPath` struct (named `FieldPath` in the original PR) that parses and caches the sequence of accesses to a reflected element. This is functionally similar to the `GetPath` trait, but removes the need to parse an unchanged path more than once.

### Additional Changes

Included in this PR from the original is cleaner code as well as the introduction of a new pathing operation: field access by index. This allows struct and struct variant fields to be accessed in a more performant (albeit more fragile) way if needed. This operation is faster due to not having to perform string matching. As an example, if we wanted the third field on a struct, we'd write `#2`—where `#` denotes indexed access and `2` denotes the desired field index.

This PR also contains improved documentation for `GetPath` and friends, including renaming some of the methods to be more clear to the end-user with a reduced risk of getting them mixed up.

### Future Work

There are a few things that could be done as a separate PR (order doesn't matter— they could be followup PRs or done in parallel). These are:

- [x] ~~Add support for `Tuple`. Currently, we hint that they work but they do not.~~ See #7324
- [ ] Cleanup `ReflectPathError`. I think it would be nicer to give `ReflectPathError` two variants: `ReflectPathError::ParseError` and `ReflectPathError::AccessError`, with all current variants placed within one of those two. It's not obvious when one might expect to receive one type of error over the other, so we can help by explicitly categorizing them.

---

## Changelog

- Cleaned up `GetPath` logic
- Added `ParsedPath` for cached reflection paths
- Added new reflection path syntax: struct field access by index (example syntax: `foo#1`)
- Renamed methods on `GetPath`:
  - `path` -> `reflect_path`
  - `path_mut` -> `reflect_path_mut`
  - `get_path` -> `path`
  - `get_path_mut` -> `path_mut`

## Migration Guide

`GetPath` methods have been renamed according to the following:
- `path` -> `reflect_path`
- `path_mut` -> `reflect_path_mut`
- `get_path` -> `path`
- `get_path_mut` -> `path_mut`
