### PR TITLE
[Merged by Bors] - Fix dynamic linking (on linux)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default = [
 ]
 
 # Force dynamic linking, which improves iterative compile times
-dynamic = ["bevy_dylib"]
+dynamic = ["bevy_dylib", "bevy_internal/dynamic"]
 
 # Optional bevy crates
 bevy_animation = ["bevy_internal/bevy_animation"]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
+[features]
+# Disables diagnostics that are unsupported when Bevy is dynamically linked
+dynamic = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -34,7 +34,7 @@ impl SystemInformationDiagnosticsPlugin {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "bevy_dynamic_plugin")
+    not(feature = "dynamic")
 ))]
 pub mod internal {
     use bevy_ecs::{prelude::ResMut, system::Local};
@@ -142,7 +142,7 @@ pub mod internal {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "bevy_dynamic_plugin")
+    not(feature = "dynamic")
 )))]
 pub mod internal {
     pub(crate) fn setup_system() {

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -71,6 +71,9 @@ bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
+# Used to disable code that is unsupported when Bevy is dynamically linked
+dynamic = ["bevy_diagnostic/dynamic"]
+
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.9.0" }


### PR DESCRIPTION
# Problemo

Some code in #5911 and #5454 does not compile with dynamic linking enabled.
The code is behind a feature gate to prevent dynamically linked builds from breaking, but it's not quite set up correctly.

## Solution

Forward the `dynamic` feature flag to the `bevy_diagnostic` crate and gate the code behind it.
