### PR TITLE
[Merged by Bors] - Make the many_foxes plane smaller to fix shadow issues.

### DIFF
--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -160,7 +160,7 @@ fn setup(
 
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane { size: 500000.0 })),
+        mesh: meshes.add(Mesh::from(shape::Plane { size: 5000.0 })),
         material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
         ..default()
     });


### PR DESCRIPTION
# Objective

Shadows are broken on many_foxes on AMD GPUs. This seems to be due to rounding or floating point precision issues combined with the absolute unit of a plane that it's currently using.

Related: https://github.com/bevyengine/bevy/issues/6542

I'm not sure if we want to close that issue, as there's still the underlying issue of shadows breaking on overly large planes.

## Solution

Make the plane smaller.
