### PR TITLE
[Merged by Bors] - Rename dynamic feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ default = [
 ]
 
 # Force dynamic linking, which improves iterative compile times
-dynamic = ["bevy_dylib", "bevy_internal/dynamic"]
+dynamic_linking = ["bevy_dylib", "bevy_internal/dynamic_linking"]
 
 # Optional bevy crates
 bevy_animation = ["bevy_internal/bevy_animation"]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [features]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
-dynamic = []
+dynamic_linking = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -34,7 +34,7 @@ impl SystemInformationDiagnosticsPlugin {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "dynamic")
+    not(feature = "dynamic_linking")
 ))]
 pub mod internal {
     use bevy_ecs::{prelude::ResMut, system::Local};
@@ -142,7 +142,7 @@ pub mod internal {
         target_os = "android",
         target_os = "macos"
     ),
-    not(feature = "dynamic")
+    not(feature = "dynamic_linking")
 )))]
 pub mod internal {
     pub(crate) fn setup_system() {

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -15,21 +15,21 @@
 //!
 //! ## The recommended way
 //!
-//! The easiest way to enable dynamic linking is to use the `--features bevy/dynamic` flag when
+//! The easiest way to enable dynamic linking is to use the `--features bevy/dynamic_linking` flag when
 //! using the `cargo run` command:
 //!
-//! `cargo run --features bevy/dynamic`
+//! `cargo run --features bevy/dynamic_linking`
 //!
 //! ## The unrecommended way
 //!
-//! It is also possible to enable the `dynamic` feature inside of the `Cargo.toml` file. This is
+//! It is also possible to enable the `dynamic_linking` feature inside of the `Cargo.toml` file. This is
 //! unrecommended because it requires you to remove this feature every time you want to create a
 //! release build to avoid having to ship additional files with your game.
 //!
-//! To enable dynamic linking inside of the `Cargo.toml` file add the `dynamic` feature to the
+//! To enable dynamic linking inside of the `Cargo.toml` file add the `dynamic_linking` feature to the
 //! bevy dependency:
 //!
-//! `features = ["dynamic"]`
+//! `features = ["dynamic_linking"]`
 //!
 //! ## The manual way
 //!

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -2,7 +2,7 @@
 name = "bevy_internal"
 version = "0.9.0"
 edition = "2021"
-description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic' feature"
+description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic_linking' feature"
 homepage = "https://bevyengine.org"
 repository = "https://github.com/bevyengine/bevy"
 license = "MIT OR Apache-2.0"
@@ -72,7 +72,7 @@ bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render/ci_limits"]
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
 
 # Used to disable code that is unsupported when Bevy is dynamically linked
-dynamic = ["bevy_diagnostic/dynamic"]
+dynamic_linking = ["bevy_diagnostic/dynamic_linking"]
 
 [dependencies]
 # bevy

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -23,7 +23,7 @@
 |feature name|description|
 |-|-|
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading)).|
-|dynamic|Forces bevy to be dynamically linked, which improves iterative compile times.|
+|dynamic_linking|Forces bevy to be dynamically linked, which improves iterative compile times.|
 |trace|Enables system tracing.|
 |trace_chrome|Enables [tracing-chrome](https://github.com/thoren-d/tracing-chrome) as bevy_log output. This allows you to visualize system execution.|
 |trace_tracy|Enables [Tracy](https://github.com/wolfpld/tracy) as bevy_log output. This allows `Tracy` to connect to and capture profiling data as well as visualize system execution in real-time, present statistics about system execution times, and more.|

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,6 @@
 
 pub use bevy_internal::*;
 
-#[cfg(feature = "dynamic")]
+#[cfg(feature = "dynamic_linking")]
 #[allow(unused_imports)]
 use bevy_dylib;


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/7334

## Solution

- Rename `dynamic` feature to `dynamic_linking`.

---

## Migration Guide
- `dynamic` feature was renamed to `dynamic_linking`
