### PR TITLE
[Merged by Bors] - Add context to compile tests

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1545,11 +1545,12 @@ mod tests {
         #[system_param(ignore)]
         marker: PhantomData<Marker>,
     }
+    
+    // Compile tests for https://github.com/bevyengine/bevy/pull/6957.
 
     #[derive(SystemParam)]
     pub struct UnitParam;
 
-    // Compile test for https://github.com/bevyengine/bevy/pull/6957.
     #[derive(SystemParam)]
     pub struct TupleParam<'w, 's, R: Resource, L: FromWorld + Send + 'static>(
         Res<'w, R>,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1545,7 +1545,7 @@ mod tests {
         #[system_param(ignore)]
         marker: PhantomData<Marker>,
     }
-    
+
     // Compile tests for https://github.com/bevyengine/bevy/pull/6957.
 
     #[derive(SystemParam)]

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1538,6 +1538,7 @@ mod tests {
         crate::system::assert_is_system(long_system);
     }
 
+    // Compile test for https://github.com/bevyengine/bevy/pull/6919.
     #[derive(SystemParam)]
     struct MyParam<'w, T: Resource, Marker: 'static> {
         _foo: Res<'w, T>,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1481,7 +1481,7 @@ mod tests {
         system::Query,
     };
 
-    // Compile test for #2838.
+    // Compile test for https://github.com/bevyengine/bevy/pull/2838.
     #[derive(SystemParam)]
     pub struct SpecialQuery<
         'w,
@@ -1492,7 +1492,7 @@ mod tests {
         _query: Query<'w, 's, Q, F>,
     }
 
-    // Compile tests for #6694.
+    // Compile tests for https://github.com/bevyengine/bevy/pull/6694.
 
     #[derive(SystemParam)]
     pub struct SpecialRes<'w, T: Resource> {
@@ -1507,11 +1507,11 @@ mod tests {
     #[derive(Resource)]
     pub struct R<const I: usize>;
 
-    // Compile test for #7001.
+    // Compile test for https://github.com/bevyengine/bevy/pull/7001.
     #[derive(SystemParam)]
     pub struct ConstGenericParam<'w, const I: usize>(Res<'w, R<I>>);
 
-    // Compile test for #6867.
+    // Compile test for https://github.com/bevyengine/bevy/pull/6867.
     #[derive(SystemParam)]
     pub struct LongParam<'w> {
         _r0: Res<'w, R<0>>,
@@ -1548,7 +1548,7 @@ mod tests {
     #[derive(SystemParam)]
     pub struct UnitParam;
 
-    // Compile test for #6957
+    // Compile test for https://github.com/bevyengine/bevy/pull/6957.
     #[derive(SystemParam)]
     pub struct TupleParam<'w, 's, R: Resource, L: FromWorld + Send + 'static>(
         Res<'w, R>,
@@ -1558,7 +1558,7 @@ mod tests {
     #[derive(Resource)]
     struct PrivateResource;
 
-    // Regression test for #4200
+    // Regression test for https://github.com/bevyengine/bevy/issues/4200.
     #[derive(SystemParam)]
     pub struct EncapsulatedParam<'w>(Res<'w, PrivateResource>);
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1481,7 +1481,7 @@ mod tests {
         system::Query,
     };
 
-    // Compile test for #2838
+    // Compile test for #2838.
     #[derive(SystemParam)]
     pub struct SpecialQuery<
         'w,
@@ -1491,6 +1491,8 @@ mod tests {
     > {
         _query: Query<'w, 's, Q, F>,
     }
+
+    // Compile tests for #6694.
 
     #[derive(SystemParam)]
     pub struct SpecialRes<'w, T: Resource> {
@@ -1505,9 +1507,11 @@ mod tests {
     #[derive(Resource)]
     pub struct R<const I: usize>;
 
+    // Compile test for #7001.
     #[derive(SystemParam)]
     pub struct ConstGenericParam<'w, const I: usize>(Res<'w, R<I>>);
 
+    // Compile test for #6867.
     #[derive(SystemParam)]
     pub struct LongParam<'w> {
         _r0: Res<'w, R<0>>,
@@ -1544,6 +1548,7 @@ mod tests {
     #[derive(SystemParam)]
     pub struct UnitParam;
 
+    // Compile test for #6957
     #[derive(SystemParam)]
     pub struct TupleParam<'w, 's, R: Resource, L: FromWorld + Send + 'static>(
         Res<'w, R>,
@@ -1553,6 +1558,7 @@ mod tests {
     #[derive(Resource)]
     struct PrivateResource;
 
+    // Regression test for #4200
     #[derive(SystemParam)]
     pub struct EncapsulatedParam<'w>(Res<'w, PrivateResource>);
 


### PR DESCRIPTION
# Objective

`bevy_ecs/system_param.rs` contains many seemingly-arbitrary struct definitions which serve as compile tests.

## Solution

Add a comment to each one, linking the issue or PR that motivated its addition.