### PR TITLE
Add change detection that swaps between &/&mut and Ref/Mut when disabled/enabled

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -294,7 +294,7 @@ fn find_bone(
         if let Some(cached) = path_cache[idx] {
             if children.contains(&cached) {
                 if let Ok(name) = names.get(cached) {
-                    if name == part {
+                    if name.deref() == part {
                         current_entity = cached;
                         found = true;
                     }
@@ -304,7 +304,7 @@ fn find_bone(
         if !found {
             for child in children.deref() {
                 if let Ok(name) = names.get(*child) {
-                    if name == part {
+                    if name.deref() == part {
                         // Found a children with the right name, continue to the next part
                         current_entity = *child;
                         path_cache[idx] = Some(*child);
@@ -363,7 +363,7 @@ pub fn animation_player(
                 &animations,
                 &names,
                 &transforms,
-                maybe_parent,
+                maybe_parent.map(|v| v.into_inner()),
                 &parents,
                 &children,
             );

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -132,9 +132,7 @@ pub fn queue_view_tonemapping_pipelines(
 ) {
     for (entity, tonemapping) in view_targets.iter() {
         if let Tonemapping::Enabled { deband_dither } = *tonemapping {
-            let key = TonemappingPipelineKey {
-                deband_dither: deband_dither,
-            };
+            let key = TonemappingPipelineKey { deband_dither };
             let pipeline = pipelines.specialize(&pipeline_cache, &upscaling_pipeline, key);
 
             commands

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -131,9 +131,9 @@ pub fn queue_view_tonemapping_pipelines(
     view_targets: Query<(Entity, &Tonemapping)>,
 ) {
     for (entity, tonemapping) in view_targets.iter() {
-        if let Tonemapping::Enabled { deband_dither } = tonemapping {
+        if let Tonemapping::Enabled { deband_dither } = *tonemapping {
             let key = TonemappingPipelineKey {
-                deband_dither: *deband_dither,
+                deband_dither: deband_dither,
             };
             let pipeline = pipelines.specialize(&pipeline_cache, &upscaling_pipeline, key);
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -364,6 +364,44 @@ impl<'a> From<TicksMut<'a>> for Ticks<'a> {
     }
 }
 
+pub(crate) trait BuildReadWrap<'a> {
+    type Inner;
+    fn build(inner: &'a Self::Inner, ticks: Ticks<'a>) -> Self;
+}
+
+impl<'a, T> BuildReadWrap<'a> for &'a T {
+    type Inner = T;
+    fn build(inner: &'a T, _ticks: Ticks<'a>) -> Self {
+        inner
+    }
+}
+
+impl<'a, T> BuildReadWrap<'a> for Ref<'a, T> {
+    type Inner = T;
+    fn build(inner: &'a T, ticks: Ticks<'a>) -> Self {
+        Ref{value: inner, ticks}
+    }
+}
+
+pub(crate) trait BuildWriteWrap<'a> {
+    type Inner;
+    fn build(inner: &'a mut Self::Inner, ticks: TicksMut<'a>) -> Self;
+}
+
+impl<'a, T> BuildWriteWrap<'a> for &'a mut T {
+    type Inner = T;
+    fn build(inner: &'a mut T, _ticks: TicksMut<'a>) -> Self {
+        inner
+    }
+}
+
+impl<'a, T> BuildWriteWrap<'a> for Mut<'a, T> {
+    type Inner = T;
+    fn build(inner: &'a mut T, ticks: TicksMut<'a>) -> Self {
+        Mut{value: inner, ticks}
+    }
+}
+
 /// Shared borrow of a [`Resource`].
 ///
 /// See the [`Resource`] documentation for usage.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -372,7 +372,7 @@ impl<'a> From<TicksMut<'a>> for Ticks<'a> {
     }
 }
 
-pub trait BuildReadWrap<'a> : sealed::Sealed {
+pub trait BuildReadWrap<'a>: sealed::Sealed {
     type Inner;
     fn build(inner: &'a Self::Inner, ticks: Ticks<'a>) -> Self;
 }
@@ -387,11 +387,14 @@ impl<'a, T> BuildReadWrap<'a> for &'a T {
 impl<'a, T> BuildReadWrap<'a> for Ref<'a, T> {
     type Inner = T;
     fn build(inner: &'a T, ticks: Ticks<'a>) -> Self {
-        Ref{value: inner, ticks}
+        Ref {
+            value: inner,
+            ticks,
+        }
     }
 }
 
-pub trait BuildWriteWrap<'a> : sealed::Sealed {
+pub trait BuildWriteWrap<'a>: sealed::Sealed {
     type Inner;
     fn build(inner: &'a mut Self::Inner, ticks: TicksMut<'a>) -> Self;
 }
@@ -406,7 +409,10 @@ impl<'a, T> BuildWriteWrap<'a> for &'a mut T {
 impl<'a, T> BuildWriteWrap<'a> for Mut<'a, T> {
     type Inner = T;
     fn build(inner: &'a mut T, ticks: TicksMut<'a>) -> Self {
-        Mut{value: inner, ticks}
+        Mut {
+            value: inner,
+            ticks,
+        }
     }
 }
 
@@ -432,7 +438,7 @@ impl<'w, T: Resource> Res<'w, T> {
     pub fn clone(this: &Self) -> Self {
         Self {
             value: this.value,
-            ticks: this.ticks.clone(),
+            ticks: this.ticks,
         }
     }
 
@@ -561,11 +567,20 @@ pub struct Ref<'a, T: ?Sized> {
     pub(crate) ticks: Ticks<'a>,
 }
 
+impl<'a, T: ?Sized + Clone> Ref<'a, T> {
+    // This allows `Ref<'a, T>` to act more like `&'a T` making it clearer not ambiguous
+    #[allow(clippy::should_implement_trait)]
+    /// Helper method to call `Clone::clone` on the referenced value
+    pub fn clone(&self) -> T {
+        self.value.clone()
+    }
+}
+
 impl<'a, T: ?Sized> Clone for Ref<'a, T> {
     fn clone(&self) -> Self {
         Ref {
             value: self.value,
-            ticks: self.ticks.clone(),
+            ticks: self.ticks,
         }
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -310,7 +310,7 @@ macro_rules! impl_debug {
     };
 }
 
-#[derive(Clone)]
+#[derive(Copy, Clone)]
 pub struct Ticks<'a> {
     pub(crate) added: &'a Tick,
     pub(crate) changed: &'a Tick,
@@ -561,18 +561,29 @@ pub struct Ref<'a, T: ?Sized> {
     pub(crate) ticks: Ticks<'a>,
 }
 
+impl<'a, T: ?Sized> Clone for Ref<'a, T> {
+    fn clone(&self) -> Self {
+        Ref {
+            value: self.value,
+            ticks: self.ticks.clone(),
+        }
+    }
+}
+
+impl<'a, T: ?Sized> Copy for Ref<'a, T> {}
+
 impl<'a, T: ?Sized> Ref<'a, T> {
     pub fn into_inner(self) -> &'a T {
         self.value
     }
 }
 
-impl<'w, 'a, T> IntoIterator for &'a Ref<'w, T>
+impl<'w, T> IntoIterator for Ref<'w, T>
 where
-    &'a T: IntoIterator,
+    &'w T: IntoIterator,
 {
-    type Item = <&'a T as IntoIterator>::Item;
-    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+    type Item = <&'w T as IntoIterator>::Item;
+    type IntoIter = <&'w T as IntoIterator>::IntoIter;
 
     fn into_iter(self) -> Self::IntoIter {
         self.value.into_iter()

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,6 +8,14 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::ops::{Deref, DerefMut};
 
+mod sealed {
+    pub trait Sealed {}
+    impl<'a, T> Sealed for &'a T {}
+    impl<'a, T> Sealed for &'a mut T {}
+    impl<'a, T> Sealed for super::Ref<'a, T> {}
+    impl<'a, T> Sealed for super::Mut<'a, T> {}
+}
+
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
 /// Change ticks can only be scanned when systems aren't running. Thus, if the threshold is `N`,
@@ -303,7 +311,7 @@ macro_rules! impl_debug {
 }
 
 #[derive(Clone)]
-pub(crate) struct Ticks<'a> {
+pub struct Ticks<'a> {
     pub(crate) added: &'a Tick,
     pub(crate) changed: &'a Tick,
     pub(crate) last_change_tick: u32,
@@ -328,7 +336,7 @@ impl<'a> Ticks<'a> {
     }
 }
 
-pub(crate) struct TicksMut<'a> {
+pub struct TicksMut<'a> {
     pub(crate) added: &'a mut Tick,
     pub(crate) changed: &'a mut Tick,
     pub(crate) last_change_tick: u32,
@@ -364,7 +372,7 @@ impl<'a> From<TicksMut<'a>> for Ticks<'a> {
     }
 }
 
-pub(crate) trait BuildReadWrap<'a> {
+pub trait BuildReadWrap<'a> : sealed::Sealed {
     type Inner;
     fn build(inner: &'a Self::Inner, ticks: Ticks<'a>) -> Self;
 }
@@ -383,7 +391,7 @@ impl<'a, T> BuildReadWrap<'a> for Ref<'a, T> {
     }
 }
 
-pub(crate) trait BuildWriteWrap<'a> {
+pub trait BuildWriteWrap<'a> : sealed::Sealed {
     type Inner;
     fn build(inner: &'a mut Self::Inner, ticks: TicksMut<'a>) -> Self;
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,17 +1,18 @@
 //! Types for declaring and storing [`Component`]s.
 
 use crate::{
-    change_detection::MAX_CHANGE_AGE,
+    change_detection::{MAX_CHANGE_AGE, BuildReadWrap, BuildWriteWrap},
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::{OwningPtr, UnsafeCellDeref};
-use std::cell::UnsafeCell;
 use std::{
     alloc::Layout,
     any::{Any, TypeId},
+    cell::UnsafeCell,
     borrow::Cow,
+    ops::{Deref, DerefMut},
     mem::needs_drop,
 };
 
@@ -144,6 +145,10 @@ use std::{
 /// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
 pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
+    type ReadWrap<'a>: BuildReadWrap<'a, Inner = Self> + Deref<Target = Self>;
+    fn shrink_read<'wlong: 'wshort, 'wshort>(item: Self::ReadWrap<'wlong>) -> Self::ReadWrap<'wshort>;
+    type WriteWrap<'a>: BuildWriteWrap<'a, Inner = Self> + DerefMut<Target = Self>;
+    fn shrink_write<'wlong: 'wshort, 'wshort>(item: Self::WriteWrap<'wlong>) -> Self::WriteWrap<'wshort>;
 }
 
 pub struct TableStorage;

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,7 +1,7 @@
 //! Types for declaring and storing [`Component`]s.
 
 use crate::{
-    change_detection::{MAX_CHANGE_AGE, BuildReadWrap, BuildWriteWrap},
+    change_detection::{BuildReadWrap, BuildWriteWrap, MAX_CHANGE_AGE},
     storage::{SparseSetIndex, Storages},
     system::Resource,
 };
@@ -10,10 +10,10 @@ use bevy_ptr::{OwningPtr, UnsafeCellDeref};
 use std::{
     alloc::Layout,
     any::{Any, TypeId},
-    cell::UnsafeCell,
     borrow::Cow,
-    ops::{Deref, DerefMut},
+    cell::UnsafeCell,
     mem::needs_drop,
+    ops::{Deref, DerefMut},
 };
 
 /// A data type that can be used to store data for an [entity].
@@ -146,9 +146,13 @@ use std::{
 pub trait Component: Send + Sync + 'static {
     type Storage: ComponentStorage;
     type ReadWrap<'a>: BuildReadWrap<'a, Inner = Self> + Deref<Target = Self>;
-    fn shrink_read<'wlong: 'wshort, 'wshort>(item: Self::ReadWrap<'wlong>) -> Self::ReadWrap<'wshort>;
+    fn shrink_read<'wlong: 'wshort, 'wshort>(
+        item: Self::ReadWrap<'wlong>,
+    ) -> Self::ReadWrap<'wshort>;
     type WriteWrap<'a>: BuildWriteWrap<'a, Inner = Self> + DerefMut<Target = Self>;
-    fn shrink_write<'wlong: 'wshort, 'wshort>(item: Self::WriteWrap<'wlong>) -> Self::WriteWrap<'wshort>;
+    fn shrink_write<'wlong: 'wshort, 'wshort>(
+        item: Self::WriteWrap<'wlong>,
+    ) -> Self::WriteWrap<'wshort>;
 }
 
 pub struct TableStorage;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -319,7 +319,7 @@ mod tests {
         let ents = world
             .query::<(Entity, &A, &TableStored)>()
             .iter(&world)
-            .map(|(e, &i, &s)| (e, i, s))
+            .map(|(e, a, s)| (e, *a, *s))
             .collect::<Vec<_>>();
         assert_eq!(
             ents,
@@ -339,7 +339,7 @@ mod tests {
         let mut results = Vec::new();
         world
             .query::<(Entity, &A, &TableStored)>()
-            .for_each(&world, |(e, &i, &s)| results.push((e, i, s)));
+            .for_each(&world, |(e, a, s)| results.push((e, a.into_inner().clone(), s.into_inner().clone())));
         assert_eq!(
             results,
             &[
@@ -357,7 +357,7 @@ mod tests {
         let ents = world
             .query::<(Entity, &A)>()
             .iter(&world)
-            .map(|(e, &i)| (e, i))
+            .map(|(e, a)| (e, a.into_inner().clone()))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123)), (f, A(456))]);
     }
@@ -368,11 +368,11 @@ mod tests {
         let e = world.spawn((TableStored("abc"), A(123))).id();
         let mut query = world.query::<(Entity, &A)>();
 
-        let ents = query.iter(&world).map(|(e, &i)| (e, i)).collect::<Vec<_>>();
+        let ents = query.iter(&world).map(|(e, a)| (e, a.into_inner().clone())).collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123))]);
 
         let f = world.spawn((TableStored("def"), A(456), B(1))).id();
-        let ents = query.iter(&world).map(|(e, &i)| (e, i)).collect::<Vec<_>>();
+        let ents = query.iter(&world).map(|(e, a)| (e, a.into_inner().clone())).collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123)), (f, A(456))]);
     }
 
@@ -384,7 +384,7 @@ mod tests {
         let mut results = Vec::new();
         world
             .query::<(Entity, &A)>()
-            .for_each(&world, |(e, &i)| results.push((e, i)));
+            .for_each(&world, |(e, a)| results.push((e, a.into_inner().clone())));
         assert_eq!(results, &[(e, A(123)), (f, A(456))]);
     }
 
@@ -401,8 +401,8 @@ mod tests {
         world
             .query::<(Entity, &A)>()
             .par_iter(&world)
-            .for_each(|(e, &A(i))| {
-                results.lock().unwrap().push((e, i));
+            .for_each(|(e, a)| {
+                results.lock().unwrap().push((e, a.0));
             });
         results.lock().unwrap().sort();
         assert_eq!(
@@ -424,7 +424,7 @@ mod tests {
         world
             .query::<(Entity, &SparseStored)>()
             .par_iter(&world)
-            .for_each(|(e, &SparseStored(i))| results.lock().unwrap().push((e, i)));
+            .for_each(|(e, a)| results.lock().unwrap().push((e, a.0)));
         results.lock().unwrap().sort();
         assert_eq!(
             &*results.lock().unwrap(),
@@ -448,7 +448,7 @@ mod tests {
         let ents = world
             .query::<(Entity, &B)>()
             .iter(&world)
-            .map(|(e, &b)| (e, b))
+            .map(|(e, b)| (e, *b))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(f, B(1))]);
     }
@@ -461,7 +461,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, With<B>>()
             .iter(&world)
-            .cloned()
+            .map(|v| v.into_inner().clone())
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(123)]);
     }
@@ -488,7 +488,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, With<SparseStored>>()
             .iter(&world)
-            .cloned()
+            .map(|v| v.into_inner().clone())
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(123)]);
     }
@@ -514,7 +514,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, Without<B>>()
             .iter(&world)
-            .cloned()
+            .map(|v| v.into_inner().clone())
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(456)]);
     }
@@ -529,7 +529,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&B>, &A)>()
             .iter(&world)
-            .map(|(e, b, &i)| (e, b.copied(), i))
+            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, None, A(123)), (f, Some(B(1)), A(456))]);
     }
@@ -547,7 +547,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&SparseStored>, &A)>()
             .iter(&world)
-            .map(|(e, b, &i)| (e, b.copied(), i))
+            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
             .collect::<Vec<_>>();
         assert_eq!(
             ents,
@@ -566,7 +566,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&SparseStored>, &A)>()
             .iter(&world)
-            .map(|(e, b, &i)| (e, b.copied(), i))
+            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, None, A(123)), (f, None, A(456))]);
     }
@@ -581,7 +581,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, &i, &b)| (e, i, b))
+                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
                 .collect::<Vec<_>>(),
             &[(e1, A(1), B(3)), (e2, A(2), B(4))]
         );
@@ -591,7 +591,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, &i, &b)| (e, i, b))
+                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
                 .collect::<Vec<_>>(),
             &[(e2, A(2), B(4))]
         );
@@ -599,7 +599,7 @@ mod tests {
             world
                 .query::<(Entity, &B, &TableStored)>()
                 .iter(&world)
-                .map(|(e, &B(b), &TableStored(s))| (e, b, s))
+                .map(|(e, b, s)| (e, b.0, s.0))
                 .collect::<Vec<_>>(),
             &[(e2, 4, "xyz"), (e1, 3, "abc")]
         );
@@ -608,7 +608,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, &i, &b)| (e, i, b))
+                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
                 .collect::<Vec<_>>(),
             &[(e2, A(2), B(4)), (e1, A(43), B(3))]
         );
@@ -617,7 +617,7 @@ mod tests {
             world
                 .query::<(Entity, &C)>()
                 .iter(&world)
-                .map(|(e, &f)| (e, f))
+                .map(|(e, f)| (e, f.into_inner().clone()))
                 .collect::<Vec<_>>(),
             &[(e1, C)]
         );
@@ -704,7 +704,7 @@ mod tests {
 
         let mut i32_bool_query = world.query::<(&A, &B)>();
         assert!(i32_bool_query.get(&world, a).is_err());
-        assert_eq!(i32_bool_query.get(&world, c).unwrap(), (&A(789), &B(1)));
+        assert_eq!(i32_bool_query.get(&world, c).map(|(a, b)| (a.into_inner(), b.into_inner())).unwrap(), (&A(789), &B(1)));
         assert!(world.despawn(a));
         assert!(i32_query.get(&world, a).is_err());
     }
@@ -720,16 +720,16 @@ mod tests {
             .id();
 
         let mut query = world.query::<&TableStored>();
-        assert_eq!(query.get(&world, a).unwrap(), &TableStored("abc"));
-        assert_eq!(query.get(&world, b).unwrap(), &TableStored("def"));
-        assert_eq!(query.get(&world, c).unwrap(), &TableStored("ghi"));
+        assert_eq!(query.get(&world, a).unwrap().into_inner(), &TableStored("abc"));
+        assert_eq!(query.get(&world, b).unwrap().into_inner(), &TableStored("def"));
+        assert_eq!(query.get(&world, c).unwrap().into_inner(), &TableStored("ghi"));
 
         world.entity_mut(b).remove::<SparseStored>();
         world.entity_mut(c).remove::<SparseStored>();
 
-        assert_eq!(query.get(&world, a).unwrap(), &TableStored("abc"));
-        assert_eq!(query.get(&world, b).unwrap(), &TableStored("def"));
-        assert_eq!(query.get(&world, c).unwrap(), &TableStored("ghi"));
+        assert_eq!(query.get(&world, a).unwrap().into_inner(), &TableStored("abc"));
+        assert_eq!(query.get(&world, b).unwrap().into_inner(), &TableStored("def"));
+        assert_eq!(query.get(&world, c).unwrap().into_inner(), &TableStored("ghi"));
     }
 
     #[test]

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -339,7 +339,7 @@ mod tests {
         let mut results = Vec::new();
         world
             .query::<(Entity, &A, &TableStored)>()
-            .for_each(&world, |(e, a, s)| results.push((e, a.into_inner().clone(), s.into_inner().clone())));
+            .for_each(&world, |(e, a, s)| results.push((e, *a, *s)));
         assert_eq!(
             results,
             &[
@@ -357,7 +357,7 @@ mod tests {
         let ents = world
             .query::<(Entity, &A)>()
             .iter(&world)
-            .map(|(e, a)| (e, a.into_inner().clone()))
+            .map(|(e, a)| (e, *a))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123)), (f, A(456))]);
     }
@@ -368,11 +368,11 @@ mod tests {
         let e = world.spawn((TableStored("abc"), A(123))).id();
         let mut query = world.query::<(Entity, &A)>();
 
-        let ents = query.iter(&world).map(|(e, a)| (e, a.into_inner().clone())).collect::<Vec<_>>();
+        let ents = query.iter(&world).map(|(e, a)| (e, *a)).collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123))]);
 
         let f = world.spawn((TableStored("def"), A(456), B(1))).id();
-        let ents = query.iter(&world).map(|(e, a)| (e, a.into_inner().clone())).collect::<Vec<_>>();
+        let ents = query.iter(&world).map(|(e, a)| (e, *a)).collect::<Vec<_>>();
         assert_eq!(ents, &[(e, A(123)), (f, A(456))]);
     }
 
@@ -384,7 +384,7 @@ mod tests {
         let mut results = Vec::new();
         world
             .query::<(Entity, &A)>()
-            .for_each(&world, |(e, a)| results.push((e, a.into_inner().clone())));
+            .for_each(&world, |(e, a)| results.push((e, *a)));
         assert_eq!(results, &[(e, A(123)), (f, A(456))]);
     }
 
@@ -461,7 +461,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, With<B>>()
             .iter(&world)
-            .map(|v| v.into_inner().clone())
+            .map(|v| *v)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(123)]);
     }
@@ -488,7 +488,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, With<SparseStored>>()
             .iter(&world)
-            .map(|v| v.into_inner().clone())
+            .map(|v| *v)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(123)]);
     }
@@ -514,7 +514,7 @@ mod tests {
         let result = world
             .query_filtered::<&A, Without<B>>()
             .iter(&world)
-            .map(|v| v.into_inner().clone())
+            .map(|v| *v)
             .collect::<Vec<_>>();
         assert_eq!(result, vec![A(456)]);
     }
@@ -529,7 +529,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&B>, &A)>()
             .iter(&world)
-            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
+            .map(|(e, b, a)| (e, b.map(|v| *v), *a))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, None, A(123)), (f, Some(B(1)), A(456))]);
     }
@@ -547,7 +547,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&SparseStored>, &A)>()
             .iter(&world)
-            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
+            .map(|(e, b, a)| (e, b.map(|v| *v), *a))
             .collect::<Vec<_>>();
         assert_eq!(
             ents,
@@ -566,7 +566,7 @@ mod tests {
         let ents = world
             .query::<(Entity, Option<&SparseStored>, &A)>()
             .iter(&world)
-            .map(|(e, b, a)| (e, b.map(|v| v.into_inner().clone()), a.into_inner().clone()))
+            .map(|(e, b, a)| (e, b.map(|v| *v), *a))
             .collect::<Vec<_>>();
         assert_eq!(ents, &[(e, None, A(123)), (f, None, A(456))]);
     }
@@ -581,7 +581,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
+                .map(|(e, a, b)| (e, *a, *b))
                 .collect::<Vec<_>>(),
             &[(e1, A(1), B(3)), (e2, A(2), B(4))]
         );
@@ -591,7 +591,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
+                .map(|(e, a, b)| (e, *a, *b))
                 .collect::<Vec<_>>(),
             &[(e2, A(2), B(4))]
         );
@@ -608,7 +608,7 @@ mod tests {
             world
                 .query::<(Entity, &A, &B)>()
                 .iter(&world)
-                .map(|(e, a, b)| (e, a.into_inner().clone(), b.into_inner().clone()))
+                .map(|(e, a, b)| (e, *a, *b))
                 .collect::<Vec<_>>(),
             &[(e2, A(2), B(4)), (e1, A(43), B(3))]
         );
@@ -617,7 +617,7 @@ mod tests {
             world
                 .query::<(Entity, &C)>()
                 .iter(&world)
-                .map(|(e, f)| (e, f.into_inner().clone()))
+                .map(|(e, c)| (e, *c))
                 .collect::<Vec<_>>(),
             &[(e1, C)]
         );
@@ -704,7 +704,13 @@ mod tests {
 
         let mut i32_bool_query = world.query::<(&A, &B)>();
         assert!(i32_bool_query.get(&world, a).is_err());
-        assert_eq!(i32_bool_query.get(&world, c).map(|(a, b)| (a.into_inner(), b.into_inner())).unwrap(), (&A(789), &B(1)));
+        assert_eq!(
+            i32_bool_query
+                .get(&world, c)
+                .map(|(a, b)| (a.into_inner(), b.into_inner()))
+                .unwrap(),
+            (&A(789), &B(1))
+        );
         assert!(world.despawn(a));
         assert!(i32_query.get(&world, a).is_err());
     }
@@ -720,16 +726,34 @@ mod tests {
             .id();
 
         let mut query = world.query::<&TableStored>();
-        assert_eq!(query.get(&world, a).unwrap().into_inner(), &TableStored("abc"));
-        assert_eq!(query.get(&world, b).unwrap().into_inner(), &TableStored("def"));
-        assert_eq!(query.get(&world, c).unwrap().into_inner(), &TableStored("ghi"));
+        assert_eq!(
+            query.get(&world, a).unwrap().into_inner(),
+            &TableStored("abc")
+        );
+        assert_eq!(
+            query.get(&world, b).unwrap().into_inner(),
+            &TableStored("def")
+        );
+        assert_eq!(
+            query.get(&world, c).unwrap().into_inner(),
+            &TableStored("ghi")
+        );
 
         world.entity_mut(b).remove::<SparseStored>();
         world.entity_mut(c).remove::<SparseStored>();
 
-        assert_eq!(query.get(&world, a).unwrap().into_inner(), &TableStored("abc"));
-        assert_eq!(query.get(&world, b).unwrap().into_inner(), &TableStored("def"));
-        assert_eq!(query.get(&world, c).unwrap().into_inner(), &TableStored("ghi"));
+        assert_eq!(
+            query.get(&world, a).unwrap().into_inner(),
+            &TableStored("abc")
+        );
+        assert_eq!(
+            query.get(&world, b).unwrap().into_inner(),
+            &TableStored("def")
+        );
+        assert_eq!(
+            query.get(&world, c).unwrap().into_inner(),
+            &TableStored("ghi")
+        );
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
-    change_detection::{Ticks, TicksMut, BuildReadWrap, BuildWriteWrap, Mut},
+    change_detection::{BuildReadWrap, BuildWriteWrap, Mut, Ticks, TicksMut},
     component::{Component, ComponentId, ComponentStorage, ComponentTicks, StorageType, Tick},
     entity::Entity,
     query::{Access, DebugCheckedUnwrap, FilteredAccess},
@@ -622,8 +622,9 @@ unsafe impl<T: Component> WorldQuery for &T {
                         changed: changed_ticks.get(table_row.index()).deref(),
                         change_tick: fetch.change_tick,
                         last_change_tick: fetch.last_change_tick,
-                    })
-            },
+                    },
+                )
+            }
             StorageType::SparseSet => {
                 let (component, ticks) = fetch
                     .sparse_set
@@ -632,8 +633,9 @@ unsafe impl<T: Component> WorldQuery for &T {
                     .debug_checked_unwrap();
                 T::ReadWrap::<'w>::build(
                     component.deref(),
-                    Ticks::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick))
-            },
+                    Ticks::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick),
+                )
+            }
         }
     }
 
@@ -927,8 +929,9 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                         changed: changed_ticks.get(table_row.index()).deref_mut(),
                         change_tick: fetch.change_tick,
                         last_change_tick: fetch.last_change_tick,
-                    })
-            },
+                    },
+                )
+            }
             StorageType::SparseSet => {
                 let (component, ticks) = fetch
                     .sparse_set
@@ -937,7 +940,8 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                     .debug_checked_unwrap();
                 T::WriteWrap::<'w>::build(
                     component.assert_unique().deref_mut(),
-                    TicksMut::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick))
+                    TicksMut::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick),
+                )
             }
         }
     }
@@ -1061,26 +1065,30 @@ unsafe impl<'__w, T: Component> WorldQuery for Mut<'__w, T> {
             StorageType::Table => {
                 let (table_components, added_ticks, changed_ticks) =
                     fetch.table_data.debug_checked_unwrap();
-                Mut { 
+                Mut {
                     value: table_components.get(table_row.index()).deref_mut(),
                     ticks: TicksMut {
                         added: added_ticks.get(table_row.index()).deref_mut(),
                         changed: changed_ticks.get(table_row.index()).deref_mut(),
                         change_tick: fetch.change_tick,
                         last_change_tick: fetch.last_change_tick,
-                    }
+                    },
                 }
-            },
+            }
             StorageType::SparseSet => {
                 let (component, ticks) = fetch
                     .sparse_set
                     .debug_checked_unwrap()
                     .get_with_ticks(entity)
                     .debug_checked_unwrap();
-                    Mut { 
-                        value: component.assert_unique().deref_mut(),
-                        ticks: TicksMut::from_tick_cells(ticks, fetch.last_change_tick, fetch.change_tick)
-                    }
+                Mut {
+                    value: component.assert_unique().deref_mut(),
+                    ticks: TicksMut::from_tick_cells(
+                        ticks,
+                        fetch.last_change_tick,
+                        fetch.change_tick,
+                    ),
+                }
             }
         }
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -531,7 +531,7 @@ unsafe impl<T: Component> WorldQuery for &T {
     type State = ComponentId;
 
     fn shrink<'wlong: 'wshort, 'wshort>(item: T::ReadWrap<'wlong>) -> T::ReadWrap<'wshort> {
-        item
+        T::shrink_read(item)
     }
 
     const IS_DENSE: bool = {

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -61,7 +61,7 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 #[cfg(test)]
 mod tests {
     use super::{ReadOnlyWorldQuery, WorldQuery};
-    use crate::prelude::{AnyOf, Entity, Ref, Or, QueryState, With, Without};
+    use crate::prelude::{AnyOf, Entity, Or, QueryState, Ref, With, Without};
     use crate::query::{ArchetypeFilter, QueryCombinationIter};
     use crate::system::{IntoSystem, Query, System, SystemState};
     use crate::{self as bevy_ecs, component::Component, world::World};
@@ -86,13 +86,21 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(1), B(1)));
         world.spawn(A(2));
-        let values = world.query::<&A>().iter(&world).map(|v| v.into_inner()).collect::<Vec<&A>>();
+        let values = world
+            .query::<&A>()
+            .iter(&world)
+            .map(|v| v.into_inner())
+            .collect::<Vec<&A>>();
         assert_eq!(values, vec![&A(1), &A(2)]);
 
         for (_a, mut b) in world.query::<(&A, &mut B)>().iter_mut(&mut world) {
             b.0 = 3;
         }
-        let values = world.query::<&B>().iter(&world).map(|v| v.into_inner()).collect::<Vec<&B>>();
+        let values = world
+            .query::<&B>()
+            .iter(&world)
+            .map(|v| v.into_inner())
+            .collect::<Vec<&B>>();
         assert_eq!(values, vec![&B(3)]);
     }
 
@@ -244,7 +252,11 @@ mod tests {
         world.spawn(A(3));
         world.spawn(A(4));
 
-        let values: Vec<[&A; 2]> = world.query::<&A>().iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: Vec<[&A; 2]> = world
+            .query::<&A>()
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             vec![
@@ -257,7 +269,10 @@ mod tests {
             ]
         );
         let mut a_query = world.query::<&A>();
-        let values: Vec<[&A; 3]> = a_query.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: Vec<[&A; 3]> = a_query
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             vec![
@@ -276,7 +291,10 @@ mod tests {
             c.0 += 1000;
         }
 
-        let values: Vec<[&A; 3]> = a_query.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: Vec<[&A; 3]> = a_query
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             vec![
@@ -292,7 +310,10 @@ mod tests {
             b_query.iter_combinations::<2>(&world).size_hint(),
             (0, Some(0))
         );
-        let values: Vec<[&B; 2]> = b_query.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: Vec<[&B; 2]> = b_query
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(values, Vec::<[&B; 2]>::new());
     }
 
@@ -308,7 +329,10 @@ mod tests {
         world.spawn(A(4));
 
         let mut a_wout_b = world.query_filtered::<&A, Without<B>>();
-        let values: HashSet<[&A; 2]> = a_wout_b.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: HashSet<[&A; 2]> = a_wout_b
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             [[&A(2), &A(3)], [&A(2), &A(4)], [&A(3), &A(4)]]
@@ -316,14 +340,20 @@ mod tests {
                 .collect::<HashSet<_>>()
         );
 
-        let values: HashSet<[&A; 3]> = a_wout_b.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: HashSet<[&A; 3]> = a_wout_b
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             [[&A(2), &A(3), &A(4)],].into_iter().collect::<HashSet<_>>()
         );
 
         let mut query = world.query_filtered::<&A, Or<(With<A>, With<B>)>>();
-        let values: HashSet<[&A; 2]> = query.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: HashSet<[&A; 2]> = query
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             [
@@ -346,7 +376,10 @@ mod tests {
             c.0 += 1000;
         }
 
-        let values: HashSet<[&A; 3]> = a_wout_b.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: HashSet<[&A; 3]> = a_wout_b
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             [[&A(12), &A(103), &A(1004)],]
@@ -394,7 +427,10 @@ mod tests {
             c.0 += 1000;
         }
 
-        let values: HashSet<[&A; 3]> = query_changed.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: HashSet<[&A; 3]> = query_changed
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             [
@@ -423,7 +459,10 @@ mod tests {
         }
 
         let mut query = world.query::<&Sparse>();
-        let values: Vec<[&Sparse; 3]> = query.iter_combinations(&world).map(|l| l.map(|v| v.into_inner())).collect();
+        let values: Vec<[&Sparse; 3]> = query
+            .iter_combinations(&world)
+            .map(|l| l.map(|v| v.into_inner()))
+            .collect();
         assert_eq!(
             values,
             vec![
@@ -453,7 +492,11 @@ mod tests {
             b.0 = 3;
         }
 
-        let values = world.query::<&B>().iter(&world).map(|v| v.into_inner()).collect::<Vec<&B>>();
+        let values = world
+            .query::<&B>()
+            .iter(&world)
+            .map(|v| v.into_inner())
+            .collect::<Vec<&B>>();
         assert_eq!(values, vec![&B(3)]);
     }
 
@@ -465,8 +508,11 @@ mod tests {
         world.spawn(A(2));
         world.spawn(C(3));
 
-        let values: Vec<(Option<&A>, Option<&B>)> =
-            world.query::<AnyOf<(&A, &B)>>().iter(&world).map(|(a, b)| (a.map(|v| v.into_inner()), b.map(|v| v.into_inner()))).collect();
+        let values: Vec<(Option<&A>, Option<&B>)> = world
+            .query::<AnyOf<(&A, &B)>>()
+            .iter(&world)
+            .map(|(a, b)| (a.map(|v| v.into_inner()), b.map(|v| v.into_inner())))
+            .collect();
 
         assert_eq!(
             values,
@@ -544,12 +590,12 @@ mod tests {
             let custom_param_data = world
                 .query::<FancyParam>()
                 .iter(&world)
-                .map(|fancy| (fancy.e, *fancy.b, fancy.opt.map(|v| v.into_inner().clone())))
+                .map(|fancy| (fancy.e, *fancy.b, fancy.opt.map(|v| *v)))
                 .collect::<Vec<_>>();
             let normal_data = world
                 .query::<(Entity, &B, Option<&Sparse>)>()
                 .iter(&world)
-                .map(|(e, b, opt)| (e, *b, opt.map(|v| v.into_inner().clone())))
+                .map(|(e, b, opt)| (e, *b, opt.map(|v| *v)))
                 .collect::<Vec<_>>();
             assert_eq!(custom_param_data, normal_data);
         }
@@ -574,7 +620,7 @@ mod tests {
                          opt_bsparse: MaybeBSparseItem { blah: bsparse },
                      }| {
                         (
-                            (a.map(|v| v.into_inner().clone()), b.map(|v| v.into_inner().clone()), c.map(|v| v.into_inner().clone())),
+                            (a.map(|v| *v), b.map(|v| *v), c.map(|v| *v)),
                             bsparse.map(|(b, sparse)| (*b, *sparse)),
                         )
                     },
@@ -585,7 +631,7 @@ mod tests {
                 .iter(&world)
                 .map(|((a, b, c), bsparse)| {
                     (
-                        (a.map(|v| v.into_inner().clone()), b.map(|v| v.into_inner().clone()), c.map(|v| v.into_inner().clone())),
+                        (a.map(|v| *v), b.map(|v| *v), c.map(|v| *v)),
                         bsparse.map(|(b, sparse)| (*b, *sparse)),
                     )
                 })

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -588,7 +588,7 @@ mod tests {
         let mut count = 0;
 
         let mut q = world.query::<&Zst>();
-        for &Zst in q.iter(&world) {
+        for _ref in q.iter(&world) {
             count += 1;
         }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -923,13 +923,17 @@ mod tests {
             fn hold_component<'w>(&mut self, world: &'w World, entity: Entity) -> Holder<'w> {
                 let q = self.state_q.get(world);
                 let a = q.get_inner(entity).unwrap();
-                Holder { value: a.into_inner() }
+                Holder {
+                    value: a.into_inner(),
+                }
             }
             fn hold_components<'w>(&mut self, world: &'w World) -> Vec<Holder<'w>> {
                 let mut components = Vec::new();
                 let q = self.state_q.get(world);
                 for a in q.iter_inner() {
-                    components.push(Holder { value: a.into_inner() });
+                    components.push(Holder {
+                        value: a.into_inner(),
+                    });
                 }
                 components
             }

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -883,7 +883,7 @@ mod tests {
         {
             let query = system_state.get(&world);
             assert_eq!(
-                query.iter().collect::<Vec<_>>(),
+                query.iter().map(|v| v.into_inner()).collect::<Vec<_>>(),
                 vec![&A(1)],
                 "exactly one component returned"
             );
@@ -893,7 +893,7 @@ mod tests {
         {
             let query = system_state.get(&world);
             assert_eq!(
-                query.iter().collect::<Vec<_>>(),
+                query.iter().map(|v| v.into_inner()).collect::<Vec<_>>(),
                 vec![&A(1), &A(2)],
                 "components from both archetypes returned"
             );
@@ -923,13 +923,13 @@ mod tests {
             fn hold_component<'w>(&mut self, world: &'w World, entity: Entity) -> Holder<'w> {
                 let q = self.state_q.get(world);
                 let a = q.get_inner(entity).unwrap();
-                Holder { value: a }
+                Holder { value: a.into_inner() }
             }
             fn hold_components<'w>(&mut self, world: &'w World) -> Vec<Holder<'w>> {
                 let mut components = Vec::new();
                 let q = self.state_q.get(world);
                 for a in q.iter_inner() {
-                    components.push(Holder { value: a });
+                    components.push(Holder { value: a.into_inner() });
                 }
                 components
             }
@@ -954,7 +954,7 @@ mod tests {
                 "both components returned by iter_mut of &mut"
             );
             assert_eq!(
-                query.iter().collect::<Vec<&A>>(),
+                query.iter().map(|v| v.into_inner()).collect::<Vec<&A>>(),
                 vec![&A(1), &A(2)],
                 "both components returned by iter of &mut"
             );

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -2,7 +2,7 @@ pub use crate::change_detection::{NonSendMut, Res, ResMut};
 use crate::{
     archetype::{Archetype, Archetypes},
     bundle::Bundles,
-    change_detection::{Ticks, TicksMut, DetectChanges},
+    change_detection::{DetectChanges, Ticks, TicksMut},
     component::{Component, ComponentId, ComponentTicks, Components},
     entity::{Entities, Entity},
     query::{

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.rs
@@ -13,14 +13,14 @@ fn main() {
         let mut query = system_state.get_mut(&mut world);
         dbg!("hi");
         {
-            let data: &Foo = query.get(e).unwrap();
+            let data: &Foo = query.get(e).unwrap().into_inner();
             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
-            let data: &Foo = query.get(e).unwrap();
+            let data: &Foo = query.get(e).unwrap().into_inner();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
@@ -37,45 +37,45 @@ fn main() {
         }
 
         {
-            let data: &Foo = query.single();
+            let data: &Foo = query.single().into_inner();
             let mut data2: Mut<Foo> = query.single_mut();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
             let mut data2: Mut<Foo> = query.single_mut();
-            let data: &Foo = query.single();
+            let data: &Foo = query.single().into_inner();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
-            let data: &Foo = query.get_single().unwrap();
+            let data: &Foo = query.get_single().unwrap().into_inner();
             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
-            let data: &Foo = query.get_single().unwrap();
+            let data: &Foo = query.get_single().unwrap().into_inner();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
-            let data: &Foo = query.iter().next().unwrap();
+            let data: &Foo = query.iter().next().unwrap().into_inner();
             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
-            let data: &Foo = query.iter().next().unwrap();
+            let data: &Foo = query.iter().next().unwrap().into_inner();
             assert_eq!(data, &mut *data2); // oops UB
         }
 
         {
             let mut opt_data: Option<&Foo> = None;
             let mut opt_data_2: Option<Mut<Foo>> = None;
-            query.for_each(|data| opt_data = Some(data));
+            query.for_each(|data| opt_data = Some(data.into_inner()));
             query.for_each_mut(|data| opt_data_2 = Some(data));
             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
         }
@@ -84,7 +84,7 @@ fn main() {
             let mut opt_data_2: Option<Mut<Foo>> = None;
             let mut opt_data: Option<&Foo> = None;
             query.for_each_mut(|data| opt_data_2 = Some(data));
-            query.for_each(|data| opt_data = Some(data));
+            query.for_each(|data| opt_data = Some(data.into_inner()));
             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
         }
         dbg!("bye");

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
@@ -1,7 +1,7 @@
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:17:39
    |
-16 |             let data: &Foo = query.get(e).unwrap();
+16 |             let data: &Foo = query.get(e).unwrap().into_inner();
    |                              ------------ immutable borrow occurs here
 17 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -13,7 +13,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |
 22 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
    |                                       ---------------- mutable borrow occurs here
-23 |             let data: &Foo = query.get(e).unwrap();
+23 |             let data: &Foo = query.get(e).unwrap().into_inner();
    |                              ^^^^^^^^^^^^ immutable borrow occurs here
 24 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
@@ -41,7 +41,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:41:39
    |
-40 |             let data: &Foo = query.single();
+40 |             let data: &Foo = query.single().into_inner();
    |                              -------------- immutable borrow occurs here
 41 |             let mut data2: Mut<Foo> = query.single_mut();
    |                                       ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -53,7 +53,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |
 46 |             let mut data2: Mut<Foo> = query.single_mut();
    |                                       ------------------ mutable borrow occurs here
-47 |             let data: &Foo = query.single();
+47 |             let data: &Foo = query.single().into_inner();
    |                              ^^^^^^^^^^^^^^ immutable borrow occurs here
 48 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
@@ -61,7 +61,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:53:39
    |
-52 |             let data: &Foo = query.get_single().unwrap();
+52 |             let data: &Foo = query.get_single().unwrap().into_inner();
    |                              ------------------ immutable borrow occurs here
 53 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
    |                                       ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -73,7 +73,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |
 58 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
    |                                       ---------------------- mutable borrow occurs here
-59 |             let data: &Foo = query.get_single().unwrap();
+59 |             let data: &Foo = query.get_single().unwrap().into_inner();
    |                              ^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
 60 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
@@ -81,7 +81,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:65:39
    |
-64 |             let data: &Foo = query.iter().next().unwrap();
+64 |             let data: &Foo = query.iter().next().unwrap().into_inner();
    |                              ------------ immutable borrow occurs here
 65 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
@@ -93,7 +93,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |
 70 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
    |                                       ---------------- mutable borrow occurs here
-71 |             let data: &Foo = query.iter().next().unwrap();
+71 |             let data: &Foo = query.iter().next().unwrap().into_inner();
    |                              ^^^^^^^^^^^^ immutable borrow occurs here
 72 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
@@ -101,8 +101,8 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:79:13
    |
-78 |             query.for_each(|data| opt_data = Some(data));
-   |             -------------------------------------------- immutable borrow occurs here
+78 |             query.for_each(|data| opt_data = Some(data.into_inner()));
+   |             --------------------------------------------------------- immutable borrow occurs here
 79 |             query.for_each_mut(|data| opt_data_2 = Some(data));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 80 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
@@ -113,7 +113,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |
 86 |             query.for_each_mut(|data| opt_data_2 = Some(data));
    |             -------------------------------------------------- mutable borrow occurs here
-87 |             query.for_each(|data| opt_data = Some(data));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+87 |             query.for_each(|data| opt_data = Some(data.into_inner()));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
 88 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
    |                                                 ---------- mutable borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
@@ -20,4 +20,4 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
    |                  ^^^^^^^^^^^^ second mutable borrow occurs here
 ...
 25 |     b.0 = a.0
-   |           --- first borrow later used here
+   |           - first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_get_lifetime_safety.stderr
@@ -8,4 +8,4 @@ error[E0502]: cannot borrow `*world` as mutable because it is also borrowed as i
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
 24 |         println!("{}", a1.0);
-   |                        ---- immutable borrow later used here
+   |                        -- immutable borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_lifetime_safety.stderr
@@ -8,4 +8,4 @@ error[E0502]: cannot borrow `*world` as mutable because it is also borrowed as i
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 ...
 24 |         println!("{}", a1.0);
-   |                        ---- immutable borrow later used here
+   |                        -- immutable borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.rs
@@ -15,7 +15,7 @@ fn main() {
         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
         assert_eq!(
             // this should fail to compile due to the later use of mut_vec
-            query.iter().collect::<Vec<&A>>(),
+            query.iter().map(|v| v.into_inner()).collect::<Vec<&A>>(),
             vec![&A(1), &A(2)],
             "both components returned by iter of &mut"
         );

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
@@ -4,7 +4,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
 15 |         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
    |                       ---------------- mutable borrow occurs here
 ...
-18 |             query.iter().collect::<Vec<&A>>(),
+18 |             query.iter().map(|v| v.into_inner()).collect::<Vec<&A>>(),
    |             ^^^^^^^^^^^^ immutable borrow occurs here
 ...
 23 |             mut_vec.iter().map(|m| **m).collect::<Vec<A>>(),

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -204,7 +204,7 @@ mod tests {
         let mut results = world
             .query::<(&N, &Idx)>()
             .iter(&world)
-            .map(|(a, b)| (a.into_inner().clone(), *b))
+            .map(|(a, b)| (a.clone(), *b))
             .collect::<Vec<_>>();
         results.sort_unstable_by_key(|(_, index)| *index);
 

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -204,7 +204,7 @@ mod tests {
         let mut results = world
             .query::<(&N, &Idx)>()
             .iter(&world)
-            .map(|(a, b)| (a.clone(), *b))
+            .map(|(a, b)| (a.into_inner().clone(), *b))
             .collect::<Vec<_>>();
         results.sort_unstable_by_key(|(_, index)| *index);
 

--- a/crates/bevy_hierarchy/src/query_extension.rs
+++ b/crates/bevy_hierarchy/src/query_extension.rs
@@ -2,8 +2,9 @@ use std::collections::VecDeque;
 
 use bevy_ecs::{
     entity::Entity,
+    prelude::Component,
     query::{ReadOnlyWorldQuery, WorldQuery},
-    system::Query, prelude::Component,
+    system::Query,
 };
 
 use crate::{Children, Parent};
@@ -200,7 +201,10 @@ mod tests {
         let mut system_state = SystemState::<(Query<&Parent>, Query<&A>)>::new(world);
         let (parent_query, a_query) = system_state.get(world);
 
-        let result: Vec<_> = a_query.iter_many(parent_query.iter_ancestors(c)).map(|v| v.into_inner()).collect();
+        let result: Vec<_> = a_query
+            .iter_many(parent_query.iter_ancestors(c))
+            .map(|v| v.into_inner())
+            .collect();
 
         assert_eq!([&A(1), &A(0)], result.as_slice());
     }

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -52,7 +52,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
                 This will cause inconsistent behaviors! See https://bevyengine.org/learn/errors/#b0004",
                 ty_name = get_short_name(std::any::type_name::<T>()),
-                name = name.map_or("An entity".to_owned(), |s| format!("The {s} entity")),
+                name = name.map_or("An entity".to_owned(), |s| format!("The {} entity", s.as_ref())),
             );
         }
     }

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -481,6 +481,6 @@ impl ExtractComponent for FogSettings {
     type Out = Self;
 
     fn extract_component(item: QueryItem<Self::Query>) -> Option<Self::Out> {
-        Some(item.clone())
+        Some(item.into_inner().clone())
     }
 }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1886,7 +1886,10 @@ pub fn check_light_mesh_visibility(
             continue;
         }
 
-        let view_mask = maybe_view_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+        let view_mask = maybe_view_mask
+            .map(|v| v.into_inner())
+            .copied()
+            .unwrap_or_default();
 
         for (entity, mut computed_visibility, maybe_entity_mask, maybe_aabb, maybe_transform) in
             &mut visible_entity_query
@@ -1895,7 +1898,10 @@ pub fn check_light_mesh_visibility(
                 continue;
             }
 
-            let entity_mask = maybe_entity_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+            let entity_mask = maybe_entity_mask
+                .map(|v| v.into_inner())
+                .copied()
+                .unwrap_or_default();
             if !view_mask.intersects(&entity_mask) {
                 continue;
             }
@@ -1912,7 +1918,12 @@ pub fn check_light_mesh_visibility(
                         view_frusta.iter().zip(view_visible_entities)
                     {
                         // Disable near-plane culling, as a shadow caster could lie before the near plane.
-                        if !frustum.intersects_obb(aabb.into_inner(), &transform.compute_matrix(), false, true) {
+                        if !frustum.intersects_obb(
+                            aabb.into_inner(),
+                            &transform.compute_matrix(),
+                            false,
+                            true,
+                        ) {
                             continue;
                         }
 
@@ -1948,7 +1959,10 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                let view_mask = maybe_view_mask
+                    .map(|v| v.into_inner())
+                    .copied()
+                    .unwrap_or_default();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -1966,7 +1980,10 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                    let entity_mask = maybe_entity_mask
+                        .map(|v| v.into_inner())
+                        .copied()
+                        .unwrap_or_default();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }
@@ -2012,7 +2029,10 @@ pub fn check_light_mesh_visibility(
                     continue;
                 }
 
-                let view_mask = maybe_view_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                let view_mask = maybe_view_mask
+                    .map(|v| v.into_inner())
+                    .copied()
+                    .unwrap_or_default();
                 let light_sphere = Sphere {
                     center: Vec3A::from(transform.translation()),
                     radius: point_light.range,
@@ -2030,7 +2050,10 @@ pub fn check_light_mesh_visibility(
                         continue;
                     }
 
-                    let entity_mask = maybe_entity_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                    let entity_mask = maybe_entity_mask
+                        .map(|v| v.into_inner())
+                        .copied()
+                        .unwrap_or_default();
                     if !view_mask.intersects(&entity_mask) {
                         continue;
                     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -349,7 +349,10 @@ impl<P: PhaseItem, M: Material, const I: usize> RenderCommand<P> for SetMaterial
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material = materials.into_inner().get(material_handle.into_inner()).unwrap();
+        let material = materials
+            .into_inner()
+            .get(material_handle.into_inner())
+            .unwrap();
         pass.set_bind_group(I, &material.bind_group, &[]);
         RenderCommandResult::Success
     }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
         lifetimeless::{Read, SRes},
         Commands, Query, Res, ResMut, Resource, SystemParamItem,
     },
-    world::{FromWorld, World, Ref},
+    world::{FromWorld, Ref, World},
 };
 use bevy_reflect::TypeUuid;
 use bevy_render::{

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -14,7 +14,7 @@ use bevy_ecs::{
         lifetimeless::{Read, SRes},
         Commands, Query, Res, ResMut, Resource, SystemParamItem,
     },
-    world::{FromWorld, World},
+    world::{FromWorld, World, Ref},
 };
 use bevy_reflect::TypeUuid;
 use bevy_render::{
@@ -531,8 +531,8 @@ pub fn queue_prepass_material_meshes<M: Material>(
             };
 
             let (Some(material), Some(mesh)) = (
-                render_materials.get(material_handle),
-                render_meshes.get(mesh_handle),
+                render_materials.get(material_handle.into_inner()),
+                render_meshes.get(mesh_handle.into_inner()),
             ) else {
                 continue;
             };
@@ -603,7 +603,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
     #[inline]
     fn render<'w>(
         _item: &P,
-        view_uniform_offset: &'_ ViewUniformOffset,
+        view_uniform_offset: Ref<'_, ViewUniformOffset>,
         _entity: (),
         prepass_view_bind_group: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -502,7 +502,7 @@ pub fn extract_lights(
             }
             // TODO: This is very much not ideal. We should be able to re-use the vector memory.
             // However, since exclusive access to the main world in extract is ill-advised, we just clone here.
-            let render_cubemap_visible_entities = cubemap_visible_entities.into_inner().clone();
+            let render_cubemap_visible_entities = cubemap_visible_entities.clone();
             point_lights_values.push((
                 entity,
                 (
@@ -539,7 +539,7 @@ pub fn extract_lights(
             }
             // TODO: This is very much not ideal. We should be able to re-use the vector memory.
             // However, since exclusive access to the main world in extract is ill-advised, we just clone here.
-            let render_visible_entities = visible_entities.into_inner().clone();
+            let render_visible_entities = visible_entities.clone();
             let texel_size =
                 2.0 * spot_light.outer_angle.tan() / directional_light_shadow_map.size as f32;
 
@@ -589,7 +589,7 @@ pub fn extract_lights(
         }
 
         // TODO: As above
-        let render_visible_entities = visible_entities.into_inner().clone();
+        let render_visible_entities = visible_entities.clone();
         commands.get_or_spawn(entity).insert((
             ExtractedDirectionalLight {
                 color: directional_light.color,
@@ -599,7 +599,7 @@ pub fn extract_lights(
                 shadow_depth_bias: directional_light.shadow_depth_bias,
                 // The factor of SQRT_2 is for the worst-case diagonal offset
                 shadow_normal_bias: directional_light.shadow_normal_bias * std::f32::consts::SQRT_2,
-                cascade_shadow_config: cascade_config.into_inner().clone(),
+                cascade_shadow_config: cascade_config.clone(),
                 cascades: cascades.cascades.clone(),
             },
             render_visible_entities,
@@ -910,7 +910,7 @@ pub fn prepare_lights(
     }
 
     let mut gpu_point_lights = Vec::new();
-    for (index, (&entity, light)) in point_lights.iter().map(|(e,v)| (e, v.clone())).enumerate() {
+    for (index, (&entity, light)) in point_lights.iter().map(|(e, v)| (e, *v)).enumerate() {
         let mut flags = PointLightFlags::NONE;
 
         // Lights are sorted, shadow enabled lights are first
@@ -1104,10 +1104,7 @@ pub fn prepare_lights(
             .take(point_light_shadow_maps_count)
             .filter(|(_, light)| light.shadows_enabled)
         {
-            let light_index = *global_light_meta
-                .entity_to_index
-                .get(&light_entity)
-                .unwrap();
+            let light_index = *global_light_meta.entity_to_index.get(light_entity).unwrap();
             // ignore scale because we don't want to effectively scale light radius and range
             // by applying those as a view transform to shadow map rendering of objects
             // and ignore rotation because we want the shadow map projections to align with the axes
@@ -1711,7 +1708,8 @@ pub fn queue_shadows(
         for view_light_entity in view_lights.lights.iter().copied() {
             let (light_entity, mut shadow_phase) =
                 view_light_shadow_phases.get_mut(view_light_entity).unwrap();
-            let is_directional_light = matches!(light_entity.into_inner(), LightEntity::Directional { .. });
+            let is_directional_light =
+                matches!(light_entity.into_inner(), LightEntity::Directional { .. });
             let visible_entities = match light_entity.into_inner() {
                 LightEntity::Directional {
                     light_entity,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -238,9 +238,12 @@ pub fn extract_skinned_meshes(
             continue;
         }
         // PERF: This can be expensive, can we move this to prepare?
-        if let Some(skinned_joints) =
-            SkinnedMeshJoints::build(skin.into_inner(), &inverse_bindposes, &joint_query, &mut uniform.buffer)
-        {
+        if let Some(skinned_joints) = SkinnedMeshJoints::build(
+            skin.into_inner(),
+            &inverse_bindposes,
+            &joint_query,
+            &mut uniform.buffer,
+        ) {
             last_start = last_start.max(skinned_joints.index as usize);
             values.push((entity, skinned_joints.to_buffer_index()));
         }
@@ -986,7 +989,10 @@ pub fn queue_mesh_view_bind_groups(
             // When using WebGL with MSAA, we can't create the fallback textures required by the prepass
             // When using WebGL, and MSAA is disabled, we can't bind the textures either
             if cfg!(not(feature = "webgl")) {
-                let depth_view = match prepass_textures.map(|v| v.into_inner()).and_then(|x| x.depth.as_ref()) {
+                let depth_view = match prepass_textures
+                    .map(|v| v.into_inner())
+                    .and_then(|x| x.depth.as_ref())
+                {
                     Some(texture) => &texture.default_view,
                     None => {
                         &fallback_depths
@@ -999,7 +1005,10 @@ pub fn queue_mesh_view_bind_groups(
                     resource: BindingResource::TextureView(depth_view),
                 });
 
-                let normal_view = match prepass_textures.map(|v| v.into_inner()).and_then(|x| x.normal.as_ref()) {
+                let normal_view = match prepass_textures
+                    .map(|v| v.into_inner())
+                    .and_then(|x| x.normal.as_ref())
+                {
                     Some(texture) => &texture.default_view,
                     None => {
                         &fallback_images

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -239,7 +239,7 @@ pub fn extract_skinned_meshes(
         }
         // PERF: This can be expensive, can we move this to prepare?
         if let Some(skinned_joints) =
-            SkinnedMeshJoints::build(skin, &inverse_bindposes, &joint_query, &mut uniform.buffer)
+            SkinnedMeshJoints::build(skin.into_inner(), &inverse_bindposes, &joint_query, &mut uniform.buffer)
         {
             last_start = last_start.max(skinned_joints.index as usize);
             values.push((entity, skinned_joints.to_buffer_index()));
@@ -986,7 +986,7 @@ pub fn queue_mesh_view_bind_groups(
             // When using WebGL with MSAA, we can't create the fallback textures required by the prepass
             // When using WebGL, and MSAA is disabled, we can't bind the textures either
             if cfg!(not(feature = "webgl")) {
-                let depth_view = match prepass_textures.and_then(|x| x.depth.as_ref()) {
+                let depth_view = match prepass_textures.map(|v| v.into_inner()).and_then(|x| x.depth.as_ref()) {
                     Some(texture) => &texture.default_view,
                     None => {
                         &fallback_depths
@@ -999,7 +999,7 @@ pub fn queue_mesh_view_bind_groups(
                     resource: BindingResource::TextureView(depth_view),
                 });
 
-                let normal_view = match prepass_textures.and_then(|x| x.normal.as_ref()) {
+                let normal_view = match prepass_textures.map(|v| v.into_inner()).and_then(|x| x.normal.as_ref()) {
                     Some(texture) => &texture.default_view,
                     None => {
                         &fallback_images
@@ -1050,7 +1050,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshViewBindGroup<I> 
     ) -> RenderCommandResult {
         pass.set_bind_group(
             I,
-            &mesh_view_bind_group.value,
+            &mesh_view_bind_group.into_inner().value,
             &[view_uniform.offset, view_lights.offset, view_fog.offset],
         );
 
@@ -1104,7 +1104,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
         meshes: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        if let Some(gpu_mesh) = meshes.into_inner().get(mesh_handle) {
+        if let Some(gpu_mesh) = meshes.into_inner().get(mesh_handle.into_inner()) {
             pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
             match &gpu_mesh.buffer_info {
                 GpuBufferInfo::Indexed {

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -117,8 +117,8 @@ fn queue_wireframes(
 
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let add_render_phase =
-            |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
-                if let Some(mesh) = render_meshes.get(mesh_handle) {
+            |(entity, mesh_handle, mesh_uniform): (Entity, Ref<Handle<Mesh>>, Ref<MeshUniform>)| {
+                if let Some(mesh) = render_meshes.get(mesh_handle.into_inner()) {
                     let key = view_key
                         | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                     let pipeline_id = pipelines.specialize(

--- a/crates/bevy_render/macros/src/extract_component.rs
+++ b/crates/bevy_render/macros/src/extract_component.rs
@@ -44,7 +44,7 @@ pub fn derive_extract_component(input: TokenStream) -> TokenStream {
             type Out = Self;
 
             fn extract_component(item: #bevy_ecs_path::query::QueryItem<'_, Self::Query>) -> Option<Self::Out> {
-                Some(item.clone())
+                Some(item.into_inner().clone())
             }
         }
     })

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -15,7 +15,8 @@ use bevy_ecs::{
     event::EventReader,
     prelude::With,
     reflect::ReflectComponent,
-    system::{Commands, Query, Res}, world::{Mut, Ref},
+    system::{Commands, Query, Res},
+    world::{Mut, Ref},
 };
 use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
@@ -568,7 +569,7 @@ pub fn extract_cameras(
                         viewport_size.y,
                     ),
                 },
-                visible_entities.into_inner().clone(),
+                visible_entities.clone(),
             ));
         }
     }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -15,7 +15,7 @@ use bevy_ecs::{
     event::EventReader,
     prelude::With,
     reflect::ReflectComponent,
-    system::{Commands, Query, Res},
+    system::{Commands, Query, Res}, world::{Mut, Ref},
 };
 use bevy_math::{Mat4, Ray, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
@@ -400,7 +400,7 @@ impl NormalizedRenderTarget {
 
     pub fn get_render_target_info<'a>(
         &self,
-        resolutions: impl IntoIterator<Item = (Entity, &'a Window)>,
+        resolutions: impl IntoIterator<Item = (Entity, Ref<'a, Window>)>,
         images: &Assets<Image>,
     ) -> Option<RenderTargetInfo> {
         match self {
@@ -469,7 +469,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     primary_window: Query<Entity, With<PrimaryWindow>>,
     windows: Query<(Entity, &Window)>,
     images: Res<Assets<Image>>,
-    mut cameras: Query<(&mut Camera, &mut T)>,
+    mut cameras: Query<(&mut Camera, Mut<T>)>,
 ) {
     let primary_window = primary_window.iter().next();
 
@@ -568,7 +568,7 @@ pub fn extract_cameras(
                         viewport_size.y,
                     ),
                 },
-                visible_entities.clone(),
+                visible_entities.into_inner().clone(),
             ));
         }
     }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -372,7 +372,10 @@ pub fn check_visibility(
     >,
 ) {
     for (mut visible_entities, frustum, maybe_view_mask) in &mut view_query {
-        let view_mask = maybe_view_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+        let view_mask = maybe_view_mask
+            .map(|v| v.into_inner())
+            .copied()
+            .unwrap_or_default();
 
         visible_entities.entities.clear();
         visible_aabb_query.par_iter_mut().for_each_mut(
@@ -390,7 +393,10 @@ pub fn check_visibility(
                     return;
                 }
 
-                let entity_mask = maybe_entity_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                let entity_mask = maybe_entity_mask
+                    .map(|v| v.into_inner())
+                    .copied()
+                    .unwrap_or_default();
                 if !view_mask.intersects(&entity_mask) {
                     return;
                 }
@@ -428,7 +434,10 @@ pub fn check_visibility(
                     return;
                 }
 
-                let entity_mask = maybe_entity_mask.map(|v| v.into_inner()).copied().unwrap_or_default();
+                let entity_mask = maybe_entity_mask
+                    .map(|v| v.into_inner())
+                    .copied()
+                    .unwrap_or_default();
                 if !view_mask.intersects(&entity_mask) {
                     return;
                 }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -92,7 +92,7 @@ fn extract_windows(
 
         let mut extracted_window = extracted_windows.entry(entity).or_insert(ExtractedWindow {
             entity,
-            handle: handle.clone(),
+            handle: handle.into_inner().clone(),
             physical_width: new_width,
             physical_height: new_height,
             present_mode: window.present_mode,

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -92,7 +92,7 @@ fn extract_windows(
 
         let mut extracted_window = extracted_windows.entry(entity).or_insert(ExtractedWindow {
             entity,
-            handle: handle.into_inner().clone(),
+            handle: handle.clone(),
             physical_width: new_width,
             physical_height: new_height,
             present_mode: window.present_mode,

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -59,7 +59,7 @@ pub fn scene_spawner(
     mut scene_spawner: ResMut<SceneSpawner>,
 ) {
     for (entity, scene, instance) in &mut scene_to_spawn {
-        let new_instance = scene_spawner.spawn_as_child(scene.clone(), entity);
+        let new_instance = scene_spawner.spawn_as_child(scene.into_inner().clone(), entity);
         if let Some(mut old_instance) = instance {
             scene_spawner.despawn_instance(**old_instance);
             *old_instance = SceneInstance(new_instance);
@@ -68,7 +68,7 @@ pub fn scene_spawner(
         }
     }
     for (entity, dynamic_scene, instance) in &mut dynamic_scene_to_spawn {
-        let new_instance = scene_spawner.spawn_dynamic_as_child(dynamic_scene.clone(), entity);
+        let new_instance = scene_spawner.spawn_dynamic_as_child(dynamic_scene.into_inner().clone(), entity);
         if let Some(mut old_instance) = instance {
             scene_spawner.despawn_instance(**old_instance);
             *old_instance = SceneInstance(new_instance);

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -59,7 +59,7 @@ pub fn scene_spawner(
     mut scene_spawner: ResMut<SceneSpawner>,
 ) {
     for (entity, scene, instance) in &mut scene_to_spawn {
-        let new_instance = scene_spawner.spawn_as_child(scene.into_inner().clone(), entity);
+        let new_instance = scene_spawner.spawn_as_child(scene.clone(), entity);
         if let Some(mut old_instance) = instance {
             scene_spawner.despawn_instance(**old_instance);
             *old_instance = SceneInstance(new_instance);
@@ -68,7 +68,7 @@ pub fn scene_spawner(
         }
     }
     for (entity, dynamic_scene, instance) in &mut dynamic_scene_to_spawn {
-        let new_instance = scene_spawner.spawn_dynamic_as_child(dynamic_scene.into_inner().clone(), entity);
+        let new_instance = scene_spawner.spawn_dynamic_as_child(dynamic_scene.clone(), entity);
         if let Some(mut old_instance) = instance {
             scene_spawner.despawn_instance(**old_instance);
             *old_instance = SceneInstance(new_instance);

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -308,7 +308,7 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material2d = materials.into_inner().get(material2d_handle).unwrap();
+        let material2d = materials.into_inner().get(material2d_handle.into_inner()).unwrap();
         pass.set_bind_group(I, &material2d.bind_group, &[]);
         RenderCommandResult::Success
     }
@@ -343,7 +343,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
         let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
-        if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {
+        if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping.map(|v| v.into_inner()) {
             if !view.hdr {
                 view_key |= Mesh2dPipelineKey::TONEMAP_IN_SHADER;
 
@@ -357,7 +357,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
             if let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) =
                 material2d_meshes.get(*visible_entity)
             {
-                if let Some(material2d) = render_materials.get(material2d_handle) {
+                if let Some(material2d) = render_materials.get(material2d_handle.into_inner()) {
                     if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
                         let mesh_key = view_key
                             | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -308,7 +308,10 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material2d = materials.into_inner().get(material2d_handle.into_inner()).unwrap();
+        let material2d = materials
+            .into_inner()
+            .get(material2d_handle.into_inner())
+            .unwrap();
         pass.set_bind_group(I, &material2d.bind_group, &[]);
         RenderCommandResult::Success
     }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -509,7 +509,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dViewBindGroup<I
         _param: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        pass.set_bind_group(I, &mesh2d_view_bind_group.value, &[view_uniform.offset]);
+        pass.set_bind_group(I, &mesh2d_view_bind_group.into_inner().value, &[view_uniform.offset]);
 
         RenderCommandResult::Success
     }
@@ -525,7 +525,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dBindGroup<I> {
     fn render<'w>(
         _item: &P,
         _view: (),
-        mesh2d_index: &'_ DynamicUniformIndex<Mesh2dUniform>,
+        mesh2d_index: Ref<'_, DynamicUniformIndex<Mesh2dUniform>>,
         mesh2d_bind_group: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -509,7 +509,11 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dViewBindGroup<I
         _param: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        pass.set_bind_group(I, &mesh2d_view_bind_group.into_inner().value, &[view_uniform.offset]);
+        pass.set_bind_group(
+            I,
+            &mesh2d_view_bind_group.into_inner().value,
+            &[view_uniform.offset],
+        );
 
         RenderCommandResult::Success
     }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -518,7 +518,9 @@ pub fn queue_sprites(
 
         for (mut transparent_phase, visible_entities, view, tonemapping) in &mut views {
             let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
-            if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping.map(|v| v.into_inner()) {
+            if let Some(Tonemapping::Enabled { deband_dither }) =
+                tonemapping.map(|v| v.into_inner())
+            {
                 if !view.hdr {
                     view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -362,7 +362,7 @@ pub fn extract_sprites(
         if !visibility.is_visible() {
             continue;
         }
-        if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
+        if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle.into_inner()) {
             let rect = Some(texture_atlas.textures[atlas_sprite.index]);
             extracted_sprites.sprites.push(ExtractedSprite {
                 entity,
@@ -518,7 +518,7 @@ pub fn queue_sprites(
 
         for (mut transparent_phase, visible_entities, view, tonemapping) in &mut views {
             let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
-            if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping {
+            if let Some(Tonemapping::Enabled { deband_dither }) = tonemapping.map(|v| v.into_inner()) {
                 if !view.hdr {
                     view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
 
@@ -704,7 +704,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteViewBindGroup<I
 
     fn render<'w>(
         _item: &P,
-        view_uniform: &'_ ViewUniformOffset,
+        view_uniform: Ref<'_, ViewUniformOffset>,
         _entity: (),
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
@@ -726,7 +726,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
     fn render<'w>(
         _item: &P,
         _view: (),
-        sprite_batch: &'_ SpriteBatch,
+        sprite_batch: Ref<'_, SpriteBatch>,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -753,7 +753,7 @@ impl<P: BatchedPhaseItem> RenderCommand<P> for DrawSpriteBatch {
     fn render<'w>(
         item: &P,
         _view: (),
-        sprite_batch: &'_ SpriteBatch,
+        sprite_batch: Ref<'_, SpriteBatch>,
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -376,7 +376,10 @@ mod test {
 
         let mut state = app.world.query::<&GlobalTransform>();
         for global in state.iter(&app.world) {
-            assert_eq!(global.into_inner(), &GlobalTransform::from_translation(translation));
+            assert_eq!(
+                global.into_inner(),
+                &GlobalTransform::from_translation(translation)
+            );
         }
     }
 

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -376,7 +376,7 @@ mod test {
 
         let mut state = app.world.query::<&GlobalTransform>();
         for global in state.iter(&app.world) {
-            assert_eq!(global, &GlobalTransform::from_translation(translation));
+            assert_eq!(global.into_inner(), &GlobalTransform::from_translation(translation));
         }
     }
 

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -262,7 +262,12 @@ pub fn flex_node_system(
         for (entity, style, calculated_size) in &query {
             // TODO: remove node from old hierarchy if its root has changed
             if let Some(calculated_size) = calculated_size {
-                flex_surface.upsert_leaf(entity, style.into_inner(), *calculated_size, scaling_factor);
+                flex_surface.upsert_leaf(
+                    entity,
+                    style.into_inner(),
+                    *calculated_size,
+                    scaling_factor,
+                );
             } else {
                 flex_surface.upsert_node(entity, style.into_inner(), scaling_factor);
             }

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -262,9 +262,9 @@ pub fn flex_node_system(
         for (entity, style, calculated_size) in &query {
             // TODO: remove node from old hierarchy if its root has changed
             if let Some(calculated_size) = calculated_size {
-                flex_surface.upsert_leaf(entity, style, *calculated_size, scaling_factor);
+                flex_surface.upsert_leaf(entity, style.into_inner(), *calculated_size, scaling_factor);
             } else {
-                flex_surface.upsert_node(entity, style, scaling_factor);
+                flex_surface.upsert_node(entity, style.into_inner(), scaling_factor);
             }
         }
     }
@@ -276,7 +276,7 @@ pub fn flex_node_system(
     }
 
     for (entity, style, calculated_size) in &changed_size_query {
-        flex_surface.upsert_leaf(entity, style, *calculated_size, scale_factor);
+        flex_surface.upsert_leaf(entity, style.into_inner(), *calculated_size, scale_factor);
     }
 
     // clean up removed nodes
@@ -290,7 +290,7 @@ pub fn flex_node_system(
         flex_surface.try_remove_children(entity);
     }
     for (entity, children) in &children_query {
-        flex_surface.update_children(entity, children);
+        flex_surface.update_children(entity, children.into_inner());
     }
 
     // compute layouts

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -169,7 +169,7 @@ pub fn ui_focus_system(
 
     let cursor_position = camera
         .iter()
-        .filter(|(_, camera_ui)| !is_ui_disabled(*camera_ui))
+        .filter(|(_, camera_ui)| !is_ui_disabled(camera_ui.map(|v| v.into_inner())))
         .filter_map(|(camera, _)| {
             if let Some(NormalizedRenderTarget::Window(window_id)) =
                 camera.target.normalize(primary_window)
@@ -281,7 +281,7 @@ pub fn ui_focus_system(
             }
         }
 
-        match node.focus_policy.unwrap_or(&FocusPolicy::Block) {
+        match node.focus_policy.map(|v| v.into_inner()).unwrap_or(&FocusPolicy::Block) {
             FocusPolicy::Block => {
                 break;
             }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -281,7 +281,11 @@ pub fn ui_focus_system(
             }
         }
 
-        match node.focus_policy.map(|v| v.into_inner()).unwrap_or(&FocusPolicy::Block) {
+        match node
+            .focus_policy
+            .map(|v| v.into_inner())
+            .unwrap_or(&FocusPolicy::Block)
+        {
             FocusPolicy::Block => {
                 break;
             }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -256,7 +256,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
 ) {
     for (entity, camera, camera_ui) in &query {
         // ignore cameras with disabled ui
-        if matches!(camera_ui, Some(&UiCameraConfig { show_ui: false, .. })) {
+        if matches!(camera_ui.map(|v| v.into_inner()), Some(&UiCameraConfig { show_ui: false, .. })) {
             continue;
         }
         if let (Some(logical_size), Some((physical_origin, _)), Some(physical_size)) = (

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -256,7 +256,10 @@ pub fn extract_default_ui_camera_view<T: Component>(
 ) {
     for (entity, camera, camera_ui) in &query {
         // ignore cameras with disabled ui
-        if matches!(camera_ui.map(|v| v.into_inner()), Some(&UiCameraConfig { show_ui: false, .. })) {
+        if matches!(
+            camera_ui.map(|v| v.into_inner()),
+            Some(&UiCameraConfig { show_ui: false, .. })
+        ) {
             continue;
         }
         if let (Some(logical_size), Some((physical_origin, _)), Some(physical_size)) = (

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -63,7 +63,7 @@ impl Node for UiPassNode {
             return Ok(());
         }
         // Don't render UI for cameras where it is explicitly disabled
-        if matches!(camera_ui, Some(&UiCameraConfig { show_ui: false })) {
+        if matches!(camera_ui.map(|v| v.into_inner()), Some(&UiCameraConfig { show_ui: false })) {
             return Ok(());
         }
 
@@ -139,7 +139,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUiViewBindGroup<I> {
 
     fn render<'w>(
         _item: &P,
-        view_uniform: &'w ViewUniformOffset,
+        view_uniform: Ref<'w, ViewUniformOffset>,
         _entity: (),
         ui_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
@@ -162,7 +162,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUiTextureBindGroup<I>
     fn render<'w>(
         _item: &P,
         _view: (),
-        batch: &'w UiBatch,
+        batch: Ref<'w, UiBatch>,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -181,7 +181,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawUiNode {
     fn render<'w>(
         _item: &P,
         _view: (),
-        batch: &'w UiBatch,
+        batch: Ref<'w, UiBatch>,
         ui_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -63,7 +63,10 @@ impl Node for UiPassNode {
             return Ok(());
         }
         // Don't render UI for cameras where it is explicitly disabled
-        if matches!(camera_ui.map(|v| v.into_inner()), Some(&UiCameraConfig { show_ui: false })) {
+        if matches!(
+            camera_ui.map(|v| v.into_inner()),
+            Some(&UiCameraConfig { show_ui: false })
+        ) {
             return Ok(());
         }
 

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -76,7 +76,7 @@ fn insert_context_hierarchy(
         }
     }
 
-    let z_index = zindex_query.get(entity).unwrap_or(&ZIndex::Local(0));
+    let z_index = zindex_query.get(entity).map(|v| v.into_inner()).unwrap_or(&ZIndex::Local(0));
     let (entity_context, z_index) = match z_index {
         ZIndex::Local(value) => (parent_context.unwrap_or(global_context), *value),
         ZIndex::Global(value) => (global_context, *value),
@@ -193,7 +193,7 @@ mod tests {
         let actual_result = ui_stack
             .uinodes
             .iter()
-            .map(|entity| query.get(&world, *entity).unwrap().clone())
+            .map(|entity| query.get(&world, *entity).unwrap().into_inner().clone())
             .collect::<Vec<_>>();
         let expected_result = vec![
             (Label("1-2-1")), // ZIndex::Global(-3)

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -76,7 +76,10 @@ fn insert_context_hierarchy(
         }
     }
 
-    let z_index = zindex_query.get(entity).map(|v| v.into_inner()).unwrap_or(&ZIndex::Local(0));
+    let z_index = zindex_query
+        .get(entity)
+        .map(|v| v.into_inner())
+        .unwrap_or(&ZIndex::Local(0));
     let (entity_context, z_index) = match z_index {
         ZIndex::Local(value) => (parent_context.unwrap_or(global_context), *value),
         ZIndex::Global(value) => (global_context, *value),
@@ -193,7 +196,7 @@ mod tests {
         let actual_result = ui_stack
             .uinodes
             .iter()
-            .map(|entity| query.get(&world, *entity).unwrap().into_inner().clone())
+            .map(|entity| query.get(&world, *entity).unwrap().clone())
             .collect::<Vec<_>>();
         let expected_result = vec![
             (Label("1-2-1")), // ZIndex::Global(-3)

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -325,7 +325,7 @@ fn example_control_system(
     let randomize_colors = input.just_pressed(KeyCode::C);
 
     for (material_handle, controls) in &controllable {
-        let mut material = materials.get_mut(material_handle).unwrap();
+        let mut material = materials.get_mut(material_handle.into_inner()).unwrap();
         material.base_color.set_a(state.alpha);
 
         if controls.color && randomize_colors {
@@ -362,7 +362,7 @@ fn example_control_system(
             labelled.get(label.entity).unwrap().translation() + Vec3::new(0.0, 1.0, 0.0);
 
         let viewport_position = camera
-            .world_to_viewport(camera_global_transform, world_position)
+            .world_to_viewport(camera_global_transform.into_inner(), world_position)
             .unwrap();
 
         style.position.bottom = Val::Px(viewport_position.y);

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -168,7 +168,7 @@ fn asset_loaded(
         // spawn cube
         let mut updated = false;
         for handle in cubes.iter() {
-            if let Some(material) = cubemap_materials.get_mut(handle) {
+            if let Some(material) = cubemap_materials.get_mut(handle.into_inner()) {
                 updated = true;
                 material.base_color_texture = Some(cubemap.image_handle.clone_weak());
             }

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -100,7 +100,7 @@ struct NestedQuery {
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
 struct GenericQuery<T: Component, P: Component> {
-    generic: (&'static T, &'static P),
+    generic: (Ref<'static, T>, Ref<'static, P>),
 }
 
 #[derive(WorldQuery)]

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -38,8 +38,7 @@ struct ComponentZ;
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct ReadOnlyCustomQuery<T: Component + Debug, P: Component + Debug>
-    where <T as Component>::ReadWrap<'static>: Debug, <P as Component>::ReadWrap<'static>: Debug {
+struct ReadOnlyCustomQuery<T: Component + Debug, P: Component + Debug> {
     entity: Entity,
     a: &'static ComponentA,
     b: Option<&'static ComponentB>,
@@ -73,8 +72,7 @@ fn print_components_read_only(
 // using the `derive` attribute.
 #[derive(WorldQuery)]
 #[world_query(mutable, derive(Debug))]
-struct CustomQuery<T: Component + Debug, P: Component + Debug>
-    where <T as Component>::ReadWrap<'static>: Debug, <P as Component>::ReadWrap<'static>: Debug {
+struct CustomQuery<T: Component + Debug, P: Component + Debug> {
     entity: Entity,
     a: &'static mut ComponentA,
     b: Option<&'static mut ComponentB>,
@@ -101,7 +99,7 @@ struct NestedQuery {
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct GenericQuery<T: Component + Debug, P: Component + Debug> {
+struct GenericQuery<T: Component, P: Component> {
     generic: (&'static T, &'static P),
 }
 

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -38,7 +38,8 @@ struct ComponentZ;
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct ReadOnlyCustomQuery<T: Component + Debug, P: Component + Debug> {
+struct ReadOnlyCustomQuery<T: Component + Debug, P: Component + Debug>
+    where <T as Component>::ReadWrap<'static>: Debug, <P as Component>::ReadWrap<'static>: Debug {
     entity: Entity,
     a: &'static ComponentA,
     b: Option<&'static ComponentB>,
@@ -72,7 +73,8 @@ fn print_components_read_only(
 // using the `derive` attribute.
 #[derive(WorldQuery)]
 #[world_query(mutable, derive(Debug))]
-struct CustomQuery<T: Component + Debug, P: Component + Debug> {
+struct CustomQuery<T: Component + Debug, P: Component + Debug>
+    where <T as Component>::ReadWrap<'static>: Debug, <P as Component>::ReadWrap<'static>: Debug {
     entity: Entity,
     a: &'static mut ComponentA,
     b: Option<&'static mut ComponentB>,
@@ -99,7 +101,7 @@ struct NestedQuery {
 
 #[derive(WorldQuery)]
 #[world_query(derive(Debug))]
-struct GenericQuery<T: Component, P: Component> {
+struct GenericQuery<T: Component + Debug, P: Component + Debug> {
     generic: (&'static T, &'static P),
 }
 

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -156,8 +156,9 @@ fn generate_bodies(
 
 fn interact_bodies(mut query: Query<(&Mass, &GlobalTransform, &mut Acceleration)>) {
     let mut iter = query.iter_combinations_mut();
-    while let Some([(Mass(m1), transform1, mut acc1), (Mass(m2), transform2, mut acc2)]) =
-        iter.fetch_next().map(|l| l.map(|(m, g, a)| (m.into_inner(), g.into_inner(), a)))
+    while let Some([(Mass(m1), transform1, mut acc1), (Mass(m2), transform2, mut acc2)]) = iter
+        .fetch_next()
+        .map(|l| l.map(|(m, g, a)| (m.into_inner(), g.into_inner(), a)))
     {
         let delta = transform2.translation() - transform1.translation();
         let distance_sq: f32 = delta.length_squared();

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -157,7 +157,7 @@ fn generate_bodies(
 fn interact_bodies(mut query: Query<(&Mass, &GlobalTransform, &mut Acceleration)>) {
     let mut iter = query.iter_combinations_mut();
     while let Some([(Mass(m1), transform1, mut acc1), (Mass(m2), transform2, mut acc2)]) =
-        iter.fetch_next()
+        iter.fetch_next().map(|l| l.map(|(m, g, a)| (m.into_inner(), g.into_inner(), a)))
     {
         let delta = transform2.translation() - transform1.translation();
         let distance_sq: f32 = delta.length_squared();

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -192,7 +192,12 @@ fn select_system(
 
     if let Ok((contributor, mut sprite, mut transform)) = query.get_mut(entity) {
         let mut text = text_query.single_mut();
-        select(&mut sprite, contributor.into_inner(), &mut transform, &mut text);
+        select(
+            &mut sprite,
+            contributor.into_inner(),
+            &mut transform,
+            &mut text,
+        );
     }
 }
 

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -179,7 +179,7 @@ fn select_system(
 
     let entity = contributor_selection.order[contributor_selection.idx];
     if let Ok((contributor, mut sprite, mut transform)) = query.get_mut(entity) {
-        deselect(&mut sprite, contributor, &mut transform);
+        deselect(&mut sprite, contributor.into_inner(), &mut transform);
     }
 
     if (contributor_selection.idx + 1) < contributor_selection.order.len() {
@@ -192,7 +192,7 @@ fn select_system(
 
     if let Ok((contributor, mut sprite, mut transform)) = query.get_mut(entity) {
         let mut text = text_query.single_mut();
-        select(&mut sprite, contributor, &mut transform, &mut text);
+        select(&mut sprite, contributor.into_inner(), &mut transform, &mut text);
     }
 }
 

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -810,7 +810,7 @@ mod menu {
     ) {
         for (interaction, menu_button_action) in &interaction_query {
             if *interaction == Interaction::Clicked {
-                match menu_button_action {
+                match menu_button_action.into_inner() {
                     MenuButtonAction::Quit => app_exit_events.send(AppExit),
                     MenuButtonAction::Play => {
                         game_state.set(GameState::Game).unwrap();

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -117,7 +117,7 @@ fn queue_custom(
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
         for (entity, mesh_uniform, mesh_handle) in &material_meshes {
-            if let Some(mesh) = meshes.get(mesh_handle) {
+            if let Some(mesh) = meshes.get(mesh_handle.into_inner()) {
                 let key =
                     view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
                 let pipeline = pipelines
@@ -227,17 +227,17 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
     fn render<'w>(
         _item: &P,
         _view: (),
-        (mesh_handle, instance_buffer): (&'w Handle<Mesh>, &'w InstanceBuffer),
+        (mesh_handle, instance_buffer): (Ref<'w, Handle<Mesh>>, Ref<'w, InstanceBuffer>),
         meshes: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let gpu_mesh = match meshes.into_inner().get(mesh_handle) {
+        let gpu_mesh = match meshes.into_inner().get(mesh_handle.into_inner()) {
             Some(gpu_mesh) => gpu_mesh,
             None => return RenderCommandResult::Failure,
         };
 
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
-        pass.set_vertex_buffer(1, instance_buffer.buffer.slice(..));
+        pass.set_vertex_buffer(1, instance_buffer.into_inner().buffer.slice(..));
 
         match &gpu_mesh.buffer_info {
             GpuBufferInfo::Indexed {

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -222,7 +222,7 @@ fn update(
 ) {
     if keycode.just_pressed(KeyCode::Space) {
         let handle = material_handle.single();
-        let mut mat = materials.get_mut(handle).unwrap();
+        let mut mat = materials.get_mut(handle.into_inner()).unwrap();
         let out_text;
         if mat.show_depth == 1.0 {
             out_text = "normal";

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -116,7 +116,7 @@ fn animate_sprite(
     for (mut timer, mut sprite, texture_atlas_handle) in query.iter_mut() {
         timer.tick(time.delta());
         if timer.just_finished() {
-            let texture_atlas = texture_atlases.get(texture_atlas_handle).unwrap();
+            let texture_atlas = texture_atlases.get(texture_atlas_handle.into_inner()).unwrap();
             sprite.index = (sprite.index + 1) % texture_atlas.textures.len();
         }
     }

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -116,7 +116,9 @@ fn animate_sprite(
     for (mut timer, mut sprite, texture_atlas_handle) in query.iter_mut() {
         timer.tick(time.delta());
         if timer.just_finished() {
-            let texture_atlas = texture_atlases.get(texture_atlas_handle.into_inner()).unwrap();
+            let texture_atlas = texture_atlases
+                .get(texture_atlas_handle.into_inner())
+                .unwrap();
             sprite.index = (sprite.index + 1) % texture_atlas.textures.len();
         }
     }

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -35,7 +35,10 @@ fn button_system(
         Changed<Interaction>,
     >,
 ) {
-    for (interaction, mut material, IdleColor(idle_color)) in interaction_query.iter_mut().map(|(i, b, c)| (i.into_inner(), b, c.into_inner())) {
+    for (interaction, mut material, IdleColor(idle_color)) in interaction_query
+        .iter_mut()
+        .map(|(i, b, c)| (i.into_inner(), b, c.into_inner()))
+    {
         if matches!(interaction, Interaction::Hovered) {
             *material = Color::ORANGE_RED.into();
         } else {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -35,7 +35,7 @@ fn button_system(
         Changed<Interaction>,
     >,
 ) {
-    for (interaction, mut material, IdleColor(idle_color)) in interaction_query.iter_mut() {
+    for (interaction, mut material, IdleColor(idle_color)) in interaction_query.iter_mut().map(|(i, b, c)| (i.into_inner(), b, c.into_inner())) {
         if matches!(interaction, Interaction::Hovered) {
             *material = Color::ORANGE_RED.into();
         } else {


### PR DESCRIPTION
# Objective

- Fixes #7322 
- When change detection is enabled &T becomes Ref<T> and &mut T becomes Mut<T> in queries
- When change detection is disabled &T and &mut T stay as themselves

## Solution

- Based extensively off #6659
- Effectively duplicates the work for Ref

---

## Changelog

- Now you can disable change detection for a particular component which will elide the Ref/Mut types

```
#[derive(Component)]
#[component(change_detection = false)]
pub struct ChangeDetectionless;
```

`ChangeDetectionless` when queried will return `&T` and `&mut T` instead of a wrapper type and similarly change detection in general will be disabled for the type.

- When change detection is enabled (the default) a wrapper type is returned that contains the change detection information for `&T` in a similar fashion to `&mut T` returning `Mut<T>` this type is `Ref<T>`

## Migration Guide

- All existing usages of a query containing `&T` will be returning `Ref<T>` unless change detection is disabled via the new `change_detection(false)` attribute on `#[derive(Component)]`. While many uses will work the same thanks to the `Deref<Target = &T` impl, pattern matching to get a value out will break. Either disable change detection if it is not required or avoid pattern matching and instead explicitly deref to get the underlying value.
