### PR TITLE
Replace crossbeam with std::sync::mpsc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,7 +136,6 @@ serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"
 # Needed to poll Task examples
 futures-lite = "1.11.3"
-crossbeam-channel = "0.5.0"
 
 [[example]]
 name = "hello_world"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -25,7 +25,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 
 # other
 serde = { version = "1", features = ["derive"] }
-crossbeam-channel = "0.5.0"
 anyhow = "1.0.4"
 thiserror = "1.0"
 downcast-rs = "1.2.0"

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -24,6 +24,3 @@ serde = { version = "1.0", optional = true }
 
 [features]
 serialize = ["dep:serde"]
-
-[dev-dependencies]
-crossbeam-channel = "0.5.0"

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -146,21 +146,21 @@ mod tests {
         app.add_plugin(TaskPoolPlugin::default());
         app.add_plugin(TypeRegistrationPlugin::default());
 
-        let (async_tx, async_rx) = crossbeam_channel::unbounded();
+        let (async_tx, async_rx) = std::sync::mpsc::channel();
         AsyncComputeTaskPool::get()
             .spawn_local(async move {
                 async_tx.send(()).unwrap();
             })
             .detach();
 
-        let (compute_tx, compute_rx) = crossbeam_channel::unbounded();
+        let (compute_tx, compute_rx) = std::sync::mpsc::channel();
         ComputeTaskPool::get()
             .spawn_local(async move {
                 compute_tx.send(()).unwrap();
             })
             .detach();
 
-        let (io_tx, io_rx) = crossbeam_channel::unbounded();
+        let (io_tx, io_rx) = std::sync::mpsc::channel();
         IoTaskPool::get()
             .spawn_local(async move {
                 io_tx.send(()).unwrap();

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -20,5 +20,4 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.9.0", features = ["bevy"
 bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 
 # other
-crossbeam-channel = "0.5.0"
 serde = { version = "1", features = ["derive"], optional = true }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -30,7 +30,6 @@ raw-window-handle = "0.5"
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
-crossbeam-channel = "0.5"
 
 [package.metadata.docs.rs]
 features = ["x11"]


### PR DESCRIPTION
# Objective

Fixes #7153.

## Solution

Remove `crossbeam_channel` as a dependency and replace it with `std::sync::mpsc` instead.

A one-to-one conversion was not possible because `crossbeam_channel` supports `Sync` while the `Receiver` in `std::sync::mpsc` does not, so I tried to make use of `bevy_utils::sync_cell::SyncCell`.

`bevy_asset` had many many issues with this though, I tried to sort through them but I couldn't figure out what to do now or I'm taking the wrong approach.

## Current problems

* I tried to get around `Arc<RefChangeChannel>` needing to be `mut` now with `SyncCell` by wrapping the inner `RefChangeChannel` in a `Mutex`, but this results in `future cannot be sent between threads safetly` in `AssetServer::load_untracked`.
* `impl Clone` for `Handle` is also a problem, since we don't have a `mut` borrow of `self`
* A lot more places where we need `mut` now

---

## Changelog

Removed `crossbeam_channel` dependency.
Replaced `crossbeam_channel` usage with `std::sync::mpsc`.

## Migration Guide

*Unsure*
