### PR TITLE
[Merged by Bors] - AppExit documentation updates (#7067)

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1166,7 +1166,11 @@ fn run_once(mut app: App) {
 ///
 /// You can also use this event to detect that an exit was requested. In order to receive it, systems
 /// subscribing to this event should run after it was emitted and before the schedule of the same
-/// frame is over.
+/// frame is over. This is important since [`App::run()`] might never return.
+///
+/// If you don't require access to other components or resources, consider implementing the [`Drop`]
+/// trait on components/resources for code that runs on exit. That saves you from worrying about
+/// system schedule ordering, and is idiomatic Rust.
 #[derive(Debug, Clone, Default)]
 pub struct AppExit;
 


### PR DESCRIPTION
# Objective

Help users understand how to write code that runs when the app is exiting.

See:

- #7067 (Partial resolution)

## Solution

Added documentation to `AppExit` class that mentions using the `Drop` trait for code that needs to run on program exit, as well as linking to the caveat about `App::run()` not being guaranteed to return.