### PR TITLE
[Merged by Bors] - schedule_v3: fix default set for systems not being applied

### DIFF
--- a/crates/bevy_ecs/src/schedule_v3/schedule.rs
+++ b/crates/bevy_ecs/src/schedule_v3/schedule.rs
@@ -341,9 +341,11 @@ impl ScheduleGraph {
 
         let id = NodeId::System(self.systems.len());
 
-        if graph_info.sets.is_empty() {
-            if let Some(default) = self.default_set.as_ref() {
-                graph_info.sets.push(default.dyn_clone());
+        if let [single_set] = graph_info.sets.as_slice() {
+            if single_set.is_system_type() {
+                if let Some(default) = self.default_set.as_ref() {
+                    graph_info.sets.push(default.dyn_clone());
+                }
             }
         }
 


### PR DESCRIPTION
# Objective

`add_system(system)` without any `.in_set` configuration should land in `CoreSet::Update`.
We check that the sets are empty, but for systems there is always the `SystemTypeset`.

## Solution

- instead of `is_empty()`, check that the only set it the `SystemTypeSet`