### PR TITLE
Exit schedule for systems to run at end of app run

### DIFF
--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -64,3 +64,12 @@ pub enum StartupStage {
     /// The [`Stage`](bevy_ecs::schedule::Stage) that runs once after [`StartupStage::Startup`].
     PostStartup,
 }
+
+/// The label for the exit [`Schedule`](bevy_ecs::schedule::Schedule),
+/// which runs once at the end of the [`App`].
+#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
+pub struct ExitSchedule;
+
+/// The only stage in the exit schedule.
+#[derive(Debug, Hash, PartialEq, Eq, Clone, StageLabel)]
+pub struct ExitStage;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -260,6 +260,7 @@ pub fn winit_runner(mut app: App) {
 
         if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
             if app_exit_event_reader.iter(app_exit_events).last().is_some() {
+                app.teardown();
                 *control_flow = ControlFlow::Exit;
                 return;
             }


### PR DESCRIPTION
# Objective

Adding a structure for systems that run only when the App is closing.

Fixes #7067

## Solution

Adds a Schedule to the default stages with label `ExitSchedule` to run systems at the end of the App.

## Changelog

### Added

- Created `ExitSchedule` struct as label for new exit schedule.
- Created `ExitStage` struct as label for new exit schedule's only stage, since it seems schedules need at least one stage currently. I presume this will be easy enough to remove after the stageless RFC.
- Updated `AppExit` documentation to mention exit systems.
- Added `add_exit_system` and `add_exit_system_set` APIs to `App` to add systems to the exit schedule.
- Added `teardown` API to App so that runners can call the exit schedule.
- Test for default schedule runner to verify exit systems are run when the App is closing.

### Changed

- Default schedule runner now calls `App::teardown` before exiting.
- Winit schedule runner now calls `App::teardown` before exiting.
- Added ExitSchedule to the `App::add_default_stages()` method.

## Migration Guide

 - Custom runners would have to call `App::teardown` in order to run exit systems.