### PR TITLE
[Merged by Bors] - UI text layout example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1522,7 +1522,7 @@ path = "examples/ui/text_layout.rs"
 
 [package.metadata.example.text_layout]
 name = "Text Layout"
-description = "Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text"
+description = "Demonstrates the use of FlexWrap to arrange nodes into rows and how the AlignItems and JustifyContent properties can be composed to layout text"
 category = "UI (User Interface)"
 wasm = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1522,7 +1522,7 @@ path = "examples/ui/text_layout.rs"
 
 [package.metadata.example.text_layout]
 name = "Text Layout"
-description = "Demonstrates the use of FlexWrap to arrange nodes into rows and how the AlignItems and JustifyContent properties can be composed to layout text"
+description = "Demonstrates the arrangement of UI nodes into rows with FlexWrap and how the AlignItems and JustifyContent properties can be composed to layout text"
 category = "UI (User Interface)"
 wasm = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1522,7 +1522,7 @@ path = "examples/ui/text_layout.rs"
 
 [package.metadata.example.text_layout]
 name = "Text Layout"
-description = "Demonstrates how the AlignItems and JustifyContent settings can be composed to layout text"
+description = "Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text"
 category = "UI (User Interface)"
 wasm = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1517,6 +1517,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_layout"
+path = "examples/ui/text_layout.rs"
+
+[package.metadata.example.text_layout]
+name = "Text Layout"
+description = "Demonstrates how the AlignItems and JustifyContent settings can be composed to layout text"
+category = "UI (User Interface)"
+wasm = false
+
+
+[[example]]
 name = "transparency_ui"
 path = "examples/ui/transparency_ui.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1522,7 +1522,7 @@ path = "examples/ui/text_layout.rs"
 
 [package.metadata.example.text_layout]
 name = "Text Layout"
-description = "Demonstrates the arrangement of UI nodes into rows with FlexWrap and how the AlignItems and JustifyContent properties can be composed to layout text"
+description = "Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text"
 category = "UI (User Interface)"
 wasm = false
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,7 +317,7 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
-[Text Layout](../examples/ui/text_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text.
+[Text Layout](../examples/ui/text_layout.rs) | Demonstrates arranging nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,8 +317,8 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
-[Text Layout](../examples/ui/text_layout.rs) | Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
+[Text Layout](../examples/ui/text_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI
 [UI Scaling](../examples/ui/ui_scaling.rs) | Illustrates how to scale the UI

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,6 +317,7 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
+[Text Layout](../examples/ui/text_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text.
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,7 +317,7 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
-[Text Layout](../examples/ui/text_layout.rs) | Demonstrates the arrangement of UI nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
+[Text Layout](../examples/ui/text_layout.rs) | Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/README.md
+++ b/examples/README.md
@@ -317,7 +317,7 @@ Example | Description
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
-[Text Layout](../examples/ui/text_layout.rs) | Demonstrates arranging nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
+[Text Layout](../examples/ui/text_layout.rs) | Demonstrates the arrangement of UI nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,0 +1,111 @@
+//! Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text.
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                resolution: [1200., 1000.].into(),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }))
+        .add_startup_system(spawn_layout)
+        .run();
+}
+
+fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+    commands
+        // spawn the root panel
+        .spawn(NodeBundle {
+            style: Style {
+                // Fill the entire window
+                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                // Wrap the child nodes into rows
+                flex_wrap: FlexWrap::Wrap,
+                // Stack the wrapped child nodes downwards from the top, without spacing between the rows.
+                align_content: AlignContent::FlexStart,
+                ..Default::default()
+            },
+            background_color: BackgroundColor(Color::CYAN),
+            ..Default::default()
+        })
+        // spawn one child node for each combination of AlignItems and JustifyContent
+        .with_children(|builder| {
+            let alignments = [
+                AlignItems::Baseline,
+                AlignItems::Center,
+                AlignItems::FlexEnd,
+                AlignItems::FlexStart,
+                AlignItems::Stretch,
+            ];
+            let justifications = [
+                JustifyContent::Center,
+                JustifyContent::FlexEnd,
+                JustifyContent::FlexStart,
+                JustifyContent::SpaceAround,
+                JustifyContent::SpaceEvenly,
+                JustifyContent::SpaceBetween,
+            ];
+            for align_items in alignments.into_iter() {
+                for justify_content in justifications.into_iter() {
+                    spawn_child_node(builder, &asset_server, align_items, justify_content);
+                }
+            }
+        });
+}
+
+fn spawn_child_node(
+    parent: &mut ChildBuilder,
+    asset_server: &AssetServer,
+    align_items: AlignItems,
+    justify_content: JustifyContent,
+) {
+    parent
+        .spawn(NodeBundle {
+            style: Style {
+                flex_direction: FlexDirection::Column,
+                align_items,
+                justify_content,
+                size: Size::new(Val::Px(190.), Val::Px(190.)),
+                margin: UiRect::all(Val::Px(5.)),
+                padding: UiRect::all(Val::Px(3.)),
+                ..Default::default()
+            },
+            background_color: BackgroundColor(Color::BLACK),
+            ..Default::default()
+        })
+        .with_children(|builder| {
+            let labels = [
+                (format!("{:?}", align_items), Color::MAROON, Val::Px(0.)),
+                (
+                    format!("{:?}", justify_content),
+                    Color::DARK_GREEN,
+                    Val::Px(3.),
+                ),
+            ];
+            for (text, color, top_margin) in labels {
+                builder
+                    .spawn(NodeBundle {
+                        style: Style {
+                            margin: UiRect::top(top_margin),
+                            padding: UiRect::all(Val::Px(5.)),
+                            ..Default::default()
+                        },
+                        background_color: BackgroundColor(color),
+                        ..Default::default()
+                    })
+                    .with_children(|builder| {
+                        builder.spawn(TextBundle::from_section(
+                            text,
+                            TextStyle {
+                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                                font_size: 24.0,
+                                color: Color::ANTIQUE_WHITE,
+                            },
+                        ));
+                    });
+            }
+        });
+}

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,11 +1,16 @@
-//! Demonstrates the arrangement of UI nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
+//! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
+
+const ALIGN_ITEMS_COLOR: Color = Color::rgb(212. / 255., 17. / 255., 89. / 255.);
+const JUSTIFY_CONTENT_COLOR: Color = Color::rgb(26. / 255., 133. / 255., 255. / 255.);
+const MARGIN: Val = Val::Px(5.);
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                resolution: [1200., 1000.].into(),
+                resolution: [870., 1066.].into(),
+                title: "Bevy Text Layout Example".to_string(),
                 ..Default::default()
             }),
             ..Default::default()
@@ -15,94 +20,165 @@ fn main() {
 }
 
 fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
+    let font = asset_server.load("fonts/FiraSans-Bold.ttf");
     commands.spawn(Camera2dBundle::default());
     commands
-        // spawn the root panel
         .spawn(NodeBundle {
             style: Style {
-                // Fill the entire window
+                // fill the entire window
                 size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
-                // Wrap the child nodes into rows
-                flex_wrap: FlexWrap::Wrap,
-                // Stack the wrapped child nodes downwards from the top, without spacing between the rows.
-                align_content: AlignContent::FlexStart,
-                ..Default::default()
-            },
-            background_color: BackgroundColor(Color::CYAN),
-            ..Default::default()
-        })
-        // spawn one child node for each combination of `AlignItems` and `JustifyContent`
-        .with_children(|builder| {
-            let alignments = [
-                AlignItems::Baseline,
-                AlignItems::Center,
-                AlignItems::FlexEnd,
-                AlignItems::FlexStart,
-                AlignItems::Stretch,
-            ];
-            let justifications = [
-                JustifyContent::Center,
-                JustifyContent::FlexEnd,
-                JustifyContent::FlexStart,
-                JustifyContent::SpaceAround,
-                JustifyContent::SpaceEvenly,
-                JustifyContent::SpaceBetween,
-            ];
-            for align_items in alignments.into_iter() {
-                for justify_content in justifications.into_iter() {
-                    spawn_child_node(builder, &asset_server, align_items, justify_content);
-                }
-            }
-        });
-}
-
-fn spawn_child_node(
-    parent: &mut ChildBuilder,
-    asset_server: &AssetServer,
-    align_items: AlignItems,
-    justify_content: JustifyContent,
-) {
-    parent
-        .spawn(NodeBundle {
-            style: Style {
                 flex_direction: FlexDirection::Column,
-                align_items,
-                justify_content,
-                size: Size::new(Val::Px(190.), Val::Px(190.)),
-                margin: UiRect::all(Val::Px(5.)),
-                padding: UiRect::all(Val::Px(3.)),
+                align_items: AlignItems::Center,
                 ..Default::default()
             },
             background_color: BackgroundColor(Color::BLACK),
             ..Default::default()
         })
         .with_children(|builder| {
+            // spawn the key
+            builder
+                .spawn(NodeBundle {
+                    style: Style {
+                        flex_direction: FlexDirection::Row,
+                        margin: UiRect::top(MARGIN),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .with_children(|builder| {
+                    spawn_nested_text_bundle(
+                        builder,
+                        font.clone(),
+                        ALIGN_ITEMS_COLOR,
+                        UiRect::right(MARGIN),
+                        "AlignItems",
+                    );
+                    spawn_nested_text_bundle(
+                        builder,
+                        font.clone(),
+                        JUSTIFY_CONTENT_COLOR,
+                        UiRect::default(),
+                        "JustifyContent",
+                    );
+                });
+
+            builder
+                .spawn(NodeBundle {
+                    style: Style {
+                        min_size: Size::new(Val::Px(850.), Val::Px(1020.)),
+                        flex_direction: FlexDirection::Column,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .with_children(|builder| {
+                    // spawn one child node for each combination of `AlignItems` and `JustifyContent`
+                    let justifications = [
+                        JustifyContent::FlexStart,
+                        JustifyContent::Center,
+                        JustifyContent::FlexEnd,
+                        JustifyContent::SpaceAround,
+                        JustifyContent::SpaceEvenly,
+                        JustifyContent::SpaceBetween,
+                    ];
+                    let alignments = [
+                        AlignItems::Baseline,
+                        AlignItems::FlexStart,
+                        AlignItems::Center,
+                        AlignItems::FlexEnd,
+                        AlignItems::Stretch,
+                    ];
+                    for justify_content in justifications {
+                        builder
+                            .spawn(NodeBundle {
+                                style: Style {
+                                    flex_direction: FlexDirection::Row,
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            })
+                            .with_children(|builder| {
+                                for align_items in alignments {
+                                    spawn_child_node(
+                                        builder,
+                                        font.clone(),
+                                        align_items,
+                                        justify_content,
+                                    );
+                                }
+                            });
+                    }
+                });
+        });
+}
+
+fn spawn_child_node(
+    builder: &mut ChildBuilder,
+    font: Handle<Font>,
+    align_items: AlignItems,
+    justify_content: JustifyContent,
+) {
+    builder
+        .spawn(NodeBundle {
+            style: Style {
+                flex_direction: FlexDirection::Column,
+                align_items,
+                justify_content,
+                size: Size::new(Val::Px(160.), Val::Px(160.)),
+                margin: UiRect::all(MARGIN),
+                ..Default::default()
+            },
+            background_color: BackgroundColor(Color::DARK_GRAY),
+            ..Default::default()
+        })
+        .with_children(|builder| {
             let labels = [
-                (format!("{:?}", align_items), Color::MAROON, 0.),
-                (format!("{:?}", justify_content), Color::DARK_GREEN, 3.),
+                (format!("{:?}", align_items), ALIGN_ITEMS_COLOR, 0.),
+                (format!("{:?}", justify_content), JUSTIFY_CONTENT_COLOR, 3.),
             ];
             for (text, color, top_margin) in labels {
                 // We nest the text within a parent node because margins and padding can't be directly applied to text nodes currently.
-                builder
-                    .spawn(NodeBundle {
-                        style: Style {
-                            margin: UiRect::top(Val::Px(top_margin)),
-                            padding: UiRect::all(Val::Px(5.)),
-                            ..Default::default()
-                        },
-                        background_color: BackgroundColor(color),
-                        ..Default::default()
-                    })
-                    .with_children(|builder| {
-                        builder.spawn(TextBundle::from_section(
-                            text,
-                            TextStyle {
-                                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 24.0,
-                                color: Color::ANTIQUE_WHITE,
-                            },
-                        ));
-                    });
+                spawn_nested_text_bundle(
+                    builder,
+                    font.clone(),
+                    color,
+                    UiRect::top(Val::Px(top_margin)),
+                    &text,
+                );
             }
+        });
+}
+
+fn spawn_nested_text_bundle(
+    builder: &mut ChildBuilder,
+    font: Handle<Font>,
+    background_color: Color,
+    margin: UiRect,
+    text: &str,
+) {
+    builder
+        .spawn(NodeBundle {
+            style: Style {
+                margin,
+                padding: UiRect {
+                    top: Val::Px(1.),
+                    left: Val::Px(5.),
+                    right: Val::Px(5.),
+                    bottom: Val::Px(1.),
+                },
+                ..Default::default()
+            },
+            background_color: BackgroundColor(background_color),
+            ..Default::default()
+        })
+        .with_children(|builder| {
+            builder.spawn(TextBundle::from_section(
+                text,
+                TextStyle {
+                    font,
+                    font_size: 24.0,
+                    color: Color::BLACK,
+                },
+            ));
         });
 }

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -133,8 +133,8 @@ fn spawn_child_node(
         })
         .with_children(|builder| {
             let labels = [
-                (format!("{:?}", align_items), ALIGN_ITEMS_COLOR, 0.),
-                (format!("{:?}", justify_content), JUSTIFY_CONTENT_COLOR, 3.),
+                (format!("{align_items:?}"), ALIGN_ITEMS_COLOR, 0.),
+                (format!("{justify_content:?}"), JUSTIFY_CONTENT_COLOR, 3.),
             ];
             for (text, color, top_margin) in labels {
                 // We nest the text within a parent node because margins and padding can't be directly applied to text nodes currently.

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,8 +1,8 @@
 //! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
 
-const ALIGN_ITEMS_COLOR: Color = Color::rgb(212. / 255., 17. / 255., 89. / 255.);
-const JUSTIFY_CONTENT_COLOR: Color = Color::rgb(26. / 255., 133. / 255., 255. / 255.);
+const ALIGN_ITEMS_COLOR: Color = Color::rgb(1., 0.066, 0.349);
+const JUSTIFY_CONTENT_COLOR: Color = Color::rgb(0.102, 0.522, 1.);
 const MARGIN: Val = Val::Px(5.);
 
 fn main() {

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how the AlignItems and JustifyContent properties can be composed to layout text.
+//! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
 
 fn main() {
@@ -31,7 +31,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
             background_color: BackgroundColor(Color::CYAN),
             ..Default::default()
         })
-        // spawn one child node for each combination of AlignItems and JustifyContent
+        // spawn one child node for each combination of `AlignItems` and `JustifyContent`
         .with_children(|builder| {
             let alignments = [
                 AlignItems::Baseline,

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -78,18 +78,15 @@ fn spawn_child_node(
         })
         .with_children(|builder| {
             let labels = [
-                (format!("{:?}", align_items), Color::MAROON, Val::Px(0.)),
-                (
-                    format!("{:?}", justify_content),
-                    Color::DARK_GREEN,
-                    Val::Px(3.),
-                ),
+                (format!("{:?}", align_items), Color::MAROON, 0.),
+                (format!("{:?}", justify_content), Color::DARK_GREEN, 3.),
             ];
             for (text, color, top_margin) in labels {
+                // We nest the text within a parent node because margins and padding can't be directly applied to text nodes currently.
                 builder
                     .spawn(NodeBundle {
                         style: Style {
-                            margin: UiRect::top(top_margin),
+                            margin: UiRect::top(Val::Px(top_margin)),
                             padding: UiRect::all(Val::Px(5.)),
                             ..Default::default()
                         },

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
+//! Demonstrates arranging nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
 
 fn main() {

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -77,8 +77,8 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         JustifyContent::FlexStart,
                         JustifyContent::Center,
                         JustifyContent::FlexEnd,
-                        JustifyContent::SpaceAround,
                         JustifyContent::SpaceEvenly,
+                        JustifyContent::SpaceAround,
                         JustifyContent::SpaceBetween,
                     ];
                     let alignments = [

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -1,4 +1,4 @@
-//! Demonstrates arranging nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
+//! Demonstrates the arrangement of UI nodes into rows with `FlexWrap` and how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
 use bevy::prelude::*;
 
 fn main() {


### PR DESCRIPTION
## Objective

An example that demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.

<img width="654" alt="text_layout_example" src="https://user-images.githubusercontent.com/27962798/215116345-daa8ef60-634b-40c6-9b6d-356de3af620c.png">


