### PR TITLE
[Merged by Bors] - Fix a few uninlined_format_args lints

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -280,13 +280,11 @@ impl CascadeShadowConfig {
     ) -> Self {
         assert!(
             num_cascades > 0,
-            "num_cascades must be positive, but was {}",
-            num_cascades
+            "num_cascades must be positive, but was {num_cascades}",
         );
         assert!(
             (0.0..1.0).contains(&overlap_proportion),
-            "overlap_proportion must be in [0.0, 1.0) but was {}",
-            overlap_proportion
+            "overlap_proportion must be in [0.0, 1.0) but was {overlap_proportion}",
         );
         Self {
             bounds: calculate_cascade_bounds(num_cascades, nearest_bound, shadow_maximum_distance),
@@ -397,8 +395,8 @@ fn calculate_cascade(
     z_near: f32,
     z_far: f32,
 ) -> Cascade {
-    debug_assert!(z_near <= 0.0, "z_near {} must be <= 0.0", z_near);
-    debug_assert!(z_far <= 0.0, "z_far {} must be <= 0.0", z_far);
+    debug_assert!(z_near <= 0.0, "z_near {z_near} must be <= 0.0");
+    debug_assert!(z_far <= 0.0, "z_far {z_far} must be <= 0.0");
     // NOTE: This whole function is very sensitive to floating point precision and instability and
     // has followed instructions to avoid view dependence from the section on cascade shadow maps in
     // Eric Lengyel's Foundations of Game Engine Development 2: Rendering. Be very careful when

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -55,7 +55,7 @@ fn setup(
     let textures: Vec<_> = TILE_ID
         .iter()
         .map(|id| {
-            let path = format!("textures/rpg/tiles/generic-rpg-tile{:0>2}.png", id);
+            let path = format!("textures/rpg/tiles/generic-rpg-tile{id:0>2}.png");
             asset_server.load(path)
         })
         .collect();


### PR DESCRIPTION
# Objective

Prevent things from breaking tomorrow when rust 1.67 is released.

## Solution

Fix a few `uninlined_format_args` lints in recently introduced code.