### PR TITLE
[Merged by Bors] - Bump MSRV to 1.67

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
-rust-version = "1.66.0"
+rust-version = "1.67.0"
 
 [workspace]
 exclude = ["benches", "crates/bevy_ecs_compile_fail_tests", "crates/bevy_reflect_compile_fail_tests"]


### PR DESCRIPTION
# Objective
Bump the MSRV to 1.67. Enable cleanup PRs like #7346 to work.

## Solution
Bump it to 1.67

---

## Changelog
Changed: The MSRV of the engine is now 1.67.
