### PR TITLE
make shaders work when MAX_CASCADES_PER_LIGHT is undefined

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -35,7 +35,9 @@ struct DirectionalCascade {
 }
     
 struct DirectionalLight {
+#ifdef MAX_CASCADES_PER_LIGHT
     cascades: array<DirectionalCascade, #{MAX_CASCADES_PER_LIGHT}>,
+#endif
     color: vec4<f32>,
     direction_to_light: vec3<f32>,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.


### PR DESCRIPTION
# Objective

The `post_processing` and `shader_prepass` examples are both currently broken on main. This, combined with https://github.com/bevyengine/bevy/pull/6997 fixes them.

## Solution

The same fix as https://github.com/bevyengine/bevy/pull/6997, just wrap the line in an #ifdef so it doesn't cause issues.