### PR TITLE
[Merged by Bors] - Move all logic to `UnsafeWorldCell`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -446,6 +446,7 @@ unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let (ptr, ticks) = world
+            .as_unsafe_world_cell_migration_internal()
             .get_resource_with_ticks(component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -486,6 +487,7 @@ unsafe impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
+            .as_unsafe_world_cell_migration_internal()
             .get_resource_with_ticks(component_id)
             .map(|(ptr, ticks)| Res {
                 value: ptr.deref(),
@@ -540,7 +542,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
     ) -> Self::Item<'w, 's> {
         let value = world
             .as_unsafe_world_cell_migration_internal()
-            .get_resource_mut_with_id(component_id)
+            .get_resource_mut_by_id(component_id)
             .unwrap_or_else(|| {
                 panic!(
                     "Resource requested by {} does not exist: {}",
@@ -549,7 +551,7 @@ unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
                 )
             });
         ResMut {
-            value: value.value,
+            value: value.value.deref_mut::<T>(),
             ticks: TicksMut {
                 added: value.ticks.added,
                 changed: value.ticks.changed,
@@ -578,9 +580,9 @@ unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
     ) -> Self::Item<'w, 's> {
         world
             .as_unsafe_world_cell_migration_internal()
-            .get_resource_mut_with_id(component_id)
+            .get_resource_mut_by_id(component_id)
             .map(|value| ResMut {
-                value: value.value,
+                value: value.value.deref_mut::<T>(),
                 ticks: TicksMut {
                     added: value.ticks.added,
                     changed: value.ticks.changed,
@@ -889,6 +891,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let (ptr, ticks) = world
+            .as_unsafe_world_cell_migration_internal()
             .get_non_send_with_ticks(component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -927,6 +930,7 @@ unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
+            .as_unsafe_world_cell_migration_internal()
             .get_non_send_with_ticks(component_id)
             .map(|(ptr, ticks)| NonSend {
                 value: ptr.deref(),
@@ -979,6 +983,7 @@ unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         let (ptr, ticks) = world
+            .as_unsafe_world_cell_migration_internal()
             .get_non_send_with_ticks(component_id)
             .unwrap_or_else(|| {
                 panic!(
@@ -1011,6 +1016,7 @@ unsafe impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
         change_tick: u32,
     ) -> Self::Item<'w, 's> {
         world
+            .as_unsafe_world_cell_migration_internal()
             .get_non_send_with_ticks(component_id)
             .map(|(ptr, ticks)| NonSendMut {
                 value: ptr.assert_unique().deref_mut(),

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1,10 +1,8 @@
 use crate::{
     archetype::{Archetype, ArchetypeId, Archetypes},
     bundle::{Bundle, BundleInfo},
-    change_detection::{MutUntyped, TicksMut},
-    component::{
-        Component, ComponentId, ComponentStorage, ComponentTicks, Components, StorageType,
-    },
+    change_detection::MutUntyped,
+    component::{Component, ComponentId, ComponentTicks, Components, StorageType},
     entity::{Entities, Entity, EntityLocation},
     removal_detection::RemovedComponentEvents,
     storage::Storages,
@@ -79,12 +77,14 @@ impl<'w> EntityRef<'w> {
 
     #[inline]
     pub fn contains_id(&self, component_id: ComponentId) -> bool {
-        contains_component_with_id(self.world, component_id, self.location)
+        self.as_unsafe_world_cell_readonly()
+            .contains_id(component_id)
     }
 
     #[inline]
     pub fn contains_type_id(&self, type_id: TypeId) -> bool {
-        contains_component_with_type(self.world, type_id, self.location)
+        self.as_unsafe_world_cell_readonly()
+            .contains_type_id(type_id)
     }
 
     #[inline]
@@ -209,12 +209,14 @@ impl<'w> EntityMut<'w> {
 
     #[inline]
     pub fn contains_id(&self, component_id: ComponentId) -> bool {
-        contains_component_with_id(self.world, component_id, self.location)
+        self.as_unsafe_world_cell_readonly()
+            .contains_id(component_id)
     }
 
     #[inline]
     pub fn contains_type_id(&self, type_id: TypeId) -> bool {
-        contains_component_with_type(self.world, type_id, self.location)
+        self.as_unsafe_world_cell_readonly()
+            .contains_type_id(type_id)
     }
 
     #[inline]
@@ -600,19 +602,10 @@ impl<'w> EntityMut<'w> {
     /// which is only valid while the [`EntityMut`] is alive.
     #[inline]
     pub fn get_by_id(&self, component_id: ComponentId) -> Option<Ptr<'_>> {
-        let info = self.world.components().get_info(component_id)?;
         // SAFETY:
-        // - entity_location is valid
-        // - component_id is valid as checked by the line above
-        // - the storage type is accurate as checked by the fetched ComponentInfo
-        unsafe {
-            self.world.get_component(
-                component_id,
-                info.storage_type(),
-                self.entity,
-                self.location,
-            )
-        }
+        // - `&self` ensures that no mutable references exist to this entity's components.
+        // - `as_unsafe_world_cell_readonly` gives read only permission for all components on this entity
+        unsafe { self.as_unsafe_world_cell_readonly().get_by_id(component_id) }
     }
 
     /// Gets a [`MutUntyped`] of the component of the given [`ComponentId`] from the entity.
@@ -625,30 +618,11 @@ impl<'w> EntityMut<'w> {
     /// which is only valid while the [`EntityMut`] is alive.
     #[inline]
     pub fn get_mut_by_id(&mut self, component_id: ComponentId) -> Option<MutUntyped<'_>> {
-        self.world.components().get_info(component_id)?;
-        // SAFETY: entity_location is valid, component_id is valid as checked by the line above
-        unsafe { get_mut_by_id(self.world, self.entity, self.location, component_id) }
+        // SAFETY:
+        // - `&mut self` ensures that no references exist to this entity's components.
+        // - `as_unsafe_world_cell` gives mutable permission for all components on this entity
+        unsafe { self.as_unsafe_world_cell().get_mut_by_id(component_id) }
     }
-}
-
-pub(crate) fn contains_component_with_type(
-    world: &World,
-    type_id: TypeId,
-    location: EntityLocation,
-) -> bool {
-    if let Some(component_id) = world.components.get_id(type_id) {
-        contains_component_with_id(world, component_id, location)
-    } else {
-        false
-    }
-}
-
-pub(crate) fn contains_component_with_id(
-    world: &World,
-    component_id: ComponentId,
-    location: EntityLocation,
-) -> bool {
-    world.archetypes[location.archetype_id].contains(component_id)
 }
 
 /// Removes a bundle from the given archetype and returns the resulting archetype (or None if the
@@ -766,59 +740,6 @@ fn sorted_remove<T: Eq + Ord + Copy>(source: &mut Vec<T>, remove: &[T]) {
             true
         }
     });
-}
-
-// SAFETY: EntityLocation must be valid
-#[inline]
-pub(crate) unsafe fn get_mut<T: Component>(
-    world: &mut World,
-    entity: Entity,
-    location: EntityLocation,
-) -> Option<Mut<'_, T>> {
-    let change_tick = world.change_tick();
-    let last_change_tick = world.last_change_tick();
-    // SAFETY:
-    // - world access is unique
-    // - entity location is valid
-    // - returned component is of type T
-    world
-        .get_component_and_ticks_with_type(
-            TypeId::of::<T>(),
-            T::Storage::STORAGE_TYPE,
-            entity,
-            location,
-        )
-        .map(|(value, ticks)| Mut {
-            // SAFETY:
-            // - world access is unique and ties world lifetime to `Mut` lifetime
-            // - `value` is of type `T`
-            value: value.assert_unique().deref_mut::<T>(),
-            ticks: TicksMut::from_tick_cells(ticks, last_change_tick, change_tick),
-        })
-}
-
-// SAFETY: EntityLocation must be valid, component_id must be valid
-#[inline]
-pub(crate) unsafe fn get_mut_by_id(
-    world: &mut World,
-    entity: Entity,
-    location: EntityLocation,
-    component_id: ComponentId,
-) -> Option<MutUntyped<'_>> {
-    let change_tick = world.change_tick();
-    // SAFETY: component_id is valid
-    let info = world.components.get_info_unchecked(component_id);
-    // SAFETY:
-    // - world access is unique
-    // - entity location is valid
-    // - returned component is of type T
-    world
-        .get_component_and_ticks(component_id, info.storage_type(), entity, location)
-        .map(|(value, ticks)| MutUntyped {
-            // SAFETY: world access is unique and ties world lifetime to `MutUntyped` lifetime
-            value: value.assert_unique(),
-            ticks: TicksMut::from_tick_cells(ticks, world.last_change_tick(), change_tick),
-        })
 }
 
 /// Moves component data out of storage.

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -156,7 +156,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn entities(self) -> &'w Entities {
         // SAFETY:
         // - we only access world metadata
-        &unsafe { self.unsafe_world() }.entities
+        &unsafe { self.world_metadata() }.entities
     }
 
     /// Retrieves this world's [Archetypes] collection
@@ -164,7 +164,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn archetypes(self) -> &'w Archetypes {
         // SAFETY:
         // - we only access world metadata
-        &unsafe { self.unsafe_world() }.archetypes
+        &unsafe { self.world_metadata() }.archetypes
     }
 
     /// Retrieves this world's [Components] collection
@@ -172,7 +172,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn components(self) -> &'w Components {
         // SAFETY:
         // - we only access world metadata
-        &unsafe { self.unsafe_world() }.components
+        &unsafe { self.world_metadata() }.components
     }
 
     /// Retrieves this world's [Bundles] collection
@@ -180,7 +180,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn bundles(self) -> &'w Bundles {
         // SAFETY:
         // - we only access world metadata
-        &unsafe { self.unsafe_world() }.bundles
+        &unsafe { self.world_metadata() }.bundles
     }
 
     /// Reads the current change tick of this world.
@@ -188,7 +188,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn read_change_tick(self) -> u32 {
         // SAFETY:
         // - we only access world metadata
-        unsafe { self.unsafe_world() }
+        unsafe { self.world_metadata() }
             .change_tick
             .load(Ordering::Acquire)
     }
@@ -197,14 +197,14 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn last_change_tick(self) -> u32 {
         // SAFETY:
         // - we only access world metadata
-        unsafe { self.unsafe_world() }.last_change_tick
+        unsafe { self.world_metadata() }.last_change_tick
     }
 
     #[inline]
     pub fn increment_change_tick(self) -> u32 {
         // SAFETY:
         // - we only access world metadata
-        unsafe { self.unsafe_world() }
+        unsafe { self.world_metadata() }
             .change_tick
             .fetch_add(1, Ordering::AcqRel)
     }
@@ -217,7 +217,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<ArchetypeComponentId> {
         // SAFETY:
         // - we only access world metadata
-        let resource = unsafe { self.unsafe_world() }
+        let resource = unsafe { self.world_metadata() }
             .storages
             .resources
             .get(component_id)?;
@@ -232,7 +232,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<ArchetypeComponentId> {
         // SAFETY:
         // - we only access world metadata
-        let resource = unsafe { self.unsafe_world() }
+        let resource = unsafe { self.world_metadata() }
             .storages
             .non_send_resources
             .get(component_id)?;

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -1,18 +1,20 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
-use super::{entity_ref, Mut, World};
+use super::{Mut, World};
 use crate::{
-    archetype::{Archetype, Archetypes},
+    archetype::{Archetype, ArchetypeComponentId, Archetypes},
     bundle::Bundles,
     change_detection::{MutUntyped, TicksMut},
-    component::{ComponentId, ComponentStorage, ComponentTicks, Components},
+    component::{
+        ComponentId, ComponentStorage, ComponentTicks, Components, StorageType, TickCells,
+    },
     entity::{Entities, Entity, EntityLocation},
     prelude::Component,
-    storage::Storages,
+    storage::{Column, ComponentSparseSet, TableRow},
     system::Resource,
 };
 use bevy_ptr::Ptr;
-use std::any::TypeId;
+use std::{any::TypeId, cell::UnsafeCell, marker::PhantomData, sync::atomic::Ordering};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -70,75 +72,177 @@ use std::any::TypeId;
 /// }
 /// ```
 #[derive(Copy, Clone)]
-pub struct UnsafeWorldCell<'w>(&'w World);
+pub struct UnsafeWorldCell<'w>(*mut World, PhantomData<(&'w World, &'w UnsafeCell<World>)>);
+
+// SAFETY: `&World` and `&mut World` are both `Send`
+unsafe impl Send for UnsafeWorldCell<'_> {}
+// SAFETY: `&World` and `&mut World` are both `Sync`
+unsafe impl Sync for UnsafeWorldCell<'_> {}
 
 impl<'w> UnsafeWorldCell<'w> {
-    pub(crate) fn new(world: &'w World) -> Self {
-        UnsafeWorldCell(world)
+    /// Creates a [`UnsafeWorldCell`] that can be used to access everything immutably
+    pub(crate) fn new_readonly(world: &'w World) -> Self {
+        UnsafeWorldCell(world as *const World as *mut World, PhantomData)
+    }
+
+    /// Creates [`UnsafeWorldCell`] that can be used to access everything mutably
+    pub(crate) fn new_mutable(world: &'w mut World) -> Self {
+        Self(world as *mut World, PhantomData)
+    }
+
+    /// This `&mut World` counts as a mutable borrow of every resource and component for the purposes
+    /// of safety invariants that talk about borrows on component/resource data not existing. This is
+    /// true even for methods that do not explicitly call out `&mut World` as problematic.
+    ///
+    /// # Safety
+    /// - must have permission to access everything mutably
+    /// - there must be no other borrows on world
+    /// - returned borrow must not be used in any way if the world is accessed
+    ///   through other means than the `&mut World` after this call.
+    pub unsafe fn world_mut(self) -> &'w mut World {
+        // SAFETY:
+        // - caller ensures the created `&mut World` is the only borrow of world
+        unsafe { &mut *self.0 }
     }
 
     /// Gets a reference to the [`&World`](crate::world::World) this [`UnsafeWorldCell`] belongs to.
-    /// This can be used to call methods like [`World::contains_resource`] which aren't exposed and but don't perform any accesses.
-    ///
-    /// **Note**: You *must not* hand out a `&World` reference to arbitrary safe code when the [`UnsafeWorldCell`] is currently
-    /// being used for mutable accesses.
+    /// This can be used for arbitrary shared/readonly access.
     ///
     /// # Safety
-    /// - the world must not be used to access any resources or components. You can use it to safely access metadata.
+    /// - must have permission to access the whole world immutably
+    /// - there must be no live exclusive borrows on world data
+    /// - there must be no live exclusive borrow of world
     pub unsafe fn world(self) -> &'w World {
-        self.0
+        // SAFETY:
+        // - caller ensures there is no `&mut World` this makes it okay to make a `&World`
+        // - caller ensures there is no mutable borrows of world data, this means the caller cannot
+        //   misuse the returned `&World`
+        unsafe { &*self.0 }
+    }
+
+    /// Gets a reference to the [`World`] this [`UnsafeWorldCell`] belong to.
+    /// This can be used for arbitrary read only access of world metadata
+    ///
+    /// You should attempt to use various safe methods on [`UnsafeWorldCell`] for
+    /// metadata access before using this method.
+    ///
+    /// # Safety
+    /// - must only be used to access world metadata
+    pub unsafe fn world_metadata(self) -> &'w World {
+        // SAFETY: caller ensures that returned reference is not used to violate aliasing rules
+        unsafe { self.unsafe_world() }
+    }
+
+    /// Variant on [`UnsafeWorldCell::world`] solely used for implementing this type's methods.
+    /// It allows having an `&World` even with live mutable borrows of components and resources
+    /// so the returned `&World` should not be handed out to safe code and care should be taken
+    /// when working with it.
+    ///
+    /// Deliberately private as the correct way to access data in a [`World`] that may have existing
+    /// mutable borrows of data inside it, is to use [`UnsafeWorldCell`].
+    ///
+    /// # Safety
+    /// - must not be used in a way that would conflict with any
+    ///   live exclusive borrows on world data
+    unsafe fn unsafe_world(self) -> &'w World {
+        // SAFETY:
+        // - caller ensures that the returned `&World` is not used in a way that would conflict
+        //   with any existing mutable borrows of world data
+        unsafe { &*self.0 }
     }
 
     /// Retrieves this world's [Entities] collection
     #[inline]
     pub fn entities(self) -> &'w Entities {
-        &self.0.entities
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.unsafe_world() }.entities
     }
 
     /// Retrieves this world's [Archetypes] collection
     #[inline]
     pub fn archetypes(self) -> &'w Archetypes {
-        &self.0.archetypes
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.unsafe_world() }.archetypes
     }
 
     /// Retrieves this world's [Components] collection
     #[inline]
     pub fn components(self) -> &'w Components {
-        &self.0.components
-    }
-
-    /// Retrieves this world's [Storages] collection
-    #[inline]
-    pub fn storages(self) -> &'w Storages {
-        &self.0.storages
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.unsafe_world() }.components
     }
 
     /// Retrieves this world's [Bundles] collection
     #[inline]
     pub fn bundles(self) -> &'w Bundles {
-        &self.0.bundles
+        // SAFETY:
+        // - we only access world metadata
+        &unsafe { self.unsafe_world() }.bundles
     }
 
     /// Reads the current change tick of this world.
     #[inline]
     pub fn read_change_tick(self) -> u32 {
-        self.0.read_change_tick()
+        // SAFETY:
+        // - we only access world metadata
+        unsafe { self.unsafe_world() }
+            .change_tick
+            .load(Ordering::Acquire)
     }
 
     #[inline]
     pub fn last_change_tick(self) -> u32 {
-        self.0.last_change_tick()
+        // SAFETY:
+        // - we only access world metadata
+        unsafe { self.unsafe_world() }.last_change_tick
     }
 
     #[inline]
     pub fn increment_change_tick(self) -> u32 {
-        self.0.increment_change_tick()
+        // SAFETY:
+        // - we only access world metadata
+        unsafe { self.unsafe_world() }
+            .change_tick
+            .fetch_add(1, Ordering::AcqRel)
+    }
+
+    /// Shorthand helper function for getting the [`ArchetypeComponentId`] for a resource.
+    #[inline]
+    pub(crate) fn get_resource_archetype_component_id(
+        self,
+        component_id: ComponentId,
+    ) -> Option<ArchetypeComponentId> {
+        // SAFETY:
+        // - we only access world metadata
+        let resource = unsafe { self.unsafe_world() }
+            .storages
+            .resources
+            .get(component_id)?;
+        Some(resource.id())
+    }
+
+    /// Shorthand helper function for getting the [`ArchetypeComponentId`] for a resource.
+    #[inline]
+    pub(crate) fn get_non_send_archetype_component_id(
+        self,
+        component_id: ComponentId,
+    ) -> Option<ArchetypeComponentId> {
+        // SAFETY:
+        // - we only access world metadata
+        let resource = unsafe { self.unsafe_world() }
+            .storages
+            .non_send_resources
+            .get(component_id)?;
+        Some(resource.id())
     }
 
     /// Retrieves an [`UnsafeWorldCellEntityRef`] that exposes read and write operations for the given `entity`.
     /// Similar to the [`UnsafeWorldCell`], you are in charge of making sure that no aliasing rules are violated.
     pub fn get_entity(self, entity: Entity) -> Option<UnsafeWorldCellEntityRef<'w>> {
-        let location = self.0.entities.get(entity)?;
+        let location = self.entities().get(entity)?;
         Some(UnsafeWorldCellEntityRef::new(self, entity, location))
     }
 
@@ -150,7 +254,14 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_resource<R: Resource>(self) -> Option<&'w R> {
-        self.0.get_resource::<R>()
+        let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
+        // SAFETY: caller ensures `self` has permission to access the resource
+        //  caller also ensure that no mutable reference to the resource exists
+        unsafe {
+            self.get_resource_by_id(component_id)
+                // SAFETY: `component_id` was obtained from the type ID of `R`.
+                .map(|ptr| ptr.deref::<R>())
+        }
     }
 
     /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
@@ -166,7 +277,13 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
-        self.0.get_resource_by_id(component_id)
+        // SAFETY: caller ensures that `self` has permission to access `R`
+        //  caller ensures that no mutable reference exists to `R`
+        unsafe { self.unsafe_world() }
+            .storages
+            .resources
+            .get(component_id)?
+            .get_data()
     }
 
     /// Gets a reference to the non-send resource of the given type if it exists
@@ -177,7 +294,14 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_non_send_resource<R: 'static>(self) -> Option<&'w R> {
-        self.0.get_non_send_resource()
+        let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
+        // SAFETY: caller ensures that `self` has permission to access `R`
+        //  caller ensures that no mutable reference exists to `R`
+        unsafe {
+            self.get_non_send_resource_by_id(component_id)
+                // SAEFTY: `component_id` was obtained from `TypeId::of::<R>()`
+                .map(|ptr| ptr.deref::<R>())
+        }
     }
 
     /// Gets a `!Send` resource to the resource with the id [`ComponentId`] if it exists.
@@ -196,7 +320,9 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no mutable reference to the resource exists at the same time
     #[inline]
     pub unsafe fn get_non_send_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
-        self.0
+        // SAFETY: we only access data on world that the caller has ensured is unaliased and we have
+        //  permission to access.
+        unsafe { self.unsafe_world() }
             .storages
             .non_send_resources
             .get(component_id)?
@@ -211,12 +337,15 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no other references to the resource exist at the same time
     #[inline]
     pub unsafe fn get_resource_mut<R: Resource>(self) -> Option<Mut<'w, R>> {
-        let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
+        let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
         // SAFETY:
-        // - component_id is of type `R`
-        // - caller ensures aliasing rules
-        // - `R` is Send + Sync
-        unsafe { self.get_resource_mut_with_id(component_id) }
+        // - caller ensures `self` has permission to access the resource mutably
+        // - caller ensures no other references to the resource exist
+        unsafe {
+            self.get_resource_mut_by_id(component_id)
+                // `component_id` was gotten from `TypeId::of::<R>()`
+                .map(|ptr| ptr.with_type::<R>())
+        }
     }
 
     /// Gets a pointer to the resource with the id [`ComponentId`] if it exists.
@@ -232,10 +361,16 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no other references to the resource exist at the same time
     #[inline]
     pub unsafe fn get_resource_mut_by_id(
-        &self,
+        self,
         component_id: ComponentId,
     ) -> Option<MutUntyped<'w>> {
-        let (ptr, ticks) = self.0.get_resource_with_ticks(component_id)?;
+        // SAFETY: we only access data that the caller has ensured is unaliased and `self`
+        //  has permission to access.
+        let (ptr, ticks) = unsafe { self.unsafe_world() }
+            .storages
+            .resources
+            .get(component_id)?
+            .get_with_ticks()?;
 
         // SAFETY:
         // - index is in-bounds because the column is initialized and non-empty
@@ -259,9 +394,15 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no other references to the resource exist at the same time
     #[inline]
     pub unsafe fn get_non_send_resource_mut<R: 'static>(self) -> Option<Mut<'w, R>> {
-        let component_id = self.0.components.get_resource_id(TypeId::of::<R>())?;
-        // SAFETY: component_id matches `R`, rest is promised by caller
-        unsafe { self.get_non_send_mut_with_id(component_id) }
+        let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
+        // SAFETY:
+        // - caller ensures that `self` has permission to access the resource
+        // - caller ensures that the resource is unaliased
+        unsafe {
+            self.get_non_send_resource_mut_by_id(component_id)
+                // SAFETY: `component_id` was gotten by `TypeId::of::<R>()`
+                .map(|ptr| ptr.with_type::<R>())
+        }
     }
 
     /// Gets a `!Send` resource to the resource with the id [`ComponentId`] if it exists.
@@ -280,11 +421,17 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - no other references to the resource exist at the same time
     #[inline]
     pub unsafe fn get_non_send_resource_mut_by_id(
-        &mut self,
+        self,
         component_id: ComponentId,
-    ) -> Option<MutUntyped<'_>> {
+    ) -> Option<MutUntyped<'w>> {
         let change_tick = self.read_change_tick();
-        let (ptr, ticks) = self.0.get_non_send_with_ticks(component_id)?;
+        // SAFETY: we only access data that the caller has ensured is unaliased and `self`
+        //  has permission to access.
+        let (ptr, ticks) = unsafe { self.unsafe_world() }
+            .storages
+            .non_send_resources
+            .get(component_id)?
+            .get_with_ticks()?;
 
         let ticks =
             // SAFETY: This function has exclusive access to the world so nothing aliases `ticks`.
@@ -298,59 +445,52 @@ impl<'w> UnsafeWorldCell<'w> {
             ticks,
         })
     }
-}
 
-impl<'w> UnsafeWorldCell<'w> {
+    // Shorthand helper function for getting the data and change ticks for a resource.
+    ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - `component_id` must be assigned to a component of type `R`
-    /// - the [`UnsafeWorldCell`] has permission to access the resource
-    /// - no other mutable references to the resource exist at the same time
+    /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
+    /// - no mutable references to the resource exist at the same time
     #[inline]
-    pub(crate) unsafe fn get_resource_mut_with_id<R>(
-        &self,
+    pub(crate) unsafe fn get_resource_with_ticks(
+        self,
         component_id: ComponentId,
-    ) -> Option<Mut<'w, R>> {
-        let (ptr, ticks) = self.0.get_resource_with_ticks(component_id)?;
-
+    ) -> Option<(Ptr<'w>, TickCells<'w>)> {
         // SAFETY:
-        // - This caller ensures that nothing aliases `ticks`.
-        // - index is in-bounds because the column is initialized and non-empty
-        let ticks = unsafe {
-            TicksMut::from_tick_cells(ticks, self.last_change_tick(), self.read_change_tick())
-        };
-
-        Some(Mut {
-            // SAFETY: caller ensures aliasing rules, ptr is of type `R`
-            value: unsafe { ptr.assert_unique().deref_mut() },
-            ticks,
-        })
+        // - caller ensures there is no `&mut World`
+        // - caller ensures there are no mutable borrows of this resource
+        // - caller ensures that we have permission to access this resource
+        unsafe { self.unsafe_world() }
+            .storages
+            .resources
+            .get(component_id)?
+            .get_with_ticks()
     }
 
+    // Shorthand helper function for getting the data and change ticks for a resource.
+    ///
+    /// # Panics
+    /// This function will panic if it isn't called from the same thread that the resource was inserted from.
+    ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - `component_id` must be assigned to a component of type `R`.
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
-    /// - no other references to the resource exist at the same time
+    /// - no mutable references to the resource exist at the same time
     #[inline]
-    pub(crate) unsafe fn get_non_send_mut_with_id<R: 'static>(
-        &self,
+    pub(crate) unsafe fn get_non_send_with_ticks(
+        self,
         component_id: ComponentId,
-    ) -> Option<Mut<'w, R>> {
-        let (ptr, ticks) = self
-            .0
+    ) -> Option<(Ptr<'w>, TickCells<'w>)> {
+        // SAFETY:
+        // - caller ensures there is no `&mut World`
+        // - caller ensures there are no mutable borrows of this resource
+        // - caller ensures that we have permission to access this resource
+        unsafe { self.unsafe_world() }
             .storages
             .non_send_resources
             .get(component_id)?
-            .get_with_ticks()?;
-        Some(Mut {
-            // SAFETY: caller ensures unique access
-            value: unsafe { ptr.assert_unique().deref_mut() },
-            // SAFETY: caller ensures unique access
-            ticks: unsafe {
-                TicksMut::from_tick_cells(ticks, self.last_change_tick(), self.read_change_tick())
-            },
-        })
+            .get_with_ticks()
     }
 }
 
@@ -388,7 +528,7 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
 
     #[inline]
     pub fn archetype(self) -> &'w Archetype {
-        &self.world.0.archetypes[self.location.archetype_id]
+        &self.world.archetypes()[self.location.archetype_id]
     }
 
     #[inline]
@@ -403,12 +543,16 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
 
     #[inline]
     pub fn contains_id(self, component_id: ComponentId) -> bool {
-        entity_ref::contains_component_with_id(self.world.0, component_id, self.location)
+        self.archetype().contains(component_id)
     }
 
     #[inline]
     pub fn contains_type_id(self, type_id: TypeId) -> bool {
-        entity_ref::contains_component_with_type(self.world.0, type_id, self.location)
+        let id = match self.world.components().get_id(type_id) {
+            Some(id) => id,
+            None => return false,
+        };
+        self.contains_id(id)
     }
 
     /// # Safety
@@ -417,20 +561,21 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get<T: Component>(self) -> Option<&'w T> {
+        let component_id = self.world.components().get_id(TypeId::of::<T>())?;
+
         // SAFETY:
         // - entity location is valid
         // - proper world access is promised by caller
         unsafe {
-            self.world
-                .0
-                .get_component_with_type(
-                    TypeId::of::<T>(),
-                    T::Storage::STORAGE_TYPE,
-                    self.entity,
-                    self.location,
-                )
-                // SAFETY: returned component is of type T
-                .map(|value| value.deref::<T>())
+            get_component(
+                self.world,
+                component_id,
+                T::Storage::STORAGE_TYPE,
+                self.entity,
+                self.location,
+            )
+            // SAFETY: returned component is of type T
+            .map(|value| value.deref::<T>())
         }
     }
 
@@ -443,12 +588,15 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_change_ticks<T: Component>(self) -> Option<ComponentTicks> {
+        let component_id = self.world.components().get_id(TypeId::of::<T>())?;
+
         // SAFETY:
         // - entity location is valid
         // - proper world acess is promised by caller
         unsafe {
-            self.world.0.get_ticks_with_type(
-                TypeId::of::<T>(),
+            get_ticks(
+                self.world,
+                component_id,
                 T::Storage::STORAGE_TYPE,
                 self.entity,
                 self.location,
@@ -478,7 +626,8 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
         // - world access is immutable, lifetime tied to `&self`
         // - the storage type provided is correct for T
         unsafe {
-            self.world.0.get_ticks(
+            get_ticks(
+                self.world,
                 component_id,
                 info.storage_type(),
                 self.entity,
@@ -509,23 +658,24 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
         last_change_tick: u32,
         change_tick: u32,
     ) -> Option<Mut<'w, T>> {
+        let component_id = self.world.components().get_id(TypeId::of::<T>())?;
+
         // SAFETY:
         // - `storage_type` is correct
         // - `location` is valid
         // - aliasing rules are ensured by caller
         unsafe {
-            self.world
-                .0
-                .get_component_and_ticks_with_type(
-                    TypeId::of::<T>(),
-                    T::Storage::STORAGE_TYPE,
-                    self.entity,
-                    self.location,
-                )
-                .map(|(value, cells)| Mut {
-                    value: value.assert_unique().deref_mut::<T>(),
-                    ticks: TicksMut::from_tick_cells(cells, last_change_tick, change_tick),
-                })
+            get_component_and_ticks(
+                self.world,
+                component_id,
+                T::Storage::STORAGE_TYPE,
+                self.entity,
+                self.location,
+            )
+            .map(|(value, cells)| Mut {
+                value: value.assert_unique().deref_mut::<T>(),
+                ticks: TicksMut::from_tick_cells(cells, last_change_tick, change_tick),
+            })
         }
     }
 }
@@ -546,10 +696,11 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
-        let info = self.world.0.components.get_info(component_id)?;
+        let info = self.world.components().get_info(component_id)?;
         // SAFETY: entity_location is valid, component_id is valid as checked by the line above
         unsafe {
-            self.world.0.get_component(
+            get_component(
+                self.world,
                 component_id,
                 info.storage_type(),
                 self.entity,
@@ -570,26 +721,148 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut_by_id(self, component_id: ComponentId) -> Option<MutUntyped<'w>> {
-        let info = self.world.0.components.get_info(component_id)?;
+        let info = self.world.components().get_info(component_id)?;
         // SAFETY: entity_location is valid, component_id is valid as checked by the line above
         unsafe {
-            self.world
-                .0
-                .get_component_and_ticks(
-                    component_id,
-                    info.storage_type(),
-                    self.entity,
-                    self.location,
-                )
-                .map(|(value, cells)| MutUntyped {
-                    // SAFETY: world access validated by caller and ties world lifetime to `MutUntyped` lifetime
-                    value: value.assert_unique(),
-                    ticks: TicksMut::from_tick_cells(
-                        cells,
-                        self.world.last_change_tick(),
-                        self.world.read_change_tick(),
-                    ),
-                })
+            get_component_and_ticks(
+                self.world,
+                component_id,
+                info.storage_type(),
+                self.entity,
+                self.location,
+            )
+            .map(|(value, cells)| MutUntyped {
+                // SAFETY: world access validated by caller and ties world lifetime to `MutUntyped` lifetime
+                value: value.assert_unique(),
+                ticks: TicksMut::from_tick_cells(
+                    cells,
+                    self.world.last_change_tick(),
+                    self.world.read_change_tick(),
+                ),
+            })
         }
+    }
+}
+
+impl<'w> UnsafeWorldCell<'w> {
+    #[inline]
+    /// # Safety:
+    /// - the returned `Column` is only used in ways that this [`UnsafeWorldCell`] has permission for.
+    /// - the returned `Column` is only used in ways that would not conflict with any existing
+    ///   borrows of world data.
+    unsafe fn fetch_table(
+        self,
+        location: EntityLocation,
+        component_id: ComponentId,
+    ) -> Option<(&'w Column, TableRow)> {
+        let archetype = &self.archetypes()[location.archetype_id];
+        // SAFETY: caller ensures returned data is not misused and we have not created any borrows
+        // of component/resource data
+        let table = &unsafe { self.unsafe_world() }.storages.tables[archetype.table_id()];
+        let components = table.get_column(component_id)?;
+        let table_row = archetype.entity_table_row(location.archetype_row);
+        Some((components, table_row))
+    }
+
+    #[inline]
+    /// # Safety:
+    /// - the returned `ComponentSparseSet` is only used in ways that this [`UnsafeWorldCell`] has permission for.
+    /// - the returned `ComponentSparseSet` is only used in ways that would not conflict with any existing
+    ///   borrows of world data.
+    unsafe fn fetch_sparse_set(self, component_id: ComponentId) -> Option<&'w ComponentSparseSet> {
+        // SAFETY: caller ensures returned data is not misused and we have not created any borrows
+        // of component/resource data
+        unsafe { self.unsafe_world() }
+            .storages
+            .sparse_sets
+            .get(component_id)
+    }
+}
+
+/// Get an untyped pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`] in the provided [`World`](crate::world::World).
+///
+/// # Safety
+/// - `location` must refer to an archetype that contains `entity`
+/// the archetype
+/// - `component_id` must be valid
+/// - `storage_type` must accurately reflect where the components for `component_id` are stored.
+/// - the caller must ensure that no aliasing rules are violated
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn get_component(
+    world: UnsafeWorldCell<'_>,
+    component_id: ComponentId,
+    storage_type: StorageType,
+    entity: Entity,
+    location: EntityLocation,
+) -> Option<Ptr<'_>> {
+    // SAFETY: component_id exists and is therefore valid
+    match storage_type {
+        StorageType::Table => {
+            let (components, table_row) = world.fetch_table(location, component_id)?;
+            // SAFETY: archetypes only store valid table_rows and caller ensure aliasing rules
+            Some(components.get_data_unchecked(table_row))
+        }
+        StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get(entity),
+    }
+}
+
+/// Get an untyped pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`]
+///
+/// # Safety
+/// - `location` must refer to an archetype that contains `entity`
+/// - `component_id` must be valid
+/// - `storage_type` must accurately reflect where the components for `component_id` are stored.
+/// - the caller must ensure that no aliasing rules are violated
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn get_component_and_ticks(
+    world: UnsafeWorldCell<'_>,
+    component_id: ComponentId,
+    storage_type: StorageType,
+    entity: Entity,
+    location: EntityLocation,
+) -> Option<(Ptr<'_>, TickCells<'_>)> {
+    match storage_type {
+        StorageType::Table => {
+            let (components, table_row) = world.fetch_table(location, component_id)?;
+
+            // SAFETY: archetypes only store valid table_rows and caller ensure aliasing rules
+            Some((
+                components.get_data_unchecked(table_row),
+                TickCells {
+                    added: components.get_added_ticks_unchecked(table_row),
+                    changed: components.get_changed_ticks_unchecked(table_row),
+                },
+            ))
+        }
+        StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_with_ticks(entity),
+    }
+}
+
+/// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`]
+///
+/// # Safety
+/// - `location` must refer to an archetype that contains `entity`
+/// the archetype
+/// - `component_id` must be valid
+/// - `storage_type` must accurately reflect where the components for `component_id` are stored.
+/// - the caller must ensure that no aliasing rules are violated
+#[inline]
+#[allow(unsafe_op_in_unsafe_fn)]
+unsafe fn get_ticks(
+    world: UnsafeWorldCell<'_>,
+    component_id: ComponentId,
+    storage_type: StorageType,
+    entity: Entity,
+    location: EntityLocation,
+) -> Option<ComponentTicks> {
+    match storage_type {
+        StorageType::Table => {
+            let (components, table_row) = world.fetch_table(location, component_id)?;
+            // SAFETY: archetypes only store valid table_rows and caller ensure aliasing rules
+            Some(components.get_ticks_unchecked(table_row))
+        }
+        StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_ticks(entity),
     }
 }


### PR DESCRIPTION
# Objective

- Implementing logic used by system params and `UnsafeWorldCell` on `&World` is sus since `&World` generally denotes shared read only access to world but this is a lie in the above situations. Move most/all logic that uses `&World` to mean `UnsafeWorldCell` onto `UnsafeWorldCell`
-  Add a way to take a `&mut World` out of `UnsafeWorldCell` and use this in `WorldCell`'s `Drop` impl instead of a `UnsafeCell` field

---

## Changelog

- changed some `UnsafeWorldCell` methods to take `self` instead of `&self`/`&mut self` since there is literally no point to them doing that
- `UnsafeWorldCell::world` is now used to get immutable access to the whole world instead of just the metadata which can now be done via `UnsafeWorldCell::world_metadata`
- `UnsafeWorldCell::world_mut` now exists and can be used to get a `&mut World` out of `UnsafeWorldCell`
- removed `UnsafeWorldCell::storages` since that is probably unsound since storages contains the actual component/resource data not just metadata

## Migration guide

N/A none of the breaking changes here make any difference for a 0.9->0.10 transition since `UnsafeWorldCell` did not exist in 0.9