### PR TITLE
[Merged by Bors] - Fix formatting in `Name` docs

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -8,7 +8,8 @@ use std::{
     ops::Deref,
 };
 
-/// Component used to identify an entity. Stores a hash for faster comparisons
+/// Component used to identify an entity. Stores a hash for faster comparisons.
+///
 /// The hash is eagerly re-computed upon each update to the name.
 ///
 /// [`Name`] should not be treated as a globally unique identifier for entities,


### PR DESCRIPTION
# Objective

There's no period at the end of the first line of the `Name` documentation, and this messes up the grammar of the summary rustdoc creates:
```
                                                                          ↓
Component used to identify an entity. Stores a hash for faster comparisons The hash is eagerly re-computed upon each update to the name.
```

## Solution

I added it.