### PR TITLE
[Merged by Bors] - Allow returning a value from `EntityMut::world_scope`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -546,7 +546,7 @@ impl<'w> EntityMut<'w> {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// #[derive(Resource, Clone, Copy)]
+    /// #[derive(Resource, Default, Clone, Copy)]
     /// struct R(u32);
     ///
     /// # let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -540,6 +540,28 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Gives mutable access to this `EntityMut`'s [`World`] in a temporary scope.
+    /// This is a safe alternative to using [`Self::world_mut`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Resource, Clone, Copy)]
+    /// struct R(u32);
+    ///
+    /// # let mut world = World::new();
+    /// # world.init_resource::<R>();
+    /// # let mut entity = world.spawn_empty();
+    /// // This closure gives us temporary access to the world.
+    /// let val = entity.world_scope(|world: &mut World| {
+    ///     // Mutate the world while we have access to it.
+    ///     let mut r = world.resource_mut::<R>();
+    ///     r.0 += 1;
+    ///     
+    ///     // Return a value from the world before giving it back to the `EntityMut`.
+    ///     *r
+    /// });
+    /// ```
     pub fn world_scope<U>(&mut self, f: impl FnOnce(&mut World) -> U) -> U {
         let val = f(self.world);
         self.update_location();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -540,9 +540,10 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Gives mutable access to this `EntityMut`'s [`World`] in a temporary scope.
-    pub fn world_scope(&mut self, f: impl FnOnce(&mut World)) {
-        f(self.world);
+    pub fn world_scope<U>(&mut self, f: impl FnOnce(&mut World) -> U) -> U {
+        let val = f(self.world);
         self.update_location();
+        val
     }
 
     /// Updates the internal entity location to match the current location in the internal

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -553,7 +553,7 @@ impl<'w> EntityMut<'w> {
     /// # world.init_resource::<R>();
     /// # let mut entity = world.spawn_empty();
     /// // This closure gives us temporary access to the world.
-    /// let val = entity.world_scope(|world: &mut World| {
+    /// let new_r = entity.world_scope(|world: &mut World| {
     ///     // Mutate the world while we have access to it.
     ///     let mut r = world.resource_mut::<R>();
     ///     r.0 += 1;
@@ -561,6 +561,7 @@ impl<'w> EntityMut<'w> {
     ///     // Return a value from the world before giving it back to the `EntityMut`.
     ///     *r
     /// });
+    /// # assert_eq!(new_r.0, 1);
     /// ```
     pub fn world_scope<U>(&mut self, f: impl FnOnce(&mut World) -> U) -> U {
         let val = f(self.world);


### PR DESCRIPTION
# Objective

The function `EntityMut::world_scope` is a safe abstraction that allows you to temporarily get mutable access to the underlying `World` of an `EntityMut`. This function is purely stateful, meaning it is not easily possible to return a value from it.

## Solution

Allow returning a computed value from the closure. This is similar to how `World::resource_scope` works.

---

## Changelog

- The function `EntityMut::world_scope` now allows returning a value from the immediately-computed closure.
