### PR TITLE
[Merged by Bors] - Fix unsoundness in `EntityMut::world_scope`

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -546,7 +546,7 @@ impl<'w> EntityMut<'w> {
 
         // Update the stored `EntityLocation` for this instance.
         // This will get called at the end of this scope, even if the closure `f` unwinds.
-        let _on_drop = bevy_utils::OnDrop::new(|| {
+        let _cleanup_guard = bevy_utils::OnDrop::new(move || {
             // SAFETY:
             // - This will only be invoked at the end of the outer scope, at which point
             //   `self` will no longer be borrowed, which ensures the references don't alias.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -583,8 +583,10 @@ impl<'w> EntityMut<'w> {
     }
 
     /// Updates the internal entity location to match the current location in the internal
-    /// [`World`]. This is only needed if the user called [`EntityMut::world`], which enables the
-    /// location to change.
+    /// [`World`].
+    ///
+    /// This is *only* required when using the unsafe function [`EntityMut::world_mut`],
+    /// which enables the location to change.
     pub fn update_location(&mut self) {
         self.location = self.world.entities().get(self.entity).unwrap();
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -544,19 +544,37 @@ impl<'w> EntityMut<'w> {
         // Erase the lifetime of self, so we can get around the borrow checker.
         let this_ptr = self as *mut Self;
 
+        // Make sure `self` cannot get observed in this scope.
+        // NOTE: This is probably unnecessary, but we are excercising extreme caution here.
+        #[allow(clippy::forget_ref)]
+        std::mem::forget(self);
+
         // Update the stored `EntityLocation` for this instance.
         // This will get called at the end of this scope, even if the closure `f` unwinds.
         let _cleanup_guard = bevy_utils::OnDrop::new(move || {
             // SAFETY:
-            // - This will only be invoked at the end of the outer scope, at which point
-            //   `self` will no longer be borrowed, which ensures the references don't alias.
+            // - When this closure gets called at the end of the outer scope,
+            //   then any other mutable references to `this_ptr` will have been released,
+            //   which ensures that this will not alias.
             // - The pointer must otherwise be safe to dereference, since it was obtained
             //   from a mutable reference.
             let this = unsafe { &mut *this_ptr };
             this.update_location();
         });
 
-        f(self.world);
+        {
+            // SAFETY:
+            // - `this_ptr` does not have any current aliased mutable references.
+            //   `this` will get released at the end of the current scope, which ensures
+            //   that it won't alias when `_cleanup_guard` gets called.
+            // - The pointer must otherwise be safe to dereference, since it was obtained
+            //   from a mutable reference.
+            let this = unsafe { &mut *this_ptr };
+            f(this.world);
+
+            // `this` will get released at the end of this scope,
+            // which allows `_cleanup_guard` to safely take a reference to
+        }
     }
 
     /// Updates the internal entity location to match the current location in the internal

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -923,4 +923,23 @@ mod tests {
         assert!(entity.get_by_id(invalid_component_id).is_none());
         assert!(entity.get_mut_by_id(invalid_component_id).is_none());
     }
+
+    #[test]
+    fn entity_mut_world_scope_panic() {
+        let mut world = World::new();
+
+        let mut entity = world.spawn_empty();
+        let id = entity.id();
+        entity.world_scope(|w| {
+            // Change the entity's `EnityLocation`, which invalidates the original `EntityMut`.
+            // This will get updated at the end of the scope.
+            w.entity_mut(id).insert(TestComponent(0));
+
+            // Ensure that the entity location still gets updated even in case of a panic.
+            panic!()
+        });
+
+        // Despawn the entity. If the `EntityLocation` has not been updated, this will cause UB.
+        entity.despawn();
+    }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -963,6 +963,7 @@ mod tests {
         assert!(entity.get_mut_by_id(invalid_component_id).is_none());
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7387
     #[test]
     fn entity_mut_world_scope_panic() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -976,7 +976,7 @@ mod tests {
                 w.entity_mut(id).insert(TestComponent(0));
 
                 // Ensure that the entity location still gets updated even in case of a panic.
-                panic!()
+                panic!("this should get caught by the outer scope")
             });
         }));
         assert!(res.is_err());

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -972,7 +972,7 @@ mod tests {
         let id = entity.id();
         let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
             entity.world_scope(|w| {
-                // Change the entity's `EnityLocation`, which invalidates the original `EntityMut`.
+                // Change the entity's `EntityLocation`, which invalidates the original `EntityMut`.
                 // This will get updated at the end of the scope.
                 w.entity_mut(id).insert(TestComponent(0));
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::debug;
-use std::{any::TypeId, panic::AssertUnwindSafe};
+use std::any::TypeId;
 
 use super::unsafe_world_cell::UnsafeWorldCellEntityRef;
 
@@ -564,9 +564,22 @@ impl<'w> EntityMut<'w> {
     /// # assert_eq!(new_r.0, 1);
     /// ```
     pub fn world_scope<U>(&mut self, f: impl FnOnce(&mut World) -> U) -> U {
-        let value = std::panic::catch_unwind(AssertUnwindSafe(|| f(self.world)));
-        self.update_location();
-        value.unwrap_or_else(|e| std::panic::panic_any(e))
+        // Erase the lifetime of self, so we can get around the borrow checker.
+        let this_ptr = self as *mut Self;
+
+        // Update the stored `EntityLocation` for this instance.
+        // This will get called at the end of this scope, even if the closure `f` unwinds.
+        let _cleanup_guard = bevy_utils::OnDrop::new(move || {
+            // SAFETY:
+            // - When this closure gets called at the end of the outer scope,
+            //   the reference to `self` will be inactive, which ensures that this will not alias.
+            // - The pointer must otherwise be safe to dereference, since it was obtained
+            //   from a mutable reference.
+            let this = unsafe { &mut *this_ptr };
+            this.update_location();
+        });
+
+        f(self.world)
     }
 
     /// Updates the internal entity location to match the current location in the internal

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -969,6 +969,7 @@ mod tests {
         let mut world = World::new();
 
         let mut entity = world.spawn_empty();
+        let old_location = entity.location();
         let id = entity.id();
         let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
             entity.world_scope(|w| {
@@ -982,7 +983,7 @@ mod tests {
         }));
         assert!(res.is_err());
 
-        // If the `EntityLocation` has not been updated, this will cause UB.
-        entity.insert(TestComponent(0));
+        // Ensure that the location has been properly updated.
+        assert!(entity.location() != old_location);
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -944,7 +944,7 @@ mod tests {
         }));
         assert!(res.is_err());
 
-        // Despawn the entity. If the `EntityLocation` has not been updated, this will cause UB.
-        entity.despawn();
+        // If the `EntityLocation` has not been updated, this will cause UB.
+        entity.insert(TestComponent(0));
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -572,8 +572,7 @@ impl<'w> EntityMut<'w> {
         let _cleanup_guard = bevy_utils::OnDrop::new(move || {
             // SAFETY:
             // - When this closure gets called at the end of the outer scope,
-            //   then any other mutable references to `this_ptr` will have been released,
-            //   which ensures that this will not alias.
+            //   the reference to `self` will be inactive, which ensures that this will not alias.
             // - The pointer must otherwise be safe to dereference, since it was obtained
             //   from a mutable reference.
             let this = unsafe { &mut *this_ptr };


### PR DESCRIPTION
# Objective

Found while working on #7385.

The struct `EntityMut` has the safety invariant that it's cached `EntityLocation` must always accurately specify where the entity is stored. Thus, any time its location might be invalidated (such as by calling `EntityMut::world_mut` and moving archetypes), the cached location *must* be updated by calling `EntityMut::update_location`.

The method `world_scope` encapsulates this pattern in safe API by requiring world mutations to be done in a closure, after which `update_location` will automatically be called. However, this method has a soundness hole: if a panic occurs within the closure, then `update_location` will never get called. If the panic is caught in an outer scope, then the `EntityMut` will be left with an outdated location, which is undefined behavior.

An example of this can be seen in the unit test `entity_mut_world_scope_panic`, which has been added to this PR as a regression test. Without the other changes in this PR, that test will invoke undefined behavior in safe code.

## Solution

Call `EntityMut::update_location()` from within a `Drop` impl, which ensures that it will get executed even if `EntityMut::world_scope` unwinds.