### PR TITLE
Made converters public so that they can be used by the users

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,4 +1,5 @@
-mod converters;
+pub mod converters;
+
 mod system;
 #[cfg(target_arch = "wasm32")]
 mod web_resize;


### PR DESCRIPTION
# Objective

- Make all the `bevy_winit::converters` accessible to the users