### PR TITLE
[Merged by Bors] - re-enable tests on apple silicon

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -442,9 +442,6 @@ mod tests {
     }
 
     #[test]
-    // Don't run on a m1 as they have a 41ns precision
-    // https://github.com/rust-lang/rust/issues/91417
-    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn update_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);
@@ -577,9 +574,6 @@ mod tests {
     }
 
     #[test]
-    // Don't run on a m1 as they have a 41ns precision
-    // https://github.com/rust-lang/rust/issues/91417
-    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn relative_speed_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);
@@ -682,9 +676,6 @@ mod tests {
     }
 
     #[test]
-    // Don't run on a m1 as they have a 41ns precision
-    // https://github.com/rust-lang/rust/issues/91417
-    #[cfg(not(all(target_arch = "aarch64", target_vendor = "apple")))]
     fn pause_test() {
         let start_instant = Instant::now();
         let mut time = Time::new(start_instant);


### PR DESCRIPTION
# Objective

- Fixes #6687

## Solution

- The future is now! Rust 1.67 was released with the fix
