### PR TITLE
Fix bevymark crash

### DIFF
--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -70,9 +70,10 @@ fn scheduled_spawner(
     mut counter: ResMut<BevyCounter>,
     bird_texture: Res<BirdTexture>,
 ) {
-    let window = match windows.get_single() {
-        Ok(window) => window,
-        Err(_) => return,
+    let window = if let Ok(window) = windows.get_single() {
+        window
+    } else {
+        return;
     };
 
     if scheduled.wave > 0 {

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -70,7 +70,10 @@ fn scheduled_spawner(
     mut counter: ResMut<BevyCounter>,
     bird_texture: Res<BirdTexture>,
 ) {
-    let window = windows.single();
+    let window = match windows.get_single() {
+        Ok(window) => window,
+        Err(_) => return
+    };
 
     if scheduled.wave > 0 {
         spawn_birds(

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -52,7 +52,7 @@ fn main() {
         .add_system_set(
             SystemSet::new()
                 .with_run_criteria(FixedTimestep::step(0.2))
-                .with_system(scheduled_spawner),
+                .with_system(scheduled_spawner.pipe(ignore)),
         )
         .run();
 }
@@ -69,12 +69,8 @@ fn scheduled_spawner(
     mut scheduled: ResMut<BirdScheduled>,
     mut counter: ResMut<BevyCounter>,
     bird_texture: Res<BirdTexture>,
-) {
-    let window = if let Ok(window) = windows.get_single() {
-        window
-    } else {
-        return;
-    };
+) -> Option<()> {
+    let window = windows.get_single().ok()?;
 
     if scheduled.wave > 0 {
         spawn_birds(
@@ -89,6 +85,7 @@ fn scheduled_spawner(
         counter.color = Color::rgb_linear(rng.gen(), rng.gen(), rng.gen());
         scheduled.wave -= 1;
     }
+    Some(())
 }
 
 #[derive(Resource, Deref)]

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -72,7 +72,7 @@ fn scheduled_spawner(
 ) {
     let window = match windows.get_single() {
         Ok(window) => window,
-        Err(_) => return
+        Err(_) => return,
     };
 
     if scheduled.wave > 0 {


### PR DESCRIPTION
# Objective

Fixes #7403

## Solution

- Replace `windows.single()` with `windows.get_single()?` then use system piping to return early.
