### PR TITLE
[Merged by Bors] - Use only one sampler in the array texture example.

### DIFF
--- a/assets/shaders/texture_binding_array.wgsl
+++ b/assets/shaders/texture_binding_array.wgsl
@@ -1,7 +1,9 @@
 @group(1) @binding(0)
 var textures: binding_array<texture_2d<f32>>;
 @group(1) @binding(1)
-var samplers: binding_array<sampler>;
+var nearest_sampler: sampler;
+// We can also have array of samplers
+// var samplers: binding_array<sampler>;
 
 @fragment
 fn fragment(
@@ -11,5 +13,5 @@ fn fragment(
     let coords = clamp(vec2<u32>(uv * 4.0), vec2<u32>(0u), vec2<u32>(3u));
     let index = coords.y * 4u + coords.x;
     let inner_uv = fract(uv * 4.0);
-    return textureSample(textures[index], samplers[index], inner_uv);
+    return textureSample(textures[index], nearest_sampler, inner_uv);
 }

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -113,7 +113,7 @@ impl AsBindGroup for BindlessMaterial {
                 },
                 BindGroupEntry {
                     binding: 1,
-                    resource: BindingResource::Sampler(&*fallback_image.sampler),
+                    resource: BindingResource::Sampler(&fallback_image.sampler),
                 },
             ],
         });

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -94,16 +94,13 @@ impl AsBindGroup for BindlessMaterial {
         }
 
         let textures = vec![&fallback_image.texture_view; MAX_TEXTURE_COUNT];
-        let samplers = vec![&fallback_image.sampler; MAX_TEXTURE_COUNT];
 
         // convert bevy's resource types to WGPU's references
         let mut textures: Vec<_> = textures.into_iter().map(|texture| &**texture).collect();
-        let mut samplers: Vec<_> = samplers.into_iter().map(|sampler| &**sampler).collect();
 
         // fill in up to the first `MAX_TEXTURE_COUNT` textures and samplers to the arrays
         for (id, image) in images.into_iter().enumerate() {
             textures[id] = &*image.texture_view;
-            samplers[id] = &*image.sampler;
         }
 
         let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
@@ -116,7 +113,7 @@ impl AsBindGroup for BindlessMaterial {
                 },
                 BindGroupEntry {
                     binding: 1,
-                    resource: BindingResource::SamplerArray(&samplers[..]),
+                    resource: BindingResource::Sampler(&*fallback_image.sampler),
                 },
             ],
         });
@@ -146,12 +143,14 @@ impl AsBindGroup for BindlessMaterial {
                     },
                     count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
                 },
-                // @group(1) @binding(1) var samplers: binding_array<sampler>;
+                // @group(1) @binding(1) var nearest_sampler: sampler;
                 BindGroupLayoutEntry {
                     binding: 1,
                     visibility: ShaderStages::FRAGMENT,
                     ty: BindingType::Sampler(SamplerBindingType::Filtering),
-                    count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
+                    count: None,
+                    // note: we can also have an array of samplers
+                    // count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
                 },
             ],
         })

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -149,7 +149,8 @@ impl AsBindGroup for BindlessMaterial {
                     visibility: ShaderStages::FRAGMENT,
                     ty: BindingType::Sampler(SamplerBindingType::Filtering),
                     count: None,
-                    // note: we can also have an array of samplers
+                    // Note: as textures, multiple samplers can also be bound onto one binding slot.
+                    // One may need to pay attention to the limit of sampler binding amount on some platforms.
                     // count: NonZeroU32::new(MAX_TEXTURE_COUNT as u32),
                 },
             ],


### PR DESCRIPTION
# Objective

Fixes #7373 

## Solution

Use only one sampler instead of an array of samplers.