### PR TITLE
Better ergonomics for `WorldBorrow[Mut]` API

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -283,6 +283,17 @@ macro_rules! impl_methods {
                     ticks: self.ticks,
                 }
             }
+
+            /// Attempt to map to an inner value by applying a function to the contained reference, without flagging a change.
+            ///
+            /// You should never modify the argument passed to the closure -- if you want to modify the data
+            /// without flagging a change, consider using [`DetectChangesMut::bypass_change_detection`] to make your intent explicit.
+            pub fn try_map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> Option<&mut U>) -> Option<Mut<'a, U>> {
+                Some(Mut {
+                    value: f(self.value)?,
+                    ticks: self.ticks,
+                })
+            }
         }
     };
 }

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -160,6 +160,20 @@ impl<'w, T> WorldBorrow<'w, T> {
     }
 }
 
+impl<'w, T> Clone for WorldBorrow<'w, T> {
+    fn clone(&self) -> Self {
+        // NOTE: technically there is a redundant assert in the following call.
+        // `self.witness` guarantees that assertion is never violated.
+        // It should be cheap enough so let's keep it this way until profiling proves otherwise.
+        WorldBorrow::try_new(
+            || Some(self.value),
+            self.witness.archetype_component_id,
+            self.witness.access.clone(),
+        )
+        .unwrap()
+    }
+}
+
 impl<'w, T> Deref for WorldBorrow<'w, T> {
     type Target = T;
 


### PR DESCRIPTION
# Objective

- Allow mapping a `WorldBorrow[Mut]<T>` to `WorldBorrow[Mut]<U>`
- Allow cloning a `WorldBorrow<T>`

Consider the following example:
```rust
#[derive(Resource)]
struct SomeResource {
    some_field: Vec<u32>,
    some_other_field: Option<Vec<u32>>,
}

pub fn get_global_some_field(world: &WorldCell) -> Option<WorldBorrow<[u32]>> {
    Some(world.resource::<SomeResource>()?.map(|res| &res.some_field))
}

pub fn get_global_some_other_field(world: &WorldCell) -> Option<WorldBorrow<[u32]>> {
    Some(world.resource::<SomeResource>()?.try_map(|res| res.some_field.as_ref())?)
}
```

Previously it is very complicated to define the two accessor functions, because `&[u32]` must outlive the `WorldBorrow<SomeResource>`, and we have to e.g. return a wrapper around `WorldBorrow<SomeResource>` implementing `Deref<[u16]>`.

Now that we have two functions consuming `WorldBorrow`s, it might also be desirable to keep the original borrow by cloning it beforehand. Therefore we implement `Clone` for `WorldBorrow<T>`.

## Solution

- `map` and `try_map` consumes `self` and moves the witness of borrow.
- `clone` simply borrows the data again from the same world.

## Unresolved Questions

- `map` and `try_map` are introduced as functions instead of inherent methods
  - Official Guideline: https://rust-lang.github.io/api-guidelines/predictability.html#smart-pointers-do-not-add-inherent-methods-c-smart-ptr
  - But `Mut::map_unchanged` is already an inherent method, so there is an inconsistency

---

## Changelog

- Add `map` and `try_map` for `WorldBorrow` and `WorldBorrowMut`
- Implement `Clone` for `WorldBorrow`
    Technically this will break downstream code because `borrow.clone()` is now ambiguous

## Migration Guide

`WorldBorrow<T>` now implements `Clone`. If you have code cloning the inner value behind a `WorldBorrow`:
```rust
let borrow: WorldBorrow<T>;
let cloned = borrow.clone(); // T
```
You need to explicitly dereference the borrow to clone the inner value:
```rust
let t_cloned = T::clone(&borrow); // or
let t_cloned = (*borrow).clone();
```
Now you may also clone the borrow itself:
```rust
let borrow_cloned = borrow.clone(); // or
let borrow_cloned = WorldBorrow::clone(&borrow);
```