### PR TITLE
Make ComponentTicks available from ChangeTrackers

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1156,6 +1156,10 @@ impl<T: Component> ChangeTrackers<T> {
         self.component_ticks
             .is_changed(self.last_change_tick, self.change_tick)
     }
+
+    pub fn ticks(&self) -> &ComponentTicks {
+        &self.component_ticks
+    }
 }
 
 #[doc(hidden)]


### PR DESCRIPTION
# Objective

To implement [indexes](https://github.com/chrisjuchem/bevy_mod_index), I need to be able to check if a component has changed since an arbitrary time, not just since the last time the system ran.

## Solution

Allow for getting a read only reference to `ComponentTicks` from `ChangeTrackers` so that `ComponentTicks::is_added` and `ComponentTicks::is_changed` can be used, since they take the `last_change_tick` as a parameter.

## Alternatives

Implement `is_added_since` and `is_changed_since` on `ChangeTrackers` itself, deferring to `ComponentTicks` under the hood.


## Changelog

- Added `ticks` method to `ChangeTrackers` to get the `ComponentTicks` tracking when a component was added/changed.

