### PR TITLE
[Merged by Bors] - Fix missing import in array_texture example

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -6,6 +6,7 @@
 #import bevy_pbr::clustered_forward
 #import bevy_pbr::lighting
 #import bevy_pbr::shadows
+#import bevy_pbr::fog
 #import bevy_pbr::pbr_functions
 
 @group(1) @binding(0)


### PR DESCRIPTION
# Objective

Fixes #7417 

## Solution

Just adds the missing `bevy_pbr::fog` import.