### PR TITLE
[Merged by Bors] - Fix post_processing and shader_prepass examples

### DIFF
--- a/assets/shaders/custom_material_chromatic_aberration.wgsl
+++ b/assets/shaders/custom_material_chromatic_aberration.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::mesh_view_bindings
+#import bevy_pbr::mesh2d_view_bindings
 #import bevy_pbr::utils
 
 @group(1) @binding(0)
@@ -22,7 +22,7 @@ fn fragment(
         textureSample(texture, our_sampler, uv + vec2<f32>(-offset_strength, 0.0)).g,
         textureSample(texture, our_sampler, uv + vec2<f32>(0.0, offset_strength)).b,
         1.0
-        );
+    );
 
     return output_color;
 }

--- a/assets/shaders/custom_material_chromatic_aberration.wgsl
+++ b/assets/shaders/custom_material_chromatic_aberration.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::mesh2d_view_bindings
+#import bevy_sprite::mesh2d_view_bindings
 #import bevy_pbr::utils
 
 @group(1) @binding(0)

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -46,7 +46,7 @@ use bevy_utils::{tracing::error, HashMap};
 use crate::{
     AlphaMode, DrawMesh, Material, MaterialPipeline, MaterialPipelineKey, MeshPipeline,
     MeshPipelineKey, MeshUniform, RenderMaterials, SetMaterialBindGroup, SetMeshBindGroup,
-    MAX_DIRECTIONAL_LIGHTS,
+    MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS,
 };
 
 use std::{hash::Hash, marker::PhantomData};
@@ -210,6 +210,10 @@ where
         shader_defs.push(ShaderDefVal::Int(
             "MAX_DIRECTIONAL_LIGHTS".to_string(),
             MAX_DIRECTIONAL_LIGHTS as i32,
+        ));
+        shader_defs.push(ShaderDefVal::Int(
+            "MAX_CASCADES_PER_LIGHT".to_string(),
+            MAX_CASCADES_PER_LIGHT as i32,
         ));
 
         if layout.contains(Mesh::ATTRIBUTE_UV_0) {


### PR DESCRIPTION
# Objective

- Fix `post_processing` and `shader_prepass` examples as they fail when compiling shaders due to missing shader defs
- Fixes #6799
- Fixes #6996
- Fixes #7375 
- Supercedes #6997
- Supercedes #7380 

## Solution

- The prepass was broken due to a missing `MAX_CASCADES_PER_LIGHT` shader def. Add it.
- The shader used in the `post_processing` example is applied to a 2D mesh, so use the correct mesh2d_view_bindings shader import.