### PR TITLE
[Merged by Bors] - Added buffer usage field to buffers

### DIFF
--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -104,7 +104,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Adds more [`BufferUsages`] to the buffer.
+    /// Add more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
@@ -229,7 +229,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Adds more [`BufferUsages`] to the buffer.
+    /// Add more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -109,7 +109,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
     /// This method only allows addition of flags to the default usage flags.
     ///
     /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::STORAGE`.
-    pub fn set_usage(&mut self, usage: BufferUsages) {
+    pub fn add_usages(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
     }
@@ -234,7 +234,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
     /// This method only allows addition of flags to the default usage flags.
     ///
     /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::STORAGE`.
-    pub fn set_usage(&mut self, usage: BufferUsages) {
+    pub fn add_usages(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
     }

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -46,7 +46,7 @@ impl<T: ShaderType> From<T> for StorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -60,7 +60,7 @@ impl<T: ShaderType + Default> Default for StorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -106,6 +106,8 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
 
     /// Set the buffer usage of the buffer.
     ///
+    /// This method only allows addition of flags to the default usage flags.
+    ///
     /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
@@ -125,7 +127,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::STORAGE | self.buffer_usage,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;
@@ -176,7 +178,7 @@ impl<T: ShaderType> Default for DynamicStorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -229,6 +231,8 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
 
     /// Set the buffer usage of the buffer.
     ///
+    /// This method only allows addition of flags to the default usage flags.
+    ///
     /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
@@ -242,7 +246,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::STORAGE | self.buffer_usage,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -104,7 +104,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Set the buffer usage of the buffer.
+    /// Adds more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
@@ -229,7 +229,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Set the buffer usage of the buffer.
+    /// Adds more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -108,7 +108,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
-    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
+    /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::STORAGE`.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -233,7 +233,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
-    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
+    /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::STORAGE`.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -46,7 +46,7 @@ impl<T: ShaderType> From<T> for StorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -60,7 +60,7 @@ impl<T: ShaderType + Default> Default for StorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -104,6 +104,9 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         self.label.as_deref()
     }
 
+    /// Set the buffer usage of the buffer.
+    ///
+    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -122,7 +125,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: self.buffer_usage,
+                usage: BufferUsages::STORAGE | self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;
@@ -173,7 +176,7 @@ impl<T: ShaderType> Default for DynamicStorageBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -224,6 +227,9 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         self.label.as_deref()
     }
 
+    /// Set the buffer usage of the buffer.
+    ///
+    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::STORAGE.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -236,7 +242,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: self.buffer_usage,
+                usage: BufferUsages::STORAGE | self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -34,6 +34,7 @@ pub struct StorageBuffer<T: ShaderType> {
     capacity: usize,
     label: Option<String>,
     label_changed: bool,
+    buffer_usage: BufferUsages,
 }
 
 impl<T: ShaderType> From<T> for StorageBuffer<T> {
@@ -45,6 +46,7 @@ impl<T: ShaderType> From<T> for StorageBuffer<T> {
             capacity: 0,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -58,6 +60,7 @@ impl<T: ShaderType + Default> Default for StorageBuffer<T> {
             capacity: 0,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -101,6 +104,10 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         self.label.as_deref()
     }
 
+    pub fn set_usage(&mut self, usage: BufferUsages) {
+        self.buffer_usage.set(usage, true);
+    }
+
     /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
     /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
     ///
@@ -114,7 +121,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         if self.capacity < size || self.label_changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;
@@ -153,6 +160,7 @@ pub struct DynamicStorageBuffer<T: ShaderType> {
     capacity: usize,
     label: Option<String>,
     label_changed: bool,
+    buffer_usage: BufferUsages,
 }
 
 impl<T: ShaderType> Default for DynamicStorageBuffer<T> {
@@ -164,6 +172,7 @@ impl<T: ShaderType> Default for DynamicStorageBuffer<T> {
             capacity: 0,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
         }
     }
 }
@@ -214,6 +223,10 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         self.label.as_deref()
     }
 
+    pub fn set_usage(&mut self, usage: BufferUsages) {
+        self.buffer_usage.set(usage, true);
+    }
+
     #[inline]
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
         let size = self.scratch.as_ref().len();
@@ -221,7 +234,7 @@ impl<T: ShaderType + WriteInto> DynamicStorageBuffer<T> {
         if self.capacity < size || self.label_changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::COPY_DST | BufferUsages::STORAGE,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -33,6 +33,7 @@ pub struct UniformBuffer<T: ShaderType> {
     buffer: Option<Buffer>,
     label: Option<String>,
     label_changed: bool,
+    buffer_usage: BufferUsages,
 }
 
 impl<T: ShaderType> From<T> for UniformBuffer<T> {
@@ -43,6 +44,7 @@ impl<T: ShaderType> From<T> for UniformBuffer<T> {
             buffer: None,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -55,6 +57,7 @@ impl<T: ShaderType + Default> Default for UniformBuffer<T> {
             buffer: None,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -99,6 +102,10 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         self.label.as_deref()
     }
 
+    pub fn set_usage(&mut self, usage: BufferUsages) {
+        self.buffer_usage.set(usage, true);
+    }
+
     /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
     /// and the provided [`RenderQueue`](crate::renderer::RenderQueue), if a GPU-side backing buffer already exists.
     ///
@@ -110,7 +117,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         if self.label_changed || self.buffer.is_none() {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.label_changed = false;
@@ -146,6 +153,7 @@ pub struct DynamicUniformBuffer<T: ShaderType> {
     capacity: usize,
     label: Option<String>,
     label_changed: bool,
+    buffer_usage: BufferUsages,
 }
 
 impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
@@ -157,6 +165,7 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
             capacity: 0,
             label: None,
             label_changed: false,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -208,6 +217,10 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         self.label.as_deref()
     }
 
+    pub fn set_usage(&mut self, usage: BufferUsages) {
+        self.buffer_usage.set(usage, true);
+    }
+
     /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
     /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
     ///
@@ -220,7 +233,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         if self.capacity < size || self.label_changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -44,7 +44,7 @@ impl<T: ShaderType> From<T> for UniformBuffer<T> {
             buffer: None,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -57,7 +57,7 @@ impl<T: ShaderType + Default> Default for UniformBuffer<T> {
             buffer: None,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -102,6 +102,9 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         self.label.as_deref()
     }
 
+    /// Set the buffer usage of the buffer.
+    ///
+    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -118,7 +121,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         if self.changed || self.buffer.is_none() {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: self.buffer_usage,
+                usage: BufferUsages::UNIFORM | self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.changed = false;
@@ -166,7 +169,7 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
+            buffer_usage: BufferUsages::COPY_DST,
         }
     }
 }
@@ -218,6 +221,9 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         self.label.as_deref()
     }
 
+    /// Set the buffer usage of the buffer.
+    ///
+    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -235,7 +241,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: self.buffer_usage,
+                usage: BufferUsages::UNIFORM | self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -44,7 +44,7 @@ impl<T: ShaderType> From<T> for UniformBuffer<T> {
             buffer: None,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -57,7 +57,7 @@ impl<T: ShaderType + Default> Default for UniformBuffer<T> {
             buffer: None,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -104,6 +104,8 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
 
     /// Set the buffer usage of the buffer.
     ///
+    /// This method only allows addition of flags to the default usage flags.
+    ///
     /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
@@ -121,7 +123,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         if self.changed || self.buffer.is_none() {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::UNIFORM | self.buffer_usage,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.changed = false;
@@ -169,7 +171,7 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
             capacity: 0,
             label: None,
             changed: false,
-            buffer_usage: BufferUsages::COPY_DST,
+            buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
 }
@@ -223,6 +225,8 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
 
     /// Set the buffer usage of the buffer.
     ///
+    /// This method only allows addition of flags to the default usage flags.
+    ///
     /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
@@ -241,7 +245,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
-                usage: BufferUsages::UNIFORM | self.buffer_usage,
+                usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -102,7 +102,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Set the buffer usage of the buffer.
+    /// Adds more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
@@ -223,7 +223,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Set the buffer usage of the buffer.
+    /// Adds more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -32,7 +32,7 @@ pub struct UniformBuffer<T: ShaderType> {
     scratch: UniformBufferWrapper<Vec<u8>>,
     buffer: Option<Buffer>,
     label: Option<String>,
-    label_changed: bool,
+    changed: bool,
     buffer_usage: BufferUsages,
 }
 
@@ -43,7 +43,7 @@ impl<T: ShaderType> From<T> for UniformBuffer<T> {
             scratch: UniformBufferWrapper::new(Vec::new()),
             buffer: None,
             label: None,
-            label_changed: false,
+            changed: false,
             buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
@@ -56,7 +56,7 @@ impl<T: ShaderType + Default> Default for UniformBuffer<T> {
             scratch: UniformBufferWrapper::new(Vec::new()),
             buffer: None,
             label: None,
-            label_changed: false,
+            changed: false,
             buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
@@ -92,7 +92,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         let label = label.map(str::to_string);
 
         if label != self.label {
-            self.label_changed = true;
+            self.changed = true;
         }
 
         self.label = label;
@@ -103,7 +103,8 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
     }
 
     pub fn set_usage(&mut self, usage: BufferUsages) {
-        self.buffer_usage.set(usage, true);
+        self.buffer_usage |= usage;
+        self.changed = true;
     }
 
     /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
@@ -114,13 +115,13 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
         self.scratch.write(&self.value).unwrap();
 
-        if self.label_changed || self.buffer.is_none() {
+        if self.changed || self.buffer.is_none() {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
                 usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
-            self.label_changed = false;
+            self.changed = false;
         } else if let Some(buffer) = &self.buffer {
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }
@@ -152,7 +153,7 @@ pub struct DynamicUniformBuffer<T: ShaderType> {
     buffer: Option<Buffer>,
     capacity: usize,
     label: Option<String>,
-    label_changed: bool,
+    changed: bool,
     buffer_usage: BufferUsages,
 }
 
@@ -164,7 +165,7 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
             buffer: None,
             capacity: 0,
             label: None,
-            label_changed: false,
+            changed: false,
             buffer_usage: BufferUsages::COPY_DST | BufferUsages::UNIFORM,
         }
     }
@@ -207,7 +208,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         let label = label.map(str::to_string);
 
         if label != self.label {
-            self.label_changed = true;
+            self.changed = true;
         }
 
         self.label = label;
@@ -218,7 +219,8 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     }
 
     pub fn set_usage(&mut self, usage: BufferUsages) {
-        self.buffer_usage.set(usage, true);
+        self.buffer_usage |= usage;
+        self.changed = true;
     }
 
     /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
@@ -230,14 +232,14 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
         let size = self.scratch.as_ref().len();
 
-        if self.capacity < size || self.label_changed {
+        if self.capacity < size || self.changed {
             self.buffer = Some(device.create_buffer_with_data(&BufferInitDescriptor {
                 label: self.label.as_deref(),
                 usage: self.buffer_usage,
                 contents: self.scratch.as_ref(),
             }));
             self.capacity = size;
-            self.label_changed = false;
+            self.changed = false;
         } else if let Some(buffer) = &self.buffer {
             queue.write_buffer(buffer, 0, self.scratch.as_ref());
         }

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -102,7 +102,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Adds more [`BufferUsages`] to the buffer.
+    /// Add more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
@@ -223,7 +223,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         self.label.as_deref()
     }
 
-    /// Adds more [`BufferUsages`] to the buffer.
+    /// Add more [`BufferUsages`] to the buffer.
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -107,7 +107,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
     /// This method only allows addition of flags to the default usage flags.
     ///
     /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::UNIFORM`.
-    pub fn set_usage(&mut self, usage: BufferUsages) {
+    pub fn add_usages(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
     }
@@ -228,7 +228,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     /// This method only allows addition of flags to the default usage flags.
     ///
     /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::UNIFORM`.
-    pub fn set_usage(&mut self, usage: BufferUsages) {
+    pub fn add_usages(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
     }

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -106,7 +106,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
-    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
+    /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::UNIFORM`.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;
@@ -227,7 +227,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     ///
     /// This method only allows addition of flags to the default usage flags.
     ///
-    /// The default values for buffer usage are BufferUsages::COPY_DST and BufferUsages::UNIFORM.
+    /// The default values for buffer usage are `BufferUsages::COPY_DST` and `BufferUsages::UNIFORM`.
     pub fn set_usage(&mut self, usage: BufferUsages) {
         self.buffer_usage |= usage;
         self.changed = true;


### PR DESCRIPTION
# Objective

Buffers in bevy do not allow for setting buffer usage flags which can be useful for setting COPY_SRC, MAP_READ, MAP_WRITE, which allows for buffers to be copied from gpu to cpu for inspection.

## Solution

Add buffer_usage field to buffers and a set_usage function to set them

