### PR TITLE
[Merged by Bors] - Fix CI welcome message

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -3,7 +3,10 @@ name: Welcome new contributors
 # This workflow has write permissions on the repo
 # It must not checkout a PR and run untrusted code
 
-on: pull_request_target
+on:
+  pull_request_target:
+    types:
+      - opened
 
 jobs:
   welcome:
@@ -38,5 +41,5 @@ jobs:
               repo: context.repo.repo,
               body: `**Welcome**, new contributor!
 
-                Please make sure you're read our [contributing guide](CONTRIBUTING.md) and we look forward to reviewing your Pull request shortly ✨`
+              Please make sure you're read our [contributing guide](https://github.com/bevyengine/bevy/blob/main/CONTRIBUTING.md) and we look forward to reviewing your Pull request shortly ✨`
             })

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -41,5 +41,5 @@ jobs:
               repo: context.repo.repo,
               body: `**Welcome**, new contributor!
 
-              Please make sure you're read our [contributing guide](https://github.com/bevyengine/bevy/blob/main/CONTRIBUTING.md) and we look forward to reviewing your Pull request shortly ✨`
+              Please make sure you're read our [contributing guide](https://github.com/bevyengine/bevy/blob/main/CONTRIBUTING.md) and we look forward to reviewing your pull request shortly ✨`
             })

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -41,5 +41,5 @@ jobs:
               repo: context.repo.repo,
               body: `**Welcome**, new contributor!
 
-              Please make sure you're read our [contributing guide](https://github.com/bevyengine/bevy/blob/main/CONTRIBUTING.md) and we look forward to reviewing your pull request shortly ✨`
+              Please make sure you've read our [contributing guide](https://github.com/bevyengine/bevy/blob/main/CONTRIBUTING.md) and we look forward to reviewing your pull request shortly ✨`
             })


### PR DESCRIPTION
# Objective

Fixes #7424

## Solution

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target
> By default, a workflow only runs when a pull_request_target event's activity type is opened, synchronize, or reopened.

Specify `opened` so that this only runs when a PR is opened

While I was in there, I fixed a couple other issues:
- extra indentation that was causing the welcome message to be put in a code block.
- broken relative link in message (was resolving to <https://github.com/bevyengine/bevy/pull/CONTRIBUTING.md>)
- fixed a few other minor typos in the message

cc @mockersf 