### PR TITLE
[Merged by Bors] - bevy_pbr: Clear fog DynamicUniformBuffer before populating each frame

### DIFF
--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -53,6 +53,8 @@ pub fn prepare_fog(
     mut fog_meta: ResMut<FogMeta>,
     views: Query<(Entity, Option<&FogSettings>), With<ExtractedView>>,
 ) {
+    fog_meta.gpu_fogs.clear();
+
     for (entity, fog) in &views {
         let gpu_fog = if let Some(fog) = fog {
             match &fog.falloff {


### PR DESCRIPTION
# Objective

- Fix a bug causing performance to drop over time because the GPU fog buffer was endlessly growing

## Solution

- Clear the fog buffer every frame before populating it