### PR TITLE
[Merged by Bors] - Cleanup many sprites stress tests

### DIFF
--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -13,6 +13,7 @@ use bevy::{
     math::Quat,
     prelude::*,
     render::camera::Camera,
+    window::PresentMode,
 };
 
 use rand::Rng;

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -1,10 +1,10 @@
 //! Renders a lot of animated sprites to allow performance testing.
 //!
-//! It sets up many animated sprites in different sizes and rotations, and at different scales in the world,
-//! and moves the camera over them to see how well frustum culling works.
+//! It sets up many animated sprites in different sizes and rotations,
+//! and at different scales in the world, and moves the camera over them.
 //!
-//! To measure performance realistically, be sure to run this in release mode.
-//! `cargo run --example many_animated_sprites --release`
+//! Having sprites out of the camera's field of view should also help stress
+//! test any future potential 2d frustum culling implementation.
 
 use std::time::Duration;
 
@@ -24,7 +24,13 @@ fn main() {
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugins(DefaultPlugins)
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                present_mode: PresentMode::AutoNoVsync,
+                ..default()
+            }),
+            ..default()
+        }))
         .add_startup_system(setup)
         .add_system(animate_sprite)
         .add_system(print_sprite_count)
@@ -37,6 +43,8 @@ fn setup(
     assets: Res<AssetServer>,
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
 ) {
+    warn!(include_str!("warning_string.txt"));
+
     let mut rng = rand::thread_rng();
 
     let tile_size = Vec2::splat(64.0);

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -1,8 +1,11 @@
 //! Renders a lot of sprites to allow performance testing.
 //! See <https://github.com/bevyengine/bevy/pull/1492>
 //!
-//! It sets up many sprites in different sizes and rotations, and at different scales in the world,
-//! and moves the camera over them to see how well frustum culling works.
+//! It sets up many animated sprites in different sizes and rotations,
+//! and at different scales in the world, and moves the camera over them.
+//!
+//! Having sprites out of the camera's field of view should also help stress
+//! test any future potential 2d frustum culling implementation.
 //!
 //! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered
 //! in multiple batches, reducing performance but useful for testing.


### PR DESCRIPTION
Since the new renderer, no frustum culling is applied to 2d components
(be it Sprite or Mesh2d), the stress_tests docs is therefore misleading
and should be updated.

Furthermore, the `many_animated_sprites` example, unlike `many_sprites`
kept vsync enabled, making the stress test less useful than it could be.
We now disable vsync for `many_animated_sprites`.

Also, `many_animated_sprites` didn't have the stress_tests warning
message, instead, it had a paragraph in the module doc. I replaced the
module doc paragraph by the warning message, to be more in line with
other examples.

## Solution

- Remove the paragraph about frustum culling in the `many_sprites`
  and `many_animated_sprites` stress tests