### PR TITLE
[Merged by Bors] - Stageless: fix unapplied systems

### DIFF
--- a/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
@@ -181,7 +181,7 @@ impl SystemExecutor for MultiThreadedExecutor {
 
                 // SAFETY: all systems have completed
                 let world = unsafe { &mut *world.get() };
-                apply_system_buffers(&mut self.unapplied_systems, systems, world);
+                apply_system_buffers(&self.unapplied_systems, systems, world);
                 self.unapplied_systems.clear();
                 debug_assert!(self.unapplied_systems.is_clear());
 
@@ -460,12 +460,12 @@ impl MultiThreadedExecutor {
         let sender = self.sender.clone();
         if is_apply_system_buffers(system) {
             // TODO: avoid allocation
-            let mut unapplied_systems = self.unapplied_systems.clone();
+            let unapplied_systems = self.unapplied_systems.clone();
             self.unapplied_systems.clear();
             let task = async move {
                 #[cfg(feature = "trace")]
                 let system_guard = system_span.enter();
-                apply_system_buffers(&mut unapplied_systems, systems, world);
+                apply_system_buffers(&unapplied_systems, systems, world);
                 #[cfg(feature = "trace")]
                 drop(system_guard);
                 sender
@@ -547,7 +547,7 @@ impl MultiThreadedExecutor {
 }
 
 fn apply_system_buffers(
-    unapplied_systems: &mut FixedBitSet,
+    unapplied_systems: &FixedBitSet,
     systems: &[SyncUnsafeCell<BoxedSystem>],
     world: &mut World,
 ) {


### PR DESCRIPTION
# Objective

- The stageless executor keeps track of systems that have run, but have not applied their system buffers. The bitset for that was being cloned into apply_system_buffers and cleared in that function, but we need to clear the original version instead of the cloned version

## Solution

- move the clear out of the apply_system_buffers function.