### PR TITLE
[Merged by Bors] - Add constructor `new` to `ArrayIter`

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -270,10 +270,7 @@ impl Array for DynamicArray {
 
     #[inline]
     fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
+        ArrayIter::new(self, 0)
     }
 
     #[inline]
@@ -303,8 +300,18 @@ impl Typed for DynamicArray {
 
 /// An iterator over an [`Array`].
 pub struct ArrayIter<'a> {
-    pub(crate) array: &'a dyn Array,
-    pub(crate) index: usize,
+    array: &'a dyn Array,
+    index: usize,
+}
+
+impl<'a> ArrayIter<'a> {
+    /// Creates a new [`ArrayIter`].
+    ///
+    /// It is an [`Iterator`] for [`Array`] whose elements start from `index`.
+    #[inline]
+    pub fn new(array: &'a dyn Array, index: usize) -> ArrayIter {
+        ArrayIter { array, index }
+    }
 }
 
 impl<'a> Iterator for ArrayIter<'a> {

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -270,7 +270,7 @@ impl Array for DynamicArray {
 
     #[inline]
     fn iter(&self) -> ArrayIter {
-        ArrayIter::new(self, 0)
+        ArrayIter::new(self)
     }
 
     #[inline]
@@ -309,8 +309,8 @@ impl<'a> ArrayIter<'a> {
     ///
     /// It is an [`Iterator`] for [`Array`] whose elements start from `index`.
     #[inline]
-    pub fn new(array: &'a dyn Array, index: usize) -> ArrayIter {
-        ArrayIter { array, index }
+    pub const fn new(array: &'a dyn Array) -> ArrayIter {
+        ArrayIter { array, index: 0 }
     }
 }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -306,8 +306,6 @@ pub struct ArrayIter<'a> {
 
 impl<'a> ArrayIter<'a> {
     /// Creates a new [`ArrayIter`].
-    ///
-    /// It is an [`Iterator`] for [`Array`] whose elements start from `index`.
     #[inline]
     pub const fn new(array: &'a dyn Array) -> ArrayIter {
         ArrayIter { array, index: 0 }

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -32,7 +32,7 @@ where
     }
 
     fn iter(&self) -> ArrayIter {
-        ArrayIter::new(self, 0)
+        ArrayIter::new(self)
     }
 
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -32,10 +32,7 @@ where
     }
 
     fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
+        ArrayIter::new(self, 0)
     }
 
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -198,10 +198,7 @@ macro_rules! impl_reflect_for_veclike {
 
             #[inline]
             fn iter(&self) -> ArrayIter {
-                ArrayIter {
-                    array: self,
-                    index: 0,
-                }
+                ArrayIter::new(self, 0)
             }
 
             #[inline]
@@ -552,10 +549,7 @@ impl<T: Reflect, const N: usize> Array for [T; N] {
 
     #[inline]
     fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
+        ArrayIter::new(self, 0)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -198,7 +198,7 @@ macro_rules! impl_reflect_for_veclike {
 
             #[inline]
             fn iter(&self) -> ArrayIter {
-                ArrayIter::new(self, 0)
+                ArrayIter::new(self)
             }
 
             #[inline]
@@ -549,7 +549,7 @@ impl<T: Reflect, const N: usize> Array for [T; N] {
 
     #[inline]
     fn iter(&self) -> ArrayIter {
-        ArrayIter::new(self, 0)
+        ArrayIter::new(self)
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -176,7 +176,7 @@ impl Array for DynamicList {
     }
 
     fn iter(&self) -> ArrayIter {
-        ArrayIter::new(self, 0)
+        ArrayIter::new(self)
     }
 
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -176,10 +176,7 @@ impl Array for DynamicList {
     }
 
     fn iter(&self) -> ArrayIter {
-        ArrayIter {
-            array: self,
-            index: 0,
-        }
+        ArrayIter::new(self, 0)
     }
 
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {


### PR DESCRIPTION
# Objective

- Fixes #7430.

## Solution

- Changed fields of `ArrayIter` to be private.
- Add a constructor `new` to `ArrayIter`.
- Replace normal struct creation with `new`.

---

## Changelog

- Add a constructor `new` to `ArrayIter`.
