### PR TITLE
Separate image and background color values

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -61,7 +61,7 @@ impl Default for NodeBundle {
 }
 
 /// A UI node that is an image
-#[derive(Bundle, Clone, Debug, Default)]
+#[derive(Bundle, Clone, Debug)]
 pub struct ImageBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -70,8 +70,6 @@ pub struct ImageBundle {
     /// The calculated size based on the given image
     pub calculated_size: CalculatedSize,
     /// The background color, which serves as a "fill" for this node
-    ///
-    /// Combines with `UiImage` to tint the provided image.
     pub background_color: BackgroundColor,
     /// The image of the node
     pub image: UiImage,
@@ -93,6 +91,25 @@ pub struct ImageBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+}
+
+impl Default for ImageBundle {
+    fn default() -> Self {
+        ImageBundle {
+            image: Default::default(),
+            calculated_size: Default::default(),
+            // Transparent background
+            background_color: Color::NONE.into(),
+            node: Default::default(),
+            style: Default::default(),
+            focus_policy: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            computed_visibility: Default::default(),
+            z_index: Default::default(),
+        }
+    }
 }
 
 /// A UI node that is text

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -601,6 +601,8 @@ impl From<Color> for BackgroundColor {
 pub struct UiImage {
     /// Handle to the texture
     pub texture: Handle<Image>,
+    /// image's color tint
+    pub color: Color,
     /// Whether the image should be flipped along its x-axis
     pub flip_x: bool,
     /// Whether the image should be flipped along its y-axis
@@ -611,6 +613,7 @@ impl Default for UiImage {
     fn default() -> UiImage {
         UiImage {
             texture: DEFAULT_IMAGE_HANDLE.typed(),
+            color: Color::WHITE,
             flip_x: false,
             flip_y: false,
         }


### PR DESCRIPTION
# Objective

* It's confusing that the `BackgroundColor` component is also used to control image color.
* Padding for ImageNodes isn't implemented atm, but when it is, `BackgroundColor` could be used to set the color of the padded area.
* At the moment you have to nest a transparent image inside of another node to give it a background color.
* If a texture doesn't load at the moment, nothing is drawn. With a separate background color, you could fill the node with a bright color to indicate a missing texture. 

## Solution
Add a `color` field to `UiImage` and use it instead of `BackgroundColor` for image colors.
Draw separate background and image rects for each node, if the respective components are present.

## Changelog
    * added a `color` field to `UiImage`
    * added a manual impl of `Default` for `ImageBundle`
    * changed default `background_color` of `ImageBundle` to `Color::NONE`
    * changed extract_uinodes to queue separate rects for the background color and the image

## Migration Guide

To set the color tint of an image, instead of using the `BackgroundColor` component use the `color` field of `UiImage`.
