### PR TITLE
[Merged by Bors] - Rename the `background_color` of 'ExtractedUiNode` to `color`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -169,7 +169,7 @@ fn get_ui_graph(render_app: &mut App) -> RenderGraph {
 pub struct ExtractedUiNode {
     pub stack_index: usize,
     pub transform: Mat4,
-    pub background_color: Color,
+    pub color: Color,
     pub rect: Rect,
     pub image: Handle<Image>,
     pub atlas_size: Option<Vec2>,
@@ -221,7 +221,7 @@ pub fn extract_uinodes(
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
                 transform: transform.compute_matrix(),
-                background_color: color.0,
+                color: color.0,
                 rect: Rect {
                     min: Vec2::ZERO,
                     max: uinode.calculated_size,
@@ -357,7 +357,7 @@ pub fn extract_text_uinodes(
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,
                     transform: extracted_transform,
-                    background_color: color,
+                    color,
                     rect,
                     image: texture,
                     atlas_size,
@@ -524,7 +524,7 @@ pub fn prepare_uinodes(
             uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
         }
 
-        let color = extracted_uinode.background_color.as_linear_rgba_f32();
+        let color = extracted_uinode.color.as_linear_rgba_f32();
         for i in QUAD_INDICES {
             ui_meta.vertices.push(UiVertex {
                 position: positions_clipped[i].into(),


### PR DESCRIPTION
# Problem
The field is called `background_color` but it is also used to hold the colors of text glyphs and images.
It's mildly confusing and longer to type than just `color`.

## Solution
Rename `background_color` to `color`.

## Changelog
* Renamed the `background_color` field of `ExtractedUiNode` to `color`.

## Migration Guide
* The `background_color` field of `ExtractedUiNode` is now named `color`.
