### PR TITLE
adding reflection for Cow<'static, [T]>

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1039,6 +1039,130 @@ impl FromReflect for Cow<'static, str> {
     }
 }
 
+impl<T: Clone + std::marker::Sync + std::marker::Send + std::hash::Hash + std::cmp::PartialEq>
+    Reflect for Cow<'static, [T]>
+{
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_type_info(&self) -> &'static TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            *self = value.clone();
+        } else {
+            panic!("Value is not a {}.", std::any::type_name::<Self>());
+        }
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Value(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Value(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Value(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone())
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        let mut hasher = crate::ReflectHasher::default();
+        Hash::hash(&std::any::Any::type_id(self), &mut hasher);
+        Hash::hash(self, &mut hasher);
+        Some(hasher.finish())
+    }
+
+    fn reflect_partial_eq<'a>(&self, value: &dyn Reflect) -> Option<bool> {
+        let value = value.as_any();
+        if let Some(value) = value.downcast_ref::<Self>() {
+            Some(match (self, value) {
+                (Cow::Borrowed(l0), Cow::Borrowed(r0)) => l0 == r0,
+                (Cow::Owned(l0), Cow::Owned(r0)) => l0 == r0,
+                _ => false,
+            })
+        } else {
+            Some(false)
+        }
+    }
+}
+
+impl<
+        T: Clone
+            + std::marker::Sync
+            + std::marker::Send
+            + std::hash::Hash
+            + std::cmp::PartialEq
+            + 'static,
+    > Typed for Cow<'static, [T]>
+{
+    fn type_info() -> &'static TypeInfo {
+        static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
+        CELL.get_or_set(|| TypeInfo::Value(ValueInfo::new::<Self>()))
+    }
+}
+
+impl<T: Clone + std::marker::Sync + std::marker::Send> GetTypeRegistration for Cow<'static, [T]> {
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Cow<'static, str>>();
+        registration.insert::<ReflectDeserialize>(FromType::<Cow<'static, str>>::from_type());
+        registration.insert::<ReflectFromPtr>(FromType::<Cow<'static, str>>::from_type());
+        registration.insert::<ReflectSerialize>(FromType::<Cow<'static, str>>::from_type());
+        registration
+    }
+}
+
+impl<T: Clone + std::marker::Sync + std::marker::Send + std::hash::Hash + std::cmp::PartialEq>
+    FromReflect for Cow<'static, [T]>
+{
+    fn from_reflect(reflect: &dyn crate::Reflect) -> Option<Self> {
+        Some(
+            reflect
+                .as_any()
+                .downcast_ref::<Cow<'static, [T]>>()?
+                .clone(),
+        )
+    }
+}
+
 impl Reflect for &'static Path {
     fn type_name(&self) -> &str {
         std::any::type_name::<Self>()

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -106,7 +106,10 @@ mod tests {
         Deserializer,
     };
     use std::any::TypeId;
-    use std::fmt::{Debug, Formatter};
+    use std::{
+        borrow::Cow,
+        fmt::{Debug, Formatter},
+    };
 
     use super::prelude::*;
     use super::*;
@@ -553,6 +556,8 @@ mod tests {
             b: Bar,
             u: usize,
             t: ([f32; 3], String),
+            v: Cow<'static, str>,
+            w: Cow<'static, [u8]>,
         }
 
         let foo = Foo {
@@ -561,6 +566,8 @@ mod tests {
             b: Bar { y: 255 },
             u: 1111111111111,
             t: ([3.0, 2.0, 1.0], "Tuple String".to_string()),
+            v: Cow::Owned("Cow String".to_string()),
+            w: Cow::Owned(vec![1, 2, 3]),
         };
 
         let foo2: Box<dyn Reflect> = Box::new(foo.clone());
@@ -823,6 +830,36 @@ mod tests {
         let value: &dyn Reflect = &[1usize, 2usize, 3usize];
         let info = value.get_type_info();
         assert!(info.is::<MyArray>());
+
+        // Cow<'static, str>
+        type MyCowStr = Cow<'static, str>;
+
+        let info = MyCowStr::type_info();
+        if let TypeInfo::Value(info) = info {
+            assert!(info.is::<MyCowStr>());
+            assert_eq!(std::any::type_name::<MyCowStr>(), info.type_name());
+        } else {
+            panic!("Expected `TypeInfo::Value`");
+        }
+
+        let value: &dyn Reflect = &Cow::<'static, str>::Owned("Hello!".to_string());
+        let info = value.get_type_info();
+        assert!(info.is::<MyCowStr>());
+
+        // Cow<'static, [u8]>
+        type MyCowSlice = Cow<'static, [u8]>;
+
+        let info = MyCowSlice::type_info();
+        if let TypeInfo::Value(info) = info {
+            assert!(info.is::<MyCowSlice>());
+            assert_eq!(std::any::type_name::<MyCowSlice>(), info.type_name());
+        } else {
+            panic!("Expected `TypeInfo::Value`");
+        }
+
+        let value: &dyn Reflect = &Cow::<'static, [u8]>::Owned(vec![0, 1, 2, 3]);
+        let info = value.get_type_info();
+        assert!(info.is::<MyCowSlice>());
 
         // Map
         type MyMap = HashMap<usize, f32>;


### PR DESCRIPTION
# Objective

- Implementing reflection for Cow<'static, [T]>
- Hopefully fixes #7429

## Solution

- Implementing Reflect, Typed, GetTypeRegistration, and FromReflect for Cow<'static, [T]>

---

## Notes

I have not used bevy_reflection much yet, so I may not fully understand all the use cases. This is also my first attempt at contributing, so I would appreciate any feedback or recommendations for changes. I tried to add cases for using Cow<'static, str> and Cow<'static, [u8]> to some of the bevy_reflect tests, but I can't guarantee those tests are comprehensive enough.
