### PR TITLE
[Merged by Bors] - Better cascades config defaults + builder, tweak example configs

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -226,15 +226,23 @@ pub struct DirectionalLightShadowMap {
 
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
-        #[cfg(feature = "webgl")]
-        return Self { size: 2048 };
-        #[cfg(not(feature = "webgl"))]
         return Self { size: 2048 };
     }
 }
 
 /// Controls how cascaded shadow mapping works.
 /// Prefer using [`CascadeShadowConfigBuilder`] to construct an instance.
+///
+/// ```
+/// # use bevy_pbr::CascadeShadowConfig;
+/// # use bevy_pbr::CascadeShadowConfigBuilder;
+/// # use bevy_utils::default;
+/// #
+/// let config: CascadeShadowConfig = CascadeShadowConfigBuilder {
+///   maximum_distance: 100.0,
+///   ..default()
+/// }.into();
+/// ```
 #[derive(Component, Clone, Debug, Reflect)]
 #[reflect(Component)]
 pub struct CascadeShadowConfig {
@@ -248,7 +256,7 @@ pub struct CascadeShadowConfig {
 
 impl Default for CascadeShadowConfig {
     fn default() -> Self {
-        CascadeShadowConfigBuilder::new().build()
+        CascadeShadowConfigBuilder::default().into()
     }
 }
 
@@ -268,37 +276,7 @@ fn calculate_cascade_bounds(
 
 /// Builder for [`CascadeShadowConfig`].
 pub struct CascadeShadowConfigBuilder {
-    num_cascades: usize,
-    minimum_distance: f32,
-    maximum_distance: f32,
-    first_cascade_far_bound: f32,
-    overlap_proportion: f32,
-}
-
-impl CascadeShadowConfigBuilder {
-    /// Constructs a new builder.
-    pub fn new() -> Self {
-        if cfg!(feature = "webgl") {
-            // Currently only support one cascade in webgl.
-            Self {
-                num_cascades: 1,
-                minimum_distance: 0.1,
-                maximum_distance: 100.0,
-                first_cascade_far_bound: 5.0,
-                overlap_proportion: 0.2,
-            }
-        } else {
-            Self {
-                num_cascades: 4,
-                minimum_distance: 0.1,
-                maximum_distance: 1000.0,
-                first_cascade_far_bound: 5.0,
-                overlap_proportion: 0.2,
-            }
-        }
-    }
-
-    /// Sets the number of shadow cascades.
+    /// The number of shadow cascades.
     /// More cascades increases shadow quality by mitigating perspective aliasing - a phenomenom where areas
     /// nearer the camera are covered by fewer shadow map texels than areas further from the camera, causing
     /// blocky looking shadows.
@@ -310,12 +288,8 @@ impl CascadeShadowConfigBuilder {
     /// In case rendered geometry covers a relatively narrow and static depth relative to camera, it may
     /// make more sense to use fewer cascades and a higher resolution shadow map texture as perspective aliasing
     /// is not as much an issue. Be sure to adjust `minimum_distance` and `maximum_distance` appropriately.
-    pub fn num_cascades(mut self, n: usize) -> Self {
-        self.num_cascades = n;
-        self
-    }
-
-    /// Sets the minimum shadow distance, which can help improve the texel resolution of the first cascade.
+    pub num_cascades: usize,
+    /// The minimum shadow distance, which can help improve the texel resolution of the first cascade.
     /// Areas nearer to the camera than this will likely receive no shadows.
     ///
     /// NOTE: Due to implementation details, this usually does not impact shadow quality as much as
@@ -323,34 +297,21 @@ impl CascadeShadowConfigBuilder {
     /// texel resolution of the first cascade is dominated by the width / height of the view frustum plane
     /// at `first_cascade_far_bound` rather than the depth of the frustum from `minimum_distance` to
     /// `first_cascade_far_bound`.
-    pub fn minimum_distance(mut self, d: f32) -> Self {
-        self.minimum_distance = d;
-        self
-    }
-
-    /// Sets the maximum shadow distance.
+    pub minimum_distance: f32,
+    /// The maximum shadow distance.
     /// Areas further from the camera than this will likely receive no shadows.
-    pub fn maximum_distance(mut self, d: f32) -> Self {
-        self.maximum_distance = d;
-        self
-    }
-
+    pub maximum_distance: f32,
     /// Sets the far bound of the first cascade, relative to the view origin.
     /// In-between cascades will be exponentially spaced relative to the maximum shadow distance.
     /// NOTE: This is ignored if there is only one cascade, the maximum distance takes precedence.
-    pub fn first_cascade_far_bound(mut self, bound: f32) -> Self {
-        self.first_cascade_far_bound = bound;
-        self
-    }
-
+    pub first_cascade_far_bound: f32,
     /// Sets the overlap proportion between cascades.
     /// The overlap is used to make the transition from one cascade's shadow map to the next
     /// less abrupt by blending between both shadow maps.
-    pub fn overlap_proportion(mut self, p: f32) -> Self {
-        self.overlap_proportion = p;
-        self
-    }
+    pub overlap_proportion: f32,
+}
 
+impl CascadeShadowConfigBuilder {
     /// Returns the cascade config as specified by this builder.
     pub fn build(&self) -> CascadeShadowConfig {
         assert!(
@@ -359,13 +320,18 @@ impl CascadeShadowConfigBuilder {
             self.num_cascades
         );
         assert!(
-            (0.0..self.first_cascade_far_bound).contains(&self.minimum_distance),
-            "minimum_distance must be in [0.0, first_cascade_far_bound), but was {}",
+            self.minimum_distance >= 0.0,
+            "maximum_distance must be non-negative, but was {}",
             self.minimum_distance
         );
         assert!(
-            self.maximum_distance >= 0.0,
-            "maximum_distance must be non-negative, but was {}",
+            self.num_cascades == 1 || self.minimum_distance < self.first_cascade_far_bound,
+            "minimum_distance must be less than first_cascade_far_bound, but was {}",
+            self.minimum_distance
+        );
+        assert!(
+            self.maximum_distance > self.minimum_distance,
+            "maximum_distance must be greater than minimum_distance, but was {}",
             self.maximum_distance
         );
         assert!(
@@ -387,7 +353,30 @@ impl CascadeShadowConfigBuilder {
 
 impl Default for CascadeShadowConfigBuilder {
     fn default() -> Self {
-        Self::new()
+        if cfg!(feature = "webgl") {
+            // Currently only support one cascade in webgl.
+            Self {
+                num_cascades: 1,
+                minimum_distance: 0.1,
+                maximum_distance: 100.0,
+                first_cascade_far_bound: 5.0,
+                overlap_proportion: 0.2,
+            }
+        } else {
+            Self {
+                num_cascades: 4,
+                minimum_distance: 0.1,
+                maximum_distance: 1000.0,
+                first_cascade_far_bound: 5.0,
+                overlap_proportion: 0.2,
+            }
+        }
+    }
+}
+
+impl From<CascadeShadowConfigBuilder> for CascadeShadowConfig {
+    fn from(builder: CascadeShadowConfigBuilder) -> Self {
+        builder.build()
     }
 }
 

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -317,7 +317,7 @@ impl CascadeShadowConfigBuilder {
 
     /// Sets the minimum shadow distance, which can help improve the texel resolution of the first cascade.
     /// Areas nearer to the camera than this will likely receive no shadows.
-    /// 
+    ///
     /// NOTE: Due to implementation details, this usually does not impact shadow quality as much as
     /// `first_cascade_far_bound` and `maximum_distance`. At many view frustum field-of-views, the
     /// texel resolution of the first cascade is dominated by the width / height of the view frustum plane

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -227,7 +227,7 @@ pub struct DirectionalLightShadowMap {
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
         #[cfg(feature = "webgl")]
-        return Self { size: 1024 };
+        return Self { size: 2048 };
         #[cfg(not(feature = "webgl"))]
         return Self { size: 2048 };
     }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -315,10 +315,14 @@ impl CascadeShadowConfigBuilder {
         self
     }
 
-    /// Sets the minimum shadow distance.
+    /// Sets the minimum shadow distance, which can help improve the texel resolution of the first cascade.
     /// Areas nearer to the camera than this will likely receive no shadows.
+    /// 
     /// NOTE: Due to implementation details, this usually does not impact shadow quality as much as
-    /// `first_cascade_far_bound` and `maximum_distance`.
+    /// `first_cascade_far_bound` and `maximum_distance`. At many view frustum field-of-views, the
+    /// texel resolution of the first cascade is dominated by the width / height of the view frustum plane
+    /// at `first_cascade_far_bound` rather than the depth of the frustum from `minimum_distance` to
+    /// `first_cascade_far_bound`.
     pub fn minimum_distance(mut self, d: f32) -> Self {
         self.minimum_distance = d;
         self

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -305,9 +305,9 @@ impl CascadeShadowConfigBuilder {
     ///
     /// This does come at the cost increased rendering overhead, however this overhead is still less
     /// than if you were to use fewer cascades and much larger shadow map textures to achieve the
-    /// same quality leveland much larger shadow map textures to achieve the same quality level
+    /// same quality level.
     ///
-    /// In cases rendered geometry covers a relatively narrow and static depth relative to camera, it may
+    /// In case rendered geometry covers a relatively narrow and static depth relative to camera, it may
     /// make more sense to use fewer cascades and a higher resolution shadow map texture as perspective aliasing
     /// is not as much an issue. Be sure to adjust `minimum_distance` and `maximum_distance` appropriately.
     pub fn num_cascades(mut self, n: usize) -> Self {

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -318,7 +318,7 @@ impl CascadeShadowConfigBuilder {
     /// Sets the minimum shadow distance.
     /// Areas nearer to the camera than this will likely receive no shadows.
     /// NOTE: Due to implementation details, this usually does not impact shadow quality as much as
-    /// [`first_cascade_far_bound`] and [`maximum_distance`].
+    /// `first_cascade_far_bound` and `maximum_distance`.
     pub fn minimum_distance(mut self, d: f32) -> Self {
         self.minimum_distance = d;
         self

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -353,8 +353,8 @@ impl CascadeShadowConfigBuilder {
             self.num_cascades
         );
         assert!(
-            self.minimum_distance >= 0.0,
-            "minimum_distance must be non-negative, but was {}",
+            (0.0..self.first_cascade_far_bound).contains(&self.minimum_distance),
+            "minimum_distance must be in [0.0, first_cascade_far_bound), but was {}",
             self.minimum_distance
         );
         assert!(

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -317,6 +317,8 @@ impl CascadeShadowConfigBuilder {
 
     /// Sets the minimum shadow distance.
     /// Areas nearer to the camera than this will likely receive no shadows.
+    /// NOTE: Due to implementation details, this usually does not impact shadow quality as much as
+    /// [`first_cascade_far_bound`] and [`maximum_distance`].
     pub fn minimum_distance(mut self, d: f32) -> Self {
         self.minimum_distance = d;
         self
@@ -329,7 +331,7 @@ impl CascadeShadowConfigBuilder {
         self
     }
 
-    /// Sets the far bound of the first cascade.
+    /// Sets the far bound of the first cascade, relative to the view origin.
     /// In-between cascades will be exponentially spaced relative to the maximum shadow distance.
     /// NOTE: This is ignored if there is only one cascade, the maximum distance takes precedence.
     pub fn first_cascade_far_bound(mut self, bound: f32) -> Self {

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -337,6 +337,14 @@ impl CascadeShadowConfigBuilder {
         self
     }
 
+    /// Sets the overlap proportion between cascades.
+    /// The overlap is used to make the transition from one cascade's shadow map to the next
+    /// less abrupt by blending between both shadow maps.
+    pub fn overlap_proportion(mut self, p: f32) -> Self {
+        self.overlap_proportion = p;
+        self
+    }
+
     /// Returns the cascade config as specified by this builder.
     pub fn build(&self) -> CascadeShadowConfig {
         assert!(

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -226,7 +226,7 @@ pub struct DirectionalLightShadowMap {
 
 impl Default for DirectionalLightShadowMap {
     fn default() -> Self {
-        return Self { size: 2048 };
+        Self { size: 2048 }
     }
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -169,7 +169,7 @@ fn get_ui_graph(render_app: &mut App) -> RenderGraph {
 pub struct ExtractedUiNode {
     pub stack_index: usize,
     pub transform: Mat4,
-    pub background_color: Color,
+    pub color: Color,
     pub rect: Rect,
     pub image: Handle<Image>,
     pub atlas_size: Option<Vec2>,
@@ -221,7 +221,7 @@ pub fn extract_uinodes(
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
                 transform: transform.compute_matrix(),
-                background_color: color.0,
+                color: color.0,
                 rect: Rect {
                     min: Vec2::ZERO,
                     max: uinode.calculated_size,
@@ -357,7 +357,7 @@ pub fn extract_text_uinodes(
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,
                     transform: extracted_transform,
-                    background_color: color,
+                    color,
                     rect,
                     image: texture,
                     atlas_size,
@@ -524,7 +524,7 @@ pub fn prepare_uinodes(
             uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
         }
 
-        let color = extracted_uinode.background_color.as_linear_rgba_f32();
+        let color = extracted_uinode.color.as_linear_rgba_f32();
         for i in QUAD_INDICES {
             ui_meta.vertices.push(UiVertex {
                 position: positions_clipped[i].into(),

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -8,7 +8,7 @@
 //! | `S`                | Toggle Directional Light Fog Influence |
 
 use bevy::{
-    pbr::{CascadeShadowConfig, NotShadowCaster},
+    pbr::{CascadeShadowConfigBuilder, NotShadowCaster},
     prelude::*,
 };
 
@@ -49,9 +49,10 @@ fn setup_terrain_scene(
     asset_server: Res<AssetServer>,
 ) {
     // Configure a properly scaled cascade shadow map for this scene (defaults are too large, mesh units are in km)
-    // For WebGL we only support 1 cascade level for now
-    let cascade_shadow_config =
-        CascadeShadowConfig::new(if cfg!(feature = "webgl") { 1 } else { 4 }, 0.5, 2.5, 0.2);
+    let cascade_shadow_config = CascadeShadowConfigBuilder::new()
+        .first_cascade_far_bound(0.5)
+        .maximum_distance(2.0)
+        .build();
 
     // Sun
     commands.spawn(DirectionalLightBundle {

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -49,10 +49,12 @@ fn setup_terrain_scene(
     asset_server: Res<AssetServer>,
 ) {
     // Configure a properly scaled cascade shadow map for this scene (defaults are too large, mesh units are in km)
-    let cascade_shadow_config = CascadeShadowConfigBuilder::new()
-        .first_cascade_far_bound(0.3)
-        .maximum_distance(3.0)
-        .build();
+    let cascade_shadow_config = CascadeShadowConfigBuilder {
+        first_cascade_far_bound: 0.3,
+        maximum_distance: 3.0,
+        ..default()
+    }
+    .build();
 
     // Sun
     commands.spawn(DirectionalLightBundle {

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -50,8 +50,8 @@ fn setup_terrain_scene(
 ) {
     // Configure a properly scaled cascade shadow map for this scene (defaults are too large, mesh units are in km)
     let cascade_shadow_config = CascadeShadowConfigBuilder::new()
-        .first_cascade_far_bound(0.5)
-        .maximum_distance(2.0)
+        .first_cascade_far_bound(0.3)
+        .maximum_distance(3.0)
         .build();
 
     // Sun

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -4,6 +4,7 @@ use std::f32::consts::PI;
 
 use bevy::{
     core_pipeline::fxaa::{Fxaa, Sensitivity},
+    pbr::CascadeShadowConfigBuilder,
     prelude::*,
     render::{
         render_resource::{Extent3d, SamplerDescriptor, TextureDimension, TextureFormat},
@@ -81,6 +82,10 @@ fn setup(
             PI * -0.15,
             PI * -0.15,
         )),
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .maximum_distance(3.0)
+            .first_cascade_far_bound(0.7)
+            .build(),
         ..default()
     });
 

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -82,10 +82,12 @@ fn setup(
             PI * -0.15,
             PI * -0.15,
         )),
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .maximum_distance(3.0)
-            .first_cascade_far_bound(0.9)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            maximum_distance: 3.0,
+            first_cascade_far_bound: 0.9,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -84,7 +84,7 @@ fn setup(
         )),
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
             .maximum_distance(3.0)
-            .first_cascade_far_bound(0.7)
+            .first_cascade_far_bound(0.9)
             .build(),
         ..default()
     });

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -198,10 +198,10 @@ fn setup(
         },
         // The default cascade config is designed to handle large scenes.
         // As this example has a much smaller world, we can tighten the shadow
-        // far bound for better visual quality.
+        // bounds for better visual quality.
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(5.0)
-            .maximum_distance(30.0)
+            .first_cascade_far_bound(4.0)
+            .maximum_distance(10.0)
             .build(),
         ..default()
     });

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -3,7 +3,7 @@
 
 use std::f32::consts::PI;
 
-use bevy::{pbr::CascadeShadowConfig, prelude::*};
+use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 
 fn main() {
     App::new()
@@ -199,7 +199,10 @@ fn setup(
         // The default cascade config is designed to handle large scenes.
         // As this example has a much smaller world, we can tighten the shadow
         // far bound for better visual quality.
-        cascade_shadow_config: CascadeShadowConfig::new(4, 5.0, 30.0, 0.2),
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .first_cascade_far_bound(5.0)
+            .maximum_distance(30.0)
+            .build(),
         ..default()
     });
 

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -199,10 +199,12 @@ fn setup(
         // The default cascade config is designed to handle large scenes.
         // As this example has a much smaller world, we can tighten the shadow
         // bounds for better visual quality.
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(4.0)
-            .maximum_distance(10.0)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            first_cascade_far_bound: 4.0,
+            maximum_distance: 10.0,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -2,7 +2,7 @@
 
 use std::f32::consts::*;
 
-use bevy::{pbr::CascadeShadowConfig, prelude::*};
+use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 
 fn main() {
     App::new()
@@ -28,7 +28,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         // This is a relatively small scene, so use tighter shadow
         // cascade bounds than the default for better quality.
-        cascade_shadow_config: CascadeShadowConfig::new(1, 1.1, 1.5, 0.3),
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .num_cascades(1)
+            .minimum_distance(0.5)
+            .maximum_distance(1.0)
+            .build(),
         ..default()
     });
     commands.spawn(SceneBundle {

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -2,7 +2,10 @@
 
 use std::f32::consts::*;
 
-use bevy::{pbr::{CascadeShadowConfigBuilder, DirectionalLightShadowMap}, prelude::*};
+use bevy::{
+    pbr::{CascadeShadowConfigBuilder, DirectionalLightShadowMap},
+    prelude::*,
+};
 
 fn main() {
     App::new()

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -31,7 +31,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
             .num_cascades(1)
             .minimum_distance(0.5)
-            .maximum_distance(1.0)
+            .maximum_distance(0.6)
             .build(),
         ..default()
     });

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -2,7 +2,7 @@
 
 use std::f32::consts::*;
 
-use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
+use bevy::{pbr::{CascadeShadowConfigBuilder, DirectionalLightShadowMap}, prelude::*};
 
 fn main() {
     App::new()
@@ -10,6 +10,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0 / 5.0f32,
         })
+        .insert_resource(DirectionalLightShadowMap { size: 4096 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(animate_light_direction)
@@ -28,10 +29,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         // This is a relatively small scene, so use tighter shadow
         // cascade bounds than the default for better quality.
+        // We also adjusted the shadow map to be larger since we're
+        // only using a single cascade.
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
             .num_cascades(1)
-            .minimum_distance(0.5)
-            .maximum_distance(0.6)
+            .maximum_distance(1.6)
             .build(),
         ..default()
     });

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -34,10 +34,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         // cascade bounds than the default for better quality.
         // We also adjusted the shadow map to be larger since we're
         // only using a single cascade.
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .num_cascades(1)
-            .maximum_distance(1.6)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            num_cascades: 1,
+            maximum_distance: 1.6,
+            ..default()
+        }
+        .into(),
         ..default()
     });
     commands.spawn(SceneBundle {

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -110,7 +110,8 @@ fn setup(
             -PI / 4.,
         )),
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .maximum_distance(30.0)
+            .first_cascade_far_bound(7.0)
+            .maximum_distance(25.0)
             .build(),
         ..default()
     });

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -109,10 +109,12 @@ fn setup(
             PI / 2.,
             -PI / 4.,
         )),
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(7.0)
-            .maximum_distance(25.0)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            first_cascade_far_bound: 7.0,
+            maximum_distance: 25.0,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    pbr::{NotShadowCaster, NotShadowReceiver},
+    pbr::{CascadeShadowConfigBuilder, NotShadowCaster, NotShadowReceiver},
     prelude::*,
 };
 
@@ -109,6 +109,9 @@ fn setup(
             PI / 2.,
             -PI / 4.,
         )),
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .maximum_distance(30.0)
+            .build(),
         ..default()
     });
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -41,11 +41,13 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .num_cascades(2)
-            .first_cascade_far_bound(200.0)
-            .maximum_distance(280.0)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            num_cascades: 2,
+            first_cascade_far_bound: 200.0,
+            maximum_distance: 280.0,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,8 +3,8 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    core_pipeline::clear_color::ClearColorConfig, prelude::*, render::camera::Viewport,
-    window::WindowResized,
+    core_pipeline::clear_color::ClearColorConfig, pbr::CascadeShadowConfigBuilder, prelude::*,
+    render::camera::Viewport, window::WindowResized,
 };
 
 fn main() {
@@ -41,6 +41,9 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .maximum_distance(300.0)
+            .build(),
         ..default()
     });
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -42,7 +42,9 @@ fn setup(
             ..default()
         },
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .maximum_distance(300.0)
+            .num_cascades(2)
+            .first_cascade_far_bound(200.0)
+            .maximum_distance(280.0)
             .build(),
         ..default()
     });

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -57,6 +57,7 @@ fn setup(
             ..default()
         },
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .first_cascade_far_bound(200.0)
             .maximum_distance(400.0)
             .build(),
         ..default()

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -56,10 +56,12 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(200.0)
-            .maximum_distance(400.0)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            first_cascade_far_bound: 200.0,
+            maximum_distance: 400.0,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -3,6 +3,7 @@
 use std::f32::consts::PI;
 use std::time::Duration;
 
+use bevy::pbr::CascadeShadowConfigBuilder;
 use bevy::prelude::*;
 
 fn main() {
@@ -55,6 +56,9 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .maximum_distance(400.0)
+            .build(),
         ..default()
     });
 

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -173,10 +173,12 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
-        cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(0.9 * radius)
-            .maximum_distance(2.8 * radius)
-            .build(),
+        cascade_shadow_config: CascadeShadowConfigBuilder {
+            first_cascade_far_bound: 0.9 * radius,
+            maximum_distance: 2.8 * radius,
+            ..default()
+        }
+        .into(),
         ..default()
     });
 

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    pbr::CascadeShadowConfigBuilder,
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -172,6 +173,10 @@ fn setup(
             shadows_enabled: true,
             ..default()
         },
+        cascade_shadow_config: CascadeShadowConfigBuilder::new()
+            .first_cascade_far_bound(1.2 * radius)
+            .maximum_distance(2.0 * radius)
+            .build(),
         ..default()
     });
 

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -174,8 +174,8 @@ fn setup(
             ..default()
         },
         cascade_shadow_config: CascadeShadowConfigBuilder::new()
-            .first_cascade_far_bound(1.2 * radius)
-            .maximum_distance(2.0 * radius)
+            .first_cascade_far_bound(0.9 * radius)
+            .maximum_distance(2.8 * radius)
             .build(),
         ..default()
     });


### PR DESCRIPTION
# Objective

- Improve ergonomics / documentation of cascaded shadow maps
- Allow for the customization of the nearest shadowing distance.
- Fixes #7393 
- Fixes #7362 

## Solution

- Introduce `CascadeShadowConfigBuilder`
- Tweak various example cascade settings for better quality.

---

## Changelog

- Made examples look nicer under cascaded shadow maps.
- Introduce `CascadeShadowConfigBuilder` to help with creating `CascadeShadowConfig`

## Migration Guide

- Configure settings for cascaded shadow maps for directional lights using the newly introduced `CascadeShadowConfigBuilder`.