### PR TITLE
Transform lifetimes in ignored fields when deriving `SystemParam`

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1574,4 +1574,11 @@ mod tests {
     {
         _q: Query<'w, 's, Q, ()>,
     }
+
+    // regression test for https://github.com/bevyengine/bevy/issues/7447.
+    #[derive(SystemParam)]
+    pub struct IgnoredPhantomDataWithLifetime<'s> {
+        #[system_param(ignore)]
+        marker: PhantomData<&'s ()>
+    }
 }


### PR DESCRIPTION
# Objective

- Fixes #7447

## Solution

- Transform lifetimes in ignored fields of the struct (`'w` -> `'_w`, `'s` -> `'_s` for `get_param` function macro derive)

---

## Changelog

- Add `transform_lifetimes_in_type` and its family
- Use underscore prefix instead of `w2`, `s2`  in `get_param` quote (a bit like `type Item` above)
- Add regression test

## TODO

- [ ] Consider expanding `Type::Verbatim` and `Type::Macro` (if it's possible?)
- [ ] Benchmark compile time
- [ ] Check if the code style fits correctly along with other codes
- [ ] Fix my broken rustfmt
- [ ] Add docs
