### PR TITLE
[Merged by Bors] - Fix ignored lifetimes in `#[derive(SystemParam)]`

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -506,7 +506,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     >::get_param(&mut state.state, system_meta, world, change_tick);
                     #struct_name {
                         #(#fields: #field_locals,)*
-                        #(#ignored_fields: <#ignored_field_types>::default(),)*
+                        #(#ignored_fields: std::default::Default::default(),)*
                     }
                 }
             }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1541,11 +1541,12 @@ mod tests {
     }
 
     // Compile test for https://github.com/bevyengine/bevy/pull/6919.
+    // Regression test for https://github.com/bevyengine/bevy/issues/7447.
     #[derive(SystemParam)]
-    struct MyParam<'w, T: Resource, Marker: 'static> {
+    struct IgnoredParam<'w, T: Resource, Marker: 'static> {
         _foo: Res<'w, T>,
         #[system_param(ignore)]
-        marker: PhantomData<Marker>,
+        marker: PhantomData<&'w Marker>,
     }
 
     // Compile tests for https://github.com/bevyengine/bevy/pull/6957.
@@ -1573,14 +1574,5 @@ mod tests {
         Q: 'static + WorldQuery,
     {
         _q: Query<'w, 's, Q, ()>,
-    }
-
-    // Regression test for https://github.com/bevyengine/bevy/issues/7447.
-    #[derive(SystemParam)]
-    pub struct InputResources<'w, 's> {
-        pub keyboard_input: Res<'w, R<0>>,
-        pub egui_input: ResMut<'w, R<1>>,
-        #[system_param(ignore)]
-        _marker: PhantomData<&'s ()>,
     }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1574,4 +1574,13 @@ mod tests {
     {
         _q: Query<'w, 's, Q, ()>,
     }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/7447.
+    #[derive(SystemParam)]
+    pub struct InputResources<'w, 's> {
+        pub keyboard_input: Res<'w, R<0>>,
+        pub egui_input: ResMut<'w, R<1>>,
+        #[system_param(ignore)]
+        _marker: PhantomData<&'s ()>,
+    }
 }


### PR DESCRIPTION
# Objective

Fix #7447.

The `SystemParam` derive uses the wrong lifetimes for ignored fields.

## Solution

Use type inference instead of explicitly naming the types of ignored fields. This allows the compiler to automatically use the correct lifetime.