### PR TITLE
fix some post-processing issues

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -136,7 +136,7 @@ pub fn queue_view_tonemapping_pipelines(
     let mut final_order = HashMap::<NormalizedRenderTarget, isize>::default();
     for (_, _, camera) in view_targets.iter() {
         if let Some(target) = camera.target.as_ref() {
-            let entry = final_order.entry(target.clone()).or_default();
+            let entry = final_order.entry(target.clone()).or_insert(isize::MIN);
             *entry = camera.order.max(*entry);
         }
     }

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -150,7 +150,7 @@ fn queue_view_upscaling_pipelines(
             view_target.out_texture_format()
         } else {
             // write back to input
-            view_target.base_texture_format()
+            view_target.main_texture_format()
         };
         let msaa_samples = if is_final { 1 } else { msaa.samples() };
 

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -134,7 +134,7 @@ fn queue_view_upscaling_pipelines(
     let mut final_order = HashMap::<NormalizedRenderTarget, isize>::default();
     for (_, _, camera) in view_targets.iter() {
         if let Some(target) = camera.target.as_ref() {
-            let entry = final_order.entry(target.clone()).or_default();
+            let entry = final_order.entry(target.clone()).or_insert(isize::MIN);
             *entry = camera.order.max(*entry);
         }
     }

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -56,6 +56,11 @@ impl Node for UpscalingNode {
             Err(_) => return Ok(()),
         };
 
+        if !upscaling_target.is_final && target.is_current_base() {
+            // input is already output, nothing to do
+            return Ok(());
+        }
+
         let upscaled_texture = target.main_texture();
 
         let mut cached_bind_group = self.cached_texture_bind_group.lock().unwrap();

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -89,15 +89,21 @@ impl Node for UpscalingNode {
             }
         };
 
-        let pipeline = match pipeline_cache.get_render_pipeline(upscaling_target.0) {
+        let pipeline = match pipeline_cache.get_render_pipeline(upscaling_target.pipeline) {
             Some(pipeline) => pipeline,
             None => return Ok(()),
+        };
+
+        let view_attachment = if upscaling_target.is_final {
+            target.out_texture()
+        } else {
+            target.base_texture()
         };
 
         let pass_descriptor = RenderPassDescriptor {
             label: Some("upscaling_pass"),
             color_attachments: &[Some(RenderPassColorAttachment {
-                view: target.out_texture(),
+                view: view_attachment,
                 resolve_target: None,
                 ops: Operations {
                     load: LoadOp::Clear(Default::default()),

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -218,10 +218,20 @@ impl ViewTarget {
         &self.out_texture
     }
 
+    /// the initial texture that will be written to.
+    pub fn base_texture(&self) -> &TextureView {
+        self.sampled_main_texture().unwrap_or(&self.main_textures.a)
+    }
+
     /// The format of the final texture this view will render to
     #[inline]
     pub fn out_texture_format(&self) -> TextureFormat {
         self.out_texture_format
+    }
+
+    /// the format of the initial texture that will be written to.
+    pub fn base_texture_format(&self) -> TextureFormat {
+        self.main_texture_format
     }
 
     /// This will start a new "post process write", which assumes that the caller

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -223,6 +223,11 @@ impl ViewTarget {
         self.sampled_main_texture().unwrap_or(&self.main_textures.a)
     }
 
+    /// is the last written texture also the base texture
+    pub fn is_current_base(&self) -> bool {
+        self.sampled_main_texture().is_none() && self.main_texture.load(Ordering::SeqCst) == 0
+    }
+
     /// The format of the final texture this view will render to
     #[inline]
     pub fn out_texture_format(&self) -> TextureFormat {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -234,11 +234,6 @@ impl ViewTarget {
         self.out_texture_format
     }
 
-    /// the format of the initial texture that will be written to.
-    pub fn base_texture_format(&self) -> TextureFormat {
-        self.main_texture_format
-    }
-
     /// This will start a new "post process write", which assumes that the caller
     /// will write the [`PostProcessWrite`]'s `source` to the `destination`.
     ///


### PR DESCRIPTION
# Objective

fix a few post-processing issues

## Solution

- fxaa now respects viewport
- tonemapping is only done on the final camera for a given target
- upscaling writes to the input texture (if required) instead of the output texture if the active camera is not the final camera for a given target (stops post-processing and UI from being dropped for cameras that are not last with MSAA targets, or the last effect from being dropped for non-MSAA targets)

should fix #7435 and hopefully fix #5721 (haven't tested that)