### PR TITLE
[Merged by Bors] - Follow up on Todo in bevy_reflect_derive

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -1,10 +1,9 @@
 use crate::fq_std::{FQAny, FQBox, FQDefault, FQOption, FQResult};
 use crate::impls::impl_typed;
-use crate::utility::extend_where_clause;
+use crate::utility::{extend_where_clause, ident_or_index};
 use crate::ReflectStruct;
 use proc_macro::TokenStream;
 use quote::{quote, ToTokens};
-use syn::{Index, Member};
 
 /// Implements `Struct`, `GetTypeRegistration`, and `Reflect` for the given derive data.
 pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
@@ -26,14 +25,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {
         .collect::<Vec<String>>();
     let field_idents = reflect_struct
         .active_fields()
-        .map(|field| {
-            field
-                .data
-                .ident
-                .as_ref()
-                .map(|ident| Member::Named(ident.clone()))
-                .unwrap_or_else(|| Member::Unnamed(Index::from(field.index)))
-        })
+        .map(|field| ident_or_index(field.data.ident.as_ref(), field.index))
         .collect::<Vec<_>>();
     let field_types = reflect_struct.active_types();
     let field_count = field_idents.len();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -52,8 +52,6 @@ pub(crate) struct ResultSifter<T> {
 /// a tuple struct or a struct with named fields. If you don't have a field name,
 /// it means you need to access the struct through an index.
 pub(crate) fn ident_or_index(ident: Option<&Ident>, index: usize) -> Member {
-    // TODO(Quality) when #4761 is merged, code that does this should be replaced
-    // by a call to `ident_or_index`.
     ident.map_or_else(
         || Member::Unnamed(index.into()),
         |ident| Member::Named(ident.clone()),


### PR DESCRIPTION
# Objective

Follow up on Todo in bevy_reflect_derive

## Solution

- Replaced all Instances that do the same as `ident_or_index` with a call to it.
- Only the following Line wasn't replaced, as it only wants the index, and not the ident:
[https://github.com/bevyengine/bevy/blob/69fc8c6b70dd350ef31eb260a1137a2d6c8a3c19/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs#L18](https://github.com/bevyengine/bevy/blob/69fc8c6b70dd350ef31eb260a1137a2d6c8a3c19/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs#L18)