### PR TITLE
[Merged by Bors] - feat: improve `initialize_bundle` error message

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -746,7 +746,7 @@ unsafe fn initialize_bundle(
             .into_iter()
             .map(|id| {
                 // SAFETY: component_id exists and is therefore valid
-                components.get_info_unchecked(id).name()
+                unsafe { components.get_info_unchecked(id).name() }
             })
             .collect::<Vec<_>>()
             .join(", ");

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -733,6 +733,7 @@ unsafe fn initialize_bundle(
     deduped.dedup();
 
     if deduped.len() != component_ids.len() {
+        // TODO: Replace with `Vec::partition_dedup` once https://github.com/rust-lang/rust/issues/54279 is stabilized
         let mut seen = HashSet::new();
         let mut dups = Vec::new();
         for id in component_ids {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -750,10 +750,7 @@ unsafe fn initialize_bundle(
             .collect::<Vec<_>>()
             .join(", ");
 
-        panic!(
-            "Bundle {bundle_type_name} has duplicate components: {}",
-            names
-        );
+        panic!("Bundle {bundle_type_name} has duplicate components: {names}");
     }
 
     BundleInfo { id, component_ids }


### PR DESCRIPTION
# Objective

This PR improves message that caused by duplicate components in bundle.

## Solution

Show names of duplicate components.

The solution is not very elegant, in my opinion, I will be happy to listen to suggestions for improving it