### PR TITLE
[Merged by Bors] - Base Sets

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -552,7 +552,7 @@ impl Plugin for AnimationPlugin {
             .register_type::<AnimationPlayer>()
             .add_system(
                 animation_player
-                    .in_set(CoreSet::PostUpdate)
+                    .in_base_set(CoreSet::PostUpdate)
                     .before(TransformSystem::TransformPropagate),
             );
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -328,14 +328,14 @@ impl App {
                 apply_state_transition::<S>,
             )
                 .chain()
-                .in_set(CoreSet::StateTransitions),
+                .in_base_set(CoreSet::StateTransitions),
         );
 
         let main_schedule = self.get_schedule_mut(CoreSchedule::Main).unwrap();
         for variant in S::variants() {
             main_schedule.configure_set(
                 OnUpdate(variant.clone())
-                    .in_set(CoreSet::StateTransitions)
+                    .in_base_set(CoreSet::StateTransitions)
                     .run_if(state_equals(variant))
                     .after(apply_state_transition::<S>),
             );
@@ -580,7 +580,7 @@ impl App {
     {
         if !self.world.contains_resource::<Events<T>>() {
             self.init_resource::<Events<T>>()
-                .add_system(Events::<T>::update_system.in_set(CoreSet::First));
+                .add_system(Events::<T>::update_system.in_base_set(CoreSet::First));
         }
         self
     }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -29,8 +29,8 @@ pub mod prelude {
 
 use bevy_ecs::{
     schedule_v3::{
-        apply_system_buffers, IntoSystemConfig, IntoSystemSetConfig, Schedule, ScheduleLabel,
-        SystemSet,
+        apply_system_buffers, IntoSystemConfig, IntoSystemSetConfig, IntoSystemSetConfigs,
+        Schedule, ScheduleLabel, SystemSet,
     },
     system::Local,
     world::World,
@@ -90,6 +90,7 @@ impl CoreSchedule {
 /// that runs immediately after the matching system set.
 /// These can be useful for ordering, but you almost never want to add your systems to these sets.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+#[system_set(base)]
 pub enum CoreSet {
     /// Runs before all other members of this set.
     First,
@@ -129,20 +130,30 @@ impl CoreSet {
         let mut schedule = Schedule::new();
 
         // Create "stage-like" structure using buffer flushes + ordering
-        schedule.add_system(apply_system_buffers.in_set(FirstFlush));
-        schedule.add_system(apply_system_buffers.in_set(PreUpdateFlush));
-        schedule.add_system(apply_system_buffers.in_set(UpdateFlush));
-        schedule.add_system(apply_system_buffers.in_set(PostUpdateFlush));
-        schedule.add_system(apply_system_buffers.in_set(LastFlush));
-
-        schedule.configure_set(First.before(FirstFlush));
-        schedule.configure_set(PreUpdate.after(FirstFlush).before(PreUpdateFlush));
-        schedule.configure_set(StateTransitions.after(PreUpdateFlush).before(FixedUpdate));
-        schedule.configure_set(FixedUpdate.after(StateTransitions).before(Update));
-        schedule.configure_set(Update.after(FixedUpdate).before(UpdateFlush));
-        schedule.configure_set(PostUpdate.after(UpdateFlush).before(PostUpdateFlush));
-        schedule.configure_set(Last.after(PostUpdateFlush).before(LastFlush));
-
+        schedule
+            .set_default_base_set(Update)
+            .add_system(apply_system_buffers.in_base_set(FirstFlush))
+            .add_system(apply_system_buffers.in_base_set(PreUpdateFlush))
+            .add_system(apply_system_buffers.in_base_set(UpdateFlush))
+            .add_system(apply_system_buffers.in_base_set(PostUpdateFlush))
+            .add_system(apply_system_buffers.in_base_set(LastFlush))
+            .configure_sets(
+                (
+                    First,
+                    FirstFlush,
+                    PreUpdate,
+                    PreUpdateFlush,
+                    StateTransitions,
+                    FixedUpdate,
+                    Update,
+                    UpdateFlush,
+                    PostUpdate,
+                    PostUpdateFlush,
+                    Last,
+                    LastFlush,
+                )
+                    .chain(),
+            );
         schedule
     }
 }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -644,7 +644,7 @@ pub fn free_unused_assets_system(asset_server: Res<AssetServer>) {
 mod test {
     use super::*;
     use crate::{loader::LoadedAsset, update_asset_storage_system};
-    use bevy_app::{App, CoreSet};
+    use bevy_app::App;
     use bevy_ecs::prelude::*;
     use bevy_reflect::TypeUuid;
     use bevy_utils::BoxedFuture;
@@ -852,16 +852,8 @@ mod test {
         let mut app = App::new();
         app.insert_resource(assets);
         app.insert_resource(asset_server);
-        app.add_system(
-            free_unused_assets_system
-                .in_set(FreeUnusedAssets)
-                .in_set(CoreSet::Update),
-        );
-        app.add_system(
-            update_asset_storage_system::<PngAsset>
-                .after(FreeUnusedAssets)
-                .in_set(CoreSet::Update),
-        );
+        app.add_system(free_unused_assets_system.in_set(FreeUnusedAssets));
+        app.add_system(update_asset_storage_system::<PngAsset>.after(FreeUnusedAssets));
 
         fn load_asset(path: AssetPath, world: &World) -> HandleUntyped {
             let asset_server = world.resource::<AssetServer>();

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -331,8 +331,8 @@ impl AddAsset for App {
         };
 
         self.insert_resource(assets)
-            .add_system(Assets::<T>::asset_event_system.in_set(AssetSet::AssetEvents))
-            .add_system(update_asset_storage_system::<T>.in_set(AssetSet::LoadAssets))
+            .add_system(Assets::<T>::asset_event_system.in_base_set(AssetSet::AssetEvents))
+            .add_system(update_asset_storage_system::<T>.in_base_set(AssetSet::LoadAssets))
             .register_type::<Handle<T>>()
             .add_event::<AssetEvent<T>>()
     }

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -2,7 +2,7 @@
 //!
 //! Internal assets (e.g. shaders) are bundled directly into an application and can't be hot
 //! reloaded using the conventional API.
-use bevy_app::{App, CoreSet, Plugin};
+use bevy_app::{App, Plugin};
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_tasks::{IoTaskPool, TaskPoolBuilder};
 use bevy_utils::HashMap;

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -75,7 +75,7 @@ impl Plugin for DebugAssetServerPlugin {
             watch_for_changes: true,
         });
         app.insert_non_send_resource(DebugAssetApp(debug_asset_app));
-        app.add_system(run_debug_asset_app.in_set(CoreSet::Update));
+        app.add_system(run_debug_asset_app);
     }
 }
 

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -19,7 +19,7 @@ impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
 impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {
     fn build(&self, app: &mut App) {
         app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system.in_set(CoreSet::Update));
+            .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -51,6 +51,7 @@ use bevy_ecs::prelude::*;
 
 /// [`SystemSet`]s for asset loading in an [`App`] schedule.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+#[system_set(base)]
 pub enum AssetSet {
     /// Asset storages are updated.
     LoadAssets,
@@ -109,22 +110,20 @@ impl Plugin for AssetPlugin {
 
         app.configure_set(
             AssetSet::LoadAssets
-                .no_default_set()
                 .before(CoreSet::PreUpdate)
                 .after(CoreSet::First),
         )
         .configure_set(
             AssetSet::AssetEvents
-                .no_default_set()
                 .after(CoreSet::PostUpdate)
                 .before(CoreSet::Last),
         )
-        .add_system(asset_server::free_unused_assets_system.in_set(CoreSet::PreUpdate));
+        .add_system(asset_server::free_unused_assets_system.in_base_set(CoreSet::PreUpdate));
 
         #[cfg(all(
             feature = "filesystem_watcher",
             all(not(target_arch = "wasm32"), not(target_os = "android"))
         ))]
-        app.add_system(io::filesystem_watcher_system.in_set(AssetSet::LoadAssets));
+        app.add_system(io::filesystem_watcher_system.in_base_set(AssetSet::LoadAssets));
     }
 }

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -56,7 +56,7 @@ impl Plugin for AudioPlugin {
             .add_asset::<AudioSource>()
             .add_asset::<AudioSink>()
             .init_resource::<Audio<AudioSource>>()
-            .add_system(play_queued_audio_system::<AudioSource>.in_set(CoreSet::PostUpdate));
+            .add_system(play_queued_audio_system::<AudioSource>.in_base_set(CoreSet::PostUpdate));
 
         #[cfg(any(feature = "mp3", feature = "flac", feature = "wav", feature = "vorbis"))]
         app.init_asset_loader::<AudioLoader>();
@@ -71,6 +71,6 @@ impl AddAudioSource for App {
         self.add_asset::<T>()
             .init_resource::<Audio<T>>()
             .init_resource::<AudioOutput<T>>()
-            .add_system(play_queued_audio_system::<T>.in_set(CoreSet::PostUpdate))
+            .add_system(play_queued_audio_system::<T>.in_base_set(CoreSet::PostUpdate))
     }
 }

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -107,7 +107,7 @@ impl Plugin for TaskPoolPlugin {
         self.task_pool_options.create_default_pools();
 
         #[cfg(not(target_arch = "wasm32"))]
-        app.add_system(tick_global_task_pools.in_set(bevy_app::CoreSet::Last));
+        app.add_system(tick_global_task_pools.in_base_set(bevy_app::CoreSet::Last));
     }
 }
 /// A dummy type that is [`!Send`](Send), to force systems to run on the main thread.
@@ -142,7 +142,7 @@ pub struct FrameCountPlugin;
 impl Plugin for FrameCountPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<FrameCount>();
-        app.add_system(update_frame_count.in_set(CoreSet::Last));
+        app.add_system(update_frame_count.in_base_set(CoreSet::Last));
     }
 }
 

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -10,7 +10,7 @@ pub struct EntityCountDiagnosticsPlugin;
 impl Plugin for EntityCountDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system.in_set(CoreSet::Update));
+            .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -11,7 +11,7 @@ pub struct FrameTimeDiagnosticsPlugin;
 impl Plugin for FrameTimeDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system.in_set(CoreSet::Update));
+            .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -37,9 +37,9 @@ impl Plugin for LogDiagnosticsPlugin {
         });
 
         if self.debug {
-            app.add_system(Self::log_diagnostics_debug_system.in_set(CoreSet::PostUpdate));
+            app.add_system(Self::log_diagnostics_debug_system.in_base_set(CoreSet::PostUpdate));
         } else {
-            app.add_system(Self::log_diagnostics_system.in_set(CoreSet::PostUpdate));
+            app.add_system(Self::log_diagnostics_system.in_base_set(CoreSet::PostUpdate));
         }
     }
 }

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -16,7 +16,7 @@ pub struct SystemInformationDiagnosticsPlugin;
 impl Plugin for SystemInformationDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
         app.add_startup_system(internal::setup_system.in_set(StartupSet::Startup))
-            .add_system(internal::diagnostic_system.in_set(CoreSet::Update));
+            .add_system(internal::diagnostic_system);
     }
 }
 

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -2,9 +2,10 @@ extern crate proc_macro;
 
 mod component;
 mod fetch;
+mod set;
 
-use crate::fetch::derive_world_query_impl;
-use bevy_macro_utils::{derive_boxed_label, derive_set, get_named_struct_fields, BevyManifest};
+use crate::{fetch::derive_world_query_impl, set::derive_set};
+use bevy_macro_utils::{derive_boxed_label, get_named_struct_fields, BevyManifest};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
@@ -537,7 +538,7 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
 }
 
 /// Derive macro generating an impl of the trait `SystemSet`.
-#[proc_macro_derive(SystemSet)]
+#[proc_macro_derive(SystemSet, attributes(system_set))]
 pub fn derive_system_set(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let mut trait_path = bevy_ecs_path();

--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -1,0 +1,84 @@
+use proc_macro::TokenStream;
+use quote::{quote, ToTokens};
+use syn::parse::{Parse, ParseStream};
+
+pub static SYSTEM_SET_ATTRIBUTE_NAME: &str = "system_set";
+pub static BASE_ATTRIBUTE_NAME: &str = "base";
+
+/// Derive a label trait
+///
+/// # Args
+///
+/// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
+/// - `trait_path`: The path [`syn::Path`] to the label trait
+pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
+    let ident = input.ident;
+
+    let mut is_base = false;
+    for attr in &input.attrs {
+        if !attr
+            .path
+            .get_ident()
+            .map_or(false, |ident| ident == SYSTEM_SET_ATTRIBUTE_NAME)
+        {
+            continue;
+        }
+
+        attr.parse_args_with(|input: ParseStream| {
+            let meta = input.parse_terminated::<syn::Meta, syn::token::Comma>(syn::Meta::parse)?;
+            for meta in meta {
+                let ident = meta.path().get_ident().unwrap_or_else(|| {
+                    panic!(
+                        "Unrecognized attribute: `{}`",
+                        meta.path().to_token_stream()
+                    )
+                });
+                if ident == BASE_ATTRIBUTE_NAME {
+                    if let syn::Meta::Path(_) = meta {
+                        is_base = true;
+                    } else {
+                        panic!(
+                            "The `{BASE_ATTRIBUTE_NAME}` attribute is expected to have no value or arguments",
+                        );
+                    }
+                } else {
+                    panic!(
+                        "Unrecognized attribute: `{}`",
+                        meta.path().to_token_stream()
+                    );
+                }
+            }
+            Ok(())
+        })
+        .unwrap_or_else(|_| panic!("Invalid `{SYSTEM_SET_ATTRIBUTE_NAME}` attribute format"));
+    }
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
+        where_token: Default::default(),
+        predicates: Default::default(),
+    });
+    where_clause.predicates.push(
+        syn::parse2(quote! {
+            Self: 'static + Send + Sync + Clone + Eq + ::std::fmt::Debug + ::std::hash::Hash
+        })
+        .unwrap(),
+    );
+
+    (quote! {
+        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
+            fn is_system_type(&self) -> bool {
+                false
+            }
+
+            fn is_base(&self) -> bool {
+                #is_base
+            }
+
+            fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
+                std::boxed::Box::new(std::clone::Clone::clone(self))
+            }
+        }
+    })
+    .into()
+}

--- a/crates/bevy_ecs/src/schedule_v3/config.rs
+++ b/crates/bevy_ecs/src/schedule_v3/config.rs
@@ -120,10 +120,12 @@ where
         SystemSetConfig::new(Box::new(self))
     }
 
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_set(set)
     }
 
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_base_set(set)
     }
@@ -162,10 +164,12 @@ impl IntoSystemSetConfig for BoxedSystemSet {
         SystemSetConfig::new(self)
     }
 
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_set(set)
     }
 
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfig {
         self.into_config().in_base_set(set)
     }
@@ -204,6 +208,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
         self
     }
 
+    #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -221,6 +226,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
         self
     }
 
+    #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -322,10 +328,12 @@ where
         SystemConfig::new(Box::new(IntoSystem::into_system(self)))
     }
 
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_set(set)
     }
 
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_base_set(set)
     }
@@ -364,10 +372,12 @@ impl IntoSystemConfig<()> for BoxedSystem<(), ()> {
         SystemConfig::new(self)
     }
 
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_set(set)
     }
 
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemConfig {
         self.into_config().in_base_set(set)
     }
@@ -406,6 +416,7 @@ impl IntoSystemConfig<()> for SystemConfig {
         self
     }
 
+    #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -419,6 +430,7 @@ impl IntoSystemConfig<()> for SystemConfig {
         self
     }
 
+    #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -516,11 +528,13 @@ where
     fn into_configs(self) -> SystemConfigs;
 
     /// Add these systems to the provided `set`.
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemConfigs {
         self.into_configs().in_set(set)
     }
 
     /// Add these systems to the provided "base" `set`.
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemConfigs {
         self.into_configs().in_base_set(set)
     }
@@ -565,6 +579,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
         self
     }
 
+    #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -581,6 +596,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
         self
     }
 
+    #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -665,11 +681,13 @@ where
     fn into_configs(self) -> SystemSetConfigs;
 
     /// Add these system sets to the provided `set`.
+    #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemSetConfigs {
         self.into_configs().in_set(set)
     }
 
     /// Add these system sets to the provided "base" `set`.
+    #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfigs {
         self.into_configs().in_base_set(set)
     }
@@ -709,6 +727,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
         self
     }
 
+    #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
@@ -729,6 +748,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
         self
     }
 
+    #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),

--- a/crates/bevy_ecs/src/schedule_v3/config.rs
+++ b/crates/bevy_ecs/src/schedule_v3/config.rs
@@ -88,7 +88,7 @@ pub trait IntoSystemSetConfig: sealed::IntoSystemSetConfig {
     /// Add to the provided `set`.
     #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemSetConfig;
-    /// Add to the provided "base" `set`.
+    /// Add to the provided "base" `set`. For more information on base sets, see [`SystemSet::is_base`].
     #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfig;
     /// Add this set to the schedules's default base set.
@@ -230,11 +230,11 @@ impl IntoSystemSetConfig for SystemSetConfig {
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
-            "adding arbitrary systems to a system type set is not allowed"
+            "System type sets cannot be base sets."
         );
         assert!(
             set.is_base(),
-            "Normal sets cannot be added to system sets using 'in_base_set'. Use 'in_set' instead."
+            "Sets cannot be added to normal sets using 'in_base_set'. Use 'in_set' instead."
         );
         assert!(
             !self.set.is_base(),
@@ -296,7 +296,7 @@ pub trait IntoSystemConfig<Params>: sealed::IntoSystemConfig<Params> {
     /// Add to `set` membership.
     #[track_caller]
     fn in_set(self, set: impl SystemSet) -> SystemConfig;
-    /// Add to the "base" `set` membership.
+    /// Add to the provided "base" `set`. For more information on base sets, see [`SystemSet::is_base`].
     #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemConfig;
     /// Don't add this system to the schedules's default set.
@@ -434,11 +434,11 @@ impl IntoSystemConfig<()> for SystemConfig {
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
-            "adding arbitrary systems to a system type set is not allowed"
+            "System type sets cannot be base sets."
         );
         assert!(
             set.is_base(),
-            "Systems cannot be added to normal system sets using 'in_base_set'. Use 'in_set' instead."
+            "Systems cannot be added to normal sets using 'in_base_set'. Use 'in_set' instead."
         );
         self.graph_info.set_base_set(Box::new(set));
         self
@@ -533,7 +533,7 @@ where
         self.into_configs().in_set(set)
     }
 
-    /// Add these systems to the provided "base" `set`.
+    /// Add these systems to the provided "base" `set`. For more information on base sets, see [`SystemSet::is_base`].
     #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemConfigs {
         self.into_configs().in_base_set(set)
@@ -600,11 +600,11 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
-            "adding arbitrary systems to a system type set is not allowed"
+            "System type sets cannot be base sets."
         );
         assert!(
             set.is_base(),
-            "Systems cannot be added to normal system sets using 'in_base_set'. Use 'in_set' instead."
+            "Systems cannot be added to normal sets using 'in_base_set'. Use 'in_set' instead."
         );
         for config in &mut self.systems {
             config.graph_info.set_base_set(set.dyn_clone());
@@ -686,7 +686,7 @@ where
         self.into_configs().in_set(set)
     }
 
-    /// Add these system sets to the provided "base" `set`.
+    /// Add these system sets to the provided "base" `set`. For more information on base sets, see [`SystemSet::is_base`].
     #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfigs {
         self.into_configs().in_base_set(set)
@@ -752,11 +752,11 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
             !set.is_system_type(),
-            "adding arbitrary systems to a system type set is not allowed"
+            "System type sets cannot be base sets."
         );
         assert!(
             set.is_base(),
-            "Sets cannot be added to normal system sets using 'in_base_set'. Use 'in_set' instead."
+            "Sets cannot be added to normal sets using 'in_base_set'. Use 'in_set' instead."
         );
         for config in &mut self.sets {
             assert!(

--- a/crates/bevy_ecs/src/schedule_v3/config.rs
+++ b/crates/bevy_ecs/src/schedule_v3/config.rs
@@ -91,7 +91,7 @@ pub trait IntoSystemSetConfig: sealed::IntoSystemSetConfig {
     /// Add to the provided "base" `set`.
     #[track_caller]
     fn in_base_set(self, set: impl SystemSet) -> SystemSetConfig;
-    /// Don't add this set to the schedules's default base set.
+    /// Add this set to the schedules's default base set.
     fn in_default_base_set(self) -> SystemSetConfig;
     /// Run before all systems in `set`.
     fn before<M>(self, set: impl IntoSystemSet<M>) -> SystemSetConfig;

--- a/crates/bevy_ecs/src/schedule_v3/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/mod.rs
@@ -54,8 +54,8 @@ pub(super) struct SystemSchedule {
     pub(super) set_ids: Vec<NodeId>,
     pub(super) system_dependencies: Vec<usize>,
     pub(super) system_dependents: Vec<Vec<usize>>,
-    pub(super) sets_of_systems: Vec<FixedBitSet>,
-    pub(super) systems_in_sets: Vec<FixedBitSet>,
+    pub(super) sets_with_conditions_of_systems: Vec<FixedBitSet>,
+    pub(super) systems_in_sets_with_conditions: Vec<FixedBitSet>,
 }
 
 impl SystemSchedule {
@@ -68,8 +68,8 @@ impl SystemSchedule {
             set_ids: Vec::new(),
             system_dependencies: Vec::new(),
             system_dependents: Vec::new(),
-            sets_of_systems: Vec::new(),
-            systems_in_sets: Vec::new(),
+            sets_with_conditions_of_systems: Vec::new(),
+            systems_in_sets_with_conditions: Vec::new(),
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
@@ -32,8 +32,8 @@ struct SyncUnsafeSchedule<'a> {
 struct Conditions<'a> {
     system_conditions: &'a mut [Vec<BoxedCondition>],
     set_conditions: &'a mut [Vec<BoxedCondition>],
-    sets_of_systems: &'a [FixedBitSet],
-    systems_in_sets: &'a [FixedBitSet],
+    sets_with_conditions_of_systems: &'a [FixedBitSet],
+    systems_in_sets_with_conditions: &'a [FixedBitSet],
 }
 
 impl SyncUnsafeSchedule<'_> {
@@ -43,8 +43,8 @@ impl SyncUnsafeSchedule<'_> {
             conditions: Conditions {
                 system_conditions: &mut schedule.system_conditions,
                 set_conditions: &mut schedule.set_conditions,
-                sets_of_systems: &schedule.sets_of_systems,
-                systems_in_sets: &schedule.systems_in_sets,
+                sets_with_conditions_of_systems: &schedule.sets_with_conditions_of_systems,
+                systems_in_sets_with_conditions: &schedule.systems_in_sets_with_conditions,
             },
         }
     }
@@ -333,7 +333,9 @@ impl MultiThreadedExecutor {
         }
 
         // TODO: an earlier out if world's archetypes did not change
-        for set_idx in conditions.sets_of_systems[system_index].difference(&self.evaluated_sets) {
+        for set_idx in conditions.sets_with_conditions_of_systems[system_index]
+            .difference(&self.evaluated_sets)
+        {
             for condition in &mut conditions.set_conditions[set_idx] {
                 condition.update_archetype_component_access(world);
                 if !condition
@@ -382,7 +384,7 @@ impl MultiThreadedExecutor {
         world: &World,
     ) -> bool {
         let mut should_run = !self.skipped_systems.contains(system_index);
-        for set_idx in conditions.sets_of_systems[system_index].ones() {
+        for set_idx in conditions.sets_with_conditions_of_systems[system_index].ones() {
             if self.evaluated_sets.contains(set_idx) {
                 continue;
             }
@@ -393,7 +395,7 @@ impl MultiThreadedExecutor {
 
             if !set_conditions_met {
                 self.skipped_systems
-                    .union_with(&conditions.systems_in_sets[set_idx]);
+                    .union_with(&conditions.systems_in_sets_with_conditions[set_idx]);
             }
 
             should_run &= set_conditions_met;

--- a/crates/bevy_ecs/src/schedule_v3/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/simple.rs
@@ -41,7 +41,7 @@ impl SystemExecutor for SimpleExecutor {
             let should_run_span = info_span!("check_conditions", name = &*name).entered();
 
             let mut should_run = !self.completed_systems.contains(system_index);
-            for set_idx in schedule.sets_of_systems[system_index].ones() {
+            for set_idx in schedule.sets_with_conditions_of_systems[system_index].ones() {
                 if self.evaluated_sets.contains(set_idx) {
                     continue;
                 }
@@ -52,7 +52,7 @@ impl SystemExecutor for SimpleExecutor {
 
                 if !set_conditions_met {
                     self.completed_systems
-                        .union_with(&schedule.systems_in_sets[set_idx]);
+                        .union_with(&schedule.systems_in_sets_with_conditions[set_idx]);
                 }
 
                 should_run &= set_conditions_met;

--- a/crates/bevy_ecs/src/schedule_v3/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/single_threaded.rs
@@ -51,7 +51,7 @@ impl SystemExecutor for SingleThreadedExecutor {
             let should_run_span = info_span!("check_conditions", name = &*name).entered();
 
             let mut should_run = !self.completed_systems.contains(system_index);
-            for set_idx in schedule.sets_of_systems[system_index].ones() {
+            for set_idx in schedule.sets_with_conditions_of_systems[system_index].ones() {
                 if self.evaluated_sets.contains(set_idx) {
                     continue;
                 }
@@ -62,7 +62,7 @@ impl SystemExecutor for SingleThreadedExecutor {
 
                 if !set_conditions_met {
                     self.completed_systems
-                        .union_with(&schedule.systems_in_sets[set_idx]);
+                        .union_with(&schedule.systems_in_sets_with_conditions[set_idx]);
                 }
 
                 should_run &= set_conditions_met;

--- a/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
@@ -105,6 +105,7 @@ impl GraphInfo {
         }
     }
 
+    #[track_caller]
     pub(crate) fn set_base_set(&mut self, set: BoxedSystemSet) {
         if let Some(current) = &self.base_set {
             panic!(

--- a/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
@@ -109,8 +109,7 @@ impl GraphInfo {
     pub(crate) fn set_base_set(&mut self, set: BoxedSystemSet) {
         if let Some(current) = &self.base_set {
             panic!(
-                "Cannot set the base set because base set {:?} has already been configured.",
-                current
+                "Cannot set the base set because base set {current:?} has already been configured."
             );
         } else {
             self.base_set = Some(set);

--- a/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule_v3/graph_utils.rs
@@ -72,16 +72,47 @@ pub(crate) struct GraphInfo {
     pub(crate) sets: Vec<BoxedSystemSet>,
     pub(crate) dependencies: Vec<Dependency>,
     pub(crate) ambiguous_with: Ambiguity,
-    pub(crate) add_default_set: bool,
+    pub(crate) add_default_base_set: bool,
+    pub(crate) base_set: Option<BoxedSystemSet>,
 }
 
 impl Default for GraphInfo {
     fn default() -> Self {
         GraphInfo {
             sets: Vec::new(),
+            base_set: None,
             dependencies: Vec::new(),
             ambiguous_with: Ambiguity::default(),
-            add_default_set: true,
+            add_default_base_set: true,
+        }
+    }
+}
+
+impl GraphInfo {
+    pub(crate) fn system() -> GraphInfo {
+        GraphInfo {
+            // systems get the default base set automatically
+            add_default_base_set: true,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn system_set() -> GraphInfo {
+        GraphInfo {
+            // sets do not get the default base set automatically
+            add_default_base_set: false,
+            ..Default::default()
+        }
+    }
+
+    pub(crate) fn set_base_set(&mut self, set: BoxedSystemSet) {
+        if let Some(current) = &self.base_set {
+            panic!(
+                "Cannot set the base set because base set {:?} has already been configured.",
+                current
+            );
+        } else {
+            self.base_set = Some(set);
         }
     }
 }

--- a/crates/bevy_ecs/src/schedule_v3/set.rs
+++ b/crates/bevy_ecs/src/schedule_v3/set.rs
@@ -23,8 +23,12 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
         false
     }
 
-    /// Returns `true` if this set is a "base system set", which systems
-    /// can only belong to one of.
+    /// Returns `true` if this set is a "base system set". Systems
+    /// can only belong to one base set at a time. Systems and Sets
+    /// can only be added to base sets using specialized `in_base_set`
+    /// APIs. This enables "mutually exclusive" behaviors. It also
+    /// enables schedules to have a "default base set", which can be used
+    /// to apply default configuration to systems.
     fn is_base(&self) -> bool {
         false
     }

--- a/crates/bevy_ecs/src/schedule_v3/set.rs
+++ b/crates/bevy_ecs/src/schedule_v3/set.rs
@@ -23,6 +23,12 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
         false
     }
 
+    /// Returns `true` if this set is a "base system set", which systems
+    /// can only belong to one of.
+    fn is_base(&self) -> bool {
+        false
+    }
+
     /// Creates a boxed clone of the label corresponding to this system set.
     fn dyn_clone(&self) -> Box<dyn SystemSet>;
 }

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -24,7 +24,7 @@ impl Plugin for GilrsPlugin {
                     .add_system(
                         gilrs_event_system
                             .before(InputSystem)
-                            .in_set(CoreSet::PreUpdate),
+                            .in_base_set(CoreSet::PreUpdate),
                     );
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -99,7 +99,7 @@ impl<T: Component> Plugin for ValidParentCheckPlugin<T> {
         app.init_resource::<ReportHierarchyIssue<T>>().add_system(
             check_hierarchy_component_has_valid_parent::<T>
                 .run_if(resource_equals(ReportHierarchyIssue::<T>::new(true)))
-                .in_set(CoreSet::Last),
+                .in_base_set(CoreSet::Last),
         );
     }
 }

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -51,7 +51,7 @@ pub struct InputSystem;
 
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_set(InputSystem.in_set(CoreSet::PreUpdate))
+        app.configure_set(InputSystem.in_base_set(CoreSet::PreUpdate))
             // keyboard
             .add_event::<KeyboardInput>()
             .init_resource::<Input<KeyCode>>()

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -144,40 +144,6 @@ pub fn derive_boxed_label(input: syn::DeriveInput, trait_path: &syn::Path) -> To
 ///
 /// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
 /// - `trait_path`: The path [`syn::Path`] to the label trait
-pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
-    let ident = input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
-        where_token: Default::default(),
-        predicates: Default::default(),
-    });
-    where_clause.predicates.push(
-        syn::parse2(quote! {
-            Self: 'static + Send + Sync + Clone + Eq + ::std::fmt::Debug + ::std::hash::Hash
-        })
-        .unwrap(),
-    );
-
-    (quote! {
-        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn is_system_type(&self) -> bool {
-                false
-            }
-
-            fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
-                std::boxed::Box::new(std::clone::Clone::clone(self))
-            }
-        }
-    })
-    .into()
-}
-
-/// Derive a label trait
-///
-/// # Args
-///
-/// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
-/// - `trait_path`: The path [`syn::Path`] to the label trait
 pub fn derive_label(
     input: syn::DeriveInput,
     trait_path: &syn::Path,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -181,14 +181,10 @@ impl Plugin for PbrPlugin {
                     SimulationLightSystems::UpdateDirectionalLightCascades,
                     SimulationLightSystems::UpdateLightFrusta,
                 )
-                    .in_set(CoreSet::PostUpdate),
+                    .in_base_set(CoreSet::PostUpdate),
             )
             .add_plugin(FogPlugin)
-            .add_system(
-                // NOTE: Clusters need to have been added before update_clusters is run so
-                // add as an exclusive system
-                add_clusters.in_set(SimulationLightSystems::AddClusters),
-            )
+            .add_system(add_clusters.in_set(SimulationLightSystems::AddClusters))
             .add_system(apply_system_buffers.in_set(SimulationLightSystems::AddClustersFlush))
             .add_system(
                 assign_lights_to_clusters

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -31,7 +31,7 @@ impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraPro
             .edit_schedule(CoreSchedule::Startup, |schedule| {
                 schedule.configure_set(CameraUpdateSystem.in_set(StartupSet::PostStartup));
             })
-            .configure_set(CameraUpdateSystem.in_set(CoreSet::PostUpdate))
+            .configure_set(CameraUpdateSystem.in_base_set(CoreSet::PostUpdate))
             .add_startup_system(
                 crate::camera::camera_system::<T>
                     .in_set(CameraUpdateSystem)

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -210,19 +210,19 @@ impl Plugin for VisibilityPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
-        app.configure_set(CalculateBounds.in_set(CoreSet::PostUpdate))
+        app.configure_set(CalculateBounds.in_base_set(CoreSet::PostUpdate))
             // We add an AABB component in CaclulateBounds, which must be ready on the same frame.
             .add_system(apply_system_buffers.in_set(CalculateBoundsFlush))
             .configure_set(
                 CalculateBoundsFlush
                     .after(CalculateBounds)
-                    .in_set(CoreSet::PostUpdate),
+                    .in_base_set(CoreSet::PostUpdate),
             )
-            .configure_set(UpdateOrthographicFrusta.in_set(CoreSet::PostUpdate))
-            .configure_set(UpdatePerspectiveFrusta.in_set(CoreSet::PostUpdate))
-            .configure_set(UpdateProjectionFrusta.in_set(CoreSet::PostUpdate))
-            .configure_set(CheckVisibility.in_set(CoreSet::PostUpdate))
-            .configure_set(VisibilityPropagate.in_set(CoreSet::PostUpdate))
+            .configure_set(UpdateOrthographicFrusta.in_base_set(CoreSet::PostUpdate))
+            .configure_set(UpdatePerspectiveFrusta.in_base_set(CoreSet::PostUpdate))
+            .configure_set(UpdateProjectionFrusta.in_base_set(CoreSet::PostUpdate))
+            .configure_set(CheckVisibility.in_base_set(CoreSet::PostUpdate))
+            .configure_set(VisibilityPropagate.in_base_set(CoreSet::PostUpdate))
             .add_system(calculate_bounds.in_set(CalculateBounds))
             .add_system(
                 update_frusta::<OrthographicProjection>
@@ -247,7 +247,7 @@ impl Plugin for VisibilityPlugin {
             )
             .add_system(
                 update_frusta::<Projection>
-                    .in_set(CoreSet::PostUpdate)
+                    .in_base_set(CoreSet::PostUpdate)
                     .after(camera_system::<Projection>)
                     .after(TransformSystem::TransformPropagate),
             )

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -36,9 +36,9 @@ impl Plugin for ScenePlugin {
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()
             .init_resource::<SceneSpawner>()
-            .add_system(scene_spawner_system.in_set(CoreSet::Update))
+            .add_system(scene_spawner_system)
             // Systems `*_bundle_spawner` must run before `scene_spawner_system`
-            .add_system(scene_spawner.in_set(CoreSet::PreUpdate));
+            .add_system(scene_spawner.in_base_set(CoreSet::PreUpdate));
     }
 }
 

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -82,7 +82,7 @@ impl Plugin for TextPlugin {
             .insert_resource(TextPipeline::default())
             .add_system(
                 update_text2d_layout
-                    .in_set(CoreSet::PostUpdate)
+                    .in_base_set(CoreSet::PostUpdate)
                     .after(ModifiesWindows)
                     // Potential conflict: `Assets<Image>`
                     // In practice, they run independently since `bevy_render::camera_update_system`

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -39,9 +39,9 @@ impl Plugin for TimePlugin {
             .register_type::<Time>()
             .register_type::<Stopwatch>()
             .init_resource::<FixedTime>()
-            .configure_set(TimeSystem.in_set(CoreSet::First))
+            .configure_set(TimeSystem.in_base_set(CoreSet::First))
             .add_system(time_system.in_set(TimeSystem))
-            .add_system(run_fixed_update_schedule.in_set(CoreSet::FixedUpdate));
+            .add_system(run_fixed_update_schedule.in_base_set(CoreSet::FixedUpdate));
     }
 }
 

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -94,7 +94,7 @@ impl Plugin for TransformPlugin {
             .register_type::<GlobalTransform>()
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
             // add transform systems to startup so the first update is "correct"
-            .configure_set(TransformSystem::TransformPropagate.in_set(CoreSet::PostUpdate))
+            .configure_set(TransformSystem::TransformPropagate.in_base_set(CoreSet::PostUpdate))
             .edit_schedule(CoreSchedule::Startup, |schedule| {
                 schedule.configure_set(
                     TransformSystem::TransformPropagate.in_set(StartupSet::PostStartup),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -101,14 +101,14 @@ impl Plugin for UiPlugin {
             .register_type::<UiImage>()
             .register_type::<Val>()
             .register_type::<widget::Button>()
-            .configure_set(UiSystem::Focus.in_set(CoreSet::PreUpdate))
-            .configure_set(UiSystem::Flex.in_set(CoreSet::PostUpdate))
-            .configure_set(UiSystem::Stack.in_set(CoreSet::PostUpdate))
+            .configure_set(UiSystem::Focus.in_base_set(CoreSet::PreUpdate))
+            .configure_set(UiSystem::Flex.in_base_set(CoreSet::PostUpdate))
+            .configure_set(UiSystem::Stack.in_base_set(CoreSet::PostUpdate))
             .add_system(ui_focus_system.in_set(UiSystem::Focus).after(InputSystem))
             // add these systems to front because these must run before transform update systems
             .add_system(
                 widget::text_system
-                    .in_set(CoreSet::PostUpdate)
+                    .in_base_set(CoreSet::PostUpdate)
                     .before(UiSystem::Flex)
                     .after(ModifiesWindows)
                     // Potential conflict: `Assets<Image>`
@@ -123,7 +123,7 @@ impl Plugin for UiPlugin {
             )
             .add_system(
                 widget::update_image_calculated_size_system
-                    .in_set(CoreSet::PostUpdate)
+                    .in_base_set(CoreSet::PostUpdate)
                     .before(UiSystem::Flex)
                     // Potential conflicts: `Assets<Image>`
                     // They run independently since `widget::image_node_system` will only ever observe
@@ -142,7 +142,7 @@ impl Plugin for UiPlugin {
             .add_system(
                 update_clipping_system
                     .after(TransformSystem::TransformPropagate)
-                    .in_set(CoreSet::PostUpdate),
+                    .in_base_set(CoreSet::PostUpdate),
             );
 
         crate::render::build_ui_render(app);

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -102,7 +102,7 @@ impl Plugin for WindowPlugin {
         }
 
         if self.close_when_requested {
-            app.add_system(close_when_requested.in_set(CoreSet::PostUpdate));
+            app.add_system(close_when_requested.in_base_set(CoreSet::PostUpdate));
         }
 
         // Register event types

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -93,10 +93,10 @@ impl Plugin for WindowPlugin {
 
         match self.exit_condition {
             ExitCondition::OnPrimaryClosed => {
-                app.add_system(exit_on_primary_closed.in_set(CoreSet::PostUpdate));
+                app.add_system(exit_on_primary_closed.in_base_set(CoreSet::PostUpdate));
             }
             ExitCondition::OnAllClosed => {
-                app.add_system(exit_on_all_closed.in_set(CoreSet::PostUpdate));
+                app.add_system(exit_on_all_closed.in_base_set(CoreSet::PostUpdate));
             }
             ExitCondition::DontExit => {}
         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -70,7 +70,7 @@ impl Plugin for WinitPlugin {
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitSettings>()
             .set_runner(winit_runner)
-            .configure_set(ModifiesWindows.in_set(CoreSet::PostUpdate))
+            .configure_set(ModifiesWindows.in_base_set(CoreSet::PostUpdate))
             // exit_on_all_closed only uses the query to determine if the query is empty,
             // and so doesn't care about ordering relative to changed_window
             .add_systems(

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(sprite_movement.in_set(CoreSet::Update))
+        .add_system(sprite_movement)
         .run();
 }
 

--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_startup_system(setup)
-        .add_system(sprite_movement.in_set(CoreSet::Update))
+        .add_system(sprite_movement)
         .run();
 }
 

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_startup_system(setup)
-        .add_system(animate_sprite.in_set(CoreSet::Update))
+        .add_system(animate_sprite)
         .run();
 }
 

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -14,9 +14,9 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(animate_translation.in_set(CoreSet::Update))
-        .add_system(animate_rotation.in_set(CoreSet::Update))
-        .add_system(animate_scale.in_set(CoreSet::Update))
+        .add_system(animate_translation)
+        .add_system(animate_rotation)
+        .add_system(animate_scale)
         .run();
 }
 

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -12,7 +12,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_startup_system(setup)
-        .add_system(rotate.in_set(CoreSet::Update))
+        .add_system(rotate)
         .run();
 }
 

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -18,7 +18,7 @@ fn main() {
 
     app.add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(example_control_system.in_set(CoreSet::Update));
+        .add_system(example_control_system);
 
     // Unfortunately, MSAA and HDR are not supported simultaneously under WebGL.
     // Since this example uses HDR, we must disable MSAA for WASM builds, at least

--- a/examples/3d/bloom.rs
+++ b/examples/3d/bloom.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup_scene)
         .add_system(update_bloom_settings)
-        .add_system(bounce_spheres.in_set(CoreSet::Update))
+        .add_system(bounce_spheres)
         .run();
 }
 

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -9,8 +9,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(movement.in_set(CoreSet::Update))
-        .add_system(animate_light_direction.in_set(CoreSet::Update))
+        .add_system(movement)
+        .add_system(animate_light_direction)
         .run();
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -16,7 +16,7 @@ fn main() {
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(animate_light_direction.in_set(CoreSet::Update))
+        .add_system(animate_light_direction)
         .run();
 }
 

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -13,7 +13,7 @@ fn main() {
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(cycle_msaa.in_set(CoreSet::Update))
+        .add_system(cycle_msaa)
         .run();
 }
 

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(rotator_system.in_set(CoreSet::Update))
+        .add_system(rotator_system)
         .run();
 }
 

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -18,8 +18,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(cube_rotator_system.in_set(CoreSet::Update))
-        .add_system(rotator_system.in_set(CoreSet::Update))
+        .add_system(cube_rotator_system)
+        .add_system(rotator_system)
         .run();
 }
 

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -23,7 +23,7 @@ fn main() {
         .add_system(adjust_point_light_biases)
         .add_system(toggle_light)
         .add_system(adjust_directional_light_biases)
-        .add_system(camera_controller.in_set(CoreSet::Update))
+        .add_system(camera_controller)
         .run();
 }
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(set_camera_viewports.in_set(CoreSet::Update))
+        .add_system(set_camera_viewports)
         .run();
 }
 

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(move_scene_entities.in_set(CoreSet::Update))
+        .add_system(move_scene_entities)
         .run();
 }
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -15,7 +15,7 @@ fn main() {
         })
         .add_startup_system(setup)
         .add_system(setup_scene_once_loaded)
-        .add_system(keyboard_animation_control.in_set(CoreSet::Update))
+        .add_system(keyboard_animation_control)
         .run();
 }
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -21,7 +21,7 @@ fn main() {
             ..default()
         })
         .add_startup_system(setup)
-        .add_system(joint_animation.in_set(CoreSet::Update))
+        .add_system(joint_animation)
         .run();
 }
 

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -13,7 +13,7 @@ fn main() {
             ..default()
         })
         .add_startup_system(setup)
-        .add_system(joint_animation.in_set(CoreSet::Update))
+        .add_system(joint_animation)
         .run();
 }
 

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -240,6 +240,7 @@ fn print_at_end_round(mut counter: Local<u32>) {
 
 /// A group of related system sets, used for controlling the order of systems
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+#[system_set(base)]
 enum MySet {
     BeforeRound,
     AfterRound,
@@ -281,21 +282,21 @@ fn main() {
         // add_system(system) adds systems to the Update system set by default
         // However we can manually specify the set if we want to. The following is equivalent to
         // add_system(score_system)
-        .add_system(score_system.in_set(CoreSet::Update))
+        .add_system(score_system)
         // There are other `CoreSets`, such as `Last` which runs at the very end of each run.
-        .add_system(print_at_end_round.in_set(CoreSet::Last))
+        .add_system(print_at_end_round.in_base_set(CoreSet::Last))
         // We can also create new system sets, and order them relative to other system sets.
         // Here is what our games stage order will look like:
         // "before_round": new_player_system, new_round_system
         // "update": print_message_system, score_system
         // "after_round": score_check_system, game_over_system
-        .configure_set(MySet::BeforeRound.no_default_set().before(CoreSet::Update))
-        .configure_set(MySet::AfterRound.no_default_set().after(CoreSet::Update))
-        .add_system(new_round_system.in_set(MySet::BeforeRound))
+        .configure_set(MySet::BeforeRound.before(CoreSet::Update))
+        .configure_set(MySet::AfterRound.after(CoreSet::Update))
+        .add_system(new_round_system.in_base_set(MySet::BeforeRound))
         .add_system(
             new_player_system
                 .after(new_round_system)
-                .in_set(MySet::BeforeRound),
+                .in_base_set(MySet::BeforeRound),
         )
         .add_system(exclusive_player_system.in_set(MySet::BeforeRound))
         .add_system(score_check_system.in_set(MySet::AfterRound))

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(rotate.in_set(CoreSet::Update))
+        .add_system(rotate)
         .run();
 }
 

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -15,7 +15,7 @@ fn main() {
         .add_startup_system(generate_bodies)
         .insert_resource(FixedTime::new_from_secs(DELTA_TIME))
         .add_systems_to_schedule(CoreSchedule::FixedUpdate, (interact_bodies, integrate))
-        .add_system(look_at_star.in_set(CoreSet::Update))
+        .add_system(look_at_star)
         .insert_resource(ClearColor(Color::BLACK))
         .run();
 }

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -70,7 +70,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(spawn_system)
-        .add_system(move_system.in_set(CoreSet::Update))
-        .add_system(bounce_system.in_set(CoreSet::Update))
+        .add_system(move_system)
+        .add_system(bounce_system)
         .run();
 }

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -15,8 +15,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(remove_component.in_set(CoreSet::Update))
-        .add_system(react_on_removal.in_set(CoreSet::PostUpdate))
+        .add_system(remove_component)
+        .add_system(react_on_removal.in_base_set(CoreSet::PostUpdate))
         .run();
 }
 

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -13,9 +13,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup_contributor_selection)
         .add_startup_system(setup)
-        .add_system(velocity_system.in_set(CoreSet::Update))
-        .add_system(move_system.in_set(CoreSet::Update))
-        .add_system(collision_system.in_set(CoreSet::Update))
+        .add_system(velocity_system)
+        .add_system(move_system)
+        .add_system(collision_system)
         .add_system(select_system)
         .init_resource::<SelectionState>()
         .run();

--- a/examples/ios/src/lib.rs
+++ b/examples/ios/src/lib.rs
@@ -14,7 +14,7 @@ fn main() {
         }))
         .add_startup_system(setup_scene)
         .add_startup_system(setup_music)
-        .add_system(touch_camera.in_set(CoreSet::Update))
+        .add_system(touch_camera)
         .add_system(button_handler)
         .run();
 }

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
-        .add_system(rotate_camera.in_set(CoreSet::Update))
+        .add_system(rotate_camera)
         .run();
 }
 

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -29,7 +29,7 @@ fn main() {
             ..default()
         })
         .add_startup_system(setup)
-        .add_system(rotate.in_set(CoreSet::Update))
+        .add_system(rotate)
         .add_system(update)
         .run();
 }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -44,9 +44,9 @@ fn main() {
             color: Color::WHITE,
         })
         .add_startup_system(setup)
-        .add_system(mouse_handler.in_set(CoreSet::Update))
-        .add_system(movement_system.in_set(CoreSet::Update))
-        .add_system(collision_system.in_set(CoreSet::Update))
+        .add_system(mouse_handler)
+        .add_system(movement_system)
+        .add_system(collision_system)
         .add_system(counter_system)
         .add_system_to_schedule(CoreSchedule::FixedUpdate, scheduled_spawner)
         .insert_resource(FixedTime::new_from_secs(0.2))

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -33,13 +33,9 @@ fn main() {
             ..default()
         }))
         .add_startup_system(setup)
-        .add_system(animate_sprite.in_set(CoreSet::Update))
+        .add_system(animate_sprite)
         .add_system(print_sprite_count)
-        .add_system(
-            move_camera
-                .in_set(CoreSet::Update)
-                .after(print_sprite_count),
-        )
+        .add_system(move_camera.after(print_sprite_count))
         .run();
 }
 

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -31,8 +31,8 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
-        .add_system(move_camera.in_set(CoreSet::Update))
-        .add_system(print_mesh_count.in_set(CoreSet::Update))
+        .add_system(move_camera)
+        .add_system(print_mesh_count)
         .run();
 }
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -27,7 +27,7 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
-        .add_system(move_camera.in_set(CoreSet::Update))
+        .add_system(move_camera)
         .add_system(print_light_count)
         .add_plugin(LogVisibleLights)
         .run();

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -188,7 +188,7 @@ fn main() {
         .add_startup_system(setup)
         // Updating transforms *must* be done before `CoreSet::PostUpdate`
         // or the hierarchy will momentarily be in an invalid state.
-        .add_system(update.in_set(CoreSet::Update))
+        .add_system(update)
         .run();
 }
 

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -131,10 +131,10 @@ fn main() {
         .add_startup_system(setup_sticks)
         .add_startup_system(setup_triggers)
         .add_startup_system(setup_connected)
-        .add_system(update_buttons.in_set(CoreSet::Update))
-        .add_system(update_button_values.in_set(CoreSet::Update))
-        .add_system(update_axes.in_set(CoreSet::Update))
-        .add_system(update_connected.in_set(CoreSet::Update))
+        .add_system(update_buttons)
+        .add_system(update_button_values)
+        .add_system(update_axes)
+        .add_system(update_connected)
         .run();
 }
 

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -42,7 +42,7 @@ fn main() {
     .add_plugin(CameraControllerPlugin)
     .add_plugin(SceneViewerPlugin)
     .add_startup_system(setup)
-    .add_system(setup_scene_after_load.in_set(CoreSet::PreUpdate));
+    .add_system(setup_scene_after_load.in_base_set(CoreSet::PreUpdate));
 
     app.run();
 }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -57,13 +57,13 @@ pub struct SceneViewerPlugin;
 impl Plugin for SceneViewerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CameraTracker>()
-            .add_system(scene_load_check.in_set(CoreSet::PreUpdate))
-            .add_system(update_lights.in_set(CoreSet::Update))
-            .add_system(camera_tracker.in_set(CoreSet::Update));
+            .add_system(scene_load_check.in_base_set(CoreSet::PreUpdate))
+            .add_system(update_lights)
+            .add_system(camera_tracker);
 
         #[cfg(feature = "animation")]
-        app.add_system(start_animation.in_set(CoreSet::Update))
-            .add_system(keyboard_animation_control.in_set(CoreSet::Update));
+        app.add_system(start_animation)
+            .add_system(keyboard_animation_control);
     }
 }
 

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -14,7 +14,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(rotate_cube.in_set(CoreSet::Update))
+        .add_system(rotate_cube)
         .run();
 }
 

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -30,8 +30,8 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(change_scale_direction.in_set(CoreSet::Update))
-        .add_system(scale_cube.in_set(CoreSet::Update))
+        .add_system(change_scale_direction)
+        .add_system(scale_cube)
         .run();
 }
 

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -25,9 +25,9 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(move_cube.in_set(CoreSet::Update))
-        .add_system(rotate_cube.in_set(CoreSet::Update))
-        .add_system(scale_down_sphere_proportional_to_cube_travel_distance.in_set(CoreSet::Update))
+        .add_system(move_cube)
+        .add_system(rotate_cube)
+        .add_system(scale_down_sphere_proportional_to_cube_travel_distance)
         .run();
 }
 

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -26,7 +26,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_startup_system(setup)
-        .add_system(move_cube.in_set(CoreSet::Update))
+        .add_system(move_cube)
         .run();
 }
 

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -8,7 +8,7 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)
-        .add_system(relative_cursor_position_system.in_set(CoreSet::Update))
+        .add_system(relative_cursor_position_system)
         .run();
 }
 

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -13,8 +13,8 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_startup_system(setup)
-        .add_system(text_update_system.in_set(CoreSet::Update))
-        .add_system(text_color_system.in_set(CoreSet::Update))
+        .add_system(text_update_system)
+        .add_system(text_color_system)
         .run();
 }
 

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -17,7 +17,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_startup_system(infotext_system)
-        .add_system(change_text_system.in_set(CoreSet::Update))
+        .add_system(change_text_system)
         .run();
 }
 

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -12,7 +12,7 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)
-        .add_system(mouse_scroll.in_set(CoreSet::Update))
+        .add_system(mouse_scroll)
         .run();
 }
 

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -17,8 +17,8 @@ fn main() {
             target_time: Timer::new(Duration::from_millis(SCALE_TIME), TimerMode::Once),
         })
         .add_startup_system(setup)
-        .add_system(change_scaling.in_set(CoreSet::Update))
-        .add_system(apply_scaling.after(change_scaling).in_set(CoreSet::Update))
+        .add_system(change_scaling)
+        .add_system(apply_scaling.after(change_scaling))
         .run();
 }
 

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -34,9 +34,9 @@ fn main() {
             ..default()
         }))
         .add_startup_system(test_setup::setup)
-        .add_system(test_setup::cycle_modes.in_set(CoreSet::Update))
-        .add_system(test_setup::rotate_cube.in_set(CoreSet::Update))
-        .add_system(test_setup::update_text.in_set(CoreSet::Update))
+        .add_system(test_setup::cycle_modes)
+        .add_system(test_setup::rotate_cube)
+        .add_system(test_setup::update_text)
         .add_system(update_winit)
         .run();
 }


### PR DESCRIPTION
# Objective

NOTE: This depends on #7267 and should not be merged until #7267 is merged. If you are reviewing this before that is merged, I highly recommend viewing the Base Sets commit instead of trying to find my changes amongst those from #7267.

"Default sets" as described by the [Stageless RFC](https://github.com/bevyengine/rfcs/pull/45) have some [unfortunate consequences](https://github.com/bevyengine/bevy/discussions/7365).

## Solution

This adds "base sets" as a variant of `SystemSet`:

A set is a "base set" if `SystemSet::is_base` returns `true`. Typically this will be opted-in to using the `SystemSet` derive:

```rust
#[derive(SystemSet, Clone, Hash, Debug, PartialEq, Eq)]
#[system_set(base)]
enum MyBaseSet {
  A,
  B,
}
``` 

**Base sets are exclusive**: a system can belong to at most one "base set". Adding a system to more than one will result in an error. When possible we fail immediately during system-config-time with a nice file + line number. For the more nested graph-ey cases, this will fail at the final schedule build. 

**Base sets cannot belong to other sets**: this is where the word "base" comes from

Systems and Sets can only be added to base sets using `in_base_set`. Calling `in_set` with a base set will fail. As will calling `in_base_set` with a normal set.

```rust
app.add_system(foo.in_base_set(MyBaseSet::A))
       // X must be a normal set ... base sets cannot be added to base sets
       .configure_set(X.in_base_set(MyBaseSet::A))
```

Base sets can still be configured like normal sets:

```rust
app.add_system(MyBaseSet::B.after(MyBaseSet::Ap))
``` 

The primary use case for base sets is enabling a "default base set":

```rust
schedule.set_default_base_set(CoreSet::Update)
  // this will belong to CoreSet::Update by default
  .add_system(foo)
  // this will override the default base set with PostUpdate
  .add_system(bar.in_base_set(CoreSet::PostUpdate))
```

This allows us to build apis that work by default in the standard Bevy style. This is a rough analog to the "default stage" model, but it use the new "stageless sets" model instead, with all of the ordering flexibility (including exclusive systems) that it provides.

---

## Changelog

- Added "base sets" and ported CoreSet to use them.

## Migration Guide

TODO