### PR TITLE
[Merged by Bors] - Add `width`, `height` and `all` constructor functions to `Size`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -386,9 +386,6 @@ impl Size {
 
     /// Creates a Size where both values are [`Val::Undefined`].
     pub const UNDEFINED: Self = Self::all(Val::Undefined);
-
-    /// Creates a Size where both values are [`Val::Percent(100.)`].
-    pub const FILL: Self = Self::all(Val::Percent(100.));
 }
 
 impl Default for Size {

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -339,10 +339,7 @@ pub struct Size {
 }
 
 impl Size {
-    pub const DEFAULT: Self = Self {
-        width: Val::DEFAULT,
-        height: Val::DEFAULT,
-    };
+    pub const DEFAULT: Self = Self::all(Val::DEFAULT);
 
     /// Creates a new [`Size`] from a width and a height.
     ///
@@ -360,17 +357,38 @@ impl Size {
         Size { width, height }
     }
 
+    /// Creates a new [`Size`] where both sides take the given value.
+    pub const fn all(value: Val) -> Self {
+        Self {
+            width: value,
+            height: value,
+        }
+    }
+
+    /// Creates a new [`Size`] where `width` takes the given value.
+    pub const fn width(width: Val) -> Self {
+        Self {
+            width,
+            height: Val::DEFAULT,
+        }
+    }
+
+    /// Creates a new [`Size`] where `height` takes the given value.
+    pub const fn height(width: Val) -> Self {
+        Self {
+            width,
+            height: Val::DEFAULT,
+        }
+    }
+
     /// Creates a Size where both values are [`Val::Auto`].
-    pub const AUTO: Size = Size {
-        width: Val::Auto,
-        height: Val::Auto,
-    };
+    pub const AUTO: Self = Self::all(Val::Auto);
 
     /// Creates a Size where both values are [`Val::Undefined`].
-    pub const UNDEFINED: Size = Size {
-        width: Val::Undefined,
-        height: Val::Undefined,
-    };
+    pub const UNDEFINED: Self = Self::all(Val::Undefined);
+
+    /// Creates a Size where both values are [`Val::Percent(100.)`].
+    pub const FILL: Self = Self::all(Val::Percent(100.));
 }
 
 impl Default for Size {
@@ -443,14 +461,11 @@ mod tests {
 
     #[test]
     fn test_size_mul() {
-        assert_eq!(
-            Size::new(Val::Px(10.), Val::Px(10.)) * 2.,
-            Size::new(Val::Px(20.), Val::Px(20.))
-        );
+        assert_eq!(Size::all(Val::Px(10.)) * 2., Size::all(Val::Px(20.)));
 
-        let mut size = Size::new(Val::Px(10.), Val::Px(10.));
+        let mut size = Size::all(Val::Px(10.));
         size *= 2.;
-        assert_eq!(size, Size::new(Val::Px(20.), Val::Px(20.)));
+        assert_eq!(size, Size::all(Val::Px(20.)));
     }
 
     #[test]

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -26,7 +26,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(NodeBundle {
             style: Style {
                 // fill the entire window
-                size: Size::FILL,
+                size: Size::all(Val::Percent(100.)),
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 ..Default::default()

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -26,7 +26,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
         .spawn(NodeBundle {
             style: Style {
                 // fill the entire window
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                size: Size::FILL,
                 flex_direction: FlexDirection::Column,
                 align_items: AlignItems::Center,
                 ..Default::default()
@@ -124,7 +124,7 @@ fn spawn_child_node(
                 flex_direction: FlexDirection::Column,
                 align_items,
                 justify_content,
-                size: Size::new(Val::Px(160.), Val::Px(160.)),
+                size: Size::all(Val::Px(160.)),
                 margin: UiRect::all(MARGIN),
                 ..Default::default()
             },


### PR DESCRIPTION
## Objective

A common easy to miss mistake is to write something like:
``` rust
Size::new(Val::Percent(100.), Val::Px(100.));
```

`UiRect` has the `left`, `right`, `all`, `vertical`, etc constructor functions, `Size` is used a lot more frequently but lacks anything similar.

## Solution

Implement `all`, `width` and `height` functions for `Size`.

## Changelog

* Added `all`, `width` and `height` functions to `Size`. 