### PR TITLE
[Merged by Bors] - Remove unnecessary `Default` impl of HandleType

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -116,10 +116,7 @@ where
     marker: PhantomData<fn() -> T>,
 }
 
-// FIXME: Default is only needed because `Handle`'s field `handle_type` is currently ignored for reflection
-#[derive(Default)]
 enum HandleType {
-    #[default]
     Weak,
     Strong(Sender<RefChange>),
 }


### PR DESCRIPTION
# Objective

- Resolve a Fixme to remove the `Default` impl for `HandleType`, once Reflection no longer requires it.
- Presumebly this Comment was made before the `FromReflect` Derive used the `#[reflect(Default)]`, to substitute for the requirment that a ignored field has a `Default`.

## Solution

- Just remove the `Default` derive and comment.