### PR TITLE
[Merged by Bors] - Resolve Warnings in Action Summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,7 +224,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-          override: true
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile


### PR DESCRIPTION
# Objective

- The CI Summary shows several fixable Warnings.
Example from https://github.com/bevyengine/bevy/actions/runs/4075078887:
![Screenshot_20230202_152644](https://user-images.githubusercontent.com/66798382/216352644-62e9664b-c881-4bc5-9a80-694cef25df76.png)

- The Job `check-compiles` provided an invalid input.
- The Job `check-doc` uses an outdated Version of `actions/cache`.

## Solution

- Remove the invalid `override` input.
- Update `actions/cache@v2` to `actions/cache@v3`.