### PR TITLE
fix some post-processing issues

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -512,7 +512,11 @@ impl FromWorld for BloomPipelines {
                                 dst_factor: BlendFactor::One,
                                 operation: BlendOperation::Add,
                             },
-                            alpha: BlendComponent::REPLACE,
+                            alpha: BlendComponent {
+                                src_factor: BlendFactor::One,
+                                dst_factor: BlendFactor::One,
+                                operation: BlendOperation::Max,
+                            },
                         }),
                         write_mask: ColorWrites::ALL,
                     })],

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -96,7 +96,7 @@ impl SpecializedRenderPipeline for UpscalingPipeline {
                 entry_point: "fs_main".into(),
                 targets: vec![Some(ColorTargetState {
                     format: key.texture_format,
-                    blend: None,
+                    blend: Some(BlendState::ALPHA_BLENDING),
                     write_mask: ColorWrites::ALL,
                 })],
             }),

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -100,7 +100,7 @@ impl Node for UpscalingNode {
                 view: target.out_texture(),
                 resolve_target: None,
                 ops: Operations {
-                    load: LoadOp::Clear(Default::default()),
+                    load: LoadOp::Load,
                     store: true,
                 },
             })],

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -64,7 +64,7 @@ fn setup(
             },
             camera_3d: Camera3d {
                 // don't clear on the second camera because the first camera already cleared the window
-                clear_color: ClearColorConfig::None,
+                clear_color: ClearColorConfig::Custom(Color::NONE),
                 ..default()
             },
             ..default()

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -48,7 +48,7 @@ fn setup(
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(10.0, 10., -5.0).looking_at(Vec3::ZERO, Vec3::Y),
         camera_3d: Camera3d {
-            clear_color: ClearColorConfig::None,
+            clear_color: ClearColorConfig::Custom(Color::NONE),
             ..default()
         },
         camera: Camera {


### PR DESCRIPTION
# Objective

fix some post-processing issues

## Solution

- make upscaling load existing color, and use `Some(BlendState::ALPHA_BLENDING)` when writing each camera's result to the output texture instead of just overwriting
- also fix a minor issue with bloom where the output image's alpha was just the bloom alpha. this now needs to be maxed since we blend the output

todo:
- [ ] maybe add a `CameraBlendMode(Option<Wgpu::BlendState>)` component to allow controlling the blend mode
- [ ] maybe clear instead of loading on first upscale for a given target (wgpu docs say you must clear before loading, but it seems to work for me without ... but my ci seems to be crashing on linux examples)
- [ ] check for performance impact

fix #7435 
fix #7361
hopefully fix #5721 (again i haven't tested that)

---

## Migration Guide

- Using a clear color with alpha != 1 will lead to ghosting. make sure your clear color alpha is 1 on the first camera for a given target.
- Previously where you would use `ClearColor::None` on secondary cameras, you will now probably want `ClearColorConfig::Custom(Color::NONE)`, which will clear the texture to transparent
- this may change the apparent sensitivity of bloom on secondary cameras. this is because previously the bloom was using the clear color from previous cameras, which will now not be present in the camera's texture. you can work around this by changing the sensitivity (i found turning up the knee to 4.0 seemed to be the same as a clear color of 0.1, ymmv) or re-ordering the cameras.