### PR TITLE
update winit to 0.28

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -141,7 +141,7 @@ pub struct Window {
     /// ## Platform-specific
     ///
     /// - iOS / Android / Web / Wayland: Unsupported.
-    pub always_on_top: bool,
+    pub window_level: WindowLevel,
     /// The "html canvas" element selector.
     ///
     /// If set, this selector will be used to find a matching html canvas element,
@@ -205,7 +205,7 @@ impl Default for Window {
             decorations: true,
             transparent: false,
             focused: true,
-            always_on_top: false,
+            window_level: Default::default(),
             fit_canvas_to_parent: false,
             prevent_default_event_handling: true,
             canvas: None,
@@ -799,4 +799,31 @@ pub enum WindowMode {
     SizedFullscreen,
     /// Creates a fullscreen window that uses the maximum supported size.
     Fullscreen,
+}
+
+/// A window level groups windows with respect to their z-position.
+///
+/// The relative ordering between windows in different window levels is fixed.
+/// The z-order of a window within the same window level may change dynamically on user interaction.
+///
+/// ## Platform-specific
+///
+/// - **iOS / Android / Web / Wayland:** Unsupported.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Reflect, FromReflect)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+#[reflect(Debug, PartialEq)]
+pub enum WindowLevel {
+    /// The window will always be below normal windows.
+    ///
+    /// This is useful for a widget-based app.
+    AlwaysOnBottom,
+    /// The default.
+    #[default]
+    Normal,
+    /// The window will always be on top of normal windows.
+    AlwaysOnTop,
 }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -23,7 +23,7 @@ bevy_window = { path = "../bevy_window", version = "0.9.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 
 # other
-winit = { version = "0.27", default-features = false }
+winit = { version = "0.28", default-features = false }
 approx = { version = "0.5", default-features = false }
 raw-window-handle = "0.5"
 

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -5,7 +5,7 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
-use bevy_window::CursorIcon;
+use bevy_window::{CursorIcon, WindowLevel};
 
 pub fn convert_keyboard_input(keyboard_input: &winit::event::KeyboardInput) -> KeyboardInput {
     KeyboardInput {
@@ -264,5 +264,13 @@ pub fn convert_cursor_icon(cursor_icon: CursorIcon) -> winit::window::CursorIcon
         CursorIcon::NwseResize => winit::window::CursorIcon::NwseResize,
         CursorIcon::ColResize => winit::window::CursorIcon::ColResize,
         CursorIcon::RowResize => winit::window::CursorIcon::RowResize,
+    }
+}
+
+pub fn convert_window_level(window_level: WindowLevel) -> winit::window::WindowLevel {
+    match window_level {
+        WindowLevel::AlwaysOnBottom => winit::window::WindowLevel::AlwaysOnBottom,
+        WindowLevel::Normal => winit::window::WindowLevel::Normal,
+        WindowLevel::AlwaysOnTop => winit::window::WindowLevel::AlwaysOnTop,
     }
 }

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -19,7 +19,10 @@ use winit::{
 
 #[cfg(target_arch = "wasm32")]
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
-use crate::{converters, get_best_videomode, get_fitting_videomode, WinitWindows};
+use crate::{
+    converters::{self, convert_window_level},
+    get_best_videomode, get_fitting_videomode, WinitWindows,
+};
 #[cfg(target_arch = "wasm32")]
 use bevy_ecs::system::ResMut;
 
@@ -262,8 +265,8 @@ pub(crate) fn changed_window(
                 winit_window.focus_window();
             }
 
-            if window.always_on_top != previous.always_on_top {
-                winit_window.set_always_on_top(window.always_on_top);
+            if window.window_level != previous.window_level {
+                winit_window.set_window_level(convert_window_level(window.window_level));
             }
 
             // Currently unsupported changes

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -8,6 +8,8 @@ use winit::{
     monitor::MonitorHandle,
 };
 
+use crate::converters::convert_window_level;
+
 #[derive(Debug, Default)]
 pub struct WinitWindows {
     pub windows: HashMap<winit::window::WindowId, winit::window::Window>,
@@ -65,7 +67,7 @@ impl WinitWindows {
         };
 
         winit_window_builder = winit_window_builder
-            .with_always_on_top(window.always_on_top)
+            .with_window_level(convert_window_level(window.window_level))
             .with_resizable(window.resizable)
             .with_decorations(window.decorations)
             .with_transparent(window.transparent);

--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ yanked = "deny"
 notice = "deny"
 ignore = [
     "RUSTSEC-2020-0056", # from cpal v0.14.1 - unmaintained - https://github.com/koute/stdweb/issues/403
+    "RUSTSEC-2022-0048", # from xml-rs 0.8.4 - unmaintained - it's used in a build script of winit
 ]
 
 [licenses]
@@ -36,16 +37,11 @@ highlight = "all"
 skip = [
     { name = "ndk-sys", version = "0.3" },               # from rodio v0.16.0
     { name = "ndk", version = "0.6" },                   # from rodio v0.16.0
-    { name = "raw-window-handle", version = "0.4" },     # from winit v0.27.4
     { name = "nix", version = "0.23" },                  # from cpal v0.14.1
+    { name = "redox_syscall", version = "0.2" },         # from notify v5.1.0
     { name = "rustc_version", version = "0.2" },         # from postcard v1.0.2
     { name = "semver", version = "0.9" },                # from postcard v1.0.2
-    { name = "windows_aarch64_msvc", version = "0.36" }, # from notify v5.0.0
-    { name = "windows_i686_gnu", version = "0.36" },     # from notify v5.0.0
-    { name = "windows_i686_msvc", version = "0.36" },    # from notify v5.0.0
-    { name = "windows_x86_64_gnu", version = "0.36" },   # from notify v5.0.0
-    { name = "windows_x86_64_msvc", version = "0.36" },  # from notify v5.0.0
-    { name = "windows-sys", version = "0.36" },          # from notify v5.0.0
+    { name = "windows-sys", version = "0.42" },          # from notify v5.1.0
     { name = "windows", version = "0.37" },              # from rodio v0.16.0
     { name = "windows_aarch64_msvc", version = "0.37" }, # from rodio v0.16.0
     { name = "windows_i686_gnu", version = "0.37" },     # from rodio v0.16.0

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -11,7 +11,7 @@ fn main() {
                 // Set the window's parameters, note we're setting the window to always be on top.
                 transparent: true,
                 decorations: true,
-                always_on_top: true,
+                window_level: bevy::window::WindowLevel::AlwaysOnTop,
                 ..default()
             }),
             ..default()

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -4,7 +4,7 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode},
+    window::{CursorGrabMode, PresentMode, WindowLevel},
 };
 
 fn main() {
@@ -28,7 +28,7 @@ fn main() {
         .add_system(toggle_cursor)
         .add_system(toggle_vsync)
         .add_system(cycle_cursor_icon)
-        .add_system(toggle_always_on_top)
+        .add_system(switch_level)
         .run();
 }
 
@@ -47,23 +47,22 @@ fn toggle_vsync(input: Res<Input<KeyCode>>, mut windows: Query<&mut Window>) {
     }
 }
 
-/// This system toggles whether the window is always on top when pressing the T button
-/// You'll notice it won't be covered by other windows.
+/// This system switch the window level when pressing the T button
+/// You'll notice it won't be covered by other windows, or will be covered by all the other
+/// windows depending on the level.
 ///
 /// This feature only works on some platforms. Please check the
-/// [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowDescriptor.html#structfield.always_on_top)
+/// [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.window_level)
 /// for more details.
-fn toggle_always_on_top(input: Res<Input<KeyCode>>, mut windows: Query<&mut Window>) {
+fn switch_level(input: Res<Input<KeyCode>>, mut windows: Query<&mut Window>) {
     if input.just_pressed(KeyCode::T) {
         let mut window = windows.single_mut();
 
-        window.always_on_top = !window.always_on_top;
-
-        if window.always_on_top {
-            info!("LOCKING WINDOW ON TOP");
-        } else {
-            info!("UNLOCKING WINDOW");
-        }
+        window.window_level = match window.window_level {
+            WindowLevel::AlwaysOnBottom => WindowLevel::Normal,
+            WindowLevel::Normal => WindowLevel::AlwaysOnTop,
+            WindowLevel::AlwaysOnTop => WindowLevel::AlwaysOnBottom,
+        };
     }
 }
 


### PR DESCRIPTION
# Objective

- Update winit to 0.28

## Solution

- Small API change 
- A security advisory has been added for a unmaintained crate used by a dependency of winit build script for wayland

I didn't do anything for Android support in this PR though it should be fixable, it should be done in a separate one, maybe https://github.com/bevyengine/bevy/pull/6830 

---

## Changelog

- `window.always_on_top` has been removed, you can now use `window.window_level`

## Migration Guide

before:
```rust
    app.new()
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                always_on_top: true,
                ..default()
            }),
            ..default()
        }));
```

after:
```rust
    app.new()
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                window_level: bevy::window::WindowLevel::AlwaysOnTop,
                ..default()
            }),
            ..default()
        }));
```