### PR TITLE
[Merged by Bors] - add OpenGL and DX11 backends

### DIFF
--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -48,7 +48,7 @@ impl Default for WgpuSettings {
         let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
         } else {
-            Backends::PRIMARY
+            Backends::all()
         };
 
         let backends = Some(wgpu::util::backend_bits_from_env().unwrap_or(default_backends));


### PR DESCRIPTION
# Objective

Avoid  ‘Unable to find a GPU! Make sure you have installed required drivers!’ .
Because many devices only support OpenGL without Vulkan.

Fixes #3191

## Solution

Use all backends supported by wgpu.
