### PR TITLE
Remove hardcoded wgpu-hal

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -51,7 +51,6 @@ image = { version = "0.24", default-features = false }
 
 # misc
 wgpu = { version = "0.15.0", features = ["spirv"] }
-wgpu-hal = "0.15.1"
 codespan-reporting = "0.11.0"
 naga = { version = "0.11.0", features = ["glsl-in", "spv-in", "spv-out", "wgsl-in", "wgsl-out"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
I can't find when this was introduced, but it seems unnecessary, and prevents using custom builds of wgpu.