### PR TITLE
ecs::schedule::StateError now Clone, PartialEq, Eq; added to prelude.

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
         query::{Added, AnyOf, ChangeTrackers, Changed, Or, QueryState, With, Without},
         schedule::{
             IntoSystemDescriptor, RunCriteria, RunCriteriaDescriptorCoercion, RunCriteriaLabel,
-            Schedule, Stage, StageLabel, State, SystemLabel, SystemSet, SystemStage,
+            Schedule, Stage, StageLabel, State, StateError, SystemLabel, SystemSet, SystemStage,
         },
         system::{
             adapter as system_adapter,

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -357,7 +357,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum StateError {
     AlreadyInState,
     StateAlreadyQueued,


### PR DESCRIPTION
# Objective

Address the trivial changes I listed in [my discussion on `ecs::schedule::StateError`](https://github.com/bevyengine/bevy/discussions/7484)

## Solution

1. `ecs::schedule::StateError` is added to the `prelude`
2. `ecs::schedule::StateError` is now `Clone, PartialEq, Eq`
   - The `enum` is a `pub` error-kind, value-less `enum` and its very *Rai­son d'être* is for callers to use it to determine the kind of an `Err` variant of returned `Result`s. This is always doable with `match` and `matches!` but providing `PartialEq` and `Eq` makes it much more ergonomic – particularly for less experienced *Rustaceans*.
   - Providing `Clone` allows other error-handling and logging code to encapsulate these error-kind values without resorting to prestidigitation.
