### PR TITLE
[Merged by Bors] - Remove `ExclusiveSystemParam::apply`

### DIFF
--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -132,7 +132,11 @@ where
     }
 
     #[inline]
-    fn apply_buffers(&mut self, _world: &mut World) {}
+    fn apply_buffers(&mut self, _world: &mut World) {
+        // "pure" exclusive systems do not have any buffers to apply.
+        // Systems made by piping a normal system with an exclusive system
+        // might have buffers to apply, but this is handled by `PipeSystem`.
+    }
 
     #[inline]
     fn initialize(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -132,10 +132,7 @@ where
     }
 
     #[inline]
-    fn apply_buffers(&mut self, world: &mut World) {
-        let param_state = self.param_state.as_mut().expect(PARAM_MESSAGE);
-        Param::apply(param_state, world);
-    }
+    fn apply_buffers(&mut self, _world: &mut World) {}
 
     #[inline]
     fn initialize(&mut self, world: &mut World) {

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -12,8 +12,6 @@ pub trait ExclusiveSystemParam: Sized {
     type Item<'s>: ExclusiveSystemParam<State = Self::State>;
 
     fn init(world: &mut World, system_meta: &mut SystemMeta) -> Self::State;
-    #[inline]
-    fn apply(_state: &mut Self::State, _world: &mut World) {}
 
     fn get_param<'s>(state: &'s mut Self::State, system_meta: &SystemMeta) -> Self::Item<'s>;
 }
@@ -72,12 +70,6 @@ macro_rules! impl_exclusive_system_param_tuple {
             #[inline]
             fn init(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {
                 (($($param::init(_world, _system_meta),)*))
-            }
-
-            #[inline]
-            fn apply(state: &mut Self::State, _world: &mut World) {
-                let ($($param,)*) = state;
-                $($param::apply($param, _world);)*
             }
 
             #[inline]


### PR DESCRIPTION
# Objective

The trait method `SystemParam::apply` allows a `SystemParam` type to defer world mutations, which is internally used to apply `Commands` at the end of the stage. Any operations that require `&mut World` access must be deferred in this way, since parallel systems do not have exclusive access to the world.

The `ExclusiveSystemParam` trait (added in #6083) has an `apply` method which serves the same purpose. However, deferring mutations in this way does not make sense for exclusive systems since they already have `&mut World` access: there is no need to wait until a hard sync point, as the system *is* a hard sync point. World mutations can and should be performed within the body of the system.

## Solution

Remove the method. There were no implementations of this method in the engine.

---

## Changelog

*Note for maintainers: this changelog makes more sense if it's placed above the one for #6919.*

- Removed the method `ExclusiveSystemParamState::apply`.

## Migration Guide

*Note for maintainers: this migration guide makes more sense if it's placed above the one for #6919.*

The trait method `ExclusiveSystemParamState::apply` has been removed. If you have an exclusive system with buffers that must be applied, you should apply them within the body of the exclusive system.