### PR TITLE
[Merged by Bors] - Add unit test with system that panics

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1212,4 +1212,11 @@ mod tests {
         let query = unsafe { Query::new(&world2, &qstate, 0, 0, false) };
         query.iter();
     }
+
+    #[test]
+    #[should_panic]
+    fn panic_inside_system() {
+        let mut world = World::new();
+        run_system(&mut world, || panic!("this system panics"));
+    }
 }


### PR DESCRIPTION
# Objective

Fixes #7434.

This is my first time contributing to a Rust project, so please let me know if this wasn't the change intended by the linked issue.

## Solution

Adds a test with a system that panics to `bevy_ecs`.

I'm not sure if this is the intended panic message, but this is what the test currently results in:
```
thread 'system::tests::panic_inside_system' panicked at 'called `Option::unwrap()` on a `None` value', /Users/bjorn/workplace/bevy/crates/bevy_tasks/src/task_pool.rs:354:49
```