### PR TITLE
Stageless: avoid deadlock in `TaskPool::scope` by polling all tasks

### DIFF
--- a/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule_v3/executor/multi_threaded.rs
@@ -1,5 +1,3 @@
-use std::panic::AssertUnwindSafe;
-
 use bevy_tasks::{ComputeTaskPool, Scope, TaskPool, ThreadExecutor};
 use bevy_utils::default;
 use bevy_utils::syncunsafecell::SyncUnsafeCell;
@@ -177,10 +175,11 @@ impl SystemExecutor for MultiThreadedExecutor {
 
                         if self.num_running_systems > 0 {
                             // wait for systems to complete
-                            let index =
-                                self.receiver.recv().await.expect(
-                                    "A system has panicked so the executor cannot continue.",
-                                );
+                            let index = self
+                                .receiver
+                                .recv()
+                                .await
+                                .unwrap_or_else(|error| unreachable!("{}", error));
 
                             self.finish_system_and_signal_dependents(index);
 
@@ -430,22 +429,14 @@ impl MultiThreadedExecutor {
         let task = async move {
             #[cfg(feature = "trace")]
             let system_guard = system_span.enter();
-            let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                // SAFETY: access is compatible
-                unsafe { system.run_unsafe((), world) };
-            }));
+            // SAFETY: access is compatible
+            unsafe { system.run_unsafe((), world) };
             #[cfg(feature = "trace")]
             drop(system_guard);
-            if res.is_err() {
-                // close the channel to propagate the error to the
-                // multithreaded executor
-                sender.close();
-            } else {
-                sender
-                    .send(system_index)
-                    .await
-                    .unwrap_or_else(|error| unreachable!("{}", error));
-            }
+            sender
+                .send(system_index)
+                .await
+                .unwrap_or_else(|error| unreachable!("{}", error));
         };
 
         #[cfg(feature = "trace")]
@@ -488,21 +479,13 @@ impl MultiThreadedExecutor {
             let task = async move {
                 #[cfg(feature = "trace")]
                 let system_guard = system_span.enter();
-                let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    apply_system_buffers(&unapplied_systems, systems, world);
-                }));
+                apply_system_buffers(&unapplied_systems, systems, world);
                 #[cfg(feature = "trace")]
                 drop(system_guard);
-                if res.is_err() {
-                    // close the channel to propagate the error to the
-                    // multithreaded executor
-                    sender.close();
-                } else {
-                    sender
-                        .send(system_index)
-                        .await
-                        .unwrap_or_else(|error| unreachable!("{}", error));
-                }
+                sender
+                    .send(system_index)
+                    .await
+                    .unwrap_or_else(|error| unreachable!("{}", error));
             };
 
             #[cfg(feature = "trace")]
@@ -512,21 +495,13 @@ impl MultiThreadedExecutor {
             let task = async move {
                 #[cfg(feature = "trace")]
                 let system_guard = system_span.enter();
-                let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
-                    system.run((), world);
-                }));
+                system.run((), world);
                 #[cfg(feature = "trace")]
                 drop(system_guard);
-                if res.is_err() {
-                    // close the channel to propagate the error to the
-                    // multithreaded executor
-                    sender.close();
-                } else {
-                    sender
-                        .send(system_index)
-                        .await
-                        .unwrap_or_else(|error| unreachable!("{}", error));
-                }
+                sender
+                    .send(system_index)
+                    .await
+                    .unwrap_or_else(|error| unreachable!("{}", error));
             };
 
             #[cfg(feature = "trace")]

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -391,24 +391,23 @@ impl TaskPool {
                         let mut next = head;
                         while let Some(index) = next {
                             if let Some(result) = future::poll_once(&mut tasks[index]).await {
+                                // result is ready
                                 if result.is_some() {
-                                    // task completed, store its result
+                                    // task completed
                                     results[index] = result;
 
-                                    // remove it from the list
+                                    // remove it from the pending list
                                     let node = &mut nodes[index];
                                     let prev = node.prev.take();
                                     let next = node.next.take();
 
-                                    // connect prev.next -> next
                                     if let Some(p) = prev {
                                         nodes[p].next = next;
                                     } else {
-                                        // this was the head
+                                        // task was the head
                                         head = next;
                                     }
 
-                                    // connect prev <- next.prev
                                     if let Some(n) = next {
                                         nodes[n].prev = prev;
                                     }
@@ -416,6 +415,7 @@ impl TaskPool {
                                     must_cancel_on_failure[index] = false;
                                     completed_count += 1;
                                 } else {
+                                    // task failed
                                     failure = true;
                                     break;
                                 }

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -409,6 +409,11 @@ impl TaskPool {
                                         nodes[n].prev = prev;
                                     }
 
+                                    if head == Some(index) {
+                                        // this task was the head
+                                        head = next;
+                                    }
+
                                     must_cancel_on_failure[index] = false;
                                     completed_count += 1;
                                 } else {

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -438,6 +438,9 @@ impl TaskPool {
                             // TODO: prove that it's impossible for there to be tasks remaining
                             return results;
                         }
+
+                        // give the tasks a chance to make progress
+                        future::yield_now().await;
                     }
                 };
 

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -383,17 +383,21 @@ impl TaskPool {
                             }
                         }
 
-                        std::mem::swap(&mut pending_tasks, &mut pending_tasks_next);
-                        debug_assert!(pending_tasks_next.is_empty());
-
                         if task_failed {
                             // cancel the remaining pending tasks
-                            for index in pending_tasks.into_iter() {
+                            for index in pending_tasks
+                                .into_iter()
+                                .chain(pending_tasks_next.into_iter())
+                            {
                                 let task = tasks[index].take().unwrap();
                                 task.cancel().await;
                             }
 
                             panic!("scoped task failed");
+                        } else {
+                            debug_assert!(pending_tasks.is_empty());
+                            std::mem::swap(&mut pending_tasks, &mut pending_tasks_next);
+                            debug_assert!(pending_tasks_next.is_empty());
                         }
 
                         if pending_tasks.is_empty() && spawned_ref.is_empty() {


### PR DESCRIPTION
# Objective

Replace #7448 with the "fair polling" alternative it mentioned, so that we can continue to mirror `std::thread::scope` (i.e. keep "nested scope spawns").

> It might be possible to poll all the tasks in `get_results` in the scope. If we could do that, then the scope could panic if one of the tasks panics. It would require a data structure that we could both poll and push futures through a shared ref to it. I tried `FuturesUnordered`, but it requires an exclusive ref to poll it.

## Solution

- Revert those changes.
- Eagerly take spawned tasks from the queue and maintain a list of the pending ones.
- Poll pending tasks for completion.
- If any task fails, cancel all taken-but-unfinished tasks and then panic.