### PR TITLE
[Merged by Bors] - Only compute sprite color once per quad

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -640,11 +640,12 @@ pub fn queue_sprites(
 
                 // Store the vertex data and add the item to the render phase
                 if current_batch.colored {
+                    let vertex_color = extracted_sprite.color.as_linear_rgba_f32();
                     for i in QUAD_INDICES {
                         sprite_meta.colored_vertices.push(ColoredSpriteVertex {
                             position: positions[i],
                             uv: uvs[i].into(),
-                            color: extracted_sprite.color.as_linear_rgba_f32(),
+                            color: vertex_color,
                         });
                     }
                     let item_start = colored_index;


### PR DESCRIPTION
# Objective

This change substantially increased performance when drawing thousands of colored sprites.

## Solution

The same color is used for each vertex in the quad sprites are drawn too, but the color is converted to a linear color each time. This computation only needs to be done once.

The `as_linear_rgba_f32()` call was showing up in profiling the `basic` example in my [particle system library](https://github.com/abnormalbrain/bevy_particle_systems) as a hot path. This change added about 50 fps to the example, from about 150fps to about 200 fps, when rendering around 10k colored sprites. 

Tracy Results:
"This trace" is with the change.

Change in frame time:
![image](https://user-images.githubusercontent.com/102993888/216752612-5e0ad0ce-1c59-4b56-873e-8018287408bb.png)

Change in `queue_sprites`:
![image](https://user-images.githubusercontent.com/102993888/216752767-6f1a6a5c-6181-45d3-bf86-5823bd81dfc4.png)

