### PR TITLE
Basic concept

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -44,6 +44,7 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! {
         impl #impl_generics #bevy_ecs_path::component::Component for #struct_name #type_generics #where_clause {
             type Storage = #storage;
+            type Refs = #bevy_ecs_path::change_detection::ChangeDetectionRefs<Self>;
         }
     })
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,11 +1,14 @@
 //! Types that detect when their internal data mutate.
 
+use crate::component::ComponentRefs;
+use crate::prelude::Component;
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
     system::Resource,
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
+use std::marker::PhantomData;
 use std::ops::{Deref, DerefMut};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -579,6 +582,17 @@ change_detection_impl!(Mut<'a, T>, T,);
 change_detection_mut_impl!(Mut<'a, T>, T,);
 impl_methods!(Mut<'a, T>, T,);
 impl_debug!(Mut<'a, T>,);
+
+pub struct ChangeDetectionRefs<T: ?Sized> {
+    phantom: PhantomData<T>,
+}
+impl<T> ComponentRefs<T> for ChangeDetectionRefs<T>
+where
+    T: Sized + Component,
+{
+    type Ref<'w> = &'w T; //Ref<'w, T>;
+    type MutRef<'w> = Mut<'w, T>;
+}
 
 /// Unique mutable borrow of resources or an entity's component.
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,5 +1,8 @@
 //! Types for declaring and storing [`Component`]s.
 
+use crate::entity::Entity;
+use crate::query::{ReadFetch, WriteFetch};
+use crate::storage::TableRow;
 use crate::{
     change_detection::MAX_CHANGE_AGE,
     storage::{SparseSetIndex, Storages},
@@ -142,8 +145,21 @@ use std::{
 ///
 /// [`SyncCell`]: bevy_utils::synccell::SyncCell
 /// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
-pub trait Component: Send + Sync + 'static {
+pub trait Component: Send + Sync + Sized + 'static {
     type Storage: ComponentStorage;
+    type Refs: ComponentRefs<Self>;
+}
+
+pub trait ComponentRefs<T> {
+    type Ref<'w>: ComponentRef<'w, T>;
+    type MutRef<'w>: ComponentRefMut<'w, T>;
+}
+
+pub trait ComponentRef<'w, T> {
+    unsafe fn new(fetch: &ReadFetch<'w, T>, entity: Entity, table_row: TableRow) -> Self;
+}
+pub trait ComponentRefMut<'w, T> {
+    unsafe fn new(fetch: &WriteFetch<'w, T>, entity: Entity, table_row: TableRow) -> Self;
 }
 
 pub struct TableStorage;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,7 +29,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,
-        change_detection::{DetectChanges, DetectChangesMut, Mut, Ref},
+        change_detection::{DetectChanges, DetectChangesMut, Mut, Ref, ChangeDetectionRefs},
         component::Component,
         entity::Entity,
         event::{EventReader, EventWriter, Events},


### PR DESCRIPTION
Looking for general feedback on this idea, and help solving a lifetime error: 
```
error: lifetime may not live long enough
   --> crates/bevy_ecs/src/query/fetch.rs:535:9
    |
534 |     fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
    |               ------           ------- lifetime `'wshort` defined here
    |               |
    |               lifetime `'wlong` defined here
535 |         item
    |         ^^^^ associated function was supposed to return data with lifetime `'wlong` but it is returning data with lifetime `'wshort`
    |
    = help: consider adding the following bound: `'wshort: 'wlong`
```

# Objective

Allow users to specify which reference types they want their components to be wrapped in when used in a `Query`. This would allow:
1. Disabling change detection, by specifying `&T` and `&mut T` instead of `&T` (or `Ref<T>`) and `Mut<T>`.
2. Enabling https://github.com/chrisjuchem/bevy_mod_index to update when components are changes by providing new `Indexed` reference types.

## Solution

- Add an associated type to components through which the desired reference types can be accessed and used when creating `WorldQuery::Item`s
- (todo) Allow setting this type with a new attribute in the component derive macro
---

## Changelog
TODO


## Migration Guide
TODO
