### PR TITLE
[Merged by Bors] - add an action to ask for a migration guide when one is missing

### DIFF
--- a/.github/workflows/action-on-PR-labeled.yml
+++ b/.github/workflows/action-on-PR-labeled.yml
@@ -1,0 +1,30 @@
+name: Action on PR labeled
+
+# This workflow has write permissions on the repo
+# It must not checkout a PR and run untrusted code
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+permissions:
+  pull-requests: 'write'
+
+jobs:
+  comment-on-breaking-change-label:
+    runs-on: ubuntu-latest
+    if: github.event.label.name == 'C-Breaking-Change' && !contains(github.event.pull_request.body, '## Migration Guide')
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `It looks like your PR is a breaking change, but you didn't provide a migration guide.
+
+              Could you add some context on what users should update when this change get released in a new version of Bevy?
+              It will be used to help writing the migration guide for the version. Putting it after a \`## Migration Guide\` will help it get automatically picked up by our tooling.`
+            })


### PR DESCRIPTION
# Objective

- Help ensure migration guide are present for breaking changes

## Solution

- Add an action that adds a comment when it's missing


<img width="918" alt="Screenshot 2023-02-05 at 03 06 13" src="https://user-images.githubusercontent.com/8672791/216797861-3cbde59a-6e21-464a-9b83-a28a2474d111.png">

