### PR TITLE
[Merged by Bors] - Don't ignore UI scale for text

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -65,10 +65,12 @@ pub fn text_system(
     )>,
 ) {
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
-    let scale_factor = windows
+    let window_scale_factor = windows
         .get_single()
         .map(|window| window.resolution.scale_factor())
-        .unwrap_or(ui_scale.scale);
+        .unwrap_or(1.);
+
+    let scale_factor = ui_scale.scale * window_scale_factor;
 
     let inv_scale_factor = 1. / scale_factor;
 


### PR DESCRIPTION
# Objective

Fixes #7476. UI scale was being incorrectly ignored when a primary window exists.

## Solution

Always take into account UI scale, regardless of whether a primary window exists.

Tested locally on @forbjok 's minimal repro project https://github.com/forbjok/bevy_ui_repro with this patch, and the issue is fixed on my machine.
