### PR TITLE
[Merged by Bors] - fix typo in bevy_reflect::impls::std GetTypeRegistration for vec like…

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -317,8 +317,8 @@ macro_rules! impl_reflect_for_veclike {
 
         impl<T: FromReflect> GetTypeRegistration for $ty {
             fn get_type_registration() -> TypeRegistration {
-                let mut registration = TypeRegistration::of::<Vec<T>>();
-                registration.insert::<ReflectFromPtr>(FromType::<Vec<T>>::from_type());
+                let mut registration = TypeRegistration::of::<$ty>();
+                registration.insert::<ReflectFromPtr>(FromType::<$ty>::from_type());
                 registration
             }
         }


### PR DESCRIPTION
Implementing GetTypeRegistration in macro impl_reflect_for_veclike! had typos!
It only implement GetTypeRegistration for Vec<T>, but not for VecDeque<T>.
This will cause serialization and deserialization failure.