### PR TITLE
[Merged by Bors] - early return from multithreaded executor

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -145,6 +145,9 @@ impl SystemExecutor for MultiThreadedExecutor {
     fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         // reset counts
         let num_systems = schedule.systems.len();
+        if num_systems == 0 {
+            return;
+        }
         self.num_running_systems = 0;
         self.num_completed_systems = 0;
         self.num_dependencies_remaining.clear();


### PR DESCRIPTION
# Objective

- There is a small perf cost for starting the multithreaded executor.

## Solution

- We can skip that cost when there are zero systems in the schedule. Overall not a big perf boost unless there are a lot of empty schedules that are trying to run, but it is something.

Below is a tracy trace of the run_fixed_update_schedule for many_foxes which has zero systems in it. Yellow is main and red is this pr. The time difference between the peaks of the humps is around 15us.

![image](https://user-images.githubusercontent.com/2180432/216884536-f3af8f5e-6224-4d0f-8fbd-67b0beb90baf.png)
