### PR TITLE
[Merged by Bors] - use better set inheritance in render systems

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -254,6 +254,9 @@ impl Plugin for PbrPlugin {
 
         // Extract the required data from the main world
         render_app
+            .configure_set(RenderLightSystems::PrepareLights.in_set(RenderSet::Prepare))
+            .configure_set(RenderLightSystems::PrepareClusters.in_set(RenderSet::Prepare))
+            .configure_set(RenderLightSystems::QueueShadows.in_set(RenderSet::Queue))
             .add_systems_to_schedule(
                 ExtractSchedule,
                 (
@@ -264,8 +267,7 @@ impl Plugin for PbrPlugin {
             .add_system(
                 render::prepare_lights
                     .before(ViewSet::PrepareUniforms)
-                    .in_set(RenderLightSystems::PrepareLights)
-                    .in_set(RenderSet::Prepare),
+                    .in_set(RenderLightSystems::PrepareLights),
             )
             // A sync is needed after prepare_lights, before prepare_view_uniforms,
             // because prepare_lights creates new views for shadow mapping
@@ -277,14 +279,9 @@ impl Plugin for PbrPlugin {
             .add_system(
                 render::prepare_clusters
                     .after(render::prepare_lights)
-                    .in_set(RenderLightSystems::PrepareClusters)
-                    .in_set(RenderSet::Prepare),
+                    .in_set(RenderLightSystems::PrepareClusters),
             )
-            .add_system(
-                render::queue_shadows
-                    .in_set(RenderLightSystems::QueueShadows)
-                    .in_set(RenderSet::Queue),
-            )
+            .add_system(render::queue_shadows.in_set(RenderLightSystems::QueueShadows))
             .add_system(render::queue_shadow_view_bind_group.in_set(RenderSet::Queue))
             .add_system(sort_phase_system::<Shadow>.in_set(RenderSet::PhaseSort))
             .init_resource::<ShadowPipeline>()

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -196,11 +196,7 @@ where
                 .init_resource::<RenderMaterials<M>>()
                 .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
                 .add_system_to_schedule(ExtractSchedule, extract_materials::<M>)
-                .add_system(
-                    prepare_materials::<M>
-                        .after(PrepareAssetLabel::PreAssetPrepare)
-                        .in_set(RenderSet::Prepare),
-                )
+                .add_system(prepare_materials::<M>.after(PrepareAssetLabel::PreAssetPrepare))
                 .add_system(queue_material_meshes::<M>.in_set(RenderSet::Queue));
         }
 

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -45,11 +45,8 @@ impl Plugin for ViewPlugin {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<ViewUniforms>()
-                .add_system(
-                    prepare_view_uniforms
-                        .in_set(RenderSet::Prepare)
-                        .in_set(ViewSet::PrepareUniforms),
-                )
+                .configure_set(ViewSet::PrepareUniforms.in_set(RenderSet::Prepare))
+                .add_system(prepare_view_uniforms.in_set(ViewSet::PrepareUniforms))
                 .add_system(
                     prepare_view_targets
                         .after(WindowSystem::Prepare)

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -33,11 +33,8 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<WindowSurfaces>()
                 .init_non_send_resource::<NonSendMarker>()
                 .add_system_to_schedule(ExtractSchedule, extract_windows)
-                .add_system(
-                    prepare_windows
-                        .in_set(WindowSystem::Prepare)
-                        .in_set(RenderSet::Prepare),
-                );
+                .configure_set(WindowSystem::Prepare.in_set(RenderSet::Prepare))
+                .add_system(prepare_windows.in_set(WindowSystem::Prepare));
         }
     }
 }


### PR DESCRIPTION
# Objective
Some render systems that have system set used as a label so that they can be referenced from somewhere else.
The 1:1 translation from `add_system_to_stage(Prepare, prepare_lights.label(PrepareLights))` is `add_system(prepare_lights.in_set(Prepare).in_set(PrepareLights)`, but configuring the `PrepareLights` set to be in `Prepare` would match the intention better (there are no systems in `PrepareLights` outside of `Prepare`) and it is easier for visualization tools to deal with.

# Solution

- replace
```rust
prepare_lights in PrepareLights
prepare_lights in Prepare
```
with
```rs
prepare_lights in PrepareLights
PrepareLights in Prepare
```

**Before**
![before](https://user-images.githubusercontent.com/22177966/216961792-a0f5eba7-f161-4994-b5a4-33e98763a3b0.svg)

**After**
![after](https://user-images.githubusercontent.com/22177966/216961790-857d0062-7943-49ef-8927-e602dfbab714.svg)
