### PR TITLE
[Merged by Bors] - Fix panics in ecs_guide example

### DIFF
--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -26,7 +26,6 @@
 
 use bevy::{
     app::{AppExit, ScheduleRunnerPlugin, ScheduleRunnerSettings},
-    log::LogPlugin,
     prelude::*,
     utils::Duration,
 };
@@ -308,11 +307,6 @@ fn main() {
                 .after(score_check_system)
                 .in_base_set(MySet::AfterRound),
         )
-        // We can check our systems for execution order ambiguities by examining the output produced
-        // in the console by using the `LogPlugin` and adding the following Resource to our App :)
-        // Be aware that not everything reported by this checker is a potential problem, you'll have
-        // to make that judgement yourself.
-        .add_plugin(LogPlugin::default())
         // This call to run() starts the app we just built!
         .run();
 }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -282,7 +282,7 @@ fn main() {
         // add_system(system) adds systems to the Update system set by default
         // However we can manually specify the set if we want to. The following is equivalent to
         // add_system(score_system)
-        .add_system(score_system)
+        .add_system(score_system.in_base_set(CoreSet::Update))
         // There are other `CoreSets`, such as `Last` which runs at the very end of each run.
         .add_system(print_at_end_round.in_base_set(CoreSet::Last))
         // We can also create new system sets, and order them relative to other system sets.

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -298,13 +298,15 @@ fn main() {
                 .after(new_round_system)
                 .in_base_set(MySet::BeforeRound),
         )
-        .add_system(exclusive_player_system.in_set(MySet::BeforeRound))
-        .add_system(score_check_system.in_set(MySet::AfterRound))
+        .add_system(exclusive_player_system.in_base_set(MySet::BeforeRound))
+        .add_system(score_check_system.in_base_set(MySet::AfterRound))
         .add_system(
             // We can ensure that `game_over_system` runs after `score_check_system` using explicit ordering
             // To do this we use either `.before` or `.after` to describe the order we want the relationship
             // Since we are using `after`, `game_over_system` runs after `score_check_system`
-            game_over_system.after(score_check_system),
+            game_over_system
+                .after(score_check_system)
+                .in_base_set(MySet::AfterRound),
         )
         // We can check our systems for execution order ambiguities by examining the output produced
         // in the console by using the `LogPlugin` and adding the following Resource to our App :)


### PR DESCRIPTION
# Objective

Fixes #7565

`ecs_guide` example is currently panicking. This seems to just be a problem with the example only caused by the base sets PR.

## Solution

First, changed a few `in_set` to `in_base_set` to fix a few of

```
thread 'main' panicked at 'Systems cannot be added to 'base' system sets using 'in_set'. Use 'in_base_set' instead.', examples/ecs/ecs_guide.rs:301:45
```

And then added an `in_base_set` to fix the resulting (confusing) cycle error

```
2023-02-06T13:54:29.213843Z ERROR bevy_ecs::schedule_v3::schedule: schedule contains at least 1 cycle(s) -- cycle(s) found within:
 ---- 0: ["ecs_guide::game_over_system", "ecs_guide::score_check_system"]
```

I also changed this `add_system` call so the comment above and below make sense:
```diff
         // add_system(system) adds systems to the Update system set by default
         // However we can manually specify the set if we want to. The following is equivalent to
         // add_system(score_system)
-        .add_system(score_system)
+        .add_system(score_system.in_base_set(CoreSet::Update))
         // There are other `CoreSets`, such as `Last` which runs at the very end of each run.
```

## Notes

- Does `MySet` even need to be a base set? Seems like yes.
- Is that cycle error when there is no explicit `in_base_set` actually expected?