### PR TITLE
[Merged by Bors] - put `update_frusta::<Projection>` in `UpdateProjectionFrusta` set

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -247,7 +247,7 @@ impl Plugin for VisibilityPlugin {
             )
             .add_system(
                 update_frusta::<Projection>
-                    .in_base_set(CoreSet::PostUpdate)
+                    .in_set(UpdateProjectionFrusta)
                     .after(camera_system::<Projection>)
                     .after(TransformSystem::TransformPropagate),
             )


### PR DESCRIPTION
# Objective

- less ambiguities

- `update_frusta<PerspectiveProjection>` is in `UpdatePerspectiveFrusta` and `update_frusta<OrthographicProjection>` is in `UpdateOrthographicFrusta`, but `UpdateProjectionFrusta` is empty and `update_frusta<Projection>` is directly in `PostUpdate`

## Solution

- put `update_frusta<Projection>` in `UpdatePerspectiveFrusta` set

**Before**
![image](https://user-images.githubusercontent.com/22177966/217019086-22709204-0e39-4ffc-a43b-0175f86e17ec.png)
**After**
![image](https://user-images.githubusercontent.com/22177966/217019117-a28329a1-6614-490c-873f-773efadf6f41.png)
