### PR TITLE
[Merged by Bors] - bevy_core_pipeline: Fix prepass sort orders

### DIFF
--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -26,6 +26,8 @@
 
 pub mod node;
 
+use std::cmp::Reverse;
+
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
@@ -75,15 +77,17 @@ pub struct Opaque3dPrepass {
 }
 
 impl PhaseItem for Opaque3dPrepass {
-    type SortKey = FloatOrd;
+    // NOTE: Values increase towards the camera. Front-to-back ordering for opaque means we need a descending sort.
+    type SortKey = Reverse<FloatOrd>;
 
+    #[inline]
     fn entity(&self) -> Entity {
         self.entity
     }
 
     #[inline]
     fn sort_key(&self) -> Self::SortKey {
-        FloatOrd(self.distance)
+        Reverse(FloatOrd(self.distance))
     }
 
     #[inline]
@@ -93,7 +97,8 @@ impl PhaseItem for Opaque3dPrepass {
 
     #[inline]
     fn sort(items: &mut [Self]) {
-        radsort::sort_by_key(items, |item| item.distance);
+        // Key negated to match reversed SortKey ordering
+        radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 
@@ -117,15 +122,17 @@ pub struct AlphaMask3dPrepass {
 }
 
 impl PhaseItem for AlphaMask3dPrepass {
-    type SortKey = FloatOrd;
+    // NOTE: Values increase towards the camera. Front-to-back ordering for alpha mask means we need a descending sort.
+    type SortKey = Reverse<FloatOrd>;
 
+    #[inline]
     fn entity(&self) -> Entity {
         self.entity
     }
 
     #[inline]
     fn sort_key(&self) -> Self::SortKey {
-        FloatOrd(self.distance)
+        Reverse(FloatOrd(self.distance))
     }
 
     #[inline]
@@ -135,7 +142,8 @@ impl PhaseItem for AlphaMask3dPrepass {
 
     #[inline]
     fn sort(items: &mut [Self]) {
-        radsort::sort_by_key(items, |item| item.distance);
+        // Key negated to match reversed SortKey ordering
+        radsort::sort_by_key(items, |item| -item.distance);
     }
 }
 


### PR DESCRIPTION
# Objective

- Prepass opaque and alpha mask are incorrectly sorted back to front. This slipped through review by accident.

## Solution

- Sort prepass opaque and alpha mask front to back