### PR TITLE
Add Resource information to AmbientLight Docs

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -567,8 +567,8 @@ fn calculate_cascade(
     }
 }
 
-/// Use this resource to make an ambient light, which lights the entire scene equally.
-/// Inserted by default by [`PbrPlugin`]
+/// Use this resource to make an ambient light, which lights the entire world equally.
+/// Inserted by default by [`PbrPlugin`](bevy_pbr::PbrPlugin)
 #[derive(Resource, Clone, Debug, ExtractResource, Reflect)]
 #[reflect(Resource)]
 pub struct AmbientLight {

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -567,12 +567,14 @@ fn calculate_cascade(
     }
 }
 
-/// An ambient light, which lights the entire scene equally.
+/// Use this resource to make an ambient light, which lights the entire scene equally.
+/// Inserted by default by [`PbrPlugin`]
 #[derive(Resource, Clone, Debug, ExtractResource, Reflect)]
 #[reflect(Resource)]
 pub struct AmbientLight {
+    /// Default is white
     pub color: Color,
-    /// A direct scale factor multiplied with `color` before being passed to the shader.
+    /// A direct scale factor multiplied with `color` before being passed to the shader. Default is 0.05
     pub brightness: f32,
 }
 


### PR DESCRIPTION
# Obejctives

Fixes #7465.

## Solution

The documentation now tells the reader that AmbientLight is a Resource that has a default color of white and a default brightness of 0.05