### PR TITLE
Improve mesh uniform inverse transpose precision

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -162,8 +162,9 @@ pub fn extract_meshes(
         let uniform = MeshUniform {
             flags: flags.bits,
             transform,
-            // The following conversion to and from a 64-bit matrix improves the accuracy of the
-            // resulting 32bit Mat4, as it reduces precision lost in the inverse transpose.
+            // The following conversion to and from a 64-bit matrix reduces the amount of precision
+            // lost in the inverse transpose. Reducing precision loss here is useful because any
+            // loss here is passed into shaders and will continue to accumulate.
             inverse_transpose_model: transform.as_dmat4().inverse().transpose().as_mat4(),
         };
         if not_caster.is_some() {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -162,7 +162,9 @@ pub fn extract_meshes(
         let uniform = MeshUniform {
             flags: flags.bits,
             transform,
-            inverse_transpose_model: transform.inverse().transpose(),
+            // The following conversion to and from a 64-bit matrix improves the accuracy of the
+            // resulting 32bit Mat4, as it reduces precision lost in the inverse transpose.
+            inverse_transpose_model: transform.as_dmat4().inverse().transpose().as_mat4(),
         };
         if not_caster.is_some() {
             not_caster_commands.push((entity, (handle.clone_weak(), uniform, NotShadowCaster)));


### PR DESCRIPTION
# Objective

- The inverse transpose calculation is very lossy, which can result in lighting artifacts as scales become large.

## Solution

- By doing the inverse transpose of the mesh's matrix as a DMat4 and converting back to a Mat4, the result is more accurate and more robust at larger scales, without any increase to memory usage or doing any other calculations with 64-bit matrices. This added 64-bit inverse transform only needs to be done a single time per mesh. Because less truncation has occurred, all subsequent computations in the shader are more precise, for free.