### PR TITLE
[Merged by Bors] - Simplify a doc example for `EventWriter`

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -278,8 +278,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
 ///     // NOTE: the event won't actually be sent until commands get flushed
 ///     // at the end of the current stage.
 ///     commands.add(|w: &mut World| {
-///         let mut events_resource = w.resource_mut::<Events<_>>();
-///         events_resource.send(MyEvent);
+///         w.send_event(MyEvent);
 ///     });
 /// }
 /// ```


### PR DESCRIPTION
# Objective

Use the `World::send_event` method added in #5355 to simplify a doc example for `EventWriter`.
