### PR TITLE
[Merged by Bors] - Remove unused test resource in a bevy_ecs schedule unit test

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -175,13 +175,11 @@ mod tests {
 
         #[test]
         fn add_systems_correct_order() {
-            #[derive(Resource)]
-            struct X(Vec<TestSet>);
-
             let mut world = World::new();
+            let mut schedule = Schedule::new();
+
             world.init_resource::<SystemOrder>();
 
-            let mut schedule = Schedule::new();
             schedule.add_systems(
                 (
                     make_function_system(0),


### PR DESCRIPTION
Small commit to remove an unused resource scoped within a single bevy_ecs unit test. Also rearranged the initialization to follow initialization conventions of surrounding tests. World/Schedule initialization followed by resource initialization.

This change was tested locally with `cargo test`, and `cargo fmt` was run.

Risk should be tiny as change is scoped to a single unit test and very tiny, and I can't see any way that this resource is being used in the test.

Thank you so much!