### PR TITLE
[Merged by Bors] - Mention uniqueness check in plugin name method docs

### DIFF
--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -24,7 +24,8 @@ pub trait Plugin: Downcast + Any + Send + Sync {
         // do nothing
     }
 
-    /// Configures a name for the [`Plugin`] which is primarily used for debugging.
+    /// Configures a name for the [`Plugin`] which is primarily used for checking plugin
+    /// uniqueness and debugging.
     fn name(&self) -> &str {
         std::any::type_name::<Self>()
     }


### PR DESCRIPTION
# Objective

One of the most important usages of plugin names is currently not mentioned in its documentation: the uniqueness check

## Solution

- Mention that the plugin name is used to check for uniqueness
