### PR TITLE
Remove `impl ScheduleLabel for Box<dyn ScheduleLabel>`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -987,7 +987,7 @@ impl App {
         let mut schedules = self.world.resource_mut::<Schedules>();
 
         if schedules.get(&label).is_none() {
-            schedules.insert(label.dyn_clone(), Schedule::new());
+            schedules.insert_boxed(label.dyn_clone(), Schedule::new());
         }
 
         let schedule = schedules.get_mut(&label).unwrap();

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -47,13 +47,17 @@ impl Schedules {
     }
 
     /// Inserts a labeled schedule into the map.
-    /// 
+    ///
     /// Unlike `insert`, this method take a [`BoxedScheduleLabel`]. This is useful when you
     /// do not have a concrete schedule label and only a boxed version of it.
     ///
     /// If the map already had an entry for `label`, `schedule` is inserted,
     /// and the old schedule is returned. Otherwise, `None` is returned.
-    pub fn insert_boxed(&mut self, label: BoxedScheduleLabel, schedule: Schedule) -> Option<Schedule> {
+    pub fn insert_boxed(
+        &mut self,
+        label: BoxedScheduleLabel,
+        schedule: Schedule,
+    ) -> Option<Schedule> {
         if self.inner.contains_key(&label) {
             warn!("schedule with label {:?} already exists", label);
         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -43,6 +43,10 @@ impl Schedules {
     /// and the old schedule is returned. Otherwise, `None` is returned.
     pub fn insert(&mut self, label: impl ScheduleLabel, schedule: Schedule) -> Option<Schedule> {
         let label = label.dyn_clone();
+        self.insert_boxed(label, schedule)
+    }
+
+    pub fn insert_boxed(&mut self, label: BoxedScheduleLabel, schedule: Schedule) -> Option<Schedule> {
         if self.inner.contains_key(&label) {
             warn!("schedule with label {:?} already exists", label);
         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -46,6 +46,13 @@ impl Schedules {
         self.insert_boxed(label, schedule)
     }
 
+    /// Inserts a labeled schedule into the map.
+    /// 
+    /// Unlike `insert`, this method take a [`BoxedScheduleLabel`]. This is useful when you
+    /// do not have a concrete schedule label and only a boxed version of it.
+    ///
+    /// If the map already had an entry for `label`, `schedule` is inserted,
+    /// and the old schedule is returned. Otherwise, `None` is returned.
     pub fn insert_boxed(&mut self, label: BoxedScheduleLabel, schedule: Schedule) -> Option<Schedule> {
         if self.inner.contains_key(&label) {
             warn!("schedule with label {:?} already exists", label);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -48,7 +48,7 @@ impl Schedules {
 
     /// Inserts a labeled schedule into the map.
     ///
-    /// Unlike `insert`, this method take a [`BoxedScheduleLabel`]. This is useful when you
+    /// Unlike `insert`, this method takes a [`BoxedScheduleLabel`]. This is useful when you
     /// do not have a concrete schedule label and only a boxed version of it.
     ///
     /// If the map already had an entry for `label`, `schedule` is inserted,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1747,7 +1747,7 @@ impl World {
         let _span = bevy_utils::tracing::info_span!("schedule", name = ?extracted_label).entered();
         schedule.run(self);
         self.resource_mut::<Schedules>()
-            .insert(extracted_label, schedule);
+            .insert_boxed(extracted_label, schedule);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1726,7 +1726,8 @@ impl World {
 
     /// Runs the [`Schedule`] associated with the `label` a single time.
     ///
-    /// Unlike the `run_schedule` method, this method takes the label by reference, which can save a clone.
+    /// Unlike the `run_schedule` method, this method takes the label by reference. This is useful
+    /// when you have the schedule label behind a pointer, such as a `Box`.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.

--- a/crates/bevy_utils/src/label.rs
+++ b/crates/bevy_utils/src/label.rs
@@ -98,14 +98,6 @@ macro_rules! define_boxed_label {
                 self.dyn_clone()
             }
         }
-
-        impl $label_trait_name for Box<dyn $label_trait_name> {
-            fn dyn_clone(&self) -> Box<dyn $label_trait_name> {
-                // Be explicit that we want to use the inner value
-                // to avoid infinite recursion.
-                (**self).dyn_clone()
-            }
-        }
     };
 }
 


### PR DESCRIPTION
# Objective

Within stageless, schedule labels are stored in a HashMap as `Box<dyn ScheduleLabel>` in the `Schedules` resource. In order to support inserting both concrete labels and boxed labels, the `insert` method of `Schedules` takes an `impl ScheduleLabel`, and a global impl of `impl ScheduleLabel for Box<dyn ScheduleLabel>` was added.

However, this introduced a footgun where a user with a boxed label could accidently forget to dereference their label while working with it. Since the label always implements `ScheduleLabel` no matter how many pointers it is behind, this is not caught by the compiler and can lead to confusing errors at runtime.

* For example, a method takes a `&dyn ScheduleLabel` as argument. If the user has a `my_schedule_label: Box<dyn ScheduleLabel>`, they should pass it by `&*my_schedule_label`. It is however easy to forget to dereference and pass in `&my_schedule_label` instead. This compiles without warnings but means something entirely different.

## Solution

Remove `impl ScheduleLabel for Box<dyn ScheduleLabel>`. In order to continue to support inserting boxed labels, a `insert_boxed` method is added to `Schedules`. Two places in the code now uses `insert_boxed` where they were using `insert` before.

## Changelog

(Only relevant to bevy main users)

* Remove `impl ScheduleLabel for Box<dyn ScheduleLabel>`
* Add `insert_boxed` to `Schedules`
* `Schedules::insert` no longer accepts a boxed schedule label. Use `insert_boxed` instead.

