### PR TITLE
[Merged by Bors] - Add condition negation

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -24,8 +24,11 @@ mod sealed {
 }
 
 pub mod common_conditions {
-    use crate::schedule::{State, States};
-    use crate::system::{Res, Resource};
+    use super::Condition;
+    use crate::{
+        schedule::{State, States},
+        system::{In, IntoPipeSystem, ReadOnlySystem, Res, Resource},
+    };
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`
     /// if the first time the condition is run and false every time after
@@ -104,5 +107,38 @@ pub mod common_conditions {
             Some(current_state) => current_state.0 == state,
             None => false,
         }
+    }
+
+    /// Generates a  [`Condition`](super::Condition) that inverses the result of passed one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_ecs::prelude::*;
+    /// // Building a new schedule/app...
+    /// let mut sched = Schedule::default();
+    /// sched.add_system(
+    ///         // This system will always run.
+    ///         my_system.run_if(not(always_false))
+    ///     )
+    ///     // ...
+    /// #   ;
+    /// # let mut world = World::new();
+    /// # sched.run(&mut world);
+    ///
+    /// // A condition that always returns false.
+    /// fn always_false() -> bool {
+    ///    false
+    /// }
+    ///
+    /// # fn my_system() {}
+    /// ```
+    pub fn not<Params, C: Condition<Params>>(
+        condition: C,
+    ) -> impl ReadOnlySystem<In = (), Out = bool>
+    where
+        C::System: ReadOnlySystem,
+    {
+        condition.pipe(|In(val): In<bool>| !val)
     }
 }

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -118,20 +118,20 @@ pub mod common_conditions {
     /// // Building a new schedule/app...
     /// let mut sched = Schedule::default();
     /// sched.add_system(
-    ///         // This system will always run.
-    ///         my_system.run_if(not(always_false))
+    ///         // This system will never run.
+    ///         my_system.run_if(not(always_true))
     ///     )
     ///     // ...
     /// #   ;
     /// # let mut world = World::new();
     /// # sched.run(&mut world);
     ///
-    /// // A condition that always returns false.
-    /// fn always_false() -> bool {
-    ///    false
+    /// // A condition that always returns true.
+    /// fn always_true() -> bool {
+    ///    true
     /// }
-    ///
-    /// # fn my_system() {}
+    /// #
+    /// # fn my_system() { unreachable!() }
     /// ```
     pub fn not<Params, C: Condition<Params>>(
         condition: C,


### PR DESCRIPTION
# Objective

Closes #7202

## Solution

~~Introduce a `not` helper to pipe conditions. Opened mostly for discussion. Maybe create an extension trait with `not` method? Please, advice.~~
Introduce `not(condition)` condition that inverses the result of the passed.

---

## Changelog

### Added

- `not` condition.

