### PR TITLE
[Merged by Bors] - Rename `Tick::is_older_than` to `Tick::is_newer_than`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -138,14 +138,14 @@ macro_rules! change_detection_impl {
             fn is_added(&self) -> bool {
                 self.ticks
                     .added
-                    .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
+                    .is_newer_than(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
             fn is_changed(&self) -> bool {
                 self.ticks
                     .changed
-                    .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
+                    .is_newer_than(self.ticks.last_change_tick, self.ticks.change_tick)
             }
 
             #[inline]
@@ -653,14 +653,14 @@ impl<'a> DetectChanges for MutUntyped<'a> {
     fn is_added(&self) -> bool {
         self.ticks
             .added
-            .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
+            .is_newer_than(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]
     fn is_changed(&self) -> bool {
         self.ticks
             .changed
-            .is_older_than(self.ticks.last_change_tick, self.ticks.change_tick)
+            .is_newer_than(self.ticks.last_change_tick, self.ticks.change_tick)
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -596,8 +596,10 @@ impl Tick {
     }
 
     #[inline]
-    /// Returns `true` if the tick is older than the system last's run.
-    pub fn is_older_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
+    /// Returns `true` if the tick occurred since the system's last_change_tick.
+    ///
+    /// Uses the system's current change_tick as a reference to help deal with wraparound.
+    pub fn is_newer_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values
         // so they never get older than `u32::MAX` (the difference would overflow).
@@ -670,13 +672,13 @@ impl ComponentTicks {
     #[inline]
     /// Returns `true` if the component was added after the system last ran.
     pub fn is_added(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.added.is_older_than(last_change_tick, change_tick)
+        self.added.is_newer_than(last_change_tick, change_tick)
     }
 
     #[inline]
     /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
     pub fn is_changed(&self, last_change_tick: u32, change_tick: u32) -> bool {
-        self.changed.is_older_than(last_change_tick, change_tick)
+        self.changed.is_newer_than(last_change_tick, change_tick)
     }
 
     pub(crate) fn new(change_tick: u32) -> Self {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -596,9 +596,9 @@ impl Tick {
     }
 
     #[inline]
-    /// Returns `true` if the tick occurred since the system's last_change_tick.
+    /// Returns `true` if the tick occurred since the system's `last_change_tick`.
     ///
-    /// Uses the system's current change_tick as a reference to help deal with wraparound.
+    /// Uses the system's current `change_tick` as a reference to help deal with wraparound.
     pub fn is_newer_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -596,9 +596,9 @@ impl Tick {
     }
 
     #[inline]
-    /// Returns `true` if the tick occurred since the system's `last_change_tick`.
+    /// Returns `true` if this `Tick` occurred since the system's `last_change_tick`.
     ///
-    /// Uses the system's current `change_tick` as a reference to help deal with wraparound.
+    /// `change_tick` is the current tick of the system, used as a reference to help deal with wraparound.
     pub fn is_newer_than(&self, last_change_tick: u32, change_tick: u32) -> bool {
         // This works even with wraparound because the world tick (`change_tick`) is always "newer" than
         // `last_change_tick` and `self.tick`, and we scan periodically to clamp `ComponentTicks` values

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -509,7 +509,7 @@ macro_rules! impl_tick_filter {
                             .debug_checked_unwrap()
                             .get(table_row.index())
                             .deref()
-                            .is_older_than(fetch.last_change_tick, fetch.change_tick)
+                            .is_newer_than(fetch.last_change_tick, fetch.change_tick)
                     }
                     StorageType::SparseSet => {
                         let sparse_set = &fetch
@@ -518,7 +518,7 @@ macro_rules! impl_tick_filter {
                         $get_sparse_set(sparse_set, entity)
                             .debug_checked_unwrap()
                             .deref()
-                            .is_older_than(fetch.last_change_tick, fetch.change_tick)
+                            .is_newer_than(fetch.last_change_tick, fetch.change_tick)
                     }
                 }
             }


### PR DESCRIPTION
# Objective

Clarify what the function is actually calculating.

The `Tick::is_older_than` function is actually calculating whether the tick is newer than the system's `last_change_tick`, not older. As far as I can tell, the engine was using it correctly everywhere already. 

## Solution

- Rename the function.
---

## Changelog

- `Tick::is_older_than` was renamed to `Tick::is_newer_than`. This is not a functional change, since that was what was always being calculated, despite the wrong name.

## Migration Guide

- Replace usages of `Tick::is_older_than` with `Tick::is_newer_than`.
