### PR TITLE
create a new scope executor for every scope

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -112,7 +112,6 @@ pub struct TaskPool {
 impl TaskPool {
     thread_local! {
         static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = async_executor::LocalExecutor::new();
-        static THREAD_EXECUTOR: ThreadExecutor<'static> = ThreadExecutor::new();
     }
 
     /// Create a `TaskPool` with the default configuration.
@@ -275,9 +274,8 @@ impl TaskPool {
         F: for<'scope> FnOnce(&'scope Scope<'scope, 'env, T>),
         T: Send + 'static,
     {
-        Self::THREAD_EXECUTOR.with(|scope_executor| {
-            self.scope_with_executor_inner(true, scope_executor, scope_executor, f)
-        })
+        let scope_executor = ThreadExecutor::new();
+        self.scope_with_executor_inner(true, &scope_executor, &scope_executor, f)
     }
 
     /// This allows passing an external executor to spawn tasks on. When you pass an external executor
@@ -299,25 +297,24 @@ impl TaskPool {
         F: for<'scope> FnOnce(&'scope Scope<'scope, 'env, T>),
         T: Send + 'static,
     {
-        Self::THREAD_EXECUTOR.with(|scope_executor| {
-            // If a `external_executor` is passed use that. Otherwise get the executor stored
-            // in the `THREAD_EXECUTOR` thread local.
-            if let Some(external_executor) = external_executor {
-                self.scope_with_executor_inner(
-                    tick_task_pool_executor,
-                    external_executor,
-                    scope_executor,
-                    f,
-                )
-            } else {
-                self.scope_with_executor_inner(
-                    tick_task_pool_executor,
-                    scope_executor,
-                    scope_executor,
-                    f,
-                )
-            }
-        })
+        let scope_executor = ThreadExecutor::new();
+        // If a `external_executor` is passed use that. Otherwise get the executor stored
+        // in the `THREAD_EXECUTOR` thread local.
+        if let Some(external_executor) = external_executor {
+            self.scope_with_executor_inner(
+                tick_task_pool_executor,
+                external_executor,
+                &scope_executor,
+                f,
+            )
+        } else {
+            self.scope_with_executor_inner(
+                tick_task_pool_executor,
+                &scope_executor,
+                &scope_executor,
+                f,
+            )
+        }
     }
 
     fn scope_with_executor_inner<'env, F, T>(


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/7563
- nesting multithreaded schedules seems to deadlock.

## Solution

- Create a new scope executor for every usage of `scope`
- My current theory is that when we nests schedules we end up trying to run two tasks on the scope executor at the same time. But an executor can only run one task at a time, so it deadlocks. Unfortunately I tried to write a test for this with nesting multithreaded schedules, but it didn't deadlock.  So I'm probably misunderstanding something. But this does fix the above issue
running `cargo run --example load_gltf --features debug_asset_server` deadlocks without this pr, but works with it.

---

## Changelog

- Change scope back to create a new scope executor for every scope.