### PR TITLE
[Merged by Bors] - Rename `UnsafeWorldCellEntityRef` to `UnsafeEntityCell`

### DIFF
--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -6,7 +6,7 @@ use crate::{
     entity::{Entity, EntityMap, MapEntities, MapEntitiesError},
     system::Resource,
     world::{
-        unsafe_world_cell::{UnsafeWorldCell, UnsafeWorldCellEntityRef},
+        unsafe_world_cell::{UnsafeEntityCell, UnsafeWorldCell},
         EntityMut, EntityRef, FromWorld, World,
     },
 };
@@ -61,9 +61,8 @@ pub struct ReflectComponentFns {
     /// Function pointer implementing [`ReflectComponent::reflect_unchecked_mut()`].
     ///
     /// # Safety
-    /// The function may only be called with an [`UnsafeWorldCellEntityRef`] that can be used to mutably access the relevant component on the given entity.
-    pub reflect_unchecked_mut:
-        unsafe fn(UnsafeWorldCellEntityRef<'_>) -> Option<Mut<'_, dyn Reflect>>,
+    /// The function may only be called with an [`UnsafeEntityCell`] that can be used to mutably access the relevant component on the given entity.
+    pub reflect_unchecked_mut: unsafe fn(UnsafeEntityCell<'_>) -> Option<Mut<'_, dyn Reflect>>,
     /// Function pointer implementing [`ReflectComponent::copy()`].
     pub copy: fn(&World, &mut World, Entity, Entity),
 }
@@ -126,11 +125,11 @@ impl ReflectComponent {
     /// # Safety
     /// This method does not prevent you from having two mutable pointers to the same data,
     /// violating Rust's aliasing rules. To avoid this:
-    /// * Only call this method with a [`UnsafeWorldCellEntityRef`] that may be used to mutably access the component on the entity `entity`
+    /// * Only call this method with a [`UnsafeEntityCell`] that may be used to mutably access the component on the entity `entity`
     /// * Don't call this method more than once in the same scope for a given [`Component`].
     pub unsafe fn reflect_unchecked_mut<'a>(
         &self,
-        entity: UnsafeWorldCellEntityRef<'a>,
+        entity: UnsafeEntityCell<'a>,
     ) -> Option<Mut<'a, dyn Reflect>> {
         // SAFETY: safety requirements deferred to caller
         (self.0.reflect_unchecked_mut)(entity)
@@ -214,7 +213,7 @@ impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {
             },
             reflect_unchecked_mut: |entity| {
                 // SAFETY: reflect_unchecked_mut is an unsafe function pointer used by
-                // `reflect_unchecked_mut` which must be called with an UnsafeWorldCellEntityRef with access to the the component `C` on the `entity`
+                // `reflect_unchecked_mut` which must be called with an UnsafeEntityCell with access to the the component `C` on the `entity`
                 unsafe {
                     entity.get_mut::<C>().map(|c| Mut {
                         value: c.value as &mut dyn Reflect,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -12,7 +12,7 @@ use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::debug;
 use std::any::TypeId;
 
-use super::unsafe_world_cell::UnsafeWorldCellEntityRef;
+use super::unsafe_world_cell::UnsafeEntityCell;
 
 /// A read-only reference to a particular [`Entity`] and all of its components
 #[derive(Copy, Clone)]
@@ -41,8 +41,8 @@ impl<'w> EntityRef<'w> {
         }
     }
 
-    fn as_unsafe_world_cell_readonly(&self) -> UnsafeWorldCellEntityRef<'w> {
-        UnsafeWorldCellEntityRef::new(
+    fn as_unsafe_world_cell_readonly(&self) -> UnsafeEntityCell<'w> {
+        UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell_readonly(),
             self.entity,
             self.location,
@@ -149,15 +149,15 @@ pub struct EntityMut<'w> {
 }
 
 impl<'w> EntityMut<'w> {
-    fn as_unsafe_world_cell_readonly(&self) -> UnsafeWorldCellEntityRef<'_> {
-        UnsafeWorldCellEntityRef::new(
+    fn as_unsafe_world_cell_readonly(&self) -> UnsafeEntityCell<'_> {
+        UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell_readonly(),
             self.entity,
             self.location,
         )
     }
-    fn as_unsafe_world_cell(&mut self) -> UnsafeWorldCellEntityRef<'_> {
-        UnsafeWorldCellEntityRef::new(
+    fn as_unsafe_world_cell(&mut self) -> UnsafeEntityCell<'_> {
+        UnsafeEntityCell::new(
             self.world.as_unsafe_world_cell(),
             self.entity,
             self.location,

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -239,11 +239,11 @@ impl<'w> UnsafeWorldCell<'w> {
         Some(resource.id())
     }
 
-    /// Retrieves an [`UnsafeWorldCellEntityRef`] that exposes read and write operations for the given `entity`.
+    /// Retrieves an [`UnsafeEntityCell`] that exposes read and write operations for the given `entity`.
     /// Similar to the [`UnsafeWorldCell`], you are in charge of making sure that no aliasing rules are violated.
-    pub fn get_entity(self, entity: Entity) -> Option<UnsafeWorldCellEntityRef<'w>> {
+    pub fn get_entity(self, entity: Entity) -> Option<UnsafeEntityCell<'w>> {
         let location = self.entities().get(entity)?;
-        Some(UnsafeWorldCellEntityRef::new(self, entity, location))
+        Some(UnsafeEntityCell::new(self, entity, location))
     }
 
     /// Gets a reference to the resource of the given type if it exists
@@ -496,19 +496,19 @@ impl<'w> UnsafeWorldCell<'w> {
 
 /// A interior-mutable reference to a particular [`Entity`] and all of its components
 #[derive(Copy, Clone)]
-pub struct UnsafeWorldCellEntityRef<'w> {
+pub struct UnsafeEntityCell<'w> {
     world: UnsafeWorldCell<'w>,
     entity: Entity,
     location: EntityLocation,
 }
 
-impl<'w> UnsafeWorldCellEntityRef<'w> {
+impl<'w> UnsafeEntityCell<'w> {
     pub(crate) fn new(
         world: UnsafeWorldCell<'w>,
         entity: Entity,
         location: EntityLocation,
     ) -> Self {
-        UnsafeWorldCellEntityRef {
+        UnsafeEntityCell {
             world,
             entity,
             location,
@@ -557,7 +557,7 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
+    /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get<T: Component>(self) -> Option<&'w T> {
@@ -584,7 +584,7 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
+    /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_change_ticks<T: Component>(self) -> Option<ComponentTicks> {
@@ -607,13 +607,13 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// Retrieves the change ticks for the given [`ComponentId`]. This can be useful for implementing change
     /// detection in custom runtimes.
     ///
-    /// **You should prefer to use the typed API [`UnsafeWorldCellEntityRef::get_change_ticks`] where possible and only
+    /// **You should prefer to use the typed API [`UnsafeEntityCell::get_change_ticks`] where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
+    /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_change_ticks_by_id(
@@ -638,7 +638,7 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
+    /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut<T: Component>(self) -> Option<Mut<'w, T>> {
@@ -650,7 +650,7 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
 
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
+    /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub(crate) unsafe fn get_mut_using_ticks<T: Component>(
@@ -680,19 +680,19 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     }
 }
 
-impl<'w> UnsafeWorldCellEntityRef<'w> {
+impl<'w> UnsafeEntityCell<'w> {
     /// Gets the component of the given [`ComponentId`] from the entity.
     ///
     /// **You should prefer to use the typed API where possible and only
     /// use this in cases where the actual component types are not known at
     /// compile time.**
     ///
-    /// Unlike [`UnsafeWorldCellEntityRef::get`], this returns a raw pointer to the component,
+    /// Unlike [`UnsafeEntityCell::get`], this returns a raw pointer to the component,
     /// which is only valid while the `'w` borrow of the lifetime is active.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component
+    /// - the [`UnsafeEntityCell`] has permission to access the component
     /// - no other mutable references to the component exist at the same time
     #[inline]
     pub unsafe fn get_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
@@ -712,12 +712,12 @@ impl<'w> UnsafeWorldCellEntityRef<'w> {
     /// Retrieves a mutable untyped reference to the given `entity`'s [Component] of the given [`ComponentId`].
     /// Returns [None] if the `entity` does not have a [Component] of the given type.
     ///
-    /// **You should prefer to use the typed API [`UnsafeWorldCellEntityRef::get_mut`] where possible and only
+    /// **You should prefer to use the typed API [`UnsafeEntityCell::get_mut`] where possible and only
     /// use this in cases where the actual types are not known at compile time.**
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCellEntityRef`] has permission to access the component mutably
+    /// - the [`UnsafeEntityCell`] has permission to access the component mutably
     /// - no other references to the component exist at the same time
     #[inline]
     pub unsafe fn get_mut_by_id(self, component_id: ComponentId) -> Option<MutUntyped<'w>> {


### PR DESCRIPTION
# Objective

Make the name less verbose without sacrificing clarity.

---

## Migration Guide

*Note for maintainers:* This PR has no breaking changes relative to bevy 0.9. Instead of this PR having its own migration guide, we should just edit the changelog for #6404.

The type `UnsafeWorldCellEntityRef` has been renamed to `UnsafeEntityCell`.