### PR TITLE
[Merged by Bors] - Fix the `AlignSelf` documentation

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -227,7 +227,8 @@ pub struct Style {
     pub flex_wrap: FlexWrap,
     /// How items are aligned according to the cross axis
     pub align_items: AlignItems,
-    /// Like align_items but for only this item
+    /// How this item is aligned according to the cross axis.
+    /// Overrides `align_items`.
     pub align_self: AlignSelf,
     /// How to align each line, only applies if flex_wrap is set to
     /// [`FlexWrap::Wrap`] and there are multiple lines of items

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -329,7 +329,7 @@ impl Default for AlignItems {
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum AlignSelf {
-    /// Use the value of [`AlignItems`]
+    /// Use the parent node's [`AlignItems`] value to determine how this item should be aligned
     Auto,
     /// This item will be aligned at the start
     FlexStart,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -228,7 +228,7 @@ pub struct Style {
     /// How items are aligned according to the cross axis
     pub align_items: AlignItems,
     /// How this item is aligned according to the cross axis.
-    /// Overrides `align_items`.
+    /// Overrides [`AlignItems`].
     pub align_self: AlignSelf,
     /// How to align each line, only applies if flex_wrap is set to
     /// [`FlexWrap::Wrap`] and there are multiple lines of items
@@ -324,21 +324,22 @@ impl Default for AlignItems {
     }
 }
 
-/// Works like [`AlignItems`] but applies only to a single item
+/// How this item is aligned according to the cross axis.
+/// Overrides [`AlignItems`].
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect(PartialEq, Serialize, Deserialize)]
 pub enum AlignSelf {
     /// Use the value of [`AlignItems`]
     Auto,
-    /// If the parent has [`AlignItems::Center`] only this item will be at the start
+    /// This item will be aligned at the start
     FlexStart,
-    /// If the parent has [`AlignItems::Center`] only this item will be at the end
+    /// This item will be aligned at the end
     FlexEnd,
-    /// If the parent has [`AlignItems::FlexStart`] only this item will be at the center
+    /// This item will be aligned at the center
     Center,
-    /// If the parent has [`AlignItems::Center`] only this item will be at the baseline
+    /// This item will be aligned at the baseline
     Baseline,
-    /// If the parent has [`AlignItems::Center`] only this item will stretch along the whole cross axis
+    /// This item will be stretched across the whole cross axis
     Stretch,
 }
 


### PR DESCRIPTION
# Objective

The current `AlignSelf` doc comments: 

```rust
pub enum AlignSelf {
    /// Use the value of [`AlignItems`]
    Auto,
    /// If the parent has [`AlignItems::Center`] only this item will be at the start
    FlexStart,
    /// If the parent has [`AlignItems::Center`] only this item will be at the end
    FlexEnd,
    /// If the parent has [`AlignItems::FlexStart`] only this item will be at the center
    Center,
    /// If the parent has [`AlignItems::Center`] only this item will be at the baseline
    Baseline,
    /// If the parent has [`AlignItems::Center`] only this item will stretch along the whole cross axis
    Stretch,
}
```

Actual behaviour of `AlignSelf` in Bevy main:

<img width="642" alt="align_self" src="https://user-images.githubusercontent.com/27962798/217795178-7a82638f-118d-4474-b7f9-ca27f204731d.PNG">

The white label at the top of each column is the parent node's `AlignItems` setting.
`AlignSelf` is always applied, not (as the documentation states) only when the parent has `AlignItems::Center` or `AlignItems::FlexStart` set.

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_startup_system(setup)
        .run();
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2dBundle::default());
    commands.spawn(NodeBundle {
        style: Style {
            justify_content: JustifyContent::SpaceAround,
            align_items: AlignItems::Center,
            size: Size::new(Val::Percent(100.), Val::Percent(100.)),
            ..Default::default()
        },
        background_color: BackgroundColor(Color::NAVY),
        ..Default::default()
    }).with_children(|builder| {
        for align_items in [
            AlignItems::Baseline,
            AlignItems::FlexStart,
            AlignItems::Center,
            AlignItems::FlexEnd,
            AlignItems::Stretch,
        ] {
            builder.spawn(NodeBundle {
                style: Style {
                    align_items,
                    flex_direction: FlexDirection::Column,
                    justify_content: JustifyContent::SpaceBetween,
                    size: Size::new(Val::Px(150.), Val::Px(500.)),
                    ..Default::default()
                },
                background_color: BackgroundColor(Color::DARK_GRAY),
                ..Default::default()
            }).with_children(|builder| {
                builder.spawn((
                    TextBundle {
                        text: Text::from_section(
                            format!("AlignItems::{align_items:?}"),
                            TextStyle {
                                font: asset_server.load("fonts/FiraSans-Regular.ttf"),
                                font_size: 16.0,
                                color: Color::BLACK,
                            },
                        ),
                        style: Style {
                            align_self: AlignSelf::Stretch,
                            ..Default::default()
                        },
                        ..Default::default()
                    },
                    BackgroundColor(Color::WHITE),
                ));

                for align_self in [
                    AlignSelf::Auto,
                    AlignSelf::FlexStart,
                    AlignSelf::Center,
                    AlignSelf::FlexEnd,
                    AlignSelf::Baseline,
                    AlignSelf::Stretch,
                ] {
                    builder.spawn((
                        TextBundle {
                            text: Text::from_section(
                                format!("AlignSelf::{align_self:?}"),
                                TextStyle {
                                    font: asset_server.load("fonts/FiraSans-Regular.ttf"),
                                    font_size: 16.0,
                                    color: Color::WHITE,
                                },
                            ),
                            style: Style {
                                align_self,
                                ..Default::default()
                            },
                            ..Default::default()
                        },
                        BackgroundColor(Color::BLACK),
                    ));
                }
            });
        }
    });
}
```