### PR TITLE
improve TextStyle document

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -163,7 +163,7 @@ pub struct TextStyle {
     // The size of the font in pixels. Note that this value may surprise users who have a custom scale factor set.
     pub font_size: f32,
     pub color: Color,
-  }
+}
 
 impl Default for TextStyle {
     fn default() -> Self {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -162,7 +162,7 @@ pub struct TextStyle {
     pub font: Handle<Font>,
     /// The size of the font in pixels. 
     ///
-    ///Note that this value may surprise users who have a custom scale factor set.
+    /// Note that this value may surprise users who have a custom scale factor set.
     pub font_size: f32,
     pub color: Color,
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -160,9 +160,10 @@ impl From<TextAlignment> for glyph_brush_layout::HorizontalAlign {
 #[derive(Clone, Debug, Reflect, FromReflect)]
 pub struct TextStyle {
     pub font: Handle<Font>,
+    // The size of the font in pixels. Note that this value may surprise users who have a custom scale factor set.
     pub font_size: f32,
     pub color: Color,
-}
+  }
 
 impl Default for TextStyle {
     fn default() -> Self {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -160,7 +160,9 @@ impl From<TextAlignment> for glyph_brush_layout::HorizontalAlign {
 #[derive(Clone, Debug, Reflect, FromReflect)]
 pub struct TextStyle {
     pub font: Handle<Font>,
-    // The size of the font in pixels. Note that this value may surprise users who have a custom scale factor set.
+    /// The size of the font in pixels. 
+    ///
+    ///Note that this value may surprise users who have a custom scale factor set.
     pub font_size: f32,
     pub color: Color,
 }


### PR DESCRIPTION
# Objective

This PR just adds a comment to improve the documentation of `font_size` field of [TextStyle](https://docs.rs/bevy/latest/bevy/prelude/struct.TextStyle.html#), informing the user that he can be surprising when using a custom scaling.

Fixes #7273.


Co-authored-by: Caio <caiocesar31951910@hotmail.com>
