### PR TITLE
[Merged by Bors] - Add a `BackgroundColor` component to `TextBundle`

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -124,7 +124,7 @@ pub struct TextBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
-    /// The background color for the text
+    /// The background color that will fill the containing node
     pub background_color: BackgroundColor,
 }
 

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -96,7 +96,7 @@ pub struct ImageBundle {
 }
 
 /// A UI node that is text
-#[derive(Bundle, Clone, Debug, Default)]
+#[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {
     /// Describes the size of the node
     pub node: Node,
@@ -124,6 +124,27 @@ pub struct TextBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// The background color for the text
+    pub background_color: BackgroundColor,
+}
+
+impl Default for TextBundle {
+    fn default() -> Self {
+        Self {
+            text: Default::default(),
+            calculated_size: Default::default(),
+            // Transparent background
+            background_color: Color::NONE.into(),
+            node: Default::default(),
+            style: Default::default(),
+            focus_policy: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            computed_visibility: Default::default(),
+            z_index: Default::default(),
+        }
+    }
 }
 
 impl TextBundle {
@@ -156,6 +177,12 @@ impl TextBundle {
     /// Returns this [`TextBundle`] with a new [`Style`].
     pub const fn with_style(mut self, style: Style) -> Self {
         self.style = style;
+        self
+    }
+
+    /// Returns this [`TextBundle`] with a new [`BackgroundColor`].
+    pub const fn with_background_color(mut self, color: Color) -> Self {
+        self.background_color = BackgroundColor(color);
         self
     }
 }

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -134,7 +134,7 @@ impl Default for TextBundle {
             text: Default::default(),
             calculated_size: Default::default(),
             // Transparent background
-            background_color: Color::NONE.into(),
+            background_color: BackgroundColor(Color::NONE),
             node: Default::default(),
             style: Default::default(),
             focus_policy: Default::default(),


### PR DESCRIPTION
# Objective

`TextBundle` should have a `BackgroundColor` component.

Apart from adding emphasis etc to text, adding a background color to text nodes can be extremely useful for understanding how Bevy aligns, sizes and positions text, and identifying and debugging problems.

It's easy for users to insert the `BackgroundColor` component themselves but not immediately obvious or discoverable that it's possible. A `BackgroundColor` component allows us to add a `with_background_color` helper function to `TextBundle`.

related issue: #5935

## Solution

Add a `BackgroundColor` component to `TextBundle`.

---

## Changelog

* Added a `BackgroundColor` component to `TextBundle`.
* Added a helper method `with_background_color` to `TextBundle`.

## Migration Guide
`TextBundle` now has a `BackgroundColor` component. 

Use `TextBundle`'s `background_color` field or the `with_background_color` method to set a background color for text when spawning a text node, in place of manual insertion of a `BackgroundColor` component.