### PR TITLE
[Merged by Bors] - Changed &mut PipelineCache to &PipelineCache

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -63,7 +63,7 @@ impl<S: SpecializedComputePipeline> Default for SpecializedComputePipelines<S> {
 impl<S: SpecializedComputePipeline> SpecializedComputePipelines<S> {
     pub fn specialize(
         &mut self,
-        cache: &mut PipelineCache,
+        cache: &PipelineCache,
         specialize_pipeline: &S,
         key: S::Key,
     ) -> CachedComputePipelineId {


### PR DESCRIPTION
This was missed in #7205.
Should be fixed now. 😄 

## Migration Guide
- `SpecializedComputePipelines::specialize` now takes a `&PipelineCache` instead of a `&mut PipelineCache`