### PR TITLE
Skip drawing for zero area UI nodes

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -197,8 +197,12 @@ pub fn extract_uinodes(
         if let Ok((uinode, transform, color, maybe_image, visibility, clip)) =
             uinode_query.get(*entity)
         {
-            // Skip invisible and completely transparent nodes
-            if !visibility.is_visible() || color.0.a() == 0.0 {
+            // Skip invisible, zero area and completely transparent nodes
+            if !visibility.is_visible()
+                || color.0.a() == 0.0
+                || uinode.size().x == 0.0
+                || uinode.size().y == 0.0
+            {
                 continue;
             }
 
@@ -313,18 +317,16 @@ pub fn extract_text_uinodes(
         if let Ok((uinode, global_transform, text, text_layout_info, visibility, clip)) =
             uinode_query.get(*entity)
         {
-            if !visibility.is_visible() {
+            // Skip invisible and zero area nodes
+            if !visibility.is_visible() || uinode.size().x == 0.0 || uinode.size().y == 0.0 {
                 continue;
             }
-            // Skip if size is set to zero (e.g. when a parent is set to `Display::None`)
-            if uinode.size() == Vec2::ZERO {
-                continue;
-            }
+
             let text_glyphs = &text_layout_info.glyphs;
             let alignment_offset = (uinode.size() / -2.0).extend(0.0);
-
             let mut color = Color::WHITE;
             let mut current_section = usize::MAX;
+
             for text_glyph in text_glyphs {
                 if text_glyph.section_index != current_section {
                     color = text.sections[text_glyph.section_index]


### PR DESCRIPTION
# Objective

The extraction functions queue zero area UI nodes for rendering. They could be skipped.

Also, there is a check for text but it only skips the node if both the components of its size are zero.

## Solution

Implement a check in the extraction functions to skip the drawing of UI nodes if they have a height or width of zero.

## Changelog

    * Added a check to the UI node extraction functions to skip drawing for the nodes with a width or height of zero.
    * Changed the skip condition in `extract_text_uinodes` from `uinode.size() == Vec2::ZERO` to `uinode.size().x == 0. || uinode.size().y == 0.` to account for the case where the size is zero on one only axis.

