### PR TITLE
[Merged by Bors] - don't require features on examples where it's not the main focus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -372,7 +372,6 @@ wasm = false
 [[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
-required-features = ["ktx2", "zstd"]
 
 [package.metadata.example.load_gltf]
 name = "Load glTF"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1431,7 +1431,6 @@ wasm = true
 [[example]]
 name = "scene_viewer"
 path = "examples/tools/scene_viewer/main.rs"
-required-features = ["ktx2", "zstd"]
 
 [package.metadata.example.scene_viewer]
 name = "Scene Viewer"

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -27,11 +27,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
             ..default()
         },
+        #[cfg(all(feature = "ktx2", feature = "zstd"))]
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
     ));
+    #[cfg(not(all(feature = "ktx2", feature = "zstd")))]
+    {
+        warn!("feature ktx2 or zstd wasn't enabled.");
+        warn!("rerun this example with `--features=\"ktx2 zstd\" to get environment maps for ambient light");
+    }
+
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
             shadows_enabled: true,

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -128,6 +128,7 @@ fn setup_scene_after_load(
                 },
                 ..default()
             },
+            #[cfg(all(feature = "ktx2", feature = "zstd"))]
             EnvironmentMapLight {
                 diffuse_map: asset_server
                     .load("assets/environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
@@ -136,6 +137,11 @@ fn setup_scene_after_load(
             },
             camera_controller,
         ));
+        #[cfg(not(all(feature = "ktx2", feature = "zstd")))]
+        {
+            warn!("feature ktx2 or zstd wasn't enabled.");
+            warn!("rerun this example with `--features=\"ktx2 zstd\" to get environment maps for ambient light");
+        }
 
         // Spawn a default light if the scene does not have one
         if !scene_handle.has_light {


### PR DESCRIPTION
# Objective

- Required features were added to some examples in #7051 even though those features aren't the main focus of the examples
- Don't require features on examples that are useful without them

## Solution

- Remove required features on examples `load_gltf` and `scene_viewer`, but log a warning when they are not enabled

