### PR TITLE
[Merged by Bors] - Transparent window on macos

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -130,7 +130,9 @@ pub struct Window {
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
     /// - macOS X: Not working as expected.
-    /// macOS X transparent works with winit out of the box, so this issue might be related to: <https://github.com/gfx-rs/wgpu/issues/687>
+    ///
+    /// macOS X transparent works with winit out of the box, so this issue might be related to: <https://github.com/gfx-rs/wgpu/issues/687>.
+    /// You should also set the window `composite_alpha_mode` to `CompositeAlphaMode::PostMultiplied`.
     pub transparent: bool,
     /// Should the window start focused?
     pub focused: bool,

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -4,6 +4,8 @@
 //! [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowDescriptor.html#structfield.transparent)
 //! for more details.
 
+#[cfg(target_os = "macos")]
+use bevy::window::CompositeAlphaMode;
 use bevy::{
     prelude::*,
     window::{Window, WindowPlugin},
@@ -20,6 +22,8 @@ fn main() {
                 transparent: true,
                 // Disabling window decorations to make it feel more like a widget than a window
                 decorations: false,
+                #[cfg(target_os = "macos")]
+                composite_alpha_mode: CompositeAlphaMode::PostMultiplied,
                 ..default()
             }),
             ..default()


### PR DESCRIPTION
# Objective

- Example `transparent_window` doesn't display a transparent window on macOS
- Fixes #6330

## Solution

- Set the `composite_alpha_mode` of the window to the correct value
- Update docs