### PR TITLE
[Merged by Bors] - Use `position` in code when possible

### DIFF
--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -102,12 +102,7 @@ impl Edges {
 
     /// Removes an edge from the `input_edges` if it exists.
     pub(crate) fn remove_input_edge(&mut self, edge: Edge) -> Result<(), RenderGraphError> {
-        if let Some((index, _)) = self
-            .input_edges
-            .iter()
-            .enumerate()
-            .find(|(_i, e)| **e == edge)
-        {
+        if let Some(index) = self.input_edges.iter().position(|e| *e == edge) {
             self.input_edges.swap_remove(index);
             Ok(())
         } else {
@@ -126,12 +121,7 @@ impl Edges {
 
     /// Removes an edge from the `output_edges` if it exists.
     pub(crate) fn remove_output_edge(&mut self, edge: Edge) -> Result<(), RenderGraphError> {
-        if let Some((index, _)) = self
-            .output_edges
-            .iter()
-            .enumerate()
-            .find(|(_i, e)| **e == edge)
-        {
+        if let Some(index) = self.output_edges.iter().position(|e| *e == edge) {
             self.output_edges.swap_remove(index);
             Ok(())
         } else {

--- a/crates/bevy_render/src/render_graph/node_slot.rs
+++ b/crates/bevy_render/src/render_graph/node_slot.rs
@@ -188,12 +188,7 @@ impl SlotInfos {
         let label = label.into();
         match label {
             SlotLabel::Index(index) => Some(index),
-            SlotLabel::Name(ref name) => self
-                .slots
-                .iter()
-                .enumerate()
-                .find(|(_i, s)| s.name == *name)
-                .map(|(i, _s)| i),
+            SlotLabel::Name(ref name) => self.slots.iter().position(|s| s.name == *name),
         }
     }
 


### PR DESCRIPTION
# Objective

- This makes code a little more readable now.

## Solution

- Use `position` provided by `Iter` instead of  `enumerating` indices and `map`ping to the index.