### PR TITLE
Use `ValueInfo` inside structs in `bevy_reflect`

### DIFF
--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,6 +1,6 @@
 use crate::{
     utility::NonGenericTypeInfoCell, DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo, Typed,
+    TypeInfo, Typed, ValueInfo,
 };
 use std::{
     any::{Any, TypeId},
@@ -45,10 +45,8 @@ pub trait Array: Reflect {
 /// A container for compile-time array info.
 #[derive(Clone, Debug)]
 pub struct ArrayInfo {
-    type_name: &'static str,
-    type_id: TypeId,
-    item_type_name: &'static str,
-    item_type_id: TypeId,
+    type_value: ValueInfo,
+    item_type_value: ValueInfo,
     capacity: usize,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -63,10 +61,8 @@ impl ArrayInfo {
     ///
     pub fn new<TArray: Array, TItem: Reflect>(capacity: usize) -> Self {
         Self {
-            type_name: std::any::type_name::<TArray>(),
-            type_id: TypeId::of::<TArray>(),
-            item_type_name: std::any::type_name::<TItem>(),
-            item_type_id: TypeId::of::<TItem>(),
+            type_value: ValueInfo::new::<TArray>(),
+            item_type_value: ValueInfo::new::<TItem>(),
             capacity,
             #[cfg(feature = "documentation")]
             docs: None,
@@ -88,34 +84,34 @@ impl ArrayInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the array.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the array type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The [type name] of the array item.
     ///
     /// [type name]: std::any::type_name
     pub fn item_type_name(&self) -> &'static str {
-        self.item_type_name
+        self.item_type_value.type_name()
     }
 
     /// The [`TypeId`] of the array item.
     pub fn item_type_id(&self) -> TypeId {
-        self.item_type_id
+        self.item_type_value.type_id()
     }
 
     /// Check if the given type matches the array item type.
     pub fn item_is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.item_type_id
+        self.item_type_value.is::<T>()
     }
 
     /// The docstring of this array, if any.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,4 +1,4 @@
-use crate::{DynamicEnum, Reflect, VariantInfo, VariantType};
+use crate::{DynamicEnum, Reflect, ValueInfo, VariantInfo, VariantType};
 use bevy_utils::HashMap;
 use std::any::{Any, TypeId};
 use std::slice::Iter;
@@ -133,8 +133,7 @@ pub trait Enum: Reflect {
 #[derive(Clone, Debug)]
 pub struct EnumInfo {
     name: &'static str,
-    type_name: &'static str,
-    type_id: TypeId,
+    type_value: ValueInfo,
     variants: Box<[VariantInfo]>,
     variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
@@ -161,8 +160,7 @@ impl EnumInfo {
 
         Self {
             name,
-            type_name: std::any::type_name::<TEnum>(),
-            type_id: TypeId::of::<TEnum>(),
+            type_value: ValueInfo::new::<TEnum>(),
             variants: variants.to_vec().into_boxed_slice(),
             variant_names,
             variant_indices,
@@ -234,17 +232,17 @@ impl EnumInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the enum.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the enum type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The docstring of this enum, if any.

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,12 +1,11 @@
-use crate::Reflect;
+use crate::{Reflect, ValueInfo};
 use std::any::{Any, TypeId};
 
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]
 pub struct NamedField {
     name: &'static str,
-    type_name: &'static str,
-    type_id: TypeId,
+    value: ValueInfo,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -16,8 +15,7 @@ impl NamedField {
     pub fn new<T: Reflect>(name: &'static str) -> Self {
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
-            type_id: TypeId::of::<T>(),
+            value: ValueInfo::new::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -38,17 +36,17 @@ impl NamedField {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.value.type_name()
     }
 
     /// The [`TypeId`] of the field.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.value.type_id()
     }
 
     /// Check if the given type matches the field type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.value.is::<T>()
     }
 
     /// The docstring of this field, if any.
@@ -62,8 +60,7 @@ impl NamedField {
 #[derive(Clone, Debug)]
 pub struct UnnamedField {
     index: usize,
-    type_name: &'static str,
-    type_id: TypeId,
+    value: ValueInfo,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -72,8 +69,7 @@ impl UnnamedField {
     pub fn new<T: Reflect>(index: usize) -> Self {
         Self {
             index,
-            type_name: std::any::type_name::<T>(),
-            type_id: TypeId::of::<T>(),
+            value: ValueInfo::new::<T>(),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -94,17 +90,17 @@ impl UnnamedField {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.value.type_name()
     }
 
     /// The [`TypeId`] of the field.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.value.type_id()
     }
 
     /// Check if the given type matches the field type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.value.is::<T>()
     }
 
     /// The docstring of this field, if any.

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -4,7 +4,7 @@ use std::fmt::{Debug, Formatter};
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     Array, ArrayIter, DynamicArray, DynamicInfo, FromReflect, Reflect, ReflectMut, ReflectOwned,
-    ReflectRef, TypeInfo, Typed,
+    ReflectRef, TypeInfo, Typed, ValueInfo,
 };
 
 /// An ordered, mutable list of [Reflect] items. This corresponds to types like [`std::vec::Vec`].
@@ -59,10 +59,8 @@ pub trait List: Reflect + Array {
 /// A container for compile-time list info.
 #[derive(Clone, Debug)]
 pub struct ListInfo {
-    type_name: &'static str,
-    type_id: TypeId,
-    item_type_name: &'static str,
-    item_type_id: TypeId,
+    type_value: ValueInfo,
+    item_type_value: ValueInfo,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -71,10 +69,8 @@ impl ListInfo {
     /// Create a new [`ListInfo`].
     pub fn new<TList: List, TItem: FromReflect>() -> Self {
         Self {
-            type_name: std::any::type_name::<TList>(),
-            type_id: TypeId::of::<TList>(),
-            item_type_name: std::any::type_name::<TItem>(),
-            item_type_id: TypeId::of::<TItem>(),
+            type_value: ValueInfo::new::<TList>(),
+            item_type_value: ValueInfo::new::<TItem>(),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -90,34 +86,34 @@ impl ListInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the list.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the list type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The [type name] of the list item.
     ///
     /// [type name]: std::any::type_name
     pub fn item_type_name(&self) -> &'static str {
-        self.item_type_name
+        self.item_type_value.type_name()
     }
 
     /// The [`TypeId`] of the list item.
     pub fn item_type_id(&self) -> TypeId {
-        self.item_type_id
+        self.item_type_value.type_id()
     }
 
     /// Check if the given type matches the list item type.
     pub fn item_is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.item_type_id
+        self.item_type_value.is::<T>()
     }
 
     /// The docstring of this list, if any.

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -5,7 +5,9 @@ use std::hash::Hash;
 use bevy_utils::{Entry, HashMap};
 
 use crate::utility::NonGenericTypeInfoCell;
-use crate::{DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed};
+use crate::{
+    DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, ValueInfo,
+};
 
 /// An ordered mapping between [`Reflect`] values.
 ///
@@ -68,12 +70,9 @@ pub trait Map: Reflect {
 /// A container for compile-time map info.
 #[derive(Clone, Debug)]
 pub struct MapInfo {
-    type_name: &'static str,
-    type_id: TypeId,
-    key_type_name: &'static str,
-    key_type_id: TypeId,
-    value_type_name: &'static str,
-    value_type_id: TypeId,
+    type_value: ValueInfo,
+    key_type_value: ValueInfo,
+    value_type_value: ValueInfo,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -82,12 +81,9 @@ impl MapInfo {
     /// Create a new [`MapInfo`].
     pub fn new<TMap: Map, TKey: Hash + Reflect, TValue: Reflect>() -> Self {
         Self {
-            type_name: std::any::type_name::<TMap>(),
-            type_id: TypeId::of::<TMap>(),
-            key_type_name: std::any::type_name::<TKey>(),
-            key_type_id: TypeId::of::<TKey>(),
-            value_type_name: std::any::type_name::<TValue>(),
-            value_type_id: TypeId::of::<TValue>(),
+            type_value: ValueInfo::new::<TMap>(),
+            key_type_value: ValueInfo::new::<TKey>(),
+            value_type_value: ValueInfo::new::<TValue>(),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -103,51 +99,51 @@ impl MapInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the map.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the map type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The [type name] of the key.
     ///
     /// [type name]: std::any::type_name
     pub fn key_type_name(&self) -> &'static str {
-        self.key_type_name
+        self.key_type_value.type_name()
     }
 
     /// The [`TypeId`] of the key.
     pub fn key_type_id(&self) -> TypeId {
-        self.key_type_id
+        self.key_type_value.type_id()
     }
 
     /// Check if the given type matches the key type.
     pub fn key_is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.key_type_id
+        self.key_type_value.is::<T>()
     }
 
     /// The [type name] of the value.
     ///
     /// [type name]: std::any::type_name
     pub fn value_type_name(&self) -> &'static str {
-        self.value_type_name
+        self.value_type_value.type_name()
     }
 
     /// The [`TypeId`] of the value.
     pub fn value_type_id(&self) -> TypeId {
-        self.value_type_id
+        self.value_type_value.type_id()
     }
 
     /// Check if the given type matches the value type.
     pub fn value_is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.value_type_id
+        self.value_type_value.is::<T>()
     }
 
     /// The docstring of this map, if any.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,6 +1,7 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     DynamicInfo, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed,
+    ValueInfo,
 };
 use bevy_utils::{Entry, HashMap};
 use std::fmt::{Debug, Formatter};
@@ -72,8 +73,7 @@ pub trait Struct: Reflect {
 #[derive(Clone, Debug)]
 pub struct StructInfo {
     name: &'static str,
-    type_name: &'static str,
-    type_id: TypeId,
+    type_value: ValueInfo,
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
@@ -100,8 +100,7 @@ impl StructInfo {
 
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
-            type_id: TypeId::of::<T>(),
+            type_value: ValueInfo::new::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
@@ -161,17 +160,17 @@ impl StructInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the struct.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the struct type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The docstring of this struct, if any.

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,7 +1,7 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     DynamicInfo, FromReflect, GetTypeRegistration, Reflect, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo, TypeRegistration, Typed, UnnamedField,
+    TypeInfo, TypeRegistration, Typed, UnnamedField, ValueInfo,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -131,8 +131,7 @@ impl GetTupleField for dyn Tuple {
 /// A container for compile-time tuple info.
 #[derive(Clone, Debug)]
 pub struct TupleInfo {
-    type_name: &'static str,
-    type_id: TypeId,
+    type_value: ValueInfo,
     fields: Box<[UnnamedField]>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -147,8 +146,7 @@ impl TupleInfo {
     ///
     pub fn new<T: Reflect>(fields: &[UnnamedField]) -> Self {
         Self {
-            type_name: std::any::type_name::<T>(),
-            type_id: TypeId::of::<T>(),
+            type_value: ValueInfo::new::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -180,17 +178,17 @@ impl TupleInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the tuple.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the tuple type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The docstring of this tuple, if any.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,6 +1,7 @@
 use crate::utility::NonGenericTypeInfoCell;
 use crate::{
     DynamicInfo, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, Typed, UnnamedField,
+    ValueInfo,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -52,8 +53,7 @@ pub trait TupleStruct: Reflect {
 #[derive(Clone, Debug)]
 pub struct TupleStructInfo {
     name: &'static str,
-    type_name: &'static str,
-    type_id: TypeId,
+    type_value: ValueInfo,
     fields: Box<[UnnamedField]>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
@@ -70,8 +70,7 @@ impl TupleStructInfo {
     pub fn new<T: Reflect>(name: &'static str, fields: &[UnnamedField]) -> Self {
         Self {
             name,
-            type_name: std::any::type_name::<T>(),
-            type_id: TypeId::of::<T>(),
+            type_value: ValueInfo::new::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
             #[cfg(feature = "documentation")]
             docs: None,
@@ -112,17 +111,17 @@ impl TupleStructInfo {
     ///
     /// [type name]: std::any::type_name
     pub fn type_name(&self) -> &'static str {
-        self.type_name
+        self.type_value.type_name()
     }
 
     /// The [`TypeId`] of the tuple struct.
     pub fn type_id(&self) -> TypeId {
-        self.type_id
+        self.type_value.type_id()
     }
 
     /// Check if the given type matches the tuple struct type.
     pub fn is<T: Any>(&self) -> bool {
-        TypeId::of::<T>() == self.type_id
+        self.type_value.is::<T>()
     }
 
     /// The docstring of this struct, if any.


### PR DESCRIPTION
# Objective

- Make defining several structs in `bevy_reflect` less verbose by replacing certain fields with `ValueInfo`. Since these are private fields, no outward changes should be needed.

## Solution

Replaced fields in the form:

```rust
struct FooInfo {
    bar_name: &'static str,
    bar_id: TypeId,
}

impl FooInfo {
    fn new<T: BarType>() -> Self {
        Self {
            bar_name: std::any::type_name::<T>(),
            bar_id: TypeId::of::<T>(),
        }
    }
}
```

With the following:

```rust
struct FooInfo {
    bar_value: ValueInfo,
}

impl FooInfo {
    fn new<T: BarType>() -> Self {
        Self {
            bar_value: ValueInfo::new::<T>(),
        }
    }
}
```
