### PR TITLE
[Merged by Bors] - Fix closing window does not exit app in desktop_app mode

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -102,7 +102,8 @@ impl Plugin for WindowPlugin {
         }
 
         if self.close_when_requested {
-            app.add_system(close_when_requested.in_base_set(CoreSet::PostUpdate));
+            // Need to run before `exit_on_*` systems
+            app.add_system(close_when_requested);
         }
 
         // Register event types


### PR DESCRIPTION
# Objective

- `close_when_requested` system needs to run before `exit_on_*` systems, otherwise it takes another loop to exit app.
- Fixes #7624

## Solution

- Move `close_when_request` system to Update phase [as before](https://github.com/bevyengine/bevy/issues/7624#issuecomment-1426688070).
