### PR TITLE
Do not add `OnUpdate` system set to `CoreSet::ApplyStateTransitions`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -317,8 +317,9 @@ impl App {
     /// initial state.
     ///
     /// This also adds an [`OnUpdate`] system set for each state variant,
-    /// which run during [`CoreSet::StateTransitions`] after the transitions are applied.
+    /// which is configured to run after [`apply_state_transition::<S>`].
     /// These systems sets only run if the [`State<S>`] resource matches their label.
+    /// Like usual, if no base set is configured, these will run in [`CoreSet::Update`].
     ///
     /// If you would like to control how other systems run based on the current state,
     /// you can emulate this behavior using the [`state_equals`] [`Condition`](bevy_ecs::schedule::Condition).
@@ -341,7 +342,6 @@ impl App {
         for variant in S::variants() {
             main_schedule.configure_set(
                 OnUpdate(variant.clone())
-                    .in_base_set(CoreSet::StateTransitions)
                     .run_if(state_equals(variant))
                     .after(apply_state_transition::<S>),
             );

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -53,7 +53,9 @@ pub struct OnEnter<S: States>(pub S);
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OnExit<S: States>(pub S);
 
-/// A [`SystemSet`] that will run within `CoreSet::StateTransitions` when this state is active.
+/// A [`SystemSet`] that will run when this state is active.
+/// It should always run after [`apply_state_transition::<S>`],
+/// and is configured to do so by default.
 ///
 /// This is provided for convenience. A more general [`state_equals`](crate::schedule::common_conditions::state_equals)
 /// [condition](super::Condition) also exists for systems that need to run elsewhere.


### PR DESCRIPTION
# Objective

The inclusion of timing information in `on_update` is surprising to users, and leads to fairly tricky to debug errors whenever they attempt to schedule it.

Fixes #7632.

## Solution

The `OnUpdate` system set is no longer added to `CoreSet::ApplyStateTransitions`. This lets users change the base set, reduces the number of concerns and allows the `CoreSet::Update` base set get applied by default. This is closest to 0.9 behavior. 

This can result in a set which can span multiple base sets, which can be tricky to visualize.

## Alternatives

1. Let this error continue to bite users, but document what's going wrong better.
2. Removed the `OnUpdate` set (which stuck the system in `StateTransitions`, in favor of simply having `system.on_update(state)` as sugar for `run_if(state_equals(state))`.
3. Remove the `on_update` sugar completely and let people use run conditions themselves.
4. Remove the `OnUpdate` set, and add an `OnUpdate` schedule, which is run via a system which is by default run immediately after `apply_state_transition`.

2 doesn't work well, since I can't easily implement `.run_if` for `SystemConfigs`, as it seems to require cloning `Condition`s.

## Changelog

The `OnUpdate` set is no longer configured to run in `CoreSet::ApplyStateTransitions`.

## Migration Guide

If you needed the timing information imposed by `OnUpdate`, also add `in_base_set(CoreSet::StateTransitions))`. 