### PR TITLE
[Merged by Bors] - add len, is_empty, iter method on SparseSets, make SparseSets inspect…

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -242,7 +242,7 @@ impl ComponentInfo {
         ComponentInfo { id, descriptor }
     }
 
-    /// Create a new [`ComponentInfo`] for test purpose.
+    /// Create a new [`ComponentInfo`] for use in tests.
     #[cfg(test)]
     pub(crate) fn new_for_test(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
         Self::new(id, descriptor)

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -242,7 +242,7 @@ impl ComponentInfo {
         ComponentInfo { id, descriptor }
     }
 
-    /// Create a new ComponentInfo for test purpose
+    /// Create a new [`ComponentInfo`] for test purpose.
     #[cfg(test)]
     pub(crate) fn new_for_test(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
         Self::new(id, descriptor)

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -241,6 +241,12 @@ impl ComponentInfo {
     fn new(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
         ComponentInfo { id, descriptor }
     }
+
+    /// Create a new ComponentInfo for test purpose
+    #[cfg(test)]
+    pub(crate) fn new_for_test(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
+        Self::new(id, descriptor)
+    }
 }
 
 /// A semi-opaque value which uniquely identifies the type of a [`Component`] within a

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -238,14 +238,9 @@ impl ComponentInfo {
         self.descriptor.is_send_and_sync
     }
 
-    fn new(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
+    /// Create a new [`ComponentInfo`].
+    pub(crate) fn new(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
         ComponentInfo { id, descriptor }
-    }
-
-    /// Create a new [`ComponentInfo`] for use in tests.
-    #[cfg(test)]
-    pub(crate) fn new_for_test(id: ComponentId, descriptor: ComponentDescriptor) -> Self {
-        Self::new(id, descriptor)
     }
 }
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -509,7 +509,23 @@ impl SparseSets {
         self.sets.is_empty()
     }
 
-    pub fn get_or_insert(&mut self, component_info: &ComponentInfo) -> &mut ComponentSparseSet {
+    /// An Iterator visiting all ([`ComponentId`], [`SparseSet`]) pairs.
+    /// NOTE: Order is not guaranteed.
+    pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ComponentSparseSet)> {
+        self.sets.iter().map(|(id, data)| (*id, data))
+    }
+
+    /// Gets a reference to the [`CompnoentSparseSet`] of a [`ComponentId`].
+    pub fn get(&self, component_id: ComponentId) -> Option<&ComponentSparseSet> {
+        self.sets.get(component_id)
+    }
+
+    /// Gets a mutable reference of [`ComponentSparseSet`] of a [`ComponentInfo`].
+    /// Create a new [`ComponentSparseSet`] if not exists.
+    pub(crate) fn get_or_insert(
+        &mut self,
+        component_info: &ComponentInfo,
+    ) -> &mut ComponentSparseSet {
         if !self.sets.contains(component_info.id()) {
             self.sets.insert(
                 component_info.id(),
@@ -520,16 +536,13 @@ impl SparseSets {
         self.sets.get_mut(component_info.id()).unwrap()
     }
 
-    pub fn get(&self, component_id: ComponentId) -> Option<&ComponentSparseSet> {
-        self.sets.get(component_id)
-    }
-
-    pub fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ComponentSparseSet> {
+    /// Gets a mutable reference to the [`CompnoentSparseSet`] of a [`ComponentId`].
+    pub(crate) fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ComponentSparseSet> {
         self.sets.get_mut(component_id)
     }
 
     /// Clear entities stored in each [`SparseSet`]
-    pub fn clear_entities(&mut self) {
+    pub(crate) fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
         }
@@ -539,12 +552,6 @@ impl SparseSets {
         for set in self.sets.values_mut() {
             set.check_change_ticks(change_tick);
         }
-    }
-
-    /// An Iterator visiting all ([`ComponentId`], [`SparseSet`]) pairs.
-    /// NOTE: Order is not guaranteed.
-    pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ComponentSparseSet)> {
-        self.sets.iter().map(|(id, data)| (*id, data))
     }
 }
 
@@ -643,7 +650,7 @@ mod tests {
         fn init_component<T: Component>(sets: &mut SparseSets, id: usize) {
             let descriptor = ComponentDescriptor::new::<TestComponent1>();
             let id = ComponentId::new(id);
-            let info = ComponentInfo::new_for_test(id, descriptor);
+            let info = ComponentInfo::new(id, descriptor);
             sets.get_or_insert(&info);
         }
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -497,13 +497,13 @@ pub struct SparseSets {
 }
 
 impl SparseSets {
-    /// Returns the number of [`SparseSet`] this collection contains
+    /// Returns the number of [`SparseSet`]s this collection contains.
     #[inline]
     pub fn len(&self) -> usize {
         self.sets.len()
     }
 
-    /// Returns true if this collection contains no [`SparseSet`]
+    /// Returns true if this collection contains no [`SparseSet`]s.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.sets.is_empty()
@@ -541,7 +541,8 @@ impl SparseSets {
         }
     }
 
-    /// Create an Iterator for each [`ComponentId`] and [`SparseSet`]
+    /// An Iterator visiting all ([`ComponentId`], [`SparseSet`]) pairs.
+    /// NOTE: Order is not guaranteed.
     pub fn iter(&self) -> impl Iterator<Item = (&ComponentId, &ComponentSparseSet)> {
         self.sets.iter()
     }
@@ -629,10 +630,11 @@ mod tests {
         assert_eq!(sets.len(), 2);
 
         // check its shape by iter
-        let collected_sets = sets
+        let mut collected_sets = sets
             .iter()
             .map(|(id, set)| (*id, set.len()))
             .collect::<Vec<_>>();
+        collected_sets.sort();
         assert_eq!(
             collected_sets,
             vec![(ComponentId::new(1), 0), (ComponentId::new(2), 0),]

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -515,7 +515,7 @@ impl SparseSets {
         self.sets.iter().map(|(id, data)| (*id, data))
     }
 
-    /// Gets a reference to the [`CompnoentSparseSet`] of a [`ComponentId`].
+    /// Gets a reference to the [`ComponentSparseSet`] of a [`ComponentId`].
     pub fn get(&self, component_id: ComponentId) -> Option<&ComponentSparseSet> {
         self.sets.get(component_id)
     }
@@ -536,7 +536,7 @@ impl SparseSets {
         self.sets.get_mut(component_info.id()).unwrap()
     }
 
-    /// Gets a mutable reference to the [`CompnoentSparseSet`] of a [`ComponentId`].
+    /// Gets a mutable reference to the [`ComponentSparseSet`] of a [`ComponentId`].
     pub(crate) fn get_mut(&mut self, component_id: ComponentId) -> Option<&mut ComponentSparseSet> {
         self.sets.get_mut(component_id)
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -497,13 +497,13 @@ pub struct SparseSets {
 }
 
 impl SparseSets {
-    /// Returns the number of SparseSet this collection contains
+    /// Returns the number of [`SparseSet`] this collection contains
     #[inline]
     pub fn len(&self) -> usize {
         self.sets.len()
     }
 
-    /// Returns true if this collection contains no SparseSet
+    /// Returns true if this collection contains no [`SparseSet`]
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.sets.is_empty()
@@ -528,7 +528,7 @@ impl SparseSets {
         self.sets.get_mut(component_id)
     }
 
-    /// Clear entities stored in each SparseSet
+    /// Clear entities stored in each [`SparseSet`]
     pub fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -541,7 +541,7 @@ impl SparseSets {
         self.sets.get_mut(component_id)
     }
 
-    /// Clear entities stored in each [`SparseSet`]
+    /// Clear entities stored in each [`ComponentSparseSet`]
     pub(crate) fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -497,6 +497,18 @@ pub struct SparseSets {
 }
 
 impl SparseSets {
+    /// Returns the number of SparseSet this collection contains
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.sets.len()
+    }
+
+    /// Returns true if this collection contains no SparseSet
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.sets.is_empty()
+    }
+
     pub fn get_or_insert(&mut self, component_info: &ComponentInfo) -> &mut ComponentSparseSet {
         if !self.sets.contains(component_info.id()) {
             self.sets.insert(
@@ -516,7 +528,8 @@ impl SparseSets {
         self.sets.get_mut(component_id)
     }
 
-    pub fn clear(&mut self) {
+    /// Clear entities stored in each SparseSet
+    pub fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
         }
@@ -527,11 +540,22 @@ impl SparseSets {
             set.check_change_ticks(change_tick);
         }
     }
+
+    /// Create an Iterator for each [`ComponentId`] and [`SparseSet`]
+    pub fn iter(&self) -> impl Iterator<Item = (&ComponentId, &ComponentSparseSet)> {
+        self.sets.iter()
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::{entity::Entity, storage::SparseSet};
+    use super::SparseSets;
+    use crate::{
+        self as bevy_ecs,
+        component::{Component, ComponentDescriptor, ComponentId, ComponentInfo},
+        entity::Entity,
+        storage::SparseSet,
+    };
 
     #[derive(Debug, Eq, PartialEq)]
     struct Foo(usize);
@@ -583,5 +607,42 @@ mod tests {
 
         *set.get_mut(e1).unwrap() = Foo(11);
         assert_eq!(set.get(e1), Some(&Foo(11)));
+    }
+
+    #[test]
+    fn sparse_sets() {
+        let mut sets = SparseSets::default();
+
+        #[derive(Component, Default, Debug)]
+        struct TestComponent1;
+
+        #[derive(Component, Default, Debug)]
+        struct TestComponent2;
+
+        assert_eq!(sets.len(), 0);
+        assert!(sets.is_empty());
+
+        init_component::<TestComponent1>(&mut sets, 1);
+        assert_eq!(sets.len(), 1);
+
+        init_component::<TestComponent2>(&mut sets, 2);
+        assert_eq!(sets.len(), 2);
+
+        // check its shape by iter
+        let collected_sets = sets
+            .iter()
+            .map(|(id, set)| (*id, set.len()))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            collected_sets,
+            vec![(ComponentId::new(1), 0), (ComponentId::new(2), 0),]
+        );
+
+        fn init_component<T: Component>(sets: &mut SparseSets, id: usize) {
+            let descriptor = ComponentDescriptor::new::<TestComponent1>();
+            let id = ComponentId::new(id);
+            let info = ComponentInfo::new_for_test(id, descriptor);
+            sets.get_or_insert(&info);
+        }
     }
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -543,8 +543,8 @@ impl SparseSets {
 
     /// An Iterator visiting all ([`ComponentId`], [`SparseSet`]) pairs.
     /// NOTE: Order is not guaranteed.
-    pub fn iter(&self) -> impl Iterator<Item = (&ComponentId, &ComponentSparseSet)> {
-        self.sets.iter()
+    pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ComponentSparseSet)> {
+        self.sets.iter().map(|(id, data)| (*id, data))
     }
 }
 
@@ -632,7 +632,7 @@ mod tests {
         // check its shape by iter
         let mut collected_sets = sets
             .iter()
-            .map(|(id, set)| (*id, set.len()))
+            .map(|(id, set)| (id, set.len()))
             .collect::<Vec<_>>();
         collected_sets.sort();
         assert_eq!(

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -497,19 +497,19 @@ pub struct SparseSets {
 }
 
 impl SparseSets {
-    /// Returns the number of [`SparseSet`]s this collection contains.
+    /// Returns the number of [`ComponentSparseSet`]s this collection contains.
     #[inline]
     pub fn len(&self) -> usize {
         self.sets.len()
     }
 
-    /// Returns true if this collection contains no [`SparseSet`]s.
+    /// Returns true if this collection contains no [`ComponentSparseSet`]s.
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.sets.is_empty()
     }
 
-    /// An Iterator visiting all ([`ComponentId`], [`SparseSet`]) pairs.
+    /// An Iterator visiting all ([`ComponentId`], [`ComponentSparseSet`]) pairs.
     /// NOTE: Order is not guaranteed.
     pub fn iter(&self) -> impl Iterator<Item = (ComponentId, &ComponentSparseSet)> {
         self.sets.iter().map(|(id, data)| (*id, data))

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -654,13 +654,13 @@ pub(crate) struct TableMoveResult {
 }
 
 impl Tables {
-    /// Returns the number of [`Table`] this collection contains
+    /// Returns the number of [`Table`]s this collection contains
     #[inline]
     pub fn len(&self) -> usize {
         self.tables.len()
     }
 
-    /// Returns true if this collection contains no [`Table`]
+    /// Returns true if this collection contains no [`Table`]s
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.tables.is_empty()

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -654,11 +654,13 @@ pub(crate) struct TableMoveResult {
 }
 
 impl Tables {
+    /// Returns the number of [`Table`] this collection contains
     #[inline]
     pub fn len(&self) -> usize {
         self.tables.len()
     }
 
+    /// Returns true if this collection contains no [`Table`]
     #[inline]
     pub fn is_empty(&self) -> bool {
         self.tables.is_empty()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1538,7 +1538,7 @@ impl World {
     /// Despawns all entities in this [`World`].
     pub fn clear_entities(&mut self) {
         self.storages.tables.clear();
-        self.storages.sparse_sets.clear();
+        self.storages.sparse_sets.clear_entities();
         self.archetypes.clear_entities();
         self.entities.clear();
     }


### PR DESCRIPTION
…able like Table. Rename clear to clear_entities to clarify that metadata keeps, only value cleared

# Objective

- Provide some inspectability for SparseSets. 

## Solution

- `Tables` has these three methods, len, is_empty and iter too. Add these methods to `SparseSets`, so user can print the shape of storage.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Add `len`, `is_empty`, `iter` methods on SparseSets.
- Rename `clear` to `clear_entities` to clarify its purpose.
- Add `new_for_test` on `ComponentInfo` to make test code easy.
- Add test case covering new methods.

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- Simply adding new functionality is not a breaking change.
