### PR TITLE
[Merged by Bors] - The `size` field of `CalculatedSize` should not be a `Size`

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -15,13 +15,6 @@ pub fn from_rect(
     }
 }
 
-pub fn from_f32_size(scale_factor: f64, size: Size) -> taffy::geometry::Size<f32> {
-    taffy::geometry::Size {
-        width: val_to_f32(scale_factor, size.width),
-        height: val_to_f32(scale_factor, size.height),
-    }
-}
-
 pub fn from_val_size(
     scale_factor: f64,
     size: Size,
@@ -54,15 +47,6 @@ pub fn from_style(scale_factor: f64, value: &Style) -> taffy::style::Style {
         max_size: from_val_size(scale_factor, value.max_size),
         aspect_ratio: value.aspect_ratio,
         gap: from_val_size(scale_factor, value.gap),
-    }
-}
-
-/// Converts a [`Val`] to a [`f32`] while respecting the scale factor.
-pub fn val_to_f32(scale_factor: f64, val: Val) -> f32 {
-    match val {
-        Val::Undefined | Val::Auto => 0.0,
-        Val::Px(value) => (scale_factor * value as f64) as f32,
-        Val::Percent(value) => value / 100.0,
     }
 }
 

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -86,7 +86,10 @@ impl FlexSurface {
         let taffy_style = convert::from_style(scale_factor, style);
         let measure = taffy::node::MeasureFunc::Boxed(Box::new(
             move |constraints: Size<Option<f32>>, _available: Size<AvailableSpace>| {
-                let mut size = convert::from_f32_size(scale_factor, calculated_size.size);
+                let mut size = Size {
+                    width: (scale_factor * calculated_size.size.x as f64) as f32,
+                    height: (scale_factor * calculated_size.size.y as f64) as f32,
+                };
                 match (constraints.width, constraints.height) {
                     (None, None) => {}
                     (Some(width), None) => {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -563,7 +563,7 @@ impl Default for FlexWrap {
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]
 pub struct CalculatedSize {
-    /// The size of the node
+    /// The size of the node in logical pixels
     pub size: Vec2,
     /// Whether to attempt to preserve the aspect ratio when determining the layout for this item
     pub preserve_aspect_ratio: bool,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -564,14 +564,14 @@ impl Default for FlexWrap {
 #[reflect(Component)]
 pub struct CalculatedSize {
     /// The size of the node
-    pub size: Size,
+    pub size: Vec2,
     /// Whether to attempt to preserve the aspect ratio when determining the layout for this item
     pub preserve_aspect_ratio: bool,
 }
 
 impl CalculatedSize {
     const DEFAULT: Self = Self {
-        size: Size::DEFAULT,
+        size: Vec2::ZERO,
         preserve_aspect_ratio: false,
     };
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,9 +1,10 @@
-use crate::{CalculatedSize, Size, UiImage, Val};
+use crate::{CalculatedSize, UiImage};
 use bevy_asset::Assets;
 use bevy_ecs::{
     query::Without,
     system::{Query, Res},
 };
+use bevy_math::Vec2;
 use bevy_render::texture::Image;
 use bevy_text::Text;
 
@@ -14,10 +15,10 @@ pub fn update_image_calculated_size_system(
 ) {
     for (mut calculated_size, image) in &mut query {
         if let Some(texture) = textures.get(&image.texture) {
-            let size = Size {
-                width: Val::Px(texture.texture_descriptor.size.width as f32),
-                height: Val::Px(texture.texture_descriptor.size.height as f32),
-            };
+            let size = Vec2::new(
+                texture.texture_descriptor.size.width as f32,
+                texture.texture_descriptor.size.height as f32,
+            );
             // Update only if size has changed to avoid needless layout calculations
             if size != calculated_size.size {
                 calculated_size.size = size;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{CalculatedSize, Size, Style, UiScale, Val};
+use crate::{CalculatedSize, Style, UiScale, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -135,10 +135,10 @@ pub fn text_system(
                     panic!("Fatal error when processing text: {e}.");
                 }
                 Ok(info) => {
-                    calculated_size.size = Size {
-                        width: Val::Px(scale_value(info.size.x, inv_scale_factor)),
-                        height: Val::Px(scale_value(info.size.y, inv_scale_factor)),
-                    };
+                    calculated_size.size = Vec2::new(
+                        scale_value(info.size.x, inv_scale_factor),
+                        scale_value(info.size.y, inv_scale_factor),
+                    );
                     match text_layout_info {
                         Some(mut t) => *t = info,
                         None => {


### PR DESCRIPTION
# Objective

The `size` field of `CalculatedSize` shouldn't be a `Size` as it only ever stores (unscaled) pixel values. By default its fields are `Val::Auto` but these are converted to `0`s before being sent to Taffy.

## Solution

Change the `size` field of `CalculatedSize` to a Vec2.

## Changelog

* Changed the `size` field of `CalculatedSize` to a Vec2.
* Removed the `Val` <-> `f32`  conversion code for  `CalculatedSize`.

## Migration Guide

* The size field of `CalculatedSize` has been changed to a `Vec2`.