### PR TITLE
Renamed add_plugins to add_plugin_group to be more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ use bevy::prelude::*;
 
 fn main(){
   App::new()
-    .add_plugins(DefaultPlugins)
+    .add_plugin_group(DefaultPlugins)
     .run();
 }
 ```

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -815,7 +815,10 @@ impl App {
     }
 
     /// This function is deprecated. Please use add_plugin_group instead.
-    #[deprecated(note = "This function is deprecated in favor of add_plugin_group.")]
+    #[deprecated(
+        since = "0.9.1",
+        note = "This function is deprecated in favor of add_plugin_group."
+    )]
     pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {
         self.add_plugin_group(group)
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -814,7 +814,7 @@ impl App {
             .collect()
     }
 
-    /// This function is deprecated. Please use add_plugin_group instead.
+    /// This function is deprecated. Please use `add_plugin_group` instead.
     #[deprecated(
         since = "0.9.1",
         note = "This function is deprecated in favor of add_plugin_group."

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -814,6 +814,12 @@ impl App {
             .collect()
     }
 
+    /// This function is deprecated. Please use add_plugin_group instead.
+    #[deprecated(note = "This function is deprecated in favor of add_plugin_group.")]
+    pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {
+        self.add_plugin_group(group)
+    }
+
     /// Adds a group of [`Plugin`]s.
     ///
     /// [`Plugin`]s can be grouped into a set by using a [`PluginGroup`].

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -816,7 +816,7 @@ impl App {
 
     /// This function is deprecated. Please use `add_plugin_group` instead.
     #[deprecated(
-        since = "0.9.1",
+        since = "0.10.0",
         note = "This function is deprecated in favor of add_plugin_group."
     )]
     pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -719,7 +719,7 @@ impl App {
     /// One of Bevy's core principles is modularity. All Bevy engine features are implemented
     /// as [`Plugin`]s. This includes internal features like the renderer.
     ///
-    /// Bevy also provides a few sets of default [`Plugin`]s. See [`add_plugins`](Self::add_plugins).
+    /// Bevy also provides a few sets of default [`Plugin`]s. See [`add_plugin_group`](Self::add_plugin_group).
     ///
     /// # Examples
     ///
@@ -830,13 +830,13 @@ impl App {
     /// # use bevy_app::{prelude::*, PluginGroupBuilder, NoopPluginGroup as MinimalPlugins};
     /// #
     /// App::new()
-    ///     .add_plugins(MinimalPlugins);
+    ///     .add_plugin_group(MinimalPlugins);
     /// ```
     ///
     /// # Panics
     ///
     /// Panics if one of the plugin in the group was already added to the application.
-    pub fn add_plugins<T: PluginGroup>(&mut self, group: T) -> &mut Self {
+    pub fn add_plugin_group<T: PluginGroup>(&mut self, group: T) -> &mut Self {
         let builder = group.build();
         builder.finish(self);
         self

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -198,7 +198,7 @@ impl PluginGroupBuilder {
 /// use bevy_app::NoopPluginGroup as MinimalPlugins;
 ///
 /// fn main(){
-///     App::new().add_plugins(MinimalPlugins).run();
+///     App::new().add_plugin_group(MinimalPlugins).run();
 /// }
 /// ```
 #[doc(hidden)]

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -7,7 +7,7 @@
 //! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins};
 //! fn main() {
 //!    App::new()
-//!         .add_plugins(MinimalPlugins)
+//!         .add_plugin_group(MinimalPlugins)
 //!         .add_plugin(AssetPlugin::default())
 //!         .add_plugin(AudioPlugin)
 //!         .add_startup_system(play_background_audio)

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -52,7 +52,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// # use bevy_utils::tracing::Level;
 /// fn main() {
 ///     App::new()
-///         .add_plugins(DefaultPlugins.set(LogPlugin {
+///         .add_plugin_group(DefaultPlugins.set(LogPlugin {
 ///             level: Level::DEBUG,
 ///             filter: "wgpu=error,bevy_render=info,bevy_ecs=trace".to_string(),
 ///         }))
@@ -74,7 +74,7 @@ use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
 /// # use bevy_log::LogPlugin;
 /// fn main() {
 ///     App::new()
-///         .add_plugins(DefaultPlugins.build().disable::<LogPlugin>())
+///         .add_plugin_group(DefaultPlugins.build().disable::<LogPlugin>())
 ///         .run();
 /// }
 /// ```

--- a/errors/B0001.md
+++ b/errors/B0001.md
@@ -22,7 +22,7 @@ fn move_enemies_to_player(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(move_enemies_to_player)
         .run();
 }
@@ -54,7 +54,7 @@ fn move_enemies_to_player(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(move_enemies_to_player)
         .run();
 }
@@ -84,7 +84,7 @@ fn move_enemies_to_player(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(move_enemies_to_player)
         .run();
 }

--- a/errors/B0002.md
+++ b/errors/B0002.md
@@ -16,7 +16,7 @@ fn update_materials(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(update_materials)
         .run();
 }
@@ -37,7 +37,7 @@ fn update_materials(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(update_materials)
         .run();
 }

--- a/errors/B0003.md
+++ b/errors/B0003.md
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(despawning)
         .add_system(use_entity.after(despawning))

--- a/errors/B0004.md
+++ b/errors/B0004.md
@@ -49,7 +49,7 @@ fn setup_cube(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_cube)
         .run();
 }
@@ -96,7 +96,7 @@ fn setup_cube(
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_cube)
         .run();
 }

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -32,7 +32,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(ColoredMesh2dPlugin)
         .add_startup_system(star)
         .run();

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(sprite_movement)
         .run();

--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_plugin_group(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_startup_system(setup)
         .add_system(sprite_movement)
         .run();

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -7,7 +7,7 @@ const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_systems_to_schedule(
             CoreSchedule::FixedUpdate,

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
+        .add_plugin_group(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_startup_system(setup)
         .add_system(animate_sprite)
         .run();

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -12,7 +12,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(animate_translation)
         .add_system(animate_rotation)

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -6,7 +6,7 @@ use bevy::{asset::LoadState, prelude::*};
 fn main() {
     App::new()
         .init_resource::<RpgSpriteHandles>()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
+        .add_plugin_group(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_state::<AppState>()
         .add_system_to_schedule(OnEnter(AppState::Setup), load_textures)
         .add_system(check_textures.on_update(AppState::Setup))

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -10,7 +10,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_plugin_group(DefaultPlugins.set(ImagePlugin::default_nearest()))
         .add_startup_system(setup)
         .add_system(rotate)
         .run();

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_camera_fog)
         .add_startup_system(setup_terrain_scene)
         .add_startup_system(setup_instructions)

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -16,7 +16,7 @@ use rand::random;
 fn main() {
     let mut app = App::new();
 
-    app.add_plugins(DefaultPlugins)
+    app.add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(example_control_system);
 

--- a/examples/3d/bloom.rs
+++ b/examples/3d/bloom.rs
@@ -8,7 +8,7 @@ use std::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_scene)
         .add_system(update_bloom_settings)
         .add_system(bounce_spheres)

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -21,7 +21,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_camera_fog)
         .add_startup_system(setup_pyramid_scene)
         .add_startup_system(setup_instructions)

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -16,7 +16,7 @@ fn main() {
     App::new()
         // Disable MSAA by default
         .insert_resource(Msaa::Off)
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(toggle_fxaa)
         .run();

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -7,7 +7,7 @@ use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(movement)
         .add_system(animate_light_direction)

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<LineMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -14,7 +14,7 @@ fn main() {
             brightness: 1.0 / 5.0f32,
         })
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(animate_light_direction)
         .run();

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -11,7 +11,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(Msaa::default())
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(cycle_msaa)
         .run();

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, render::camera::ScalingMode};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotator_system)
         .run();

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -4,7 +4,7 @@ use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(environment_map_load_finish)
         .run();

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -16,7 +16,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(cube_rotator_system)
         .add_system(rotator_system)

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -18,7 +18,7 @@ fn main() {
     7/8    - decrease/increase direction light normal bias"
     );
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(adjust_point_light_biases)
         .add_system(toggle_light)

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -15,7 +15,7 @@ fn main() {
     L      - switch between directional and point lights"
     );
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(toggle_light)
         .add_system(toggle_shadows)

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -44,7 +44,7 @@ const CUBEMAPS: &[(&str, CompressedImageFormats)] = &[
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CubemapMaterial>::default())
         .add_startup_system(setup)
         .add_system(cycle_cubemap_asset)

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -9,7 +9,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(set_camera_viewports)
         .run();

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -9,7 +9,7 @@ use rand::{thread_rng, Rng};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(Msaa::default())
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(fade_transparency)
         .run();

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -4,7 +4,7 @@ use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(move_scene_entities)
         .run();

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, render::mesh::VertexAttributeValues};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(RenderPlugin {
+        .add_plugin_group(DefaultPlugins.set(RenderPlugin {
             wgpu_settings: WgpuSettings {
                 features: WgpuFeatures::POLYGON_MODE_LINE,
                 ..default()

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0,

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(AmbientLight {
             color: Color::WHITE,
             brightness: 1.0,

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -15,7 +15,7 @@ use rand::Rng;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 1.0,
             ..default()

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -7,7 +7,7 @@ use bevy::{pbr::AmbientLight, prelude::*, render::mesh::skinning::SkinnedMesh};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 1.0,
             ..default()

--- a/examples/app/drag_and_drop.rs
+++ b/examples/app/drag_and_drop.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(file_drag_and_drop_system)
         .run();
 }

--- a/examples/app/empty_defaults.rs
+++ b/examples/app/empty_defaults.rs
@@ -3,5 +3,5 @@
 use bevy::prelude::*;
 
 fn main() {
-    App::new().add_plugins(DefaultPlugins).run();
+    App::new().add_plugin_group(DefaultPlugins).run();
 }

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -12,7 +12,7 @@ fn main() {
     // this app runs once
     App::new()
         .insert_resource(ScheduleRunnerSettings::run_once())
-        .add_plugins(MinimalPlugins)
+        .add_plugin_group(MinimalPlugins)
         .add_system(hello_world_system)
         .run();
 
@@ -21,7 +21,7 @@ fn main() {
         .insert_resource(ScheduleRunnerSettings::run_loop(Duration::from_secs_f64(
             1.0 / 60.0,
         )))
-        .add_plugins(MinimalPlugins)
+        .add_plugin_group(MinimalPlugins)
         .add_system(counter)
         .run();
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
+        .add_plugin_group(DefaultPlugins.set(bevy::log::LogPlugin {
             // Uncomment this to override the default log settings:
             // level: bevy::log::Level::TRACE,
             // filter: "wgpu=warn,bevy_ecs=info".to_string(),

--- a/examples/app/no_renderer.rs
+++ b/examples/app/no_renderer.rs
@@ -11,7 +11,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(RenderPlugin {
+        .add_plugin_group(DefaultPlugins.set(RenderPlugin {
             wgpu_settings: WgpuSettings {
                 backends: None,
                 ..default()

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -8,7 +8,7 @@ use bevy::{prelude::*, utils::Duration};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // plugins are registered as part of the "app building" process
         .add_plugin(PrintMessagePlugin {
             wait_duration: Duration::from_secs(1),

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -6,11 +6,11 @@ use bevy::{app::PluginGroupBuilder, prelude::*};
 fn main() {
     App::new()
         // Two PluginGroups that are included with bevy are DefaultPlugins and MinimalPlugins
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Adding a plugin group adds all plugins in the group by default
-        .add_plugins(HelloWorldPlugins)
+        .add_plugin_group(HelloWorldPlugins)
         // You can also modify a PluginGroup (such as disabling plugins) like this:
-        // .add_plugins(
+        // .add_plugin_group(
         //     HelloWorldPlugins
         //         .build()
         //         .disable::<PrintWorldPlugin>()

--- a/examples/app/return_after_run.rs
+++ b/examples/app/return_after_run.rs
@@ -20,7 +20,7 @@ fn main() {
             return_from_run: true,
             ..default()
         })
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "Close the window to return to the main function".into(),
                 ..default()

--- a/examples/app/thread_pool_resources.rs
+++ b/examples/app/thread_pool_resources.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(TaskPoolPlugin {
+        .add_plugin_group(DefaultPlugins.set(TaskPoolPlugin {
             task_pool_options: TaskPoolOptions::with_num_threads(4),
         }))
         .run();

--- a/examples/app/without_winit.rs
+++ b/examples/app/without_winit.rs
@@ -5,7 +5,7 @@ use bevy::winit::WinitPlugin;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.build().disable::<WinitPlugin>())
+        .add_plugin_group(DefaultPlugins.build().disable::<WinitPlugin>())
         .add_system(setup_system)
         .run();
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -37,7 +37,7 @@ impl AssetLoader for CustomAssetLoader {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<State>()
         .add_asset::<CustomAsset>()
         .init_asset_loader::<CustomAssetLoader>()

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -63,7 +63,7 @@ impl Plugin for CustomAssetIoPlugin {
 
 fn main() {
     App::new()
-        .add_plugins(
+        .add_plugin_group(
             DefaultPlugins
                 .build()
                 // the custom asset io plugin must be inserted in-between the

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(AssetPlugin {
+        .add_plugin_group(DefaultPlugins.set(AssetPlugin {
             // Tell the asset server to watch for asset changes on disk:
             watch_for_changes: true,
             ..default()

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -11,7 +11,7 @@ use std::time::{Duration, Instant};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_env)
         .add_startup_system(add_assets)
         .add_startup_system(spawn_tasks)

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -9,7 +9,7 @@ use std::time::{Duration, Instant};
 fn main() {
     App::new()
         .add_event::<StreamEvent>()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(read_stream)
         .add_system(spawn_text)

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -4,7 +4,7 @@ use bevy::{audio::AudioSink, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(update_speed)
         .add_system(pause)

--- a/examples/audio/decodable.rs
+++ b/examples/audio/decodable.rs
@@ -85,7 +85,7 @@ impl Decodable for SineAudio {
 fn main() {
     let mut app = App::new();
     // register the audio source so that it can be used
-    app.add_plugins(DefaultPlugins)
+    app.add_plugin_group(DefaultPlugins)
         .add_audio_source::<SineAudio>()
         .add_startup_system(setup)
         .run();

--- a/examples/diagnostics/custom_diagnostic.rs
+++ b/examples/diagnostics/custom_diagnostic.rs
@@ -7,7 +7,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // The "print diagnostics" plugin is optional.
         // It just visualizes our diagnostics in the console.
         .add_plugin(LogDiagnosticsPlugin::default())

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -7,7 +7,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Adds frame time diagnostics
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         // Adds a system that prints diagnostics to the console

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -5,7 +5,7 @@ use rand::Rng;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(change_component)
         .add_system(change_detection)

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_event::<MyEvent>()
         .add_event::<PlaySound>()
         .init_resource::<EventTriggerState>()

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 const FIXED_TIMESTEP: f32 = 0.5;
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // this system will run once every update (it should match your screen's refresh rate)
         .add_system(frame_update)
         // add our system to the fixed timestep schedule

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -40,7 +40,7 @@ struct LevelUnload;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_state::<AppState>()
         .add_startup_system(setup_system)
         .add_system(print_text_system)

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotate)
         .run();

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -7,7 +7,7 @@ const DELTA_TIME: f32 = 0.01;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(AmbientLight {
             brightness: 0.03,
             ..default()

--- a/examples/ecs/nondeterministic_system_order.rs
+++ b/examples/ecs/nondeterministic_system_order.rs
@@ -50,7 +50,7 @@ fn main() {
         // or between DefaultPlugins and any of your third party plugins,
         // please file a bug with the repo responsible!
         // Only *you* can prevent nondeterministic bugs due to greedy parallelism.
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .run();
 }
 

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -68,7 +68,7 @@ fn bounce_system(windows: Query<&Window>, mut sprites: Query<(&Transform, &mut V
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(spawn_system)
         .add_system(move_system)
         .add_system(bounce_system)

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -13,7 +13,7 @@ fn main() {
     // With these constraints in mind we make sure to place the system that removes a `Component` in
     // `CoreSet::Update', and the system that reacts on the removal in `CoreSet::PostUpdate`.
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(remove_component)
         .add_system(react_on_removal.in_base_set(CoreSet::PostUpdate))

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -9,7 +9,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_state::<AppState>()
         .add_startup_system(setup)
         // This system runs when we enter `AppState::Menu`, during `CoreSet::StateTransitions`.

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -4,7 +4,7 @@ use bevy::{log::info, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<Countdown>()
         .add_startup_system(setup)
         .add_system(countdown)

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -22,7 +22,7 @@ fn main() {
             5.0,
             TimerMode::Repeating,
         )))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_state::<GameState>()
         .add_startup_system(setup_cameras)
         .add_system_to_schedule(OnEnter(GameState::Playing), setup)

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -52,7 +52,7 @@ const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(Scoreboard { score: 0 })
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_startup_system(setup)

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -10,7 +10,7 @@ use std::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_contributor_selection)
         .add_startup_system(setup)
         .add_system(velocity_system)

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -29,7 +29,7 @@ struct Volume(u32);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Insert as resource the initial value for the settings resources
         .insert_resource(DisplayQuality::Medium)
         .insert_resource(Volume(7))

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, window::ReceivedCharacter};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(print_char_event_system)
         .run();
 }

--- a/examples/input/gamepad_input.rs
+++ b/examples/input/gamepad_input.rs
@@ -4,7 +4,7 @@ use bevy::{input::gamepad::GamepadButton, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(gamepad_system)
         .run();
 }

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -9,7 +9,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(gamepad_events)
         .add_system(gamepad_ordered_events)
         .run();

--- a/examples/input/keyboard_input.rs
+++ b/examples/input/keyboard_input.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(keyboard_input_system)
         .run();
 }

--- a/examples/input/keyboard_input_events.rs
+++ b/examples/input/keyboard_input_events.rs
@@ -4,7 +4,7 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(print_keyboard_event_system)
         .run();
 }

--- a/examples/input/keyboard_modifiers.rs
+++ b/examples/input/keyboard_modifiers.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(keyboard_input_system)
         .run();
 }

--- a/examples/input/mouse_grab.rs
+++ b/examples/input/mouse_grab.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, window::CursorGrabMode};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(grab_mouse)
         .run();
 }

--- a/examples/input/mouse_input.rs
+++ b/examples/input/mouse_input.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(mouse_click_system)
         .run();
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -7,7 +7,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(print_mouse_events_system)
         .run();
 }

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -8,7 +8,7 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_scene)
         .add_system(toggle_ime)
         .add_system(listen_ime_events)

--- a/examples/input/touch_input.rs
+++ b/examples/input/touch_input.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::*, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(touch_system)
         .run();
 }

--- a/examples/input/touch_input_events.rs
+++ b/examples/input/touch_input_events.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::*, prelude::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_system(touch_event_system)
         .run();
 }

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -4,7 +4,7 @@ use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 #[bevy_main]
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resizable: false,
                 mode: WindowMode::BorderlessFullscreen,

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -5,7 +5,7 @@ use std::any::TypeId;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // You must manually register each instance of a generic type
         .register_type::<MyType<u32>>()
         .add_startup_system(setup)

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -15,7 +15,7 @@ use serde::de::DeserializeSeed;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .register_type::<Foo>()
         .register_type::<Bar>()
         .add_startup_system(setup)

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/reflection/trait_reflection.rs
+++ b/examples/reflection/trait_reflection.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .register_type::<MyType>()
         .run();

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -6,7 +6,7 @@ use bevy::{prelude::*, tasks::IoTaskPool, utils::Duration};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(AssetPlugin {
+        .add_plugin_group(DefaultPlugins.set(AssetPlugin {
             // This tells the AssetServer to watch for changes to assets.
             // It enables our scenes to automatically reload in game when we modify their files.
             watch_for_changes: true,

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, reflect::TypeUuid, render::render_resource::*};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -9,7 +9,7 @@ use bevy::{
 /// uniform variable.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<ArrayTextureMaterial>::default())
         .add_startup_system(setup)
         .add_system(create_array_texture)

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -23,7 +23,7 @@ const WORKGROUP_SIZE: u32 = 8;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 // uncomment for unthrottled FPS
                 // present_mode: bevy::window::PresentMode::AutoNoVsync,

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -21,7 +21,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(Material2dPlugin::<PostProcessingMaterial>::default())
         .add_startup_system(setup)
         .add_system(main_camera_cube_rotator_system)

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -26,7 +26,7 @@ use bytemuck::{Pod, Zeroable};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(CustomMaterialPlugin)
         .add_startup_system(setup)
         .run();

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -14,7 +14,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .run();

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
         .add_startup_system(setup)
         .add_system(rotate_camera)

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -15,7 +15,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(PbrPlugin {
+        .add_plugin_group(DefaultPlugins.set(PbrPlugin {
             // The prepass is enabled by default on the StandardMaterial,
             // but you can disable it if you need to.
             // prepass_enabled: false,

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroU32;
 
 fn main() {
     let mut app = App::new();
-    app.add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()));
+    app.add_plugin_group(DefaultPlugins.set(ImagePlugin::default_nearest()));
 
     let render_device = app.world.resource::<RenderDevice>();
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -28,7 +28,7 @@ struct Bird {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "BevyMark".into(),
                 resolution: (800., 600.).into(),

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -25,7 +25,7 @@ fn main() {
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
                 ..default()

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -11,7 +11,7 @@ const FONT_SIZE: f32 = 7.0;
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::Immediate,
                 ..default()

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -21,7 +21,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
                 ..default()

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -20,7 +20,7 @@ struct Foxes {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "🦊🦊🦊 Many Foxes! 🦊🦊🦊".into(),
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -15,7 +15,7 @@ use rand::{thread_rng, Rng};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: (1024.0, 768.0).into(),
                 title: "many_lights".into(),

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -33,7 +33,7 @@ fn main() {
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
                 ..default()

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -183,7 +183,7 @@ fn main() {
 
     App::new()
         .insert_resource(cfg)
-        .add_plugins(MinimalPlugins)
+        .add_plugin_group(MinimalPlugins)
         .add_plugin(TransformPlugin::default())
         .add_startup_system(setup)
         // Updating transforms *must* be done before `CoreSet::PostUpdate`

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -123,7 +123,7 @@ impl GamepadButtonBundle {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .init_resource::<ButtonMaterials>()
         .init_resource::<ButtonMeshes>()
         .init_resource::<FontHandle>()

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -24,7 +24,7 @@ fn main() {
         color: Color::WHITE,
         brightness: 1.0 / 5.0f32,
     })
-    .add_plugins(
+    .add_plugin_group(
         DefaultPlugins
             .set(WindowPlugin {
                 primary_window: Some(Window {

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -12,7 +12,7 @@ struct Rotatable {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(rotate_cube)
         .run();

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -28,7 +28,7 @@ impl Scaling {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(change_scale_direction)
         .add_system(scale_cube)

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -23,7 +23,7 @@ struct Center {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(move_cube)
         .add_system(rotate_cube)

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -24,7 +24,7 @@ impl Movable {
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(move_cube)
         .run();

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, winit::WinitSettings};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .init_resource::<State>()
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(text_update_system)
         .add_system(atlas_render_system)

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -4,7 +4,7 @@ use bevy::{prelude::*, ui::RelativeCursorPosition, winit::WinitSettings};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -10,7 +10,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(text_update_system)

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
                 ..default()

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -7,7 +7,7 @@ const MARGIN: Val = Val::Px(5.);
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: [870., 1066.].into(),
                 title: "Bevy Text Layout Example".to_string(),

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -8,7 +8,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_startup_system(setup)

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -6,7 +6,7 @@ const SCALE_TIME: u64 = 400;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .insert_resource(TextSettings {
             allow_dynamic_font_size: true,
             ..default()

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::NONE)) // Use a transparent window, to make effects obvious.
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 // Set the window's parameters, note we're setting the window to always be on top.
                 transparent: true,

--- a/examples/ui/z_index.rs
+++ b/examples/ui/z_index.rs
@@ -8,7 +8,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .run();
 }

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup)
         .add_system(change_clear_color)
         .run();

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -25,7 +25,7 @@ fn main() {
             ..default()
         })
         .insert_resource(ExampleMode::Game)
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 // Turn off vsync to maximize CPU/GPU usage
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, render::camera::RenderTarget, window::WindowRef};
 fn main() {
     App::new()
         // By default, a primary window gets spawned by `WindowPlugin`, contained in `DefaultPlugins`
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_scene)
         .add_system(bevy::window::close_on_esc)
         .run();

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, window::WindowResolution};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: WindowResolution::new(500., 300.).with_scale_factor_override(1.0),
                 ..default()

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -14,7 +14,7 @@ fn main() {
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
         .add_startup_system(setup)
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 // Setting `transparent` allows the `ClearColor`'s alpha value to take effect
                 transparent: true,

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -8,7 +8,7 @@ fn main() {
             medium: Vec2::new(800.0, 600.0),
             small: Vec2::new(640.0, 360.0),
         })
-        .add_plugins(DefaultPlugins)
+        .add_plugin_group(DefaultPlugins)
         .add_startup_system(setup_camera)
         .add_startup_system(setup_ui)
         .add_system(on_resize_system)

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -9,7 +9,7 @@ use bevy::{
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "I am a window!".into(),
                 resolution: (500., 300.).into(),

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -6,7 +6,7 @@ fn main() {
     // TODO: Combine this with `resizing` once multiple_windows is simpler than
     // it is currently.
     App::new()
-        .add_plugins(DefaultPlugins.set(WindowPlugin {
+        .add_plugin_group(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 title: "Minimising".into(),
                 ..default()

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -23,7 +23,7 @@ fn main() {
             width: MAX_WIDTH,
             height: MAX_HEIGHT,
         })
-        .add_plugins(
+        .add_plugin_group(
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     resolution: WindowResolution::new(MAX_WIDTH as f32, MAX_HEIGHT as f32)


### PR DESCRIPTION
This is my first PR so please let me know if I'm doing something incorrectly. This touches quite a few files, but it's largely just renaming the add_plugins function.

That being said, would we favor deprecating usage of add_plugins somehow (such as emitting a warning if possible?) instead of just removing it outright? Let me know if that's more desirable and I can change this PR. 

@alice-i-cecile FYI!

# Objective

- New users seem to often run into issues with add_plugins
- Fix the issue described in #7631 

## Solution

- Rename add_plugins to add_plugin_group.

---

## Migration Guide

-Users will have to change all usages of add_plugins to add_plugin_group in order to compile without warnings.

