### PR TITLE
Keep `async-channel` version same

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -20,7 +20,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.9.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.9.0" }
 bevy_ecs_macros = { path = "macros", version = "0.9.0" }
 
-async-channel = "1.4"
+async-channel = "1.8"
 event-listener = "2.5"
 thread_local = "1.1.4"
 fixedbitset = "0.4.2"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [dependencies]
 futures-lite = "1.4.0"
 async-executor = "1.3.0"
-async-channel = "1.4.2"
+async-channel = "1.8"
 async-task = "4.2.0"
 once_cell = "1.7"
 concurrent-queue = "2.0.0"


### PR DESCRIPTION
# Objective

When I update bevy to latest bevy main branch for my game, `async-channel` version conflicts.
```
error: failed to select a version for `async-channel`.
    ... required by package `bevy_render v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_render` of package `bevy_core_pipeline v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_core_pipeline` of package `bevy_gltf v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_gltf` of package `bevy_internal v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_internal` of package `bevy v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy` of package `tetris v0.1.0 (/Users/lewis/Github/tetris)`
versions that meet the requirements `^1.8` are: 1.8.0

all possible versions conflict with previously selected packages.

  previously selected package `async-channel v1.7.1`
    ... which satisfies dependency `async-channel = "^1.4"` (locked to 1.7.1) of package `bevy_ecs v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_ecs` of package `bevy_animation v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_animation` of package `bevy_gltf v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_gltf` of package `bevy_internal v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy_internal` of package `bevy v0.9.0 (https://github.com/bevyengine/bevy?rev=f7fbfaf9c72035e98c6b6cec0c7d26ff9f5b1c82#f7fbfaf9)`
    ... which satisfies git dependency `bevy` of package `tetris v0.1.0 (/Users/lewis/Github/tetris)`

failed to select a version for `async-channel` which could resolve this conflict
```

## Solution

- Keep `async-channel` version same