### PR TITLE
[Merged by Bors] - Add Beziers to `bevy_math`

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -16,6 +16,7 @@ bevy_ecs = { path = "../crates/bevy_ecs" }
 bevy_reflect = { path = "../crates/bevy_reflect" }
 bevy_tasks = { path = "../crates/bevy_tasks" }
 bevy_utils = { path = "../crates/bevy_utils" }
+bevy_math = { path = "../crates/bevy_math" }
 
 [profile.release]
 opt-level = 3
@@ -49,4 +50,9 @@ harness = false
 [[bench]]
 name = "iter"
 path = "benches/bevy_tasks/iter.rs"
+harness = false
+
+[[bench]]
+name = "bezier"
+path = "benches/bevy_math/bezier.rs"
 harness = false

--- a/benches/benches/bevy_math/bezier.rs
+++ b/benches/benches/bevy_math/bezier.rs
@@ -14,72 +14,102 @@ fn easing(c: &mut Criterion) {
 }
 
 fn fifteen_degree(c: &mut Criterion) {
-    let bezier = Bezier::new([
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 0.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 0.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 0.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 0.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
+    let bezier = Bezier::<Vec3A, 16>::new([
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
     ]);
     c.bench_function("fifteen_degree_position", |b| {
         b.iter(|| bezier.position(black_box(0.5)));
     });
 }
 
+fn quadratic_2d(c: &mut Criterion) {
+    let bezier = QuadraticBezier2d::new([[0.0, 0.0], [0.0, 1.0], [1.0, 1.0]]);
+    c.bench_function("quadratic_position_Vec2", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
 fn quadratic(c: &mut Criterion) {
-    let bezier = QuadraticBezier3d::new([
-        vec3a(0.0, 0.0, 0.0),
-        vec3a(0.0, 1.0, 0.0),
-        vec3a(1.0, 1.0, 1.0),
-    ]);
-    c.bench_function("quadratic_position", |b| {
+    let bezier = QuadraticBezier3d::new([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0]]);
+    c.bench_function("quadratic_position_Vec3A", |b| {
         b.iter(|| bezier.position(black_box(0.5)));
     });
 }
 
 fn quadratic_vec3(c: &mut Criterion) {
-    let bezier = Bezier::new([
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
-    ]);
+    let bezier = Bezier::<Vec3, 3>::new([[0.0, 0.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0]]);
     c.bench_function("quadratic_position_Vec3", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn cubic_2d(c: &mut Criterion) {
+    let bezier = CubicBezier2d::new([[0.0, 0.0], [0.0, 1.0], [1.0, 0.0], [1.0, 1.0]]);
+    c.bench_function("cubic_position_Vec2", |b| {
         b.iter(|| bezier.position(black_box(0.5)));
     });
 }
 
 fn cubic(c: &mut Criterion) {
     let bezier = CubicBezier3d::new([
-        vec3a(0.0, 0.0, 0.0),
-        vec3a(0.0, 1.0, 0.0),
-        vec3a(1.0, 0.0, 0.0),
-        vec3a(1.0, 1.0, 1.0),
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
     ]);
-    c.bench_function("cubic_position", |b| {
+    c.bench_function("cubic_position_Vec3A", |b| {
         b.iter(|| bezier.position(black_box(0.5)));
     });
 }
 
 fn cubic_vec3(c: &mut Criterion) {
-    let bezier = Bezier::new([
-        vec3(0.0, 0.0, 0.0),
-        vec3(0.0, 1.0, 0.0),
-        vec3(1.0, 0.0, 0.0),
-        vec3(1.0, 1.0, 1.0),
+    let bezier = Bezier::<Vec3, 4>::new([
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
     ]);
     c.bench_function("cubic_position_Vec3", |b| {
         b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn build_pos_cubic(c: &mut Criterion) {
+    let bezier = CubicBezier3d::new([
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
+    ]);
+    c.bench_function("build_pos_cubic_100_points", |b| {
+        b.iter(|| bezier.iter_positions(black_box(100)).collect::<Vec<_>>());
+    });
+}
+
+fn build_accel_cubic(c: &mut Criterion) {
+    let bezier = CubicBezier3d::new([
+        [0.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [1.0, 0.0, 0.0],
+        [1.0, 1.0, 1.0],
+    ]);
+    c.bench_function("build_accel_cubic_100_points", |b| {
+        b.iter(|| bezier.iter_positions(black_box(100)).collect::<Vec<_>>());
     });
 }
 
@@ -87,9 +117,13 @@ criterion_group!(
     benches,
     easing,
     fifteen_degree,
+    quadratic_2d,
     quadratic,
     quadratic_vec3,
+    cubic_2d,
     cubic,
-    cubic_vec3
+    cubic_vec3,
+    build_pos_cubic,
+    build_accel_cubic,
 );
 criterion_main!(benches);

--- a/benches/benches/bevy_math/bezier.rs
+++ b/benches/benches/bevy_math/bezier.rs
@@ -1,0 +1,95 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use bevy_math::*;
+
+fn easing(c: &mut Criterion) {
+    let cubic_bezier = CubicBezierEasing::new(vec2(0.25, 0.1), vec2(0.25, 1.0));
+    c.bench_function("easing_1000", |b| {
+        b.iter(|| {
+            (0..1000).map(|i| i as f32 / 1000.0).for_each(|t| {
+                cubic_bezier.ease(black_box(t));
+            })
+        });
+    });
+}
+
+fn fifteen_degree(c: &mut Criterion) {
+    let bezier = Bezier::new([
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+    ]);
+    c.bench_function("fifteen_degree_position", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn quadratic(c: &mut Criterion) {
+    let bezier = QuadraticBezier3d::new([
+        vec3a(0.0, 0.0, 0.0),
+        vec3a(0.0, 1.0, 0.0),
+        vec3a(1.0, 1.0, 1.0),
+    ]);
+    c.bench_function("quadratic_position", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn quadratic_vec3(c: &mut Criterion) {
+    let bezier = Bezier::new([
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+    ]);
+    c.bench_function("quadratic_position_Vec3", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn cubic(c: &mut Criterion) {
+    let bezier = CubicBezier3d::new([
+        vec3a(0.0, 0.0, 0.0),
+        vec3a(0.0, 1.0, 0.0),
+        vec3a(1.0, 0.0, 0.0),
+        vec3a(1.0, 1.0, 1.0),
+    ]);
+    c.bench_function("cubic_position", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+fn cubic_vec3(c: &mut Criterion) {
+    let bezier = Bezier::new([
+        vec3(0.0, 0.0, 0.0),
+        vec3(0.0, 1.0, 0.0),
+        vec3(1.0, 0.0, 0.0),
+        vec3(1.0, 1.0, 1.0),
+    ]);
+    c.bench_function("cubic_position_Vec3", |b| {
+        b.iter(|| bezier.position(black_box(0.5)));
+    });
+}
+
+criterion_group!(
+    benches,
+    easing,
+    fifteen_degree,
+    quadratic,
+    quadratic_vec3,
+    cubic,
+    cubic_vec3
+);
+criterion_main!(benches);

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -1,163 +1,152 @@
-use std::ops::{Add, Mul};
-
 use glam::{Vec2, Vec3};
 
-/// Provides methods for sampling Cubic Bezier curves.
-pub trait CubicBezier {
-    /// Represents a coordinate in space, this can be 3d, 2d, or even 1d.
-    type Coord: Copy + Mul<f32, Output = Self::Coord> + Add<Self::Coord, Output = Self::Coord>;
+/// A 2-dimensional Bezier curve, defined by its 4 [`Vec2`] control points.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct CubicBezier2d(pub [Vec2; 4]);
 
-    /// Returns the four control points of the cubic Bezier curve.
-    fn control_points(&self) -> [Self::Coord; 4];
+impl CubicBezier2d {
+    /// Returns the [`Vec2`] position along the Bezier curve at the supplied parametric value `t`.
+    pub fn evaluate_at(&self, t: f32) -> Vec2 {
+        bezier_impl::evaluate_cubic_bezier(self.0, t)
+    }
+
+    /// Split the Bezier curve into `subdivisions` across the length of the curve from t = `0..=1`.
+    /// evaluating the [`Vec2`] position at each step.
+    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec2> {
+        bezier_impl::cubic_bezier_to_points(self.0, subdivisions)
+    }
+}
+
+/// A 3-dimensional Bezier curve, defined by its 4 [`Vec3`] control points.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct CubicBezier3d(pub [Vec3; 4]);
+
+impl CubicBezier3d {
+    /// Returns the [`Vec3`] position along the Bezier curve at the supplied parametric value `t`.
+    pub fn evaluate_at(&self, t: f32) -> Vec3 {
+        bezier_impl::evaluate_cubic_bezier(self.0, t)
+    }
+
+    /// Split the Bezier curve into `subdivisions` across the length of the curve from t = `0..=1`.
+    /// evaluating the [`Vec3`] position at each step.
+    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec3> {
+        bezier_impl::cubic_bezier_to_points(self.0, subdivisions)
+    }
+}
+
+/// A 2-dimensional Bezier curve used for easing in animation.
+///
+/// A cubic Bezier easing curve has control point `p0` at (0, 0) and `p3` at (1, 1), leaving only
+/// `p1` and `p2` as the remaining degrees of freedom. The first and last control points are fixed
+/// to ensure the animation begins at 0, and ends at 1.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct CubicBezierEasing {
+    /// Control point P1 of the 2D cubic Bezier curve. Controls the start of the animation.
+    pub p1: Vec2,
+    /// Control point P2 of the 2D cubic Bezier curve. Controls the end of the animation.
+    pub p2: Vec2,
+}
+
+impl CubicBezierEasing {
+    /// Construct a cubic bezier curve for animation easing, with control points `p1` and `p2`.
+    pub fn new(p1: Vec2, p2: Vec2) -> Self {
+        Self { p1, p2 }
+    }
+
+    /// Maximum allowable error for iterative bezier solve
+    const MAX_ERROR: f32 = 1e-7;
+
+    /// Maximum number of iterations during bezier solve
+    const MAX_ITERS: u8 = 8;
+
+    /// Returns the x-coordinate of the point along the Bezier curve at the supplied parametric
+    /// value `t`.
+    pub fn evaluate_x_at(&self, t: f32) -> f32 {
+        bezier_impl::evaluate_cubic_bezier([0.0, self.p1.x, self.p2.x, 1.0], t)
+    }
+
+    /// Returns the y-coordinate of the point along the Bezier curve at the supplied parametric
+    /// value `t`.
+    pub fn evaluate_y_at(&self, t: f32) -> f32 {
+        bezier_impl::evaluate_cubic_bezier([0.0, self.p1.y, self.p2.y, 1.0], t)
+    }
+
+    /// Given a `time` within `0..=1`, remaps to a new value using the cubic Bezier curve as a
+    /// shaping function, where `x = time`, and `y = animation progress`. This will return `0` when
+    /// `t = 0`, and `1` when `t = 1`.
+    pub fn remap(&self, time: f32) -> f32 {
+        let x = time.clamp(0.0, 1.0);
+        let t = self.find_t_given_x(x);
+        self.evaluate_y_at(t)
+    }
+
+    /// Compute the slope `dx/dt` of a cubic bezier easing curve at the given parametric `t`.
+    pub fn dx_dt(&self, t: f32) -> f32 {
+        let p0x = 0.0;
+        let p1x = self.p1.x;
+        let p2x = self.p2.x;
+        let p3x = 1.0;
+        3. * (1. - t).powi(2) * (p1x - p0x)
+            + 6. * (1. - t) * t * (p2x - p1x)
+            + 3. * t.powi(2) * (p3x - p2x)
+    }
+
+    /// Solve for the parametric value `t` corresponding to the given value of `x`.
+    ///
+    /// This will return `x` if the solve fails to converge, which corresponds to a simple linear
+    /// interpolation.
+    pub fn find_t_given_x(&self, x: f32) -> f32 {
+        // We will use the desired value x as our initial guess for t. This is a good estimate,
+        // as cubic bezier curves for animation are usually near the line where x = t.
+        let mut t_guess = x;
+        let mut error = f32::MAX;
+        for _ in 0..Self::MAX_ITERS {
+            let x_guess = self.evaluate_x_at(t_guess);
+            error = x_guess - x;
+            if error.abs() <= Self::MAX_ERROR {
+                return t_guess;
+            }
+            let slope = self.dx_dt(t_guess);
+            t_guess -= error / slope;
+        }
+        if error.abs() <= Self::MAX_ERROR {
+            t_guess
+        } else {
+            x // fallback to linear interpolation if the solve fails
+        }
+    }
+}
+
+/// The bezier implementation is wrapped inside a private module to keep the public interface
+/// simple. This allows us to reuse the generic code across various cubic Bezier types, without
+/// exposing users to any unwieldy traits or generics in the IDE or documentation.
+#[doc(hidden)]
+mod bezier_impl {
+    use glam::{Vec2, Vec3};
+    use std::ops::{Add, Mul};
+
+    /// A point in space of any dimension that supports addition and multiplication.
+    pub trait Point: Copy + Mul<f32, Output = Self> + Add<Self, Output = Self> {}
+    impl Point for Vec3 {}
+    impl Point for Vec2 {}
+    impl Point for f32 {}
 
     /// Evaluate the cubic Bezier curve at the parametric value `t`.
-    fn evaluate_at(&self, t: f32) -> Self::Coord {
-        let p = self.control_points();
+    pub fn evaluate_cubic_bezier<P: Point>(control_points: [P; 4], t: f32) -> P {
+        let p = control_points;
         p[0] * (1. - t).powi(3)
             + p[1] * t * 3.0 * (1.0 - t).powi(2)
             + p[2] * 3.0 * (1.0 - t) * t.powi(2)
             + p[3] * t.powi(3)
     }
 
-    /// Split the Bezier curve into `subdivisions`, and sample the position at each.
-    fn to_points(&self, subdivisions: i32) -> Vec<Self::Coord> {
+    /// Split the Bezier curve into `subdivisions`, and sample the position at each [`Point`] `P`.
+    pub fn cubic_bezier_to_points<P: Point>(control_points: [P; 4], subdivisions: i32) -> Vec<P> {
         (0..=subdivisions)
             .map(|i| {
                 let t = i as f32 / subdivisions as f32;
-                self.evaluate_at(t)
+                evaluate_cubic_bezier(control_points, t)
             })
             .collect()
-    }
-}
-
-/// A 2-dimensional Bezier curve.
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-pub struct CubicBezier2d(pub [Vec2; 4]);
-
-impl CubicBezier for CubicBezier2d {
-    type Coord = Vec2;
-
-    fn control_points(&self) -> [Self::Coord; 4] {
-        self.0
-    }
-}
-
-impl CubicBezier2d {
-    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
-    pub fn evaluate_at(&self, t: f32) -> Vec2 {
-        CubicBezier::evaluate_at(self, t)
-    }
-
-    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
-    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec2> {
-        CubicBezier::to_points(self, subdivisions)
-    }
-}
-
-/// A 3-dimensional Bezier curve.
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-pub struct CubicBezier3d(pub [Vec3; 4]);
-
-impl CubicBezier for CubicBezier3d {
-    type Coord = Vec3;
-
-    fn control_points(&self) -> [Self::Coord; 4] {
-        self.0
-    }
-}
-
-impl CubicBezier3d {
-    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
-    pub fn evaluate_at(&self, t: f32) -> Vec3 {
-        CubicBezier::evaluate_at(self, t)
-    }
-
-    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
-    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec3> {
-        CubicBezier::to_points(self, subdivisions)
-    }
-}
-
-pub mod easing {
-    use super::CubicBezier;
-
-    /// Used to optimize cubic bezier easing, which only does operations in one dimension at a time,
-    /// and whose first and last control points are constrained to 0 and 1 respectively.
-    #[derive(Default, Clone, Copy, Debug, PartialEq)]
-    struct CubicBezier1d(f32, f32);
-
-    impl CubicBezier for CubicBezier1d {
-        type Coord = f32;
-
-        fn control_points(&self) -> [Self::Coord; 4] {
-            [0.0, self.0, self.1, 1.0]
-        }
-    }
-
-    /// A 2-dimensional Bezier curve used for easing in animation; the first and last control points
-    /// are constrained to (0, 0) and (1, 1) respectively.
-    #[derive(Default, Clone, Copy, Debug, PartialEq)]
-    pub struct CubicBezierEasing {
-        x: CubicBezier1d,
-        y: CubicBezier1d,
-    }
-
-    impl CubicBezierEasing {
-        /// Construct a cubic bezier curve for animation easing, with control points P1 and P2.
-        ///
-        /// This is equivalent to the syntax used to define cubic bezier easing functions in, say, CSS:
-        /// `ease-in-out = cubic-bezier(0.42, 0.0, 0.58, 1.0)`.
-        pub fn new(p1_x: f32, p1_y: f32, p2_x: f32, p2_y: f32) -> Self {
-            Self {
-                x: CubicBezier1d(p1_x, p2_x),
-                y: CubicBezier1d(p1_y, p2_y),
-            }
-        }
-
-        /// Maximum allowable error for iterative bezier solve
-        const MAX_ERROR: f32 = 1e-7;
-
-        /// Maximum number of iterations during bezier solve
-        const MAX_ITERS: u8 = 8;
-
-        /// Given a `time` within `0..=1`, remaps this using a shaping function to a new value. The
-        pub fn remap(&self, time: f32) -> f32 {
-            let x = time.clamp(0.0, 1.0);
-            let t = self.find_t_given_x(x);
-            self.y.evaluate_at(t)
-        }
-
-        /// Compute the slope `dx/dt` of a cubic bezier easing curve at the given parametric `t`.
-        pub fn dx_dt(&self, t: f32) -> f32 {
-            let p0x = 0.0;
-            let p1x = self.x.0;
-            let p2x = self.x.1;
-            let p3x = 1.0;
-            3. * (1. - t).powi(2) * (p1x - p0x)
-                + 6. * (1. - t) * t * (p2x - p1x)
-                + 3. * t.powi(2) * (p3x - p2x)
-        }
-
-        /// Solve for the parametric value `t` corresponding to the given value of `x`.
-        pub fn find_t_given_x(&self, x: f32) -> f32 {
-            // We will use the desired value x as our initial guess for t. This is a good estimate,
-            // as cubic bezier curves for animation are usually near the line where x = t.
-            let mut t_guess = x;
-            let mut error = f32::MAX;
-            for _ in 0..Self::MAX_ITERS {
-                let x_guess = self.x.evaluate_at(t_guess);
-                error = x_guess - x;
-                if error.abs() <= Self::MAX_ERROR {
-                    return t_guess;
-                }
-                let slope = self.dx_dt(t_guess);
-                t_guess -= error / slope;
-            }
-            if error.abs() <= Self::MAX_ERROR {
-                t_guess
-            } else {
-                x // fallback to linear interpolation if the solve fails
-            }
-        }
     }
 }

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -173,7 +173,7 @@ impl CubicBezierEasing {
 pub mod bezier_impl {
     use super::Point;
 
-    /// Compute the bernstein basis polynomial for iteration `i`, for a Bezier curve with with
+    /// Compute the Bernstein basis polynomial for iteration `i`, for a Bezier curve with with
     /// degree `n`, at `t`.
     #[inline]
     pub fn bernstein_basis(n: usize, i: usize, t: f32) -> f32 {

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -157,11 +157,11 @@ impl CubicBezierEasing {
             let x_guess = self.evaluate_x_at(t_guess);
             let error = x_guess - x;
             if error.abs() <= Self::MAX_ERROR {
-                return true;
+                true
             } else {
                 let slope = self.dx_dt(t_guess);
                 t_guess -= error / slope;
-                return false;
+                false
             }
         });
         t_guess.clamp(0.0, 1.0)

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -20,7 +20,7 @@ pub trait CubicBezier {
     }
 
     /// Split the Bezier curve into `subdivisions`, and sample the position at each.
-    fn into_points(&self, subdivisions: i32) -> Vec<Self::Coord> {
+    fn to_points(&self, subdivisions: i32) -> Vec<Self::Coord> {
         (0..=subdivisions)
             .map(|i| {
                 let t = i as f32 / subdivisions as f32;
@@ -49,8 +49,8 @@ impl CubicBezier2d {
     }
 
     /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
-    pub fn into_points(&self, subdivisions: i32) -> Vec<Vec2> {
-        CubicBezier::into_points(self, subdivisions)
+    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec2> {
+        CubicBezier::to_points(self, subdivisions)
     }
 }
 
@@ -73,8 +73,8 @@ impl CubicBezier3d {
     }
 
     /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
-    pub fn into_points(&self, subdivisions: i32) -> Vec<Vec3> {
-        CubicBezier::into_points(self, subdivisions)
+    pub fn to_points(&self, subdivisions: i32) -> Vec<Vec3> {
+        CubicBezier::to_points(self, subdivisions)
     }
 }
 

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -305,8 +305,10 @@ impl CubicBezierEasing {
 pub mod generic {
     use super::Point;
 
-    /// Compute the Bernstein basis polynomial for iteration `i`, for a Bezier curve with with
+    /// Compute the Bernstein basis polynomial for iteration `i`, for a Bezier curve with
     /// degree `n`, at `t`.
+    ///
+    /// For more information, see https://en.wikipedia.org/wiki/Bernstein_polynomial.
     #[inline]
     pub fn bernstein_basis(n: usize, i: usize, t: f32) -> f32 {
         (1. - t).powi((n - i) as i32) * t.powi(i as i32)

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -6,7 +6,8 @@ use std::{
     ops::{Add, Mul, Sub},
 };
 
-/// A point in space of any dimension that supports the mathematical operations needed by [`Bezier].
+/// A point in space of any dimension that supports the mathematical operations needed by
+/// [`Bezier`].
 pub trait Point:
     Mul<f32, Output = Self>
     + Add<Self, Output = Self>
@@ -322,7 +323,7 @@ pub mod generic {
 
     /// Compute the Bernstein basis polynomial `i` of degree `n`, at `t`.
     ///
-    /// For more information, see [https://en.wikipedia.org/wiki/Bernstein_polynomial].
+    /// For more information, see <https://en.wikipedia.org/wiki/Bernstein_polynomial>.
     #[inline]
     pub fn bernstein_basis(n: usize, i: usize, t: f32) -> f32 {
         (1. - t).powi((n - i) as i32) * t.powi(i as i32)

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -315,18 +315,8 @@ pub mod generic {
     /// Efficiently compute the binomial coefficient of `n` choose `k`.
     #[inline]
     const fn binomial_coeff(n: usize, k: usize) -> usize {
-        let mut i = 0;
-        let mut result = 1;
-        let k = match k > n - k {
-            true => n - k,
-            false => k,
-        };
-        while i < k {
-            result *= n - i;
-            result /= i + 1;
-            i += 1;
-        }
-        result
+        let k = usize::min(k, n - k);
+        (0..k).fold(1, |val, i| val * (n - i) / (i + 1))
     }
 
     /// Evaluate the Bezier curve B(t) of degree `N-1` at the parametric value `t`.

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -132,6 +132,7 @@ mod bezier_impl {
     impl Point for f32 {}
 
     /// Evaluate the cubic Bezier curve at the parametric value `t`.
+    #[inline]
     pub fn evaluate_cubic_bezier<P: Point>(control_points: [P; 4], t: f32) -> P {
         let p = control_points;
         p[0] * (1. - t).powi(3)
@@ -141,6 +142,7 @@ mod bezier_impl {
     }
 
     /// Split the Bezier curve into `subdivisions`, and sample the position at each [`Point`] `P`.
+    #[inline]
     pub fn cubic_bezier_to_points<P: Point>(control_points: [P; 4], subdivisions: i32) -> Vec<P> {
         (0..=subdivisions)
             .map(|i| {

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -1,0 +1,139 @@
+use std::ops::{Add, Mul};
+
+use glam::{Vec2, Vec3};
+
+/// Provides methods for sampling Cubic Bezier curves.
+pub trait CubicBezier {
+    /// Represents a coordinate in space, this can be 3d, 2d, or even 1d.
+    type Coord: Copy + Mul<f32, Output = Self::Coord> + Add<Self::Coord, Output = Self::Coord>;
+
+    /// Returns the four control points of the cubic Bezier curve.
+    fn control_points(&self) -> [Self::Coord; 4];
+
+    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
+    fn evaluate_at(&self, t: f32) -> Self::Coord {
+        let p = self.control_points();
+        p[0] * (1. - t).powi(3)
+            + p[1] * t * 3.0 * (1.0 - t).powi(2)
+            + p[2] * 3.0 * (1.0 - t) * t.powi(2)
+            + p[3] * t.powi(3)
+    }
+
+    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
+    fn into_points(&self, subdivisions: i32) -> Vec<Self::Coord> {
+        (0..=subdivisions)
+            .map(|i| {
+                let t = i as f32 / subdivisions as f32;
+                self.evaluate_at(t)
+            })
+            .collect()
+    }
+}
+
+/// A 2-dimensional Bezier curve.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct CubicBezier2d(pub [Vec2; 4]);
+
+impl CubicBezier for CubicBezier2d {
+    type Coord = Vec2;
+
+    fn control_points(&self) -> [Self::Coord; 4] {
+        self.0
+    }
+}
+
+/// A 3-dimensional Bezier curve.
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub struct CubicBezier3d(pub [Vec3; 4]);
+
+impl CubicBezier for CubicBezier3d {
+    type Coord = Vec3;
+
+    fn control_points(&self) -> [Self::Coord; 4] {
+        self.0
+    }
+}
+
+pub mod easing {
+    use super::CubicBezier;
+
+    /// Used to optimize cubic bezier easing, which only does operations in one dimension at a time,
+    /// and whose first and last control points are constrained to 0 and 1 respectively.
+    #[derive(Default, Clone, Copy, Debug, PartialEq)]
+    struct CubicBezier1d(f32, f32);
+
+    impl CubicBezier for CubicBezier1d {
+        type Coord = f32;
+
+        fn control_points(&self) -> [Self::Coord; 4] {
+            [0.0, self.0, self.1, 1.0]
+        }
+    }
+
+    /// A 2-dimensional Bezier curve used for easing in animation; the first and last control points
+    /// are constrained to (0, 0) and (1, 1) respectively.
+    #[derive(Default, Clone, Copy, Debug, PartialEq)]
+    pub struct CubicBezierEasing {
+        x: CubicBezier1d,
+        y: CubicBezier1d,
+    }
+
+    impl CubicBezierEasing {
+        /// Construct a cubic bezier curve for animation easing, with control points P1 and P2.
+        ///
+        /// This is equivalent to the syntax used to define cubic bezier easing functions in, say, CSS:
+        /// `ease-in-out = cubic-bezier(0.42, 0.0, 0.58, 1.0)`.
+        pub fn new(p1_x: f32, p1_y: f32, p2_x: f32, p2_y: f32) -> Self {
+            Self {
+                x: CubicBezier1d(p1_x, p2_x),
+                y: CubicBezier1d(p1_y, p2_y),
+            }
+        }
+
+        /// Maximum allowable error for iterative bezier solve
+        const MAX_ERROR: f32 = 1e-7;
+
+        /// Maximum number of iterations during bezier solve
+        const MAX_ITERS: u8 = 8;
+
+        /// Given a `time` within `0..=1`, remaps this using a shaping function to a new value. The
+        pub fn remap(&self, time: f32) -> f32 {
+            let x = time.clamp(0.0, 1.0);
+            let t = self.find_t_given_x(x);
+            self.y.evaluate_at(t)
+        }
+
+        /// Compute the slope `dx/dt` of a cubic bezier easing curve at the given parametric `t`.
+        pub fn dx_dt(&self, t: f32) -> f32 {
+            let p0x = 0.0;
+            let p1x = self.x.0;
+            let p2x = self.x.1;
+            let p3x = 1.0;
+            3. * (1. - t).powi(2) * (p1x - p0x)
+                + 6. * (1. - t) * t * (p2x - p1x)
+                + 3. * t.powi(2) * (p3x - p2x)
+        }
+
+        /// Solve for the parametric value `t` corresponding to the given value of `x`.
+        pub fn find_t_given_x(&self, x: f32) -> f32 {
+            // We will use the desired value x as our initial guess for t. This is a good estimate,
+            // as cubic bezier curves for animation are usually near the line where x = t.
+            let mut t_guess = x;
+            let mut error = f32::MAX;
+            for _ in 0..Self::MAX_ITERS {
+                let x_guess = self.x.evaluate_at(t_guess);
+                error = x_guess - x;
+                if error.abs() <= Self::MAX_ERROR {
+                    return t_guess;
+                }
+                let slope = self.dx_dt(t_guess);
+                t_guess -= error / slope;
+            }
+            if error.abs() <= Self::MAX_ERROR {
+                t_guess
+            } else {
+                x // fallback to linear interpolation if the solve fails
+            }
+        }
+    }
+}

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -10,7 +10,7 @@ pub trait CubicBezier {
     /// Returns the four control points of the cubic Bezier curve.
     fn control_points(&self) -> [Self::Coord; 4];
 
-    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
+    /// Evaluate the cubic Bezier curve at the parametric value `t`.
     fn evaluate_at(&self, t: f32) -> Self::Coord {
         let p = self.control_points();
         p[0] * (1. - t).powi(3)
@@ -19,7 +19,7 @@ pub trait CubicBezier {
             + p[3] * t.powi(3)
     }
 
-    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
+    /// Split the Bezier curve into `subdivisions`, and sample the position at each.
     fn into_points(&self, subdivisions: i32) -> Vec<Self::Coord> {
         (0..=subdivisions)
             .map(|i| {
@@ -42,6 +42,18 @@ impl CubicBezier for CubicBezier2d {
     }
 }
 
+impl CubicBezier2d {
+    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
+    pub fn evaluate_at(&self, t: f32) -> Vec2 {
+        CubicBezier::evaluate_at(self, t)
+    }
+
+    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
+    pub fn into_points(&self, subdivisions: i32) -> Vec<Vec2> {
+        CubicBezier::into_points(self, subdivisions)
+    }
+}
+
 /// A 3-dimensional Bezier curve.
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 pub struct CubicBezier3d(pub [Vec3; 4]);
@@ -51,6 +63,18 @@ impl CubicBezier for CubicBezier3d {
 
     fn control_points(&self) -> [Self::Coord; 4] {
         self.0
+    }
+}
+
+impl CubicBezier3d {
+    /// Returns the point along the Bezier curve at the supplied parametric value `t`.
+    pub fn evaluate_at(&self, t: f32) -> Vec3 {
+        CubicBezier::evaluate_at(self, t)
+    }
+
+    /// Iterate over points in the bezier curve from `t = 0` to `t = 1`.
+    pub fn into_points(&self, subdivisions: i32) -> Vec<Vec3> {
+        CubicBezier::into_points(self, subdivisions)
     }
 }
 

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -314,7 +314,7 @@ pub mod generic {
 
     /// Efficiently compute the binomial coefficient of `n` choose `k`.
     #[inline]
-    const fn binomial_coeff(n: usize, k: usize) -> usize {
+    fn binomial_coeff(n: usize, k: usize) -> usize {
         let k = usize::min(k, n - k);
         (0..k).fold(1, |val, i| val * (n - i) / (i + 1))
     }

--- a/crates/bevy_math/src/bezier.rs
+++ b/crates/bevy_math/src/bezier.rs
@@ -202,7 +202,7 @@ impl CubicBezierEasing {
     /// halfway through. This is known as linear interpolation, and results in objects animating
     /// with a constant velocity, and no smooth acceleration or deceleration at the start or end.
     ///
-    /// ```ignore
+    /// ```text
     /// y
     /// │         ●
     /// │       ⬈
@@ -217,7 +217,7 @@ impl CubicBezierEasing {
     /// smooth curve. As `time` (x-axis) progresses, we now follow the curved curve, and use the `y`
     /// value to determine how far along the animation is.
     ///
-    /// ```ignore
+    /// ```text
     /// y
     /// │         ⬈➔➔●
     /// │       ⬈   

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -6,9 +6,11 @@
 
 #![warn(missing_docs)]
 
+mod bezier;
 mod ray;
 mod rect;
 
+pub use bezier::{easing::CubicBezierEasing, CubicBezier2d, CubicBezier3d};
 pub use ray::Ray;
 pub use rect::Rect;
 
@@ -16,8 +18,8 @@ pub use rect::Rect;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        BVec2, BVec3, BVec4, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect,
-        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        BVec2, BVec3, BVec4, CubicBezierEasing, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4,
+        Quat, Ray, Rect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -10,7 +10,10 @@ mod bezier;
 mod ray;
 mod rect;
 
-pub use bezier::{CubicBezier2d, CubicBezier3d, CubicBezierEasing};
+pub use bezier::{
+    bezier_impl, Bezier, CubicBezier2d, CubicBezier3d, CubicBezierEasing, QuadraticBezier2d,
+    QuadraticBezier3d,
+};
 pub use ray::Ray;
 pub use rect::Rect;
 
@@ -19,7 +22,8 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         BVec2, BVec3, BVec4, CubicBezier2d, CubicBezier3d, CubicBezierEasing, EulerRot, IVec2,
-        IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        IVec3, IVec4, Mat2, Mat3, Mat4, QuadraticBezier2d, QuadraticBezier3d, Quat, Ray, Rect,
+        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -10,7 +10,7 @@ mod bezier;
 mod ray;
 mod rect;
 
-pub use bezier::{easing::CubicBezierEasing, CubicBezier2d, CubicBezier3d};
+pub use bezier::{CubicBezier2d, CubicBezier3d, CubicBezierEasing};
 pub use ray::Ray;
 pub use rect::Rect;
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -11,8 +11,8 @@ mod ray;
 mod rect;
 
 pub use bezier::{
-    bezier_impl, Bezier, CubicBezier2d, CubicBezier3d, CubicBezierEasing, QuadraticBezier2d,
-    QuadraticBezier3d,
+    generic as generic_bezier, Bezier, CubicBezier2d, CubicBezier3d, CubicBezierEasing,
+    QuadraticBezier2d, QuadraticBezier3d,
 };
 pub use ray::Ray;
 pub use rect::Rect;
@@ -21,9 +21,9 @@ pub use rect::Rect;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        BVec2, BVec3, BVec4, CubicBezier2d, CubicBezier3d, CubicBezierEasing, EulerRot, IVec2,
-        IVec3, IVec4, Mat2, Mat3, Mat4, QuadraticBezier2d, QuadraticBezier3d, Quat, Ray, Rect,
-        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        BVec2, BVec3, BVec4, Bezier, CubicBezier2d, CubicBezier3d, CubicBezierEasing, EulerRot,
+        IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, QuadraticBezier2d, QuadraticBezier3d, Quat, Ray,
+        Rect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -18,8 +18,8 @@ pub use rect::Rect;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        BVec2, BVec3, BVec4, CubicBezierEasing, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4,
-        Quat, Ray, Rect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        BVec2, BVec3, BVec4, CubicBezier2d, CubicBezier3d, CubicBezierEasing, EulerRot, IVec2,
+        IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }
 


### PR DESCRIPTION
# Objective

- Adds foundational math for Bezier curves, useful for UI/2D/3D animation and smooth paths.

https://user-images.githubusercontent.com/2632925/218883143-e138f994-1795-40da-8c59-21d779666991.mp4

## Solution

- Adds the generic `Bezier` type, and a `Point` trait. The `Point` trait allows us to use control points of any dimension, as long as they support vector math. I've implemented it for `f32`(1D), `Vec2`(2D), and `Vec3`/`Vec3A`(3D).
- Adds `CubicBezierEasing` on top of `Bezier` with the addition of an implementation of cubic Bezier easing, which is a foundational tool for UI animation.
  - This involves solving for $t$ in the parametric Bezier function $B(t)$ using the Newton-Raphson method to find a value with error $\leq$ 1e-7, capped at 8 iterations.
- Added type aliases for common Bezier curves: `CubicBezier2d`, `CubicBezier3d`, `QuadraticBezier2d`, and `QuadraticBezier3d`. These types use `Vec3A` to represent control points, as this was found to have an 80-90% speedup over using `Vec3`.
- Benchmarking shows quadratic/cubic Bezier evaluations $B(t)$ take \~1.8/2.4ns respectively. Easing, which requires an iterative solve takes \~50ns for cubic Beziers. 

---

## Changelog

- Added `CubicBezier2d`, `CubicBezier3d`, `QuadraticBezier2d`, and `QuadraticBezier3d` types with methods for sampling position, velocity, and acceleration. The generic `Bezier` type is also available, and generic over any degree of Bezier curve.
- Added `CubicBezierEasing`, with additional methods to allow for smooth easing animations.