### PR TITLE
[Merged by Bors] - Use a default implementation for `set_if_neq`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -682,7 +682,7 @@ impl<'a> DetectChangesMut for MutUntyped<'a> {
     }
 
     #[inline]
-    fn set_if_neq(&mut self, value: Self::Inner)
+    fn set_if_neq(&mut self, _: Self::Inner)
     where
         Self::Inner: Sized + PartialEq,
     {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -682,16 +682,11 @@ impl<'a> DetectChangesMut for MutUntyped<'a> {
     }
 
     #[inline]
-    fn set_if_neq<Target>(&mut self, value: Target)
+    fn set_if_neq(&mut self, value: Target)
     where
-        Self: Deref<Target = Target> + DerefMut<Target = Target>,
-        Target: PartialEq,
+        Self::Inner: Sized + PartialEq,
     {
-        // This dereference is immutable, so does not trigger change detection
-        if *<Self as Deref>::deref(self) != value {
-            // `DerefMut` usage triggers change detection
-            *<Self as DerefMut>::deref_mut(self) = value;
-        }
+        unreachable!("set_if_neq cannot be called on MutUntyped due to unsatisfied trait bounds")
     }
 }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -125,6 +125,7 @@ pub trait DetectChangesMut: DetectChanges {
     ///
     /// This is useful to ensure change detection is only triggered when the underlying value
     /// changes, instead of every time [`DerefMut`] is used.
+    #[inline]
     fn set_if_neq(&mut self, value: Self::Inner)
     where
         Self::Inner: Sized + PartialEq,

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -682,7 +682,7 @@ impl<'a> DetectChangesMut for MutUntyped<'a> {
     }
 
     #[inline]
-    fn set_if_neq(&mut self, value: Target)
+    fn set_if_neq(&mut self, value: Self::Inner)
     where
         Self::Inner: Sized + PartialEq,
     {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -127,13 +127,12 @@ pub trait DetectChangesMut: DetectChanges {
     /// changes, instead of every time [`DerefMut`] is used.
     fn set_if_neq(&mut self, value: Self::Inner)
     where
-        Self: DerefMut<Target = Self::Inner>,
         Self::Inner: Sized + PartialEq,
     {
-        // This dereference is immutable, so does not trigger change detection
-        if *<Self as Deref>::deref(self) != value {
-            // `DerefMut` usage triggers change detection
-            *<Self as DerefMut>::deref_mut(self) = value;
+        let old = self.bypass_change_detection();
+        if *old != value {
+            *old = value;
+            self.set_changed();
         }
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -686,6 +686,7 @@ impl<'a> DetectChangesMut for MutUntyped<'a> {
     where
         Self::Inner: Sized + PartialEq,
     {
+        // `PtrMut` is not `PartialEq`.
         unreachable!("set_if_neq cannot be called on MutUntyped due to unsatisfied trait bounds")
     }
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -125,10 +125,9 @@ pub trait DetectChangesMut: DetectChanges {
     ///
     /// This is useful to ensure change detection is only triggered when the underlying value
     /// changes, instead of every time [`DerefMut`] is used.
-    fn set_if_neq<Target>(&mut self, value: Target)
+    fn set_if_neq(&mut self, value: Self::Inner)
     where
-        Self: Deref<Target = Target> + DerefMut<Target = Target>,
-        Target: PartialEq;
+        Self::Inner: Sized + PartialEq;
 }
 
 macro_rules! change_detection_impl {
@@ -197,10 +196,9 @@ macro_rules! change_detection_mut_impl {
             }
 
             #[inline]
-            fn set_if_neq<Target>(&mut self, value: Target)
+            fn set_if_neq(&mut self, value: Self::Inner)
             where
-                Self: Deref<Target = Target> + DerefMut<Target = Target>,
-                Target: PartialEq,
+                Self::Inner: Sized + PartialEq
             {
                 // This dereference is immutable, so does not trigger change detection
                 if *<Self as Deref>::deref(self) != value {


### PR DESCRIPTION
# Objective

While porting my crate `bevy_trait_query` to bevy 0.10, I ran into an issue with the `DetectChangesMut` trait. Due to the way that the `set_if_neq` method (added in #6853) is implemented, you are forced to write a nonsense implementation of it for dynamically sized types. This edge case shows up when implementing trait queries, since `DetectChangesMut` is implemented for `Mut<dyn Trait>`.

## Solution

Simplify the generics for `set_if_neq` and add the `where Self::Target: Sized` trait bound to it. Add a default implementation so implementers don't need to implement a method with nonsensical trait bounds.
