### PR TITLE
[Merged by Bors] - Fixed a typo in an example state.rs

### DIFF
--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -14,7 +14,7 @@ fn main() {
         .add_startup_system(setup)
         // This system runs when we enter `AppState::Menu`, during `CoreSet::StateTransitions`.
         // All systems from the exit schedule of the state we're leaving are run first,
-        // and then all systems from the enter schedule of the state we're leaving are run second.
+        // and then all systems from the enter schedule of the state we're entering are run second.
         .add_system_to_schedule(OnEnter(AppState::Menu), setup_menu)
         // By contrast, on_update systems are stored in the main schedule, during CoreSet::Update,
         // and simply check the value of the `State<T>` resource to see if they should run each frame.


### PR DESCRIPTION
# Objective

Found and fixed a typo in an example ecs/state.rs