### PR TITLE
create window as soon as possible

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -288,34 +288,6 @@ pub fn winit_runner(mut app: App) {
             }
         }
 
-        if winit_state.active {
-            #[cfg(not(target_arch = "wasm32"))]
-            let (commands, mut new_windows, created_window_writer, winit_windows) =
-                create_window_system_state.get_mut(&mut app.world);
-
-            #[cfg(target_arch = "wasm32")]
-            let (
-                commands,
-                mut new_windows,
-                created_window_writer,
-                winit_windows,
-                canvas_parent_resize_channel,
-            ) = create_window_system_state.get_mut(&mut app.world);
-
-            // Responsible for creating new windows
-            create_window(
-                commands,
-                event_loop,
-                new_windows.iter_mut(),
-                created_window_writer,
-                winit_windows,
-                #[cfg(target_arch = "wasm32")]
-                canvas_parent_resize_channel,
-            );
-
-            create_window_system_state.apply(&mut app.world);
-        }
-
         match event {
             event::Event::NewEvents(start) => {
                 let (winit_config, window_focused_query) = focused_window_state.get(&app.world);
@@ -670,6 +642,34 @@ pub fn winit_runner(mut app: App) {
             }
 
             _ => (),
+        }
+
+        if winit_state.active {
+            #[cfg(not(target_arch = "wasm32"))]
+            let (commands, mut new_windows, created_window_writer, winit_windows) =
+                create_window_system_state.get_mut(&mut app.world);
+
+            #[cfg(target_arch = "wasm32")]
+            let (
+                commands,
+                mut new_windows,
+                created_window_writer,
+                winit_windows,
+                canvas_parent_resize_channel,
+            ) = create_window_system_state.get_mut(&mut app.world);
+
+            // Responsible for creating new windows
+            create_window(
+                commands,
+                event_loop,
+                new_windows.iter_mut(),
+                created_window_writer,
+                winit_windows,
+                #[cfg(target_arch = "wasm32")]
+                canvas_parent_resize_channel,
+            );
+
+            create_window_system_state.apply(&mut app.world);
         }
     };
 


### PR DESCRIPTION
# Objective

- Fixes #7612 
- Since #7493, windows started as unfocused (at least on macOS)

## Solution

- Creating the window at the end of the event loop after the resume event instead of at the beginning of the loop of the next event fixes the focus
