### PR TITLE
Create `get_resource_or_init` in `World`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -78,7 +78,7 @@ impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut App) {
         let settings = app
             .world
-            .get_resource_or_insert_with(ScheduleRunnerSettings::default)
+            .get_resource_or_init::<ScheduleRunnerSettings>()
             .to_owned();
         app.set_runner(move |mut app: App| {
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -33,7 +33,7 @@ use super::{Deferred, Resource, SystemBuffer, SystemMeta};
 ///
 /// impl Command for AddToCounter {
 ///     fn write(self, world: &mut World) {
-///         let mut counter = world.get_resource_or_insert_with(Counter::default);
+///         let mut counter = world.get_resource_or_init::<Counter>();
 ///         counter.0 += self.0;
 ///     }
 /// }
@@ -520,7 +520,7 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// impl Command for AddToCounter {
     ///     fn write(self, world: &mut World) {
-    ///         let mut counter = world.get_resource_or_insert_with(Counter::default);
+    ///         let mut counter = world.get_resource_or_init::<Counter>();
     ///         counter.0 += self.0;
     ///     }
     /// }
@@ -530,7 +530,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// }
     /// fn add_twenty_five_to_counter_system(mut commands: Commands) {
     ///     commands.add(|world: &mut World| {
-    ///         let mut counter = world.get_resource_or_insert_with(Counter::default);
+    ///         let mut counter = world.get_resource_or_init::<Counter>();
     ///         counter.0 += 25;
     ///     });
     /// }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -959,7 +959,10 @@ impl World {
     /// Use [`get_resource`](World::get_resource) instead if you want to handle this case.
     ///
     /// If you want to instead insert a value if the resource does not exist,
-    /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
+    /// use either:
+    ///
+    /// * [`get_resource_or_insert_with`](World::get_resource_or_insert_with)
+    /// * [`get_resource_or_init`](World::get_resource_or_init)
     #[inline]
     #[track_caller]
     pub fn resource<R: Resource>(&self) -> &R {
@@ -983,7 +986,10 @@ impl World {
     /// Use [`get_resource_mut`](World::get_resource_mut) instead if you want to handle this case.
     ///
     /// If you want to instead insert a value if the resource does not exist,
-    /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
+    /// use either:
+    ///
+    /// * [`get_resource_or_insert_with`](World::get_resource_or_insert_with)
+    /// * [`get_resource_or_init`](World::get_resource_or_init)
     #[inline]
     #[track_caller]
     pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
@@ -1045,6 +1051,13 @@ impl World {
         };
         // SAFETY: The underlying type of the resource is `R`.
         unsafe { data.with_type::<R>() }
+    }
+
+    /// Gets a mutable reference to the resource of type `T` if it exists,
+    /// otherwise inserts the resource using the result of calling `T::default`.
+    #[inline]
+    pub fn get_resource_or_init<R: Resource + Default>(&mut self) -> Mut<'_, R> {
+        self.get_resource_or_insert_with(R::default)
     }
 
     /// Gets an immutable reference to the non-send resource of the given type, if it exists.


### PR DESCRIPTION
# Objective

At the moment all references to `World::get_resource_or_insert_with` are called on the resource's `default`, so a I added a small function which does that for you. This should save *some* typing.

---

## Changelog

- Added `World::get_resource_or_init`.
