### PR TITLE
Change detection common conditions

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -104,8 +104,8 @@ pub mod common_conditions {
     }
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`
-    /// if the resource exsists and has changed.
-    pub fn resource_exsits_and_changed<T>() -> impl FnMut(Option<Res<T>>) -> bool
+    /// if the resource exists and has changed.
+    pub fn resource_exists_and_changed<T>() -> impl FnMut(Option<Res<T>>) -> bool
     where
         T: Resource,
     {


### PR DESCRIPTION
# Objective

Add some new run condition generators to the `common_conditions` module for checking the change detection of a certain resource or state.

---

## Changelog

### Added
- `resource_added<T: Resource>`
- `resource_changed<T: Resource>`
- `resource_exsits_and_changed<T: Resource>`
- `resource_added<T: Resource>`
- `state_changed<T: States>`

I have not added the rest of the methods for states because as far as I can tell you can't add them at run time, please let me know if I am wrong and I will add them too.

Another note, the fact that `state_change` will trigger even when the state was set to the same variant it already had makes me hesitant on whether to keep it as it could be a bit misleading, some opinions on this would be great.