### PR TITLE
[Merged by Bors] - Changes in the size of a text node should trigger recomputation of its text

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{CalculatedSize, Style, UiScale, Val};
+use crate::{CalculatedSize, Node, Style, UiScale, Val};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
@@ -54,7 +54,7 @@ pub fn text_system(
     mut font_atlas_set_storage: ResMut<Assets<FontAtlasSet>>,
     mut text_pipeline: ResMut<TextPipeline>,
     mut text_queries: ParamSet<(
-        Query<Entity, Or<(Changed<Text>, Changed<Style>)>>,
+        Query<Entity, Or<(Changed<Text>, Changed<Node>, Changed<Style>)>>,
         Query<Entity, (With<Text>, With<Style>)>,
         Query<(
             &Text,


### PR DESCRIPTION
# Objective

The text contained by a text node is only recomputed when its `Style` or `Text` components change, or when the scale factor changes. Not when the geometry of the text node is modified.

Make it so that any change in text node size triggers a text recomputation.

## Solution

Change `text_system` so that it queries for text nodes with changed `Node` components and recomputes their text. 

---

Most users won't notice any difference but it should fix some confusing edge cases in more complicated and interactive layouts.

## Changelog

* Added `Changed<Node>` to the change detection query of `text_system`. This ensures that any change in the size of a text node will cause any text it contains to be recomputed.
