### PR TITLE
[Merged by Bors] - Simplify generics for the `SystemParamFunction` trait

### DIFF
--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -8,7 +8,7 @@ use bevy_utils::label::DynHash;
 
 use crate::system::{
     ExclusiveSystemParam, ExclusiveSystemParamFunction, IsExclusiveFunctionSystem,
-    IsFunctionSystem, SystemParam, SystemParamFunction,
+    IsFunctionSystem, SystemParamFunction,
 };
 
 define_boxed_label!(ScheduleLabel);
@@ -130,10 +130,9 @@ impl<S: SystemSet> IntoSystemSet<()> for S {
 }
 
 // systems
-impl<In, Out, Param, Marker, F> IntoSystemSet<(IsFunctionSystem, In, Out, Param, Marker)> for F
+impl<In, Out, Marker, F> IntoSystemSet<(IsFunctionSystem, In, Out, Marker)> for F
 where
-    Param: SystemParam,
-    F: SystemParamFunction<In, Out, Param, Marker>,
+    F: SystemParamFunction<In, Out, Marker>,
 {
     type Set = SystemTypeSet<Self>;
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -142,9 +142,9 @@ where
 }
 
 // exclusive systems
-impl<In, Out, Marker, F> IntoSystemSet<(IsExclusiveFunctionSystem, In, Out, Marker)> for F
+impl<Marker, F> IntoSystemSet<(IsExclusiveFunctionSystem, Marker)> for F
 where
-    F: ExclusiveSystemParamFunction<In, Out, Marker>,
+    F: ExclusiveSystemParamFunction<Marker>,
 {
     type Set = SystemTypeSet<Self>;
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -130,9 +130,9 @@ impl<S: SystemSet> IntoSystemSet<()> for S {
 }
 
 // systems
-impl<In, Out, Marker, F> IntoSystemSet<(IsFunctionSystem, In, Out, Marker)> for F
+impl<Marker, F> IntoSystemSet<(IsFunctionSystem, Marker)> for F
 where
-    F: SystemParamFunction<In, Out, Marker>,
+    F: SystemParamFunction<Marker>,
 {
     type Set = SystemTypeSet<Self>;
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -7,8 +7,7 @@ use bevy_utils::define_boxed_label;
 use bevy_utils::label::DynHash;
 
 use crate::system::{
-    ExclusiveSystemParam, ExclusiveSystemParamFunction, IsExclusiveFunctionSystem,
-    IsFunctionSystem, SystemParamFunction,
+    ExclusiveSystemParamFunction, IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
 };
 
 define_boxed_label!(ScheduleLabel);
@@ -143,11 +142,9 @@ where
 }
 
 // exclusive systems
-impl<In, Out, Param, Marker, F> IntoSystemSet<(IsExclusiveFunctionSystem, In, Out, Param, Marker)>
-    for F
+impl<In, Out, Marker, F> IntoSystemSet<(IsExclusiveFunctionSystem, In, Out, Marker)> for F
 where
-    Param: ExclusiveSystemParam,
-    F: ExclusiveSystemParamFunction<In, Out, Param, Marker>,
+    F: ExclusiveSystemParamFunction<In, Out, Marker>,
 {
     type Set = SystemTypeSet<Self>;
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -159,9 +159,16 @@ where
 /// This trait can be useful for making your own systems which accept other systems,
 /// sometimes called higher order systems.
 pub trait ExclusiveSystemParamFunction<Marker>: Send + Sync + 'static {
+    /// The input type to this system. See [`System::In`].
     type In;
+
+    /// The return type of this system. See [`System::Out`].
     type Out;
+
+    /// The [`ExclusiveSystemParam`]/s defined by this system's `fn` parameters.
     type Param: ExclusiveSystemParam;
+
+    /// Executes this system once. See [`System::run`].
     fn run(
         &mut self,
         world: &mut World,

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -203,7 +203,7 @@ macro_rules! impl_exclusive_system_function {
             }
         }
         #[allow(non_snake_case)]
-        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: ExclusiveSystemParam),*> ExclusiveSystemParamFunction<(InputMarker, Input, Out, $($param,)*)> for Func
+        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: ExclusiveSystemParam),*> ExclusiveSystemParamFunction<(Input, Out, $($param,)* InputMarker)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut(In<Input>, &mut World, $($param),*) -> Out +

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -35,7 +35,7 @@ pub struct IsExclusiveFunctionSystem;
 impl<Marker, F> IntoSystem<F::In, F::Out, (IsExclusiveFunctionSystem, F::Param, Marker)> for F
 where
     Marker: 'static,
-    F: ExclusiveSystemParamFunction<Marker> + Send + Sync + 'static,
+    F: ExclusiveSystemParamFunction<Marker>,
     F::Param: 'static,
 {
     type System = ExclusiveFunctionSystem<F::Param, Marker, F>;
@@ -55,7 +55,7 @@ const PARAM_MESSAGE: &str = "System's param_state was not found. Did you forget 
 impl<Marker, F> System for ExclusiveFunctionSystem<F::Param, Marker, F>
 where
     Marker: 'static,
-    F: ExclusiveSystemParamFunction<Marker> + Send + Sync + 'static,
+    F: ExclusiveSystemParamFunction<Marker>,
     F::Param: 'static,
 {
     type In = F::In;

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -632,7 +632,7 @@ macro_rules! impl_system_function {
         }
 
         #[allow(non_snake_case)]
-        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(InputMarker, Input, Out, $($param,)*)> for Func
+        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(Input, Out, $($param,)* InputMarker)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut(In<Input>, $($param),*) -> Out +

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -390,7 +390,6 @@ impl<Marker, F> IntoSystem<F::In, F::Out, (IsFunctionSystem, Marker)> for F
 where
     Marker: 'static,
     F: SystemParamFunction<Marker>,
-    F::Param: 'static,
 {
     type System = FunctionSystem<Marker, F>;
     fn into_system(func: Self) -> Self::System {
@@ -419,7 +418,6 @@ impl<Marker, F> System for FunctionSystem<Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker>,
-    F::Param: 'static,
 {
     type In = F::In;
     type Out = F::Out;
@@ -531,7 +529,7 @@ unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker>,
-    F::Param: ReadOnlySystemParam + 'static,
+    F::Param: ReadOnlySystemParam,
 {
 }
 
@@ -596,8 +594,8 @@ where
 /// [`PipeSystem`]: crate::system::PipeSystem
 /// [`ParamSet`]: crate::system::ParamSet
 pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
-    type In: 'static;
-    type Out: 'static;
+    type In;
+    type Out;
     type Param: SystemParam;
     fn run(&mut self, input: Self::In, param_value: SystemParamItem<Self::Param>) -> Self::Out;
 }
@@ -632,7 +630,7 @@ macro_rules! impl_system_function {
         }
 
         #[allow(non_snake_case)]
-        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(Input, Out, $($param,)* InputMarker)> for Func
+        impl<Input, Out, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(Input, Out, $($param,)* InputMarker)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut(In<Input>, $($param),*) -> Out +

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -389,7 +389,7 @@ pub struct IsFunctionSystem;
 impl<Marker, F> IntoSystem<F::In, F::Out, (IsFunctionSystem, Marker)> for F
 where
     Marker: 'static,
-    F: SystemParamFunction<Marker> + Send + Sync + 'static,
+    F: SystemParamFunction<Marker>,
     F::Param: 'static,
 {
     type System = FunctionSystem<F::Param, Marker, F>;
@@ -418,7 +418,7 @@ where
 impl<Marker, F> System for FunctionSystem<F::Param, Marker, F>
 where
     Marker: 'static,
-    F: SystemParamFunction<Marker> + Send + Sync + 'static,
+    F: SystemParamFunction<Marker>,
     F::Param: 'static,
 {
     type In = F::In;
@@ -530,7 +530,7 @@ where
 unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<F::Param, Marker, F>
 where
     Marker: 'static,
-    F: SystemParamFunction<Marker> + Send + Sync + 'static,
+    F: SystemParamFunction<Marker>,
     F::Param: ReadOnlySystemParam + 'static,
 {
 }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -371,12 +371,12 @@ pub struct InputMarker;
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
 ///
 /// [`FunctionSystem`] must be `.initialized` before they can be run.
-pub struct FunctionSystem<Param, Marker, F>
+pub struct FunctionSystem<Marker, F>
 where
-    Param: SystemParam,
+    F: SystemParamFunction<Marker>,
 {
     func: F,
-    param_state: Option<Param::State>,
+    param_state: Option<<F::Param as SystemParam>::State>,
     system_meta: SystemMeta,
     world_id: Option<WorldId>,
     archetype_generation: ArchetypeGeneration,
@@ -392,7 +392,7 @@ where
     F: SystemParamFunction<Marker>,
     F::Param: 'static,
 {
-    type System = FunctionSystem<F::Param, Marker, F>;
+    type System = FunctionSystem<Marker, F>;
     fn into_system(func: Self) -> Self::System {
         FunctionSystem {
             func,
@@ -405,9 +405,9 @@ where
     }
 }
 
-impl<Param, Marker, F> FunctionSystem<Param, Marker, F>
+impl<Marker, F> FunctionSystem<Marker, F>
 where
-    Param: SystemParam,
+    F: SystemParamFunction<Marker>,
 {
     /// Message shown when a system isn't initialised
     // When lines get too long, rustfmt can sometimes refuse to format them.
@@ -415,7 +415,7 @@ where
     const PARAM_MESSAGE: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";
 }
 
-impl<Marker, F> System for FunctionSystem<F::Param, Marker, F>
+impl<Marker, F> System for FunctionSystem<Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker>,
@@ -527,7 +527,7 @@ where
 }
 
 /// SAFETY: `F`'s param is `ReadOnlySystemParam`, so this system will only read from the world.
-unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<F::Param, Marker, F>
+unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker>,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -371,7 +371,7 @@ pub struct InputMarker;
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
 ///
 /// [`FunctionSystem`] must be `.initialized` before they can be run.
-pub struct FunctionSystem<In, Out, Param, Marker, F>
+pub struct FunctionSystem<Param, Marker, F>
 where
     Param: SystemParam,
 {
@@ -381,7 +381,7 @@ where
     world_id: Option<WorldId>,
     archetype_generation: ArchetypeGeneration,
     // NOTE: PhantomData<fn()-> T> gives this safe Send/Sync impls
-    marker: PhantomData<fn(In) -> (Out, Marker)>,
+    marker: PhantomData<fn() -> Marker>,
 }
 
 pub struct IsFunctionSystem;
@@ -392,7 +392,7 @@ where
     F: SystemParamFunction<Marker> + Send + Sync + 'static,
     F::Param: 'static,
 {
-    type System = FunctionSystem<F::In, F::Out, F::Param, Marker, F>;
+    type System = FunctionSystem<F::Param, Marker, F>;
     fn into_system(func: Self) -> Self::System {
         FunctionSystem {
             func,
@@ -405,7 +405,7 @@ where
     }
 }
 
-impl<In, Out, Param, Marker, F> FunctionSystem<In, Out, Param, Marker, F>
+impl<Param, Marker, F> FunctionSystem<Param, Marker, F>
 where
     Param: SystemParam,
 {
@@ -415,7 +415,7 @@ where
     const PARAM_MESSAGE: &'static str = "System's param_state was not found. Did you forget to initialize this system before running it?";
 }
 
-impl<Marker, F> System for FunctionSystem<F::In, F::Out, F::Param, Marker, F>
+impl<Marker, F> System for FunctionSystem<F::Param, Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker> + Send + Sync + 'static,
@@ -527,7 +527,7 @@ where
 }
 
 /// SAFETY: `F`'s param is `ReadOnlySystemParam`, so this system will only read from the world.
-unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<F::In, F::Out, F::Param, Marker, F>
+unsafe impl<Marker, F> ReadOnlySystem for FunctionSystem<F::Param, Marker, F>
 where
     Marker: 'static,
     F: SystemParamFunction<Marker> + Send + Sync + 'static,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -558,16 +558,14 @@ where
 /// // parameters and marker type required for coherence. `B` is the second system, and
 /// // the other generics are for the input/output types of `A` and `B`.
 /// /// Pipe creates a new system which calls `a`, then calls `b` with the output of `a`
-/// pub fn pipe<AIn, Shared, BOut, A, AParam, AMarker, B, BParam, BMarker>(
+/// pub fn pipe<A, B, AMarker, BMarker>(
 ///     mut a: A,
 ///     mut b: B,
-/// ) -> impl FnMut(In<AIn>, ParamSet<(AParam, BParam)>) -> BOut
+/// ) -> impl FnMut(In<A::In>, ParamSet<(A::Param, B::Param)>) -> B::Out
 /// where
 ///     // We need A and B to be systems, add those bounds
-///     A: SystemParamFunction<AIn, Shared, AParam, AMarker>,
-///     B: SystemParamFunction<Shared, BOut, BParam, BMarker>,
-///     AParam: SystemParam,
-///     BParam: SystemParam,
+///     A: SystemParamFunction<AMarker>,
+///     B: SystemParamFunction<BMarker, In = A::Out>,
 /// {
 ///     // The type of `params` is inferred based on the return of this function above
 ///     move |In(a_in), mut params| {

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -605,7 +605,7 @@ pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
 macro_rules! impl_system_function {
     ($($param: ident),*) => {
         #[allow(non_snake_case)]
-        impl<Out, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<((), Out, ($($param,)*))> for Func
+        impl<Out, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<((), Out, $($param,)*)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut($($param),*) -> Out +
@@ -632,7 +632,7 @@ macro_rules! impl_system_function {
         }
 
         #[allow(non_snake_case)]
-        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(InputMarker, Input, Out, ($($param,)*))> for Func
+        impl<Input: 'static, Out: 'static, Func: Send + Sync + 'static, $($param: SystemParam),*> SystemParamFunction<(InputMarker, Input, Out, $($param,)*)> for Func
         where
         for <'a> &'a mut Func:
                 FnMut(In<Input>, $($param),*) -> Out +

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -554,9 +554,6 @@ where
 /// use bevy_ecs::prelude::*;
 /// use bevy_ecs::system::{SystemParam, SystemParamItem};
 ///
-/// // Unfortunately, we need all of these generics. `A` is the first system, with its
-/// // parameters and marker type required for coherence. `B` is the second system, and
-/// // the other generics are for the input/output types of `A` and `B`.
 /// /// Pipe creates a new system which calls `a`, then calls `b` with the output of `a`
 /// pub fn pipe<A, B, AMarker, BMarker>(
 ///     mut a: A,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -594,9 +594,16 @@ where
 /// [`PipeSystem`]: crate::system::PipeSystem
 /// [`ParamSet`]: crate::system::ParamSet
 pub trait SystemParamFunction<Marker>: Send + Sync + 'static {
+    /// The input type to this system. See [`System::In`].
     type In;
+
+    /// The return type of this system. See [`System::Out`].
     type Out;
+
+    /// The [`SystemParam`]/s used by this system to access the [`World`].
     type Param: SystemParam;
+
+    /// Executes this system once. See [`System::run`] or [`System::run_unsafe`].
     fn run(&mut self, input: Self::In, param_value: SystemParamItem<Self::Param>) -> Self::Out;
 }
 


### PR DESCRIPTION
# Objective

The `SystemParamFunction` (and `ExclusiveSystemParamFunction`) trait is very cumbersome to use, due to it requiring four generic type parameters. These are currently all used as marker parameters to satisfy rust's trait coherence rules.

### Example (before)

```rust
pub fn pipe<AIn, Shared, BOut, A, AParam, AMarker, B, BParam, BMarker>(
    mut system_a: A,
    mut system_b: B,
) -> impl FnMut(In<AIn>, ParamSet<(AParam, BParam)>) -> BOut
where
    A: SystemParamFunction<AIn, Shared, AParam, AMarker>,
    B: SystemParamFunction<Shared, BOut, BParam, BMarker>,
    AParam: SystemParam,
    BParam: SystemParam,
```

## Solution

Turn the `In`, `Out`, and `Param` generics into associated types. Merge the marker types together to retain coherence.

### Example (after)

```rust
pub fn pipe<A, B, AMarker, BMarker>(
    mut system_a: A,
    mut system_b: B,
) -> impl FnMut(In<A::In>, ParamSet<(A::Param, B::Param)>) -> B::Out
where
    A: SystemParamFunction<AMarker>,
    B: SystemParamFunction<BMarker, In = A::Out>,
```

---

## Changelog

+ Simplified the `SystemParamFunction` and `ExclusiveSystemParamFunction` traits.

## Migration Guide

*The guide for #7023 has been merged into this one.*

For the `SystemParamFunction` trait, the type parameters `In`, `Out`, and `Param` have been turned into associated types.

```rust
// Before
fn my_generic_system<T, In, Out, Param, Marker>(system_function: T)
where
    T: SystemParamFunction<In, Out, Param, Marker>,
    T: Param: SystemParam,
{ ... }

// After
fn my_generic_system<T, Marker>(system_function: T)
where
    T: SystemParamFunction<Marker>,
{ ... }
```

For the `ExclusiveSystemParamFunction` trait, the type parameter `Param` has been turned into an associated type.
Also, `In` and `Out` associated types have been added, since exclusive systems now support system piping.

```rust
// Before
fn my_exclusive_system<T, Param, Marker>(system_function: T)
where
    T: ExclusiveSystemParamFunction<Param, Marker>,
    T: Param: ExclusiveSystemParam,
{ ... }

// After
fn my_exclusive_system<T, Marker>(system_function: T)
where
    T: ExclusiveSystemParamFunction<Marker>,
{ ... }
```
