### PR TITLE
[Merged by Bors] - Rename state_equals condition to in_state

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -321,7 +321,7 @@ impl App {
     /// These systems sets only run if the [`State<S>`] resource matches their label.
     ///
     /// If you would like to control how other systems run based on the current state,
-    /// you can emulate this behavior using the [`state_equals`] [`Condition`](bevy_ecs::schedule::Condition).
+    /// you can emulate this behavior using the [`in_state`] [`Condition`](bevy_ecs::schedule::Condition).
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.
@@ -342,7 +342,7 @@ impl App {
             main_schedule.configure_set(
                 OnUpdate(variant.clone())
                     .in_base_set(CoreSet::Update)
-                    .run_if(state_equals(variant))
+                    .run_if(in_state(variant))
                     .after(apply_state_transition::<S>),
             );
         }

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -92,7 +92,7 @@ pub mod common_conditions {
     /// # Panics
     ///
     /// The condition will panic if the resource does not exist.
-    pub fn state_equals<S: States>(state: S) -> impl FnMut(Res<State<S>>) -> bool {
+    pub fn in_state<S: States>(state: S) -> impl FnMut(Res<State<S>>) -> bool {
         move |current_state: Res<State<S>>| current_state.0 == state
     }
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -56,7 +56,7 @@ pub struct OnExit<S: States>(pub S);
 /// A [`SystemSet`] that will run within `CoreSet::Update` when this state is active.
 ///
 /// This set, when created via `App::add_state`, is configured with both a base set and a run condition.
-/// If all you want is the run condition, use the [`state_equals`](crate::schedule::common_conditions::state_equals)
+/// If all you want is the run condition, use the [`in_state`](crate::schedule::common_conditions::in_state)
 /// [condition](super::Condition) directly.
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OnUpdate<S: States>(pub S);


### PR DESCRIPTION
# Objective

- Improve readability of the run condition for systems only running in a certain state

## Solution

- Rename `state_equals` to `in_state` (see [comment by cart](https://github.com/bevyengine/bevy/pull/7634#issuecomment-1428740311) in #7634 )
- `.run_if(state_equals(variant))` now is `.run_if(in_state(variant))`

This breaks the naming pattern a bit with the related conditions `state_exists` and `state_exists_and_equals` but I could not think of better names for those and think the improved readability of `in_state` is worth it.