### PR TITLE
Add support for adding custom log layers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -658,6 +658,16 @@ category = "Application"
 wasm = true
 
 [[example]]
+name = "log_layers"
+path = "examples/app/log_layers.rs"
+
+[package.metadata.example.log_layers]
+name = "Log layers"
+description = "Illustrate how to add custom log layers"
+category = "Application"
+wasm = false
+
+[[example]]
 name = "plugin"
 path = "examples/app/plugin.rs"
 

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -25,6 +25,7 @@ pub mod prelude {
     };
 }
 
+use bevy_utils::tracing::Subscriber;
 pub use bevy_utils::tracing::{
     debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     Level,
@@ -32,6 +33,7 @@ pub use bevy_utils::tracing::{
 
 use bevy_app::{App, Plugin};
 use tracing_log::LogTracer;
+pub use tracing_subscriber;
 #[cfg(feature = "tracing-chrome")]
 use tracing_subscriber::fmt::{format::DefaultFields, FormattedFields};
 use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
@@ -91,6 +93,21 @@ pub struct LogPlugin {
     /// Filters out logs that are "less than" the given level.
     /// This can be further filtered using the `filter` setting.
     pub level: Level,
+
+    // todo: better way of passing layers to plugin
+    pub extra_layers: std::sync::Arc<
+        std::sync::Mutex<
+            Option<
+                Vec<
+                    Box<
+                        dyn tracing_subscriber::layer::Layer<Box<dyn Subscriber + Send + Sync>>
+                            + Send
+                            + Sync,
+                    >,
+                >,
+            >,
+        >,
+    >,
 }
 
 impl Default for LogPlugin {
@@ -98,6 +115,7 @@ impl Default for LogPlugin {
         Self {
             filter: "wgpu=error".to_string(),
             level: Level::INFO,
+            extra_layers: Default::default(),
         }
     }
 }
@@ -187,8 +205,18 @@ impl Plugin for LogPlugin {
         }
 
         let logger_already_set = LogTracer::init().is_err();
-        let subscriber_already_set =
-            bevy_utils::tracing::subscriber::set_global_default(finished_subscriber).is_err();
+
+        let extra_layers = self.extra_layers.lock().unwrap().take();
+
+        let subscriber_already_set = if let Some(layers) = extra_layers {
+            let subscriber = Box::new(finished_subscriber);
+            let subscriber = layers.with_subscriber(subscriber);
+            // let subscriber = subscriber.with(self.extra_layers);
+            bevy_utils::tracing::subscriber::set_global_default(subscriber)
+        } else {
+            bevy_utils::tracing::subscriber::set_global_default(finished_subscriber)
+        }
+        .is_err();
 
         match (logger_already_set, subscriber_already_set) {
             (true, true) => warn!(

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,30 +1,91 @@
 //! This example illustrates how to add custom log layers in bevy.
 
-use bevy::log::tracing_subscriber::Layer;
-use bevy::prelude::*;
+// use bevy::log::tracing_subscriber::Layer;
+use bevy::{
+    log::tracing_subscriber::Layer,
+    prelude::*,
+    utils::tracing::{field::Visit, span},
+};
 use std::sync::{Arc, Mutex};
 
-struct MyLayer;
+struct ShowErrorLayer(crossbeam_channel::Sender<String>);
 
-impl<S: bevy::utils::tracing::Subscriber> Layer<S> for MyLayer {
+#[derive(Resource)]
+struct ErrorMessageReceiver(crossbeam_channel::Receiver<String>);
+
+#[derive(Component)]
+struct LastErrorText;
+
+impl<S: bevy::utils::tracing::Subscriber> Layer<S> for ShowErrorLayer {
     fn on_event(
         &self,
         event: &bevy::utils::tracing::Event<'_>,
         _ctx: bevy::log::tracing_subscriber::layer::Context<'_, S>,
     ) {
-        eprintln!("LOGGED MY WAY: {event:#?}");
+        eprintln!("log events handled my way!: {event:#?}");
+        if let &bevy::log::Level::ERROR = event.metadata().level() {
+            let mut visitor = Visitor(self.0.clone());
+            event.record(&mut visitor);
+            // event.record(|field| {});
+            // if let Some(first_record) = event.fields().next() {
+            // self.0.send(first_record).unwrap();
+            // }
+        }
+    }
+}
+
+struct Visitor(crossbeam_channel::Sender<String>);
+
+impl Visit for Visitor {
+    fn record_error(
+        &mut self,
+        _field: &bevy::utils::tracing::field::Field,
+        value: &(dyn std::error::Error + 'static),
+    ) {
+        // self.record_debug(field, &bevy::utils::tracing::field::DisplayValue(value))
+        self.0.send(value.to_string());
+    }
+
+    fn record_debug(
+        &mut self,
+        _field: &bevy::utils::tracing::field::Field,
+        value: &dyn std::fmt::Debug,
+    ) {
+        self.0.send(format!("{value:?}"));
+        // self.record_debug(field, &value)
     }
 }
 
 fn main() {
+    let (sender, receiver) = crossbeam_channel::unbounded();
+
     App::new()
+        .insert_resource(ErrorMessageReceiver(receiver))
         .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
             // todo: fix horrible hack
-            extra_layers: Arc::new(Mutex::new(Some(vec![Box::new(MyLayer)]))),
+            extra_layers: Arc::new(Mutex::new(Some(vec![Box::new(ShowErrorLayer(sender))]))),
             ..default()
         }))
         .add_startup_system(log_system)
+        .add_startup_system(text_setup)
+        .add_system(text_update)
         .run();
+}
+
+fn text_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    // UI camera
+    commands.spawn(Camera2dBundle::default());
+
+    // Text with multiple sections
+    commands.spawn((
+        // Create a TextBundle that has a Text with a list of sections.
+        TextBundle::from_sections([TextSection::from_style(TextStyle {
+            font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+            font_size: 60.0,
+            color: Color::RED,
+        })]),
+        LastErrorText,
+    ));
 }
 
 fn log_system() {
@@ -42,4 +103,15 @@ fn log_system() {
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:
     // https://docs.rs/tracing-subscriber/*/tracing_subscriber/filter/struct.EnvFilter.html
+}
+
+fn text_update(
+    errors: Res<ErrorMessageReceiver>,
+    mut query: Query<&mut Text, With<LastErrorText>>,
+) {
+    for error in errors.0.try_iter() {
+        if let Ok(mut text) = query.get_single_mut() {
+            text.sections[0].value = error;
+        }
+    }
 }

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,14 +1,10 @@
 //! This example illustrates how to add custom log layers in bevy.
 
 // use bevy::log::tracing_subscriber::Layer;
-use bevy::{
-    log::tracing_subscriber::Layer,
-    prelude::*,
-    utils::tracing::{field::Visit, span},
-};
+use bevy::{log::tracing_subscriber::Layer, prelude::*, utils::tracing::field::Visit};
 use std::sync::{Arc, Mutex};
 
-struct ShowErrorLayer(crossbeam_channel::Sender<String>);
+struct ChannelLayer(crossbeam_channel::Sender<String>);
 
 #[derive(Resource)]
 struct ErrorMessageReceiver(crossbeam_channel::Receiver<String>);
@@ -16,43 +12,39 @@ struct ErrorMessageReceiver(crossbeam_channel::Receiver<String>);
 #[derive(Component)]
 struct LastErrorText;
 
-impl<S: bevy::utils::tracing::Subscriber> Layer<S> for ShowErrorLayer {
+impl<S: bevy::utils::tracing::Subscriber> Layer<S> for ChannelLayer {
+    fn enabled(
+        &self,
+        metadata: &bevy::utils::tracing::Metadata<'_>,
+        _ctx: bevy::log::tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        // we're only interested in errors
+        *metadata.level() <= bevy::log::Level::ERROR
+    }
+
     fn on_event(
         &self,
         event: &bevy::utils::tracing::Event<'_>,
         _ctx: bevy::log::tracing_subscriber::layer::Context<'_, S>,
     ) {
-        eprintln!("log events handled my way!: {event:#?}");
-        if let &bevy::log::Level::ERROR = event.metadata().level() {
-            let mut visitor = Visitor(self.0.clone());
-            event.record(&mut visitor);
-            // event.record(|field| {});
-            // if let Some(first_record) = event.fields().next() {
-            // self.0.send(first_record).unwrap();
-            // }
-        }
+        // log received events to std err, including metadata
+        eprintln!("logged my way: {event:#?}");
+
+        let mut visitor = Visitor(self.0.clone());
+        event.record(&mut visitor);
     }
 }
 
 struct Visitor(crossbeam_channel::Sender<String>);
 
 impl Visit for Visitor {
-    fn record_error(
-        &mut self,
-        _field: &bevy::utils::tracing::field::Field,
-        value: &(dyn std::error::Error + 'static),
-    ) {
-        // self.record_debug(field, &bevy::utils::tracing::field::DisplayValue(value))
-        self.0.send(value.to_string());
-    }
-
     fn record_debug(
         &mut self,
         _field: &bevy::utils::tracing::field::Field,
         value: &dyn std::fmt::Debug,
     ) {
-        self.0.send(format!("{value:?}"));
-        // self.record_debug(field, &value)
+        // will fail if the receiver is dropped. In that case, we do nothing.
+        _ = self.0.try_send(format!("{value:?}"));
     }
 }
 
@@ -63,49 +55,39 @@ fn main() {
         .insert_resource(ErrorMessageReceiver(receiver))
         .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
             // todo: fix horrible hack
-            extra_layers: Arc::new(Mutex::new(Some(vec![Box::new(ShowErrorLayer(sender))]))),
+            extra_layers: Arc::new(Mutex::new(Some(vec![Box::new(ChannelLayer(sender))]))),
             ..default()
         }))
         .add_startup_system(log_system)
         .add_startup_system(text_setup)
-        .add_system(text_update)
+        .add_system(update_screen_text)
         .run();
 }
 
 fn text_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    // UI camera
     commands.spawn(Camera2dBundle::default());
 
-    // Text with multiple sections
     commands.spawn((
-        // Create a TextBundle that has a Text with a list of sections.
         TextBundle::from_sections([TextSection::from_style(TextStyle {
             font: asset_server.load("fonts/FiraMono-Medium.ttf"),
             font_size: 60.0,
-            color: Color::RED,
+            color: Color::MAROON,
         })]),
         LastErrorText,
     ));
 }
 
 fn log_system() {
-    // here is how you write new logs at each "log level" (in "least important" to "most important"
-    // order)
-    trace!("very noisy");
-    debug!("helpful for debugging");
-    info!("helpful information that is worth printing by default");
-    warn!("something bad happened that isn't a failure, but thats worth calling out");
+    // here is how you write new logs at each "log level" (in "most import" to
+    // "least important" order)
     error!("something failed");
-
-    // by default, trace and debug logs are ignored because they are "noisy"
-    // you can control what level is logged by setting up the LogPlugin
-    // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
-    // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
-    // the format used here is super flexible. check out this documentation for more info:
-    // https://docs.rs/tracing-subscriber/*/tracing_subscriber/filter/struct.EnvFilter.html
+    warn!("something bad happened that isn't a failure, but thats worth calling out");
+    info!("helpful information that is worth printing by default");
+    debug!("helpful for debugging");
+    trace!("very noisy");
 }
 
-fn text_update(
+fn update_screen_text(
     errors: Res<ErrorMessageReceiver>,
     mut query: Query<&mut Text, With<LastErrorText>>,
 ) {

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,11 +1,15 @@
 //! This example illustrates how to add custom log layers in bevy.
 
-use bevy::{log::tracing_subscriber::Layer, prelude::*, utils::tracing::field::Visit};
+use bevy::{
+    log::tracing_subscriber::Layer,
+    prelude::*,
+    utils::tracing::{field::Visit, Subscriber},
+};
 use std::sync::{Arc, Mutex};
 
 struct DebugLogToStdErrLayer;
 
-impl<S: bevy::utils::tracing::Subscriber> Layer<S> for DebugLogToStdErrLayer {
+impl<S: Subscriber> Layer<S> for DebugLogToStdErrLayer {
     fn on_event(
         &self,
         event: &bevy::utils::tracing::Event<'_>,
@@ -27,7 +31,7 @@ struct ErrorMessageReceiver(crossbeam_channel::Receiver<String>);
 #[derive(Component)]
 struct LastErrorText;
 
-impl<S: bevy::utils::tracing::Subscriber> Layer<S> for ChannelLayer {
+impl<S: Subscriber> Layer<S> for ChannelLayer {
     fn on_event(
         &self,
         event: &bevy::utils::tracing::Event<'_>,

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,0 +1,45 @@
+//! This example illustrates how to add custom log layers in bevy.
+
+use bevy::log::tracing_subscriber::Layer;
+use bevy::prelude::*;
+use std::sync::{Arc, Mutex};
+
+struct MyLayer;
+
+impl<S: bevy::utils::tracing::Subscriber> Layer<S> for MyLayer {
+    fn on_event(
+        &self,
+        event: &bevy::utils::tracing::Event<'_>,
+        _ctx: bevy::log::tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        eprintln!("LOGGED MY WAY: {event:#?}");
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
+            // todo: fix horrible hack
+            extra_layers: Arc::new(Mutex::new(Some(vec![Box::new(MyLayer)]))),
+            ..default()
+        }))
+        .add_startup_system(log_system)
+        .run();
+}
+
+fn log_system() {
+    // here is how you write new logs at each "log level" (in "least important" to "most important"
+    // order)
+    trace!("very noisy");
+    debug!("helpful for debugging");
+    info!("helpful information that is worth printing by default");
+    warn!("something bad happened that isn't a failure, but thats worth calling out");
+    error!("something failed");
+
+    // by default, trace and debug logs are ignored because they are "noisy"
+    // you can control what level is logged by setting up the LogPlugin
+    // alternatively you can set the log level via the RUST_LOG=LEVEL environment variable
+    // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
+    // the format used here is super flexible. check out this documentation for more info:
+    // https://docs.rs/tracing-subscriber/*/tracing_subscriber/filter/struct.EnvFilter.html
+}


### PR DESCRIPTION
# Objective

- Currently, custom log layers can not co-exist with `LogPlugin`
- This makes it hard to integrate with other error diagnostics solutions like automatic error reporting, saving logs to files, etc. without also losing the normal functionality of bevy's logging
- Enabler for #5233, alternative to #5342

## Solution

- Add a number of user-specified, boxed `Subscribers` to `LogPlugin`'s settings

---

## Additional notes

Draft PR because how `extra_layers` is passed in (`Arc<Mutex<Option<Vec>>>`) is pretty ugly. I'm not sure what the current idiom of letting `Plugin::build` take ownership of something is? Should it be in a resource instead?
