### PR TITLE
[Merged by Bors] - Include 2x/8x sample counts for Msaa

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -66,11 +66,9 @@ impl Plugin for ViewPlugin {
 ///
 /// The number of samples to run for Multi-Sample Anti-Aliasing. Higher numbers result in
 /// smoother edges.
-/// Defaults to 4.
+/// Defaults to 4 samples.
 ///
-/// Note that WGPU currently only supports 1 or 4 samples.
-/// Ultimately we plan on supporting whatever is natively supported on a given device.
-/// Check out this issue for more info: <https://github.com/gfx-rs/wgpu/issues/1832>
+/// Note that web currently only supports 1 or 4 samples.
 ///
 /// # Example
 /// ```
@@ -84,8 +82,10 @@ impl Plugin for ViewPlugin {
 #[reflect(Resource)]
 pub enum Msaa {
     Off = 1,
+    Sample2 = 2,
     #[default]
     Sample4 = 4,
+    Sample8 = 8,
 }
 
 impl Msaa {

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -237,16 +237,13 @@ pub fn prepare_windows(
         let sample_flags = render_adapter
             .get_texture_format_features(surface_configuration.format)
             .flags;
-        match *msaa {
-            Msaa::Off => (),
-            Msaa::Sample4 => {
-                if !sample_flags.contains(wgpu::TextureFormatFeatureFlags::MULTISAMPLE_X4) {
-                    bevy_log::warn!(
-                        "MSAA 4x is not supported on this device. Falling back to disabling MSAA."
-                    );
-                    *msaa = Msaa::Off;
-                }
-            }
+
+        if !sample_flags.sample_count_supported(msaa.samples()) {
+            bevy_log::warn!(
+                "MSAA {}x is not supported on this device. Falling back to disabling MSAA.",
+                msaa.samples(),
+            );
+            *msaa = Msaa::Off;
         }
 
         // A recurring issue is hitting `wgpu::SurfaceError::Timeout` on certain Linux

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -239,22 +239,24 @@ pub fn prepare_windows(
             .flags;
 
         if !sample_flags.sample_count_supported(msaa.samples()) {
-            if sample_flags.sample_count_supported(Msaa::default().samples()) {
-                bevy_log::warn!(
-                    "MSAA {}x is not supported on this device. Falling back to MSAA {}x.",
-                    msaa.samples(),
-                    Msaa::default().samples(),
-                );
-
-                *msaa = Msaa::default();
+            let fallback = if sample_flags.sample_count_supported(Msaa::default().samples()) {
+                Msaa::default()
             } else {
-                bevy_log::warn!(
-                    "MSAA {}x is not supported on this device. Falling back to disabling MSAA.",
-                    msaa.samples(),
-                );
+                Msaa::Off
+            };
 
-                *msaa = Msaa::Off;
-            }
+            let fallback_str = if fallback == Msaa::Off {
+                "disabling MSAA".to_owned()
+            } else {
+                format!("MSAA {}x", fallback.samples())
+            };
+
+            bevy_log::warn!(
+                "MSAA {}x is not supported on this device. Falling back to {}.",
+                msaa.samples(),
+                fallback_str,
+            );
+            *msaa = fallback;
         }
 
         // A recurring issue is hitting `wgpu::SurfaceError::Timeout` on certain Linux

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -239,11 +239,22 @@ pub fn prepare_windows(
             .flags;
 
         if !sample_flags.sample_count_supported(msaa.samples()) {
-            bevy_log::warn!(
-                "MSAA {}x is not supported on this device. Falling back to disabling MSAA.",
-                msaa.samples(),
-            );
-            *msaa = Msaa::Off;
+            if sample_flags.sample_count_supported(Msaa::default().samples()) {
+                bevy_log::warn!(
+                    "MSAA {}x is not supported on this device. Falling back to MSAA {}x.",
+                    msaa.samples(),
+                    Msaa::default().samples(),
+                );
+
+                *msaa = Msaa::default();
+            } else {
+                bevy_log::warn!(
+                    "MSAA {}x is not supported on this device. Falling back to disabling MSAA.",
+                    msaa.samples(),
+                );
+
+                *msaa = Msaa::Off;
+            }
         }
 
         // A recurring issue is hitting `wgpu::SurfaceError::Timeout` on certain Linux

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -2,9 +2,7 @@
 //! will result in smoother edges, but it will also increase the cost to render those edges. The
 //! range should generally be somewhere between 1 (no multi sampling, but cheap) to 8 (crisp but
 //! expensive).
-//! Note that WGPU currently only supports 1 or 4 samples.
-//! Ultimately we plan on supporting whatever is natively supported on a given device.
-//! Check out [this issue](https://github.com/gfx-rs/wgpu/issues/1832) for more info.
+//! Note that web currently only supports 1 or 4 samples.
 
 use bevy::prelude::*;
 
@@ -23,7 +21,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    info!("Press 'm' to toggle MSAA");
+    info!("Press '1/2/4/8' respectively to set MSAA sample count");
     info!("Using 4x MSAA");
 
     // cube
@@ -45,16 +43,23 @@ fn setup(
 }
 
 fn cycle_msaa(input: Res<Input<KeyCode>>, mut msaa: ResMut<Msaa>) {
-    if input.just_pressed(KeyCode::M) {
-        match *msaa {
-            Msaa::Sample4 => {
-                info!("Not using MSAA");
-                *msaa = Msaa::Off;
-            }
-            Msaa::Off => {
-                info!("Using 4x MSAA");
-                *msaa = Msaa::Sample4;
-            }
-        }
+    if input.just_pressed(KeyCode::Key1) {
+        info!("Not using MSAA");
+        *msaa = Msaa::Off;
+    }
+
+    if input.just_pressed(KeyCode::Key2) {
+        info!("Using 2x MSAA");
+        *msaa = Msaa::Sample2;
+    }
+
+    if input.just_pressed(KeyCode::Key4) {
+        info!("Using 4x MSAA");
+        *msaa = Msaa::Sample4;
+    }
+
+    if input.just_pressed(KeyCode::Key8) {
+        info!("Using 8x MSAA");
+        *msaa = Msaa::Sample8;
     }
 }


### PR DESCRIPTION
# Objective
Fixes #7295 

Should we maybe default to 4x if 2x/8x is selected but not supported?

---

## Changelog
- Added 2x and 8x sample counts for MSAA.
