### PR TITLE
[Merged by Bors] - Improve the documentation for `flex-basis`

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -247,7 +247,9 @@ pub struct Style {
     pub flex_grow: f32,
     /// How to shrink if there's not enough space available
     pub flex_shrink: f32,
-    /// The initial size of the item
+    /// The initial length of the main axis, before other properties are applied.
+    /// 
+    /// `flex_basis` overrides `size` if both are set, but it obeys the bounds defined by `min_size` and `max_size`.
     pub flex_basis: Val,
     /// The ideal size of the flexbox
     ///

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -249,7 +249,7 @@ pub struct Style {
     pub flex_shrink: f32,
     /// The initial length of the main axis, before other properties are applied.
     /// 
-    /// `flex_basis` overrides `size` if both are set, but it obeys the bounds defined by `min_size` and `max_size`.
+    /// If both are set, `flex_basis` overrides `size` on the main axis but it obeys the bounds defined by `min_size` and `max_size`.
     pub flex_basis: Val,
     /// The ideal size of the flexbox
     ///

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -248,7 +248,7 @@ pub struct Style {
     /// How to shrink if there's not enough space available
     pub flex_shrink: f32,
     /// The initial length of the main axis, before other properties are applied.
-    /// 
+    ///
     /// If both are set, `flex_basis` overrides `size` on the main axis but it obeys the bounds defined by `min_size` and `max_size`.
     pub flex_basis: Val,
     /// The ideal size of the flexbox


### PR DESCRIPTION
# Objective

The current doc comment for `flex-basis` states that it is "The initial size of the item", which is a bit confusing since size in Bevy is mostly used to refer to two-dimensional extents but `flex-basis` is a one-dimensional value.

It also needs to explain that:
* `flex-basis` sets the initial length of the main axis.
* Overrides `size` on the main axis.
* Obeys the `min_size` and `max_size` constraints.