### PR TITLE
Allow tuples in `add_plugins`.

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{CoreSchedule, CoreSet, Plugin, StartupSet};
+use crate::{CoreSchedule, CoreSet, IntoPlugin, IntoPluginGroup, Plugin, StartupSet};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     prelude::*,
@@ -14,7 +14,6 @@ use std::fmt::Debug;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 
-use super::sealed::{IntoPlugin, IntoPluginGroup};
 bevy_utils::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
     AppLabel,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -821,7 +821,7 @@ impl App {
     /// The [`PluginGroup`]s available by default are `DefaultPlugins` and `MinimalPlugins`.
     ///
     /// To customize the plugins in the group (reorder, disable a plugin, add a new plugin
-    /// before / after another plugin), call [`build()`](PluginGroup::build) on the group,
+    /// before / after another plugin), call [`build()`](super::PluginGroup::build) on the group,
     /// which will convert it to a [`PluginGroupBuilder`](crate::PluginGroupBuilder).
     ///
     /// You can also specify a group of [`Plugin`]s by using a tuple over [`Plugin`]s and

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -753,7 +753,7 @@ impl App {
         }
     }
 
-    /// Boxed variant of `add_plugin`, can be used from a [`PluginGroup`]
+    /// Boxed variant of `add_plugin`, can be used from a [`PluginGroup`](super::PluginGroup)
     pub(crate) fn add_boxed_plugin(
         &mut self,
         plugin: Box<dyn Plugin>,

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
 
-use self::sealed::{IntoPlugin, IntoPluginGroup};
+use super::sealed::{IntoPlugin, IntoPluginGroup};
 bevy_utils::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
     AppLabel,
@@ -1002,86 +1002,6 @@ impl App {
 
         self
     }
-}
-
-mod sealed {
-    use bevy_ecs::all_tuples;
-
-    use crate::{App, Plugin, PluginGroup, PluginGroupBuilder};
-
-    pub trait IntoPlugin<Marker> {
-        type Plugin: Plugin;
-        fn into_plugin(self, app: &mut App) -> Self::Plugin;
-    }
-
-    pub trait IntoPluginGroup<Marker>: IntoPluginGroupBuilder<Marker> {}
-
-    pub trait IntoPluginGroupBuilder<Marker> {
-        fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder;
-    }
-
-    pub struct IsPlugin;
-    pub struct IsPluginGroup;
-    pub struct IsFunction;
-
-    impl<P: Plugin> IntoPlugin<IsPlugin> for P {
-        type Plugin = Self;
-        fn into_plugin(self, _: &mut App) -> Self {
-            self
-        }
-    }
-
-    impl<P: Plugin> IntoPluginGroupBuilder<IsPlugin> for P {
-        fn into_plugin_group_builder(self, _: &mut App) -> PluginGroupBuilder {
-            PluginGroupBuilder::from_plugin(self)
-        }
-    }
-
-    impl<P: PluginGroup> IntoPluginGroupBuilder<IsPluginGroup> for P {
-        fn into_plugin_group_builder(self, _: &mut App) -> PluginGroupBuilder {
-            self.build()
-        }
-    }
-
-    impl<P: PluginGroup> IntoPluginGroup<IsPluginGroup> for P {}
-
-    impl<F: FnOnce(&mut App) -> P, P: Plugin> IntoPlugin<IsFunction> for F {
-        type Plugin = P;
-
-        fn into_plugin(self, app: &mut App) -> Self::Plugin {
-            self(app)
-        }
-    }
-
-    impl<F: FnOnce(&mut App) -> PG, PG: PluginGroup> IntoPluginGroupBuilder<IsFunction> for F {
-        fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder {
-            self(app).build()
-        }
-    }
-
-    impl<F: FnOnce(&mut App) -> PG, PG: PluginGroup> IntoPluginGroup<IsFunction> for F {}
-
-    macro_rules! impl_plugin_collection {
-        ($(($param: ident, $plugins: ident)),*) => {
-            impl<$($param, $plugins),*> IntoPluginGroupBuilder<($($param,)*)> for ($($plugins,)*)
-            where
-                $($plugins: IntoPluginGroupBuilder<$param>),*
-            {
-                #[allow(non_snake_case, unused_variables)]
-                fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder {
-                    let ($($plugins,)*) = self;
-                    PluginGroupBuilder::merge(vec![$($plugins.into_plugin_group_builder(app),)*])
-                }
-            }
-
-            impl<$($param, $plugins),*> IntoPluginGroup<($($param,)*)> for ($($plugins,)*)
-            where
-                $($plugins: IntoPluginGroupBuilder<$param>),*
-            {}
-        }
-    }
-
-    all_tuples!(impl_plugin_collection, 0, 15, P, S);
 }
 
 fn run_once(mut app: App) {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1035,7 +1035,7 @@ pub struct AppExit;
 
 #[cfg(test)]
 mod tests {
-    use crate::{App, Plugin};
+    use crate::{App, Plugin, PluginGroup, PluginGroupBuilder};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -1054,6 +1054,15 @@ mod tests {
         fn build(&self, _app: &mut crate::App) {}
         fn is_unique(&self) -> bool {
             false
+        }
+    }
+
+    struct PluginGroupAB;
+    impl PluginGroup for PluginGroupAB {
+        fn build(self) -> PluginGroupBuilder {
+            PluginGroupBuilder::start::<Self>()
+                .add(PluginA)
+                .add(PluginB)
         }
     }
 
@@ -1115,6 +1124,13 @@ mod tests {
 
         App::new()
             .add_plugin(LoggerPlugin::with_loggers(Loggers))
+            .run();
+    }
+
+    #[test]
+    fn add_multiple_plugins_at_once() {
+        App::new()
+            .add_plugins((PluginC(()), PluginD, PluginGroupAB, PluginD))
             .run();
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1035,7 +1035,7 @@ mod sealed {
 
     impl<F: FnOnce(&mut App)> Add<IsFunction> for F {
         fn add_to(self, app: &mut App) {
-            self(app)
+            self(app);
         }
     }
 }
@@ -1126,7 +1126,7 @@ mod tests {
         impl LoggerPlugin {
             fn with_loggers(loggers: Loggers) -> impl FnOnce(&mut App) {
                 |app| {
-                    app.insert_resource::<Loggers>(loggers).add(LoggerPlugin);
+                    app.insert_resource(loggers).add(LoggerPlugin);
                 }
             }
         }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1090,9 +1090,8 @@ mod tests {
         App::new().add_plugin(PluginRun);
     }
 
-    // Just for Demonstration purposes, will be removed
     #[test]
-    fn logger_example() {
+    fn add_plugin_via_factory_fn() {
         use bevy_ecs::system::Resource;
         #[derive(Resource)]
         struct Loggers;

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -824,17 +824,30 @@ impl App {
     /// before / after another plugin), call [`build()`](PluginGroup::build) on the group,
     /// which will convert it to a [`PluginGroupBuilder`](crate::PluginGroupBuilder).
     ///
+    /// You can also specify a group of [`Plugin`]s by using a tuple over [`Plugin`]s and
+    /// [`PluginGroup`]s.
+    ///
     /// ## Examples
     /// ```
     /// # use bevy_app::{prelude::*, PluginGroupBuilder, NoopPluginGroup as MinimalPlugins};
     /// #
+    /// # // Dummies created to avoid using `bevy_log`,
+    /// # // which pulls in too many dependencies and breaks rust-analyzer
+    /// # pub struct LogPlugin;
+    /// # impl Plugin for LogPlugin {
+    /// #     fn build(&self, app: &mut App) {}
+    /// # }
     /// App::new()
     ///     .add_plugins(MinimalPlugins);
+    /// App::new()
+    ///     .add_plugins((MinimalPlugins, LogPlugin));
     /// ```
     ///
     /// # Panics
     ///
     /// Panics if one of the plugin in the group was already added to the application.
+    ///
+    /// [`PluginGroup`]:super::PluginGroup
     pub fn add_plugins<P>(&mut self, group: impl IntoPluginGroup<P>) -> &mut Self {
         let builder = group.into_plugin_group_builder(self);
         builder.finish(self);

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -50,14 +50,14 @@ pub(super) mod sealed {
 
     use crate::{App, Plugin, PluginGroup, PluginGroupBuilder};
 
-    pub trait IntoPlugin<Marker> {
+    pub trait IntoPlugin<Params> {
         type Plugin: Plugin;
         fn into_plugin(self, app: &mut App) -> Self::Plugin;
     }
 
-    pub trait IntoPluginGroup<Marker>: IntoPluginGroupBuilder<Marker> {}
+    pub trait IntoPluginGroup<Params>: IntoPluginGroupBuilder<Params> {}
 
-    pub trait IntoPluginGroupBuilder<Marker> {
+    pub trait IntoPluginGroupBuilder<Params> {
         fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder;
     }
 

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -44,3 +44,83 @@ impl_downcast!(Plugin);
 ///
 /// See `bevy_dynamic_plugin/src/loader.rs#dynamically_load_plugin`.
 pub type CreatePlugin = unsafe fn() -> *mut dyn Plugin;
+
+pub(super) mod sealed {
+    use bevy_ecs::all_tuples;
+
+    use crate::{App, Plugin, PluginGroup, PluginGroupBuilder};
+
+    pub trait IntoPlugin<Marker> {
+        type Plugin: Plugin;
+        fn into_plugin(self, app: &mut App) -> Self::Plugin;
+    }
+
+    pub trait IntoPluginGroup<Marker>: IntoPluginGroupBuilder<Marker> {}
+
+    pub trait IntoPluginGroupBuilder<Marker> {
+        fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder;
+    }
+
+    pub struct IsPlugin;
+    pub struct IsPluginGroup;
+    pub struct IsFunction;
+
+    impl<P: Plugin> IntoPlugin<IsPlugin> for P {
+        type Plugin = Self;
+        fn into_plugin(self, _: &mut App) -> Self {
+            self
+        }
+    }
+
+    impl<P: Plugin> IntoPluginGroupBuilder<IsPlugin> for P {
+        fn into_plugin_group_builder(self, _: &mut App) -> PluginGroupBuilder {
+            PluginGroupBuilder::from_plugin(self)
+        }
+    }
+
+    impl<P: PluginGroup> IntoPluginGroupBuilder<IsPluginGroup> for P {
+        fn into_plugin_group_builder(self, _: &mut App) -> PluginGroupBuilder {
+            self.build()
+        }
+    }
+
+    impl<P: PluginGroup> IntoPluginGroup<IsPluginGroup> for P {}
+
+    impl<F: FnOnce(&mut App) -> P, P: Plugin> IntoPlugin<IsFunction> for F {
+        type Plugin = P;
+
+        fn into_plugin(self, app: &mut App) -> Self::Plugin {
+            self(app)
+        }
+    }
+
+    impl<F: FnOnce(&mut App) -> PG, PG: PluginGroup> IntoPluginGroupBuilder<IsFunction> for F {
+        fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder {
+            self(app).build()
+        }
+    }
+
+    impl<F: FnOnce(&mut App) -> PG, PG: PluginGroup> IntoPluginGroup<IsFunction> for F {}
+
+    macro_rules! impl_plugin_collection {
+        ($(($param: ident, $plugins: ident)),*) => {
+            impl<$($param, $plugins),*> IntoPluginGroupBuilder<($($param,)*)> for ($($plugins,)*)
+            where
+                $($plugins: IntoPluginGroupBuilder<$param>),*
+            {
+                #[allow(non_snake_case, unused_variables)]
+                fn into_plugin_group_builder(self, app: &mut App) -> PluginGroupBuilder {
+                    let ($($plugins,)*) = self;
+                    PluginGroupBuilder::merge(vec![$($plugins.into_plugin_group_builder(app),)*])
+                }
+            }
+
+            impl<$($param, $plugins),*> IntoPluginGroup<($($param,)*)> for ($($plugins,)*)
+            where
+                $($plugins: IntoPluginGroupBuilder<$param>),*
+            {}
+        }
+    }
+
+    all_tuples!(impl_plugin_collection, 0, 15, P, S);
+}

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -45,7 +45,15 @@ impl_downcast!(Plugin);
 /// See `bevy_dynamic_plugin/src/loader.rs#dynamically_load_plugin`.
 pub type CreatePlugin = unsafe fn() -> *mut dyn Plugin;
 
-pub(super) mod sealed {
+/// Types that can be converted into a [`Plugin`].
+///
+/// This is implemented for all types which implement [`Plugin`] or
+/// [`FnOnce(&mut App) -> impl Plugin`](FnOnce).
+pub trait IntoPlugin<Params>: sealed::IntoPlugin<Params> {}
+
+impl<Params, T> IntoPlugin<Params> for T where T: sealed::IntoPlugin<Params> {}
+
+mod sealed {
 
     use crate::{App, Plugin};
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -47,6 +47,39 @@ impl PluginGroupBuilder {
         }
     }
 
+    pub(crate) fn from_plugin<P: Plugin>(plugin: P) -> Self {
+        Self {
+            group_name: plugin.name().to_string(),
+            plugins: Default::default(),
+            order: Default::default(),
+        }
+        .add(plugin)
+    }
+
+    pub(crate) fn merge(builders: Vec<PluginGroupBuilder>) -> Self {
+        let mut group_name = "(".to_string();
+        let mut plugins = HashMap::new();
+        let mut order = Vec::new();
+        let mut first = true;
+        for mut builder in builders {
+            if first {
+                first = false;
+            } else {
+                group_name += ", ";
+            }
+            for (type_id, entry) in builder.plugins {
+                plugins.insert(type_id, entry);
+            }
+            order.append(&mut builder.order);
+        }
+        group_name += ")";
+        Self {
+            group_name,
+            plugins,
+            order,
+        }
+    }
+
     /// Finds the index of a target [`Plugin`]. Panics if the target's [`TypeId`] is not found.
     fn index_of<Target: Plugin>(&self) -> usize {
         let index = self

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -225,7 +225,16 @@ impl PluginGroupBuilder {
     }
 }
 
-pub(super) mod sealed {
+/// Types that can be converted into a [`PluginGroup`].
+///
+/// This is implemented for all types which implement [`PluginGroup`] or
+/// [`FnOnce(&mut App) -> impl PluginGroup`](FnOnce) and for tuples over types that implement
+/// [`IntoPlugin`](super::IntoPlugin) or  [`IntoPluginGroup`].
+pub trait IntoPluginGroup<Params>: sealed::IntoPluginGroup<Params> {}
+
+impl<Params, T> IntoPluginGroup<Params> for T where T: sealed::IntoPluginGroup<Params> {}
+
+mod sealed {
     use bevy_ecs::all_tuples;
 
     use crate::{App, Plugin, PluginGroup, PluginGroupBuilder};


### PR DESCRIPTION
# Objective

~~This is just a small idea of mine about a possible unified API.~~
(see https://github.com/bevyengine/bevy/pull/7687#issuecomment-1431564245)

- Helps #7682

## Solution

(see https://github.com/bevyengine/bevy/pull/7687#issuecomment-1431564245)
~~Add a single `add` method to which a `Plugin`, a `PluginGroup` or a `FnOnce(&mut App)` can be passed~~. Plugins that need resources to be inserted before they can be built (because they don't want to use an ugly hack like `Arc<Mutex<Option<T>>>`) can now provide an constructor that returns an `FnOnce` which takes care of that (see `logger_example`). 

Pros:
- Can pass tuples to `add_plugins`.
- ~~Added Flexibility: Application code can easily and ergonomically split up setup code into functions that take an &mut App parameter.~~
- ~~Users don't have to worry about the difference of `add_plugin` vs `add_plugins`~~
- ~~Shorter to write: `app.add_plugins(DefaultPlugins)` vs `app.add(DefaultPlugins)`. The type names already make clear that Plugins are added.~~

~~Cons:~~
- ~~Redundancy on the API level. This can be solved by removing `add_plugin` and `add_plugins` or reducing their visibility.~~
- Probably harder to write docs.  
