### PR TITLE
[Merged by Bors] - Fix trait bounds for run conditions

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -138,12 +138,9 @@ pub mod common_conditions {
     /// #
     /// # fn my_system() { unreachable!() }
     /// ```
-    pub fn not<Params, C: Condition<Params>>(
-        condition: C,
-    ) -> impl ReadOnlySystem<In = (), Out = bool>
-    where
-        C::System: ReadOnlySystem,
-    {
+    pub fn not<Params, C>(
+        condition: impl Condition<Params>,
+    ) -> impl ReadOnlySystem<In = (), Out = bool> {
         condition.pipe(|In(val): In<bool>| !val)
     }
 }

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -13,13 +13,18 @@ impl<Params, F> Condition<Params> for F where F: sealed::Condition<Params> {}
 mod sealed {
     use crate::system::{IntoSystem, ReadOnlySystem};
 
-    pub trait Condition<Params>: IntoSystem<(), bool, Params> {}
+    pub trait Condition<Params>:
+        IntoSystem<(), bool, Params, System = Self::ReadOnlySystem>
+    {
+        type ReadOnlySystem: ReadOnlySystem;
+    }
 
     impl<Params, F> Condition<Params> for F
     where
         F: IntoSystem<(), bool, Params>,
         F::System: ReadOnlySystem,
     {
+        type ReadOnlySystem: ReadOnlySystem = F::System;
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -138,7 +138,7 @@ pub mod common_conditions {
     /// #
     /// # fn my_system() { unreachable!() }
     /// ```
-    pub fn not<Params, C>(
+    pub fn not<Params>(
         condition: impl Condition<Params>,
     ) -> impl ReadOnlySystem<In = (), Out = bool> {
         condition.pipe(|In(val): In<bool>| !val)

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -16,6 +16,8 @@ mod sealed {
     pub trait Condition<Params>:
         IntoSystem<(), bool, Params, System = Self::ReadOnlySystem>
     {
+        // This associated type is necessary to let the compiler
+        // know that `Self::System` is `ReadOnlySystem`.
         type ReadOnlySystem: ReadOnlySystem<In = (), Out = bool>;
     }
 

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -16,7 +16,7 @@ mod sealed {
     pub trait Condition<Params>:
         IntoSystem<(), bool, Params, System = Self::ReadOnlySystem>
     {
-        type ReadOnlySystem: ReadOnlySystem;
+        type ReadOnlySystem: ReadOnlySystem<In = (), Out = bool>;
     }
 
     impl<Params, F> Condition<Params> for F
@@ -24,7 +24,7 @@ mod sealed {
         F: IntoSystem<(), bool, Params>,
         F::System: ReadOnlySystem,
     {
-        type ReadOnlySystem: ReadOnlySystem = F::System;
+        type ReadOnlySystem = F::System;
     }
 }
 


### PR DESCRIPTION
# Objective

The trait `Condition<>` is implemented for any type that can be converted into a `ReadOnlySystem` which takes no inputs and returns a bool. However, due to the current implementation, consumers of the trait cannot rely on the fact that `<T as Condition>::System` implements `ReadOnlySystem`. In cases such as the `not` combinator (added in #7559), we are required to add redundant `T::System: ReadOnlySystem` trait bounds, even though this should be implied by the `Condition<>` trait.

## Solution

Add a hidden associated type which allows the compiler to figure out that the `System` associated type implements `ReadOnlySystem`.
