### PR TITLE
UI Focus System improvements

### DIFF
--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -95,7 +95,7 @@ fn menu(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Clicked(_) => {
                 *color = PRESSED_BUTTON.into();
                 next_state.set(AppState::InGame);
             }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -362,7 +362,9 @@ mod menu {
     ) {
         for (interaction, mut color, selected) in &mut interaction_query {
             *color = match (*interaction, selected) {
-                (Interaction::Clicked, _) | (Interaction::None, Some(_)) => PRESSED_BUTTON.into(),
+                (Interaction::Clicked(_), _) | (Interaction::None, Some(_)) => {
+                    PRESSED_BUTTON.into()
+                }
                 (Interaction::Hovered, Some(_)) => HOVERED_PRESSED_BUTTON.into(),
                 (Interaction::Hovered, None) => HOVERED_BUTTON.into(),
                 (Interaction::None, None) => NORMAL_BUTTON.into(),
@@ -379,7 +381,7 @@ mod menu {
         mut setting: ResMut<T>,
     ) {
         for (interaction, button_setting, entity) in &interaction_query {
-            if *interaction == Interaction::Clicked && *setting != *button_setting {
+            if matches!(*interaction, Interaction::Clicked(_)) && *setting != *button_setting {
                 let (previous_button, mut previous_color) = selected_query.single_mut();
                 *previous_color = NORMAL_BUTTON.into();
                 commands.entity(previous_button).remove::<SelectedOption>();
@@ -796,7 +798,7 @@ mod menu {
         mut game_state: ResMut<NextState<GameState>>,
     ) {
         for (interaction, menu_button_action) in &interaction_query {
-            if *interaction == Interaction::Clicked {
+            if matches!(*interaction, Interaction::Clicked(_)) {
                 match menu_button_action {
                     MenuButtonAction::Quit => app_exit_events.send(AppExit),
                     MenuButtonAction::Play => {

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -135,7 +135,7 @@ fn button_handler(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Clicked(_) => {
                 *color = Color::BLUE.into();
             }
             Interaction::Hovered => {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -27,7 +27,7 @@ fn button_system(
     for (interaction, mut color, children) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Clicked(_) => {
                 text.sections[0].value = "Press".to_string();
                 *color = PRESSED_BUTTON.into();
             }


### PR DESCRIPTION
# Objective
At the moment the position where a click has occurred has to be manually tracked.

## Solution
This PR makes the process easier, by providing the position where the button has clicked, not changing while it is clicked (in contrast to RelativeCursorPosition). It also improves the understand-ability/readability of the `ui_focus_system` by getting rid of the partial-read iterator, replacing it with easy-readable if statements.

## Changelog
- added `Vec2`(position of the click) to `Interaction::Clicked`

## Migration Guide
- replace `*interaction == Interaction::Clicked` with `matches!(*interaction, Interaction::Clicked(_))`