### PR TITLE
Deprecate add_startup_system/s

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -465,6 +465,7 @@ impl App {
     /// App::new()
     ///     .add_startup_system(my_startup_system);
     /// ```
+    #[deprecated = "Add system to CoreSchedule::Startup directly"]
     pub fn add_startup_system<P>(&mut self, system: impl IntoSystemConfig<P>) -> &mut Self {
         self.add_system_to_schedule(CoreSchedule::Startup, system)
     }
@@ -490,6 +491,7 @@ impl App {
     ///     )
     /// );
     /// ```
+    #[deprecated = "Add systems to CoreSchedule::Startup directly"]
     pub fn add_startup_systems<P>(&mut self, systems: impl IntoSystemConfigs<P>) -> &mut Self {
         self.add_systems_to_schedule(CoreSchedule::Startup, systems)
     }

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -18,8 +18,11 @@ impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
 
 impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system);
+        app.add_system_to_schedule(
+            CoreSchedule::Startup,
+            Self::setup_system.in_set(StartupSet::Startup),
+        )
+        .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -4,13 +4,13 @@
 //! # use bevy_ecs::{system::Res, event::EventWriter};
 //! # use bevy_audio::{Audio, AudioPlugin};
 //! # use bevy_asset::{AssetPlugin, AssetServer};
-//! # use bevy_app::{App, AppExit, NoopPluginGroup as MinimalPlugins};
+//! # use bevy_app::{App, AppExit, CoreSchedule, NoopPluginGroup as MinimalPlugins};
 //! fn main() {
 //!    App::new()
 //!         .add_plugins(MinimalPlugins)
 //!         .add_plugin(AssetPlugin::default())
 //!         .add_plugin(AudioPlugin)
-//!         .add_startup_system(play_background_audio)
+//!         .add_system_to_schedule(CoreSchedule::Startup, play_background_audio)
 //!         .run();
 //! }
 //!

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -9,8 +9,11 @@ pub struct EntityCountDiagnosticsPlugin;
 
 impl Plugin for EntityCountDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system);
+        app.add_system_to_schedule(
+            CoreSchedule::Startup,
+            Self::setup_system.in_set(StartupSet::Startup),
+        )
+        .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -10,8 +10,11 @@ pub struct FrameTimeDiagnosticsPlugin;
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
-        app.add_startup_system(Self::setup_system.in_set(StartupSet::Startup))
-            .add_system(Self::diagnostic_system);
+        app.add_system_to_schedule(
+            CoreSchedule::Startup,
+            Self::setup_system.in_set(StartupSet::Startup),
+        )
+        .add_system(Self::diagnostic_system);
     }
 }
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -18,7 +18,8 @@ pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<Diagnostics>().add_startup_system(
+        app.init_resource::<Diagnostics>().add_system_to_schedule(
+            CoreSchedule::Startup,
             system_information_diagnostics_plugin::internal::log_system_info
                 .in_set(StartupSet::Startup),
         );

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -15,8 +15,11 @@ use bevy_ecs::prelude::*;
 pub struct SystemInformationDiagnosticsPlugin;
 impl Plugin for SystemInformationDiagnosticsPlugin {
     fn build(&self, app: &mut App) {
-        app.add_startup_system(internal::setup_system.in_set(StartupSet::Startup))
-            .add_system(internal::diagnostic_system);
+        app.add_system_to_schedule(
+            CoreSchedule::Startup,
+            internal::setup_system.in_set(StartupSet::Startup),
+        )
+        .add_system(internal::diagnostic_system);
     }
 }
 

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -1,7 +1,7 @@
 mod converter;
 mod gilrs_system;
 
-use bevy_app::{App, CoreSet, Plugin, StartupSet};
+use bevy_app::{App, CoreSchedule, CoreSet, Plugin, StartupSet};
 use bevy_ecs::prelude::*;
 use bevy_input::InputSystem;
 use bevy_utils::tracing::error;
@@ -20,7 +20,10 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.insert_non_send_resource(gilrs)
-                    .add_startup_system(gilrs_event_startup_system.in_set(StartupSet::PreStartup))
+                    .add_system_to_schedule(
+                        CoreSchedule::Startup,
+                        gilrs_event_startup_system.in_set(StartupSet::PreStartup),
+                    )
                     .add_system(
                         gilrs_event_system
                             .before(InputSystem)

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -31,7 +31,8 @@ impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraPro
                 schedule.configure_set(CameraUpdateSystem.in_set(StartupSet::PostStartup));
             })
             .configure_set(CameraUpdateSystem.in_base_set(CoreSet::PostUpdate))
-            .add_startup_system(
+            .add_system_to_schedule(
+                CoreSchedule::Startup,
                 crate::camera::camera_system::<T>
                     .in_set(CameraUpdateSystem)
                     // We assume that each camera will only have one projection,

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -103,12 +103,15 @@ impl Plugin for TransformPlugin {
             // FIXME: https://github.com/bevyengine/bevy/issues/4381
             // These systems cannot access the same entities,
             // due to subtle query filtering that is not yet correctly computed in the ambiguity detector
-            .add_startup_system(
-                sync_simple_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(propagate_transforms),
+            .add_systems_to_schedule(
+                CoreSchedule::Startup,
+                (
+                    sync_simple_transforms
+                        .in_set(TransformSystem::TransformPropagate)
+                        .ambiguous_with(propagate_transforms),
+                    propagate_transforms.in_set(TransformSystem::TransformPropagate),
+                ),
             )
-            .add_startup_system(propagate_transforms.in_set(TransformSystem::TransformPropagate))
             .add_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -34,7 +34,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(ColoredMesh2dPlugin)
-        .add_startup_system(star)
+        .add_system_to_schedule(CoreSchedule::Startup, star)
         .run();
 }
 

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -9,7 +9,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(sprite_movement)
         .run();
 }

--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(sprite_movement)
         .run();
 }

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -8,7 +8,7 @@ const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_systems_to_schedule(
             CoreSchedule::FixedUpdate,
             (

--- a/examples/2d/sprite.rs
+++ b/examples/2d/sprite.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/2d/sprite_flipping.rs
+++ b/examples/2d/sprite_flipping.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(animate_sprite)
         .run();
 }

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -13,7 +13,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(animate_translation)
         .add_system(animate_rotation)
         .add_system(animate_scale)

--- a/examples/2d/transparency_2d.rs
+++ b/examples/2d/transparency_2d.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -11,7 +11,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotate)
         .run();
 }

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -15,9 +15,10 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera_fog)
-        .add_startup_system(setup_terrain_scene)
-        .add_startup_system(setup_instructions)
+        .add_systems_to_schedule(
+            CoreSchedule::Startup,
+            (setup_camera_fog, setup_terrain_scene, setup_instructions),
+        )
         .add_system(toggle_system)
         .run();
 }

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -17,7 +17,7 @@ fn main() {
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(example_control_system);
 
     // Unfortunately, MSAA and HDR are not supported simultaneously under WebGL.

--- a/examples/3d/bloom.rs
+++ b/examples/3d/bloom.rs
@@ -9,7 +9,7 @@ use std::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_scene)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_scene)
         .add_system(update_bloom_settings)
         .add_system(bounce_spheres)
         .run();

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -22,9 +22,10 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera_fog)
-        .add_startup_system(setup_pyramid_scene)
-        .add_startup_system(setup_instructions)
+        .add_systems_to_schedule(
+            CoreSchedule::Startup,
+            (setup_camera_fog, setup_pyramid_scene, setup_instructions),
+        )
         .add_system(update_system)
         .run();
 }

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -17,7 +17,7 @@ fn main() {
         // Disable MSAA by default
         .insert_resource(Msaa::Off)
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(toggle_fxaa)
         .run();
 }

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -8,7 +8,7 @@ use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(movement)
         .add_system(animate_light_direction)
         .run();

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -17,7 +17,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<LineMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -15,7 +15,7 @@ fn main() {
         })
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(animate_light_direction)
         .run();
 }

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -12,7 +12,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(cycle_msaa)
         .run();
 }

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, render::camera::ScalingMode};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotator_system)
         .run();
 }

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -5,7 +5,7 @@ use bevy::{asset::LoadState, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(environment_map_load_finish)
         .run();
 }

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -17,7 +17,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(cube_rotator_system)
         .add_system(rotator_system)
         .run();

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -19,7 +19,7 @@ fn main() {
     );
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(adjust_point_light_biases)
         .add_system(toggle_light)
         .add_system(adjust_directional_light_biases)

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -16,7 +16,7 @@ fn main() {
     );
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(toggle_light)
         .add_system(toggle_shadows)
         .run();

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -46,7 +46,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CubemapMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(cycle_cubemap_asset)
         .add_system(asset_loaded.after(cycle_cubemap_asset))
         .add_system(camera_controller)

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -10,7 +10,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(set_camera_viewports)
         .run();
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -12,7 +12,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(light_sway)
         .add_system(movement)
         .run();

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(fade_transparency)
         .run();
 }

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -5,7 +5,7 @@ use bevy::{core_pipeline::clear_color::ClearColorConfig, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(move_scene_entities)
         .run();
 }

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -5,7 +5,7 @@ use bevy::{prelude::*, render::mesh::VertexAttributeValues};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -15,7 +15,7 @@ fn main() {
             },
         }))
         .add_plugin(WireframePlugin)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -13,7 +13,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(setup_scene_once_loaded)
         .add_system(keyboard_animation_control)
         .run();

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -11,7 +11,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -20,7 +20,7 @@ fn main() {
             brightness: 1.0,
             ..default()
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(joint_animation)
         .run();
 }

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -12,7 +12,7 @@ fn main() {
             brightness: 1.0,
             ..default()
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(joint_animation)
         .run();
 }

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -41,7 +41,7 @@ fn main() {
         .init_resource::<State>()
         .add_asset::<CustomAsset>()
         .init_asset_loader::<CustomAssetLoader>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(print_on_load)
         .run();
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -75,7 +75,7 @@ fn main() {
                 // asset system are initialized correctly.
                 .add_before::<bevy::asset::AssetPlugin, _>(CustomAssetIoPlugin),
         )
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -11,7 +11,7 @@ fn main() {
             watch_for_changes: true,
             ..default()
         }))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -12,9 +12,7 @@ use std::time::{Duration, Instant};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_env)
-        .add_startup_system(add_assets)
-        .add_startup_system(spawn_tasks)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup_env, add_assets, spawn_tasks))
         .add_system(handle_tasks)
         .run();
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_event::<StreamEvent>()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(read_stream)
         .add_system(spawn_text)
         .add_system(move_text)

--- a/examples/audio/audio.rs
+++ b/examples/audio/audio.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -5,7 +5,7 @@ use bevy::{audio::AudioSink, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(update_speed)
         .add_system(pause)
         .add_system(volume)

--- a/examples/audio/decodable.rs
+++ b/examples/audio/decodable.rs
@@ -87,7 +87,7 @@ fn main() {
     // register the audio source so that it can be used
     app.add_plugins(DefaultPlugins)
         .add_audio_source::<SineAudio>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/diagnostics/custom_diagnostic.rs
+++ b/examples/diagnostics/custom_diagnostic.rs
@@ -11,7 +11,7 @@ fn main() {
         // The "print diagnostics" plugin is optional.
         // It just visualizes our diagnostics in the console.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup_diagnostic_system)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_diagnostic_system)
         .add_system(my_system)
         .run();
 }

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -6,7 +6,7 @@ use rand::Rng;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(change_component)
         .add_system(change_detection)
         .add_system(tracker_monitoring)

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -17,7 +17,7 @@ use std::fmt::Debug;
 
 fn main() {
     App::new()
-        .add_startup_system(spawn)
+        .add_system_to_schedule(CoreSchedule::Startup, spawn)
         .add_system(print_components_read_only)
         .add_system(print_components_iter_mut.after(print_components_read_only))
         .add_system(print_components_iter.after(print_components_iter_mut))

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -139,8 +139,9 @@ fn game_over_system(
 
 // This is a "startup" system that runs exactly once when the app starts up. Startup systems are
 // generally used to create the initial "state" of our game. The only thing that distinguishes a
-// "startup" system from a "normal" system is how it is registered:      Startup:
-// app.add_startup_system(startup_system)      Normal:  app.add_system(normal_system)
+// "startup" system from a "normal" system is how it is registered:
+// Startup: app.add_system_to_schedule(CoreSchedule::Startup, startup_system)
+// Normal:  app.add_system(normal_system)
 fn startup_system(mut commands: Commands, mut game_state: ResMut<GameState>) {
     // Create our game rules resource
     commands.insert_resource(GameRules {
@@ -259,9 +260,9 @@ fn main() {
         // that :) The plugin below runs our app's "system schedule" once every 5 seconds
         // (configured above).
         .add_plugin(ScheduleRunnerPlugin::default())
-        // Startup systems run exactly once BEFORE all other systems. These are generally used for
+        // The startup schedule runs exactly once BEFORE all other systems. These are generally used for
         // app initialization code (ex: adding entities and resources)
-        .add_startup_system(startup_system)
+        .add_system_to_schedule(CoreSchedule::Startup, startup_system)
         .add_system(print_message_system)
         // SYSTEM EXECUTION ORDER
         //

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -42,7 +42,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_state::<AppState>()
-        .add_startup_system(setup_system)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_system)
         .add_system(print_text_system)
         .add_system(transition_to_in_game_system.in_set(OnUpdate(AppState::MainMenu)))
         // add the cleanup systems

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -7,7 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotate)
         .run();
 }

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -12,7 +12,7 @@ fn main() {
             brightness: 0.03,
             ..default()
         })
-        .add_startup_system(generate_bodies)
+        .add_system_to_schedule(CoreSchedule::Startup, generate_bodies)
         .insert_resource(FixedTime::new_from_secs(DELTA_TIME))
         .add_systems_to_schedule(CoreSchedule::FixedUpdate, (interact_bodies, integrate))
         .add_system(look_at_star)

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -69,7 +69,7 @@ fn bounce_system(windows: Query<&Window>, mut sprites: Query<(&Transform, &mut V
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(spawn_system)
+        .add_system_to_schedule(CoreSchedule::Startup, spawn_system)
         .add_system(move_system)
         .add_system(bounce_system)
         .run();

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -14,7 +14,7 @@ fn main() {
     // `CoreSet::Update', and the system that reacts on the removal in `CoreSet::PostUpdate`.
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(remove_component)
         .add_system(react_on_removal.in_base_set(CoreSet::PostUpdate))
         .run();

--- a/examples/ecs/startup_system.rs
+++ b/examples/ecs/startup_system.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_startup_system(startup_system)
+        .add_system_to_schedule(CoreSchedule::Startup, startup_system)
         .add_system(normal_system)
         .run();
 }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_state::<AppState>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         // This system runs when we enter `AppState::Menu`, during `CoreSet::StateTransitions`.
         // All systems from the exit schedule of the state we're leaving are run first,
         // and then all systems from the enter schedule of the state we're entering are run second.

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -5,7 +5,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 fn main() {
     App::new()
         .insert_resource(PlayerCount(0))
-        .add_startup_system(spawn)
+        .add_system_to_schedule(CoreSchedule::Startup, spawn)
         .add_system(count_players)
         .run();
 }

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_resource::<Countdown>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(countdown)
         .add_system(print_when_completed)
         .run();

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -24,7 +24,7 @@ fn main() {
         )))
         .add_plugins(DefaultPlugins)
         .add_state::<GameState>()
-        .add_startup_system(setup_cameras)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_cameras)
         .add_system_to_schedule(OnEnter(GameState::Playing), setup)
         .add_systems(
             (

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -55,7 +55,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .insert_resource(Scoreboard { score: 0 })
         .insert_resource(ClearColor(BACKGROUND_COLOR))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_event::<CollisionEvent>()
         // Add our gameplay simulation systems to the fixed timestep schedule
         .add_systems_to_schedule(

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -11,8 +11,7 @@ use std::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_contributor_selection)
-        .add_startup_system(setup)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup, setup_contributor_selection))
         .add_system(velocity_system)
         .add_system(move_system)
         .add_system(collision_system)

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -33,7 +33,7 @@ fn main() {
         // Insert as resource the initial value for the settings resources
         .insert_resource(DisplayQuality::Medium)
         .insert_resource(Volume(7))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         // Declare the game state, whose starting value is determined by the `Default` trait
         .add_state::<GameState>()
         // Adds the plugins for each state

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -9,7 +9,7 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_scene)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_scene)
         .add_system(toggle_ime)
         .add_system(listen_ime_events)
         .add_system(listen_received_character_events)

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -12,8 +12,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_music)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup_scene, setup_music))
         .add_system(touch_camera)
         .add_system(button_handler)
         .run();

--- a/examples/reflection/generic_reflection.rs
+++ b/examples/reflection/generic_reflection.rs
@@ -8,7 +8,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // You must manually register each instance of a generic type
         .register_type::<MyType<u32>>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -18,7 +18,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .register_type::<Foo>()
         .register_type::<Bar>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/reflection/trait_reflection.rs
+++ b/examples/reflection/trait_reflection.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .register_type::<MyType>()
         .run();
 }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -14,9 +14,10 @@ fn main() {
         }))
         .register_type::<ComponentA>()
         .register_type::<ComponentB>()
-        .add_startup_system(save_scene_system)
-        .add_startup_system(load_scene_system)
-        .add_startup_system(infotext_system)
+        .add_systems_to_schedule(
+            CoreSchedule::Startup,
+            (save_scene_system, load_scene_system, infotext_system),
+        )
         .add_system(log_system)
         .run();
 }

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<ArrayTextureMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(create_array_texture)
         .run();
 }

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -32,7 +32,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(GameOfLifeComputePlugin)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/custom_vertex_attribute.rs
+++ b/examples/shader/custom_vertex_attribute.rs
@@ -17,7 +17,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -23,7 +23,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(Material2dPlugin::<PostProcessingMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(main_camera_cube_rotator_system)
         .run();
 }

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -16,7 +16,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -28,7 +28,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(CustomMaterialPlugin)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -16,7 +16,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotate_camera)
         .run();
 }

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -28,7 +28,7 @@ fn main() {
             prepass_enabled: false,
             ..default()
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotate)
         .add_system(update)
         .run();

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -33,7 +33,7 @@ fn main() {
     }
 
     app.add_plugin(MaterialPlugin::<BindlessMaterial>::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -43,7 +43,7 @@ fn main() {
             count: 0,
             color: Color::WHITE,
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(mouse_handler)
         .add_system(movement_system)
         .add_system(collision_system)

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -32,7 +32,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(animate_sprite)
         .add_system(print_sprite_count)
         .add_system(move_camera.after(print_sprite_count))

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -21,7 +21,7 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .init_resource::<UiFont>()
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(button_system)
         .run();
 }

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -30,7 +30,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(move_camera)
         .add_system(print_mesh_count)
         .run();

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -41,7 +41,7 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(setup_scene_once_loaded)
         .add_system(keyboard_animation_control)
         .add_system(update_fox_rings.after(keyboard_animation_control))

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -26,7 +26,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(move_camera)
         .add_system(print_light_count)
         .add_plugin(LogVisibleLights)

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -40,7 +40,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(print_sprite_count)
         .add_system(move_camera.after(print_sprite_count))
         .run();

--- a/examples/stress_tests/transform_hierarchy.rs
+++ b/examples/stress_tests/transform_hierarchy.rs
@@ -185,7 +185,7 @@ fn main() {
         .insert_resource(cfg)
         .add_plugins(MinimalPlugins)
         .add_plugin(TransformPlugin::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         // Updating transforms *must* be done before `CoreSet::PostUpdate`
         // or the hierarchy will momentarily be in an invalid state.
         .add_system(update)

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -127,10 +127,10 @@ fn main() {
         .init_resource::<ButtonMaterials>()
         .init_resource::<ButtonMeshes>()
         .init_resource::<FontHandle>()
-        .add_startup_system(setup)
-        .add_startup_system(setup_sticks)
-        .add_startup_system(setup_triggers)
-        .add_startup_system(setup_connected)
+        .add_systems_to_schedule(
+            CoreSchedule::Startup,
+            (setup, setup_sticks, setup_triggers, setup_connected),
+        )
         .add_system(update_buttons)
         .add_system(update_button_values)
         .add_system(update_axes)

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -41,7 +41,7 @@ fn main() {
     )
     .add_plugin(CameraControllerPlugin)
     .add_plugin(SceneViewerPlugin)
-    .add_startup_system(setup)
+    .add_system_to_schedule(CoreSchedule::Startup, setup)
     .add_system(setup_scene_after_load.in_base_set(CoreSet::PreUpdate));
 
     app.run();

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -13,7 +13,7 @@ struct Rotatable {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(rotate_cube)
         .run();
 }

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -29,7 +29,7 @@ impl Scaling {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(change_scale_direction)
         .add_system(scale_cube)
         .run();

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -24,7 +24,7 @@ struct Center {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(move_cube)
         .add_system(rotate_cube)
         .add_system(scale_down_sphere_proportional_to_cube_travel_distance)

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -25,7 +25,7 @@ impl Movable {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(move_cube)
         .run();
 }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -8,7 +8,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(button_system)
         .run();
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -8,7 +8,7 @@ fn main() {
         .init_resource::<State>()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(text_update_system)
         .add_system(atlas_render_system)
         .run();

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(relative_cursor_position_system)
         .run();
 }

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -12,7 +12,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(text_update_system)
         .add_system(text_color_system)
         .run();

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -16,7 +16,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin)
-        .add_startup_system(infotext_system)
+        .add_system_to_schedule(CoreSchedule::Startup, infotext_system)
         .add_system(change_text_system)
         .run();
 }

--- a/examples/ui/text_layout.rs
+++ b/examples/ui/text_layout.rs
@@ -15,7 +15,7 @@ fn main() {
             }),
             ..Default::default()
         }))
-        .add_startup_system(spawn_layout)
+        .add_system_to_schedule(CoreSchedule::Startup, spawn_layout)
         .run();
 }
 

--- a/examples/ui/transparency_ui.rs
+++ b/examples/ui/transparency_ui.rs
@@ -7,7 +7,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -11,7 +11,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(mouse_scroll)
         .run();
 }

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -16,7 +16,7 @@ fn main() {
             target_scale: 1.0,
             target_time: Timer::new(Duration::from_millis(SCALE_TIME), TimerMode::Once),
         })
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(change_scaling)
         .add_system(apply_scaling.after(change_scaling))
         .run();

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -16,7 +16,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(toggle_mouse_passthrough) // This allows us to hit 'P' to toggle on/off the mouse's passthrough
         .run();
 }

--- a/examples/ui/z_index.rs
+++ b/examples/ui/z_index.rs
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .run();
 }
 

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -8,7 +8,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(change_clear_color)
         .run();
 }

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -33,7 +33,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(test_setup::setup)
+        .add_system_to_schedule(CoreSchedule::Startup, test_setup::setup)
         .add_system(test_setup::cycle_modes)
         .add_system(test_setup::rotate_cube)
         .add_system(test_setup::update_text)

--- a/examples/window/multiple_windows.rs
+++ b/examples/window/multiple_windows.rs
@@ -6,7 +6,7 @@ fn main() {
     App::new()
         // By default, a primary window gets spawned by `WindowPlugin`, contained in `DefaultPlugins`
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_scene)
+        .add_system_to_schedule(CoreSchedule::Startup, setup_scene)
         .add_system(bevy::window::close_on_esc)
         .run();
 }

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -12,7 +12,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_system(display_override)
         .add_system(toggle_override)
         .add_system(change_scale_factor)

--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -13,7 +13,7 @@ fn main() {
     App::new()
         // ClearColor must have 0 alpha, otherwise some color will bleed through
         .insert_resource(ClearColor(Color::NONE))
-        .add_startup_system(setup)
+        .add_system_to_schedule(CoreSchedule::Startup, setup)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 // Setting `transparent` allows the `ClearColor`'s alpha value to take effect

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -9,8 +9,7 @@ fn main() {
             small: Vec2::new(640.0, 360.0),
         })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera)
-        .add_startup_system(setup_ui)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup_camera, setup_ui))
         .add_system(on_resize_system)
         .add_system(toggle_resolution)
         .run();

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -14,8 +14,7 @@ fn main() {
             ..default()
         }))
         .add_system(minimise_automatically)
-        .add_startup_system(setup_3d)
-        .add_startup_system(setup_2d)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup_2d, setup_3d))
         .run();
 }
 

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -38,8 +38,7 @@ fn main() {
         .add_system(change_window_size)
         .add_system(sync_dimensions)
         .add_system(bevy::window::close_on_esc)
-        .add_startup_system(setup_3d)
-        .add_startup_system(setup_2d)
+        .add_systems_to_schedule(CoreSchedule::Startup, (setup_2d, setup_3d))
         .run();
 }
 


### PR DESCRIPTION
# Objective

Startup systems used to require `add_startup_system` and belonged to special startup stages. This is no longer necessary: They can just be added to the `CoreSchedule::Startup` instead (and `add_startup_system`/`add_startup_systems` are one-liners doing that).

Outside of example apps, startup system aren't as useful anyways as using states is more common, so removing their special status makes sense.

## Changelog

- deprecated `App::add_startup_system`/`add_startup_systems`

## Migration Guide

- replace `add_startup_system(my_system)` with `add_system_to_schedule(CoreSchedule::Startup, my_system)`