### PR TITLE
[Merged by Bors] - Make ktx2 and zstd default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,14 +190,14 @@ jobs:
       - name: Build bevy
         # this uses the same command as when running the example to ensure build is reused
         run: |
-          TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome,ktx2,zstd"
+          TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome"
       - name: Run examples
         run: |
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo -n $example_name > last_example_run
             echo "running $example_name - "`date`
-            time TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example xvfb-run cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome,ktx2,zstd"
+            time TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example xvfb-run cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome"
             sleep 10
           done
           zip traces.zip trace*.json

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         # this uses the same command as when running the example to ensure build is reused
         run: |
-          WGPU_BACKEND=dx12 CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,ktx2,zstd"
+          WGPU_BACKEND=dx12 CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing"
 
       - name: Run examples
         shell: bash
@@ -88,7 +88,7 @@ jobs:
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo "running $example_name - "`date`
-            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing,ktx2,zstd"
+            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing"
             sleep 10
           done
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,11 @@ repository = "https://github.com/bevyengine/bevy"
 rust-version = "1.67.0"
 
 [workspace]
-exclude = ["benches", "crates/bevy_ecs_compile_fail_tests", "crates/bevy_reflect_compile_fail_tests"]
+exclude = [
+  "benches",
+  "crates/bevy_ecs_compile_fail_tests",
+  "crates/bevy_reflect_compile_fail_tests",
+]
 members = [
   "crates/*",
   "examples/mobile",
@@ -40,10 +44,12 @@ default = [
   "bevy_ui",
   "png",
   "hdr",
+  "ktx2",
+  "zstd",
   "vorbis",
   "x11",
   "filesystem_watcher",
-  "android_shared_stdcxx"
+  "android_shared_stdcxx",
 ]
 
 # Force dynamic linking, which improves iterative compile times

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -432,7 +432,6 @@ wasm = true
 [[example]]
 name = "pbr"
 path = "examples/3d/pbr.rs"
-required-features = ["ktx2", "zstd"]
 
 [package.metadata.example.pbr]
 name = "Physically Based Rendering"
@@ -473,7 +472,6 @@ wasm = true
 [[example]]
 name = "skybox"
 path = "examples/3d/skybox.rs"
-required-features = ["ktx2", "zstd"]
 
 [package.metadata.example.skybox]
 name = "Skybox"

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -95,15 +95,3 @@ impl std::fmt::Display for FileTextureError {
         )
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_supported_file_extensions() {
-        for ext in FILE_EXTENSIONS {
-            assert!(image::ImageFormat::from_extension(ext).is_some());
-        }
-    }
-}

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -27,17 +27,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 .looking_at(Vec3::new(0.0, 0.3, 0.0), Vec3::Y),
             ..default()
         },
-        #[cfg(all(feature = "ktx2", feature = "zstd"))]
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
     ));
-    #[cfg(not(all(feature = "ktx2", feature = "zstd")))]
-    {
-        warn!("feature ktx2 or zstd wasn't enabled.");
-        warn!("rerun this example with `--features=\"ktx2 zstd\" to get environment maps for ambient light");
-    }
 
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -128,7 +128,6 @@ fn setup_scene_after_load(
                 },
                 ..default()
             },
-            #[cfg(all(feature = "ktx2", feature = "zstd"))]
             EnvironmentMapLight {
                 diffuse_map: asset_server
                     .load("assets/environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
@@ -137,11 +136,6 @@ fn setup_scene_after_load(
             },
             camera_controller,
         ));
-        #[cfg(not(all(feature = "ktx2", feature = "zstd")))]
-        {
-            warn!("feature ktx2 or zstd wasn't enabled.");
-            warn!("rerun this example with `--features=\"ktx2 zstd\" to get environment maps for ambient light");
-        }
 
         // Spawn a default light if the scene does not have one
         if !scene_handle.has_light {


### PR DESCRIPTION
# Objective
- Environment maps use these formats, and in the future rendering LUTs will need textures loaded by default in the engine

## Solution

- Make ktx2 and zstd part of the default feature
- Let examples assume these features are enabled

---

## Changelog
- `ktx2` and `zstd` are now part of bevy's default enabled features

## Migration Guide

- If you used the `ktx2` or `zstd` features, you no longer need to explicitly enable them, as they are now part of bevy's default enabled features