### PR TITLE
Print warning when optimizations are disabled

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -8,7 +8,10 @@ use bevy_ecs::{
         ScheduleLabel,
     },
 };
-use bevy_utils::{tracing::debug, HashMap, HashSet};
+use bevy_utils::{
+    tracing::{debug, warn},
+    HashMap, HashSet,
+};
 use std::fmt::Debug;
 
 #[cfg(feature = "trace")]
@@ -190,6 +193,8 @@ impl Default for App {
         app.init_resource::<AppTypeRegistry>();
 
         app.add_default_schedules();
+
+        app.add_system_to_schedule(CoreSchedule::Startup, warn_on_missing_optimization);
 
         app.add_event::<AppExit>();
 
@@ -1006,6 +1011,12 @@ impl App {
 
 fn run_once(mut app: App) {
     app.update();
+}
+
+fn warn_on_missing_optimization() {
+    if bevy_ecs::OPT_LEVEL == "0" {
+        warn!("Running without optimizations. To enable them, see https://bevyengine.org/learn/book/getting-started/setup/#compile-with-performance-optimizations");
+    }
 }
 
 /// An event that indicates the [`App`] should exit. This will fully exit the app process at the

--- a/crates/bevy_ecs/build.rs
+++ b/crates/bevy_ecs/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    // Passes the optimization level on to the crate.
+    // Used by bevy_app to emit a warning if bevy_ecs isn't optimized.
+    println!(
+        "cargo:rustc-env=OPT_LEVEL={}",
+        std::env::var("OPT_LEVEL").unwrap()
+    );
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -57,6 +57,13 @@ pub use bevy_ecs_macros::all_tuples;
 /// A specialized hashmap type with Key of `TypeId`
 type TypeIdMap<V> = rustc_hash::FxHashMap<TypeId, V>;
 
+/// Optimization level with which this crate is compiled.
+/// Used by bevy_app to emit a warning if bevy_ecs is unoptimized.
+/// When https://github.com/rust-lang/rust/issues/54140 is stabilized,
+/// the warning can be emitted here at compile time.
+#[doc(hidden)]
+pub const OPT_LEVEL: &str = env!("OPT_LEVEL");
+
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;


### PR DESCRIPTION
# Objective
Fixes #1827

## Solution

- Check optimization level of bevy_ecs
- Print warning on startup
- ~Should the warning mention that you can enable optimizations for dependencies even in debug mode?~