### PR TITLE
[Merged by Bors] - Fix failing CI `check-bans` due to duplicate `windows` dependency

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,7 @@ skip = [
     { name = "rustc_version", version = "0.2" },         # from postcard v1.0.2
     { name = "semver", version = "0.9" },                # from postcard v1.0.2
     { name = "windows-sys", version = "0.42" },          # from notify v5.1.0
+		{ name = "windows", version = "0.43"},               # from gilrs v0.10.1
     { name = "windows", version = "0.37" },              # from rodio v0.16.0
     { name = "windows_aarch64_msvc", version = "0.37" }, # from rodio v0.16.0
     { name = "windows_i686_gnu", version = "0.37" },     # from rodio v0.16.0

--- a/deny.toml
+++ b/deny.toml
@@ -42,7 +42,7 @@ skip = [
     { name = "rustc_version", version = "0.2" },         # from postcard v1.0.2
     { name = "semver", version = "0.9" },                # from postcard v1.0.2
     { name = "windows-sys", version = "0.42" },          # from notify v5.1.0
-		{ name = "windows", version = "0.43"},               # from gilrs v0.10.1
+    { name = "windows", version = "0.43"},               # from gilrs v0.10.1
     { name = "windows", version = "0.37" },              # from rodio v0.16.0
     { name = "windows_aarch64_msvc", version = "0.37" }, # from rodio v0.16.0
     { name = "windows_i686_gnu", version = "0.37" },     # from rodio v0.16.0


### PR DESCRIPTION
# Objective

Fixes #7654 

## Solution

Add `windows v0.43` to the list of skipped dependencies checked by CI (until `gilrs` publishes a new release with `windows v0.44`)

