### PR TITLE
[Merged by Bors] - Allow adding systems to multiple sets that share the same base set

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -796,6 +796,28 @@ mod tests {
         }
 
         #[test]
+        fn allow_same_base_sets() {
+            let mut world = World::new();
+
+            let mut schedule = Schedule::new();
+            schedule
+                .configure_set(Normal::X.in_base_set(Base::A))
+                .configure_set(Normal::Y.in_base_set(Base::A))
+                .add_system(named_system.in_set(Normal::X).in_set(Normal::Y));
+
+            let result = schedule.initialize(&mut world);
+            assert!(matches!(result, Ok(())));
+
+            let mut schedule = Schedule::new();
+            schedule
+                .configure_set(Normal::X.in_base_set(Base::A))
+                .configure_set(Normal::Y.in_base_set(Base::A).in_set(Normal::X));
+
+            let result = schedule.initialize(&mut world);
+            assert!(matches!(result, Ok(())));
+        }
+
+        #[test]
         fn default_base_set_ordering() {
             let mut world = World::default();
             let mut schedule = Schedule::default();

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -710,20 +710,26 @@ impl ScheduleGraph {
                         neighbor,
                     )? {
                         if let Some(first_set) = base_set {
-                            return Err(match node_id {
-                                NodeId::System(index) => {
-                                    ScheduleBuildError::SystemInMultipleBaseSets {
-                                        system: systems[index].name(),
-                                        first_set: system_sets[first_set.index()].name(),
-                                        second_set: system_sets[calculated_base_set.index()].name(),
+                            if first_set != calculated_base_set {
+                                return Err(match node_id {
+                                    NodeId::System(index) => {
+                                        ScheduleBuildError::SystemInMultipleBaseSets {
+                                            system: systems[index].name(),
+                                            first_set: system_sets[first_set.index()].name(),
+                                            second_set: system_sets[calculated_base_set.index()]
+                                                .name(),
+                                        }
                                     }
-                                }
-                                NodeId::Set(index) => ScheduleBuildError::SetInMultipleBaseSets {
-                                    set: system_sets[index].name(),
-                                    first_set: system_sets[first_set.index()].name(),
-                                    second_set: system_sets[calculated_base_set.index()].name(),
-                                },
-                            });
+                                    NodeId::Set(index) => {
+                                        ScheduleBuildError::SetInMultipleBaseSets {
+                                            set: system_sets[index].name(),
+                                            first_set: system_sets[first_set.index()].name(),
+                                            second_set: system_sets[calculated_base_set.index()]
+                                                .name(),
+                                        }
+                                    }
+                                });
+                            }
                         }
                         base_set = Some(calculated_base_set);
                     }


### PR DESCRIPTION
# Objective

Fixes #7702.

## Solution

- Added an test that ensures that no error is returned if a system or set is inside two different sets that share the same base set.
- Added an check to only return an error if the two base sets are not equal.
