### PR TITLE
[Merged by Bors] - change `is_system_type() -> bool` to `system_type() -> Option<TypeId>`

### DIFF
--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -67,10 +67,6 @@ pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStrea
 
     (quote! {
         impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn is_system_type(&self) -> bool {
-                false
-            }
-
             fn is_base(&self) -> bool {
                 #is_base
             }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -21,7 +21,7 @@ impl SystemSetConfig {
         // system type sets are automatically populated
         // to avoid unintentionally broad changes, they cannot be configured
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "configuring system type sets is not allowed"
         );
 
@@ -200,7 +200,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
         assert!(
@@ -218,7 +218,7 @@ impl IntoSystemSetConfig for SystemSetConfig {
     #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "System type sets cannot be base sets."
         );
         assert!(
@@ -394,7 +394,7 @@ impl IntoSystemConfig<()> for SystemConfig {
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
         assert!(
@@ -408,7 +408,7 @@ impl IntoSystemConfig<()> for SystemConfig {
     #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "System type sets cannot be base sets."
         );
         assert!(
@@ -548,7 +548,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
         assert!(
@@ -565,7 +565,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "System type sets cannot be base sets."
         );
         assert!(
@@ -692,7 +692,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
         assert!(
@@ -713,7 +713,7 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
     #[track_caller]
     fn in_base_set(mut self, set: impl SystemSet) -> Self {
         assert!(
-            !set.is_system_type(),
+            set.system_type().is_none(),
             "System type sets cannot be base sets."
         );
         assert!(

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -330,7 +330,7 @@ impl SystemSetNode {
     }
 
     pub fn is_system_type(&self) -> bool {
-        self.inner.is_system_type()
+        self.inner.system_type().is_some()
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -1,3 +1,4 @@
+use std::any::TypeId;
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
@@ -17,9 +18,9 @@ pub type BoxedScheduleLabel = Box<dyn ScheduleLabel>;
 
 /// Types that identify logical groups of systems.
 pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
-    /// Returns `true` if this system set is a [`SystemTypeSet`].
-    fn is_system_type(&self) -> bool {
-        false
+    /// Returns `Some` if this system set is a [`SystemTypeSet`].
+    fn system_type(&self) -> Option<TypeId> {
+        None
     }
 
     /// Returns `true` if this set is a "base system set". Systems
@@ -102,8 +103,8 @@ impl<T> PartialEq for SystemTypeSet<T> {
 impl<T> Eq for SystemTypeSet<T> {}
 
 impl<T> SystemSet for SystemTypeSet<T> {
-    fn is_system_type(&self) -> bool {
-        true
+    fn system_type(&self) -> Option<TypeId> {
+        Some(TypeId::of::<T>())
     }
 
     fn dyn_clone(&self) -> Box<dyn SystemSet> {


### PR DESCRIPTION
# Objective

- it would be nice to be able to associate a `NodeId` of a system type set to the `NodeId` of the actual system (used in bevy_mod_debugdump)

## Solution

- make `system_type` return the type id of the system
  - that way you can check if a `dyn SystemSet` is the system type set of a `dyn System`
- I don't know if this information is already present somewhere else in the scheduler or if there is a better way to expose it