### PR TITLE
[Merged by Bors] - Default to using ExecutorKind::SingleThreaded on wasm32

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -24,19 +24,22 @@ pub(super) trait SystemExecutor: Send + Sync {
 
 /// Specifies how a [`Schedule`](super::Schedule) will be run.
 ///
-/// [`MultiThreaded`](ExecutorKind::MultiThreaded) is the default.
+/// The default depends on the target platform:
+///  - [`SingleThreaded`](ExecutorKind::SingleThreaded) on WASM.
+///  - [`MultiThreaded`](ExecutorKind::MultiThreaded) everywhere else.
 #[derive(PartialEq, Eq, Default)]
 pub enum ExecutorKind {
     /// Runs the schedule using a single thread.
     ///
     /// Useful if you're dealing with a single-threaded environment, saving your threads for
     /// other things, or just trying minimize overhead.
+    #[cfg_attr(target_arch = "wasm32", default)]
     SingleThreaded,
     /// Like [`SingleThreaded`](ExecutorKind::SingleThreaded) but calls [`apply_buffers`](crate::system::System::apply_buffers)
     /// immediately after running each system.
     Simple,
     /// Runs the schedule using a thread pool. Non-conflicting systems can run in parallel.
-    #[default]
+    #[cfg_attr(not(target_arch = "wasm32"), default)]
     MultiThreaded,
 }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -114,6 +114,14 @@ impl Schedules {
     }
 }
 
+fn make_executor(kind: ExecutorKind) -> Box<dyn SystemExecutor> {
+    match kind {
+        ExecutorKind::Simple => Box::new(SimpleExecutor::new()),
+        ExecutorKind::SingleThreaded => Box::new(SingleThreadedExecutor::new()),
+        ExecutorKind::MultiThreaded => Box::new(MultiThreadedExecutor::new()),
+    }
+}
+
 /// A collection of systems, and the metadata and executor needed to run them
 /// in a certain order under certain conditions.
 pub struct Schedule {
@@ -135,7 +143,7 @@ impl Schedule {
         Self {
             graph: ScheduleGraph::new(),
             executable: SystemSchedule::new(),
-            executor: Box::new(MultiThreadedExecutor::new()),
+            executor: make_executor(ExecutorKind::default()),
             executor_initialized: false,
         }
     }
@@ -184,11 +192,7 @@ impl Schedule {
     /// Sets the schedule's execution strategy.
     pub fn set_executor_kind(&mut self, executor: ExecutorKind) -> &mut Self {
         if executor != self.executor.kind() {
-            self.executor = match executor {
-                ExecutorKind::Simple => Box::new(SimpleExecutor::new()),
-                ExecutorKind::SingleThreaded => Box::new(SingleThreadedExecutor::new()),
-                ExecutorKind::MultiThreaded => Box::new(MultiThreadedExecutor::new()),
-            };
+            self.executor = make_executor(executor);
             self.executor_initialized = false;
         }
         self


### PR DESCRIPTION
# Objective
Web builds do not support running on multiple threads right now. Defaulting to the multi-threaded executor has significant overhead without any benefit.

## Solution
Default to the single threaded executor on wasm32 builds.