### PR TITLE
[Merged by Bors] - Allow shared access to `SyncCell` for types that are already `Sync`

### DIFF
--- a/crates/bevy_utils/src/synccell.rs
+++ b/crates/bevy_utils/src/synccell.rs
@@ -47,5 +47,5 @@ impl<T: ?Sized> SyncCell<T> {
 
 // SAFETY: `Sync` only allows multithreaded access via immutable reference.
 // As `SyncCell` requires an exclusive reference to access the wrapped value for `!Sync` types,
-// marking this type as `Sync` does not actually allow multi-threaded access to `!Sync` types.
+// marking this type as `Sync` does not actually allow unsychronized access to the inner value.
 unsafe impl<T: ?Sized> Sync for SyncCell<T> {}

--- a/crates/bevy_utils/src/synccell.rs
+++ b/crates/bevy_utils/src/synccell.rs
@@ -29,6 +29,14 @@ impl<T: ?Sized> SyncCell<T> {
         &mut self.inner
     }
 
+    /// For types that implement [`Sync`], gets read-only access to this `SyncCell`'s inner value.
+    pub fn read(&self) -> &T
+    where
+        T: Sync,
+    {
+        &self.inner
+    }
+
     /// Build a mutable reference to a `SyncCell` from a mutable reference
     /// to its inner value, to skip constructing with [`new()`](SyncCell::new()).
     pub fn from_mut(r: &'_ mut T) -> &'_ mut SyncCell<T> {
@@ -38,6 +46,6 @@ impl<T: ?Sized> SyncCell<T> {
 }
 
 // SAFETY: `Sync` only allows multithreaded access via immutable reference.
-// As `SyncCell` requires an exclusive reference to access the wrapped value,
-// marking this type as `Sync` does not actually allow threaded access to the inner value.
+// As `SyncCell` requires an exclusive reference to access the wrapped value for `!Sync` types,
+// marking this type as `Sync` does not actually allow multi-threaded access to `!Sync` types.
 unsafe impl<T: ?Sized> Sync for SyncCell<T> {}

--- a/crates/bevy_utils/src/synccell.rs
+++ b/crates/bevy_utils/src/synccell.rs
@@ -29,7 +29,7 @@ impl<T: ?Sized> SyncCell<T> {
         &mut self.inner
     }
 
-    /// For types that implement [`Sync`], gets read-only access to this `SyncCell`'s inner value.
+    /// For types that implement [`Sync`], get shared access to this `SyncCell`'s inner value.
     pub fn read(&self) -> &T
     where
         T: Sync,


### PR DESCRIPTION
# Objective

The type `SyncCell<T>` (added in #5483) is used to force any wrapped type to be `Sync`, by only allowing exclusive access to the wrapped value. This restriction is unnecessary for types which are already `Sync`.

---

## Changelog

+ Added the method `read` to `SyncCell`, which allows shared access to values that already implement the `Sync` trait.
