### PR TITLE
compute schedule data in separate function

### DIFF
--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -129,21 +129,21 @@ pub(crate) fn row_col(index: usize, num_cols: usize) -> (usize, usize) {
 }
 
 /// Stores the results of the graph analysis.
-pub(crate) struct CheckGraphResults<V> {
+pub struct CheckGraphResults<V> {
     /// Boolean reachability matrix for the graph.
-    pub(crate) reachable: FixedBitSet,
+    pub reachable: FixedBitSet,
     /// Pairs of nodes that have a path connecting them.
-    pub(crate) connected: HashSet<(V, V)>,
+    pub connected: HashSet<(V, V)>,
     /// Pairs of nodes that don't have a path connecting them.
-    pub(crate) disconnected: HashSet<(V, V)>,
+    pub disconnected: HashSet<(V, V)>,
     /// Edges that are redundant because a longer path exists.
-    pub(crate) transitive_edges: Vec<(V, V)>,
+    pub transitive_edges: Vec<(V, V)>,
     /// Variant of the graph with no transitive edges.
-    pub(crate) transitive_reduction: DiGraphMap<V, ()>,
+    pub transitive_reduction: DiGraphMap<V, ()>,
     /// Variant of the graph with all possible transitive edges.
     // TODO: this will very likely be used by "if-needed" ordering
     #[allow(dead_code)]
-    pub(crate) transitive_closure: DiGraphMap<V, ()>,
+    pub transitive_closure: DiGraphMap<V, ()>,
 }
 
 impl<V: NodeTrait + Debug> Default for CheckGraphResults<V> {

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -1,7 +1,7 @@
 mod condition;
 mod config;
 mod executor;
-mod graph_utils;
+pub mod graph_utils;
 #[allow(clippy::module_inception)]
 mod schedule;
 mod set;

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1345,6 +1345,7 @@ impl ScheduleGraph {
     }
 }
 
+#[non_exhaustive]
 pub struct ComputedScheduleData {
     pub hier_results: CheckGraphResults<NodeId>,
     pub hier_scc: Vec<Vec<NodeId>>,


### PR DESCRIPTION
alternative to https://github.com/bevyengine/bevy/pull/7716

# Objective

- allow third party tools to use information that is computed anyways

## Solution

- instead of computing all the data in `build_schedule`, add `fn compute_schedule_data( -> ComputedScheduleData` with
```rust
pub struct ComputedScheduleData {
    pub hier_results: CheckGraphResults<NodeId>,
    pub hier_scc: Vec<Vec<NodeId>>,
    pub hier_topsort: Vec<NodeId>,
    pub dep_results: CheckGraphResults<NodeId>,
    pub dep_scc: Vec<Vec<NodeId>>,
    pub dep_topsort: Vec<NodeId>,

    pub dep_flattened: DiGraphMap<NodeId, ()>,
    pub dep_flat_scc: Vec<Vec<NodeId>>,
    pub dep_flat_results: CheckGraphResults<NodeId>,
    pub dep_flat_topsort: Vec<NodeId>,

    pub ambiguous_with_flattened: UnGraphMap<NodeId, ()>,

    pub set_systems: HashMap<NodeId, Vec<NodeId>>,
    pub set_system_bitsets: HashMap<NodeId, FixedBitSet>,
    pub conflicting_systems: Vec<(NodeId, NodeId, Vec<ComponentId>)>,
}
```

Advantages:
- we have this information so why not expose it to other who want it
Disadvantages:
- exposes a bunch of implementation details, so changes are breaking

Alternatives:
- don't expose it, let people calculate themselves
- keep using `build_schedule` and store more info https://github.com/bevyengine/bevy/pull/7716
- do this PR but make fields private that aren't explicitly motivated by third party usage (`*_scc` and `*_results` are mostly for cycle checking and removing redundant edges, `conflicting_systems` is definitely useful, `set_systems` seems useful as well)