### PR TITLE
[Merged by Bors] - fix ambiguities in render schedule

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -68,7 +68,11 @@ impl Plugin for Core3dPlugin {
             .init_resource::<DrawFunctions<AlphaMask3d>>()
             .init_resource::<DrawFunctions<Transparent3d>>()
             .add_system_to_schedule(ExtractSchedule, extract_core_3d_camera_phases)
-            .add_system(prepare_core_3d_depth_textures.in_set(RenderSet::Prepare))
+            .add_system(
+                prepare_core_3d_depth_textures
+                    .in_set(RenderSet::Prepare)
+                    .after(bevy_render::view::prepare_windows),
+            )
             .add_system(sort_phase_system::<Opaque3d>.in_set(RenderSet::PhaseSort))
             .add_system(sort_phase_system::<AlphaMask3d>.in_set(RenderSet::PhaseSort))
             .add_system(sort_phase_system::<Transparent3d>.in_set(RenderSet::PhaseSort));

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -98,7 +98,11 @@ where
 
         render_app
             .add_system_to_schedule(ExtractSchedule, extract_camera_prepass_phase)
-            .add_system(prepare_prepass_textures.in_set(RenderSet::Prepare))
+            .add_system(
+                prepare_prepass_textures
+                    .in_set(RenderSet::Prepare)
+                    .after(bevy_render::view::prepare_windows),
+            )
             .add_system(queue_prepass_view_bind_group::<M>.in_set(RenderSet::Queue))
             .add_system(queue_prepass_material_meshes::<M>.in_set(RenderSet::Queue))
             .add_system(sort_phase_system::<Opaque3dPrepass>.in_set(RenderSet::PhaseSort))

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,8 +1,9 @@
 use crate::{
-    environment_map, EnvironmentMapLight, FogMeta, GlobalLightMeta, GpuFog, GpuLights,
-    GpuPointLights, LightMeta, NotShadowCaster, NotShadowReceiver, ShadowPipeline,
-    ViewClusterBindings, ViewFogUniformOffset, ViewLightsUniformOffset, ViewShadowBindings,
-    CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT, MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS,
+    environment_map, queue_shadow_view_bind_group, EnvironmentMapLight, FogMeta, GlobalLightMeta,
+    GpuFog, GpuLights, GpuPointLights, LightMeta, NotShadowCaster, NotShadowReceiver,
+    ShadowPipeline, ViewClusterBindings, ViewFogUniformOffset, ViewLightsUniformOffset,
+    ViewShadowBindings, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT, MAX_CASCADES_PER_LIGHT,
+    MAX_DIRECTIONAL_LIGHTS,
 };
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Assets, Handle, HandleUntyped};
@@ -105,7 +106,11 @@ impl Plugin for MeshRenderPlugin {
                 .add_systems_to_schedule(ExtractSchedule, (extract_meshes, extract_skinned_meshes))
                 .add_system(prepare_skinned_meshes.in_set(RenderSet::Prepare))
                 .add_system(queue_mesh_bind_group.in_set(RenderSet::Queue))
-                .add_system(queue_mesh_view_bind_groups.in_set(RenderSet::Queue));
+                .add_system(
+                    queue_mesh_view_bind_groups
+                        .in_set(RenderSet::Queue)
+                        .ambiguous_with(queue_shadow_view_bind_group), // queue_mesh_view_bind_groups does not read `shadow_view_bind_group`
+                );
         }
     }
 }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -176,7 +176,7 @@ impl<A: RenderAsset> Default for PrepareNextFrameAssets<A> {
 
 /// This system prepares all assets of the corresponding [`RenderAsset`] type
 /// which where extracted this frame for the GPU.
-fn prepare_assets<R: RenderAsset>(
+pub fn prepare_assets<R: RenderAsset>(
     mut extracted_assets: ResMut<ExtractedAssets<R>>,
     mut render_assets: ResMut<RenderAssets<R>>,
     mut prepare_next_frame: ResMut<PrepareNextFrameAssets<R>>,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -56,7 +56,8 @@ impl Plugin for ViewPlugin {
                 .add_system(
                     prepare_view_targets
                         .after(WindowSystem::Prepare)
-                        .in_set(RenderSet::Prepare),
+                        .in_set(RenderSet::Prepare)
+                        .after(crate::render_asset::prepare_assets::<Image>),
                 );
         }
     }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -234,6 +234,7 @@ pub fn prepare_windows(
         // This is an ugly hack to work around drivers that don't support MSAA.
         // This should be removed once https://github.com/bevyengine/bevy/issues/7194 lands and we're doing proper
         // feature detection for MSAA.
+        // When removed, we can also remove the `.after(prepare_windows)` of `prepare_core_3d_depth_textures` and `prepare_prepass_textures`
         let sample_flags = render_adapter
             .get_texture_format_features(surface_configuration.format)
             .flags;

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -77,7 +77,11 @@ impl Plugin for SpritePlugin {
                         extract_sprite_events,
                     ),
                 )
-                .add_system(queue_sprites.in_set(RenderSet::Queue));
+                .add_system(
+                    queue_sprites
+                        .in_set(RenderSet::Queue)
+                        .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
+                );
         };
     }
 }


### PR DESCRIPTION
# Objective

- ambiguities bad

## Solution

- solve ambiguities
  - by either ignoring (e.g. on `queue_mesh_view_bind_groups` since `LightMeta` access is different)
  - by introducing a dependency (`prepare_windows -> prepare_*` because the latter use the fallback Msaa)
- make `prepare_assets` public so that we can do a proper `.after`