### PR TITLE
Change default wgpu backend from `all` to `primary` on windows

### DIFF
--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -47,8 +47,10 @@ impl Default for WgpuSettings {
     fn default() -> Self {
         let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
-        } else {
+        } else if cfg!(windows) {
             Backends::PRIMARY
+        } else {
+            Backends::all()
         };
 
         let backends = Some(wgpu::util::backend_bits_from_env().unwrap_or(default_backends));

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -47,6 +47,7 @@ impl Default for WgpuSettings {
     fn default() -> Self {
         let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
+        // TODO: When https://github.com/gfx-rs/wgpu/issues/2540 is fixed, Windows can also use all()
         } else if cfg!(windows) {
             Backends::PRIMARY
         } else {

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -48,7 +48,7 @@ impl Default for WgpuSettings {
         let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
         // TODO: When https://github.com/gfx-rs/wgpu/issues/2540 is fixed, Windows can also use all()
-        } else if cfg!(windows) {
+        } else if cfg!(target_os = "windows") {
             Backends::PRIMARY
         } else {
             Backends::all()

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -48,7 +48,7 @@ impl Default for WgpuSettings {
         let default_backends = if cfg!(feature = "webgl") {
             Backends::GL
         } else {
-            Backends::all()
+            Backends::PRIMARY
         };
 
         let backends = Some(wgpu::util::backend_bits_from_env().unwrap_or(default_backends));


### PR DESCRIPTION
# Objective

Temporary fix for #7620

## Solution

Revert the default wgpu backends back to `PRIMARY` from `all()`.
Reverting #7481

I personally believe this is a temporary fix for 0.10, if gfx-rs/wgpu#2540 is fixed before 0.10 I think if should be fine to leave it on `all()` but that issue hasn't had much activity.

I think we should also keep in mind wither more people are running into the issue of `Unable to find a GPU!` than there are people suffering from #7620 to try and please the most users.