### PR TITLE
[Merged by Bors] - EnvironmentMapLight support for WebGL2

### DIFF
--- a/crates/bevy_pbr/src/environment_map/environment_map.wgsl
+++ b/crates/bevy_pbr/src/environment_map/environment_map.wgsl
@@ -18,7 +18,11 @@ fn environment_map_light(
 ) -> EnvironmentMapLight {
 
     // Split-sum approximation for image based lighting: https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
+#ifndef WEBGL
     let smallest_specular_mip_level = textureNumLevels(environment_map_specular) - 1i;
+#else
+    let smallest_specular_mip_level = lights.environment_map_smallest_specular_mip_level;
+#endif
     let radiance_level = perceptual_roughness * f32(smallest_specular_mip_level);
     let irradiance = textureSample(environment_map_diffuse, environment_map_sampler, N).rgb;
     let radiance = textureSampleLevel(environment_map_specular, environment_map_sampler, R, radiance_level).rgb;

--- a/crates/bevy_pbr/src/environment_map/environment_map.wgsl
+++ b/crates/bevy_pbr/src/environment_map/environment_map.wgsl
@@ -18,12 +18,9 @@ fn environment_map_light(
 ) -> EnvironmentMapLight {
 
     // Split-sum approximation for image based lighting: https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
-#ifndef WEBGL
-    let smallest_specular_mip_level = textureNumLevels(environment_map_specular) - 1i;
-#else
-    let smallest_specular_mip_level = lights.environment_map_smallest_specular_mip_level;
-#endif
-    let radiance_level = perceptual_roughness * f32(smallest_specular_mip_level);
+    // Technically we could use textureNumLevels(environment_map_specular) - 1 here, but we use a uniform
+    // because textureNumLevels() does not work on WebGL2
+    let radiance_level = perceptual_roughness * f32(lights.environment_map_smallest_specular_mip_level);
     let irradiance = textureSample(environment_map_diffuse, environment_map_sampler, N).rgb;
     let radiance = textureSampleLevel(environment_map_specular, environment_map_sampler, R, radiance_level).rgb;
 

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -218,6 +218,9 @@ pub struct GpuLights {
     n_directional_lights: u32,
     // offset from spot light's light index to spot light's shadow map index
     spot_light_shadowmap_offset: i32,
+    // textureNumLevels() is not supported on WebGL2
+    #[cfg(feature = "webgl")]
+    environment_map_smallest_specular_mip_level: i32,
 }
 
 // NOTE: this must be kept in sync with the same constants in pbr.frag
@@ -787,12 +790,22 @@ pub(crate) fn spot_light_projection_matrix(angle: f32) -> Mat4 {
 pub fn prepare_lights(
     mut commands: Commands,
     mut texture_cache: ResMut<TextureCache>,
+    #[cfg(feature = "webgl")] images: Res<RenderAssets<Image>>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut global_light_meta: ResMut<GlobalLightMeta>,
     mut light_meta: ResMut<LightMeta>,
-    views: Query<
+    #[cfg(not(feature = "webgl"))] views: Query<
         (Entity, &ExtractedView, &ExtractedClusterConfig),
+        With<RenderPhase<Transparent3d>>,
+    >,
+    #[cfg(feature = "webgl")] views: Query<
+        (
+            Entity,
+            &ExtractedView,
+            &ExtractedClusterConfig,
+            Option<&crate::EnvironmentMapLight>,
+        ),
         With<RenderPhase<Transparent3d>>,
     >,
     ambient_light: Res<AmbientLight>,
@@ -1029,7 +1042,12 @@ pub fn prepare_lights(
         .write_buffer(&render_device, &render_queue);
 
     // set up light data for each view
-    for (entity, extracted_view, clusters) in &views {
+    for view in &views {
+        #[cfg(not(feature = "webgl"))]
+        let (entity, extracted_view, clusters) = view;
+        #[cfg(feature = "webgl")]
+        let (entity, extracted_view, clusters, environment_map) = view;
+
         let point_light_depth_texture = texture_cache.get(
             &render_device,
             TextureDescriptor {
@@ -1096,6 +1114,11 @@ pub fn prepare_lights(
             // index to shadow map index, we need to subtract point light count and add directional shadowmap count.
             spot_light_shadowmap_offset: num_directional_cascades_enabled as i32
                 - point_light_count as i32,
+            #[cfg(feature = "webgl")]
+            environment_map_smallest_specular_mip_level: environment_map
+                .and_then(|env_map| images.get(&env_map.specular_map))
+                .map(|specular_map| specular_map.mip_level_count as i32 - 1)
+                .unwrap_or(0),
         };
 
         // TODO: this should select lights based on relevance to the view instead of the first ones that show up in a query

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -537,6 +537,7 @@ impl FromWorld for MeshPipeline {
                     image.texture_descriptor.size.width as f32,
                     image.texture_descriptor.size.height as f32,
                 ),
+                mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };
 
@@ -650,6 +651,9 @@ impl SpecializedMeshPipeline for MeshPipeline {
     ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
         let mut shader_defs = Vec::new();
         let mut vertex_attributes = Vec::new();
+
+        #[cfg(feature = "webgl")]
+        shader_defs.push("WEBGL".into());
 
         if layout.contains(Mesh::ATTRIBUTE_POSITION) {
             shader_defs.push("VERTEX_POSITIONS".into());

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -652,9 +652,6 @@ impl SpecializedMeshPipeline for MeshPipeline {
         let mut shader_defs = Vec::new();
         let mut vertex_attributes = Vec::new();
 
-        #[cfg(feature = "webgl")]
-        shader_defs.push("WEBGL".into());
-
         if layout.contains(Mesh::ATTRIBUTE_POSITION) {
             shader_defs.push("VERTEX_POSITIONS".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_POSITION.at_shader_location(0));

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -24,7 +24,7 @@ struct DirectionalCascade {
     texel_size: f32,
     far_bound: f32,
 }
-    
+
 struct DirectionalLight {
     cascades: array<DirectionalCascade, #{MAX_CASCADES_PER_LIGHT}>,
     color: vec4<f32>,
@@ -59,6 +59,9 @@ struct Lights {
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
+#ifdef WEBGL
+    environment_map_smallest_specular_mip_level: i32,
+#endif
 };
 
 struct Fog {

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -59,9 +59,7 @@ struct Lights {
     cluster_factors: vec4<f32>,
     n_directional_lights: u32,
     spot_light_shadowmap_offset: i32,
-#ifdef WEBGL
-    environment_map_smallest_specular_mip_level: i32,
-#endif
+    environment_map_smallest_specular_mip_level: u32,
 };
 
 struct Fog {

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -78,6 +78,7 @@ fn fallback_image_new(
             image.texture_descriptor.size.width as f32,
             image.texture_descriptor.size.height as f32,
         ),
+        mip_level_count: image.texture_descriptor.mip_level_count,
     }
 }
 

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -494,6 +494,7 @@ pub struct GpuImage {
     pub texture_format: TextureFormat,
     pub sampler: Sampler,
     pub size: Vec2,
+    pub mip_level_count: u32,
 }
 
 impl RenderAsset for Image {
@@ -543,6 +544,7 @@ impl RenderAsset for Image {
             texture_format: image.texture_descriptor.format,
             sampler,
             size,
+            mip_level_count: image.texture_descriptor.mip_level_count,
         })
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -252,6 +252,7 @@ impl FromWorld for Mesh2dPipeline {
                     image.texture_descriptor.size.width as f32,
                     image.texture_descriptor.size.height as f32,
                 ),
+                mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };
         Mesh2dPipeline {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -131,6 +131,7 @@ impl FromWorld for SpritePipeline {
                     image.texture_descriptor.size.width as f32,
                     image.texture_descriptor.size.height as f32,
                 ),
+                mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };
 


### PR DESCRIPTION
# Objective

- Fix the environment map shader not working under webgl due to textureNumLevels() not being supported
- Fixes https://github.com/bevyengine/bevy/issues/7722

## Solution

- Instead of using textureNumLevels(), put an extra field in the GpuLights uniform to store the mip count