### PR TITLE
[Merged by Bors] - Use `Commands::spawn_batch` in bevymark example

### DIFF
--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -7,7 +7,7 @@ use bevy::{
     prelude::*,
     window::{PresentMode, WindowResolution},
 };
-use rand::{thread_rng, Rng};
+use rand::{rngs::StdRng, thread_rng, Rng, SeedableRng};
 
 const BIRDS_PER_SECOND: u32 = 10000;
 const GRAVITY: f32 = -9.8 * 100.0;
@@ -178,11 +178,16 @@ fn spawn_birds(
 ) {
     let bird_x = (primary_window_resolution.width() / -2.) + HALF_BIRD_SIZE;
     let bird_y = (primary_window_resolution.height() / 2.) - HALF_BIRD_SIZE;
-    let mut rng = thread_rng();
 
-    for count in 0..spawn_count {
-        let bird_z = (counter.count + count) as f32 * 0.00001;
-        commands.spawn((
+    let mut rng = StdRng::from_entropy();
+
+    let color = counter.color;
+    let current_count = counter.count;
+
+    commands.spawn_batch((0..spawn_count).map(move |count| {
+        let velocity_x = rng.gen::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5);
+        let bird_z = (current_count + count) as f32 * 0.00001;
+        (
             SpriteBundle {
                 texture: texture.clone(),
                 transform: Transform {
@@ -190,21 +195,15 @@ fn spawn_birds(
                     scale: Vec3::splat(BIRD_SCALE),
                     ..default()
                 },
-                sprite: Sprite {
-                    color: counter.color,
-                    ..default()
-                },
+                sprite: Sprite { color, ..default() },
                 ..default()
             },
             Bird {
-                velocity: Vec3::new(
-                    rng.gen::<f32>() * MAX_VELOCITY - (MAX_VELOCITY * 0.5),
-                    0.,
-                    0.,
-                ),
+                velocity: Vec3::new(velocity_x, 0., 0.),
             },
-        ));
-    }
+        )
+    }));
+
     counter.count += spawn_count;
 }
 


### PR DESCRIPTION
# Objective

Fixes #7735

## Solution

Use `spawn_batch` instead of `spawn` repeatedly in a for loop

I have decided to switch from using rands `thread_rng()` to its `StdRng`,  this allows us to avoid calling `collect()` on the bundle iterator, if collecting is fine then I can revert it back to using `thread_rng()`.
