### PR TITLE
[Merged by Bors] - Allow relative speed of -0.0

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -399,7 +399,7 @@ impl Time {
     #[inline]
     pub fn set_relative_speed_f64(&mut self, ratio: f64) {
         assert!(ratio.is_finite(), "tried to go infinitely fast");
-        assert!(ratio.is_sign_positive(), "tried to go back in time");
+        assert!(ratio >= 0.0, "tried to go back in time");
         self.relative_speed = ratio;
     }
 


### PR DESCRIPTION
# Objective

-0.0 should typically be treated exactly the same as 0.0, but this assertion was rejecting it while allowing 0.0. The `Duration` API handles this correctly (on recent Rust versions) and returns a zero `Duration` for both -0.0 and 0.0.

## Solution

Check for `ratio >= 0.0`, which is true if `ratio` is `-0.0`.

---

## Changelog

Allow relative speed of -0.0 in the `Time::set_relative_speed_fXX` methods.