### PR TITLE
[Merged by Bors] - Implement `SystemParam` for `WorldId`

### DIFF
--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -39,9 +39,7 @@ unsafe impl SystemParam for WorldId {
 
     type Item<'world, 'state> = WorldId;
 
-    fn init_state(_: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {
-        ()
-    }
+    fn init_state(_: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {}
 
     unsafe fn get_param<'world, 'state>(
         _: &'state mut Self::State,

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -35,12 +35,12 @@ unsafe impl ReadOnlySystemParam for WorldId {}
 
 // SAFETY: A World's ID is immutable and fetching it from the World does not borrow anything
 unsafe impl SystemParam for WorldId {
-    type State = WorldId;
+    type State = ();
 
     type Item<'world, 'state> = WorldId;
 
-    fn init_state(world: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {
-        world.id
+    fn init_state(_: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {
+        ()
     }
 
     unsafe fn get_param<'world, 'state>(

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -1,4 +1,7 @@
-use crate::storage::SparseSetIndex;
+use crate::{
+    storage::SparseSetIndex,
+    system::{ReadOnlySystemParam, SystemParam},
+};
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Hash)]
@@ -24,6 +27,29 @@ impl WorldId {
             })
             .map(WorldId)
             .ok()
+    }
+}
+
+// SAFETY: Has read-only access to shared World metadata
+unsafe impl ReadOnlySystemParam for WorldId {}
+
+// SAFETY: A World's ID is immutable and fetching it from the World does not borrow anything
+unsafe impl SystemParam for WorldId {
+    type State = WorldId;
+
+    type Item<'world, 'state> = WorldId;
+
+    fn init_state(world: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {
+        world.id
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        _: &'state mut Self::State,
+        _: &crate::system::SystemMeta,
+        world: &'world super::World,
+        _: u32,
+    ) -> Self::Item<'world, 'state> {
+        world.id
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #7736

## Solution

Implement the `SystemParam` trait for `WorldId`

## Changelog

- `WorldId` can now be taken as a system parameter and will return the id of the world the system is running in