### PR TITLE
[Merged by Bors] - for disconnected, use Vec instead of HashSet to reduce insert overhead

### DIFF
--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -135,7 +135,7 @@ pub(crate) struct CheckGraphResults<V> {
     /// Pairs of nodes that have a path connecting them.
     pub(crate) connected: HashSet<(V, V)>,
     /// Pairs of nodes that don't have a path connecting them.
-    pub(crate) disconnected: HashSet<(V, V)>,
+    pub(crate) disconnected: Vec<(V, V)>,
     /// Edges that are redundant because a longer path exists.
     pub(crate) transitive_edges: Vec<(V, V)>,
     /// Variant of the graph with no transitive edges.
@@ -151,7 +151,7 @@ impl<V: NodeTrait + Debug> Default for CheckGraphResults<V> {
         Self {
             reachable: FixedBitSet::new(),
             connected: HashSet::new(),
-            disconnected: HashSet::new(),
+            disconnected: Vec::new(),
             transitive_edges: Vec::new(),
             transitive_reduction: DiGraphMap::new(),
             transitive_closure: DiGraphMap::new(),
@@ -198,7 +198,7 @@ where
 
     let mut reachable = FixedBitSet::with_capacity(n * n);
     let mut connected = HashSet::new();
-    let mut disconnected = HashSet::new();
+    let mut disconnected = Vec::new();
 
     let mut transitive_edges = Vec::new();
     let mut transitive_reduction = DiGraphMap::<V, ()>::new();
@@ -255,7 +255,7 @@ where
             if reachable[index] {
                 connected.insert(pair);
             } else {
-                disconnected.insert(pair);
+                disconnected.push(pair);
             }
         }
     }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1141,7 +1141,7 @@ impl ScheduleGraph {
 
         // check for conflicts
         let mut conflicting_systems = Vec::new();
-        for &(a, b) in flat_results.disconnected.iter() {
+        for &(a, b) in &flat_results.disconnected {
             if self.ambiguous_with_flattened.contains_edge(a, b)
                 || self.ambiguous_with_all.contains(&a)
                 || self.ambiguous_with_all.contains(&b)


### PR DESCRIPTION
# Objective

- Improve `Schedule::initialize` performance

## Solution

- replace `disconnected`'s type from HashSet to Vec in `check_graph`


