### PR TITLE
Add `TextLayoutInfo` to `TextBundle` and `Text2dBundle`

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -158,12 +158,7 @@ pub fn update_text2d_layout(
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut font_atlas_set_storage: ResMut<Assets<FontAtlasSet>>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut text_query: Query<(
-        Entity,
-        Ref<Text>,
-        &Text2dBounds,
-        &mut TextLayoutInfo,
-    )>,
+    mut text_query: Query<(Entity, Ref<Text>, &Text2dBounds, &mut TextLayoutInfo)>,
 ) {
     // We need to consume the entire iterator, hence `last`
     let factor_changed = scale_factor_changed.iter().last().is_some();

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     prelude::{Color, ComputedVisibility},
     view::Visibility,
 };
-use bevy_text::{Text, TextAlignment, TextSection, TextStyle, TextLayoutInfo};
+use bevy_text::{Text, TextAlignment, TextLayoutInfo, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// The basic UI node

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -9,7 +9,7 @@ use bevy_render::{
     prelude::{Color, ComputedVisibility},
     view::Visibility,
 };
-use bevy_text::{Text, TextAlignment, TextSection, TextStyle};
+use bevy_text::{Text, TextAlignment, TextSection, TextStyle, TextLayoutInfo};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// The basic UI node
@@ -104,6 +104,8 @@ pub struct TextBundle {
     pub style: Style,
     /// Contains the text of the node
     pub text: Text,
+    /// Text layout information
+    pub text_layout_info: TextLayoutInfo,
     /// The calculated size based on the given image
     pub calculated_size: CalculatedSize,
     /// Whether this node should block interaction with lower nodes

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -55,12 +55,7 @@ pub fn text_system(
     mut text_queries: ParamSet<(
         Query<Entity, Or<(Changed<Text>, Changed<Node>, Changed<Style>)>>,
         Query<Entity, (With<Text>, With<Style>)>,
-        Query<(
-            &Text,
-            &Style,
-            &mut CalculatedSize,
-            &mut TextLayoutInfo,
-        )>,
+        Query<(&Text, &Style, &mut CalculatedSize, &mut TextLayoutInfo)>,
     )>,
 ) {
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
@@ -95,7 +90,8 @@ pub fn text_system(
     let mut new_queue = Vec::new();
     let mut query = text_queries.p2();
     for entity in queued_text_ids.drain(..) {
-        if let Ok((text, style, mut calculated_size, mut text_layout_info)) = query.get_mut(entity) {
+        if let Ok((text, style, mut calculated_size, mut text_layout_info)) = query.get_mut(entity)
+        {
             let node_size = Vec2::new(
                 text_constraint(
                     style.min_size.width,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -3,7 +3,7 @@ use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
     query::{Changed, Or, With},
-    system::{Commands, Local, ParamSet, Query, Res, ResMut},
+    system::{Local, ParamSet, Query, Res, ResMut},
 };
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
@@ -41,7 +41,6 @@ pub fn text_constraint(min_size: Val, size: Val, max_size: Val, scale_factor: f6
 /// It does not modify or observe existing ones.
 #[allow(clippy::too_many_arguments)]
 pub fn text_system(
-    mut commands: Commands,
     mut queued_text_ids: Local<Vec<Entity>>,
     mut last_scale_factor: Local<f64>,
     mut textures: ResMut<Assets<Image>>,
@@ -60,7 +59,7 @@ pub fn text_system(
             &Text,
             &Style,
             &mut CalculatedSize,
-            Option<&mut TextLayoutInfo>,
+            &mut TextLayoutInfo,
         )>,
     )>,
 ) {
@@ -96,7 +95,7 @@ pub fn text_system(
     let mut new_queue = Vec::new();
     let mut query = text_queries.p2();
     for entity in queued_text_ids.drain(..) {
-        if let Ok((text, style, mut calculated_size, text_layout_info)) = query.get_mut(entity) {
+        if let Ok((text, style, mut calculated_size, mut text_layout_info)) = query.get_mut(entity) {
             let node_size = Vec2::new(
                 text_constraint(
                     style.min_size.width,
@@ -139,12 +138,7 @@ pub fn text_system(
                         scale_value(info.size.x, inv_scale_factor),
                         scale_value(info.size.y, inv_scale_factor),
                     );
-                    match text_layout_info {
-                        Some(mut t) => *t = info,
-                        None => {
-                            commands.entity(entity).insert(info);
-                        }
-                    }
+                    *text_layout_info = info;
                 }
             }
         }


### PR DESCRIPTION
# Objective

`TextBundle` and `Text2dBundle` don't have `TextLayoutInfo` components. Instead, `TextLayoutInfo` is inserted by the `update_2d_layout` and `text_system` systems. This seems to be both more complicated and marginally less efficient than just adding the component to the bundles directly. 

## Solution

* Add the `TextLayoutInfo` component to the `TextBundle` and `Text2dBundle` bundles.
* Change optional `TextLayoutInfo` queries to non-optional.
* Clean up the text systems by removing the `Commands` parameters and match statements.

---

## Changelog
* Added the `TextLayoutInfo` component to `TextBundle`.
* Added the `TextLayoutInfo` component to `Text2dBundle`.
* Changed optional `TextLayoutInfo` queries to be non-optional.

## Migration Guide

The `TextLayoutInfo` component has been added to `TextBundle` and `Text2dBundle`.

To draw text using the text2d or ui text systems entities must have the `TextLayoutInfo` component.
