### PR TITLE
[Merged by Bors] - Remove obsolete `after(apply_state_transition::<S>)`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -342,8 +342,7 @@ impl App {
             main_schedule.configure_set(
                 OnUpdate(variant.clone())
                     .in_base_set(CoreSet::Update)
-                    .run_if(in_state(variant))
-                    .after(apply_state_transition::<S>),
+                    .run_if(in_state(variant)),
             );
         }
 


### PR DESCRIPTION
# Objective

- Fixes #7636.

## Solution

`apply_state_transitions::<S>` runs in `CoreSet::StateTransitions` which is already scheduled before `CoreSet::Update`. Therefore explicitly scheduling `OnUpdate` after `apply_state_transitions::<S>` is not necessary.
