### PR TITLE
[Merged by Bors] - Use default schedule consistently in `add_state`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -328,7 +328,15 @@ impl App {
     pub fn add_state<S: States>(&mut self) -> &mut Self {
         self.init_resource::<State<S>>();
         self.init_resource::<NextState<S>>();
-        self.add_systems(
+
+        let mut schedules = self.world.resource_mut::<Schedules>();
+
+        let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) else {
+            let schedule_label = &self.default_schedule_label;
+            panic!("Default schedule {schedule_label:?} does not exist.")
+        };
+
+        default_schedule.add_systems(
             (
                 run_enter_schedule::<S>.run_if(run_once_condition()),
                 apply_state_transition::<S>,
@@ -337,9 +345,8 @@ impl App {
                 .in_base_set(CoreSet::StateTransitions),
         );
 
-        let main_schedule = self.get_schedule_mut(CoreSchedule::Main).unwrap();
         for variant in S::variants() {
-            main_schedule.configure_set(
+            default_schedule.configure_set(
                 OnUpdate(variant.clone())
                     .in_base_set(CoreSet::Update)
                     .run_if(in_state(variant))


### PR DESCRIPTION
# Objective

When working on #7750 I noticed that `CoreSchedule::Main` was explicitly used to get the schedule for the `OnUpdate` set. This can lead to failures or weird behavior if `add_state` is used with a differently configured `default_schedule_label`, because the other systems are added to the default schedule. This PR fixes that.

## Solution

Use `default_schedule_label` to retrieve a single schedule to which all systems are added.
