### PR TITLE
[Merged by Bors] - Retain `::` after `>`, `)` or `]` when shortening type names

### DIFF
--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -43,7 +43,7 @@ pub fn get_short_name(full_name: &str) -> String {
                 {
                     parsed_name.push_str("::");
                     // Move the index past the "::"
-                    index += special_character_index + 3
+                    index += special_character_index + 3;
                 }
                 // Move the index just past the special character
                 _ => index += special_character_index + 1,

--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -36,8 +36,18 @@ pub fn get_short_name(full_name: &str) -> String {
             let special_character =
                 &rest_of_string[special_character_index..=special_character_index];
             parsed_name.push_str(special_character);
-            // Move the index just past the special character
-            index += special_character_index + 1;
+
+            match special_character {
+                ">" | ")" | "]"
+                    if rest_of_string[special_character_index + 1..].starts_with("::") =>
+                {
+                    parsed_name.push_str("::");
+                    // Move the index past the "::"
+                    index += special_character_index + 3
+                }
+                // Move the index just past the special character
+                _ => index += special_character_index + 1,
+            }
         } else {
             // If there are no special characters left, we're done!
             parsed_name += collapse_type_name(rest_of_string);
@@ -105,6 +115,22 @@ mod name_formatting_tests {
         assert_eq!(
             get_short_name("bevy::mad_science::do_mad_science<mad_science::Test<mad_science::Tube>, bavy::TypeSystemAbuse>"),
             "do_mad_science<Test<Tube>, TypeSystemAbuse>".to_string()
+        );
+    }
+
+    #[test]
+    fn sub_path_after_closing_bracket() {
+        assert_eq!(
+            get_short_name("bevy_asset::assets::Assets<bevy_scene::dynamic_scene::DynamicScene>::asset_event_system"),
+            "Assets<DynamicScene>::asset_event_system".to_string()
+        );
+        assert_eq!(
+            get_short_name("(String, String)::default"),
+            "(String, String)::default".to_string()
+        );
+        assert_eq!(
+            get_short_name("[i32; 16]::default"),
+            "[i32; 16]::default".to_string()
         );
     }
 }


### PR DESCRIPTION
# Objective

While working on #7442 i discovered that `get_short_name` does not work well with sub paths after closing brackets. It currently turns `bevy_asset::assets::Assets<bevy_scene::dynamic_scene::DynamicScene>::asset_event_system` into `Assets<DynamicScene>asset_event_system`. This PR fixes that.

## Solution
- Retain `::` after a closing bracket like `>`, `)` or `]`.
- Add a test for all sub path after closing bracket cases. 