### PR TITLE
improve bevy_ecs's inspectability

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -42,3 +42,7 @@ path = "examples/resources.rs"
 [[example]]
 name = "change_detection"
 path = "examples/change_detection.rs"
+
+[[example]]
+name = "world_diagnostic"
+path = "examples/world_diagnostic.rs"

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -1,7 +1,11 @@
 use std::borrow::Cow;
 use std::fmt::Write;
 
-use bevy_ecs::{prelude::*, schedule::NodeId};
+use bevy_ecs::{
+    component::ComponentId,
+    prelude::*,
+    schedule::{Dag, NodeId},
+};
 use bevy_ecs_macros::{ScheduleLabel, SystemSet};
 use bevy_utils::HashMap;
 
@@ -10,6 +14,21 @@ fn empty_system() {}
 fn first_system() {}
 
 fn second_system() {}
+
+fn increase_game_state_count(mut state: ResMut<GameState>) {
+    state.counter += 1;
+}
+
+fn sync_counter(state: Res<GameState>, mut query: Query<&mut Counter>) {
+    for mut counter in query.iter_mut() {
+        counter.0 = state.counter;
+    }
+}
+
+#[derive(Resource, Default)]
+struct GameState {
+    counter: usize,
+}
 
 #[derive(SystemSet, Hash, Clone, Copy, PartialEq, Eq, Debug)]
 enum MySet {
@@ -29,6 +48,10 @@ struct Counter(usize);
 
 #[derive(Component)]
 struct HitPoint(usize);
+
+#[derive(Component)]
+#[component(storage = "SparseSet")]
+struct HighlightFlag;
 
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum ScheduleLabel {
@@ -56,44 +79,120 @@ fn diagnostic_world(world: &World) -> Result<String, std::fmt::Error> {
     let component_size = world.components().len();
     let archetype_size = world.archetypes().len();
     let entity_size = world.entities().len();
+    let resource_size = world.storages().resources.len();
+    let non_send_resource_size = world.storages().non_send_resources.len();
+    let table_size = world.storages().tables.len();
+    let sparse_set_size = world.storages().sparse_sets.len();
 
-    writeln!(result, "World shape:")?;
-    writeln!(result, "  component: {bundle_size}")?;
-    writeln!(result, "  bundle: {component_size}")?;
-    writeln!(result, "  archetype: {archetype_size}")?;
-    writeln!(result, "  entity: {entity_size}")?;
+    writeln!(result, "world:")?;
+    writeln!(result, "  summary:")?;
+    writeln!(result, "    component: {bundle_size}")?;
+    writeln!(result, "    bundle: {component_size}")?;
+    writeln!(result, "    archetype: {archetype_size}")?;
+    writeln!(result, "    entity: {entity_size}")?;
+    writeln!(result, "    resource: {resource_size}")?;
+    writeln!(result, "    resource(non send): {non_send_resource_size}")?;
+    writeln!(result, "    table: {table_size}")?;
+    writeln!(result, "    sparse set: {sparse_set_size}")?;
 
-    if let Some(schedules) = world.get_resource::<Schedules>() {
-        result.push_str(&diagnostic_schedules(schedules)?);
-    }
-
-    writeln!(result, "World detail:")?;
+    writeln!(result, "  detail:")?;
     let bundles = world.bundles().iter().collect::<Vec<_>>();
     if bundle_size > 0 {
-        writeln!(result, "  bundles:")?;
+        writeln!(result, "    bundles:")?;
         for bundle in bundles {
-            writeln!(result, "    {:?}: {:?}", bundle.id(), bundle.components())?;
+            writeln!(
+                result,
+                "      {:?}: {:?}",
+                bundle.id(),
+                bundle
+                    .components()
+                    .iter()
+                    .map(|id| component_display(*id, world))
+                    .collect::<Vec<_>>()
+            )?;
+        }
+    }
+
+    if component_size > 0 {
+        writeln!(result, "    components:")?;
+
+        for component in world.components().iter() {
+            writeln!(
+                result,
+                "      {:?}({name}) {storage_type:?} {send_sync}",
+                component.id(),
+                name = component.name(),
+                storage_type = component.storage_type(),
+                send_sync = if component.is_send_and_sync() {
+                    "send_sync"
+                } else {
+                    "non_send_sync"
+                }
+            )?;
         }
     }
 
     if archetype_size > 0 {
-        writeln!(result, "  archetypes:")?;
+        writeln!(result, "    archetypes:")?;
         for archetype in world.archetypes().iter() {
             writeln!(
                 result,
-                "    {:?}: components:{:?} entity count: {}",
+                "      {:?}: components:{:?} table:{:?} entity:{}",
                 archetype.id(),
-                archetype.components().collect::<Vec<_>>(),
-                archetype.len()
+                archetype
+                    .components()
+                    .map(|id| component_display(id, world))
+                    .collect::<Vec<_>>(),
+                archetype.table_id(),
+                archetype.len(),
             )?;
         }
+    }
+
+    if table_size > 0 {
+        writeln!(result, "    tables:")?;
+        for (idx, table) in world.storages().tables.iter().enumerate() {
+            writeln!(result, "      [{idx}] entities: {}", table.entity_count())?;
+        }
+    }
+
+    if resource_size > 0 {
+        writeln!(result, "    resources:")?;
+        for (component_id, _resource_data) in world.storages().resources.iter() {
+            writeln!(result, "      {}", component_display(component_id, world))?;
+        }
+    }
+
+    if non_send_resource_size > 0 {
+        writeln!(result, "    resources(non send):")?;
+        for (component_id, _resource_data) in world.storages().non_send_resources.iter() {
+            let component = world.components().get_info(component_id).unwrap();
+            writeln!(result, "      {:?}({})", component_id, component.name(),)?;
+        }
+    }
+
+    if sparse_set_size > 0 {
+        writeln!(result, "    sparse_set:")?;
+        for (component_id, sparse_set) in world.storages().sparse_sets.iter() {
+            let component_display = component_display(component_id, world);
+            writeln!(
+                result,
+                "      {} entity:{}",
+                component_display,
+                sparse_set.len()
+            )?;
+        }
+    }
+
+    if let Some(schedules) = world.get_resource::<Schedules>() {
+        result.push_str(&diagnostic_schedules(schedules)?);
     }
 
     Ok(result)
 }
 
 fn diagnostic_schedules(schedules: &Schedules) -> Result<String, std::fmt::Error> {
-    let mut result = "".to_string();
+    let mut result = "Schedule:\n".to_string();
 
     let label_with_schedules = schedules.iter().collect::<Vec<_>>();
     writeln!(result, "  schedules: {}", label_with_schedules.len())?;
@@ -114,57 +213,82 @@ fn diagnostic_schedules(schedules: &Schedules) -> Result<String, std::fmt::Error
             schedule.get_executor_kind(),
         )?;
 
-        let schedule_graph = schedule.graph();
         {
-            let hierarchy_dag = schedule_graph.hierarchy();
-            writeln!(result, "    hierachy:")?;
-            for (l, r, _) in hierarchy_dag.graph().all_edges() {
-                let l_name = id_to_names.get(&l).unwrap();
-                let r_name = id_to_names.get(&r).unwrap();
-                writeln!(result, "      {l:?}({l_name:?}) -> {r:?}({r_name:?})")?;
-            }
-        }
+            // schedule graphs
+            let schedule_graph = schedule.graph();
 
-        {
-            let dag = schedule_graph.dependency();
-            writeln!(result, "    dependency:")?;
-            for (l, r, _) in dag.graph().all_edges() {
-                let l_name = id_to_names.get(&l).unwrap();
-                let r_name = id_to_names.get(&r).unwrap();
-                writeln!(result, "      {l:?}({l_name:?}) -> {r:?}({r_name:?})")?;
-            }
+            writeln!(
+                result,
+                "{}",
+                diagnose_dag("hierachy", schedule_graph.hierarchy(), &id_to_names, "  ")?
+                    .trim_end()
+            )?;
 
-            writeln!(result, "    topsorted:")?;
-            for node_name in dag
-                .cached_topsort()
-                .iter()
-                .map(|node_id| id_to_names.get(node_id).unwrap())
-            {
-                writeln!(result, "      {node_name}")?;
-            }
-        }
+            writeln!(
+                result,
+                "{}",
+                diagnose_dag(
+                    "dependency",
+                    schedule_graph.dependency(),
+                    &id_to_names,
+                    "  "
+                )?
+                .trim_end()
+            )?;
 
-        {
-            let dag = schedule_graph.dependency_flatten();
-            writeln!(result, "    dependency flatten:")?;
-            for (l, r, _) in dag.graph().all_edges() {
-                let l_name = id_to_names.get(&l).unwrap();
-                let r_name = id_to_names.get(&r).unwrap();
-                writeln!(result, "      {l:?}({l_name:?}) -> {r:?}({r_name:?})")?;
-            }
-
-            writeln!(result, "    topsorted:")?;
-            for node_name in dag
-                .cached_topsort()
-                .iter()
-                .map(|node_id| id_to_names.get(node_id).unwrap())
-            {
-                writeln!(result, "      {node_name}")?;
-            }
+            writeln!(
+                result,
+                "{}",
+                diagnose_dag(
+                    "dependency flatten",
+                    schedule_graph.dependency_flatten(),
+                    &id_to_names,
+                    "  "
+                )?
+                .trim_end()
+            )?;
         }
     }
 
     Ok(result)
+}
+
+fn diagnose_dag(
+    name: &str,
+    dag: &Dag,
+    id_to_names: &HashMap<NodeId, Cow<'static, str>>,
+    prefix: &str,
+) -> Result<String, std::fmt::Error> {
+    let mut result = "".to_string();
+    writeln!(result, "{prefix}{name}:")?;
+
+    writeln!(result, "{prefix}  nodes:")?;
+    for node_id in dag.graph().nodes().into_iter() {
+        let name = id_to_names.get(&node_id).unwrap();
+        writeln!(result, "{prefix}    {node_id:?}({name})")?;
+    }
+
+    writeln!(result, "{prefix}  edges:")?;
+    for (l, r, _) in dag.graph().all_edges() {
+        let l_name = id_to_names.get(&l).unwrap();
+        let r_name = id_to_names.get(&r).unwrap();
+        writeln!(result, "{prefix}    {l:?}({l_name}) -> {r:?}({r_name})")?;
+    }
+
+    writeln!(result, "{prefix}  topsorted:")?;
+    for (node_id, node_name) in dag
+        .cached_topsort()
+        .iter()
+        .map(|node_id| (node_id, id_to_names.get(node_id).unwrap()))
+    {
+        writeln!(result, "{prefix}    {node_id:?}({node_name})")?;
+    }
+    Ok(result)
+}
+
+fn component_display(component_id: ComponentId, world: &World) -> String {
+    let component = world.components().get_info(component_id).unwrap();
+    format!("{:?}({})", component_id, component.name())
 }
 
 // In this example we add a counter resource and increase it's value in one system,
@@ -190,33 +314,41 @@ fn main() {
             .in_set(MySet::Set1)
             .in_base_set(MyBaseSet::BaseSet1),
     );
-    {
-        println!("adding first_system");
-        schedule.add_system(
-            first_system
-                .before(second_system)
-                .in_set(MySet::Set2)
-                .in_base_set(MyBaseSet::BaseSet2),
-        );
-    }
-    {
-        println!("adding second_system");
-        schedule.add_system(
-            second_system
-                .in_set(MySet::Set2)
-                .in_base_set(MyBaseSet::BaseSet2),
-        );
-    }
+    schedule.add_system(
+        increase_game_state_count
+            .in_set(MySet::Set1)
+            .before(sync_counter),
+    );
+    schedule.add_system(sync_counter);
+    schedule.add_system(
+        first_system
+            .before(second_system)
+            .in_set(MySet::Set2)
+            .in_base_set(MyBaseSet::BaseSet2),
+    );
+    schedule.add_system(
+        second_system
+            .in_set(MySet::Set2)
+            .in_base_set(MyBaseSet::BaseSet2),
+    );
     world.add_schedule(schedule, ScheduleLabel::Bar);
+
+    world.init_resource::<GameState>();
 
     world.run_schedule(ScheduleLabel::Bar);
     world.run_schedule(DiagnosticLabel);
 
     let player = world.spawn(HitPoint(100)).id();
+    // create an achetype with 2 table components and 1 sparse set
+    world.spawn((HitPoint(100), Counter(1), HighlightFlag));
     world.run_schedule(ScheduleLabel::Bar);
     world.run_schedule(DiagnosticLabel);
 
     world.entity_mut(player).insert((Counter(0),));
+    world.run_schedule(ScheduleLabel::Bar);
+    world.run_schedule(DiagnosticLabel);
+
+    world.entity_mut(player).insert((HighlightFlag,));
     world.run_schedule(ScheduleLabel::Bar);
     world.run_schedule(DiagnosticLabel);
 

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -34,7 +34,10 @@ pub enum ScheduleLabel {
     Bar,
 }
 
-/// A special schedule label for
+/// A special label for diagnostic.
+/// If the diagnostic system running in same label as CoreSet,
+/// then it is not able to get the [`Schedule`] instance from that label.
+/// ([`World::run_schedule_ref`] for reference)
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DiagnosticLabel;
 

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -1,0 +1,66 @@
+use bevy_ecs::prelude::*;
+
+fn empty_system() {}
+
+#[derive(Component)]
+struct Counter(usize);
+
+#[derive(Component)]
+struct HitPoint(usize);
+
+/// World diagnostic example.
+/// can be called directly on World or run as a system.
+fn diagnostic_world(world: &World) {
+    let bundle_size = world.bundles().len();
+    let component_size = world.components().len();
+    let archetype_size = world.archetypes().len();
+    let entity_size = world.entities().len();
+
+    println!("***************");
+    println!("World shape:");
+    println!("  component: {bundle_size}");
+    println!("  bundle: {component_size}");
+    println!("  archetype: {archetype_size}");
+    println!("  entity: {entity_size}");
+
+    println!("World detail:");
+    let bundles = world.bundles().iter().collect::<Vec<_>>();
+    if bundle_size > 0 {
+        println!("  bundles:");
+        for bundle in bundles.iter() {
+            println!("    {:?}: {:?}", bundle.id(), bundle.components());
+        }
+    }
+
+    if archetype_size > 0 {
+        println!("  archetypes:");
+        for archetype in world.archetypes().iter() {
+            println!(
+                "    {:?}: components:{:?} entity count: {}",
+                archetype.id(),
+                archetype.components().collect::<Vec<_>>(),
+                archetype.len()
+            );
+        }
+    }
+}
+
+// In this example we add a counter resource and increase it's value in one system,
+// while a different system prints the current count to the console.
+fn main() {
+    let mut world = World::new();
+    let mut schedule = Schedule::default();
+    schedule.add_system(empty_system);
+    schedule.add_system(diagnostic_world);
+
+    schedule.run(&mut world);
+
+    let player = world.spawn(HitPoint(100)).id();
+    schedule.run(&mut world);
+
+    world.entity_mut(player).insert((Counter(0),));
+    schedule.run(&mut world);
+
+    world.entity_mut(player).despawn();
+    schedule.run(&mut world);
+}

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -35,9 +35,9 @@ pub enum ScheduleLabel {
 }
 
 /// A special label for diagnostic.
-/// If the diagnostic system running in same label as CoreSet,
-/// then it is not able to get the [`Schedule`] instance from that label.
-/// ([`World::run_schedule_ref`] for reference)
+/// If the diagnostic system running in a common used label, like the ones
+/// defined as `bevy_app::CoreSchedule`, it is not able to get the corresponding
+/// [`Schedule`] instance. ([`World::run_schedule_ref`] for reference)
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct DiagnosticLabel;
 

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -54,13 +54,13 @@ fn diagnostic_world(world: &World) {
     println!("  entity: {entity_size}");
 
     let schedules = world.get_resource::<Schedules>().unwrap();
-    diagnostic_schedules(&schedules);
+    diagnostic_schedules(schedules);
 
     println!("World detail:");
     let bundles = world.bundles().iter().collect::<Vec<_>>();
     if bundle_size > 0 {
         println!("  bundles:");
-        for bundle in bundles.iter() {
+        for bundle in bundles {
             println!("    {:?}: {:?}", bundle.id(), bundle.components());
         }
     }
@@ -96,7 +96,7 @@ fn diagnostic_schedules(schedules: &Schedules) {
             for (l, r, _) in hierarchy_dag.graph().all_edges() {
                 let l_name = name_for_node_id(l, schedule);
                 let r_name = name_for_node_id(r, schedule);
-                println!("    {l:?}({l_name:?}) -> {r:?}({r_name:?})");
+                println!("      {l:?}({l_name:?}) -> {r:?}({r_name:?})");
             }
         }
 
@@ -106,7 +106,7 @@ fn diagnostic_schedules(schedules: &Schedules) {
             for (l, r, _) in dependency_dag.graph().all_edges() {
                 let l_name = name_for_node_id(l, schedule);
                 let r_name = name_for_node_id(r, schedule);
-                println!("    {l:?}({l_name:?}) -> {r:?}({r_name:?})");
+                println!("      {l:?}({l_name:?}) -> {r:?}({r_name:?})");
             }
         }
     }

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -263,7 +263,7 @@ fn diagnose_dag(
     writeln!(result, "{prefix}{name}:")?;
 
     writeln!(result, "{prefix}  nodes:")?;
-    for node_id in dag.graph().nodes().into_iter() {
+    for node_id in dag.graph().nodes() {
         let name = id_to_names.get(&node_id).unwrap();
         writeln!(result, "{prefix}    {node_id:?}({name})")?;
     }

--- a/crates/bevy_ecs/examples/world_diagnostic.rs
+++ b/crates/bevy_ecs/examples/world_diagnostic.rs
@@ -1,12 +1,42 @@
-use bevy_ecs::prelude::*;
+use std::borrow::Cow;
+
+use bevy_ecs::{prelude::*, schedule::NodeId};
+use bevy_ecs_macros::{ScheduleLabel, SystemSet};
 
 fn empty_system() {}
+
+fn first_system() {}
+
+fn second_system() {}
+
+#[derive(SystemSet, Hash, Clone, Copy, PartialEq, Eq, Debug)]
+enum MySet {
+    Set1,
+    Set2,
+}
+
+#[derive(SystemSet, Hash, Clone, Copy, PartialEq, Eq, Debug)]
+#[system_set(base)]
+enum MyBaseSet {
+    BaseSet1,
+    BaseSet2,
+}
 
 #[derive(Component)]
 struct Counter(usize);
 
 #[derive(Component)]
 struct HitPoint(usize);
+
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ScheduleLabel {
+    Foo,
+    Bar,
+}
+
+/// A special schedule label for
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct DiagnosticLabel;
 
 /// World diagnostic example.
 /// can be called directly on World or run as a system.
@@ -22,6 +52,9 @@ fn diagnostic_world(world: &World) {
     println!("  bundle: {component_size}");
     println!("  archetype: {archetype_size}");
     println!("  entity: {entity_size}");
+
+    let schedules = world.get_resource::<Schedules>().unwrap();
+    diagnostic_schedules(&schedules);
 
     println!("World detail:");
     let bundles = world.bundles().iter().collect::<Vec<_>>();
@@ -45,22 +78,102 @@ fn diagnostic_world(world: &World) {
     }
 }
 
+fn diagnostic_schedules(schedules: &Schedules) {
+    let label_with_schedules = schedules.iter().collect::<Vec<_>>();
+    println!("  schedules: {}", label_with_schedules.len());
+
+    for (label, schedule) in label_with_schedules {
+        println!(
+            "    label: {:?} kind:{:?}",
+            label,
+            schedule.get_executor_kind(),
+        );
+
+        let schedule_graph = schedule.graph();
+        {
+            let hierarchy_dag = schedule_graph.hierarchy();
+            println!("    hierachy:");
+            for (l, r, _) in hierarchy_dag.graph().all_edges() {
+                let l_name = name_for_node_id(l, schedule);
+                let r_name = name_for_node_id(r, schedule);
+                println!("    {l:?}({l_name:?}) -> {r:?}({r_name:?})");
+            }
+        }
+
+        {
+            let dependency_dag = schedule_graph.dependency();
+            println!("    dependency:");
+            for (l, r, _) in dependency_dag.graph().all_edges() {
+                let l_name = name_for_node_id(l, schedule);
+                let r_name = name_for_node_id(r, schedule);
+                println!("    {l:?}({l_name:?}) -> {r:?}({r_name:?})");
+            }
+        }
+    }
+}
+
+fn name_for_node_id(node_id: NodeId, schedule: &Schedule) -> Option<Cow<'static, str>> {
+    match node_id {
+        bevy_ecs::schedule::NodeId::System(_) => {
+            let system = schedule.get_system_at(node_id)?;
+            system.name()
+        }
+        bevy_ecs::schedule::NodeId::Set(_) => {
+            let set = schedule.graph().get_set_at(node_id)?;
+            format!("{set:?}").into()
+        }
+    }
+    .into()
+}
+
 // In this example we add a counter resource and increase it's value in one system,
 // while a different system prints the current count to the console.
 fn main() {
     let mut world = World::new();
-    let mut schedule = Schedule::default();
-    schedule.add_system(empty_system);
-    schedule.add_system(diagnostic_world);
+    world.init_resource::<Schedules>();
 
-    schedule.run(&mut world);
+    {
+        let mut diagnostic_shedule = Schedule::default();
+        diagnostic_shedule.add_system(diagnostic_world);
+        world.add_schedule(diagnostic_shedule, DiagnosticLabel);
+    }
+
+    let mut schedule = Schedule::default();
+    schedule.configure_set(MySet::Set1);
+    schedule.configure_set(MySet::Set2);
+    schedule.configure_set(MyBaseSet::BaseSet1);
+    schedule.configure_set(MyBaseSet::BaseSet2);
+
+    schedule.add_system(
+        empty_system
+            .in_set(MySet::Set1)
+            .in_base_set(MyBaseSet::BaseSet1),
+    );
+    schedule.add_system(
+        first_system
+            .before(second_system)
+            .in_set(MySet::Set2)
+            .in_base_set(MyBaseSet::BaseSet2),
+    );
+    schedule.add_system(
+        second_system
+            .in_set(MySet::Set2)
+            .in_base_set(MyBaseSet::BaseSet2),
+    );
+    world.add_schedule(schedule, ScheduleLabel::Bar);
+
+    world.run_schedule(ScheduleLabel::Bar);
+    world.run_schedule(DiagnosticLabel);
 
     let player = world.spawn(HitPoint(100)).id();
-    schedule.run(&mut world);
+    world.run_schedule(ScheduleLabel::Bar);
+    world.run_schedule(DiagnosticLabel);
 
     world.entity_mut(player).insert((Counter(0),));
-    schedule.run(&mut world);
+    world.run_schedule(ScheduleLabel::Bar);
+    world.run_schedule(DiagnosticLabel);
 
     world.entity_mut(player).despawn();
-    schedule.run(&mut world);
+    world.run_schedule(ScheduleLabel::Bar);
+    world.run_schedule(DiagnosticLabel);
 }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -689,6 +689,16 @@ pub struct Bundles {
 }
 
 impl Bundles {
+    /// The total number of [`Bundle`] stored in [`World`]
+    pub fn len(&self) -> usize {
+        self.bundle_infos.len()
+    }
+
+    /// Iterate over [`BundleInfo`]
+    pub fn iter(&self) -> impl Iterator<Item = &BundleInfo> {
+        self.bundle_infos.iter()
+    }
+
     #[inline]
     pub fn get(&self, bundle_id: BundleId) -> Option<&BundleInfo> {
         self.bundle_infos.get(bundle_id.index())

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -689,12 +689,12 @@ pub struct Bundles {
 }
 
 impl Bundles {
-    /// The total number of [`Bundle`] stored in [`World`]
+    /// The total number of [`Bundle`] registered in [`Storages`](crate::storage::Storages)
     pub fn len(&self) -> usize {
         self.bundle_infos.len()
     }
 
-    /// Returns true if no [`Bundle`] registered in [`World`]
+    /// Returns true if no [`Bundle`] registered in [`Storages`](crate::storage::Storages)
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -694,6 +694,11 @@ impl Bundles {
         self.bundle_infos.len()
     }
 
+    /// Returns true if no [`Bundle`] registered in [`World`]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// Iterate over [`BundleInfo`]
     pub fn iter(&self) -> impl Iterator<Item = &BundleInfo> {
         self.bundle_infos.iter()

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -581,6 +581,7 @@ impl Components {
         ComponentId(*index)
     }
 
+    /// Iterate [`ComponentInfo`] for this [`World`]
     pub fn iter(&self) -> impl Iterator<Item = &ComponentInfo> + '_ {
         self.components.iter()
     }

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -27,7 +27,7 @@ pub(super) trait SystemExecutor: Send + Sync {
 /// The default depends on the target platform:
 ///  - [`SingleThreaded`](ExecutorKind::SingleThreaded) on WASM.
 ///  - [`MultiThreaded`](ExecutorKind::MultiThreaded) everywhere else.
-#[derive(PartialEq, Eq, Default)]
+#[derive(PartialEq, Eq, Default, Debug, Copy, Clone)]
 pub enum ExecutorKind {
     /// Runs the schedule using a single thread.
     ///

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -431,18 +431,15 @@ impl ScheduleGraph {
     }
 
     /// Returns the system at the given [`NodeId`], if it exists.
-    /// NOTE: systems will be moved to [`SystemSchedule`] while running, so
-    ///   should use [`Schedule::get_system_at`] whenever possible.
+    /// NOTE: systems will be moved from [`ScheduleGraph`] to [`SystemSchedule`] while running,
+    ///     use [`Schedule::get_system_at`] instead whenever possible.
     pub fn get_system_at(&self, id: NodeId) -> Option<&dyn System<In = (), Out = ()>> {
         if !id.is_system() {
             return None;
         }
-        let result = self
-            .systems
+        self.systems
             .get(id.index())
-            .and_then(|system| system.inner.as_deref());
-
-        result
+            .and_then(|system| system.inner.as_deref())
     }
 
     /// Returns the system at the given [`NodeId`].

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1789,6 +1789,7 @@ impl<T: Default> FromWorld for T {
 mod tests {
     use super::{FromWorld, World};
     use crate::{
+        archetype::ArchetypeId,
         change_detection::DetectChangesMut,
         component::{ComponentDescriptor, ComponentInfo, StorageType},
         ptr::OwningPtr,
@@ -2176,6 +2177,14 @@ mod tests {
     #[test]
     fn spawn_empty_bundle() {
         let mut world = World::new();
-        world.spawn(());
+        let entity = world.spawn(());
+        assert!(entity.archetype().id() == ArchetypeId::EMPTY);
+
+        let bundles = world.bundles().iter().collect::<Vec<_>>();
+        assert_eq!(bundles.len(), 1);
+
+        let bundle = bundles[0];
+        assert_eq!(bundle.id().index(), 0);
+        assert!(bundle.components().is_empty());
     }
 }


### PR DESCRIPTION
# Objective

- Improve world inspectability. 

## Solution

- Add len, iter to `Bundles`, so user can get how many bundles registered in world with `world.bundles().len()`.
- Add an example to show how to inspect `World`.

The output for example like:
```bash

***************
World shape:
  component: 2
  bundle: 2
  archetype: 3
  entity: 1
World detail:
  bundles:
    BundleId(0): [ComponentId(0)]
    BundleId(1): [ComponentId(1)]
  archetypes:
    ArchetypeId(0): components:[] entity count: 0
    ArchetypeId(1): components:[ComponentId(0)] entity count: 0
    ArchetypeId(2): components:[ComponentId(0), ComponentId(1)] entity count: 1
***************
World shape:
  component: 2
  bundle: 2
  archetype: 3
  entity: 0
World detail:
  bundles:
    BundleId(0): [ComponentId(0)]
    BundleId(1): [ComponentId(1)]
  archetypes:
    ArchetypeId(0): components:[] entity count: 0
    ArchetypeId(1): components:[ComponentId(0)] entity count: 0
    ArchetypeId(2): components:[ComponentId(0), ComponentId(1)] entity count: 0

```