### PR TITLE
Use string interning to avoid boxing labels

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -125,7 +125,7 @@ impl MainScheduleOrder {
         let index = self
             .labels
             .iter()
-            .position(|current| (**current).eq(&after))
+            .position(|current| (current.as_dyn_eq()).dyn_eq(after.as_dyn_eq()))
             .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
         self.labels.insert(index + 1, Box::new(schedule));
     }

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -208,5 +208,5 @@ pub fn derive_app_label(input: TokenStream) -> TokenStream {
     let input = syn::parse_macro_input!(input as syn::DeriveInput);
     let mut trait_path = BevyManifest::default().get_path("bevy_app");
     trait_path.segments.push(format_ident!("AppLabel").into());
-    derive_label(input, &trait_path, "app_label")
+    derive_label(input, &trait_path)
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -6,9 +6,7 @@ mod set;
 mod states;
 
 use crate::{fetch::derive_world_query_impl, set::derive_set};
-use bevy_macro_utils::{
-    derive_boxed_label, ensure_no_collision, get_named_struct_fields, BevyManifest,
-};
+use bevy_macro_utils::{derive_label, ensure_no_collision, get_named_struct_fields, BevyManifest};
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{format_ident, quote};
@@ -435,7 +433,7 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
     trait_path
         .segments
         .push(format_ident!("ScheduleLabel").into());
-    derive_boxed_label(input, &trait_path)
+    derive_label(input, &trait_path)
 }
 
 /// Derive macro generating an impl of the trait `SystemSet`.

--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -23,11 +23,7 @@ pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStrea
     );
 
     (quote! {
-        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
-                std::boxed::Box::new(std::clone::Clone::clone(self))
-            }
-        }
+        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {}
     })
     .into()
 }

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -4,7 +4,7 @@ use crate::{
     schedule::{
         condition::{BoxedCondition, Condition},
         graph_utils::{Ambiguity, Dependency, DependencyKind, GraphInfo},
-        set::{BoxedSystemSet, IntoSystemSet, SystemSet},
+        set::{IntoSystemSet, SystemSet, SystemSetUntyped},
     },
     system::{BoxedSystem, IntoSystem, System},
 };
@@ -20,7 +20,7 @@ fn new_condition<M>(condition: impl Condition<M>) -> BoxedCondition {
     Box::new(condition_system)
 }
 
-fn ambiguous_with(graph_info: &mut GraphInfo, set: BoxedSystemSet) {
+fn ambiguous_with(graph_info: &mut GraphInfo, set: SystemSetUntyped) {
     match &mut graph_info.ambiguous_with {
         detection @ Ambiguity::Check => {
             *detection = Ambiguity::IgnoreWithSet(vec![set]);
@@ -83,20 +83,20 @@ impl SystemConfigs {
         })
     }
 
-    pub(crate) fn in_set_inner(&mut self, set: BoxedSystemSet) {
+    pub(crate) fn in_set_inner(&mut self, set: SystemSetUntyped) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.graph_info.sets.push(set);
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.in_set_inner(set.dyn_clone());
+                    config.in_set_inner(set);
                 }
             }
         }
     }
 
-    fn before_inner(&mut self, set: BoxedSystemSet) {
+    fn before_inner(&mut self, set: SystemSetUntyped) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config
@@ -106,13 +106,13 @@ impl SystemConfigs {
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.before_inner(set.dyn_clone());
+                    config.before_inner(set);
                 }
             }
         }
     }
 
-    fn after_inner(&mut self, set: BoxedSystemSet) {
+    fn after_inner(&mut self, set: SystemSetUntyped) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config
@@ -122,7 +122,7 @@ impl SystemConfigs {
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.after_inner(set.dyn_clone());
+                    config.after_inner(set);
                 }
             }
         }
@@ -141,14 +141,14 @@ impl SystemConfigs {
         }
     }
 
-    fn ambiguous_with_inner(&mut self, set: BoxedSystemSet) {
+    fn ambiguous_with_inner(&mut self, set: SystemSetUntyped) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 ambiguous_with(&mut config.graph_info, set);
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.ambiguous_with_inner(set.dyn_clone());
+                    config.ambiguous_with_inner(set);
                 }
             }
         }
@@ -302,25 +302,26 @@ impl IntoSystemConfigs<()> for SystemConfigs {
 
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
+        let set = SystemSetUntyped::of(&set);
         assert!(
             set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
 
-        self.in_set_inner(set.dyn_clone());
+        self.in_set_inner(set);
 
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.before_inner(set.dyn_clone());
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        self.before_inner(set);
         self
     }
 
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.after_inner(set.dyn_clone());
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        self.after_inner(set);
         self
     }
 
@@ -330,8 +331,8 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     }
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
-        self.ambiguous_with_inner(set.dyn_clone());
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        self.ambiguous_with_inner(set);
         self
     }
 
@@ -382,13 +383,13 @@ all_tuples!(impl_system_collection, 1, 20, P, S);
 
 /// A [`SystemSet`] with scheduling metadata.
 pub struct SystemSetConfig {
-    pub(super) set: BoxedSystemSet,
+    pub(super) set: SystemSetUntyped,
     pub(super) graph_info: GraphInfo,
     pub(super) conditions: Vec<BoxedCondition>,
 }
 
 impl SystemSetConfig {
-    fn new(set: BoxedSystemSet) -> Self {
+    fn new(set: SystemSetUntyped) -> Self {
         // system type sets are automatically populated
         // to avoid unintentionally broad changes, they cannot be configured
         assert!(
@@ -445,11 +446,11 @@ pub trait IntoSystemSetConfig: Sized {
 
 impl<S: SystemSet> IntoSystemSetConfig for S {
     fn into_config(self) -> SystemSetConfig {
-        SystemSetConfig::new(Box::new(self))
+        SystemSetConfig::new(SystemSetUntyped::of(&self))
     }
 }
 
-impl IntoSystemSetConfig for BoxedSystemSet {
+impl IntoSystemSetConfig for SystemSetUntyped {
     fn into_config(self) -> SystemSetConfig {
         SystemSetConfig::new(self)
     }
@@ -462,27 +463,28 @@ impl IntoSystemSetConfig for SystemSetConfig {
 
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
+        let set = SystemSetUntyped::of(&set);
         assert!(
             set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
-        self.graph_info.sets.push(Box::new(set));
+        self.graph_info.sets.push(set);
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        self.graph_info.dependencies.push(Dependency::new(
-            DependencyKind::Before,
-            Box::new(set.into_system_set()),
-        ));
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        self.graph_info
+            .dependencies
+            .push(Dependency::new(DependencyKind::Before, set));
         self
     }
 
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        self.graph_info.dependencies.push(Dependency::new(
-            DependencyKind::After,
-            Box::new(set.into_system_set()),
-        ));
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        self.graph_info
+            .dependencies
+            .push(Dependency::new(DependencyKind::After, set));
         self
     }
 
@@ -492,7 +494,8 @@ impl IntoSystemSetConfig for SystemSetConfig {
     }
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        ambiguous_with(&mut self.graph_info, Box::new(set.into_system_set()));
+        let set = SystemSetUntyped::of(&set.into_system_set());
+        ambiguous_with(&mut self.graph_info, set);
         self
     }
 
@@ -561,45 +564,46 @@ impl IntoSystemSetConfigs for SystemSetConfigs {
 
     #[track_caller]
     fn in_set(mut self, set: impl SystemSet) -> Self {
+        let set = SystemSetUntyped::of(&set);
         assert!(
             set.system_type().is_none(),
             "adding arbitrary systems to a system type set is not allowed"
         );
         for config in &mut self.sets {
-            config.graph_info.sets.push(set.dyn_clone());
+            config.graph_info.sets.push(set);
         }
 
         self
     }
 
     fn before<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
+        let set = SystemSetUntyped::of(&set.into_system_set());
         for config in &mut self.sets {
             config
                 .graph_info
                 .dependencies
-                .push(Dependency::new(DependencyKind::Before, set.dyn_clone()));
+                .push(Dependency::new(DependencyKind::Before, set));
         }
 
         self
     }
 
     fn after<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
+        let set = SystemSetUntyped::of(&set.into_system_set());
         for config in &mut self.sets {
             config
                 .graph_info
                 .dependencies
-                .push(Dependency::new(DependencyKind::After, set.dyn_clone()));
+                .push(Dependency::new(DependencyKind::After, set));
         }
 
         self
     }
 
     fn ambiguous_with<M>(mut self, set: impl IntoSystemSet<M>) -> Self {
-        let set = set.into_system_set();
+        let set = SystemSetUntyped::of(&set.into_system_set());
         for config in &mut self.sets {
-            ambiguous_with(&mut config.graph_info, set.dyn_clone());
+            ambiguous_with(&mut config.graph_info, set);
         }
 
         self

--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -51,11 +51,11 @@ pub(crate) enum DependencyKind {
 #[derive(Clone)]
 pub(crate) struct Dependency {
     pub(crate) kind: DependencyKind,
-    pub(crate) set: BoxedSystemSet,
+    pub(crate) set: SystemSetUntyped,
 }
 
 impl Dependency {
-    pub fn new(kind: DependencyKind, set: BoxedSystemSet) -> Self {
+    pub fn new(kind: DependencyKind, set: SystemSetUntyped) -> Self {
         Self { kind, set }
     }
 }
@@ -66,14 +66,14 @@ pub(crate) enum Ambiguity {
     #[default]
     Check,
     /// Ignore warnings with systems in any of these system sets. May contain duplicates.
-    IgnoreWithSet(Vec<BoxedSystemSet>),
+    IgnoreWithSet(Vec<SystemSetUntyped>),
     /// Ignore all warnings.
     IgnoreAll,
 }
 
 #[derive(Clone, Default)]
 pub(crate) struct GraphInfo {
-    pub(crate) sets: Vec<BoxedSystemSet>,
+    pub(crate) sets: Vec<SystemSetUntyped>,
     pub(crate) dependencies: Vec<Dependency>,
     pub(crate) ambiguous_with: Ambiguity,
 }

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -81,7 +81,6 @@ enum SystemSetKind {
 
 /// Type-elided struct whose methods return the same values as its original [`SystemSet`].
 #[derive(Clone, Copy, Eq, PartialEq, Hash)]
-
 pub struct SystemSetUntyped {
     id: SystemSetId,
     kind: SystemSetKind,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -7,6 +7,7 @@ use crate::{
     component::{ComponentId, Tick},
     prelude::World,
     query::Access,
+    schedule::SystemSetUntyped,
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
@@ -226,7 +227,7 @@ where
         self.b.set_last_run(last_run);
     }
 
-    fn default_system_sets(&self) -> Vec<Box<dyn crate::schedule::SystemSet>> {
+    fn default_system_sets(&self) -> Vec<SystemSetUntyped> {
         let mut default_sets = self.a.default_system_sets();
         default_sets.append(&mut self.b.default_system_sets());
         default_sets

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -2,6 +2,7 @@ use crate::{
     archetype::ArchetypeComponentId,
     component::{ComponentId, Tick},
     query::Access,
+    schedule::SystemSetUntyped,
     system::{
         check_system_change_tick, ExclusiveSystemParam, ExclusiveSystemParamItem, In, IntoSystem,
         System, SystemMeta,
@@ -147,9 +148,9 @@ where
         );
     }
 
-    fn default_system_sets(&self) -> Vec<Box<dyn crate::schedule::SystemSet>> {
+    fn default_system_sets(&self) -> Vec<SystemSetUntyped> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
-        vec![Box::new(set)]
+        vec![SystemSetUntyped::of(&set)]
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -3,6 +3,7 @@ use crate::{
     component::{ComponentId, Tick},
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
+    schedule::SystemSetUntyped,
     system::{check_system_change_tick, ReadOnlySystemParam, System, SystemParam, SystemParamItem},
     world::{unsafe_world_cell::UnsafeWorldCell, World, WorldId},
 };
@@ -509,9 +510,9 @@ where
         );
     }
 
-    fn default_system_sets(&self) -> Vec<Box<dyn crate::schedule::SystemSet>> {
+    fn default_system_sets(&self) -> Vec<SystemSetUntyped> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
-        vec![Box::new(set)]
+        vec![SystemSetUntyped::of(&set)]
     }
 }
 

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -1,9 +1,13 @@
 use bevy_utils::tracing::warn;
 use core::fmt::Debug;
 
-use crate::component::Tick;
-use crate::world::unsafe_world_cell::UnsafeWorldCell;
-use crate::{archetype::ArchetypeComponentId, component::ComponentId, query::Access, world::World};
+use crate::{
+    archetype::ArchetypeComponentId,
+    component::{ComponentId, Tick},
+    query::Access,
+    schedule::SystemSetUntyped,
+    world::{unsafe_world_cell::UnsafeWorldCell, World},
+};
 
 use std::any::TypeId;
 use std::borrow::Cow;
@@ -89,7 +93,7 @@ pub trait System: Send + Sync + 'static {
     fn check_change_tick(&mut self, change_tick: Tick);
 
     /// Returns the system's default [system sets](crate::schedule::SystemSet).
-    fn default_system_sets(&self) -> Vec<Box<dyn crate::schedule::SystemSet>> {
+    fn default_system_sets(&self) -> Vec<SystemSetUntyped> {
         Vec::new()
     }
 

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -2,11 +2,11 @@
 
 use thiserror::Error;
 
-use crate::schedule::BoxedScheduleLabel;
+use crate::schedule::ScheduleId;
 
 /// The error type returned by [`World::try_run_schedule`] if the provided schedule does not exist.
 ///
 /// [`World::try_run_schedule`]: crate::world::World::try_run_schedule
 #[derive(Error, Debug)]
 #[error("The schedule with the label {0:?} was not found.")]
-pub struct TryRunScheduleError(pub BoxedScheduleLabel);
+pub struct TryRunScheduleError(pub ScheduleId);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1849,7 +1849,7 @@ impl World {
         self.try_schedule_scope(label, |world, sched| sched.run(world))
     }
 
-    /// Runs the [`Schedule`] associated with the `id` a single time.
+    /// Runs the [`Schedule`] associated with the `label` a single time.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -170,8 +170,6 @@ pub fn ensure_no_collision(value: Ident, haystack: TokenStream) -> Ident {
 /// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
 /// - `trait_path`: The path [`syn::Path`] to the label trait
 pub fn derive_label(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
-    //let bevy_utils_path = BevyManifest::default().get_path("bevy_utils");
-
     let ident = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -11,10 +11,10 @@ pub use shape::*;
 pub use symbol::*;
 
 use proc_macro::{TokenStream, TokenTree};
-use quote::{quote, quote_spanned};
+use quote::quote;
 use rustc_hash::FxHashSet;
 use std::{env, path::PathBuf};
-use syn::{spanned::Spanned, Ident};
+use syn::Ident;
 use toml_edit::{Document, Item};
 
 pub struct BevyManifest {
@@ -169,8 +169,8 @@ pub fn ensure_no_collision(value: Ident, haystack: TokenStream) -> Ident {
 ///
 /// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
 /// - `trait_path`: The path [`syn::Path`] to the label trait
-pub fn derive_boxed_label(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
-    let bevy_utils_path = BevyManifest::default().get_path("bevy_utils");
+pub fn derive_label(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
+    //let bevy_utils_path = BevyManifest::default().get_path("bevy_utils");
 
     let ident = input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
@@ -186,137 +186,11 @@ pub fn derive_boxed_label(input: syn::DeriveInput, trait_path: &syn::Path) -> To
     );
 
     (quote! {
-        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn dyn_clone(&self) -> std::boxed::Box<dyn #trait_path> {
-                std::boxed::Box::new(std::clone::Clone::clone(self))
-            }
-
-            fn as_dyn_eq(&self) -> &dyn #bevy_utils_path::label::DynEq {
-                self
-            }
-
-            fn dyn_hash(&self, mut state: &mut dyn ::std::hash::Hasher) {
-                let ty_id = #trait_path::inner_type_id(self);
-                ::std::hash::Hash::hash(&ty_id, &mut state);
-                ::std::hash::Hash::hash(self, &mut state);
-            }
-        }
+        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {}
 
         impl #impl_generics ::std::convert::AsRef<dyn #trait_path> for #ident #ty_generics #where_clause {
             fn as_ref(&self) -> &dyn #trait_path {
                 self
-            }
-        }
-    })
-    .into()
-}
-
-/// Derive a label trait
-///
-/// # Args
-///
-/// - `input`: The [`syn::DeriveInput`] for struct that is deriving the label trait
-/// - `trait_path`: The path [`syn::Path`] to the label trait
-pub fn derive_label(
-    input: syn::DeriveInput,
-    trait_path: &syn::Path,
-    attr_name: &str,
-) -> TokenStream {
-    // return true if the variant specified is an `ignore_fields` attribute
-    fn is_ignore(attr: &syn::Attribute, attr_name: &str) -> bool {
-        if attr.path().get_ident().as_ref().unwrap() != &attr_name {
-            return false;
-        }
-
-        syn::custom_keyword!(ignore_fields);
-        attr.parse_args_with(|input: syn::parse::ParseStream| {
-            let ignore = input.parse::<Option<ignore_fields>>()?.is_some();
-            Ok(ignore)
-        })
-        .unwrap()
-    }
-
-    let ident = input.ident.clone();
-
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
-    let mut where_clause = where_clause.cloned().unwrap_or_else(|| syn::WhereClause {
-        where_token: Default::default(),
-        predicates: Default::default(),
-    });
-    where_clause
-        .predicates
-        .push(syn::parse2(quote! { Self: 'static }).unwrap());
-
-    let as_str = match input.data {
-        syn::Data::Struct(d) => {
-            // see if the user tried to ignore fields incorrectly
-            if let Some(attr) = d
-                .fields
-                .iter()
-                .flat_map(|f| &f.attrs)
-                .find(|a| is_ignore(a, attr_name))
-            {
-                let err_msg = format!("`#[{attr_name}(ignore_fields)]` cannot be applied to fields individually: add it to the struct declaration");
-                return quote_spanned! {
-                    attr.span() => compile_error!(#err_msg);
-                }
-                .into();
-            }
-            // Structs must either be fieldless, or explicitly ignore the fields.
-            let ignore_fields = input.attrs.iter().any(|a| is_ignore(a, attr_name));
-            if matches!(d.fields, syn::Fields::Unit) || ignore_fields {
-                let lit = ident.to_string();
-                quote! { #lit }
-            } else {
-                let err_msg = format!("Labels cannot contain data, unless explicitly ignored with `#[{attr_name}(ignore_fields)]`");
-                return quote_spanned! {
-                    d.fields.span() => compile_error!(#err_msg);
-                }
-                .into();
-            }
-        }
-        syn::Data::Enum(d) => {
-            // check if the user put #[label(ignore_fields)] in the wrong place
-            if let Some(attr) = input.attrs.iter().find(|a| is_ignore(a, attr_name)) {
-                let err_msg = format!("`#[{attr_name}(ignore_fields)]` can only be applied to enum variants or struct declarations");
-                return quote_spanned! {
-                    attr.span() => compile_error!(#err_msg);
-                }
-                .into();
-            }
-            let arms = d.variants.iter().map(|v| {
-                // Variants must either be fieldless, or explicitly ignore the fields.
-                let ignore_fields = v.attrs.iter().any(|a| is_ignore(a, attr_name));
-                if matches!(v.fields, syn::Fields::Unit) | ignore_fields {
-                    let mut path = syn::Path::from(ident.clone());
-                    path.segments.push(v.ident.clone().into());
-                    let lit = format!("{ident}::{}", v.ident.clone());
-                    quote! { #path { .. } => #lit }
-                } else {
-                    let err_msg = format!("Label variants cannot contain data, unless explicitly ignored with `#[{attr_name}(ignore_fields)]`");
-                    quote_spanned! {
-                        v.fields.span() => _ => { compile_error!(#err_msg); }
-                    }
-                }
-            });
-            quote! {
-                match self {
-                    #(#arms),*
-                }
-            }
-        }
-        syn::Data::Union(_) => {
-            return quote_spanned! {
-                input.span() => compile_error!("Unions cannot be used as labels.");
-            }
-            .into();
-        }
-    };
-
-    (quote! {
-        impl #impl_generics #trait_path for #ident #ty_generics #where_clause {
-            fn as_str(&self) -> &'static str {
-                #as_str
             }
         }
     })

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -265,7 +265,7 @@ impl Plugin for RenderPlugin {
             app.init_resource::<ScratchMainWorld>();
 
             let mut render_app = App::empty();
-            render_app.main_schedule_label = Box::new(Render);
+            render_app.main_schedule_label = Render.as_label();
 
             let mut extract_schedule = Schedule::new();
             extract_schedule.set_apply_final_deferred(false);


### PR DESCRIPTION
# Objective

- Resolve #5569.

`Box<dyn MyLabelTrait>` labels aren't too great. Schedules could build much faster if we didn't allocate from the heap for every instance of every label. (Probably. I need to benchmark. TODO.)

I believe an improved label type would have these properties:

1. Implement `Copy`.
2. Produce a unique ID for each ***value*** (i.e. `Enum::VariantA` and `Enum::VariantB` should be different labels).
3. Inherently print the same `Debug` string as the original label.

In the past, we switched away from `Box<dyn MyLabelTrait>` but had to revert in 0.10 to have `OnEnter(state)` and `OnExit(state)` be distinct labels (3), which the label implementation at the time (#4957) did not support.

This is a simpler, "one-size-fits-all" approach than #5715. I think #7762 might be the preferable alternative though. It's very similar but has some internal differences, including special-casing in its macros for unit structs and fieldless enums.

## Solution

- Intern (allocate and leak) the `Debug` string of every label just once (on first use).
- `struct MyLabelTraitId(&'static str)` just wraps the reference to the interned string.
- Implement `Debug` for `MyLabelTraitId` to print the string.
- Use a `(TypeId, hash)` tuple for uniqueness instead of `TypeId` so that different values become different labels.
