### PR TITLE
[Merged by Bors] - Fix clippy lint

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -103,7 +103,7 @@ impl Parse for TypeUuidDef {
         let generics = input.parse::<Generics>()?;
         input.parse::<Token![,]>()?;
         let uuid = input.parse::<LitStr>()?.value();
-        let uuid = Uuid::parse_str(&uuid).map_err(|err| input.error(format!("{}", err)))?;
+        let uuid = Uuid::parse_str(&uuid).map_err(|err| input.error(format!("{err}")))?;
 
         Ok(Self {
             type_ident,


### PR DESCRIPTION
# Objective

`cargo run -p ci` is currently failing locally for me.

```
error: variables can be used directly in the `format!` string
   --> crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs:106:69
    |
106 |         let uuid = Uuid::parse_str(&uuid).map_err(|err| input.error(format!("{}", err)))?;
```

It's not clear to me why CI/clippy didn't pick this up in #6633.


