### PR TITLE
Allow SPIR-V shaders to process when shader defs are present

### DIFF
--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -296,8 +296,6 @@ pub enum ProcessShaderError {
         "Not enough '# endif' lines. Each if statement should be followed by an endif statement."
     )]
     NotEnoughEndIfs,
-    #[error("This Shader's format does not support processing shader defs.")]
-    ShaderFormatDoesNotSupportShaderDefs,
     #[error("This Shader's format does not support imports.")]
     ShaderFormatDoesNotSupportImports,
     #[error("Unresolved import: {0:?}.")]

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -477,10 +477,7 @@ impl ShaderProcessor {
             Source::Wgsl(source) => source.deref(),
             Source::Glsl(source, _stage) => source.deref(),
             Source::SpirV(source) => {
-                if shader_defs_unique.is_empty() {
-                    return Ok(ProcessedShader::SpirV(source.clone()));
-                }
-                return Err(ProcessShaderError::ShaderFormatDoesNotSupportShaderDefs);
+                return Ok(ProcessedShader::SpirV(source.clone()));
             }
         };
 


### PR DESCRIPTION
# Objective

- Prevent SPIR-V shaders from being rejected when shader defines are present.

## Solution

- Have ShaderProcessor behave as a passthrough with respect to SPIR-V shaders.

---

Fixes #7771