### PR TITLE
Split apart `FrameTimeDiagnosticsPlugin`

### DIFF
--- a/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
@@ -5,33 +5,33 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
 /// This plugin group will add "frame time" diagnostics to an App, namely:
-/// * [`FrameTimeMeasurePlugin`](crate::FrameTimeMeasurePlugin)
-/// * [`FpsMeasurePlugin`](crate::FpsMeasurePlugin)
-/// * [`FrameCountMeasurePlugin`](crate::FrameCountMeasurePlugin)
+/// * [`FrameTimePlugin`](crate::FrameTimePlugin)
+/// * [`FpsPlugin`](crate::FpsPlugin)
+/// * [`FrameCountPlugin`](crate::FrameCountPlugin)
 #[derive(Default)]
 pub struct BasicPerformanceDiagnosticsPlugins;
 
 impl PluginGroup for BasicPerformanceDiagnosticsPlugins {
     fn build(self) -> bevy_app::PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
-            .add(FpsMeasurePlugin)
-            .add(FrameTimeMeasurePlugin)
-            .add(FrameCountMeasurePlugin)
+            .add(FpsPlugin)
+            .add(FrameTimePlugin)
+            .add(FrameCountPlugin)
     }
 }
 
 /// Adds "frame time" diagnostic to an App
 #[derive(Default)]
-pub struct FrameTimeMeasurePlugin;
+pub struct FrameTimePlugin;
 
-impl Plugin for FrameTimeMeasurePlugin {
+impl Plugin for FrameTimePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::frame_time_diagnostic_system);
     }
 }
 
-impl FrameTimeMeasurePlugin {
+impl FrameTimePlugin {
     /// Used as a key to retrieve the frame time diagnostic from [Diagnostics]
     pub const FRAME_TIME: DiagnosticId =
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
@@ -51,15 +51,15 @@ impl FrameTimeMeasurePlugin {
 }
 /// Adds "frame per second" diagnostic to an App
 #[derive(Default)]
-pub struct FpsMeasurePlugin;
+pub struct FpsPlugin;
 
-impl Plugin for FpsMeasurePlugin {
+impl Plugin for FpsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::fps_diagnostic_system);
     }
 }
-impl FpsMeasurePlugin {
+impl FpsPlugin {
     /// Used as a key to retrieve the fps diagnostic from [Diagnostics]
     pub const FPS: DiagnosticId = DiagnosticId::from_u128(288146834822086093791974408528866909483);
 
@@ -78,14 +78,14 @@ impl FpsMeasurePlugin {
 }
 /// Adds "frame count" diagnostic to an App
 #[derive(Default)]
-pub struct FrameCountMeasurePlugin;
-impl Plugin for FrameCountMeasurePlugin {
+pub struct FrameCountPlugin;
+impl Plugin for FrameCountPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::frame_count_diagnostic_system);
     }
 }
-impl FrameCountMeasurePlugin {
+impl FrameCountPlugin {
     /// Used as a key to retrieve the frame count diagnostic from [Diagnostics]
     pub const FRAME_COUNT: DiagnosticId =
         DiagnosticId::from_u128(54021991829115352065418785002088010277);

--- a/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
@@ -5,33 +5,33 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
 /// This plugin group will add "frame time" diagnostics to an App, namely:
-/// * [`FrameTimeDiagnosticsPlugin`](crate::FrameTimeDiagnosticsPlugin)
-/// * [`FpsDiagnosticsPlugin`](crate::FpsDiagnosticsPlugin)
-/// * [`FrameCountDiagnosticsPlugin`](crate::FrameCountDiagnosticsPlugin)
+/// * [`FrameTimeMeasurePlugin`](crate::FrameTimeMeasurePlugin)
+/// * [`FpsMeasurePlugin`](crate::FpsMeasurePlugin)
+/// * [`FrameCountMeasurePlugin`](crate::FrameCountMeasurePlugin)
 #[derive(Default)]
 pub struct BasicPerformanceDiagnosticsPlugins;
 
 impl PluginGroup for BasicPerformanceDiagnosticsPlugins {
     fn build(self) -> bevy_app::PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
-            .add(FpsDiagnosticsPlugin)
-            .add(FrameTimeDiagnosticsPlugin)
-            .add(FrameCountDiagnosticsPlugin)
+            .add(FpsMeasurePlugin)
+            .add(FrameTimeMeasurePlugin)
+            .add(FrameCountMeasurePlugin)
     }
 }
 
 /// Adds "frame time" diagnostic to an App
 #[derive(Default)]
-pub struct FrameTimeDiagnosticsPlugin;
+pub struct FrameTimeMeasurePlugin;
 
-impl Plugin for FrameTimeDiagnosticsPlugin {
+impl Plugin for FrameTimeMeasurePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::frame_time_diagnostic_system);
     }
 }
 
-impl FrameTimeDiagnosticsPlugin {
+impl FrameTimeMeasurePlugin {
     /// Used as a key to retrieve the frame time diagnostic from [Diagnostics]
     pub const FRAME_TIME: DiagnosticId =
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
@@ -51,15 +51,15 @@ impl FrameTimeDiagnosticsPlugin {
 }
 /// Adds "frame per second" diagnostic to an App
 #[derive(Default)]
-pub struct FpsDiagnosticsPlugin;
+pub struct FpsMeasurePlugin;
 
-impl Plugin for FpsDiagnosticsPlugin {
+impl Plugin for FpsMeasurePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::fps_diagnostic_system);
     }
 }
-impl FpsDiagnosticsPlugin {
+impl FpsMeasurePlugin {
     /// Used as a key to retrieve the fps diagnostic from [Diagnostics]
     pub const FPS: DiagnosticId = DiagnosticId::from_u128(288146834822086093791974408528866909483);
 
@@ -78,14 +78,14 @@ impl FpsDiagnosticsPlugin {
 }
 /// Adds "frame count" diagnostic to an App
 #[derive(Default)]
-pub struct FrameCountDiagnosticsPlugin;
-impl Plugin for FrameCountDiagnosticsPlugin {
+pub struct FrameCountMeasurePlugin;
+impl Plugin for FrameCountMeasurePlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::frame_count_diagnostic_system);
     }
 }
-impl FrameCountDiagnosticsPlugin {
+impl FrameCountMeasurePlugin {
     /// Used as a key to retrieve the frame count diagnostic from [Diagnostics]
     pub const FRAME_COUNT: DiagnosticId =
         DiagnosticId::from_u128(54021991829115352065418785002088010277);

--- a/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
@@ -10,9 +10,9 @@ use bevy_time::Time;
 /// * [`FrameCountDiagnosticsPlugin`](crate::FrameCountDiagnosticsPlugin)
 ///
 #[derive(Default)]
-pub struct FrameTimeDiagnosticsPlugins;
+pub struct BasicPerformanceDiagnosticsPlugins;
 
-impl PluginGroup for FrameTimeDiagnosticsPlugins {
+impl PluginGroup for BasicPerformanceDiagnosticsPlugins {
     fn build(self) -> bevy_app::PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(FpsDiagnosticsPlugin)

--- a/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/basic_performance_diagnostics_plugin.rs
@@ -8,7 +8,6 @@ use bevy_time::Time;
 /// * [`FrameTimeDiagnosticsPlugin`](crate::FrameTimeDiagnosticsPlugin)
 /// * [`FpsDiagnosticsPlugin`](crate::FpsDiagnosticsPlugin)
 /// * [`FrameCountDiagnosticsPlugin`](crate::FrameCountDiagnosticsPlugin)
-///
 #[derive(Default)]
 pub struct BasicPerformanceDiagnosticsPlugins;
 
@@ -33,13 +32,15 @@ impl Plugin for FrameTimeDiagnosticsPlugin {
 }
 
 impl FrameTimeDiagnosticsPlugin {
+    /// Used as a key to retrieve the frame time diagnostic from [Diagnostics]
     pub const FRAME_TIME: DiagnosticId =
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
+    /// Adds the frame time diagnostic to the [Diagnostics] resource
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
         diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
     }
-
+    /// Updates the frame time diagnostic
     pub fn frame_time_diagnostic_system(mut diagnostics: ResMut<Diagnostics>, time: Res<Time>) {
         let delta_seconds = time.raw_delta_seconds_f64();
         if delta_seconds == 0.0 {
@@ -59,12 +60,14 @@ impl Plugin for FpsDiagnosticsPlugin {
     }
 }
 impl FpsDiagnosticsPlugin {
+    /// Used as a key to retrieve the fps diagnostic from [Diagnostics]
     pub const FPS: DiagnosticId = DiagnosticId::from_u128(288146834822086093791974408528866909483);
 
+    /// Adds the fps diagnostic to the [Diagnostics] resource
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
         diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
     }
-
+    /// Updates the fps diagnostic
     pub fn fps_diagnostic_system(mut diagnostics: ResMut<Diagnostics>, time: Res<Time>) {
         let delta_seconds = time.raw_delta_seconds_f64();
         if delta_seconds == 0.0 {
@@ -83,13 +86,15 @@ impl Plugin for FrameCountDiagnosticsPlugin {
     }
 }
 impl FrameCountDiagnosticsPlugin {
+    /// Used as a key to retrieve the frame count diagnostic from [Diagnostics]
     pub const FRAME_COUNT: DiagnosticId =
         DiagnosticId::from_u128(54021991829115352065418785002088010277);
 
+    /// Adds the frame count diagnostic to the [Diagnostics] resource
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
         diagnostics.add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 20).with_suffix("ms"));
     }
-
+    /// Updates the frame count diagnostic
     pub fn frame_count_diagnostic_system(
         mut diagnostics: ResMut<Diagnostics>,
         frame_count: Res<FrameCount>,

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -5,9 +5,9 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
 /// This plugin group will add "frame time" diagnostics to an App, namely:
-/// * [`FrameTimeDiagnosticsPlugin`](crate::diagnostic::FrameTimeDiagnosticsPlugin)
-/// * [`FpsDiagnosticsPlugin`](crate::diagnostic::FpsDiagnosticsPlugin)
-/// * [`FrameCountDiagnosticsPlugin`](crate::diagnostic::FrameCountDiagnosticsPlugin)
+/// * [`FrameTimeDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin)
+/// * [`FpsDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FpsDiagnosticsPlugin)
+/// * [`FrameCountDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FrameCountDiagnosticsPlugin)
 ///
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugins;

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -4,7 +4,11 @@ use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
-/// Adds "frame time" diagnostics to an App, specifically "frame time", "fps" and "frame count"
+/// This plugin group will add "frame time" diagnostics to an App, namely:
+/// * [`FrameTimeDiagnosticsPlugin`](crate::diagnostic::FrameTimeDiagnosticsPlugin)
+/// * [`FpsDiagnosticsPlugin`](crate::diagnostic::FpsDiagnosticsPlugin)
+/// * [`FrameCountDiagnosticsPlugin`](crate::diagnostic::FrameCountDiagnosticsPlugin)
+///
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugins;
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -20,14 +20,15 @@ impl PluginGroup for FrameTimeDiagnosticsPlugins {
 /// Adds "frame time" diagnostic to an App
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugin;
-impl Plugin for FrameTimeDiagnosticsPlugin{
+
+impl Plugin for FrameTimeDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::frame_time_diagnostic_system);
     }
 }
 
-impl FrameTimeDiagnosticsPlugin  {
+impl FrameTimeDiagnosticsPlugin {
     pub const FRAME_TIME: DiagnosticId =
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
@@ -35,10 +36,7 @@ impl FrameTimeDiagnosticsPlugin  {
         diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
     }
 
-    pub fn frame_time_diagnostic_system(
-        mut diagnostics: ResMut<Diagnostics>,
-        time: Res<Time>,
-    ) {
+    pub fn frame_time_diagnostic_system(mut diagnostics: ResMut<Diagnostics>, time: Res<Time>) {
         let delta_seconds = time.raw_delta_seconds_f64();
         if delta_seconds == 0.0 {
             return;
@@ -49,6 +47,7 @@ impl FrameTimeDiagnosticsPlugin  {
 /// Adds "frame per second" diagnostic to an App
 #[derive(Default)]
 pub struct FpsDiagnosticsPlugin;
+
 impl Plugin for FpsDiagnosticsPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
@@ -62,10 +61,7 @@ impl FpsDiagnosticsPlugin {
         diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
     }
 
-    pub fn fps_diagnostic_system(
-        mut diagnostics: ResMut<Diagnostics>,
-        time: Res<Time>,
-    ) {
+    pub fn fps_diagnostic_system(mut diagnostics: ResMut<Diagnostics>, time: Res<Time>) {
         let delta_seconds = time.raw_delta_seconds_f64();
         if delta_seconds == 0.0 {
             return;

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -5,9 +5,9 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
 /// This plugin group will add "frame time" diagnostics to an App, namely:
-/// * [`FrameTimeDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin)
-/// * [`FpsDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FpsDiagnosticsPlugin)
-/// * [`FrameCountDiagnosticsPlugin`](crate::diagnostic::frame_time_diagnostics_plugin::FrameCountDiagnosticsPlugin)
+/// * [`FrameTimeDiagnosticsPlugin`](crate::FrameTimeDiagnosticsPlugin)
+/// * [`FpsDiagnosticsPlugin`](crate::FpsDiagnosticsPlugin)
+/// * [`FrameCountDiagnosticsPlugin`](crate::FrameCountDiagnosticsPlugin)
 ///
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugins;

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -1,48 +1,99 @@
 use crate::{Diagnostic, DiagnosticId, Diagnostics};
-use bevy_app::prelude::*;
+use bevy_app::{prelude::*, PluginGroupBuilder};
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
-/// Adds "frame time" diagnostic to an App, specifically "frame time", "fps" and "frame count"
+/// Adds "frame time" diagnostics to an App, specifically "frame time", "fps" and "frame count"
 #[derive(Default)]
-pub struct FrameTimeDiagnosticsPlugin;
+pub struct FrameTimeDiagnosticsPlugins;
 
-impl Plugin for FrameTimeDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
-        app.add_startup_system(Self::setup_system)
-            .add_system(Self::diagnostic_system);
+impl PluginGroup for FrameTimeDiagnosticsPlugins {
+    fn build(self) -> bevy_app::PluginGroupBuilder {
+        PluginGroupBuilder::start::<Self>()
+            .add(FpsDiagnosticsPlugin)
+            .add(FrameTimeDiagnosticsPlugin)
+            .add(FrameCountDiagnosticsPlugin)
     }
 }
 
-impl FrameTimeDiagnosticsPlugin {
-    pub const FPS: DiagnosticId = DiagnosticId::from_u128(288146834822086093791974408528866909483);
-    pub const FRAME_COUNT: DiagnosticId =
-        DiagnosticId::from_u128(54021991829115352065418785002088010277);
+/// Adds "frame time" diagnostic to an App
+#[derive(Default)]
+pub struct FrameTimeDiagnosticsPlugin;
+impl Plugin for FrameTimeDiagnosticsPlugin{
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_startup_system(Self::setup_system)
+            .add_system(Self::frame_time_diagnostic_system);
+    }
+}
+
+impl FrameTimeDiagnosticsPlugin  {
     pub const FRAME_TIME: DiagnosticId =
         DiagnosticId::from_u128(73441630925388532774622109383099159699);
 
     pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
         diagnostics.add(Diagnostic::new(Self::FRAME_TIME, "frame_time", 20).with_suffix("ms"));
-        diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
-        diagnostics
-            .add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 1).with_smoothing_factor(0.0));
     }
 
-    pub fn diagnostic_system(
+    pub fn frame_time_diagnostic_system(
         mut diagnostics: ResMut<Diagnostics>,
         time: Res<Time>,
-        frame_count: Res<FrameCount>,
     ) {
-        diagnostics.add_measurement(Self::FRAME_COUNT, || frame_count.0 as f64);
-
         let delta_seconds = time.raw_delta_seconds_f64();
         if delta_seconds == 0.0 {
             return;
         }
-
         diagnostics.add_measurement(Self::FRAME_TIME, || delta_seconds * 1000.0);
+    }
+}
+/// Adds "frame per second" diagnostic to an App
+#[derive(Default)]
+pub struct FpsDiagnosticsPlugin;
+impl Plugin for FpsDiagnosticsPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_startup_system(Self::setup_system)
+            .add_system(Self::fps_diagnostic_system);
+    }
+}
+impl FpsDiagnosticsPlugin {
+    pub const FPS: DiagnosticId = DiagnosticId::from_u128(288146834822086093791974408528866909483);
 
+    pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
+        diagnostics.add(Diagnostic::new(Self::FPS, "fps", 20));
+    }
+
+    pub fn fps_diagnostic_system(
+        mut diagnostics: ResMut<Diagnostics>,
+        time: Res<Time>,
+    ) {
+        let delta_seconds = time.raw_delta_seconds_f64();
+        if delta_seconds == 0.0 {
+            return;
+        }
         diagnostics.add_measurement(Self::FPS, || 1.0 / delta_seconds);
+    }
+}
+/// Adds "frame count" diagnostic to an App
+#[derive(Default)]
+pub struct FrameCountDiagnosticsPlugin;
+impl Plugin for FrameCountDiagnosticsPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.add_startup_system(Self::setup_system)
+            .add_system(Self::frame_count_diagnostic_system);
+    }
+}
+impl FrameCountDiagnosticsPlugin {
+    pub const FRAME_COUNT: DiagnosticId =
+        DiagnosticId::from_u128(54021991829115352065418785002088010277);
+
+    pub fn setup_system(mut diagnostics: ResMut<Diagnostics>) {
+        diagnostics.add(Diagnostic::new(Self::FRAME_COUNT, "frame_count", 20).with_suffix("ms"));
+    }
+
+    pub fn frame_count_diagnostic_system(
+        mut diagnostics: ResMut<Diagnostics>,
+        frame_count: Res<FrameCount>,
+    ) {
+        diagnostics.add_measurement(Self::FRAME_COUNT, || frame_count.0 as f64);
     }
 }

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -1,15 +1,15 @@
 mod diagnostic;
 mod entity_count_diagnostics_plugin;
-mod frame_time_diagnostics_plugin;
+mod basic_performance_diagnostics_plugin;
 mod log_diagnostics_plugin;
 mod system_information_diagnostics_plugin;
 
 use bevy_app::prelude::*;
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
-pub use frame_time_diagnostics_plugin::{
+pub use basic_performance_diagnostics_plugin::{
     FpsDiagnosticsPlugin, FrameCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin,
-    FrameTimeDiagnosticsPlugins,
+    BasicPerformanceDiagnosticsPlugins,
 };
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -7,7 +7,7 @@ mod system_information_diagnostics_plugin;
 use bevy_app::prelude::*;
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
-pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
+pub use frame_time_diagnostics_plugin::{FrameTimeDiagnosticsPlugins,FrameTimeDiagnosticsPlugin,FpsDiagnosticsPlugin,FrameCountDiagnosticsPlugin};
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -5,8 +5,8 @@ mod log_diagnostics_plugin;
 mod system_information_diagnostics_plugin;
 
 pub use basic_performance_diagnostics_plugin::{
-    BasicPerformanceDiagnosticsPlugins, FpsDiagnosticsPlugin, FrameCountDiagnosticsPlugin,
-    FrameTimeDiagnosticsPlugin,
+    BasicPerformanceDiagnosticsPlugins, FpsMeasurePlugin, FrameCountMeasurePlugin,
+    FrameTimeMeasurePlugin,
 };
 use bevy_app::prelude::*;
 pub use diagnostic::*;

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -5,8 +5,7 @@ mod log_diagnostics_plugin;
 mod system_information_diagnostics_plugin;
 
 pub use basic_performance_diagnostics_plugin::{
-    BasicPerformanceDiagnosticsPlugins, FpsMeasurePlugin, FrameCountMeasurePlugin,
-    FrameTimeMeasurePlugin,
+    BasicPerformanceDiagnosticsPlugins, FpsPlugin, FrameCountPlugin, FrameTimePlugin,
 };
 use bevy_app::prelude::*;
 pub use diagnostic::*;

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -1,16 +1,16 @@
+mod basic_performance_diagnostics_plugin;
 mod diagnostic;
 mod entity_count_diagnostics_plugin;
-mod basic_performance_diagnostics_plugin;
 mod log_diagnostics_plugin;
 mod system_information_diagnostics_plugin;
 
+pub use basic_performance_diagnostics_plugin::{
+    BasicPerformanceDiagnosticsPlugins, FpsDiagnosticsPlugin, FrameCountDiagnosticsPlugin,
+    FrameTimeDiagnosticsPlugin,
+};
 use bevy_app::prelude::*;
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
-pub use basic_performance_diagnostics_plugin::{
-    FpsDiagnosticsPlugin, FrameCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin,
-    BasicPerformanceDiagnosticsPlugins,
-};
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -7,7 +7,10 @@ mod system_information_diagnostics_plugin;
 use bevy_app::prelude::*;
 pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
-pub use frame_time_diagnostics_plugin::{FrameTimeDiagnosticsPlugins,FrameTimeDiagnosticsPlugin,FpsDiagnosticsPlugin,FrameCountDiagnosticsPlugin};
+pub use frame_time_diagnostics_plugin::{
+    FpsDiagnosticsPlugin, FrameCountDiagnosticsPlugin, FrameTimeDiagnosticsPlugin,
+    FrameTimeDiagnosticsPlugins,
+};
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
 

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::*;
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     pbr::NotShadowCaster,
     prelude::*,
 };
@@ -10,7 +10,7 @@ use rand::{thread_rng, Rng};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(light_sway)

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -1,7 +1,7 @@
 use std::f32::consts::*;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     pbr::NotShadowCaster,
     prelude::*,
 };
@@ -10,7 +10,7 @@ use rand::{thread_rng, Rng};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(light_sway)

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -1,7 +1,7 @@
 //! Shows different built-in plugins that logs diagnostics, like frames per second (FPS), to the console.
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeDiagnosticsPlugins, LogDiagnosticsPlugin},
     prelude::*,
 };
 
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // Adds frame time diagnostics
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugins(FrameTimeDiagnosticsPlugins::default())
         // Adds a system that prints diagnostics to the console
         .add_plugin(LogDiagnosticsPlugin::default())
         // Any plugin can register diagnostics

--- a/examples/diagnostics/log_diagnostics.rs
+++ b/examples/diagnostics/log_diagnostics.rs
@@ -1,7 +1,7 @@
 //! Shows different built-in plugins that logs diagnostics, like frames per second (FPS), to the console.
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugins, LogDiagnosticsPlugin},
+    diagnostic::{BasicPerformanceDiagnosticsPlugins, LogDiagnosticsPlugin},
     prelude::*,
 };
 
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // Adds frame time diagnostics
-        .add_plugins(FrameTimeDiagnosticsPlugins::default())
+        .add_plugins(BasicPerformanceDiagnosticsPlugins::default())
         // Adds a system that prints diagnostics to the console
         .add_plugin(LogDiagnosticsPlugin::default())
         // Any plugin can register diagnostics

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -3,7 +3,7 @@
 //! Usage: spawn more entities by clicking on the screen.
 
 use bevy::{
-    diagnostic::{Diagnostics, FpsMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FpsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
 };
@@ -37,7 +37,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FpsMeasurePlugin::default())
+        .add_plugin(FpsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .insert_resource(BevyCounter {
             count: 0,
@@ -252,7 +252,7 @@ fn counter_system(
         text.sections[1].value = counter.count.to_string();
     }
 
-    if let Some(fps) = diagnostics.get(FpsMeasurePlugin::FPS) {
+    if let Some(fps) = diagnostics.get(FpsPlugin::FPS) {
         if let Some(raw) = fps.value() {
             text.sections[3].value = format!("{raw:.2}");
         }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -3,7 +3,7 @@
 //! Usage: spawn more entities by clicking on the screen.
 
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{Diagnostics, LogDiagnosticsPlugin, FpsDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
 };
@@ -37,7 +37,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FpsDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .insert_resource(BevyCounter {
             count: 0,
@@ -252,7 +252,7 @@ fn counter_system(
         text.sections[1].value = counter.count.to_string();
     }
 
-    if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+    if let Some(fps) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
         if let Some(raw) = fps.value() {
             text.sections[3].value = format!("{raw:.2}");
         }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -3,7 +3,7 @@
 //! Usage: spawn more entities by clicking on the screen.
 
 use bevy::{
-    diagnostic::{Diagnostics, FpsDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FpsMeasurePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
 };
@@ -37,7 +37,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FpsDiagnosticsPlugin::default())
+        .add_plugin(FpsMeasurePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .insert_resource(BevyCounter {
             count: 0,
@@ -252,7 +252,7 @@ fn counter_system(
         text.sections[1].value = counter.count.to_string();
     }
 
-    if let Some(fps) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
+    if let Some(fps) = diagnostics.get(FpsMeasurePlugin::FPS) {
         if let Some(raw) = fps.value() {
             text.sections[3].value = format!("{raw:.2}");
         }

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -3,7 +3,7 @@
 //! Usage: spawn more entities by clicking on the screen.
 
 use bevy::{
-    diagnostic::{Diagnostics, LogDiagnosticsPlugin, FpsDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FpsDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowResolution},
 };

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -9,7 +9,7 @@
 use std::time::Duration;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     math::Quat,
     prelude::*,
     render::camera::Camera,
@@ -24,7 +24,7 @@ fn main() {
     App::new()
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -9,7 +9,7 @@
 use std::time::Duration;
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     math::Quat,
     prelude::*,
     render::camera::Camera,
@@ -24,7 +24,7 @@ fn main() {
     App::new()
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -18,7 +18,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .init_resource::<UiFont>()
         .add_startup_system(setup)

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -1,5 +1,5 @@
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -18,7 +18,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .init_resource::<UiFont>()
         .add_startup_system(setup)

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -13,7 +13,7 @@
 use std::f64::consts::PI;
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -28,7 +28,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(move_camera)

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -13,7 +13,7 @@
 use std::f64::consts::PI;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -28,7 +28,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(move_camera)

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -5,7 +5,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -28,7 +28,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeMeasurePlugin)
+        .add_plugin(FrameTimePlugin)
         .add_plugin(LogDiagnosticsPlugin::default())
         .insert_resource(Foxes {
             count: std::env::args()

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -5,7 +5,7 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -28,7 +28,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin)
+        .add_plugin(FrameTimeMeasurePlugin)
         .add_plugin(LogDiagnosticsPlugin::default())
         .insert_resource(Foxes {
             count: std::env::args()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -4,7 +4,7 @@
 use std::f64::consts::PI;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
@@ -24,7 +24,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(move_camera)

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -4,7 +4,7 @@
 use std::f64::consts::PI;
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
@@ -24,7 +24,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(move_camera)

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -11,7 +11,7 @@
 //! in multiple batches, reducing performance but useful for testing.
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -32,7 +32,7 @@ fn main() {
         ))
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeMeasurePlugin::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -11,7 +11,7 @@
 //! in multiple batches, reducing performance but useful for testing.
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -32,7 +32,7 @@ fn main() {
         ))
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeMeasurePlugin::default())
+        .add_plugin(FrameTimePlugin::default())
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -4,14 +4,14 @@
 //! in the bottom right. For text within a scene, please see the text2d example.
 
 use bevy::{
-    diagnostic::{Diagnostics, FpsMeasurePlugin},
+    diagnostic::{Diagnostics, FpsPlugin},
     prelude::*,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(FpsMeasurePlugin::default())
+        .add_plugin(FpsPlugin::default())
         .add_startup_system(setup)
         .add_system(text_update_system)
         .add_system(text_color_system)
@@ -92,7 +92,7 @@ fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText
 
 fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
-        if let Some(fps) = diagnostics.get(FpsMeasurePlugin::FPS) {
+        if let Some(fps) = diagnostics.get(FpsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
                 // Update the value of the second section
                 text.sections[1].value = format!("{value:.2}");

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -4,14 +4,14 @@
 //! in the bottom right. For text within a scene, please see the text2d example.
 
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FpsDiagnosticsPlugin},
     prelude::*,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
+        .add_plugin(FpsDiagnosticsPlugin::default())
         .add_startup_system(setup)
         .add_system(text_update_system)
         .add_system(text_color_system)
@@ -92,7 +92,7 @@ fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText
 
 fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
-        if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+        if let Some(fps) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
             if let Some(value) = fps.smoothed() {
                 // Update the value of the second section
                 text.sections[1].value = format!("{value:.2}");

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -4,14 +4,14 @@
 //! in the bottom right. For text within a scene, please see the text2d example.
 
 use bevy::{
-    diagnostic::{Diagnostics, FpsDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FpsMeasurePlugin},
     prelude::*,
 };
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(FpsDiagnosticsPlugin::default())
+        .add_plugin(FpsMeasurePlugin::default())
         .add_startup_system(setup)
         .add_system(text_update_system)
         .add_system(text_color_system)
@@ -92,7 +92,7 @@ fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText
 
 fn text_update_system(diagnostics: Res<Diagnostics>, mut query: Query<&mut Text, With<FpsText>>) {
     for mut text in &mut query {
-        if let Some(fps) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
+        if let Some(fps) = diagnostics.get(FpsMeasurePlugin::FPS) {
             if let Some(value) = fps.smoothed() {
                 // Update the value of the second section
                 text.sections[1].value = format!("{value:.2}");

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     diagnostic::{
-        Diagnostics, FpsDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, FrameTimeDiagnosticsPlugins,
+        Diagnostics, FpsDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, BasicPerformanceDiagnosticsPlugins,
     },
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -17,7 +17,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugins(FrameTimeDiagnosticsPlugins)
+        .add_plugins(BasicPerformanceDiagnosticsPlugins)
         .add_startup_system(infotext_system)
         .add_system(change_text_system)
         .run();

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -2,8 +2,8 @@
 
 use bevy::{
     diagnostic::{
-        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsDiagnosticsPlugin,
-        FrameTimeDiagnosticsPlugin,
+        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsMeasurePlugin,
+        FrameTimeMeasurePlugin,
     },
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -161,14 +161,14 @@ fn change_text_system(
 ) {
     for mut text in &mut query {
         let mut fps = 0.0;
-        if let Some(fps_diagnostic) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
+        if let Some(fps_diagnostic) = diagnostics.get(FpsMeasurePlugin::FPS) {
             if let Some(fps_smoothed) = fps_diagnostic.smoothed() {
                 fps = fps_smoothed;
             }
         }
 
         let mut frame_time = time.delta_seconds_f64();
-        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FRAME_TIME)
+        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeMeasurePlugin::FRAME_TIME)
         {
             if let Some(frame_time_smoothed) = frame_time_diagnostic.smoothed() {
                 frame_time = frame_time_smoothed;

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -1,7 +1,9 @@
 //! Shows various text layout options.
 
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugins, FrameTimeDiagnosticsPlugin, FpsDiagnosticsPlugin},
+    diagnostic::{
+        Diagnostics, FpsDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, FrameTimeDiagnosticsPlugins,
+    },
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -2,7 +2,8 @@
 
 use bevy::{
     diagnostic::{
-        Diagnostics, FpsDiagnosticsPlugin, FrameTimeDiagnosticsPlugin, BasicPerformanceDiagnosticsPlugins,
+        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsDiagnosticsPlugin,
+        FrameTimeDiagnosticsPlugin,
     },
     prelude::*,
     window::{PresentMode, WindowPlugin},

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -1,7 +1,7 @@
 //! Shows various text layout options.
 
 use bevy::{
-    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugin},
+    diagnostic::{Diagnostics, FrameTimeDiagnosticsPlugins, FrameTimeDiagnosticsPlugin, FpsDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -15,7 +15,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(FrameTimeDiagnosticsPlugin)
+        .add_plugins(FrameTimeDiagnosticsPlugins)
         .add_startup_system(infotext_system)
         .add_system(change_text_system)
         .run();
@@ -158,7 +158,7 @@ fn change_text_system(
 ) {
     for mut text in &mut query {
         let mut fps = 0.0;
-        if let Some(fps_diagnostic) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+        if let Some(fps_diagnostic) = diagnostics.get(FpsDiagnosticsPlugin::FPS) {
             if let Some(fps_smoothed) = fps_diagnostic.smoothed() {
                 fps = fps_smoothed;
             }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -1,9 +1,7 @@
 //! Shows various text layout options.
 
 use bevy::{
-    diagnostic::{
-        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsMeasurePlugin, FrameTimeMeasurePlugin,
-    },
+    diagnostic::{BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsPlugin, FrameTimePlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin},
 };
@@ -160,14 +158,14 @@ fn change_text_system(
 ) {
     for mut text in &mut query {
         let mut fps = 0.0;
-        if let Some(fps_diagnostic) = diagnostics.get(FpsMeasurePlugin::FPS) {
+        if let Some(fps_diagnostic) = diagnostics.get(FpsPlugin::FPS) {
             if let Some(fps_smoothed) = fps_diagnostic.smoothed() {
                 fps = fps_smoothed;
             }
         }
 
         let mut frame_time = time.delta_seconds_f64();
-        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeMeasurePlugin::FRAME_TIME) {
+        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimePlugin::FRAME_TIME) {
             if let Some(frame_time_smoothed) = frame_time_diagnostic.smoothed() {
                 frame_time = frame_time_smoothed;
             }

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -2,8 +2,7 @@
 
 use bevy::{
     diagnostic::{
-        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsMeasurePlugin,
-        FrameTimeMeasurePlugin,
+        BasicPerformanceDiagnosticsPlugins, Diagnostics, FpsMeasurePlugin, FrameTimeMeasurePlugin,
     },
     prelude::*,
     window::{PresentMode, WindowPlugin},
@@ -168,8 +167,7 @@ fn change_text_system(
         }
 
         let mut frame_time = time.delta_seconds_f64();
-        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeMeasurePlugin::FRAME_TIME)
-        {
+        if let Some(frame_time_diagnostic) = diagnostics.get(FrameTimeMeasurePlugin::FRAME_TIME) {
             if let Some(frame_time_smoothed) = frame_time_diagnostic.smoothed() {
                 frame_time = frame_time_smoothed;
             }

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -2,7 +2,7 @@
 //! the mouse pointer in various ways.
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{CursorGrabMode, PresentMode, WindowLevel},
 };
@@ -23,7 +23,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin)
+        .add_plugin(FrameTimeMeasurePlugin)
         .add_system(change_title)
         .add_system(toggle_cursor)
         .add_system(toggle_vsync)

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -2,7 +2,7 @@
 //! the mouse pointer in various ways.
 
 use bevy::{
-    diagnostic::{FrameTimeMeasurePlugin, LogDiagnosticsPlugin},
+    diagnostic::{FrameTimePlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{CursorGrabMode, PresentMode, WindowLevel},
 };
@@ -23,7 +23,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeMeasurePlugin)
+        .add_plugin(FrameTimePlugin)
         .add_system(change_title)
         .add_system(toggle_cursor)
         .add_system(toggle_vsync)


### PR DESCRIPTION
# Objective
Allowing more fine graded control over the diagnostics plugin
Fixes #7776 

## Solution

- Describe the solution used to achieve the objective above.
The `FrameTimeDiagnosticsPlugin` is now a plugin group named `FrameTimeDiagnosticsPlugins`
containing the plugins:
```
FpsDiagnosticsPlugin
FrameTimeDiagnosticsPlugin
FrameCountDiagnosticsPlugin
```
---

## Migration Guide
The `FrameTimeDiagnosticsPlugin` is now a plugin group named `BasicPerformanceDiagnosticsPlugins`
```rust
// Old
App::new()
    .add_plugin(FrameTimeDiagnosticsPlugin)
// New
App::new()
    .add_plugins(BasicPerformanceDiagnosticsPlugins)
```