### PR TITLE
[Merged by Bors] - impl `Reflect` for `std::collections::HashMap` instead of only `bevy::utils::HashMap` (#7739)

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use crate::utility::{reflect_hasher, GenericTypeInfoCell, NonGenericTypeInfoCell};
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
-use bevy_utils::{hashbrown::HashMap, HashSet};
+use bevy_utils::HashSet;
 use bevy_utils::{Duration, Instant};
 use std::{
     any::Any,
@@ -347,199 +347,215 @@ impl_reflect_for_veclike!(
     VecDeque::<T>
 );
 
-impl<K: FromReflect + Eq + Hash, V: FromReflect, S: BuildHasher + Send + Sync + 'static> Map
-    for HashMap<K, V, S>
-{
-    fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
-        key.downcast_ref::<K>()
-            .and_then(|key| HashMap::get(self, key))
-            .map(|value| value as &dyn Reflect)
-    }
-
-    fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
-        key.downcast_ref::<K>()
-            .and_then(move |key| HashMap::get_mut(self, key))
-            .map(|value| value as &mut dyn Reflect)
-    }
-
-    fn get_at(&self, index: usize) -> Option<(&dyn Reflect, &dyn Reflect)> {
-        self.iter()
-            .nth(index)
-            .map(|(key, value)| (key as &dyn Reflect, value as &dyn Reflect))
-    }
-
-    fn len(&self) -> usize {
-        Self::len(self)
-    }
-
-    fn iter(&self) -> MapIter {
-        MapIter {
-            map: self,
-            index: 0,
-        }
-    }
-
-    fn drain(self: Box<Self>) -> Vec<(Box<dyn Reflect>, Box<dyn Reflect>)> {
-        self.into_iter()
-            .map(|(key, value)| {
-                (
-                    Box::new(key) as Box<dyn Reflect>,
-                    Box::new(value) as Box<dyn Reflect>,
-                )
-            })
-            .collect()
-    }
-
-    fn clone_dynamic(&self) -> DynamicMap {
-        let mut dynamic_map = DynamicMap::default();
-        dynamic_map.set_name(self.type_name().to_string());
-        for (k, v) in self {
-            dynamic_map.insert_boxed(k.clone_value(), v.clone_value());
-        }
-        dynamic_map
-    }
-
-    fn insert_boxed(
-        &mut self,
-        key: Box<dyn Reflect>,
-        value: Box<dyn Reflect>,
-    ) -> Option<Box<dyn Reflect>> {
-        let key = K::take_from_reflect(key).unwrap_or_else(|key| {
-            panic!(
-                "Attempted to insert invalid key of type {}.",
-                key.type_name()
-            )
-        });
-        let value = V::take_from_reflect(value).unwrap_or_else(|value| {
-            panic!(
-                "Attempted to insert invalid value of type {}.",
-                value.type_name()
-            )
-        });
-        self.insert(key, value)
-            .map(|old_value| Box::new(old_value) as Box<dyn Reflect>)
-    }
-
-    fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
-        let mut from_reflect = None;
-        key.downcast_ref::<K>()
-            .or_else(|| {
-                from_reflect = K::from_reflect(key);
-                from_reflect.as_ref()
-            })
-            .and_then(|key| self.remove(key))
-            .map(|value| Box::new(value) as Box<dyn Reflect>)
-    }
-}
-
-impl<K: FromReflect + Eq + Hash, V: FromReflect, S: BuildHasher + Send + Sync + 'static> Reflect
-    for HashMap<K, V, S>
-{
-    fn type_name(&self) -> &str {
-        std::any::type_name::<Self>()
-    }
-
-    fn get_type_info(&self) -> &'static TypeInfo {
-        <Self as Typed>::type_info()
-    }
-
-    fn into_any(self: Box<Self>) -> Box<dyn Any> {
-        self
-    }
-
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
-    fn as_any_mut(&mut self) -> &mut dyn Any {
-        self
-    }
-
-    #[inline]
-    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
-        self
-    }
-
-    fn as_reflect(&self) -> &dyn Reflect {
-        self
-    }
-
-    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
-        self
-    }
-
-    fn apply(&mut self, value: &dyn Reflect) {
-        map_apply(self, value);
-    }
-
-    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
-        *self = value.take()?;
-        Ok(())
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Map(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Map(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Map(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone_dynamic())
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        map_partial_eq(self, value)
-    }
-}
-
-impl<K: FromReflect + Eq + Hash, V: FromReflect, S: BuildHasher + Send + Sync + 'static> Typed
-    for HashMap<K, V, S>
-{
-    fn type_info() -> &'static TypeInfo {
-        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
-        CELL.get_or_insert::<Self, _>(|| TypeInfo::Map(MapInfo::new::<Self, K, V>()))
-    }
-}
-
-impl<K, V, S> GetTypeRegistration for HashMap<K, V, S>
-where
-    K: FromReflect + Eq + Hash,
-    V: FromReflect,
-    S: BuildHasher + Send + Sync + 'static,
-{
-    fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<HashMap<K, V, S>>();
-        registration.insert::<ReflectFromPtr>(FromType::<HashMap<K, V, S>>::from_type());
-        registration
-    }
-}
-
-impl<K, V, S> FromReflect for HashMap<K, V, S>
-where
-    K: FromReflect + Eq + Hash,
-    V: FromReflect,
-    S: BuildHasher + Default + Send + Sync + 'static,
-{
-    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        if let ReflectRef::Map(ref_map) = reflect.reflect_ref() {
-            let mut new_map = Self::with_capacity_and_hasher(ref_map.len(), S::default());
-            for (key, value) in ref_map.iter() {
-                let new_key = K::from_reflect(key)?;
-                let new_value = V::from_reflect(value)?;
-                new_map.insert(new_key, new_value);
+macro_rules! impl_reflect_for_hashmap {
+    ($ty:ty) => {
+        impl<K, V, S> Map for $ty
+        where
+            K: FromReflect + Eq + Hash,
+            V: FromReflect,
+            S: BuildHasher + Send + Sync + 'static,
+        {
+            fn get(&self, key: &dyn Reflect) -> Option<&dyn Reflect> {
+                key.downcast_ref::<K>()
+                    .and_then(|key| Self::get(self, key))
+                    .map(|value| value as &dyn Reflect)
             }
-            Some(new_map)
-        } else {
-            None
+
+            fn get_mut(&mut self, key: &dyn Reflect) -> Option<&mut dyn Reflect> {
+                key.downcast_ref::<K>()
+                    .and_then(move |key| Self::get_mut(self, key))
+                    .map(|value| value as &mut dyn Reflect)
+            }
+
+            fn get_at(&self, index: usize) -> Option<(&dyn Reflect, &dyn Reflect)> {
+                self.iter()
+                    .nth(index)
+                    .map(|(key, value)| (key as &dyn Reflect, value as &dyn Reflect))
+            }
+
+            fn len(&self) -> usize {
+                Self::len(self)
+            }
+
+            fn iter(&self) -> MapIter {
+                MapIter {
+                    map: self,
+                    index: 0,
+                }
+            }
+
+            fn drain(self: Box<Self>) -> Vec<(Box<dyn Reflect>, Box<dyn Reflect>)> {
+                self.into_iter()
+                    .map(|(key, value)| {
+                        (
+                            Box::new(key) as Box<dyn Reflect>,
+                            Box::new(value) as Box<dyn Reflect>,
+                        )
+                    })
+                    .collect()
+            }
+
+            fn clone_dynamic(&self) -> DynamicMap {
+                let mut dynamic_map = DynamicMap::default();
+                dynamic_map.set_name(self.type_name().to_string());
+                for (k, v) in self {
+                    dynamic_map.insert_boxed(k.clone_value(), v.clone_value());
+                }
+                dynamic_map
+            }
+
+            fn insert_boxed(
+                &mut self,
+                key: Box<dyn Reflect>,
+                value: Box<dyn Reflect>,
+            ) -> Option<Box<dyn Reflect>> {
+                let key = K::take_from_reflect(key).unwrap_or_else(|key| {
+                    panic!(
+                        "Attempted to insert invalid key of type {}.",
+                        key.type_name()
+                    )
+                });
+                let value = V::take_from_reflect(value).unwrap_or_else(|value| {
+                    panic!(
+                        "Attempted to insert invalid value of type {}.",
+                        value.type_name()
+                    )
+                });
+                self.insert(key, value)
+                    .map(|old_value| Box::new(old_value) as Box<dyn Reflect>)
+            }
+
+            fn remove(&mut self, key: &dyn Reflect) -> Option<Box<dyn Reflect>> {
+                let mut from_reflect = None;
+                key.downcast_ref::<K>()
+                    .or_else(|| {
+                        from_reflect = K::from_reflect(key);
+                        from_reflect.as_ref()
+                    })
+                    .and_then(|key| self.remove(key))
+                    .map(|value| Box::new(value) as Box<dyn Reflect>)
+            }
         }
-    }
+
+        impl<K, V, S> Reflect for $ty
+        where
+            K: FromReflect + Eq + Hash,
+            V: FromReflect,
+            S: BuildHasher + Send + Sync + 'static,
+        {
+            fn type_name(&self) -> &str {
+                std::any::type_name::<Self>()
+            }
+
+            fn get_type_info(&self) -> &'static TypeInfo {
+                <Self as Typed>::type_info()
+            }
+
+            fn into_any(self: Box<Self>) -> Box<dyn Any> {
+                self
+            }
+
+            fn as_any(&self) -> &dyn Any {
+                self
+            }
+
+            fn as_any_mut(&mut self) -> &mut dyn Any {
+                self
+            }
+
+            #[inline]
+            fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+                self
+            }
+
+            fn as_reflect(&self) -> &dyn Reflect {
+                self
+            }
+
+            fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+                self
+            }
+
+            fn apply(&mut self, value: &dyn Reflect) {
+                map_apply(self, value);
+            }
+
+            fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+                *self = value.take()?;
+                Ok(())
+            }
+
+            fn reflect_ref(&self) -> ReflectRef {
+                ReflectRef::Map(self)
+            }
+
+            fn reflect_mut(&mut self) -> ReflectMut {
+                ReflectMut::Map(self)
+            }
+
+            fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+                ReflectOwned::Map(self)
+            }
+
+            fn clone_value(&self) -> Box<dyn Reflect> {
+                Box::new(self.clone_dynamic())
+            }
+
+            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+                map_partial_eq(self, value)
+            }
+        }
+
+        impl<K, V, S> Typed for $ty
+        where
+            K: FromReflect + Eq + Hash,
+            V: FromReflect,
+            S: BuildHasher + Send + Sync + 'static,
+        {
+            fn type_info() -> &'static TypeInfo {
+                static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+                CELL.get_or_insert::<Self, _>(|| TypeInfo::Map(MapInfo::new::<Self, K, V>()))
+            }
+        }
+
+        impl<K, V, S> GetTypeRegistration for $ty
+        where
+            K: FromReflect + Eq + Hash,
+            V: FromReflect,
+            S: BuildHasher + Send + Sync + 'static,
+        {
+            fn get_type_registration() -> TypeRegistration {
+                let mut registration = TypeRegistration::of::<Self>();
+                registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+                registration
+            }
+        }
+
+        impl<K, V, S> FromReflect for $ty
+        where
+            K: FromReflect + Eq + Hash,
+            V: FromReflect,
+            S: BuildHasher + Default + Send + Sync + 'static,
+        {
+            fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+                if let ReflectRef::Map(ref_map) = reflect.reflect_ref() {
+                    let mut new_map = Self::with_capacity_and_hasher(ref_map.len(), S::default());
+                    for (key, value) in ref_map.iter() {
+                        let new_key = K::from_reflect(key)?;
+                        let new_value = V::from_reflect(value)?;
+                        new_map.insert(new_key, new_value);
+                    }
+                    Some(new_map)
+                } else {
+                    None
+                }
+            }
+        }
+    };
 }
+
+impl_reflect_for_hashmap!(bevy_utils::hashbrown::HashMap<K, V, S>);
+impl_reflect_for_hashmap!(std::collections::HashMap<K, V, S>);
 
 impl<T: Reflect, const N: usize> Array for [T; N] {
     #[inline]


### PR DESCRIPTION
# Objective

Implement `Reflect` for `std::collections::HashMap<K, V, S>` as well as `hashbrown::HashMap<K, V, S>` rather than just for `hashbrown::HashMap<K, V, RandomState>`. Fixes #7739.

## Solution

Rather than implementing on `HashMap<K, V>` I instead implemented most of the related traits on `HashMap<K, V, S> where S: BuildHasher + Send + Sync + 'static` and then `FromReflect` also needs the extra bound `S: Default` because it needs to use `with_capacity_and_hasher` so needs to be able to generate a default hasher.

As the API of `hashbrown::HashMap` is identical to `collections::HashMap` making them both work just required creating an `impl_reflect_for_hashmap` macro like the `impl_reflect_for_veclike` above and then applying this to both HashMaps.

---

## Changelog

`std::collections::HashMap` can now be reflected. Also more `State` generics than just `RandomState` can now be reflected for both `hashbrown::HashMap` and `collections::HashMap`