### PR TITLE
[Merged by Bors] - Make boxed conditions read-only

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1,8 +1,8 @@
 use std::borrow::Cow;
 
-use crate::system::{BoxedSystem, CombinatorSystem, Combine, IntoSystem, System};
+use crate::system::{CombinatorSystem, Combine, IntoSystem, ReadOnlySystem, System};
 
-pub type BoxedCondition = BoxedSystem<(), bool>;
+pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
 
 /// A system that determines if one or more scheduled systems should run.
 ///


### PR DESCRIPTION
# Objective

The `BoxedCondition` type alias does not require the underlying system to be read-only.

## Solution

Define the type alias using `ReadOnlySystem` instead of `System`.
