### PR TITLE
Add orthographic camera support back to directional shadows

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -425,6 +425,17 @@ pub fn update_directional_light_cascades(
                     transform.compute_matrix(),
                 ))
             }
+            (entity, transform, Projection::Orthographic(projection), camera)
+                if camera.is_active =>
+            {
+                Some((
+                    entity,
+                    ((projection.right - projection.left) / (projection.top - projection.bottom))
+                        .abs(),
+                    std::f32::consts::FRAC_PI_4,
+                    transform.compute_matrix(),
+                ))
+            }
             _ => None,
         })
         .collect::<Vec<_>>();


### PR DESCRIPTION
# Objective

Fixes (pending, a discord user said that they would open an issue)

## Solution

This **seems** like a simple fix, but I'm not 100% confident and I may have messed up the math in some way.

However, this seems to be producing similar results to 0.9.