### PR TITLE
[Merged by Bors] - Only execute `#define` if current scope is accepting lines

### DIFF
--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -2536,7 +2536,6 @@ This should not be part of the result
         assert_eq!(result.get_wgsl_source().unwrap(), EXPECTED);
     }
 
-
     #[test]
     fn process_shader_define_in_shader_with_value() {
         #[rustfmt::skip]

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -2509,6 +2509,35 @@ defined at end
     }
 
     #[test]
+    fn process_shader_define_only_in_accepting_scopes() {
+        #[rustfmt::skip]
+        const WGSL: &str = r"
+#define GUARD
+#ifndef GUARD
+#define GUARDED
+#endif
+#ifdef GUARDED
+This should not be part of the result
+#endif
+";
+
+        #[rustfmt::skip]
+        const EXPECTED: &str = r"
+";
+        let processor = ShaderProcessor::default();
+        let result = processor
+            .process(
+                &Shader::from_wgsl(WGSL),
+                &[],
+                &HashMap::default(),
+                &HashMap::default(),
+            )
+            .unwrap();
+        assert_eq!(result.get_wgsl_source().unwrap(), EXPECTED);
+    }
+
+
+    #[test]
     fn process_shader_define_in_shader_with_value() {
         #[rustfmt::skip]
         const WGSL: &str = r"

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -561,26 +561,6 @@ impl ShaderProcessor {
                 let current_valid = scopes.last().unwrap().is_accepting_lines();
 
                 scopes.push(Scope::new(current_valid && new_scope));
-            } else if let Some(cap) = self.define_regex.captures(line) {
-                let def = cap.get(1).unwrap();
-                let name = def.as_str().to_string();
-
-                if let Some(val) = cap.get(2) {
-                    if let Ok(val) = val.as_str().parse::<u32>() {
-                        shader_defs_unique.insert(name.clone(), ShaderDefVal::UInt(name, val));
-                    } else if let Ok(val) = val.as_str().parse::<i32>() {
-                        shader_defs_unique.insert(name.clone(), ShaderDefVal::Int(name, val));
-                    } else if let Ok(val) = val.as_str().parse::<bool>() {
-                        shader_defs_unique.insert(name.clone(), ShaderDefVal::Bool(name, val));
-                    } else {
-                        return Err(ProcessShaderError::InvalidShaderDefDefinitionValue {
-                            shader_def_name: name,
-                            value: val.as_str().to_string(),
-                        });
-                    }
-                } else {
-                    shader_defs_unique.insert(name.clone(), ShaderDefVal::Bool(name, true));
-                }
             } else if let Some(cap) = self.else_ifdef_regex.captures(line) {
                 // When should we accept the code in an
                 //
@@ -685,6 +665,26 @@ impl ShaderProcessor {
                     .is_match(line)
                 {
                     // ignore import path lines
+                } else if let Some(cap) = self.define_regex.captures(line) {
+                    let def = cap.get(1).unwrap();
+                    let name = def.as_str().to_string();
+
+                    if let Some(val) = cap.get(2) {
+                        if let Ok(val) = val.as_str().parse::<u32>() {
+                            shader_defs_unique.insert(name.clone(), ShaderDefVal::UInt(name, val));
+                        } else if let Ok(val) = val.as_str().parse::<i32>() {
+                            shader_defs_unique.insert(name.clone(), ShaderDefVal::Int(name, val));
+                        } else if let Ok(val) = val.as_str().parse::<bool>() {
+                            shader_defs_unique.insert(name.clone(), ShaderDefVal::Bool(name, val));
+                        } else {
+                            return Err(ProcessShaderError::InvalidShaderDefDefinitionValue {
+                                shader_def_name: name,
+                                value: val.as_str().to_string(),
+                            });
+                        }
+                    } else {
+                        shader_defs_unique.insert(name.clone(), ShaderDefVal::Bool(name, true));
+                    }
                 } else {
                     let mut line_with_defs = line.to_string();
                     for capture in self.def_regex.captures_iter(line) {


### PR DESCRIPTION
# Objective

While working on #7784, I noticed that a `#define VAR` in a `.wgsl` file is always effective, even if it its scope is not accepting lines. 

Example:
```c
#define A
#ifndef A
#define B
#endif
```

Currently, `B` will be defined although it shouldn't. This PR fixes that. 

## Solution

Move the branch responsible for `#define` lines into the last else branch, which is only evaluated if the current scope is accepting lines.