### PR TITLE
Allow `ambiguous_with` with multiple system-type set instances

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -553,7 +553,7 @@ mod tests {
                 Err(ScheduleBuildError::SystemTypeSetAmbiguity(_))
             ));
 
-            // same goes for `ambiguous_with`
+            // `ambiguous_with` is allowed
             let mut schedule = Schedule::new();
             schedule.add_system(foo);
             schedule.add_system(bar.ambiguous_with(foo));
@@ -561,10 +561,7 @@ mod tests {
             assert!(result.is_ok());
             schedule.add_system(foo);
             let result = schedule.initialize(&mut world);
-            assert!(matches!(
-                result,
-                Err(ScheduleBuildError::SystemTypeSetAmbiguity(_))
-            ));
+            assert!(result.is_ok());
         }
 
         #[test]

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1062,7 +1062,7 @@ impl ScheduleGraph {
             }
         }
 
-        // check that there are no edges to system-type sets that have multiple instances
+        // check that there are no directed edges to system-type sets that have multiple instances
         for (&id, systems) in set_systems.iter() {
             let set = &self.system_sets[id.index()];
             if set.is_system_type() {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1067,7 +1067,6 @@ impl ScheduleGraph {
             let set = &self.system_sets[id.index()];
             if set.is_system_type() {
                 let instances = systems.len();
-                let ambiguous_with = self.ambiguous_with.edges(id);
                 let before = self
                     .dependency
                     .graph
@@ -1076,7 +1075,7 @@ impl ScheduleGraph {
                     .dependency
                     .graph
                     .edges_directed(id, Direction::Outgoing);
-                let relations = before.count() + after.count() + ambiguous_with.count();
+                let relations = before.count() + after.count();
                 if instances > 1 && relations > 0 {
                     return Err(ScheduleBuildError::SystemTypeSetAmbiguity(
                         self.get_node_name(&id),


### PR DESCRIPTION
`ambiguous_with` is for indicating there's no dependency between systems. I don't think a system should fail when multiple instances exist of a system it explicitly is not ordering itself relative to.

This is currently preventing adding additional instances of the transform propagation systems, which blocks `bevy_rapier`.