### PR TITLE
[Merged by Bors] - Fix unsoundnes in `insert` `remove` and `despawn`

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -555,7 +555,16 @@ impl<'a, 'b> BundleInserter<'a, 'b> {
             InsertBundleResult::NewArchetypeSameTable { new_archetype } => {
                 let result = self.archetype.swap_remove(location.archetype_row);
                 if let Some(swapped_entity) = result.swapped_entity {
-                    self.entities.set(swapped_entity.index(), location);
+                    let swapped_location = self.entities.get(swapped_entity).unwrap();
+                    self.entities.set(
+                        swapped_entity.index(),
+                        EntityLocation {
+                            archetype_id: swapped_location.archetype_id,
+                            archetype_row: location.archetype_row,
+                            table_id: swapped_location.table_id,
+                            table_row: swapped_location.table_row,
+                        },
+                    );
                 }
                 let new_location = new_archetype.allocate(entity, result.table_row);
                 self.entities.set(entity.index(), new_location);
@@ -583,7 +592,16 @@ impl<'a, 'b> BundleInserter<'a, 'b> {
             } => {
                 let result = self.archetype.swap_remove(location.archetype_row);
                 if let Some(swapped_entity) = result.swapped_entity {
-                    self.entities.set(swapped_entity.index(), location);
+                    let swapped_location = self.entities.get(swapped_entity).unwrap();
+                    self.entities.set(
+                        swapped_entity.index(),
+                        EntityLocation {
+                            archetype_id: swapped_location.archetype_id,
+                            archetype_row: location.archetype_row,
+                            table_id: swapped_location.table_id,
+                            table_row: swapped_location.table_row,
+                        },
+                    );
                 }
                 // PERF: store "non bundle" components in edge, then just move those to avoid
                 // redundant copies
@@ -608,6 +626,15 @@ impl<'a, 'b> BundleInserter<'a, 'b> {
                             .add(swapped_location.archetype_id.index())
                     };
 
+                    self.entities.set(
+                        swapped_entity.index(),
+                        EntityLocation {
+                            archetype_id: swapped_location.archetype_id,
+                            archetype_row: swapped_location.archetype_row,
+                            table_id: swapped_location.table_id,
+                            table_row: result.table_row,
+                        },
+                    );
                     swapped_archetype
                         .set_entity_table_row(swapped_location.archetype_row, result.table_row);
                 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -927,6 +927,7 @@ mod tests {
         assert!(entity.location() != old_location);
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7805
     #[test]
     fn removing_sparse_updates_archetype_row() {
         #[derive(Component, PartialEq, Debug)]
@@ -944,6 +945,7 @@ mod tests {
         assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7805
     #[test]
     fn removing_dense_updates_table_row() {
         #[derive(Component, PartialEq, Debug)]
@@ -961,6 +963,7 @@ mod tests {
         assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7805
     #[test]
     fn inserting_sparse_updates_archetype_row() {
         use bevy_ecs::prelude::*;
@@ -980,6 +983,7 @@ mod tests {
         assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7805
     #[test]
     fn inserting_dense_updates_archetype_row() {
         use bevy_ecs::prelude::*;
@@ -1008,6 +1012,7 @@ mod tests {
         assert_eq!(world.entity(e1).get::<Dense>().unwrap(), &Dense(0));
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/7805
     #[test]
     fn inserting_dense_updates_table_row() {
         use bevy_ecs::prelude::*;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -960,4 +960,79 @@ mod tests {
         world.entity_mut(e1).remove::<Dense>();
         assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
     }
+
+    #[test]
+    fn inserting_sparse_updates_archetype_row() {
+        use bevy_ecs::prelude::*;
+
+        #[derive(Component, PartialEq, Debug)]
+        struct Dense(u8);
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+        let e1 = world.spawn(Dense(0)).id();
+        let e2 = world.spawn(Dense(1)).id();
+
+        world.entity_mut(e1).insert(Sparse);
+        assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
+    }
+
+    #[test]
+    fn inserting_dense_updates_archetype_row() {
+        use bevy_ecs::prelude::*;
+
+        #[derive(Component, PartialEq, Debug)]
+        struct Dense(u8);
+
+        #[derive(Component)]
+        struct Dense2;
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+        let e1 = world.spawn(Dense(0)).id();
+        let e2 = world.spawn(Dense(1)).id();
+
+        world.entity_mut(e1).insert(Sparse).remove::<Sparse>();
+
+        // archetype with [e2, e1]
+        // table with [e1, e2]
+
+        world.entity_mut(e2).insert(Dense2);
+
+        assert_eq!(world.entity(e1).get::<Dense>().unwrap(), &Dense(0));
+    }
+
+    #[test]
+    fn inserting_dense_updates_table_row() {
+        use bevy_ecs::prelude::*;
+
+        #[derive(Component, PartialEq, Debug)]
+        struct Dense(u8);
+
+        #[derive(Component)]
+        struct Dense2;
+
+        #[derive(Component)]
+        #[component(storage = "SparseSet")]
+        struct Sparse;
+
+        let mut world = World::new();
+        let e1 = world.spawn(Dense(0)).id();
+        let e2 = world.spawn(Dense(1)).id();
+
+        world.entity_mut(e1).insert(Sparse).remove::<Sparse>();
+
+        // archetype with [e2, e1]
+        // table with [e1, e2]
+
+        world.entity_mut(e1).insert(Dense2);
+
+        assert_eq!(world.entity(e2).get::<Dense>().unwrap(), &Dense(1));
+    }
 }


### PR DESCRIPTION
`EntityMut::move_entity_from_remove` had two soundness bugs:

- When removing the entity from the archetype, the swapped entity had its table row updated to the same as the removed entity's
- When removing the entity from the table, the swapped entity did not have its table row updated

`BundleInsert::insert` had two/three soundness bugs
- When moving an entity to a new archetype from an `insert`, the swapped entity had its table row set to a different entities 
- When moving an entity to a new table from an `insert`, the swapped entity did not have its table row updated 
See added tests for examples that trigger those bugs

`EntityMut::despawn` had two soundness bugs
- When despawning an entity, the swapped entity had its table row set to a different entities even if the table didnt change
- When despawning an entity, the swapped entity did not have its table row updated 