### PR TITLE
[Merged by Bors] - add common run conditions to bevy_input

### DIFF
--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -23,3 +23,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.9.0", features = ["glam"
 # other
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1.0"
+
+[dev-dependencies]
+bevy = { path = "../../", version = "0.9.0" }

--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -20,7 +20,7 @@ use std::hash::Hash;
 /// }
 /// ```
 ///
-/// If you want other system to be able to access whether the toggled state is active,
+/// If you want other systems to be able to access whether the toggled state is active,
 /// you should use a custom resource or a state for that:
 /// ```rust,no_run
 /// use bevy::prelude::*;

--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -1,0 +1,97 @@
+use crate::Input;
+use bevy_ecs::system::Res;
+use std::hash::Hash;
+
+/// Stateful run condition that can be toggled via a input press using [`Input::just_pressed`].
+///
+/// ```rust,no_run
+/// use bevy::prelude::*;
+/// use bevy::input::common_conditions::input_toggle_active;
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_system(pause_menu.run_if(input_toggle_active(false, KeyCode::Escape)))
+///         .run();
+/// }
+///
+/// fn pause_menu() {
+///     println!("in pause menu");
+/// }
+/// ```
+///
+/// If you want other system to be able to access whether the toggled state is active,
+/// you should use a custom resource or a state for that:
+/// ```rust,no_run
+/// use bevy::prelude::*;
+/// use bevy::input::common_conditions::input_toggle_active;
+///
+/// #[derive(Resource, Default)]
+/// struct Paused(bool);
+///
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .init_resource::<Paused>()
+///         .add_system(pause_menu.run_if(|paused: Res<Paused>| paused.0))
+///         .run();
+/// }
+///
+/// fn update_pause_state(mut paused: ResMut<Paused>, input: Input<KeyCode>) {
+///   if input.just_pressed(KeyCode::Escape) {
+///     paused.0 = !paused.0;
+///   }
+/// }
+///
+/// fn pause_menu() {
+///     println!("in pause menu");
+/// }
+///
+/// ```
+pub fn input_toggle_active<T>(default: bool, input: T) -> impl FnMut(Res<Input<T>>) -> bool
+where
+    T: Copy + Eq + Hash + Send + Sync + 'static,
+{
+    let mut active = default;
+    move |inputs: Res<Input<T>>| {
+        active ^= inputs.just_pressed(input);
+        active
+    }
+}
+
+/// Run condition that is active if [`Input::pressed`] is true for the given input.
+pub fn input_pressed<T>(input: T) -> impl FnMut(Res<Input<T>>) -> bool
+where
+    T: Copy + Eq + Hash + Send + Sync + 'static,
+{
+    move |inputs: Res<Input<T>>| inputs.pressed(input)
+}
+
+/// Run condition that is active if [`Input::just_pressed`] is true for the given input.
+///
+/// ```rust,no_run
+/// use bevy::prelude::*;
+/// use bevy::input::common_conditions::input_just_pressed;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_system(jump.run_if(input_just_pressed(KeyCode::Space)))
+///         .run();
+/// }
+///
+/// # fn jump() {}
+/// ```
+pub fn input_just_pressed<T>(input: T) -> impl FnMut(Res<Input<T>>) -> bool
+where
+    T: Copy + Eq + Hash + Send + Sync + 'static,
+{
+    move |inputs: Res<Input<T>>| inputs.just_pressed(input)
+}
+
+/// Run condition that is active if [`Input::just_released`] is true for the given input.
+pub fn input_just_released<T>(input: T) -> impl FnMut(Res<Input<T>>) -> bool
+where
+    T: Copy + Eq + Hash + Send + Sync + 'static,
+{
+    move |inputs: Res<Input<T>>| inputs.just_released(input)
+}

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,4 +1,6 @@
 mod axis;
+/// Common run conditions
+pub mod common_conditions;
 pub mod gamepad;
 mod input;
 pub mod keyboard;


### PR DESCRIPTION
# Objective

Common run conditions can be very useful for quick and ergonomic changes to when a system runs.
Specifically what I'd like to be able to do is
```rust
use bevy::prelude::*;
use bevy::input::common_conditions::input_toggle_active;

fn main() {
  App::new()
    .add_plugins(DefaultPlugins)
    .add_plugin(
      bevy_inspector_egui::quick::WorldInspectorPlugin::default()
        .run_if(input_toggle_active(true, KeyCode::Escape)
    )
    .run();
}
```

## Solution

- add `bevy_input::common_conditions` module with `input_toggle_active`, `input_pressed`, `input_just_pressed`, `input_just_released`

## Changelog

- added common run conditions for `bevy_input`
- you can now use `.add_system(jump.run_if(input_just_pressed(KeyCode::Space)))`