### PR TITLE
[Merged by Bors] - fix `Time::pause` docs (missing "not")

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -405,7 +405,7 @@ impl Time {
 
     /// Stops the clock, preventing it from advancing until resumed.
     ///
-    /// **Note:** This does affect the `raw_*` measurements.
+    /// **Note:** This does not affect the `raw_*` measurements.
     #[inline]
     pub fn pause(&mut self) {
         self.paused = true;


### PR DESCRIPTION
# Objective

Time pausing does *not* affect `raw_*`.

## Solution

- add missing word "not"