### PR TITLE
[Merged by Bors] - Avoid using `SystemTypeSet` for transform systems ambiguity

### DIFF
--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -90,6 +90,9 @@ pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
     fn build(&self, app: &mut App) {
+        #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
+        struct Set;
+
         app.register_type::<Transform>()
             .register_type::<GlobalTransform>()
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
@@ -106,14 +109,22 @@ impl Plugin for TransformPlugin {
             .add_startup_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(propagate_transforms),
+                    .ambiguous_with(Set),
             )
-            .add_startup_system(propagate_transforms.in_set(TransformSystem::TransformPropagate))
+            .add_startup_system(
+                propagate_transforms
+                    .in_set(TransformSystem::TransformPropagate)
+                    .in_set(Set),
+            )
             .add_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(propagate_transforms),
+                    .ambiguous_with(Set),
             )
-            .add_system(propagate_transforms.in_set(TransformSystem::TransformPropagate));
+            .add_system(
+                propagate_transforms
+                    .in_set(TransformSystem::TransformPropagate)
+                    .in_set(Set),
+            );
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -90,8 +90,10 @@ pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
     fn build(&self, app: &mut App) {
+        // A set for `propagate_transforms` to mark it as ambiguous with `sync_simple_transforms`.
+        // Used instead of the `SystemTypeSet` as that would not allow multiple instances of the system.
         #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-        struct Set;
+        struct PropagateTransformsSet;
 
         app.register_type::<Transform>()
             .register_type::<GlobalTransform>()
@@ -109,22 +111,22 @@ impl Plugin for TransformPlugin {
             .add_startup_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(Set),
+                    .ambiguous_with(PropagateTransformsSet),
             )
             .add_startup_system(
                 propagate_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .in_set(Set),
+                    .in_set(PropagateTransformsSet),
             )
             .add_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(Set),
+                    .ambiguous_with(PropagateTransformsSet),
             )
             .add_system(
                 propagate_transforms
                     .in_set(TransformSystem::TransformPropagate)
-                    .in_set(Set),
+                    .in_set(PropagateTransformsSet),
             );
     }
 }


### PR DESCRIPTION
Alternative to #7804

Allows other instances of the `sync_simple_transforms` and `propagate_transforms` systems to be added.