### PR TITLE
[Merged by Bors] - bevy_reflect: Add missing primitive registrations

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -73,6 +73,7 @@ impl TypeRegistry {
     pub fn new() -> Self {
         let mut registry = Self::empty();
         registry.register::<bool>();
+        registry.register::<char>();
         registry.register::<u8>();
         registry.register::<u16>();
         registry.register::<u32>();
@@ -87,6 +88,7 @@ impl TypeRegistry {
         registry.register::<isize>();
         registry.register::<f32>();
         registry.register::<f64>();
+        registry.register::<String>();
         registry
     }
 


### PR DESCRIPTION
# Objective

There were a couple primitive types missing from the default `TypeRegistry` constructor.

## Solution

Added the missing registrations for `char` and `String`.
