### PR TITLE
Fix look_to resulting in NaN rotations

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -123,6 +123,7 @@ impl Transform {
     ///
     /// It is not possible to construct a rotation when the resulting forward direction is parallel with `up`.
     /// If this happens, an orthogonal vector to `up` will be used as the "right" direction to get a valid value.
+    /// It is also not possible when the target is at the same place as the transform. In this case, the Z axis will be used as the "forward" direction.
     #[inline]
     #[must_use]
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
@@ -135,6 +136,7 @@ impl Transform {
     ///
     /// It is not possible to construct a rotation when `direction` is parallel with `up`.
     /// If this happens, an orthogonal vector to `up` will be used as the "right" direction to get a valid value.
+    /// It is also not possible when the direction provided is zero. In this case, the Z axis will be used as the "forward" direction.
     #[inline]
     #[must_use]
     pub fn looking_to(mut self, direction: Vec3, up: Vec3) -> Self {
@@ -334,6 +336,7 @@ impl Transform {
     ///
     /// It is not possible to construct a rotation when the resulting forward direction is parallel with `up`.
     /// If this happens, an orthogonal vector to `up` will be used as the "right" direction to get a valid value.
+    /// It is also not possible when the target is at the same place as the transform. In this case, the Z axis will be used as the "forward" direction.
     #[inline]
     pub fn look_at(&mut self, target: Vec3, up: Vec3) {
         self.look_to(target - self.translation, up);
@@ -344,9 +347,10 @@ impl Transform {
     ///
     /// It is not possible to construct a rotation when `direction` is parallel with `up`.
     /// If this happens, an orthogonal vector to `up` will be used as the "right" direction to get a valid value.
+    /// It is also not possible when the direction provided is zero. In this case, the Z axis will be used as the "forward" direction.
     #[inline]
     pub fn look_to(&mut self, direction: Vec3, up: Vec3) {
-        let forward = -direction.normalize();
+        let forward = -direction.try_normalize().unwrap_or(Vec3::Z);
         let right = up
             .cross(forward)
             .try_normalize()

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -122,7 +122,7 @@ impl Transform {
     /// points towards the `target` position and [`Transform::up`] points towards `up`.
     ///
     /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
-    /// * if `target` is the same as the transtorm translation, `Vec3::Z` is used instead
+    /// * if `target` is the same as the transform translation, `Vec3::Z` is used instead
     /// * if `up` is zero, `Vec3::Y` is used instead
     /// * if the resulting forward direction is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]


### PR DESCRIPTION
# Objective

- Fixes #7802, Fixes #3736
- Alternative to #6136 

## Solution

- if direction is parallel to up, use an orthogonal vector
- if direction is zero, use Z
