### PR TITLE
[Merged by Bors] - Use a bounded channel in the multithreaded executor

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -121,7 +121,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         let sys_count = schedule.system_ids.len();
         let set_count = schedule.set_ids.len();
 
-        let (tx, rx) = async_channel::bounded(sys_count.min(1));
+        let (tx, rx) = async_channel::bounded(sys_count.max(1));
 
         self.sender = tx;
         self.receiver = rx;

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -121,7 +121,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         let sys_count = schedule.system_ids.len();
         let set_count = schedule.set_ids.len();
 
-        let (tx, rx) = async_channel::bounded(sys_count);
+        let (tx, rx) = async_channel::bounded(sys_count.min(1));
 
         self.sender = tx;
         self.receiver = rx;

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -121,6 +121,10 @@ impl SystemExecutor for MultiThreadedExecutor {
         let sys_count = schedule.system_ids.len();
         let set_count = schedule.set_ids.len();
 
+        let (tx, rx) = async_channel::bounded(sys_count);
+
+        self.sender = tx;
+        self.receiver = rx;
         self.evaluated_sets = FixedBitSet::with_capacity(set_count);
         self.ready_systems = FixedBitSet::with_capacity(sys_count);
         self.ready_systems_copy = FixedBitSet::with_capacity(sys_count);


### PR DESCRIPTION
# Objective
This is a follow-up to #7745. An unbounded `async_channel`  occasionally allocates whenever it exceeds the capacity of the current buffer in it's internal linked list. This is avoidable.

This also used to be a bounded channel before stageless, which was introduced in #4919.

## Solution
Use a bounded channel to avoid allocations on system completion.

This shouldn't conflict with #7745, as it's impossible for the scheduler to exceed the channel capacity, even if somehow every system completed at the same time.