### PR TITLE
[Merged by Bors] - Remove mention of Windows 11 from Window::transparent's docs

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -131,7 +131,6 @@ pub struct Window {
     /// - iOS / Android / Web: Unsupported.
     /// - macOS X: Not working as expected.
     /// macOS X transparent works with winit out of the box, so this issue might be related to: <https://github.com/gfx-rs/wgpu/issues/687>
-    /// Windows 11 is related to <https://github.com/rust-windowing/winit/issues/2082>
     pub transparent: bool,
     /// Should the window start focused?
     pub focused: bool,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -130,7 +130,6 @@ pub struct Window {
     /// ## Platform-specific
     /// - iOS / Android / Web: Unsupported.
     /// - macOS X: Not working as expected.
-    /// - Windows 11: Not working as expected
     /// macOS X transparent works with winit out of the box, so this issue might be related to: <https://github.com/gfx-rs/wgpu/issues/687>
     /// Windows 11 is related to <https://github.com/rust-windowing/winit/issues/2082>
     pub transparent: bool,


### PR DESCRIPTION
# Objective
Fix #7544. Update docs for `Window::transparent` regarding Windows 11 platform support. Following the update to winit 0.28, this has been fixed.

## Solution
Remove the mention in the docs.