### PR TITLE
[Merged by Bors] - Update toml_edit to 0.19

### DIFF
--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -9,6 +9,6 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-toml_edit = "0.18"
+toml_edit = "0.19"
 syn = "1.0"
 quote = "1.0"

--- a/tools/build-example-pages/Cargo.toml
+++ b/tools/build-example-pages/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-toml_edit = "0.18"
+toml_edit = "0.19"
 tera = "1.15"
 serde = { version = "1.0", features = [ "derive" ] }
 bitflags = "1.3"


### PR DESCRIPTION
# Objective
Noticed cargo-deny was failing on #6874 because of toml_edit.

## Solution
Update toml_edit to 0.19.