### PR TITLE
[Merged by Bors] - Use correct terminology for a `NonSend` run condition panic

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -58,7 +58,7 @@ fn new_condition<M>(condition: impl Condition<M>) -> BoxedCondition {
     let condition_system = IntoSystem::into_system(condition);
     assert!(
         condition_system.is_send(),
-        "Condition `{}` accesses `!Send` resources. This is not currently supported.",
+        "Condition `{}` accesses `NonSend` resources. This is not currently supported.",
         condition_system.name()
     );
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -58,7 +58,7 @@ fn new_condition<M>(condition: impl Condition<M>) -> BoxedCondition {
     let condition_system = IntoSystem::into_system(condition);
     assert!(
         condition_system.is_send(),
-        "Condition `{}` accesses thread-local resources. This is not currently supported.",
+        "Condition `{}` accesses `!Send` resources. This is not currently supported.",
         condition_system.name()
     );
 


### PR DESCRIPTION
# Objective

There is a panic that occurs when creating a run condition that accesses `NonSend` resources, but it refers to them as 'thread-local' resources instead.

## Solution

Correct the terminology.