### PR TITLE
[Merged by Bors] - Text2d doesn't recompute text on changes to the text's bounds

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -168,7 +168,7 @@ pub fn update_text2d_layout(
     mut text_query: Query<(
         Entity,
         Ref<Text>,
-        &Text2dBounds,
+        Ref<Text2dBounds>,
         Option<&mut TextLayoutInfo>,
     )>,
 ) {
@@ -182,7 +182,7 @@ pub fn update_text2d_layout(
         .unwrap_or(1.0);
 
     for (entity, text, bounds, text_layout_info) in &mut text_query {
-        if factor_changed || text.is_changed() || queue.remove(&entity) {
+        if factor_changed || text.is_changed() || bounds.is_changed() || queue.remove(&entity) {
             let text_bounds = Vec2::new(
                 scale_value(bounds.size.x, scale_factor),
                 scale_value(bounds.size.y, scale_factor),


### PR DESCRIPTION
# Objective

Text2d entity's text needs to be recomputed when their bounds are changed, but it isn't.

# Solution
Change `update_text2d_layout` to query for `Ref<Text2dBounds>` and recompute the text if the bounds have changed.