### PR TITLE
Remove unused `alpha_mode` from 3d\texture.rs example

### DIFF
--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -32,7 +32,6 @@ fn setup(
     // this material renders the texture normally
     let material_handle = materials.add(StandardMaterial {
         base_color_texture: Some(texture_handle.clone()),
-        alpha_mode: AlphaMode::Blend,
         unlit: true,
         ..default()
     });
@@ -41,7 +40,6 @@ fn setup(
     let red_material_handle = materials.add(StandardMaterial {
         base_color: Color::rgba(1.0, 0.0, 0.0, 0.5),
         base_color_texture: Some(texture_handle.clone()),
-        alpha_mode: AlphaMode::Blend,
         unlit: true,
         ..default()
     });
@@ -50,7 +48,6 @@ fn setup(
     let blue_material_handle = materials.add(StandardMaterial {
         base_color: Color::rgba(0.0, 0.0, 1.0, 0.5),
         base_color_texture: Some(texture_handle),
-        alpha_mode: AlphaMode::Blend,
         unlit: true,
         ..default()
     });


### PR DESCRIPTION
As `unlit` is set to true, alpha_mode of StandardMaterial is ignored, and therefore setting it in this example has no effect.

# Objective

Removes a redundancy in the 3D texture example file. According to the StandardMaterial docs:
> Normals, occlusion textures, roughness, metallic, reflectance, emissive, shadows, alpha mode and ambient light are ignored if this is set to `true`.

Assuming this comment is true, then the specification of the StandardMaterial's `alpha_mode` in the example is redundant and can be removed.

## Solution

Removed the lines containing redundant declaration of the StandardMaterial's `alpha_mode`.

---