### PR TITLE
[Merged by Bors] - single parent set for transform propagate

### DIFF
--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -100,6 +100,7 @@ impl Plugin for TransformPlugin {
             .add_plugin(ValidParentCheckPlugin::<GlobalTransform>::default())
             // add transform systems to startup so the first update is "correct"
             .configure_set(TransformSystem::TransformPropagate.in_base_set(CoreSet::PostUpdate))
+            .configure_set(PropagateTransformsSet.in_set(TransformSystem::TransformPropagate))
             .edit_schedule(CoreSchedule::Startup, |schedule| {
                 schedule.configure_set(
                     TransformSystem::TransformPropagate.in_base_set(StartupSet::PostStartup),
@@ -115,7 +116,6 @@ impl Plugin for TransformPlugin {
             )
             .add_startup_system(
                 propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
                     .in_set(PropagateTransformsSet),
             )
             .add_system(
@@ -125,7 +125,6 @@ impl Plugin for TransformPlugin {
             )
             .add_system(
                 propagate_transforms
-                    .in_set(TransformSystem::TransformPropagate)
                     .in_set(PropagateTransformsSet),
             );
     }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -114,18 +114,12 @@ impl Plugin for TransformPlugin {
                     .in_set(TransformSystem::TransformPropagate)
                     .ambiguous_with(PropagateTransformsSet),
             )
-            .add_startup_system(
-                propagate_transforms
-                    .in_set(PropagateTransformsSet),
-            )
+            .add_startup_system(propagate_transforms.in_set(PropagateTransformsSet))
             .add_system(
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
                     .ambiguous_with(PropagateTransformsSet),
             )
-            .add_system(
-                propagate_transforms
-                    .in_set(PropagateTransformsSet),
-            );
+            .add_system(propagate_transforms.in_set(PropagateTransformsSet));
     }
 }


### PR DESCRIPTION
# Objective

- have no system belonging to multiple sets

go from
![before](https://user-images.githubusercontent.com/22177966/222439644-7cf2f84e-0839-4703-a7b4-66ffe92c6aa1.png)
to
![after](https://user-images.githubusercontent.com/22177966/222439747-37872d59-6b8e-4fff-a579-6d40c38f73d3.png)

## Solution

- `propagate_transforms in PropagateTransformSets in TransformSystem::TransformPropagate` instead of
```
propagate_transforms in PropagateTransformSets
propagate_transforms in TransformSystem::TransformPropagate
PropagateTransformsSet is free
```
