### PR TITLE
[Merged by Bors] - Fix `bevy_ui` compile error without `bevy_text`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -9,6 +9,7 @@ mod render;
 mod stack;
 mod ui_node;
 
+#[cfg(feature = "bevy_text")]
 mod accessibility;
 pub mod camera_config;
 pub mod node_bundles;
@@ -103,7 +104,6 @@ impl Plugin for UiPlugin {
             .register_type::<Val>()
             .register_type::<widget::Button>()
             .register_type::<widget::Label>()
-            .add_plugin(accessibility::AccessibilityPlugin)
             .configure_set(UiSystem::Focus.in_base_set(CoreSet::PreUpdate))
             .configure_set(UiSystem::Flex.in_base_set(CoreSet::PostUpdate))
             .configure_set(UiSystem::Stack.in_base_set(CoreSet::PostUpdate))
@@ -124,6 +124,8 @@ impl Plugin for UiPlugin {
                 // they will never observe each other's effects.
                 .ambiguous_with(bevy_text::update_text2d_layout),
         );
+        #[cfg(feature = "bevy_text")]
+        app.add_plugin(accessibility::AccessibilityPlugin);
         app.add_system({
             let system = widget::update_image_calculated_size_system
                 .in_base_set(CoreSet::PostUpdate)


### PR DESCRIPTION
# Objective

- Fixes #7874.
- The `bevy_text` dependency is optional for `bevy_ui`, but the `accessibility` module depended on it.

## Solution

- Guard the `accessibility` module behind the `bevy_text` feature and only add the plugin when it's enabled.
