### PR TITLE
[Merged by Bors] - Fix dependency of shadow mapping on the optional `PrepassPlugin`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -651,6 +651,13 @@ description = "Showcases wireframe rendering"
 category = "3D Rendering"
 wasm = true
 
+[[example]]
+name = "no_prepass"
+path = "tests/3d/no_prepass.rs"
+
+[package.metadata.example.no_prepass]
+hidden = true
+
 # Animation
 [[example]]
 name = "animated_fox"

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,7 +1,7 @@
 use crate::{
     queue_mesh_view_bind_groups, render, AlphaMode, DrawMesh, DrawPrepass, EnvironmentMapLight,
-    MeshPipeline, MeshPipelineKey, MeshUniform, PrepassPlugin, RenderLightSystems,
-    SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
+    MeshPipeline, MeshPipelineKey, MeshUniform, PrepassPipelinePlugin, PrepassPlugin,
+    RenderLightSystems, SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
 };
 use bevy_app::{App, IntoSystemAppConfig, Plugin};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
@@ -212,6 +212,9 @@ where
                 )
                 .add_system(queue_material_meshes::<M>.in_set(RenderSet::Queue));
         }
+
+        // PrepassPipelinePlugin is required for shadow mapping and the optional PrepassPlugin
+        app.add_plugin(PrepassPipelinePlugin::<M>::default());
 
         if self.prepass_enabled {
             app.add_plugin(PrepassPlugin::<M>::default());

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -61,7 +61,7 @@ pub const PREPASS_UTILS_SHADER_HANDLE: HandleUntyped =
 
 /// Sets up everything required to use the prepass pipeline.
 ///
-/// This does not add the actual prepasses, see [`PrepassPipeline`] for that.
+/// This does not add the actual prepasses, see [`PrepassPlugin`] for that.
 pub struct PrepassPipelinePlugin<M: Material>(PhantomData<M>);
 
 impl<M: Material> Default for PrepassPipelinePlugin<M> {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -59,6 +59,9 @@ pub const PREPASS_BINDINGS_SHADER_HANDLE: HandleUntyped =
 pub const PREPASS_UTILS_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 4603948296044544);
 
+/// Sets up everything required to use the prepass pipeline.
+///
+/// This does not add the actual prepasses, see [`PrepassPipeline`] for that.
 pub struct PrepassPipelinePlugin<M: Material>(PhantomData<M>);
 
 impl<M: Material> Default for PrepassPipelinePlugin<M> {
@@ -105,6 +108,9 @@ where
     }
 }
 
+/// Sets up the prepasses for a [`Material`].
+///
+/// This depends on the [`PrepassPipelinePlugin`].
 pub struct PrepassPlugin<M: Material>(PhantomData<M>);
 
 impl<M: Material> Default for PrepassPlugin<M> {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -281,11 +281,12 @@ where
 
         let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;
 
-        // The fragment shader is only used when the normal prepass is enabled or the material uses alpha cutoff values
-        let fragment = if key
-            .mesh_key
-            .intersects(MeshPipelineKey::NORMAL_PREPASS | MeshPipelineKey::ALPHA_MASK)
-            || blend_key == MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA
+        // The fragment shader is only used when the normal prepass is enabled
+        // or the material uses alpha cutoff values and doesn't rely on the standard prepass shader
+        let fragment = if key.mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS)
+            || ((key.mesh_key.contains(MeshPipelineKey::ALPHA_MASK)
+                || blend_key == MeshPipelineKey::BLEND_PREMULTIPLIED_ALPHA)
+                && self.material_fragment_shader.is_some())
         {
             // Use the fragment shader from the material if present
             let frag_shader_handle = if let Some(handle) = &self.material_fragment_shader {

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -140,7 +140,6 @@ where
             .add_system(sort_phase_system::<AlphaMask3dPrepass>.in_set(RenderSet::PhaseSort))
             .init_resource::<DrawFunctions<Opaque3dPrepass>>()
             .init_resource::<DrawFunctions<AlphaMask3dPrepass>>()
-            .init_resource::<SpecializedMeshPipelines<PrepassPipeline<M>>>()
             .add_render_command::<Opaque3dPrepass, DrawPrepass<M>>()
             .add_render_command::<AlphaMask3dPrepass, DrawPrepass<M>>();
     }

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -73,6 +73,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 }
 
 #ifdef NORMAL_PREPASS
+
 struct FragmentInput {
     @location(1) world_normal: vec3<f32>,
 }
@@ -81,4 +82,10 @@ struct FragmentInput {
 fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
     return vec4(in.world_normal * 0.5 + vec3(0.5), 1.0);
 }
+
+#else // NORMAL_PREPASS
+
+@fragment
+fn fragment(in: VertexOutput) {}
+
 #endif // NORMAL_PREPASS

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -73,7 +73,6 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 }
 
 #ifdef NORMAL_PREPASS
-
 struct FragmentInput {
     @location(1) world_normal: vec3<f32>,
 }
@@ -82,10 +81,4 @@ struct FragmentInput {
 fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
     return vec4(in.world_normal * 0.5 + vec3(0.5), 1.0);
 }
-
-#else // NORMAL_PREPASS
-
-@fragment
-fn fragment(in: VertexOutput) {}
-
 #endif // NORMAL_PREPASS

--- a/tests/3d/no_prepass.rs
+++ b/tests/3d/no_prepass.rs
@@ -1,0 +1,11 @@
+//! A test to confirm that `bevy` allows disabling the prepass of the standard material.
+//! This is run in CI to ensure that this doesn't regress again.
+use bevy::{pbr::PbrPlugin, prelude::*};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(PbrPlugin {
+            prepass_enabled: false,
+        }))
+        .run();
+}


### PR DESCRIPTION
# Objective

Unfortunately, there are three issues with my changes introduced by #7784.

1.  The changes left some dead code. This is already taken care of here: #7875.
2. Disabling prepass causes failures because the shadow mapping relies on the `PrepassPlugin` now.
3. Custom materials use the `prepass.wgsl` shader, but this does not always define a fragment entry point.

This PR fixes 2. and 3. and resolves #7879.

## Solution

- Add a regression test with disabled prepass.
- Split `PrepassPlugin` into two plugins:
  - `PrepassPipelinePlugin` contains the part that is required for the shadow mapping to work and is unconditionally added.
  - `PrepassPlugin` now only adds the systems and resources required for the "real" prepasses.
- Add a noop fragment entry point to `prepass.wgsl`, used if `NORMAL_PASS` is not defined.
