### PR TITLE
[Merged by Bors] - Revise docs for system set marker traits

### DIFF
--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -37,14 +37,15 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     fn dyn_clone(&self) -> Box<dyn SystemSet>;
 }
 
-/// A system set that is never contained in another set.
-/// Systems and other system sets may only belong to one base set.
+/// A marker trait for `SystemSet` types where `is_base` returns `true`.
+/// This should only be implemented for types that satisfy this requirement.
 ///
-/// This should only be implemented for types that return `true` from [`SystemSet::is_base`].
+/// A base set is a system set that is never contained in another set.
+/// Systems and other system sets may only belong to one base set.
 pub trait BaseSystemSet: SystemSet {}
 
-/// System sets that are *not* base sets. This should not be implemented for
-/// any types that implement [`BaseSystemSet`].
+/// A marker trait for `SystemSet` types where `is_base` returns `false`.
+/// This should only be implemented for types that satisfy this requirement.
 pub trait FreeSystemSet: SystemSet {}
 
 impl PartialEq for dyn SystemSet {

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -38,15 +38,15 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
 }
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `true`.
-/// This should only be implemented for types that satisfy this requirement,
-/// and is automatically implented for applicable types by `#[derive(SystemSet)]`
+/// This should only be implemented for types that satisfy this requirement.
+/// It is automatically implented for applicable types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait BaseSystemSet: SystemSet {}
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `false`.
-/// This should only be implemented for types that satisfy this requirement,
-/// and is automatically implented for applicable types by `#[derive(SystemSet)]`
+/// This should only be implemented for types that satisfy this requirement.
+/// It is automatically implented for applicable types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait FreeSystemSet: SystemSet {}

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -39,14 +39,14 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `true`.
 /// This should only be implemented for types that satisfy this requirement.
-/// It is automatically implented for base set types by `#[derive(SystemSet)]`.
+/// It is automatically implemented for base set types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait BaseSystemSet: SystemSet {}
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `false`.
 /// This should only be implemented for types that satisfy this requirement.
-/// It is automatically implented for non-base set types by `#[derive(SystemSet)]`.
+/// It is automatically implemented for non-base set types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait FreeSystemSet: SystemSet {}

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -39,14 +39,14 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `true`.
 /// This should only be implemented for types that satisfy this requirement.
-/// It is automatically implented for applicable types by `#[derive(SystemSet)]`.
+/// It is automatically implented for base set types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait BaseSystemSet: SystemSet {}
 
 /// A marker trait for `SystemSet` types where [`is_base`] returns `false`.
 /// This should only be implemented for types that satisfy this requirement.
-/// It is automatically implented for applicable types by `#[derive(SystemSet)]`.
+/// It is automatically implented for non-base set types by `#[derive(SystemSet)]`.
 ///
 /// [`is_base`]: SystemSet::is_base
 pub trait FreeSystemSet: SystemSet {}

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -37,15 +37,18 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     fn dyn_clone(&self) -> Box<dyn SystemSet>;
 }
 
-/// A marker trait for `SystemSet` types where `is_base` returns `true`.
-/// This should only be implemented for types that satisfy this requirement.
+/// A marker trait for `SystemSet` types where [`is_base`] returns `true`.
+/// This should only be implemented for types that satisfy this requirement,
+/// and is automatically implented for applicable types by `#[derive(SystemSet)]`
 ///
-/// A base set is a system set that is never contained in another set.
-/// Systems and other system sets may only belong to one base set.
+/// [`is_base`]: SystemSet::is_base
 pub trait BaseSystemSet: SystemSet {}
 
-/// A marker trait for `SystemSet` types where `is_base` returns `false`.
-/// This should only be implemented for types that satisfy this requirement.
+/// A marker trait for `SystemSet` types where [`is_base`] returns `false`.
+/// This should only be implemented for types that satisfy this requirement,
+/// and is automatically implented for applicable types by `#[derive(SystemSet)]`
+///
+/// [`is_base`]: SystemSet::is_base
 pub trait FreeSystemSet: SystemSet {}
 
 impl PartialEq for dyn SystemSet {


### PR DESCRIPTION
# Objective

#7863 introduced a potential footgun. When trying to incorrectly add a user-defined type using `in_base_set`, the compiler will suggest that the user implement `BaseSystemSet` for their type. This is a reasonable-sounding suggestion, however this is not the correct way to make a base set, and will lead to a confusing panic message when a marker trait is implemented for the wrong type.

## Solution

Rewrite the documentation for these traits, making it more clear that `BaseSystemSet` is a marker for types that are already base sets, and not a way to define a base set.
