### PR TITLE
[Merged by Bors] - Update `glam` to `0.23`

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
-glam = "0.22"
+glam = "0.23"
 rand = "0.8"
 rand_chacha = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -13,4 +13,4 @@ proc-macro = true
 
 [dependencies]
 bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.9.0" }
-encase_derive_impl = "0.4.0"
+encase_derive_impl = "0.5.0"

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.22", features = ["bytemuck"] }
+glam = { version = "0.23", features = ["bytemuck"] }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -11,7 +11,7 @@ license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 
 [dependencies]
-glam = "0.22"
+glam = "0.23"
 
 [[example]]
 name = "generate"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -31,7 +31,7 @@ thiserror = "1.0"
 once_cell = "1.11"
 serde = "1"
 smallvec = { version = "1.6", features = ["serde", "union", "const_generics"], optional = true }
-glam = { version = "0.22", features = ["serde"], optional = true }
+glam = { version = "0.23", features = ["serde"], optional = true }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -64,7 +64,7 @@ thread_local = "1.1"
 thiserror = "1.0"
 futures-lite = "1.4.0"
 anyhow = "1.0"
-hexasphere = "8.0"
+hexasphere = "8.1"
 parking_lot = "0.12.1"
 regex = "1.5"
 ddsfile = { version = "0.5.0", optional = true }
@@ -74,7 +74,7 @@ flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.2.4", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
-encase = { version = "0.4", features = ["glam"] }
+encase = { version = "0.5", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = ["profile-with-tracing"], optional = true }
 async-channel = "1.8"


### PR DESCRIPTION
# Objective

- Update `glam` to the latest version.

## Solution

- Update `glam` to version `0.23`.

Since the breaking change in `glam` only affects the `scalar-math` feature, this should cause no issues.