### PR TITLE
[Merged by Bors] - Remove the early exit to make sure the prepass textures are cleared

### DIFF
--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -69,10 +69,6 @@ impl Node for PrepassNode {
             return Ok(());
         };
 
-        if opaque_prepass_phase.items.is_empty() && alpha_mask_prepass_phase.items.is_empty() {
-            return Ok(());
-        }
-
         let mut color_attachments = vec![];
         if let Some(view_normals_texture) = &view_prepass_textures.normal {
             color_attachments.push(Some(RenderPassColorAttachment {


### PR DESCRIPTION
# Objective

- Fixes #7888.

## Solution

- Remove the early exit to make sure the prepass textures are cleared.