### PR TITLE
Lock `hexasphere` version to `8.0.0`

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -64,7 +64,7 @@ thread_local = "1.1"
 thiserror = "1.0"
 futures-lite = "1.4.0"
 anyhow = "1.0"
-hexasphere = "8.0"
+hexasphere = "=8.0.0"
 parking_lot = "0.12.1"
 regex = "1.5"
 ddsfile = { version = "0.5.0", optional = true }


### PR DESCRIPTION
# Objective

- `hexasphere` released version `8.1` with `glam` updated to `0.23`, leading to duplicate `glam` versions in the dependency tree and causing CI to fail.

## Solution

- Lock the `hexasphere` version to `8.0` for now, until all dependencies have updated `glam`.