### PR TITLE
Fix UI example logo

### DIFF
--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -296,11 +296,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             image: asset_server.load("branding/bevy_logo_dark_big.png").into(),
                             ..default()
                         });
-                        // .with_children(|parent| {
-                        //     // alt text
-                        //     parent
-                        //         .spawn(TextBundle::from_section("Bevy logo", TextStyle::default()));
-                        // });
                 });
         });
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -294,14 +294,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..default()
                             },
                             image: asset_server.load("branding/bevy_logo_dark_big.png").into(),
-                        ..default()
                             ..default()
-                        })
-                        .with_children(|parent| {
-                            // alt text
-                            parent
-                                .spawn(TextBundle::from_section("Bevy logo", TextStyle::default()));
                         });
+                        // .with_children(|parent| {
+                        //     // alt text
+                        //     parent
+                        //         .spawn(TextBundle::from_section("Bevy logo", TextStyle::default()));
+                        // });
                 });
         });
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -293,6 +293,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 size: Size::width(Val::Px(500.0)),
                                 ..default()
                             },
+                            image: asset_server.load("branding/bevy_logo_dark_big.png").into(),
+                        ..default()
                             ..default()
                         })
                         .with_children(|parent| {


### PR DESCRIPTION
# Objective

The AccessKit PR removed the loading of the image logo from the UI example.
It also added some alt text as a child of the logo without a TextStyle, which would cause the image not to display even if it were loaded because of how the size of intrinsic nodes is calculated.
I'm not sure what the intent was here.

## Solution

Remove the alt text, and put the image back in.
