### PR TITLE
[Merged by Bors] - Add bevy logo to the lighting example to demo alpha mask shadows

### DIFF
--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -80,7 +80,6 @@ fn setup(
         },
         Movable,
     ));
-    });
 
     // cube
     commands.spawn((

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -22,6 +22,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    asset_server: Res<AssetServer>,
 ) {
     // ground plane
     commands.spawn(PbrBundle {
@@ -56,6 +57,22 @@ fn setup(
         material: materials.add(StandardMaterial {
             base_color: Color::INDIGO,
             perceptual_roughness: 1.0,
+            ..default()
+        }),
+        ..default()
+    });
+
+    // Bevy logo to demonstrate alpha mask shadows
+    let mut transform = Transform::from_xyz(-2.2, 0.5, 1.0);
+    transform.rotate_y(PI / 8.);
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Mesh::from(shape::Quad::new(Vec2::new(2.0, 0.5)))),
+        transform,
+        material: materials.add(StandardMaterial {
+            base_color_texture: Some(asset_server.load("branding/bevy_logo_light.png")),
+            perceptual_roughness: 1.0,
+            alpha_mode: AlphaMode::Mask(0.5),
+            cull_mode: None,
             ..default()
         }),
         ..default()

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -65,17 +65,21 @@ fn setup(
     // Bevy logo to demonstrate alpha mask shadows
     let mut transform = Transform::from_xyz(-2.2, 0.5, 1.0);
     transform.rotate_y(PI / 8.);
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Quad::new(Vec2::new(2.0, 0.5)))),
-        transform,
-        material: materials.add(StandardMaterial {
-            base_color_texture: Some(asset_server.load("branding/bevy_logo_light.png")),
-            perceptual_roughness: 1.0,
-            alpha_mode: AlphaMode::Mask(0.5),
-            cull_mode: None,
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Quad::new(Vec2::new(2.0, 0.5)))),
+            transform,
+            material: materials.add(StandardMaterial {
+                base_color_texture: Some(asset_server.load("branding/bevy_logo_light.png")),
+                perceptual_roughness: 1.0,
+                alpha_mode: AlphaMode::Mask(0.5),
+                cull_mode: None,
+                ..default()
+            }),
             ..default()
-        }),
-        ..default()
+        },
+        Movable,
+    ));
     });
 
     // cube


### PR DESCRIPTION
$subj

![Screenshot 2023-03-04 at 15 46 05](https://user-images.githubusercontent.com/302146/222910129-0a38dc9c-ff65-46d9-adcc-9e26694c9c22.png)