### PR TITLE
[Merged by Bors] - Change the `Node` doc comments to state that it stores the size in logical pixels

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -18,7 +18,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 /// Useful as a container for a variety of child nodes.
 #[derive(Bundle, Clone, Debug)]
 pub struct NodeBundle {
-    /// Describes the logical soze of the node
+    /// Describes the logical size of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -64,7 +64,7 @@ impl Default for NodeBundle {
 /// A UI node that is an image
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct ImageBundle {
-    /// Describes the logical soze of the node
+    /// Describes the logical size of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -100,7 +100,7 @@ pub struct ImageBundle {
 /// A UI node that is text
 #[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {
-    /// Describes the logical soze of the node
+    /// Describes the logical size of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -194,7 +194,7 @@ impl TextBundle {
 /// A UI node that is a button
 #[derive(Bundle, Clone, Debug)]
 pub struct ButtonBundle {
-    /// Describes the logical soze of the node
+    /// Describes the logical size of the node
     pub node: Node,
     /// Marker component that signals this node is a button
     pub button: Button,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -18,7 +18,7 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 /// Useful as a container for a variety of child nodes.
 #[derive(Bundle, Clone, Debug)]
 pub struct NodeBundle {
-    /// Describes the size of the node
+    /// Describes the logical soze of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -64,7 +64,7 @@ impl Default for NodeBundle {
 /// A UI node that is an image
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct ImageBundle {
-    /// Describes the size of the node
+    /// Describes the logical soze of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -100,7 +100,7 @@ pub struct ImageBundle {
 /// A UI node that is text
 #[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {
-    /// Describes the size of the node
+    /// Describes the logical soze of the node
     pub node: Node,
     /// Describes the style including flexbox settings
     pub style: Style,
@@ -194,7 +194,7 @@ impl TextBundle {
 /// A UI node that is a button
 #[derive(Bundle, Clone, Debug)]
 pub struct ButtonBundle {
-    /// Describes the size of the node
+    /// Describes the logical soze of the node
     pub node: Node,
     /// Marker component that signals this node is a button
     pub button: Button,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -15,13 +15,13 @@ use thiserror::Error;
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Node {
-    /// The size of the node as width and height in pixels
+    /// The size of the node as width and height in logical pixels
     /// automatically calculated by [`super::flex::flex_node_system`]
     pub(crate) calculated_size: Vec2,
 }
 
 impl Node {
-    /// The calculated node size as width and height in pixels
+    /// The calculated node size as width and height in logical pixels
     /// automatically calculated by [`super::flex::flex_node_system`]
     pub fn size(&self) -> Vec2 {
         self.calculated_size


### PR DESCRIPTION
# Objective

Current `Node` doc comment:
```rust
/// The size of the node as width and height in pixels
/// automatically calculated by [`super::flex::flex_node_system`]
```

It should be changed to make it clear that `Node` stores the size in logical pixels, not physical.

