### PR TITLE
Initialize empty schedules when calling `.in_schedule` if they do not already exist

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1024,7 +1024,7 @@ mod tests {
         system::Commands,
     };
 
-    use crate::{App, IntoSystemAppConfig, Plugin};
+    use crate::{App, IntoSystemAppConfig, IntoSystemAppConfigs, Plugin};
 
     struct PluginA;
     impl Plugin for PluginA {
@@ -1084,17 +1084,51 @@ mod tests {
         #[default]
         MainMenu,
     }
-    fn on_enter(mut commands: Commands) {
+    fn bar(mut commands: Commands) {
+        commands.spawn_empty();
+    }
+
+    fn foo(mut commands: Commands) {
         commands.spawn_empty();
     }
 
     #[test]
     fn add_system_should_create_schedule_if_it_does_not_exist() {
         let mut app = App::new();
-        app.add_system(on_enter.in_schedule(OnEnter(AppState::MainMenu)))
+        app.add_system(foo.in_schedule(OnEnter(AppState::MainMenu)))
             .add_state::<AppState>();
 
         app.world.run_schedule(OnEnter(AppState::MainMenu));
         assert_eq!(app.world.entities().len(), 1);
+    }
+
+    #[test]
+    fn add_system_should_create_schedule_if_it_does_not_exist2() {
+        let mut app = App::new();
+        app.add_state::<AppState>()
+            .add_system(foo.in_schedule(OnEnter(AppState::MainMenu)));
+
+        app.world.run_schedule(OnEnter(AppState::MainMenu));
+        assert_eq!(app.world.entities().len(), 1);
+    }
+
+    #[test]
+    fn add_systems_should_create_schedule_if_it_does_not_exist() {
+        let mut app = App::new();
+        app.add_state::<AppState>()
+            .add_systems((foo, bar).in_schedule(OnEnter(AppState::MainMenu)));
+
+        app.world.run_schedule(OnEnter(AppState::MainMenu));
+        assert_eq!(app.world.entities().len(), 2);
+    }
+
+    #[test]
+    fn add_systems_should_create_schedule_if_it_does_not_exist2() {
+        let mut app = App::new();
+        app.add_systems((foo, bar).in_schedule(OnEnter(AppState::MainMenu)))
+            .add_state::<AppState>();
+
+        app.world.run_schedule(OnEnter(AppState::MainMenu));
+        assert_eq!(app.world.entities().len(), 2);
     }
 }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -390,8 +390,7 @@ impl App {
             if let Some(schedule) = schedules.get_mut(&*schedule_label) {
                 schedule.add_system(system);
             } else {
-                self
-                    .add_schedule(schedule_label, Schedule::new())
+                self.add_schedule(schedule_label, Schedule::new())
                     .add_system(system);
             }
         } else if let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -355,11 +355,14 @@ impl App {
                     .run_if(in_state(variant)),
             );
         }
-
         // These are different for loops to avoid conflicting access to self
         for variant in S::variants() {
-            self.add_schedule(OnEnter(variant.clone()), Schedule::new());
-            self.add_schedule(OnExit(variant), Schedule::new());
+            if self.get_schedule(OnEnter(variant.clone())).is_none() {
+                self.add_schedule(OnEnter(variant.clone()), Schedule::new());
+            }
+            if self.get_schedule(OnExit(variant.clone())).is_none() {
+                self.add_schedule(OnExit(variant), Schedule::new());
+            }
         }
 
         self

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -390,7 +390,9 @@ impl App {
             if let Some(schedule) = schedules.get_mut(&*schedule_label) {
                 schedule.add_system(system);
             } else {
-                panic!("Schedule {schedule_label:?} does not exist.")
+                self
+                    .add_schedule(schedule_label, Schedule::new())
+                    .add_system(system);
             }
         } else if let Some(default_schedule) = schedules.get_mut(&*self.default_schedule_label) {
             default_schedule.add_system(system);

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -313,7 +313,7 @@ impl App {
     }
 
     /// Adds [`State<S>`] and [`NextState<S>`] resources, [`OnEnter`] and [`OnExit`] schedules
-    /// for each state variant, an instance of [`apply_state_transition::<S>`] in
+    /// for each state variant (if they don't already exist), an instance of [`apply_state_transition::<S>`] in
     /// [`CoreSet::StateTransitions`] so that transitions happen before [`CoreSet::Update`] and
     /// a instance of [`run_enter_schedule::<S>`] in [`CoreSet::StateTransitions`] with a
     /// [`run_once`](`run_once_condition`) condition to run the on enter schedule of the

--- a/crates/bevy_app/src/config.rs
+++ b/crates/bevy_app/src/config.rs
@@ -190,7 +190,10 @@ pub trait IntoSystemAppConfigs<Marker>: Sized {
 
     /// Adds the systems to the provided `schedule`.
     ///
+    /// If a schedule with specified label does not exist, it will be created.
+    ///
     /// If a schedule is not specified, they will be added to the [`App`]'s default schedule.
+    ///
     ///
     /// [`App`]: crate::App
     ///

--- a/crates/bevy_app/src/config.rs
+++ b/crates/bevy_app/src/config.rs
@@ -192,7 +192,7 @@ pub trait IntoSystemAppConfigs<Marker>: Sized {
     ///
     /// If a schedule with specified label does not exist, it will be created.
     ///
-    /// If a schedule is not specified, they will be added to the [`App`]'s default schedule.
+    /// If a schedule with the specified label does not exist, an empty one will be created.
     ///
     ///
     /// [`App`]: crate::App


### PR DESCRIPTION
# Objective
Fixes [#7910](#https://github.com/bevyengine/bevy/issues/7910)

## Solution
create shedule if it does not exist by the time `add_system` called

My first PR. Not sure how much this solution feet here but at least it seems to work. Any comment is appreciated.


