### PR TITLE
[Merged by Bors] - Fix dev dependency version

### DIFF
--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -18,7 +18,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.9.0", features = ["bevy"
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev_dependencies]
-bevy_tasks = { path = "../bevy_tasks", version = "0.9.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.9.0" }
 
 [features]
 serialize = ["dep:serde", "bevy_math/serialize"]


### PR DESCRIPTION
We need to revert this to 0.9.0 so we can run the post release job.