### PR TITLE
[Merged by Bors] - Fix malformed dev-dependencies

### DIFF
--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -17,7 +17,7 @@ bevy_math = { path = "../bevy_math", version = "0.9.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.9.0", features = ["bevy"] }
 serde = { version = "1", features = ["derive"], optional = true }
 
-[dev_dependencies]
+[dev-dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.9.0" }
 
 [features]


### PR DESCRIPTION
This was causing the "post release version bump" to fail