### PR TITLE
UI Nodes with a `CalculatedSize` shouldn't have child nodes or both `Image` and `Text` components

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -161,7 +161,7 @@ impl Plugin for UiPlugin {
 
 pub fn detect_calculated_size_conflict(
     #[cfg(feature = "bevy_text")] text_and_image: Query<
-        Entity,
+        (),
         (
             With<Node>,
             With<UiImage>,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -16,8 +16,6 @@ pub mod node_bundles;
 pub mod update;
 pub mod widget;
 
-use std::sync::Arc;
-
 use bevy_hierarchy::Children;
 #[cfg(feature = "bevy_text")]
 use bevy_render::camera::CameraUpdateSystem;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -162,8 +162,15 @@ impl Plugin for UiPlugin {
 }
 
 pub fn detect_calculated_size_conflict(
-    #[cfg(feature = "bevy_text")]
-    text_and_image: Query<Entity, (With<Node>, With<UiImage>, With<bevy_text::Text>, With<CalculatedSize>)>,
+    #[cfg(feature = "bevy_text")] text_and_image: Query<
+        Entity,
+        (
+            With<Node>,
+            With<UiImage>,
+            With<bevy_text::Text>,
+            With<CalculatedSize>,
+        ),
+    >,
     parent_query: Query<&Children, (With<CalculatedSize>, With<Node>)>,
     child_query: Query<&Node>,
 ) {

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -62,7 +62,7 @@ impl Default for NodeBundle {
 }
 
 /// A UI node that is an image
-/// 
+///
 /// Image nodes must not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct ImageBundle {
@@ -100,7 +100,7 @@ pub struct ImageBundle {
 
 #[cfg(feature = "bevy_text")]
 /// A UI node that is text
-/// 
+///
 /// Text nodes must not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -62,6 +62,8 @@ impl Default for NodeBundle {
 }
 
 /// A UI node that is an image
+/// 
+/// Image nodes should not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct ImageBundle {
     /// Describes the logical size of the node
@@ -98,6 +100,8 @@ pub struct ImageBundle {
 
 #[cfg(feature = "bevy_text")]
 /// A UI node that is text
+/// 
+/// Text nodes should not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -63,7 +63,7 @@ impl Default for NodeBundle {
 
 /// A UI node that is an image
 /// 
-/// Image nodes should not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
+/// Image nodes must not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct ImageBundle {
     /// Describes the logical size of the node
@@ -101,7 +101,7 @@ pub struct ImageBundle {
 #[cfg(feature = "bevy_text")]
 /// A UI node that is text
 /// 
-/// Text nodes should not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
+/// Text nodes must not be given child nodes, as the UI layout system will not be able to properly determine the size of the node.
 #[derive(Bundle, Clone, Debug)]
 pub struct TextBundle {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -626,7 +626,7 @@ impl Default for FlexWrap {
 
 /// The calculated size of the node
 /// 
-/// UI Nodes with a `CalculatedSize` component should not be given child UI nodes.
+/// UI Nodes with a `CalculatedSize` component must not be given child UI nodes.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]
 pub struct CalculatedSize {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -625,6 +625,8 @@ impl Default for FlexWrap {
 }
 
 /// The calculated size of the node
+/// 
+/// UI Nodes with a `CalculatedSize` component should not be given child UI nodes.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]
 pub struct CalculatedSize {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -625,7 +625,7 @@ impl Default for FlexWrap {
 }
 
 /// The calculated size of the node
-/// 
+///
 /// UI Nodes with a `CalculatedSize` component must not be given child UI nodes.
 #[derive(Component, Copy, Clone, Debug, Reflect)]
 #[reflect(Component)]

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,18 +1,13 @@
 use crate::{CalculatedSize, UiImage};
 use bevy_asset::Assets;
-#[cfg(feature = "bevy_text")]
-use bevy_ecs::query::Without;
 use bevy_ecs::system::{Query, Res};
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
-#[cfg(feature = "bevy_text")]
-use bevy_text::Text;
 
 /// Updates calculated size of the node based on the image provided
 pub fn update_image_calculated_size_system(
     textures: Res<Assets<Image>>,
-    #[cfg(feature = "bevy_text")] mut query: Query<(&mut CalculatedSize, &UiImage), Without<Text>>,
-    #[cfg(not(feature = "bevy_text"))] mut query: Query<(&mut CalculatedSize, &UiImage)>,
+    mut query: Query<(&mut CalculatedSize, &UiImage)>,
 ) {
     for (mut calculated_size, image) in &mut query {
         if let Some(texture) = textures.get(&image.texture) {


### PR DESCRIPTION
# Objective

If a parent UI node with a `MeasureFunc` has a child node, the parent's size won't be determined by the `MeasureFunc`.

Ui Nodes with `CalculatedSize`. `Image`, and `Text` components won't be sized correctly. 

It's hard to understand/explain, sometimes causes no problems, and sometimes causes unpredictable and confusing bugs.

#7894 is an example of where this has caused a problem.

## Solution

Add some doc comments telling users not to do any of these things.
Panic if any of them is done.

## Changelog

* Added a system `detect_calculated_size_conflicts` that panics if a Ui Node with a `CalculatedSize` component has a child UI node or both `Image` and `Text` components