### PR TITLE
Clarify breaking release frequency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bevy is a refreshingly simple data-driven game engine built in Rust. It is free 
 
 ## WARNING
 
-Bevy is still in the _very_ early stages of development. APIs can and will change (now is the time to make suggestions!). Important features are missing. Documentation is sparse. Please don't build any serious projects in Bevy unless you are prepared to be broken by API changes on a roughly quarterly basis.
+Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. And minor versions of Bevy containing breaking changes to the API are released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). Use at your own risk.
 
 **MSRV:** Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bevy is a refreshingly simple data-driven game engine built in Rust. It is free 
 
 ## WARNING
 
-Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. A new version of Bevy containing serious breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). Use at your own risk.
+Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. A new version of Bevy containing breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). We provide [migration guides](https://bevyengine.org/learn/book/migration-guides/), but we can't guarantee migrations will always be easy. Use only if you are willing to work in this environment.
 
 **MSRV:** Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bevy is a refreshingly simple data-driven game engine built in Rust. It is free 
 
 ## WARNING
 
-Bevy is still in the _very_ early stages of development. APIs can and will change (now is the time to make suggestions!). Important features are missing. Documentation is sparse. Please don't build any serious projects in Bevy unless you are prepared to be broken by API changes constantly.
+Bevy is still in the _very_ early stages of development. APIs can and will change (now is the time to make suggestions!). Important features are missing. Documentation is sparse. Please don't build any serious projects in Bevy unless you are prepared to be broken by API changes on a roughly quarterly basis.
 
 **MSRV:** Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Bevy is a refreshingly simple data-driven game engine built in Rust. It is free 
 
 ## WARNING
 
-Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. And minor versions of Bevy containing breaking changes to the API are released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). Use at your own risk.
+Bevy is still in the early stages of development. Important features are missing. Documentation is sparse. A new version of Bevy containing serious breaking changes to the API is released [approximately once every 3 months](https://bevyengine.org/news/bevy-0-6/#the-train-release-schedule). Use at your own risk.
 
 **MSRV:** Bevy relies heavily on improvements in the Rust language and compiler.
 As a result, the Minimum Supported Rust Version (MSRV) is "the latest stable release" of Rust.


### PR DESCRIPTION
# Objective

Bevy's README is ambiguous about how often "frequent" breaking changes occur. And some people [have taken it](https://news.ycombinator.com/item?id=35045509) to mean that breaking changes may occur every few days in patch releases. I personally find this reading a little odd, but it never hurts to be clear.

## Solution

Be specific that breaking changes in Bevy tend to land on a roughly quarterly basis.