### PR TITLE
Add OnTransition schedule that is ran between OnExit and OnEnter

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -40,8 +40,8 @@ pub mod prelude {
         schedule::{
             apply_state_transition, apply_system_buffers, common_conditions::*, Condition,
             IntoSystemConfig, IntoSystemConfigs, IntoSystemSet, IntoSystemSetConfig,
-            IntoSystemSetConfigs, NextState, OnEnter, OnExit, OnUpdate, Schedule, Schedules, State,
-            States, SystemSet,
+            IntoSystemSetConfigs, NextState, OnEnter, OnExit, OnTransition, OnUpdate, Schedule,
+            Schedules, State, States, SystemSet,
         },
         system::{
             adapter as system_adapter,

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -54,6 +54,13 @@ pub struct OnEnter<S: States>(pub S);
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct OnExit<S: States>(pub S);
 
+/// The label of a [`Schedule`](super::Schedule) that **only** runs whenever [`State<S>`]
+/// exits the first given state, AND enters the second given state.
+///
+/// Systems added to this schedule are always ran *after* [`OnExit`], and *before* [`OnEnter`].
+#[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct OnTransition<S: States>(pub S, pub S);
+
 /// A [`SystemSet`] that will run within `CoreSet::Update` when this state is active.
 ///
 /// This set, when created via `App::add_state`, is configured with both a base set and a run condition.
@@ -105,7 +112,8 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
         next_state_resource.set_changed();
 
         let exited = mem::replace(&mut world.resource_mut::<State<S>>().0, entered.clone());
-        world.run_schedule(OnExit(exited));
+        world.run_schedule(OnExit(exited.clone()));
+        world.run_schedule(OnTransition(exited, entered.clone()));
         world.run_schedule(OnEnter(entered));
     }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -55,11 +55,16 @@ pub struct OnEnter<S: States>(pub S);
 pub struct OnExit<S: States>(pub S);
 
 /// The label of a [`Schedule`](super::Schedule) that **only** runs whenever [`State<S>`]
-/// exits the first given state, AND enters the second given state.
+/// exits the `from` state, AND enters the `to` state.
 ///
 /// Systems added to this schedule are always ran *after* [`OnExit`], and *before* [`OnEnter`].
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
-pub struct OnTransition<S: States>(pub S, pub S);
+pub struct OnTransition<S: States> {
+    /// The state being exited.
+    pub from: S,
+    /// The state being entered.
+    pub to: S,
+}
 
 /// A [`SystemSet`] that will run within `CoreSet::Update` when this state is active.
 ///
@@ -113,7 +118,10 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
 
         let exited = mem::replace(&mut world.resource_mut::<State<S>>().0, entered.clone());
         world.run_schedule(OnExit(exited.clone()));
-        world.run_schedule(OnTransition(exited, entered.clone()));
+        world.run_schedule(OnTransition {
+            from: exited,
+            to: entered.clone(),
+        });
         world.run_schedule(OnEnter(entered));
     }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -4,7 +4,7 @@ use std::mem;
 
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
-use crate::schedule::{ScheduleLabel, SystemSet, Schedules};
+use crate::schedule::{ScheduleLabel, Schedules, SystemSet};
 use crate::system::Resource;
 use crate::world::World;
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -10,6 +10,8 @@ use crate::world::World;
 
 pub use bevy_ecs_macros::States;
 
+use super::Schedules;
+
 /// Types that can define world-wide states in a finite-state machine.
 ///
 /// The [`Default`] trait defines the starting state.
@@ -118,10 +120,15 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
 
         let exited = mem::replace(&mut world.resource_mut::<State<S>>().0, entered.clone());
         world.run_schedule(OnExit(exited.clone()));
-        world.run_schedule(OnTransition {
+
+        let transition_schedule = OnTransition {
             from: exited,
             to: entered.clone(),
-        });
+        };
+        if world.resource::<Schedules>().contains(&transition_schedule) {
+            world.run_schedule(transition_schedule);
+        }
+        
         world.run_schedule(OnEnter(entered));
     }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -4,13 +4,11 @@ use std::mem;
 
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
-use crate::schedule::{ScheduleLabel, SystemSet};
+use crate::schedule::{ScheduleLabel, SystemSet, Schedules};
 use crate::system::Resource;
 use crate::world::World;
 
 pub use bevy_ecs_macros::States;
-
-use super::Schedules;
 
 /// Types that can define world-wide states in a finite-state machine.
 ///
@@ -128,7 +126,7 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
         if world.resource::<Schedules>().contains(&transition_schedule) {
             world.run_schedule(transition_schedule);
         }
-        
+
         world.run_schedule(OnEnter(entered));
     }
 }


### PR DESCRIPTION
# Objective

Fix #7647

## Solution

Implements the solution described by @LiamGallagher737 in #7647.

---

## Changelog

### Added

- `OnTransition`: Alternative to OnEnter and OnExit to enable more specific state transition logic.