### PR TITLE
Only run validation jobs in Merge Queues

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   build-and-install-on-iOS:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -33,6 +34,7 @@ jobs:
         run: cd examples/mobile && make install
 
   build-android:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -60,6 +62,7 @@ jobs:
         run: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME cargo apk build --package bevy_mobile_example
 
   run-examples-on-windows-dx12:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: windows-latest
     timeout-minutes: 60
     steps:
@@ -94,6 +97,7 @@ jobs:
           done
 
   run-examples-on-wasm:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -150,6 +154,7 @@ jobs:
           path: .github/start-wasm-example/screenshot-*.png
 
   build-without-default-features:
+    if: ${{ github.event_name == 'merge_group' }}
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -2,6 +2,7 @@ name: validation jobs
 
 on:
   merge_group:
+  pull_request:
   push:
     branches:
       - staging


### PR DESCRIPTION
# Objective

We want to run more expensive validation, but only in merge queues (not during normal PR CI). 

## Solution

Using `if` statements in the yaml is the [recommended workaround](https://github.com/community/community/discussions/46757#discussioncomment-4909336) here.

