### PR TITLE
Fix broken code behind wasm feature flag in blend_modes example

### DIFF
--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -24,7 +24,7 @@ fn main() {
     // Since this example uses HDR, we must disable MSAA for WASM builds, at least
     // until WebGPU is ready and no longer behind a feature flag in Web browsers.
     #[cfg(target_arch = "wasm32")]
-    app.insert_resource(Msaa { samples: 1 }); // Default is 4 samples (MSAA on)
+    app.insert_resource(Msaa::Off);
 
     app.run();
 }


### PR DESCRIPTION
Removed the comment as it's documented on `Msaa` (easy for it to become outdated as well)

For the 0.10.1 milestone so we don't have an incorrect example for 3+ months q: