### PR TITLE
don't panic on unknown ambiguity

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1138,17 +1138,17 @@ impl ScheduleGraph {
                     ambiguous_with_flattened.add_edge(lhs, rhs, ());
                 }
                 (NodeId::Set(_), NodeId::System(_)) => {
-                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&vec![]) {
+                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&Vec::new()) {
                         ambiguous_with_flattened.add_edge(lhs_, rhs, ());
                     }
                 }
                 (NodeId::System(_), NodeId::Set(_)) => {
-                    for &rhs_ in set_systems.get(&rhs).unwrap_or(&vec![]) {
+                    for &rhs_ in set_systems.get(&rhs).unwrap_or(&Vec::new()) {
                         ambiguous_with_flattened.add_edge(lhs, rhs_, ());
                     }
                 }
                 (NodeId::Set(_), NodeId::Set(_)) => {
-                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&vec![]) {
+                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&Vec::new()) {
                         for &rhs_ in set_systems.get(&rhs).unwrap_or(&vec![]) {
                             ambiguous_with_flattened.add_edge(lhs_, rhs_, ());
                         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1138,18 +1138,18 @@ impl ScheduleGraph {
                     ambiguous_with_flattened.add_edge(lhs, rhs, ());
                 }
                 (NodeId::Set(_), NodeId::System(_)) => {
-                    for &lhs_ in set_systems.get(&lhs).unwrap() {
+                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&vec![]) {
                         ambiguous_with_flattened.add_edge(lhs_, rhs, ());
                     }
                 }
                 (NodeId::System(_), NodeId::Set(_)) => {
-                    for &rhs_ in set_systems.get(&rhs).unwrap() {
+                    for &rhs_ in set_systems.get(&rhs).unwrap_or(&vec![]) {
                         ambiguous_with_flattened.add_edge(lhs, rhs_, ());
                     }
                 }
                 (NodeId::Set(_), NodeId::Set(_)) => {
-                    for &lhs_ in set_systems.get(&lhs).unwrap() {
-                        for &rhs_ in set_systems.get(&rhs).unwrap() {
+                    for &lhs_ in set_systems.get(&lhs).unwrap_or(&vec![]) {
+                        for &rhs_ in set_systems.get(&rhs).unwrap_or(&vec![]) {
                             ambiguous_with_flattened.add_edge(lhs_, rhs_, ());
                         }
                     }


### PR DESCRIPTION
# Objective

- Fixes #7949
- don't panic

## Solution

- #7949 happens because the `exit_on_all_closed` system is used to declare an ambiguity with another, but it isn't added if the exit condition is not `OnPrimaryClosed`
- while we could fix all cases in Bevy, having ambiguities with unknown systems can be something that happens with optional / third party plugins
- allow ambiguity with things that don't exist
