### PR TITLE
Bugfix: Scene reload fix (nonbreaking)

### DIFF
--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -412,8 +412,8 @@ impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]
 pub struct ReflectMapEntities {
-    map_all_entities: fn(&mut World, &EntityMap) -> Result<(), MapEntitiesError>,
-    map_entities: fn(&mut World, &EntityMap, &[Entity]) -> Result<(), MapEntitiesError>,
+    map_entities: fn(&mut World, &EntityMap) -> Result<(), MapEntitiesError>,
+    map_specific_entities: fn(&mut World, &EntityMap, &[Entity]) -> Result<(), MapEntitiesError>,
 }
 
 impl ReflectMapEntities {
@@ -424,35 +424,35 @@ impl ReflectMapEntities {
     /// by the [`EntityMap`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
     ///
     /// An example of this: A scene can be loaded with `Parent` components, but then a `Parent` component can be added
-    /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`](Self::map_all_entities), those `Parent`
+    /// to these entities after they have been loaded. If you reload the scene using [`map_entities`](Self::map_entities), those `Parent`
     /// components with already valid entity references could be updated to point at something else entirely.
-    pub fn map_all_entities(
+    pub fn map_entities(
         &self,
         world: &mut World,
         entity_map: &EntityMap,
     ) -> Result<(), MapEntitiesError> {
-        (self.map_all_entities)(world, entity_map)
+        (self.map_entities)(world, entity_map)
     }
 
-    /// This is like [`map_all_entities`](Self::map_all_entities), but only applied to specific entities, not all values
+    /// This is like [`map_entities`](Self::map_entities), but only applied to specific entities, not all values
     /// in the [`EntityMap`].
     ///
     /// This is useful mostly for when you need to be careful not to update components that already contain valid entity
-    /// values. See [`map_all_entities`](Self::map_all_entities) for more details.
-    pub fn map_entities(
+    /// values. See [`map_entities`](Self::map_entities) for more details.
+    pub fn map_specific_entities(
         &self,
         world: &mut World,
         entity_map: &EntityMap,
         entities: &[Entity],
     ) -> Result<(), MapEntitiesError> {
-        (self.map_entities)(world, entity_map, entities)
+        (self.map_specific_entities)(world, entity_map, entities)
     }
 }
 
 impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
-            map_entities: |world, entity_map, entities| {
+            map_specific_entities: |world, entity_map, entities| {
                 for &entity in entities {
                     if let Some(mut component) = world.get_mut::<C>(entity) {
                         component.map_entities(entity_map)?;
@@ -460,7 +460,7 @@ impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
                 }
                 Ok(())
             },
-            map_all_entities: |world, entity_map| {
+            map_entities: |world, entity_map| {
                 for entity in entity_map.values() {
                     if let Some(mut component) = world.get_mut::<C>(entity) {
                         component.map_entities(entity_map)?;

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -416,7 +416,7 @@ pub struct ReflectMapEntities {
 }
 
 impl ReflectMapEntities {
-    /// A general method for applying MapEntity behavior to all elements in an [`EntityMap`].
+    /// A general method for applying [`MapEntity`] behavior to all elements in an [`EntityMap`].
     ///
     /// Be mindful in its usage: Works best in situations where the entities in the [`EntityMap`] are newly
     /// created, before systems have a chance to add new components. If some of the entities referred to

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -424,6 +424,12 @@ impl ReflectMapEntities {
         (self.map_entities)(world, entity_map, entity_map.values().collect())
     }
 
+    /// This is like map_entities, but only applied to specific entities, not all values in the EntityMap.
+    ///
+    /// This is useful for when you only want to apply the MapEntity logic to specific entities. For example,
+    /// a scene can be loaded with Parent components, but then a Parent component can be added to these entities
+    /// after they have been loaded. If you reload the scene and used plain `map_entities`, those Parent components
+    /// with already valid entity references could be updated to point at something else entirely.
     pub fn map_specific_entities(
         &self,
         world: &mut World,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -412,27 +412,57 @@ impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]
 pub struct ReflectMapEntities {
-    map_entities: fn(&mut World, &EntityMap, &Vec<Entity>) -> Result<(), MapEntitiesError>,
+    map_entities: fn(&mut World, &EntityMap, Option<&[Entity]>) -> Result<(), MapEntitiesError>,
 }
 
 impl ReflectMapEntities {
+    /// A general method for applying MapEntity behavior to all elements in an [`EntityMap`].
+    ///
+    /// Be mindful in its usage: Works best in situations where the entities in the [`EntityMap`] are newly
+    /// created, before systems have a chance to add new components. If some of the entities referred to
+    /// by the [`EntityMap`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
+    ///
+    /// An example of this: A scene can be loaded with `Parent` components, but then a `Parent` component can be added
+    /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`], those `Parent`
+    /// components with already valid entity references could be updated to point at something else entirely.
+    pub fn map_all_entities(
+        &self,
+        world: &mut World,
+        entity_map: &EntityMap,
+    ) -> Result<(), MapEntitiesError> {
+        (self.map_entities)(world, entity_map, None)
+    }
+
+    /// This is like [`map_all_entities`](Self::map_all_entities), but only applied to specific entities, not all values
+    /// in the [`EntityMap`].
+    ///
+    /// This is useful mostly for when you need to be careful not to update components that already contain valid entity
+    /// values. See [`map_all_entities`](Self::map_all_entities) for more details.
     pub fn map_entities(
         &self,
         world: &mut World,
         entity_map: &EntityMap,
-        entities: &Vec<Entity>,
+        entities: &[Entity],
     ) -> Result<(), MapEntitiesError> {
-        (self.map_entities)(world, entity_map, entities)
+        (self.map_entities)(world, entity_map, Some(entities))
     }
 }
 
 impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
-            map_entities: |world, entity_map, entities| {
-                for &entity in entities {
-                    if let Some(mut component) = world.get_mut::<C>(entity) {
-                        component.map_entities(entity_map)?;
+            map_entities: |world, entity_map, entities_opt| {
+                if let Some(entities) = entities_opt {
+                    for &entity in entities {
+                        if let Some(mut component) = world.get_mut::<C>(entity) {
+                            component.map_entities(entity_map)?;
+                        }
+                    }
+                } else {
+                    for entity in entity_map.values() {
+                        if let Some(mut component) = world.get_mut::<C>(entity) {
+                            component.map_entities(entity_map)?;
+                        }
                     }
                 }
                 Ok(())

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -416,14 +416,14 @@ pub struct ReflectMapEntities {
 }
 
 impl ReflectMapEntities {
-    /// A general method for applying [`MapEntity`] behavior to all elements in an [`EntityMap`].
+    /// A general method for applying [`MapEntities`] behavior to all elements in an [`EntityMap`].
     ///
     /// Be mindful in its usage: Works best in situations where the entities in the [`EntityMap`] are newly
     /// created, before systems have a chance to add new components. If some of the entities referred to
     /// by the [`EntityMap`] might already contain valid entity references, you should use [`map_entities`](Self::map_entities).
     ///
     /// An example of this: A scene can be loaded with `Parent` components, but then a `Parent` component can be added
-    /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`], those `Parent`
+    /// to these entities after they have been loaded. If you reload the scene using [`map_all_entities`](Self::map_all_entities), those `Parent`
     /// components with already valid entity references could be updated to point at something else entirely.
     pub fn map_all_entities(
         &self,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -428,8 +428,8 @@ impl ReflectMapEntities {
         &self,
         world: &mut World,
         entity_map: &EntityMap,
-        entities: Vec<Entity>
-    )  -> Result<(), MapEntitiesError> {
+        entities: Vec<Entity>,
+    ) -> Result<(), MapEntitiesError> {
         (self.map_entities)(world, entity_map, entities)
     }
 }

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -412,7 +412,7 @@ impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]
 pub struct ReflectMapEntities {
-    map_entities: fn(&mut World, &EntityMap) -> Result<(), MapEntitiesError>,
+    map_entities: fn(&mut World, &EntityMap, Vec<Entity>) -> Result<(), MapEntitiesError>,
 }
 
 impl ReflectMapEntities {
@@ -421,15 +421,24 @@ impl ReflectMapEntities {
         world: &mut World,
         entity_map: &EntityMap,
     ) -> Result<(), MapEntitiesError> {
-        (self.map_entities)(world, entity_map)
+        (self.map_entities)(world, entity_map, entity_map.values().collect())
+    }
+
+    pub fn map_specific_entities(
+        &self,
+        world: &mut World,
+        entity_map: &EntityMap,
+        entities: Vec<Entity>
+    )  -> Result<(), MapEntitiesError> {
+        (self.map_entities)(world, entity_map, entities)
     }
 }
 
 impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
-            map_entities: |world, entity_map| {
-                for entity in entity_map.values() {
+            map_entities: |world, entity_map, entities| {
+                for entity in entities {
                     if let Some(mut component) = world.get_mut::<C>(entity) {
                         component.map_entities(entity_map)?;
                     }

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -424,11 +424,11 @@ impl ReflectMapEntities {
         (self.map_entities)(world, entity_map, entity_map.values().collect())
     }
 
-    /// This is like map_entities, but only applied to specific entities, not all values in the EntityMap.
+    /// This is like `map_entities`, but only applied to specific entities, not all values in the `EntityMap`.
     ///
-    /// This is useful for when you only want to apply the MapEntity logic to specific entities. For example,
-    /// a scene can be loaded with Parent components, but then a Parent component can be added to these entities
-    /// after they have been loaded. If you reload the scene and used plain `map_entities`, those Parent components
+    /// This is useful for when you only want to apply the `MapEntity` logic to specific entities. For example,
+    /// a scene can be loaded with `Parent` components, but then a `Parent` component can be added to these entities
+    /// after they have been loaded. If you reload the scene and used plain `map_entities`, those `Parent` components
     /// with already valid entity references could be updated to point at something else entirely.
     pub fn map_specific_entities(
         &self,

--- a/crates/bevy_ecs/src/reflect.rs
+++ b/crates/bevy_ecs/src/reflect.rs
@@ -412,7 +412,7 @@ impl_from_reflect_value!(Entity);
 
 #[derive(Clone)]
 pub struct ReflectMapEntities {
-    map_entities: fn(&mut World, &EntityMap, Vec<Entity>) -> Result<(), MapEntitiesError>,
+    map_entities: fn(&mut World, &EntityMap, &Vec<Entity>) -> Result<(), MapEntitiesError>,
 }
 
 impl ReflectMapEntities {
@@ -420,21 +420,7 @@ impl ReflectMapEntities {
         &self,
         world: &mut World,
         entity_map: &EntityMap,
-    ) -> Result<(), MapEntitiesError> {
-        (self.map_entities)(world, entity_map, entity_map.values().collect())
-    }
-
-    /// This is like `map_entities`, but only applied to specific entities, not all values in the `EntityMap`.
-    ///
-    /// This is useful for when you only want to apply the `MapEntity` logic to specific entities. For example,
-    /// a scene can be loaded with `Parent` components, but then a `Parent` component can be added to these entities
-    /// after they have been loaded. If you reload the scene and used plain `map_entities`, those `Parent` components
-    /// with already valid entity references could be updated to point at something else entirely.
-    pub fn map_specific_entities(
-        &self,
-        world: &mut World,
-        entity_map: &EntityMap,
-        entities: Vec<Entity>,
+        entities: &Vec<Entity>,
     ) -> Result<(), MapEntitiesError> {
         (self.map_entities)(world, entity_map, entities)
     }
@@ -444,7 +430,7 @@ impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
     fn from_type() -> Self {
         ReflectMapEntities {
             map_entities: |world, entity_map, entities| {
-                for entity in entities {
+                for &entity in entities {
                     if let Some(mut component) = world.get_mut::<C>(entity) {
                         component.map_entities(entity_map)?;
                     }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -137,11 +137,12 @@ impl DynamicScene {
 
         // Updates references to entities in the scene to entities in the world
         for (type_id, entities) in scene_mappings.into_iter() {
-            let registration = type_registry.get(type_id)
-                .expect("This TypeRegistration was where we got the TypeId initially, should be safe to unwrap");
+            let registration = type_registry.get(type_id).expect(
+                "We should be getting TypeId from this TypeRegistration in the first place",
+            );
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
-                    .map_entities(world, entity_map, &entities)
+                    .map_specific_entities(world, entity_map, &entities)
                     .unwrap();
             }
         }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -138,7 +138,7 @@ impl DynamicScene {
         // Updates references to entities in the scene to entities in the world
         for (type_id, entities) in scene_mappings.into_iter() {
             let registration = type_registry.get(type_id).expect(
-                "We should be getting TypeId from this TypeRegistration in the first place",
+                "we should be getting TypeId from this TypeRegistration in the first place",
             );
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
@@ -263,7 +263,7 @@ mod tests {
                 .get_entity(from_scene_child_entity)
                 .unwrap()
                 .get::<Parent>()
-                .expect("Something is wrong with this test, and the scene components don't have a parent/child relationship")
+                .expect("something is wrong with this test, and the scene components don't have a parent/child relationship")
                 .get(),
             "something is wrong with the this test or the code reloading scenes since the relationship between scene entities is broken"
         );

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -245,7 +245,7 @@ mod tests {
                 .get::<Parent>()
                 .unwrap()
                 .get(),
-            "Something about reloading the scene is touching entities with the same scene Ids"
+            "something about reloading the scene is touching entities with the same scene Ids"
         );
         assert_eq!(
             original_child_entity,
@@ -255,7 +255,7 @@ mod tests {
                 .get::<Parent>()
                 .unwrap()
                 .get(),
-            "Something about reloading the scene is touching components not defined in the scene but on entities defined in the scene"
+            "something about reloading the scene is touching components not defined in the scene but on entities defined in the scene"
         );
         assert_eq!(
             from_scene_parent_entity,
@@ -265,7 +265,7 @@ mod tests {
                 .get::<Parent>()
                 .expect("Something is wrong with this test, and the scene components don't have a parent/child relationship")
                 .get(),
-            "Something is wrong with the this test or the code reloading scenes since the relationship between scene entities is broken"
+            "something is wrong with the this test or the code reloading scenes since the relationship between scene entities is broken"
         );
     }
 }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -140,7 +140,7 @@ impl DynamicScene {
             let registration = type_registry.get(type_id).unwrap();
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
-                    .map_specific_entities(world, entity_map, entities)
+                    .map_entities(world, entity_map, &entities)
                     .unwrap();
             }
         }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -137,7 +137,8 @@ impl DynamicScene {
 
         // Updates references to entities in the scene to entities in the world
         for (type_id, entities) in scene_mappings.into_iter() {
-            let registration = type_registry.get(type_id).unwrap();
+            let registration = type_registry.get(type_id)
+                .expect("This TypeRegistration was where we got the TypeId initially, should be safe to unwrap");
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
                     .map_entities(world, entity_map, &entities)

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -118,11 +118,10 @@ impl Scene {
             }
         }
 
-        let entities_from_scene: Vec<_> = instance_info.entity_map.values().collect();
         for registration in type_registry.iter() {
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
-                    .map_entities(world, &instance_info.entity_map, &entities_from_scene)
+                    .map_all_entities(world, &instance_info.entity_map)
                     .unwrap();
             }
         }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -121,7 +121,7 @@ impl Scene {
         for registration in type_registry.iter() {
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
-                    .map_all_entities(world, &instance_info.entity_map)
+                    .map_entities(world, &instance_info.entity_map)
                     .unwrap();
             }
         }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -117,10 +117,12 @@ impl Scene {
                 }
             }
         }
+
+        let entities_from_scene: Vec<_> = instance_info.entity_map.values().collect();
         for registration in type_registry.iter() {
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
                 map_entities_reflect
-                    .map_entities(world, &instance_info.entity_map)
+                    .map_entities(world, &instance_info.entity_map, &entities_from_scene)
                     .unwrap();
             }
         }


### PR DESCRIPTION
# Objective

Fix a bug with scene reload.

(This is a copy of #7570 but without the breaking API change, in order to allow the bugfix to be introduced in 0.10.1)

When a scene was reloaded, it was corrupting components that weren't native to the scene itself. In particular, when a DynamicScene was created on Entity (A), all components in the scene without parents are automatically added as children of Entity (A). But if that scene was reloaded and the same ID of Entity (A) was a scene ID as well*, that parent component was corrupted, causing the hierarchy to become malformed and bevy to panic.


*For example, if Entity (A)'s ID was 3, and the scene contained an entity with ID 3

This issue could affect any components that:
* Implemented `MapEntities`, basically components that contained references to other entities
* Were added to entities from a scene file but weren't defined in the scene file

- Fixes #7529 

## Solution

The solution was to keep track of entities+components that had `MapEntities` functionality during scene load, and only apply the entity update behavior to them. They were tracked with a HashMap from the component's TypeID to a vector of entity ID's. Then the `ReflectMapEntities` struct was updated to hold a function that took a list of entities to be applied to, instead of naively applying itself to all values in the EntityMap. 

(See this PR comment https://github.com/bevyengine/bevy/pull/7570#issuecomment-1432302796 for a story-based explanation of this bug and solution)

## Changelog

### Fixed
- Components that implement `MapEntities` added to scene entities after load are not corrupted during scene reload.