### PR TITLE
Upgrade Taffy to 0.3.4

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -31,7 +31,7 @@ bevy_window = { path = "../bevy_window", version = "0.11.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.11.0-dev" }
 
 # other
-taffy = { version = "0.3.3", default-features = false, features = ["std"] }
+taffy = { version = "0.3.4", default-features = false, features = ["std"] }
 serde = { version = "1", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }


### PR DESCRIPTION
# Objective

Fixes #7952

## Solution

Upgrade Taffy to a new patch version (`v0.3.4`) which does not contain the bug.
