### PR TITLE
Recompute Aabbs for updated Meshes

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -297,7 +297,7 @@ pub fn update_bounds(
     for mesh_event in &mut events {
         match mesh_event {
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
-                let Some(mesh) = meshes.get(&handle) else { continue };
+                let Some(mesh) = meshes.get(handle) else { continue };
                 let Some(aabb) = mesh.compute_aabb() else { continue };
                 changed.insert(handle.id(), aabb);
             }


### PR DESCRIPTION
# Objective
Partially address #4294. This was attempted in #4944 and #5423., but reverted in #5489. `Aabb` components are not updated when the underlying `Mesh` has changed in some way.

## Solution
Recompute their `Aabb` when it's been updated or newly created.

Note: this only addresses when the `Mesh` is updated itself, not when the `Handle<Mesh>` has changed. I attempted to include a `Ref<Handle<Mesh>>::is_changed` check, but that easily added 1+ms on `many_cubes` to do what is basically zero work in that common case. I attempted to parallelize it with `QueryParIter`, which shrunk it down to 360us, but it still was an excessive amount of work for basically nothing. This current implementation only incurs a cost when a Mesh is created or modified.

I view this as a stop gap until we have a form of asset preprocessing that can be used to compute the Aabb offline, or force meshes to be immutable after construction and precompute it's Aabb ahead of time.

---

## Changelog
TODO

## Migration Guide
TODO