### PR TITLE
Dither fix

### DIFF
--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -106,7 +106,6 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
 
 #ifdef TONEMAP_IN_SHADER
         output_color = tone_mapping(output_color);
-#endif
 #ifdef DEBAND_DITHER
     var output_rgb = output_color.rgb;
     output_rgb = powsafe(output_rgb, 1.0 / 2.2);
@@ -115,6 +114,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
     output_rgb = powsafe(output_rgb, 2.2);
     output_color = vec4(output_rgb, output_color.a);
+#endif
 #endif
 #ifdef PREMULTIPLY_ALPHA
         output_color = premultiply_alpha(material.flags, output_color);

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -105,7 +105,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
     }
 
 #ifdef TONEMAP_IN_SHADER
-        output_color = tone_mapping(output_color);
+    output_color = tone_mapping(output_color);
 #ifdef DEBAND_DITHER
     var output_rgb = output_color.rgb;
     output_rgb = powsafe(output_rgb, 1.0 / 2.2);
@@ -117,7 +117,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
 #endif
 #endif
 #ifdef PREMULTIPLY_ALPHA
-        output_color = premultiply_alpha(material.flags, output_color);
+    output_color = premultiply_alpha(material.flags, output_color);
 #endif
     return output_color;
 }

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -270,12 +270,6 @@ fn pbr(
 }
 #endif // NORMAL_PREPASS
 
-#ifdef DEBAND_DITHER
-fn dither(color: vec4<f32>, pos: vec2<f32>) -> vec4<f32> {
-    return vec4<f32>(color.rgb + screen_space_dither(pos.xy), color.a);
-}
-#endif // DEBAND_DITHER
-
 #ifndef NORMAL_PREPASS
 fn apply_fog(input_color: vec4<f32>, fragment_world_position: vec3<f32>, view_world_position: vec3<f32>) -> vec4<f32> {
     let view_to_world = fragment_world_position.xyz - view_world_position.xyz;


### PR DESCRIPTION
- Fixes #7965
- Code quality improvements.
- Removes the unreferenced function `dither` in pbr_functions.wgsl introduced in 72fbcc7, but made obsolete in c069c54.
- Makes the reference to `screen_space_dither` in pbr.wgsl conditional on `#ifdef TONEMAP_IN_SHADER`, as the required import is conditional on the same, as deband dithering can only occur if tonemapping is also occurring.