### PR TITLE
Use derive for default impl of DynamicVariant

### DIFF
--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -8,8 +8,9 @@ use std::any::Any;
 use std::fmt::Formatter;
 
 /// A dynamic representation of an enum variant.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub enum DynamicVariant {
+    #[default]
     Unit,
     Tuple(DynamicTuple),
     Struct(DynamicStruct),
@@ -22,12 +23,6 @@ impl Clone for DynamicVariant {
             DynamicVariant::Tuple(data) => DynamicVariant::Tuple(data.clone_dynamic()),
             DynamicVariant::Struct(data) => DynamicVariant::Struct(data.clone_dynamic()),
         }
-    }
-}
-
-impl Default for DynamicVariant {
-    fn default() -> Self {
-        DynamicVariant::Unit
     }
 }
 


### PR DESCRIPTION
# Objective

In Rust 1.68 (tomorrow), the [derivable_impls](https://rust-lang.github.io/rust-clippy/master/index.html#derivable_impls) lint catches this manual `Default` impl that could be derived.

This seems like the only new lint affecting us.

## Solution

Derive `Default`.