### PR TITLE
Fixed derived reflect outputting incorrect where clause. Fixes #7989

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/from_reflect.rs
@@ -9,6 +9,7 @@ use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::{quote, ToTokens};
 use syn::{Field, Ident, Lit, LitInt, LitStr, Member};
+use bevy::reflect::WhereClauseOptions;
 
 /// Implements `FromReflect` for the given struct
 pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> TokenStream {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -122,13 +122,16 @@ pub(crate) fn extend_where_clause(
     let active_trait_bounds = &where_clause_options.active_trait_bounds;
     let ignored_trait_bounds = &where_clause_options.ignored_trait_bounds;
 
-    let mut generic_where_clause = if where_clause.is_some() {
-        quote! {#where_clause,}
+    let mut generic_where_clause = if let Some(where_clause) = where_clause {
+        // This removes the optional, user-defined trailing comma from the equation
+        let predicates = where_clause.predicates.iter();
+        quote! {where #(#predicates,)*}
     } else if !(active_types.is_empty() && ignored_types.is_empty()) {
         quote! {where}
     } else {
         quote! {}
     };
+    
     generic_where_clause.extend(quote! {
         #(#active_types: #active_trait_bounds,)*
         #(#ignored_types: #ignored_trait_bounds,)*

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -123,7 +123,7 @@ pub(crate) fn extend_where_clause(
     let ignored_trait_bounds = &where_clause_options.ignored_trait_bounds;
 
     let mut generic_where_clause = if where_clause.is_some() {
-        quote! {#where_clause}
+        quote! {#where_clause,}
     } else if !(active_types.is_empty() && ignored_types.is_empty()) {
         quote! {where}
     } else {


### PR DESCRIPTION
# Objective

- Fixes a bug where derived reflect was emitting an incorrect where clause. Specifically, a comma was omitted. Though this fix works for the specific case I had, I'm not sure it is the correct fix in general. Please review the PR changes and ensure this is the correct place where the comma should be appended. 
- Fixes #7989

## Solution

- Added the missing comma in the proc macro utility that builds the where clause. This is the only change.

---

Their is no change or migration required for this fix.