### PR TITLE
Register missing types in bevy_window

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -55,6 +55,8 @@ fn register_rust_types(app: &mut App) {
         .register_type::<OsString>()
         .register_type::<HashSet<String>>()
         .register_type::<Option<String>>()
+        .register_type::<Option<bool>>()
+        .register_type::<Option<f64>>()
         .register_type::<Cow<'static, str>>()
         .register_type::<Duration>()
         .register_type::<Instant>();
@@ -68,6 +70,7 @@ fn register_math_types(app: &mut App) {
         .register_type::<bevy_math::UVec3>()
         .register_type::<bevy_math::UVec4>()
         .register_type::<bevy_math::DVec2>()
+        .register_type::<Option<bevy_math::DVec2>>()
         .register_type::<bevy_math::DVec3>()
         .register_type::<bevy_math::DVec4>()
         .register_type::<bevy_math::BVec2>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -125,9 +125,13 @@ impl Plugin for WindowPlugin {
         // Register window descriptor and related types
         app.register_type::<Window>()
             .register_type::<Cursor>()
+            .register_type::<CursorIcon>()
+            .register_type::<CursorGrabMode>()
+            .register_type::<CompositeAlphaMode>()
             .register_type::<WindowResolution>()
             .register_type::<WindowPosition>()
             .register_type::<WindowMode>()
+            .register_type::<WindowLevel>()
             .register_type::<PresentMode>()
             .register_type::<InternalWindowState>()
             .register_type::<MonitorSelection>()


### PR DESCRIPTION
# Objective

-  Fixes https://github.com/bevyengine/bevy/issues/7990.

## Solution

- Register needed types, verified pasted code in issue works.

Do I need to register more `Option<T>` types?