### PR TITLE
do not set hit test unconditionally on window creation

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -166,11 +166,16 @@ impl WinitWindows {
         }
 
         winit_window.set_cursor_visible(window.cursor.visible);
-        if let Err(err) = winit_window.set_cursor_hittest(window.cursor.hit_test) {
-            warn!(
-                "Could not set cursor hit test for window {:?}: {:?}",
-                window.title, err
-            );
+
+        // Do not set the cursor hittest on window creation if it's false, as it will always fail on some
+        // platforms and log an unfixable warning.
+        if !window.cursor.hit_test {
+            if let Err(err) = winit_window.set_cursor_hittest(window.cursor.hit_test) {
+                warn!(
+                    "Could not set cursor hit test for window {:?}: {:?}",
+                    window.title, err
+                );
+            }
         }
 
         self.entity_to_winit.insert(entity, winit_window.id());


### PR DESCRIPTION
# Objective

- #7966 introduces an unfixable warning on some platforms (wasm, mobile, ...)

## Solution

- Do not set the window hit test if it's the default value
