### PR TITLE
Replace multiple calls to `add_system` with `add_systems`

### DIFF
--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -44,13 +44,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(no));
         for _ in 0..amount {
-            schedule.add_systems((
-                empty.run_if(no),
-                empty.run_if(no),
-                empty.run_if(no),
-                empty.run_if(no),
-                empty.run_if(no),
-            ));
+            schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(no));
         }
         // run once to initialize systems
         schedule.run(&mut world);
@@ -80,13 +74,9 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes_with_query));
         for _ in 0..amount {
-            schedule.add_systems((
-                empty.run_if(yes_with_query),
-                empty.run_if(yes_with_query),
-                empty.run_if(yes_with_query),
-                empty.run_if(yes_with_query),
-                empty.run_if(yes_with_query),
-            ));
+            schedule.add_systems(
+                (empty, empty, empty, empty, empty).distributive_run_if(yes_with_query),
+            );
         }
         // run once to initialize systems
         schedule.run(&mut world);
@@ -113,13 +103,9 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes_with_resource));
         for _ in 0..amount {
-            schedule.add_systems((
-                empty.run_if(yes_with_resource),
-                empty.run_if(yes_with_resource),
-                empty.run_if(yes_with_resource),
-                empty.run_if(yes_with_resource),
-                empty.run_if(yes_with_resource),
-            ));
+            schedule.add_systems(
+                (empty, empty, empty, empty, empty).distributive_run_if(yes_with_resource),
+            );
         }
         // run once to initialize systems
         schedule.run(&mut world);

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -21,12 +21,13 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes));
         for _ in 0..amount {
-            schedule
-                .add_system(empty.run_if(yes))
-                .add_system(empty.run_if(yes))
-                .add_system(empty.run_if(yes))
-                .add_system(empty.run_if(yes))
-                .add_system(empty.run_if(yes));
+            schedule.add_systems((
+                empty.run_if(yes),
+                empty.run_if(yes),
+                empty.run_if(yes),
+                empty.run_if(yes),
+                empty.run_if(yes),
+            ));
         }
         // run once to initialize systems
         schedule.run(&mut world);
@@ -49,12 +50,13 @@ pub fn run_condition_no(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(no));
         for _ in 0..amount {
-            schedule
-                .add_system(empty.run_if(no))
-                .add_system(empty.run_if(no))
-                .add_system(empty.run_if(no))
-                .add_system(empty.run_if(no))
-                .add_system(empty.run_if(no));
+            schedule.add_systems((
+                empty.run_if(no),
+                empty.run_if(no),
+                empty.run_if(no),
+                empty.run_if(no),
+                empty.run_if(no),
+            ));
         }
         // run once to initialize systems
         schedule.run(&mut world);
@@ -84,12 +86,13 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes_with_query));
         for _ in 0..amount {
-            schedule
-                .add_system(empty.run_if(yes_with_query))
-                .add_system(empty.run_if(yes_with_query))
-                .add_system(empty.run_if(yes_with_query))
-                .add_system(empty.run_if(yes_with_query))
-                .add_system(empty.run_if(yes_with_query));
+            schedule.add_systems((
+                empty.run_if(yes_with_query),
+                empty.run_if(yes_with_query),
+                empty.run_if(yes_with_query),
+                empty.run_if(yes_with_query),
+                empty.run_if(yes_with_query),
+            ));
         }
         // run once to initialize systems
         schedule.run(&mut world);
@@ -116,12 +119,13 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes_with_resource));
         for _ in 0..amount {
-            schedule
-                .add_system(empty.run_if(yes_with_resource))
-                .add_system(empty.run_if(yes_with_resource))
-                .add_system(empty.run_if(yes_with_resource))
-                .add_system(empty.run_if(yes_with_resource))
-                .add_system(empty.run_if(yes_with_resource));
+            schedule.add_systems((
+                empty.run_if(yes_with_resource),
+                empty.run_if(yes_with_resource),
+                empty.run_if(yes_with_resource),
+                empty.run_if(yes_with_resource),
+                empty.run_if(yes_with_resource),
+            ));
         }
         // run once to initialize systems
         schedule.run(&mut world);

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -21,13 +21,7 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
         let mut schedule = Schedule::new();
         schedule.add_system(empty.run_if(yes));
         for _ in 0..amount {
-            schedule.add_systems((
-                empty.run_if(yes),
-                empty.run_if(yes),
-                empty.run_if(yes),
-                empty.run_if(yes),
-                empty.run_if(yes),
-            ));
+            schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(yes));
         }
         // run once to initialize systems
         schedule.run(&mut world);

--- a/benches/benches/bevy_ecs/scheduling/running_systems.rs
+++ b/benches/benches/bevy_ecs/scheduling/running_systems.rs
@@ -35,12 +35,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
     for amount in 1..21 {
         let mut schedule = Schedule::new();
         for _ in 0..amount {
-            schedule
-                .add_system(empty)
-                .add_system(empty)
-                .add_system(empty)
-                .add_system(empty)
-                .add_system(empty);
+            schedule.add_systems((empty, empty, empty, empty, empty));
         }
         schedule.run(&mut world);
         group.bench_function(&format!("{:03}_systems", 5 * amount), |bencher| {
@@ -79,9 +74,9 @@ pub fn busy_systems(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
         for system_amount in 0..5 {
             let mut schedule = Schedule::new();
-            schedule.add_system(ab).add_system(cd).add_system(ce);
+            schedule.add_systems((ab, cd, ce));
             for _ in 0..system_amount {
-                schedule.add_system(ab).add_system(cd).add_system(ce);
+                schedule.add_systems((ab, cd, ce));
             }
             schedule.run(&mut world);
             group.bench_function(
@@ -130,9 +125,9 @@ pub fn contrived(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (C(0.0), D(0.0))));
         for system_amount in 0..5 {
             let mut schedule = Schedule::new();
-            schedule.add_system(s_0).add_system(s_1).add_system(s_2);
+            schedule.add_systems((s_0, s_1, s_2));
             for _ in 0..system_amount {
-                schedule.add_system(s_0).add_system(s_1).add_system(s_2);
+                schedule.add_systems((s_0, s_1, s_2));
             }
             schedule.run(&mut world);
             group.bench_function(

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -47,9 +47,7 @@ pub fn schedule(c: &mut Criterion) {
         world.spawn_batch((0..10000).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
 
         let mut schedule = Schedule::new();
-        schedule.add_system(ab);
-        schedule.add_system(cd);
-        schedule.add_system(ce);
+        schedule.add_systems((ab, cd, ce));
         schedule.run(&mut world);
 
         b.iter(move || schedule.run(&mut world));

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -33,8 +33,8 @@ pub mod prelude {
 
 use bevy_ecs::{
     schedule::{
-        apply_system_buffers, IntoSystemConfig, IntoSystemSetConfig, IntoSystemSetConfigs,
-        Schedule, ScheduleLabel, SystemSet,
+        apply_system_buffers, IntoSystemConfig, IntoSystemSetConfigs, Schedule, ScheduleLabel,
+        SystemSet,
     },
     system::Local,
     world::World,

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -205,11 +205,17 @@ impl StartupSet {
             apply_system_buffers.in_base_set(PostStartupFlush),
         ));
 
-        schedule.configure_sets((
-            PreStartup.before(PreStartupFlush),
-            Startup.after(PreStartupFlush).before(StartupFlush),
-            PostStartup.after(StartupFlush).before(PostStartupFlush),
-        ));
+        schedule.configure_sets(
+            (
+                PreStartup,
+                PreStartupFlush,
+                Startup,
+                StartupFlush,
+                PostStartup,
+                PostStartupFlush,
+            )
+                .chain(),
+        );
 
         schedule
     }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -136,11 +136,13 @@ impl CoreSet {
         // Create "stage-like" structure using buffer flushes + ordering
         schedule
             .set_default_base_set(Update)
-            .add_system(apply_system_buffers.in_base_set(FirstFlush))
-            .add_system(apply_system_buffers.in_base_set(PreUpdateFlush))
-            .add_system(apply_system_buffers.in_base_set(UpdateFlush))
-            .add_system(apply_system_buffers.in_base_set(PostUpdateFlush))
-            .add_system(apply_system_buffers.in_base_set(LastFlush))
+            .add_systems((
+                apply_system_buffers.in_base_set(FirstFlush),
+                apply_system_buffers.in_base_set(PreUpdateFlush),
+                apply_system_buffers.in_base_set(UpdateFlush),
+                apply_system_buffers.in_base_set(PostUpdateFlush),
+                apply_system_buffers.in_base_set(LastFlush),
+            ))
             .configure_sets(
                 (
                     First,
@@ -197,13 +199,17 @@ impl StartupSet {
         schedule.set_default_base_set(Startup);
 
         // Create "stage-like" structure using buffer flushes + ordering
-        schedule.add_system(apply_system_buffers.in_base_set(PreStartupFlush));
-        schedule.add_system(apply_system_buffers.in_base_set(StartupFlush));
-        schedule.add_system(apply_system_buffers.in_base_set(PostStartupFlush));
+        schedule.add_systems((
+            apply_system_buffers.in_base_set(PreStartupFlush),
+            apply_system_buffers.in_base_set(StartupFlush),
+            apply_system_buffers.in_base_set(PostStartupFlush),
+        ));
 
-        schedule.configure_set(PreStartup.before(PreStartupFlush));
-        schedule.configure_set(Startup.after(PreStartupFlush).before(StartupFlush));
-        schedule.configure_set(PostStartup.after(StartupFlush).before(PostStartupFlush));
+        schedule.configure_sets((
+            PreStartup.before(PreStartupFlush),
+            Startup.after(PreStartupFlush).before(StartupFlush),
+            PostStartup.after(StartupFlush).before(PostStartupFlush),
+        ));
 
         schedule
     }

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -852,8 +852,10 @@ mod test {
         let mut app = App::new();
         app.insert_resource(assets);
         app.insert_resource(asset_server);
-        app.add_system(free_unused_assets_system.in_set(FreeUnusedAssets));
-        app.add_system(update_asset_storage_system::<PngAsset>.after(FreeUnusedAssets));
+        app.add_systems((
+            free_unused_assets_system.in_set(FreeUnusedAssets),
+            update_asset_storage_system::<PngAsset>.after(FreeUnusedAssets),
+        ));
 
         fn load_asset(path: AssetPath, world: &World) -> HandleUntyped {
             let asset_server = world.resource::<AssetServer>();

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -331,8 +331,10 @@ impl AddAsset for App {
         };
 
         self.insert_resource(assets)
-            .add_system(Assets::<T>::asset_event_system.in_base_set(AssetSet::AssetEvents))
-            .add_system(update_asset_storage_system::<T>.in_base_set(AssetSet::LoadAssets))
+            .add_systems((
+                Assets::<T>::asset_event_system.in_base_set(AssetSet::AssetEvents),
+                update_asset_storage_system::<T>.in_base_set(AssetSet::LoadAssets),
+            ))
             .register_type::<Handle<T>>()
             .add_event::<AssetEvent<T>>()
     }

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -71,10 +71,12 @@ impl Plugin for BloomPlugin {
             .init_resource::<BloomUpsamplingPipeline>()
             .init_resource::<SpecializedRenderPipelines<BloomDownsamplingPipeline>>()
             .init_resource::<SpecializedRenderPipelines<BloomUpsamplingPipeline>>()
-            .add_system(prepare_bloom_textures.in_set(RenderSet::Prepare))
-            .add_system(prepare_downsampling_pipeline.in_set(RenderSet::Prepare))
-            .add_system(prepare_upsampling_pipeline.in_set(RenderSet::Prepare))
-            .add_system(queue_bloom_bind_groups.in_set(RenderSet::Queue));
+            .add_systems((
+                prepare_bloom_textures.in_set(RenderSet::Prepare),
+                prepare_downsampling_pipeline.in_set(RenderSet::Prepare),
+                prepare_upsampling_pipeline.in_set(RenderSet::Prepare),
+                queue_bloom_bind_groups.in_set(RenderSet::Queue),
+            ));
 
         // Add bloom to the 3d render graph
         {

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -52,13 +52,13 @@ impl Plugin for Core2dPlugin {
 
         render_app
             .init_resource::<DrawFunctions<Transparent2d>>()
-            .add_system(extract_core_2d_camera_phases.in_schedule(ExtractSchedule))
-            .add_system(sort_phase_system::<Transparent2d>.in_set(RenderSet::PhaseSort))
-            .add_system(
+            .add_systems((
+                extract_core_2d_camera_phases.in_schedule(ExtractSchedule),
+                sort_phase_system::<Transparent2d>.in_set(RenderSet::PhaseSort),
                 batch_phase_system::<Transparent2d>
                     .after(sort_phase_system::<Transparent2d>)
                     .in_set(RenderSet::PhaseSort),
-            );
+            ));
 
         let pass_node_2d = MainPass2dNode::new(&mut render_app.world);
         let tonemapping = TonemappingNode::new(&mut render_app.world);

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -68,15 +68,15 @@ impl Plugin for Core3dPlugin {
             .init_resource::<DrawFunctions<Opaque3d>>()
             .init_resource::<DrawFunctions<AlphaMask3d>>()
             .init_resource::<DrawFunctions<Transparent3d>>()
-            .add_system(extract_core_3d_camera_phases.in_schedule(ExtractSchedule))
-            .add_system(
+            .add_systems((
+                extract_core_3d_camera_phases.in_schedule(ExtractSchedule),
                 prepare_core_3d_depth_textures
                     .in_set(RenderSet::Prepare)
                     .after(bevy_render::view::prepare_windows),
-            )
-            .add_system(sort_phase_system::<Opaque3d>.in_set(RenderSet::PhaseSort))
-            .add_system(sort_phase_system::<AlphaMask3d>.in_set(RenderSet::PhaseSort))
-            .add_system(sort_phase_system::<Transparent3d>.in_set(RenderSet::PhaseSort));
+                sort_phase_system::<Opaque3d>.in_set(RenderSet::PhaseSort),
+                sort_phase_system::<AlphaMask3d>.in_set(RenderSet::PhaseSort),
+                sort_phase_system::<Transparent3d>.in_set(RenderSet::PhaseSort),
+            ));
 
         let prepass_node = PrepassNode::new(&mut render_app.world);
         let pass_node_3d = MainPass3dNode::new(&mut render_app.world);

--- a/crates/bevy_ecs/examples/change_detection.rs
+++ b/crates/bevy_ecs/examples/change_detection.rs
@@ -21,11 +21,13 @@ fn main() {
 
     // Add systems to the Schedule to execute our app logic
     // We can label our systems to force a specific run-order between some of them
-    schedule.add_system(spawn_entities.in_set(SimulationSystem::Spawn));
-    schedule.add_system(print_counter_when_changed.after(SimulationSystem::Spawn));
-    schedule.add_system(age_all_entities.in_set(SimulationSystem::Age));
-    schedule.add_system(remove_old_entities.after(SimulationSystem::Age));
-    schedule.add_system(print_changed_entities.after(SimulationSystem::Age));
+    schedule.add_systems((
+        spawn_entities.in_set(SimulationSet::Spawn),
+        print_counter_when_changed.after(SimulationSet::Spawn),
+        age_all_entities.in_set(SimulationSet::Age),
+        remove_old_entities.after(SimulationSet::Age),
+        print_changed_entities.after(SimulationSet::Age),
+    ));
 
     // Simulate 10 frames in our world
     for iteration in 1..=10 {
@@ -48,7 +50,7 @@ struct Age {
 
 // System sets can be used to group systems and configured to control relative ordering
 #[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
-enum SimulationSystem {
+enum SimulationSet {
     Spawn,
     Age,
 }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -19,8 +19,10 @@ fn main() {
     schedule.add_system(Events::<MyEvent>::update_system.in_set(FlushEvents));
 
     // Add systems sending and receiving events after the events are flushed.
-    schedule.add_system(sending_system.after(FlushEvents));
-    schedule.add_system(receiving_system.after(sending_system));
+    schedule.add_systems((
+        sending_system.after(FlushEvents),
+        receiving_system.after(sending_system),
+    ));
 
     // Simulate 10 frames of our world
     for iteration in 1..=10 {

--- a/crates/bevy_ecs/examples/resources.rs
+++ b/crates/bevy_ecs/examples/resources.rs
@@ -15,8 +15,7 @@ fn main() {
     let mut schedule = Schedule::default();
 
     // Add systems to increase the counter and to print out the current value
-    schedule.add_system(increase_counter);
-    schedule.add_system(print_counter.after(increase_counter));
+    schedule.add_systems((increase_counter, print_counter).chain());
 
     for iteration in 1..=10 {
         println!("Simulating frame {iteration}/10");

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -127,13 +127,13 @@ mod tests {
 
             world.init_resource::<SystemOrder>();
 
-            schedule.add_system(named_system);
-            schedule.add_system(make_function_system(1).before(named_system));
-            schedule.add_system(
+            schedule.add_systems((
+                named_system,
+                make_function_system(1).before(named_system),
                 make_function_system(0)
                     .after(named_system)
                     .in_set(TestSet::A),
-            );
+            ));
             schedule.run(&mut world);
 
             assert_eq!(world.resource::<SystemOrder>().0, vec![1, u32::MAX, 0]);
@@ -144,12 +144,12 @@ mod tests {
 
             // modify the schedule after it's been initialized and test ordering with sets
             schedule.configure_set(TestSet::A.after(named_system));
-            schedule.add_system(
+            schedule.add_systems((
                 make_function_system(3)
                     .before(TestSet::A)
                     .after(named_system),
-            );
-            schedule.add_system(make_function_system(4).after(TestSet::A));
+                make_function_system(4).after(TestSet::A),
+            ));
             schedule.run(&mut world);
 
             assert_eq!(
@@ -275,10 +275,12 @@ mod tests {
 
             world.init_resource::<Counter>();
 
-            schedule.add_system(counting_system.run_if(|| false).run_if(|| false));
-            schedule.add_system(counting_system.run_if(|| true).run_if(|| false));
-            schedule.add_system(counting_system.run_if(|| false).run_if(|| true));
-            schedule.add_system(counting_system.run_if(|| true).run_if(|| true));
+            schedule.add_systems((
+                counting_system.run_if(|| false).run_if(|| false),
+                counting_system.run_if(|| true).run_if(|| false),
+                counting_system.run_if(|| false).run_if(|| true),
+                counting_system.run_if(|| true).run_if(|| true),
+            ));
 
             schedule.run(&mut world);
             assert_eq!(world.resource::<Counter>().0.load(Ordering::Relaxed), 1);
@@ -535,8 +537,7 @@ mod tests {
             let mut schedule = Schedule::new();
 
             // Schedule `bar` to run after `foo`.
-            schedule.add_system(foo);
-            schedule.add_system(bar.after(foo));
+            schedule.add_systems((foo, bar.after(foo)));
 
             // There's only one `foo`, so it's fine.
             let result = schedule.initialize(&mut world);
@@ -790,8 +791,10 @@ mod tests {
             schedule
                 .set_default_base_set(Base::A)
                 .configure_set(Base::A.before(Base::B))
-                .add_system(make_function_system(0).in_base_set(Base::B))
-                .add_system(make_function_system(1));
+                .add_systems((
+                    make_function_system(0).in_base_set(Base::B),
+                    make_function_system(1),
+                ));
             schedule.run(&mut world);
 
             assert_eq!(world.resource::<SystemOrder>().0, vec![1, 0]);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -57,12 +57,11 @@
 //! # use bevy_ecs::prelude::*;
 //! # let mut app = Schedule::new();
 //! // Prints "Hello, World!" each frame.
-//! app
-//!     .add_systems((
-//!         print_first.before(print_mid),
-//!         print_mid,
-//!         print_last.after(print_mid),
-//!     ));
+//! app.add_systems((
+//!     print_first.before(print_mid),
+//!     print_mid,
+//!     print_last.after(print_mid),
+//! ));
 //! # let mut world = World::new();
 //! # app.run(&mut world);
 //!

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -335,11 +335,7 @@ mod tests {
 
         let mut schedule = Schedule::default();
 
-        schedule.add_systems((
-            incr_e_on_flip,
-            apply_system_buffers.after(incr_e_on_flip),
-            World::clear_trackers.after(apply_system_buffers),
-        ));
+        schedule.add_systems((incr_e_on_flip, apply_system_buffers, World::clear_trackers).chain());
 
         schedule.run(&mut world);
         assert_eq!(world.resource::<Added>().0, 1);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -58,9 +58,11 @@
 //! # let mut app = Schedule::new();
 //! // Prints "Hello, World!" each frame.
 //! app
-//!     .add_system(print_first.before(print_mid))
-//!     .add_system(print_mid)
-//!     .add_system(print_last.after(print_mid));
+//!     .add_systems((
+//!         print_first.before(print_mid),
+//!         print_mid,
+//!         print_last.after(print_mid),
+//!     ));
 //! # let mut world = World::new();
 //! # app.run(&mut world);
 //!
@@ -334,9 +336,11 @@ mod tests {
 
         let mut schedule = Schedule::default();
 
-        schedule.add_system(incr_e_on_flip);
-        schedule.add_system(apply_system_buffers.after(incr_e_on_flip));
-        schedule.add_system(World::clear_trackers.after(apply_system_buffers));
+        schedule.add_systems((
+            incr_e_on_flip,
+            apply_system_buffers.after(incr_e_on_flip),
+            World::clear_trackers.after(apply_system_buffers),
+        ));
 
         schedule.run(&mut world);
         assert_eq!(world.resource::<Added>().0, 1);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -163,7 +163,7 @@ mod tests {
         prelude::AnyOf,
         query::{Added, Changed, Or, With, Without},
         removal_detection::RemovedComponents,
-        schedule::{apply_system_buffers, IntoSystemConfig, Schedule},
+        schedule::{apply_system_buffers, IntoSystemConfigs, Schedule},
         system::{
             Commands, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query, QueryComponentError,
             Res, ResMut, Resource, System, SystemState,

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -55,15 +55,18 @@
 //!
 //! ```
 //! # use bevy_ecs::prelude::*;
-//! # let mut app = Schedule::new();
-//! // Prints "Hello, World!" each frame.
-//! app.add_systems((
-//!     print_first.before(print_mid),
-//!     print_mid,
-//!     print_last.after(print_mid),
-//! ));
+//! # let mut schedule = Schedule::new();
 //! # let mut world = World::new();
-//! # app.run(&mut world);
+//! // Configure these systems to run in order using `chain()`.
+//! schedule.add_systems((print_first, print_last).chain());
+//! // Prints "HelloWorld!"
+//! schedule.run(&mut world);
+//!
+//! // Configure this system to run in between the other two systems
+//! // using explicit dependencies.
+//! schedule.add_system(print_mid.after(print_first).before(print_last));
+//! // Prints "Hello, World!"
+//! schedule.run(&mut world);
 //!
 //! fn print_first() {
 //!     print!("Hello");

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -402,8 +402,7 @@ impl_param_set!();
 ///     resource.value = 0;
 ///     assert_eq!(resource.value, 0);
 /// }
-/// # schedule.add_system(read_resource_system);
-/// # schedule.add_system(write_resource_system.after(read_resource_system));
+/// # schedule.add_systems((read_resource_system, write_resource_system).chain());
 /// # schedule.run(&mut world);
 /// ```
 pub trait Resource: Send + Sync + 'static {}
@@ -867,10 +866,8 @@ pub trait SystemBuffer: FromWorld + Send + 'static {
 /// });
 ///
 /// let mut schedule = Schedule::new();
-/// schedule
-///     // These two systems have no conflicts and will run in parallel.
-///     .add_system(alert_criminal)
-///     .add_system(alert_monster);
+/// // These two systems have no conflicts and will run in parallel.
+/// schedule.add_systems((alert_criminal, alert_monster));
 ///
 /// // There are no criminals or monsters, so the alarm is not sounded.
 /// schedule.run(&mut world);

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -18,7 +18,7 @@ note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
   |
 7 | #[derive(WorldQuery)]
-  |          ^^^^^^^^^^ required by this bound in `_::assert_readonly`
+  |          ^^^^^^^^^^ required by this bound in `assert_readonly`
   = note: this error originates in the derive macro `WorldQuery` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfied
@@ -41,5 +41,5 @@ note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10
    |
 18 | #[derive(WorldQuery)]
-   |          ^^^^^^^^^^ required by this bound in `_::assert_readonly`
+   |          ^^^^^^^^^^ required by this bound in `assert_readonly`
    = note: this error originates in the derive macro `WorldQuery` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -199,14 +199,14 @@ where
                 .init_resource::<ExtractedMaterials<M>>()
                 .init_resource::<RenderMaterials<M>>()
                 .init_resource::<SpecializedMeshPipelines<MaterialPipeline<M>>>()
-                .add_system(extract_materials::<M>.in_schedule(ExtractSchedule))
-                .add_system(
+                .add_systems((
+                    extract_materials::<M>.in_schedule(ExtractSchedule),
                     prepare_materials::<M>
                         .in_set(RenderSet::Prepare)
                         .after(PrepareAssetSet::PreAssetPrepare),
-                )
-                .add_system(render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows))
-                .add_system(queue_material_meshes::<M>.in_set(RenderSet::Queue));
+                    render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows),
+                    queue_material_meshes::<M>.in_set(RenderSet::Queue),
+                ));
         }
 
         // PrepassPipelinePlugin is required for shadow mapping and the optional PrepassPlugin

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -129,15 +129,15 @@ where
         };
 
         render_app
-            .add_system(extract_camera_prepass_phase.in_schedule(ExtractSchedule))
-            .add_system(
+            .add_systems((
+                extract_camera_prepass_phase.in_schedule(ExtractSchedule),
                 prepare_prepass_textures
                     .in_set(RenderSet::Prepare)
                     .after(bevy_render::view::prepare_windows),
-            )
-            .add_system(queue_prepass_material_meshes::<M>.in_set(RenderSet::Queue))
-            .add_system(sort_phase_system::<Opaque3dPrepass>.in_set(RenderSet::PhaseSort))
-            .add_system(sort_phase_system::<AlphaMask3dPrepass>.in_set(RenderSet::PhaseSort))
+                queue_prepass_material_meshes::<M>.in_set(RenderSet::Queue),
+                sort_phase_system::<Opaque3dPrepass>.in_set(RenderSet::PhaseSort),
+                sort_phase_system::<AlphaMask3dPrepass>.in_set(RenderSet::PhaseSort),
+            ))
             .init_resource::<DrawFunctions<Opaque3dPrepass>>()
             .init_resource::<DrawFunctions<AlphaMask3dPrepass>>()
             .add_render_command::<Opaque3dPrepass, DrawPrepass<M>>()

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -108,9 +108,11 @@ impl Plugin for MeshRenderPlugin {
                 .init_resource::<MeshPipeline>()
                 .init_resource::<SkinnedMeshUniform>()
                 .add_systems((extract_meshes, extract_skinned_meshes).in_schedule(ExtractSchedule))
-                .add_system(prepare_skinned_meshes.in_set(RenderSet::Prepare))
-                .add_system(queue_mesh_bind_group.in_set(RenderSet::Queue))
-                .add_system(queue_mesh_view_bind_groups.in_set(RenderSet::Queue));
+                .add_systems((
+                    prepare_skinned_meshes.in_set(RenderSet::Prepare),
+                    queue_mesh_bind_group.in_set(RenderSet::Queue),
+                    queue_mesh_view_bind_groups.in_set(RenderSet::Queue),
+                ));
         }
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -120,14 +120,22 @@ impl RenderSet {
             apply_system_buffers.in_set(CleanupFlush),
         ));
 
-        schedule.configure_sets((
-            ExtractCommands.before(Prepare),
-            Prepare.after(ExtractCommands).before(PrepareFlush),
-            Queue.after(PrepareFlush).before(QueueFlush),
-            PhaseSort.after(QueueFlush).before(PhaseSortFlush),
-            Render.after(PhaseSortFlush).before(RenderFlush),
-            Cleanup.after(RenderFlush).before(CleanupFlush),
-        ));
+        schedule.configure_sets(
+            (
+                ExtractCommands,
+                Prepare,
+                PrepareFlush,
+                Queue,
+                QueueFlush,
+                PhaseSort,
+                PhaseSortFlush,
+                Render,
+                RenderFlush,
+                Cleanup,
+                CleanupFlush,
+            )
+                .chain(),
+        );
 
         schedule
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -112,18 +112,22 @@ impl RenderSet {
         let mut schedule = Schedule::new();
 
         // Create "stage-like" structure using buffer flushes + ordering
-        schedule.add_system(apply_system_buffers.in_set(PrepareFlush));
-        schedule.add_system(apply_system_buffers.in_set(QueueFlush));
-        schedule.add_system(apply_system_buffers.in_set(PhaseSortFlush));
-        schedule.add_system(apply_system_buffers.in_set(RenderFlush));
-        schedule.add_system(apply_system_buffers.in_set(CleanupFlush));
+        schedule.add_systems((
+            apply_system_buffers.in_set(PrepareFlush),
+            apply_system_buffers.in_set(QueueFlush),
+            apply_system_buffers.in_set(PhaseSortFlush),
+            apply_system_buffers.in_set(RenderFlush),
+            apply_system_buffers.in_set(CleanupFlush),
+        ));
 
-        schedule.configure_set(ExtractCommands.before(Prepare));
-        schedule.configure_set(Prepare.after(ExtractCommands).before(PrepareFlush));
-        schedule.configure_set(Queue.after(PrepareFlush).before(QueueFlush));
-        schedule.configure_set(PhaseSort.after(QueueFlush).before(PhaseSortFlush));
-        schedule.configure_set(Render.after(PhaseSortFlush).before(RenderFlush));
-        schedule.configure_set(Cleanup.after(RenderFlush).before(CleanupFlush));
+        schedule.configure_sets((
+            ExtractCommands.before(Prepare),
+            Prepare.after(ExtractCommands).before(PrepareFlush),
+            Queue.after(PrepareFlush).before(QueueFlush),
+            PhaseSort.after(QueueFlush).before(PhaseSortFlush),
+            Render.after(PhaseSortFlush).before(RenderFlush),
+            Cleanup.after(RenderFlush).before(CleanupFlush),
+        ));
 
         schedule
     }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -92,8 +92,10 @@ impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
                 .init_resource::<ExtractedAssets<A>>()
                 .init_resource::<RenderAssets<A>>()
                 .init_resource::<PrepareNextFrameAssets<A>>()
-                .add_system(extract_render_asset::<A>.in_schedule(ExtractSchedule))
-                .add_system(prepare_assets::<A>.in_set(self.prepare_asset_set.clone()));
+                .add_systems((
+                    extract_render_asset::<A>.in_schedule(ExtractSchedule),
+                    prepare_assets::<A>.in_set(self.prepare_asset_set.clone()),
+                ));
         }
     }
 }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -56,13 +56,13 @@ impl Plugin for ViewPlugin {
             render_app
                 .init_resource::<ViewUniforms>()
                 .configure_set(ViewSet::PrepareUniforms.in_set(RenderSet::Prepare))
-                .add_system(prepare_view_uniforms.in_set(ViewSet::PrepareUniforms))
-                .add_system(
+                .add_systems((
+                    prepare_view_uniforms.in_set(ViewSet::PrepareUniforms),
                     prepare_view_targets
                         .after(WindowSystem::Prepare)
                         .in_set(RenderSet::Prepare)
                         .after(crate::render_asset::prepare_assets::<Image>),
-                );
+                ));
         }
     }
 }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -223,8 +223,8 @@ impl Plugin for VisibilityPlugin {
             .configure_set(UpdateProjectionFrusta.in_base_set(CoreSet::PostUpdate))
             .configure_set(CheckVisibility.in_base_set(CoreSet::PostUpdate))
             .configure_set(VisibilityPropagate.in_base_set(CoreSet::PostUpdate))
-            .add_system(calculate_bounds.in_set(CalculateBounds))
-            .add_system(
+            .add_systems((
+                calculate_bounds.in_set(CalculateBounds),
                 update_frusta::<OrthographicProjection>
                     .in_set(UpdateOrthographicFrusta)
                     .after(camera_system::<OrthographicProjection>)
@@ -234,8 +234,6 @@ impl Plugin for VisibilityPlugin {
                     // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
                     .ambiguous_with(update_frusta::<PerspectiveProjection>)
                     .ambiguous_with(update_frusta::<Projection>),
-            )
-            .add_system(
                 update_frusta::<PerspectiveProjection>
                     .in_set(UpdatePerspectiveFrusta)
                     .after(camera_system::<PerspectiveProjection>)
@@ -244,15 +242,11 @@ impl Plugin for VisibilityPlugin {
                     // so these systems will run independently of one another.
                     // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
                     .ambiguous_with(update_frusta::<Projection>),
-            )
-            .add_system(
                 update_frusta::<Projection>
                     .in_set(UpdateProjectionFrusta)
                     .after(camera_system::<Projection>)
                     .after(TransformSystem::TransformPropagate),
-            )
-            .add_system(visibility_propagate_system.in_set(VisibilityPropagate))
-            .add_system(
+                visibility_propagate_system.in_set(VisibilityPropagate),
                 check_visibility
                     .in_set(CheckVisibility)
                     .after(CalculateBoundsFlush)
@@ -261,7 +255,7 @@ impl Plugin for VisibilityPlugin {
                     .after(UpdateProjectionFrusta)
                     .after(VisibilityPropagate)
                     .after(TransformSystem::TransformPropagate),
-            );
+            ));
     }
 }
 

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -161,13 +161,13 @@ where
                 .init_resource::<ExtractedMaterials2d<M>>()
                 .init_resource::<RenderMaterials2d<M>>()
                 .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .add_system(extract_materials_2d::<M>.in_schedule(ExtractSchedule))
-                .add_system(
+                .add_systems((
+                    extract_materials_2d::<M>.in_schedule(ExtractSchedule),
                     prepare_materials_2d::<M>
                         .in_set(RenderSet::Prepare)
                         .after(PrepareAssetSet::PreAssetPrepare),
-                )
-                .add_system(queue_material2d_meshes::<M>.in_set(RenderSet::Queue));
+                    queue_material2d_meshes::<M>.in_set(RenderSet::Queue),
+                ));
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -103,9 +103,11 @@ impl Plugin for Mesh2dRenderPlugin {
             render_app
                 .init_resource::<Mesh2dPipeline>()
                 .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
-                .add_system(extract_mesh2d.in_schedule(ExtractSchedule))
-                .add_system(queue_mesh2d_bind_group.in_set(RenderSet::Queue))
-                .add_system(queue_mesh2d_view_bind_groups.in_set(RenderSet::Queue));
+                .add_systems((
+                    extract_mesh2d.in_schedule(ExtractSchedule),
+                    queue_mesh2d_bind_group.in_set(RenderSet::Queue),
+                    queue_mesh2d_view_bind_groups.in_set(RenderSet::Queue),
+                ));
         }
     }
 }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -106,20 +106,20 @@ impl Plugin for TransformPlugin {
                     TransformSystem::TransformPropagate.in_base_set(StartupSet::PostStartup),
                 );
             })
-            // FIXME: https://github.com/bevyengine/bevy/issues/4381
-            // These systems cannot access the same entities,
-            // due to subtle query filtering that is not yet correctly computed in the ambiguity detector
-            .add_startup_system(
+            .add_startup_systems((
+                sync_simple_transforms
+                    .in_set(TransformSystem::TransformPropagate)
+                    // FIXME: https://github.com/bevyengine/bevy/issues/4381
+                    // These systems cannot access the same entities,
+                    // due to subtle query filtering that is not yet correctly computed in the ambiguity detector
+                    .ambiguous_with(PropagateTransformsSet),
+                propagate_transforms.in_set(PropagateTransformsSet),
+            ))
+            .add_systems((
                 sync_simple_transforms
                     .in_set(TransformSystem::TransformPropagate)
                     .ambiguous_with(PropagateTransformsSet),
-            )
-            .add_startup_system(propagate_transforms.in_set(PropagateTransformsSet))
-            .add_system(
-                sync_simple_transforms
-                    .in_set(TransformSystem::TransformPropagate)
-                    .ambiguous_with(PropagateTransformsSet),
-            )
-            .add_system(propagate_transforms.in_set(PropagateTransformsSet));
+                propagate_transforms.in_set(PropagateTransformsSet),
+            ));
     }
 }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -171,8 +171,7 @@ mod test {
         let mut world = World::default();
 
         let mut schedule = Schedule::new();
-        schedule.add_system(sync_simple_transforms);
-        schedule.add_system(propagate_transforms);
+        schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
         world.spawn(TransformBundle::from(Transform::from_xyz(1.0, 0.0, 0.0)));
@@ -210,8 +209,7 @@ mod test {
         let mut world = World::default();
 
         let mut schedule = Schedule::new();
-        schedule.add_system(sync_simple_transforms);
-        schedule.add_system(propagate_transforms);
+        schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
         let mut queue = CommandQueue::default();
@@ -251,8 +249,7 @@ mod test {
         let mut world = World::default();
 
         let mut schedule = Schedule::new();
-        schedule.add_system(sync_simple_transforms);
-        schedule.add_system(propagate_transforms);
+        schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Add parent entities
         let mut children = Vec::new();
@@ -328,8 +325,7 @@ mod test {
         let mut app = App::new();
         ComputeTaskPool::init(TaskPool::default);
 
-        app.add_system(sync_simple_transforms);
-        app.add_system(propagate_transforms);
+        app.add_systems((sync_simple_transforms, propagate_transforms));
 
         let translation = vec3(1.0, 0.0, 0.0);
 
@@ -375,8 +371,7 @@ mod test {
         let mut temp = World::new();
         let mut app = App::new();
 
-        app.add_system(propagate_transforms)
-            .add_system(sync_simple_transforms);
+        app.add_systems((propagate_transforms, sync_simple_transforms));
 
         fn setup_world(world: &mut World) -> (Entity, Entity) {
             let mut grandchild = Entity::from_raw(0);

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -149,9 +149,6 @@ pub(crate) struct AccessibilityPlugin;
 
 impl Plugin for AccessibilityPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(calc_bounds)
-            .add_system(button_changed)
-            .add_system(image_changed)
-            .add_system(label_changed);
+        app.add_systems((calc_bounds, button_changed, image_changed, label_changed));
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -141,17 +141,15 @@ impl Plugin for UiPlugin {
 
             system
         })
-        .add_system(
+        .add_systems((
             flex_node_system
                 .in_set(UiSystem::Flex)
                 .before(TransformSystem::TransformPropagate),
-        )
-        .add_system(ui_stack_system.in_set(UiSystem::Stack))
-        .add_system(
+            ui_stack_system.in_set(UiSystem::Stack),
             update_clipping_system
                 .after(TransformSystem::TransformPropagate)
                 .in_base_set(CoreSet::PostUpdate),
-        );
+        ));
 
         crate::render::build_ui_render(app);
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -86,9 +86,11 @@ pub fn build_ui_render(app: &mut App) {
             )
                 .in_schedule(ExtractSchedule),
         )
-        .add_system(prepare_uinodes.in_set(RenderSet::Prepare))
-        .add_system(queue_uinodes.in_set(RenderSet::Queue))
-        .add_system(sort_phase_system::<TransparentUi>.in_set(RenderSet::PhaseSort));
+        .add_systems((
+            prepare_uinodes.in_set(RenderSet::Prepare),
+            queue_uinodes.in_set(RenderSet::Queue),
+            sort_phase_system::<TransparentUi>.in_set(RenderSet::PhaseSort),
+        ));
 
     // Render graph
     let ui_graph_2d = get_ui_graph(render_app);

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -163,9 +163,11 @@ impl Plugin for AccessibilityPlugin {
         app.init_non_send_resource::<AccessKitAdapters>()
             .init_resource::<WinitActionHandlers>()
             .add_event::<ActionRequest>()
-            .add_system(handle_window_focus)
-            .add_system(window_closed)
-            .add_system(poll_receivers)
-            .add_system(update_accessibility_nodes);
+            .add_systems((
+                handle_window_focus,
+                window_closed,
+                poll_receivers,
+                update_accessibility_nodes,
+            ));
     }
 }

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -13,8 +13,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::DARK_GRAY))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(update_bloom_settings)
+        .add_systems((setup.on_startup(), update_bloom_settings))
         .run();
 }
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -283,8 +283,10 @@ impl Plugin for ColoredMesh2dPlugin {
             .add_render_command::<Transparent2d, DrawColoredMesh2d>()
             .init_resource::<ColoredMesh2dPipeline>()
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
-            .add_system(extract_colored_mesh2d.in_schedule(ExtractSchedule))
-            .add_system(queue_colored_mesh2d.in_set(RenderSet::Queue));
+            .add_systems((
+                extract_colored_mesh2d.in_schedule(ExtractSchedule),
+                queue_colored_mesh2d.in_set(RenderSet::Queue),
+            ));
     }
 }
 

--- a/examples/2d/move_sprite.rs
+++ b/examples/2d/move_sprite.rs
@@ -5,8 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(sprite_movement)
+        .add_systems((setup.on_startup(), sprite_movement))
         .run();
 }
 

--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -5,8 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_startup_system(setup)
-        .add_system(sprite_movement)
+        .add_systems((setup.on_startup(), sprite_movement))
         .run();
 }
 

--- a/examples/2d/sprite_sheet.rs
+++ b/examples/2d/sprite_sheet.rs
@@ -6,8 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
-        .add_startup_system(setup)
-        .add_system(animate_sprite)
+        .add_systems((setup.on_startup(), animate_sprite))
         .run();
 }
 

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -13,10 +13,12 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(animate_translation)
-        .add_system(animate_rotation)
-        .add_system(animate_scale)
+        .add_systems((
+            setup.on_startup(),
+            animate_translation,
+            animate_rotation,
+            animate_scale,
+        ))
         .run();
 }
 

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -8,9 +8,11 @@ fn main() {
         .init_resource::<RpgSpriteHandles>()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest())) // prevents blurry sprites
         .add_state::<AppState>()
-        .add_system(load_textures.in_schedule(OnEnter(AppState::Setup)))
-        .add_system(check_textures.in_set(OnUpdate(AppState::Setup)))
-        .add_system(setup.in_schedule(OnEnter(AppState::Finished)))
+        .add_systems((
+            load_textures.in_schedule(OnEnter(AppState::Setup)),
+            check_textures.in_set(OnUpdate(AppState::Setup)),
+            setup.in_schedule(OnEnter(AppState::Finished)),
+        ))
         .run();
 }
 

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -11,8 +11,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
-        .add_startup_system(setup)
-        .add_system(rotate)
+        .add_systems((setup.on_startup(), rotate))
         .run();
 }
 

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -15,9 +15,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera_fog)
-        .add_startup_system(setup_terrain_scene)
-        .add_startup_system(setup_instructions)
+        .add_startup_systems((setup_camera_fog, setup_terrain_scene, setup_instructions))
         .add_system(toggle_system)
         .run();
 }

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -17,8 +17,7 @@ fn main() {
     let mut app = App::new();
 
     app.add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(example_control_system);
+        .add_systems((setup.on_startup(), example_control_system));
 
     // Unfortunately, MSAA and HDR are not supported simultaneously under WebGL.
     // Since this example uses HDR, we must disable MSAA for WASM builds, at least

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -16,9 +16,11 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::DARK_GRAY))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_scene)
-        .add_system(update_bloom_settings)
-        .add_system(bounce_spheres)
+        .add_systems((
+            setup_scene.on_startup(),
+            update_bloom_settings,
+            bounce_spheres,
+        ))
         .run();
 }
 

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -22,9 +22,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera_fog)
-        .add_startup_system(setup_pyramid_scene)
-        .add_startup_system(setup_instructions)
+        .add_startup_systems((setup_camera_fog, setup_pyramid_scene, setup_instructions))
         .add_system(update_system)
         .run();
 }

--- a/examples/3d/fxaa.rs
+++ b/examples/3d/fxaa.rs
@@ -17,8 +17,7 @@ fn main() {
         // Disable MSAA by default
         .insert_resource(Msaa::Off)
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(toggle_fxaa)
+        .add_systems((setup.on_startup(), toggle_fxaa))
         .run();
 }
 

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -8,9 +8,7 @@ use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(movement)
-        .add_system(animate_light_direction)
+        .add_systems((setup.on_startup(), movement, animate_light_direction))
         .run();
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -15,8 +15,7 @@ fn main() {
         })
         .insert_resource(DirectionalLightShadowMap { size: 4096 })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(animate_light_direction)
+        .add_systems((setup.on_startup(), animate_light_direction))
         .run();
 }
 

--- a/examples/3d/msaa.rs
+++ b/examples/3d/msaa.rs
@@ -10,8 +10,7 @@ fn main() {
     App::new()
         .insert_resource(Msaa::default())
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(cycle_msaa)
+        .add_systems((setup.on_startup(), cycle_msaa))
         .run();
 }
 

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -6,8 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotator_system)
+        .add_systems((setup.on_startup(), rotator_system))
         .run();
 }
 

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -5,8 +5,7 @@ use bevy::{asset::LoadState, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(environment_map_load_finish)
+        .add_systems((setup.on_startup(), environment_map_load_finish))
         .run();
 }
 

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -17,9 +17,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(cube_rotator_system)
-        .add_system(rotator_system)
+        .add_systems((setup.on_startup(), cube_rotator_system, rotator_system))
         .run();
 }
 

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -19,11 +19,13 @@ fn main() {
     );
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(adjust_point_light_biases)
-        .add_system(toggle_light)
-        .add_system(adjust_directional_light_biases)
-        .add_system(camera_controller)
+        .add_systems((
+            setup.on_startup(),
+            adjust_point_light_biases,
+            toggle_light,
+            adjust_directional_light_biases,
+            camera_controller,
+        ))
         .run();
 }
 

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -16,9 +16,7 @@ fn main() {
     );
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(toggle_light)
-        .add_system(toggle_shadows)
+        .add_systems((setup.on_startup(), toggle_light, toggle_shadows))
         .run();
 }
 

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -46,11 +46,13 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CubemapMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(cycle_cubemap_asset)
-        .add_system(asset_loaded.after(cycle_cubemap_asset))
-        .add_system(camera_controller)
-        .add_system(animate_light_direction)
+        .add_systems((
+            setup.on_startup(),
+            cycle_cubemap_asset,
+            asset_loaded.after(cycle_cubemap_asset),
+            camera_controller,
+            animate_light_direction,
+        ))
         .run();
 }
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -10,8 +10,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(set_camera_viewports)
+        .add_systems((setup.on_startup(), set_camera_viewports))
         .run();
 }
 

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -12,9 +12,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(light_sway)
-        .add_system(movement)
+        .add_systems((setup.on_startup(), light_sway, movement))
         .run();
 }
 

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -27,15 +27,19 @@ fn main() {
         .init_resource::<PerMethodSettings>()
         .insert_resource(CurrentScene(1))
         .insert_resource(SelectedParameter { value: 0, max: 4 })
-        .add_startup_system(setup)
-        .add_startup_system(setup_basic_scene)
-        .add_startup_system(setup_color_gradient_scene)
-        .add_startup_system(setup_image_viewer_scene)
-        .add_system(update_image_viewer)
-        .add_system(toggle_scene)
-        .add_system(toggle_tonemapping_method)
-        .add_system(update_color_grading_settings)
-        .add_system(update_ui)
+        .add_startup_systems((
+            setup,
+            setup_basic_scene,
+            setup_color_gradient_scene,
+            setup_image_viewer_scene,
+        ))
+        .add_systems((
+            update_image_viewer,
+            toggle_scene,
+            toggle_tonemapping_method,
+            update_color_grading_settings,
+            update_ui,
+        ))
         .run();
 }
 

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -6,8 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(move_scene_entities)
+        .add_systems((setup.on_startup(), move_scene_entities))
         .run();
 }
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -13,9 +13,11 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
-        .add_system(setup_scene_once_loaded)
-        .add_system(keyboard_animation_control)
+        .add_systems((
+            setup.on_startup(),
+            setup_scene_once_loaded,
+            keyboard_animation_control,
+        ))
         .run();
 }
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -20,8 +20,7 @@ fn main() {
             brightness: 1.0,
             ..default()
         })
-        .add_startup_system(setup)
-        .add_system(joint_animation)
+        .add_systems((setup.on_startup(), joint_animation))
         .run();
 }
 

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -12,8 +12,7 @@ fn main() {
             brightness: 1.0,
             ..default()
         })
-        .add_startup_system(setup)
-        .add_system(joint_animation)
+        .add_systems((setup.on_startup(), joint_animation))
         .run();
 }
 

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -41,8 +41,7 @@ fn main() {
         .init_resource::<State>()
         .add_asset::<CustomAsset>()
         .init_asset_loader::<CustomAssetLoader>()
-        .add_startup_system(setup)
-        .add_system(print_on_load)
+        .add_systems((setup.on_startup(), print_on_load))
         .run();
 }
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -12,9 +12,7 @@ use std::time::{Duration, Instant};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_env)
-        .add_startup_system(add_assets)
-        .add_startup_system(spawn_tasks)
+        .add_startup_systems((setup_env, add_assets, spawn_tasks))
         .add_system(handle_tasks)
         .run();
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -10,10 +10,7 @@ fn main() {
     App::new()
         .add_event::<StreamEvent>()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(read_stream)
-        .add_system(spawn_text)
-        .add_system(move_text)
+        .add_systems((setup.on_startup(), read_stream, spawn_text, move_text))
         .run();
 }
 

--- a/examples/audio/audio_control.rs
+++ b/examples/audio/audio_control.rs
@@ -5,10 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(update_speed)
-        .add_system(pause)
-        .add_system(volume)
+        .add_systems((setup.on_startup(), update_speed, pause, volume))
         .run();
 }
 

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -4,8 +4,7 @@ use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(update_positions)
+        .add_systems((setup.on_startup(), update_positions))
         .run();
 }
 

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -4,8 +4,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(update_positions)
+        .add_systems((setup.on_startup(), update_positions))
         .run();
 }
 

--- a/examples/diagnostics/custom_diagnostic.rs
+++ b/examples/diagnostics/custom_diagnostic.rs
@@ -11,8 +11,7 @@ fn main() {
         // The "print diagnostics" plugin is optional.
         // It just visualizes our diagnostics in the console.
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup_diagnostic_system)
-        .add_system(my_system)
+        .add_systems((setup_diagnostic_system.on_startup(), my_system))
         .run();
 }
 

--- a/examples/ecs/apply_system_buffers.rs
+++ b/examples/ecs/apply_system_buffers.rs
@@ -15,12 +15,14 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_resource::<Timers>()
-        .add_startup_system(setup)
-        .add_system(despawn_old_and_spawn_new_fruits.before(CustomFlush))
-        .add_system(apply_system_buffers.in_set(CustomFlush))
-        .add_system(count_apple.after(CustomFlush))
-        .add_system(count_orange)
-        .add_system(bevy::window::close_on_esc)
+        .add_systems((
+            setup.on_startup(),
+            despawn_old_and_spawn_new_fruits.before(CustomFlush),
+            apply_system_buffers.in_set(CustomFlush),
+            count_apple.after(CustomFlush),
+            count_orange,
+            bevy::window::close_on_esc,
+        ))
         .run();
 }
 

--- a/examples/ecs/component_change_detection.rs
+++ b/examples/ecs/component_change_detection.rs
@@ -6,10 +6,12 @@ use rand::Rng;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(change_component)
-        .add_system(change_detection)
-        .add_system(tracker_monitoring)
+        .add_systems((
+            setup.on_startup(),
+            change_component,
+            change_detection,
+            tracker_monitoring,
+        ))
         .run();
 }
 

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -18,10 +18,15 @@ use std::fmt::Debug;
 fn main() {
     App::new()
         .add_startup_system(spawn)
-        .add_system(print_components_read_only)
-        .add_system(print_components_iter_mut.after(print_components_read_only))
-        .add_system(print_components_iter.after(print_components_iter_mut))
-        .add_system(print_components_tuple.after(print_components_iter))
+        .add_systems(
+            (
+                print_components_read_only,
+                print_components_iter_mut,
+                print_components_iter,
+                print_components_tuple,
+            )
+                .chain(),
+        )
         .run();
 }
 

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -9,9 +9,7 @@ fn main() {
         .add_event::<MyEvent>()
         .add_event::<PlaySound>()
         .init_resource::<EventTriggerState>()
-        .add_system(event_trigger)
-        .add_system(event_listener)
-        .add_system(sound_player)
+        .add_systems((event_trigger, event_listener, sound_player))
         .run();
 }
 

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -6,10 +6,12 @@ const FIXED_TIMESTEP: f32 = 0.5;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // this system will run once every update (it should match your screen's refresh rate)
-        .add_system(frame_update)
-        // add our system to the fixed timestep schedule
-        .add_system(fixed_update.in_schedule(CoreSchedule::FixedUpdate))
+        .add_systems((
+            // this system will run once every update (it should match your screen's refresh rate)
+            frame_update,
+            // add our system to the fixed timestep schedule
+            fixed_update.in_schedule(CoreSchedule::FixedUpdate),
+        ))
         // configure our fixed timestep schedule to run twice a second
         .insert_resource(FixedTime::new_from_secs(FIXED_TIMESTEP))
         .run();

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -42,11 +42,11 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_state::<AppState>()
-        .add_system(setup_system.on_startup())
-        .add_system(print_text_system)
-        .add_system(transition_to_in_game_system.in_set(OnUpdate(AppState::MainMenu)))
-        // add the cleanup systems
         .add_systems((
+            setup_system.on_startup(),
+            print_text_system,
+            transition_to_in_game_system.in_set(OnUpdate(AppState::MainMenu)),
+            // Cleanup systems.
             // Pass in the types your system should operate on using the ::<T> (turbofish) syntax
             cleanup_system::<MenuClose>.in_schedule(OnExit(AppState::MainMenu)),
             cleanup_system::<LevelUnload>.in_schedule(OnExit(AppState::InGame)),

--- a/examples/ecs/hierarchy.rs
+++ b/examples/ecs/hierarchy.rs
@@ -7,8 +7,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotate)
+        .add_systems((setup.on_startup(), rotate))
         .run();
 }
 

--- a/examples/ecs/nondeterministic_system_order.rs
+++ b/examples/ecs/nondeterministic_system_order.rs
@@ -28,24 +28,26 @@ fn main() {
         })
         .init_resource::<A>()
         .init_resource::<B>()
-        // This pair of systems has an ambiguous order,
-        // as their data access conflicts, and there's no order between them.
-        .add_system(reads_a)
-        .add_system(writes_a)
-        // This pair of systems has conflicting data access,
-        // but it's resolved with an explicit ordering:
-        // the .after relationship here means that we will always double after adding.
-        .add_system(adds_one_to_b)
-        .add_system(doubles_b.after(adds_one_to_b))
-        // This system isn't ambiguous with adds_one_to_b,
-        // due to the transitive ordering created by our constraints:
-        // if A is before B is before C, then A must be before C as well.
-        .add_system(reads_b.after(doubles_b))
-        // This system will conflict with all of our writing systems
-        // but we've silenced its ambiguity with adds_one_to_b.
-        // This should only be done in the case of clear false positives:
-        // leave a comment in your code justifying the decision!
-        .add_system(reads_a_and_b.ambiguous_with(adds_one_to_b))
+        .add_systems((
+            // This pair of systems has an ambiguous order,
+            // as their data access conflicts, and there's no order between them.
+            reads_a,
+            writes_a,
+            // This pair of systems has conflicting data access,
+            // but it's resolved with an explicit ordering:
+            // the .after relationship here means that we will always double after adding.
+            adds_one_to_b,
+            doubles_b.after(adds_one_to_b),
+            // This system isn't ambiguous with adds_one_to_b,
+            // due to the transitive ordering created by our constraints:
+            // if A is before B is before C, then A must be before C as well.
+            reads_b.after(doubles_b),
+            // This system will conflict with all of our writing systems
+            // but we've silenced its ambiguity with adds_one_to_b.
+            // This should only be done in the case of clear false positives:
+            // leave a comment in your code justifying the decision!
+            reads_a_and_b.ambiguous_with(adds_one_to_b),
+        ))
         // Be mindful, internal ambiguities are reported too!
         // If there are any ambiguities due solely to DefaultPlugins,
         // or between DefaultPlugins and any of your third party plugins,

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -69,8 +69,6 @@ fn bounce_system(windows: Query<&Window>, mut sprites: Query<(&Transform, &mut V
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(spawn_system)
-        .add_system(move_system)
-        .add_system(bounce_system)
+        .add_systems((spawn_system.on_startup(), move_system, bounce_system))
         .run();
 }

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -14,9 +14,11 @@ fn main() {
     // `CoreSet::Update', and the system that reacts on the removal in `CoreSet::PostUpdate`.
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(remove_component)
-        .add_system(react_on_removal.in_base_set(CoreSet::PostUpdate))
+        .add_systems((
+            setup.on_startup(),
+            remove_component,
+            react_on_removal.in_base_set(CoreSet::PostUpdate),
+        ))
         .run();
 }
 

--- a/examples/ecs/run_conditions.rs
+++ b/examples/ecs/run_conditions.rs
@@ -11,7 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_resource::<InputCounter>()
-        .add_system(
+        .add_systems((
             increment_input_counter
                 // The common_conditions module has a few useful run conditions
                 // for checking resources and states. These are included in the prelude.
@@ -21,8 +21,6 @@ fn main() {
                 // Both run conditions must return `true` in order for the system to run.
                 // Note that this second run condition will be evaluated even if the first returns `false`.
                 .run_if(has_user_input),
-        )
-        .add_system(
             print_input_counter
                 // `.and_then()` is a run condition combinator that only evaluates the second condition
                 // if the first condition returns `true`. This behavior is known as "short-circuiting",
@@ -35,8 +33,6 @@ fn main() {
                     // All the normal rules still apply: all parameters must be read only except for local parameters.
                     |counter: Res<InputCounter>| counter.is_changed() && !counter.is_added(),
                 )),
-        )
-        .add_system(
             print_time_message
                 // This function returns a custom run condition, much like the common conditions module.
                 // It will only return true once 2 seconds have passed.
@@ -45,7 +41,7 @@ fn main() {
                 // to inverse a run condition. In this case it will return true if
                 // less than 2.5 seconds have elapsed since the app started.
                 .run_if(not(time_passed(2.5))),
-        )
+        ))
         .run();
 }
 

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -18,9 +18,11 @@ fn main() {
         .add_system(setup_menu.in_schedule(OnEnter(AppState::Menu)))
         // By contrast, on_update systems are stored in the main schedule, during CoreSet::Update,
         // and simply check the value of the `State<T>` resource to see if they should run each frame.
-        .add_system(menu.in_set(OnUpdate(AppState::Menu)))
-        .add_system(cleanup_menu.in_schedule(OnExit(AppState::Menu)))
-        .add_system(setup_game.in_schedule(OnEnter(AppState::InGame)))
+        .add_systems((
+            menu.in_set(OnUpdate(AppState::Menu)),
+            cleanup_menu.in_schedule(OnExit(AppState::Menu)),
+            setup_game.in_schedule(OnEnter(AppState::InGame)),
+        ))
         .add_systems((movement, change_color).in_set(OnUpdate(AppState::InGame)))
         .run();
 }

--- a/examples/ecs/system_param.rs
+++ b/examples/ecs/system_param.rs
@@ -5,8 +5,7 @@ use bevy::{ecs::system::SystemParam, prelude::*};
 fn main() {
     App::new()
         .insert_resource(PlayerCount(0))
-        .add_startup_system(spawn)
-        .add_system(count_players)
+        .add_systems((spawn.on_startup(), count_players))
         .run();
 }
 

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -15,12 +15,14 @@ fn main() {
             level: Level::TRACE,
             filter: "".to_string(),
         })
-        .add_system(parse_message_system.pipe(handler_system))
-        .add_system(data_pipe_system.pipe(info))
-        .add_system(parse_message_system.pipe(dbg))
-        .add_system(warning_pipe_system.pipe(warn))
-        .add_system(parse_error_message_system.pipe(error))
-        .add_system(parse_message_system.pipe(ignore))
+        .add_systems((
+            parse_message_system.pipe(handler_system),
+            data_pipe_system.pipe(info),
+            parse_message_system.pipe(dbg),
+            warning_pipe_system.pipe(warn),
+            parse_error_message_system.pipe(error),
+            parse_message_system.pipe(ignore),
+        ))
         .run();
 }
 

--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -6,9 +6,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .init_resource::<Countdown>()
-        .add_startup_system(setup)
-        .add_system(countdown)
-        .add_system(print_when_completed)
+        .add_systems((setup.on_startup(), countdown, print_when_completed))
         .run();
 }
 

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -43,8 +43,8 @@ fn main() {
             display_score.in_schedule(OnEnter(GameState::GameOver)),
             gameover_keyboard.in_set(OnUpdate(GameState::GameOver)),
             teardown.in_schedule(OnExit(GameState::GameOver)),
+            bevy::window::close_on_esc,
         ))
-        .add_system(bevy::window::close_on_esc)
         .run();
 }
 

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -11,12 +11,13 @@ use std::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_contributor_selection)
-        .add_startup_system(setup)
-        .add_system(velocity_system)
-        .add_system(move_system)
-        .add_system(collision_system)
-        .add_system(select_system)
+        .add_startup_systems((setup_contributor_selection, setup))
+        .add_systems((
+            velocity_system,
+            move_system,
+            collision_system,
+            select_system,
+        ))
         .init_resource::<SelectionState>()
         .run();
 }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -58,15 +58,14 @@ mod splash {
     impl Plugin for SplashPlugin {
         fn build(&self, app: &mut App) {
             // As this plugin is managing the splash screen, it will focus on the state `GameState::Splash`
-            app
+            app.add_systems((
                 // When entering the state, spawn everything needed for this screen
-                .add_system(splash_setup.in_schedule(OnEnter(GameState::Splash)))
+                splash_setup.in_schedule(OnEnter(GameState::Splash)),
                 // While in this state, run the `countdown` system
-                .add_system(countdown.in_set(OnUpdate(GameState::Splash)))
+                countdown.in_set(OnUpdate(GameState::Splash)),
                 // When exiting the state, despawn everything that was spawned for this screen
-                .add_system(
-                    despawn_screen::<OnSplashScreen>.in_schedule(OnExit(GameState::Splash)),
-                );
+                despawn_screen::<OnSplashScreen>.in_schedule(OnExit(GameState::Splash)),
+            ));
         }
     }
 

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -10,8 +10,7 @@ use bevy::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_system(gamepad_events)
-        .add_system(gamepad_ordered_events)
+        .add_systems((gamepad_events, gamepad_ordered_events))
         .run();
 }
 

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -9,12 +9,14 @@ use bevy::{input::keyboard::KeyboardInput, prelude::*};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_scene)
-        .add_system(toggle_ime)
-        .add_system(listen_ime_events)
-        .add_system(listen_received_character_events)
-        .add_system(listen_keyboard_input_events)
-        .add_system(bubbling_text)
+        .add_systems((
+            setup_scene.on_startup(),
+            toggle_ime,
+            listen_ime_events,
+            listen_received_character_events,
+            listen_keyboard_input_events,
+            bubbling_text,
+        ))
         .run();
 }
 

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -12,10 +12,8 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup_scene)
-        .add_startup_system(setup_music)
-        .add_system(touch_camera)
-        .add_system(button_handler)
+        .add_startup_systems((setup_scene, setup_music))
+        .add_systems((touch_camera, button_handler))
         .run();
 }
 

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -14,9 +14,7 @@ fn main() {
         }))
         .register_type::<ComponentA>()
         .register_type::<ComponentB>()
-        .add_startup_system(save_scene_system)
-        .add_startup_system(load_scene_system)
-        .add_startup_system(infotext_system)
+        .add_startup_systems((save_scene_system, load_scene_system, infotext_system))
         .add_system(log_system)
         .run();
 }

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -11,8 +11,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<ArrayTextureMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(create_array_texture)
+        .add_systems((setup.on_startup(), create_array_texture))
         .run();
 }
 

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -23,8 +23,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(Material2dPlugin::<PostProcessingMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(main_camera_cube_rotator_system)
+        .add_systems((setup.on_startup(), main_camera_cube_rotator_system))
         .run();
 }
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -85,8 +85,10 @@ impl Plugin for CustomMaterialPlugin {
             .add_render_command::<Transparent3d, DrawCustom>()
             .init_resource::<CustomPipeline>()
             .init_resource::<SpecializedMeshPipelines<CustomPipeline>>()
-            .add_system(queue_custom.in_set(RenderSet::Queue))
-            .add_system(prepare_instance_buffers.in_set(RenderSet::Prepare));
+            .add_systems((
+                queue_custom.in_set(RenderSet::Queue),
+                prepare_instance_buffers.in_set(RenderSet::Prepare),
+            ));
     }
 }
 

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -10,8 +10,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(MaterialPlugin::<CustomMaterial>::default())
-        .add_startup_system(setup)
-        .add_system(rotate_camera)
+        .add_systems((setup.on_startup(), rotate_camera))
         .run();
 }
 

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -28,9 +28,7 @@ fn main() {
             prepass_enabled: false,
             ..default()
         })
-        .add_startup_system(setup)
-        .add_system(rotate)
-        .add_system(toggle_prepass_view)
+        .add_systems((setup.on_startup(), rotate, toggle_prepass_view))
         .run();
 }
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -43,12 +43,14 @@ fn main() {
             count: 0,
             color: Color::WHITE,
         })
-        .add_startup_system(setup)
-        .add_system(mouse_handler)
-        .add_system(movement_system)
-        .add_system(collision_system)
-        .add_system(counter_system)
-        .add_system(scheduled_spawner.in_schedule(CoreSchedule::FixedUpdate))
+        .add_systems((
+            setup.on_startup(),
+            mouse_handler,
+            movement_system,
+            collision_system,
+            counter_system,
+            scheduled_spawner.in_schedule(CoreSchedule::FixedUpdate),
+        ))
         .insert_resource(FixedTime::new_from_secs(0.2))
         .run();
 }

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -32,10 +32,12 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
-        .add_system(animate_sprite)
-        .add_system(print_sprite_count)
-        .add_system(move_camera.after(print_sprite_count))
+        .add_systems((
+            setup.on_startup(),
+            animate_sprite,
+            print_sprite_count,
+            move_camera.after(print_sprite_count),
+        ))
         .run();
 }
 

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -21,8 +21,7 @@ fn main() {
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
         .init_resource::<UiFont>()
-        .add_startup_system(setup)
-        .add_system(button_system)
+        .add_systems((setup.on_startup(), button_system))
         .run();
 }
 

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -30,9 +30,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(move_camera)
-        .add_system(print_mesh_count)
+        .add_systems((setup.on_startup(), move_camera, print_mesh_count))
         .run();
 }
 

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -41,10 +41,12 @@ fn main() {
             color: Color::WHITE,
             brightness: 1.0,
         })
-        .add_startup_system(setup)
-        .add_system(setup_scene_once_loaded)
-        .add_system(keyboard_animation_control)
-        .add_system(update_fox_rings.after(keyboard_animation_control))
+        .add_systems((
+            setup.on_startup(),
+            setup_scene_once_loaded,
+            keyboard_animation_control,
+            update_fox_rings.after(keyboard_animation_control),
+        ))
         .run();
 }
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -26,9 +26,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(move_camera)
-        .add_system(print_light_count)
+        .add_systems((setup.on_startup(), move_camera, print_light_count))
         .add_plugin(LogVisibleLights)
         .run();
 }

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -40,9 +40,11 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
-        .add_system(print_sprite_count)
-        .add_system(move_camera.after(print_sprite_count))
+        .add_systems((
+            setup.on_startup(),
+            print_sprite_count,
+            move_camera.after(print_sprite_count),
+        ))
         .run();
 }
 

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -20,8 +20,7 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(spawn)
-        .add_system(update_text_bounds)
+        .add_systems((spawn.on_startup(), update_text_bounds))
         .run();
 }
 

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -127,14 +127,13 @@ fn main() {
         .init_resource::<ButtonMaterials>()
         .init_resource::<ButtonMeshes>()
         .init_resource::<FontHandle>()
-        .add_startup_system(setup)
-        .add_startup_system(setup_sticks)
-        .add_startup_system(setup_triggers)
-        .add_startup_system(setup_connected)
-        .add_system(update_buttons)
-        .add_system(update_button_values)
-        .add_system(update_axes)
-        .add_system(update_connected)
+        .add_startup_systems((setup, setup_sticks, setup_triggers, setup_connected))
+        .add_systems((
+            update_buttons,
+            update_button_values,
+            update_axes,
+            update_connected,
+        ))
         .run();
 }
 

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -56,14 +56,14 @@ pub struct SceneViewerPlugin;
 
 impl Plugin for SceneViewerPlugin {
     fn build(&self, app: &mut App) {
-        app.init_resource::<CameraTracker>()
-            .add_system(scene_load_check.in_base_set(CoreSet::PreUpdate))
-            .add_system(update_lights)
-            .add_system(camera_tracker);
+        app.init_resource::<CameraTracker>().add_systems((
+            scene_load_check.in_base_set(CoreSet::PreUpdate),
+            update_lights,
+            camera_tracker,
+        ));
 
         #[cfg(feature = "animation")]
-        app.add_system(start_animation)
-            .add_system(keyboard_animation_control);
+        app.add_systems((start_animation, keyboard_animation_control));
     }
 }
 

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -13,8 +13,7 @@ struct Rotatable {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(rotate_cube)
+        .add_systems((setup.on_startup(), rotate_cube))
         .run();
 }
 

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -29,9 +29,7 @@ impl Scaling {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(change_scale_direction)
-        .add_system(scale_cube)
+        .add_systems((setup.on_startup(), change_scale_direction, scale_cube))
         .run();
 }
 

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -24,10 +24,12 @@ struct Center {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(move_cube)
-        .add_system(rotate_cube)
-        .add_system(scale_down_sphere_proportional_to_cube_travel_distance)
+        .add_systems((
+            setup.on_startup(),
+            move_cube,
+            rotate_cube,
+            scale_down_sphere_proportional_to_cube_travel_distance,
+        ))
         .run();
 }
 

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -25,8 +25,7 @@ impl Movable {
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(move_cube)
+        .add_systems((setup.on_startup(), move_cube))
         .run();
 }
 

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -8,8 +8,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
-        .add_system(button_system)
+        .add_systems((setup.on_startup(), button_system))
         .run();
 }
 

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -8,9 +8,7 @@ fn main() {
         .init_resource::<State>()
         .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(text_update_system)
-        .add_system(atlas_render_system)
+        .add_systems((setup.on_startup(), text_update_system, atlas_render_system))
         .run();
 }
 

--- a/examples/ui/relative_cursor_position.rs
+++ b/examples/ui/relative_cursor_position.rs
@@ -7,8 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
-        .add_system(relative_cursor_position_system)
+        .add_systems((setup.on_startup(), relative_cursor_position_system))
         .run();
 }
 

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -12,9 +12,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(text_update_system)
-        .add_system(text_color_system)
+        .add_systems((setup.on_startup(), text_update_system, text_color_system))
         .run();
 }
 

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -16,8 +16,7 @@ fn main() {
             ..default()
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin)
-        .add_startup_system(infotext_system)
-        .add_system(change_text_system)
+        .add_systems((infotext_system.on_startup(), change_text_system))
         .run();
 }
 

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -15,8 +15,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
-        .add_startup_system(setup)
-        .add_system(mouse_scroll)
+        .add_systems((setup.on_startup(), mouse_scroll))
         .run();
 }
 

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -16,9 +16,11 @@ fn main() {
             target_scale: 1.0,
             target_time: Timer::new(Duration::from_millis(SCALE_TIME), TimerMode::Once),
         })
-        .add_startup_system(setup)
-        .add_system(change_scaling)
-        .add_system(apply_scaling.after(change_scaling))
+        .add_systems((
+            setup.on_startup(),
+            change_scaling,
+            apply_scaling.after(change_scaling),
+        ))
         .run();
 }
 

--- a/examples/window/clear_color.rs
+++ b/examples/window/clear_color.rs
@@ -8,8 +8,7 @@ fn main() {
     App::new()
         .insert_resource(ClearColor(Color::rgb(0.5, 0.5, 0.9)))
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup)
-        .add_system(change_clear_color)
+        .add_systems((setup.on_startup(), change_clear_color))
         .run();
 }
 

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -33,7 +33,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_Systems((
+        .add_systems((
             test_setup::setup.on_startup(),
             test_setup::cycle_modes,
             test_setup::rotate_cube,

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -33,11 +33,13 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(test_setup::setup)
-        .add_system(test_setup::cycle_modes)
-        .add_system(test_setup::rotate_cube)
-        .add_system(test_setup::update_text)
-        .add_system(update_winit)
+        .add_Systems((
+            test_setup::setup.on_startup(),
+            test_setup::cycle_modes,
+            test_setup::rotate_cube,
+            test_setup::update_text,
+            update_winit,
+        ))
         .run();
 }
 

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -12,10 +12,12 @@ fn main() {
             }),
             ..default()
         }))
-        .add_startup_system(setup)
-        .add_system(display_override)
-        .add_system(toggle_override)
-        .add_system(change_scale_factor)
+        .add_systems((
+            setup.on_startup(),
+            display_override,
+            toggle_override,
+            change_scale_factor,
+        ))
         .run();
 }
 

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -9,10 +9,8 @@ fn main() {
             small: Vec2::new(640.0, 360.0),
         })
         .add_plugins(DefaultPlugins)
-        .add_startup_system(setup_camera)
-        .add_startup_system(setup_ui)
-        .add_system(on_resize_system)
-        .add_system(toggle_resolution)
+        .add_startup_systems((setup_camera, setup_ui))
+        .add_systems((on_resize_system, toggle_resolution))
         .run();
 }
 

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -24,11 +24,13 @@ fn main() {
         }))
         .add_plugin(LogDiagnosticsPlugin::default())
         .add_plugin(FrameTimeDiagnosticsPlugin)
-        .add_system(change_title)
-        .add_system(toggle_cursor)
-        .add_system(toggle_vsync)
-        .add_system(cycle_cursor_icon)
-        .add_system(switch_level)
+        .add_systems((
+            change_title,
+            toggle_cursor,
+            toggle_vsync,
+            cycle_cursor_icon,
+            switch_level,
+        ))
         .run();
 }
 

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -57,8 +57,7 @@ fn did_hurt_enemy() {
     app.add_event::<EnemyDied>();
 
     // Add our two systems
-    app.add_system(hurt_enemies.before(despawn_dead_enemies));
-    app.add_system(despawn_dead_enemies);
+    app.add_systems((hurt_enemies, despawn_dead_enemies).chain());
 
     // Setup test entities
     let enemy_id = app
@@ -89,8 +88,7 @@ fn did_despawn_enemy() {
     app.add_event::<EnemyDied>();
 
     // Add our two systems
-    app.add_system(hurt_enemies.before(despawn_dead_enemies));
-    app.add_system(despawn_dead_enemies);
+    app.add_systems((hurt_enemies, despawn_dead_enemies).chain());
 
     // Setup test entities
     let enemy_id = app

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -14,8 +14,7 @@ fn main() {
             ..default()
         }))
         .add_system(minimise_automatically)
-        .add_startup_system(setup_3d)
-        .add_startup_system(setup_2d)
+        .add_startup_systems((setup_3d, setup_2d))
         .run();
 }
 

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -35,11 +35,12 @@ fn main() {
             }),
         )
         .insert_resource(Phase::ContractingY)
-        .add_system(change_window_size)
-        .add_system(sync_dimensions)
-        .add_system(bevy::window::close_on_esc)
-        .add_startup_system(setup_3d)
-        .add_startup_system(setup_2d)
+        .add_systems((
+            change_window_size,
+            sync_dimensions,
+            bevy::window::close_on_esc,
+        ))
+        .add_startup_systems((setup_3d, setup_2d))
         .run();
 }
 


### PR DESCRIPTION
# Objective

When multiple systems are added to an app or schedule, prefer using `add_systems`. This makes the code less repetitive, and usually results in nicer formatting.

## Example

```rust
// Before:
schedule.add_system(ab).add_system(cd).add_system(ce);

// After:
schedule.add_systems((ab, cd, ce));
```
