### PR TITLE
Fix the `Text2d` text anchor's incorrect horizontal alignment

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -103,7 +103,7 @@ pub fn extract_text2d_sprite(
         }
 
         let text_glyphs = &text_layout_info.glyphs;
-        let text_anchor = anchor.as_vec() * Vec2::new(1., -1.) - 0.5;
+        let text_anchor = -(anchor.as_vec() + 0.5);
         let alignment_offset = text_layout_info.size * text_anchor;
         let mut color = Color::WHITE;
         let mut current_section = usize::MAX;

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -7,7 +7,8 @@
 
 use bevy::{
     prelude::*,
-    text::{BreakLineOn, Text2dBounds}, sprite::Anchor,
+    sprite::Anchor,
+    text::{BreakLineOn, Text2dBounds},
 };
 
 fn main() {
@@ -134,7 +135,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             });
         });
 
-    
     for (text_anchor, color) in [
         (Anchor::TopLeft, Color::RED),
         (Anchor::TopRight, Color::GREEN),
@@ -146,7 +146,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 sections: vec![TextSection::new(
                     format!(" Anchor::{text_anchor:?} "),
                     TextStyle {
-                        color, 
+                        color,
                         ..slightly_smaller_text_style.clone()
                     },
                 )],
@@ -156,7 +156,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text_anchor,
             ..default()
         });
-    }    
+    }
 }
 
 fn animate_translation(

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -7,7 +7,7 @@
 
 use bevy::{
     prelude::*,
-    text::{BreakLineOn, Text2dBounds},
+    text::{BreakLineOn, Text2dBounds}, sprite::Anchor,
 };
 
 fn main() {
@@ -133,6 +133,30 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             });
         });
+
+    
+    for (text_anchor, color) in [
+        (Anchor::TopLeft, Color::RED),
+        (Anchor::TopRight, Color::GREEN),
+        (Anchor::BottomRight, Color::BLUE),
+        (Anchor::BottomLeft, Color::YELLOW),
+    ] {
+        commands.spawn(Text2dBundle {
+            text: Text {
+                sections: vec![TextSection::new(
+                    format!(" Anchor::{text_anchor:?} "),
+                    TextStyle {
+                        color, 
+                        ..slightly_smaller_text_style.clone()
+                    },
+                )],
+                ..Default::default()
+            },
+            transform: Transform::from_translation(250. * Vec3::Y),
+            text_anchor,
+            ..default()
+        });
+    }    
 }
 
 fn animate_translation(


### PR DESCRIPTION
# Objective

The Text2dBundle::text_anchor is incorrectly inverted on the X-axis.

<img width="540" alt="text2d_wrong" src="https://user-images.githubusercontent.com/27962798/224292831-831b4290-b7a9-4510-adff-a4c064b461a3.png">

Fixes: #8011

## Solution

Reverse the x-axis on the text anchor translation.

<img width="549" alt="text2d_correct" src="https://user-images.githubusercontent.com/27962798/224292888-c583bed5-b040-4683-94a2-0829b06c3377.PNG">


## Changelog
 * Fixed `Text2d` text anchor point being wrongly inverted on the X axis.
* Added use of `text_anchor` to the `Text2d` example.

## Migration Guide
`Text2d::text_anchor` was incorrectly inverted on the X-axis. This has been fixed, existing code needs to swap:
* `Anchor::BottomLeft` and `Anchor::BottomRight` 
* `Anchor::CenterLeft` and `Anchor::CenterRight`
* `Anchor::TopLeft` and `Anchor::TopRight`