### PR TITLE
Process 1 in Chrome tracing starts expanded

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -12,7 +12,7 @@ You also need to select a `tracing` backend using the following cargo features:
 
 `cargo run --release --features bevy/trace_chrome`
 
-After running your app a `json` file in the "chrome tracing format" will be produced. You can open this file in your browser using <https://ui.perfetto.dev>. It will look something like this (make sure you expand `Process 1`):
+After running your app a `json` file in the "chrome tracing format" will be produced. You can open this file in your browser using <https://ui.perfetto.dev>. It will look something like this:
 
 ![image](https://user-images.githubusercontent.com/2694663/141657409-6f4a3ad3-59b6-4378-95ba-66c0dafecd8e.png)
 


### PR DESCRIPTION
# Objective

- the docs remind you to expand process 1, but it now starts expanded

## Solution

- Remove this suggestion