### PR TITLE
Pass query change ticks to `QueryParIter` instead of always using change ticks from `World`.

### DIFF
--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -751,6 +751,7 @@ mod tests {
         let _: &Foo = q.single();
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/8029
     #[test]
     fn par_iter_mut_change_detection() {
         let mut world = World::new();

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -61,8 +61,9 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 #[cfg(test)]
 mod tests {
     use super::{ReadOnlyWorldQuery, WorldQuery};
-    use crate::prelude::{AnyOf, Entity, Or, QueryState, With, Without};
+    use crate::prelude::{AnyOf, Changed, Entity, Or, QueryState, With, Without};
     use crate::query::{ArchetypeFilter, QueryCombinationIter};
+    use crate::schedule::{IntoSystemConfigs, Schedule};
     use crate::system::{IntoSystem, Query, System, SystemState};
     use crate::{self as bevy_ecs, component::Component, world::World};
     use std::any::type_name;
@@ -748,5 +749,33 @@ mod tests {
         let _: Option<&Foo> = q.get_single().ok();
         let _: [&Foo; 1] = q.many([e]);
         let _: &Foo = q.single();
+    }
+
+    #[test]
+    fn par_iter_mut_change_detection() {
+        let mut world = World::new();
+        world.spawn((A(1), B(1)));
+
+        fn propagate_system(mut query: Query<(&A, &mut B), Changed<A>>) {
+            query.par_iter_mut().for_each_mut(|(a, mut b)| {
+                b.0 = a.0;
+            });
+        }
+
+        fn modify_system(mut query: Query<&mut A>) {
+            for mut a in &mut query {
+                a.0 = 2;
+            }
+        }
+
+        let mut schedule = Schedule::new();
+        schedule.add_systems((propagate_system, modify_system).chain());
+        schedule.run(&mut world);
+        world.clear_trackers();
+        schedule.run(&mut world);
+        world.clear_trackers();
+
+        let values = world.query::<&B>().iter(&world).collect::<Vec<&B>>();
+        assert_eq!(values, vec![&B(2)]);
     }
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -820,6 +820,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         QueryParIter {
             world,
             state: self,
+            last_run: world.last_change_tick(),
+            this_run: world.read_change_tick(),
             batching_strategy: BatchingStrategy::new(),
         }
     }
@@ -835,6 +837,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         QueryParIter {
             world,
             state: self,
+            last_run: world.last_change_tick(),
+            this_run: world.read_change_tick(),
             batching_strategy: BatchingStrategy::new(),
         }
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -834,11 +834,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     #[inline]
     pub fn par_iter_mut<'w, 's>(&'s mut self, world: &'w mut World) -> QueryParIter<'w, 's, Q, F> {
         self.update_archetypes(world);
+        let this_run = world.change_tick();
         QueryParIter {
             world,
             state: self,
             last_run: world.last_change_tick(),
-            this_run: world.read_change_tick(),
+            this_run,
             batching_strategy: BatchingStrategy::new(),
         }
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -728,6 +728,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         QueryParIter {
             world: self.world,
             state: self.state.as_readonly(),
+            last_run: self.last_run,
+            this_run: self.this_run,
             batching_strategy: BatchingStrategy::new(),
         }
     }
@@ -742,6 +744,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         QueryParIter {
             world: self.world,
             state: self.state,
+            last_run: self.last_run,
+            this_run: self.this_run,
             batching_strategy: BatchingStrategy::new(),
         }
     }


### PR DESCRIPTION
# Objective

Make `Changed<T>` filters work reliably with `Query::par_iter_mut()`.  

While updating my game to Bevy 0.10, I had a bug where `GlobalTransform` was not being updated.  The problem turned out to be that I was changing `Transform` in a system that ran after the `TransformSystem::TransformPropagate` set.  I would have expected that to cause a one frame delay in updates, but instead it was ignoring them completely.  

When #4777 introduced `QueryParIter`, it consolidated code in `QueryState` that used `world.last_change_tick()` and code in `Query` that used `self.last_change_tick`.  The new code always uses `world.last_change_tick()`.  This means that any system using `Query::par_iter_mut()` uses the `last_change_tick` from the end of the previous frame, and won't see any changes made by systems that ran after it did on the previous frame.  

In particular, [`sync_simple_transforms`](https://github.com/bevyengine/bevy/blob/fd1af7c8b8a737b4da79615741f8844069bc6a5c/crates/bevy_transform/src/systems.rs#L11) never sees any `Transform` changes made by systems that run after it.  

## Solution

Pass `last_change_tick` and `change_tick` from `Query` to `QueryParIter`.  

