### PR TITLE
Make `#[system_param(ignore)]` and `#[world_query(ignore)]` unnecessary

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -7,7 +7,7 @@ mod states;
 
 use crate::{fetch::derive_world_query_impl, set::derive_set};
 use bevy_macro_utils::{derive_boxed_label, get_named_struct_fields, BevyManifest};
-use proc_macro::TokenStream;
+use proc_macro::{TokenStream, TokenTree};
 use proc_macro2::Span;
 use quote::{format_ident, quote};
 use syn::{
@@ -255,9 +255,19 @@ struct SystemParamFieldAttributes {
 
 static SYSTEM_PARAM_ATTRIBUTE_NAME: &str = "system_param";
 
+#[allow(clippy::cmp_owned)]
+fn check_for_collision(haystack: TokenStream, value: &Ident) -> bool {
+    haystack.into_iter().any(|t| match t {
+        TokenTree::Group(g) => check_for_collision(g.stream(), value),
+        TokenTree::Ident(ident) => ident.to_string() == value.to_string(),
+        TokenTree::Punct(_) | TokenTree::Literal(_) => false,
+    })
+}
+
 /// Implement `SystemParam` to use a struct as a parameter in a system
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
+    let token_stream = input.clone();
     let ast = parse_macro_input!(input as DeriveInput);
     let syn::Data::Struct(syn::DataStruct { fields: field_definitions, ..}) = ast.data else {
         return syn::Error::new(ast.span(), "Invalid `SystemParam` type: expected a `struct`")
@@ -392,6 +402,10 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 
     let struct_name = &ast.ident;
     let state_struct_visibility = &ast.vis;
+    let mut state_struct_name = format_ident!("FetchState");
+    while check_for_collision(token_stream.clone(), &state_struct_name) {
+        state_struct_name = format_ident!("{state_struct_name}A");
+    }
 
     TokenStream::from(quote! {
         // We define the FetchState struct in an anonymous scope to avoid polluting the user namespace.
@@ -399,7 +413,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         // <EventReader<'static, 'static, T> as SystemParam>::State
         const _: () = {
             #[doc(hidden)]
-            #state_struct_visibility struct FetchState <'w, 's, #(#lifetimeless_generics,)*>
+            #state_struct_visibility struct #state_struct_name <'w, 's, #(#lifetimeless_generics,)*>
             #where_clause {
                 state: (#(<#tuple_types as #path::system::SystemParam>::State,)*),
                 marker: std::marker::PhantomData<(
@@ -409,11 +423,11 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             }
 
             unsafe impl<'w, 's, #punctuated_generics> #path::system::SystemParam for #struct_name #ty_generics #where_clause {
-                type State = FetchState<'static, 'static, #punctuated_generic_idents>;
+                type State = #state_struct_name<'static, 'static, #punctuated_generic_idents>;
                 type Item<'_w, '_s> = #struct_name <#(#shadowed_lifetimes,)* #punctuated_generic_idents>;
 
                 fn init_state(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta) -> Self::State {
-                    FetchState {
+                    #state_struct_name {
                         state: <(#(#tuple_types,)*) as #path::system::SystemParam>::init_state(world, system_meta),
                         marker: std::marker::PhantomData,
                     }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -266,6 +266,8 @@ fn check_for_collision(haystack: TokenStream, value: &Ident) -> bool {
 }
 
 fn ensure_no_collision(haystack: TokenStream, mut value: Ident) -> Ident {
+    // If there's a collision, add more characters to the identifier
+    // until it doesn't collide with anything anymore.
     while check_for_collision(haystack.clone(), &value) {
         value = format_ident!("{value}X");
     }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -248,10 +248,9 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
     tokens
 }
 
+#[allow(unused)]
 #[derive(Default)]
-struct SystemParamFieldAttributes {
-    pub ignore: bool,
-}
+struct SystemParamFieldAttributes {}
 
 static SYSTEM_PARAM_ATTRIBUTE_NAME: &str = "system_param";
 
@@ -286,7 +285,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     };
     let path = bevy_ecs_path();
 
-    let field_attributes = field_definitions
+    let _field_attributes = field_definitions
         .iter()
         .map(|field| {
             (
@@ -297,14 +296,12 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     .find(|a| *a.path.get_ident().as_ref().unwrap() == SYSTEM_PARAM_ATTRIBUTE_NAME)
                     .map_or_else(SystemParamFieldAttributes::default, |a| {
                         syn::custom_keyword!(ignore);
-                        let mut attributes = SystemParamFieldAttributes::default();
-                        a.parse_args_with(|input: ParseStream| {
-                            if input.parse::<Option<ignore>>()?.is_some() {
-                                attributes.ignore = true;
-                            }
-                            Ok(())
-                        })
-                        .expect("Invalid 'system_param' attribute format.");
+                        let attributes = SystemParamFieldAttributes::default();
+                        let _: () = a
+                            .parse_args_with(|_input: ParseStream| {
+                                panic!("#[derive(SystemParam)] does not support attributes");
+                            })
+                            .expect("Invalid 'system_param' attribute format.");
 
                         attributes
                     }),
@@ -314,24 +311,17 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let mut field_locals = Vec::new();
     let mut fields = Vec::new();
     let mut field_types = Vec::new();
-    let mut ignored_fields = Vec::new();
-    let mut ignored_field_types = Vec::new();
-    for (i, (field, attrs)) in field_attributes.iter().enumerate() {
-        if attrs.ignore {
-            ignored_fields.push(field.ident.as_ref().unwrap());
-            ignored_field_types.push(&field.ty);
-        } else {
-            field_locals.push(format_ident!("f{i}"));
-            let i = Index::from(i);
-            fields.push(
-                field
-                    .ident
-                    .as_ref()
-                    .map(|f| quote! { #f })
-                    .unwrap_or_else(|| quote! { #i }),
-            );
-            field_types.push(&field.ty);
-        }
+    for (i, field) in field_definitions.iter().enumerate() {
+        field_locals.push(format_ident!("f{i}"));
+        let i = Index::from(i);
+        fields.push(
+            field
+                .ident
+                .as_ref()
+                .map(|f| quote! { #f })
+                .unwrap_or_else(|| quote! { #i }),
+        );
+        field_types.push(&field.ty);
     }
 
     let generics = ast.generics;
@@ -438,7 +428,6 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 state: (#(<#tuple_types as #path::system::SystemParam>::State,)*),
                 marker: std::marker::PhantomData<(
                     <#path::prelude::Query<'w, 's, ()> as #path::system::SystemParam>::State,
-                    #(fn() -> #ignored_field_types,)*
                 )>,
             }
 
@@ -474,7 +463,6 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                     >::get_param(&mut state.state, system_meta, world, change_tick);
                     #struct_name {
                         #(#fields: #field_locals,)*
-                        #(#ignored_fields: std::default::Default::default(),)*
                     }
                 }
             }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -363,7 +363,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         _ => unreachable!(),
     }));
 
-    let punctuated_generic_defs: Punctuated<_, Token![,]> = lifetimeless_generics
+    let punctuated_generics_no_bounds: Punctuated<_, Token![,]> = lifetimeless_generics
         .iter()
         .map(|&g| match g.clone() {
             GenericParam::Type(mut g) => {
@@ -409,7 +409,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
         // <EventReader<'static, 'static, T> as SystemParam>::State
         const _: () = {
             // Allows rebinding the lifetimes of each field type.
-            type #fields_alias <'w, 's, #punctuated_generic_defs> = (#(#tuple_types,)*);
+            type #fields_alias <'w, 's, #punctuated_generics_no_bounds> = (#(#tuple_types,)*);
 
             #[doc(hidden)]
             #state_struct_visibility struct #state_struct_name <#(#lifetimeless_generics,)*>

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -55,12 +55,8 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 /// - Methods can be implemented for the query items.
 /// - There is no hardcoded limit on the number of elements.
 ///
-/// This trait can only be derived if each field either
-///
-/// * also implements `WorldQuery`, or
-/// * is marked with `#[world_query(ignore)]`. Fields decorated with this attribute
-///   must implement [`Default`] and will be initialized to the default value as defined
-///   by the trait.
+/// This trait can only be derived if each field also implements `WorldQuery`.
+/// Note that [`PhantomData`] implements `WorldQuery` for all types.
 ///
 /// The derive macro only supports regular structs (structs with named fields).
 ///

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1388,3 +1388,66 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
 
 /// SAFETY: `NopFetch` never accesses any data
 unsafe impl<Q: WorldQuery> ReadOnlyWorldQuery for NopWorldQuery<Q> {}
+
+/// SAFETY: `PhantomData` never accesses any world data.
+unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
+    type Item<'a> = ();
+    type Fetch<'a> = ();
+    type ReadOnly = Self;
+    type State = ();
+
+    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {
+    }
+
+    unsafe fn init_fetch<'w>(
+        _world: &'w World,
+        _state: &Self::State,
+        _last_run: Tick,
+        _this_run: Tick,
+    ) -> Self::Fetch<'w> {
+    }
+
+    unsafe fn clone_fetch<'w>(_fetch: &Self::Fetch<'w>) -> Self::Fetch<'w> {}
+
+    const IS_DENSE: bool = true;
+    const IS_ARCHETYPAL: bool = true;
+
+    unsafe fn set_archetype<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _state: &Self::State,
+        _archetype: &'w Archetype,
+        _table: &'w Table,
+    ) {
+    }
+
+    unsafe fn set_table<'w>(_fetch: &mut Self::Fetch<'w>, _state: &Self::State, _table: &'w Table) {
+    }
+
+    unsafe fn fetch<'w>(
+        _fetch: &mut Self::Fetch<'w>,
+        _entity: Entity,
+        _table_row: TableRow,
+    ) -> Self::Item<'w> {
+    }
+
+    fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {}
+
+    fn update_archetype_component_access(
+        _state: &Self::State,
+        _archetype: &Archetype,
+        _access: &mut Access<ArchetypeComponentId>,
+    ) {
+    }
+
+    fn init_state(_world: &mut World) -> Self::State {}
+
+    fn matches_component_set(
+        _state: &Self::State,
+        _set_contains_id: &impl Fn(ComponentId) -> bool,
+    ) -> bool {
+        true
+    }
+}
+
+/// SAFETY: `PhantomData` never accesses any world data.
+unsafe impl<T: ?Sized> ReadOnlyWorldQuery for PhantomData<T> {}

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1396,8 +1396,7 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     type ReadOnly = Self;
     type State = ();
 
-    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {
-    }
+    fn shrink<'wlong: 'wshort, 'wshort>(_item: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
     unsafe fn init_fetch<'w>(
         _world: &'w World,
@@ -1451,3 +1450,15 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
 
 /// SAFETY: `PhantomData` never accesses any world data.
 unsafe impl<T: ?Sized> ReadOnlyWorldQuery for PhantomData<T> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as bevy_ecs;
+
+    // Compile test for [insert this PR].
+    #[derive(WorldQuery)]
+    pub struct IgnoredQuery<Marker> {
+        _marker: PhantomData<Marker>,
+    }
+}

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -36,12 +36,10 @@ use std::{
 /// Derived `SystemParam` structs may have two lifetimes: `'w` for data stored in the [`World`],
 /// and `'s` for data stored in the parameter's state.
 ///
-/// ## Attributes
+/// ## `PhantomData`
 ///
-/// `#[system_param(ignore)]`:
-/// Can be added to any field in the struct. Fields decorated with this attribute
-/// will be created with the default value upon realisation.
-/// This is most useful for `PhantomData` fields, such as markers for generic types.
+/// [`PhantomData`] is a special type of `SystemParam` that does nothing.
+/// This is useful for constraining generic types or lifetimes.
 ///
 /// # Example
 ///
@@ -55,7 +53,6 @@ use std::{
 /// #[derive(SystemParam)]
 /// struct MyParam<'w, Marker: 'static> {
 ///     foo: Res<'w, SomeResource>,
-///     #[system_param(ignore)]
 ///     marker: PhantomData<Marker>,
 /// }
 ///
@@ -1469,7 +1466,6 @@ pub mod lifetimeless {
 /// #[derive(SystemParam)]
 /// struct GenericParam<'w, 's, T: SystemParam> {
 ///     field: T,
-///     #[system_param(ignore)]
 ///     // Use the lifetimes in this type, or they will be unbound.
 ///     phantom: core::marker::PhantomData<&'w &'s ()>
 /// }
@@ -1627,7 +1623,6 @@ mod tests {
     #[derive(SystemParam)]
     struct IgnoredParam<'w, T: Resource, Marker: 'static> {
         _foo: Res<'w, T>,
-        #[system_param(ignore)]
         marker: PhantomData<&'w Marker>,
     }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -19,6 +19,7 @@ use bevy_utils::{all_tuples, synccell::SyncCell};
 use std::{
     borrow::Cow,
     fmt::Debug,
+    marker::PhantomData,
     ops::{Deref, DerefMut},
 };
 
@@ -1533,6 +1534,26 @@ unsafe impl<P: SystemParam + 'static> SystemParam for StaticSystemParam<'_, '_, 
         StaticSystemParam(P::get_param(state, system_meta, world, change_tick))
     }
 }
+
+// SAFETY: No world access.
+unsafe impl<T: ?Sized> SystemParam for PhantomData<T> {
+    type State = ();
+    type Item<'world, 'state> = Self;
+
+    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {}
+
+    unsafe fn get_param<'world, 'state>(
+        _state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        _world: &'world World,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        PhantomData
+    }
+}
+
+// SAFETY: No world access.
+unsafe impl<T: ?Sized> ReadOnlySystemParam for PhantomData<T> {}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Objective

When using `PhantomData` fields with the `#[derive(SystemParam)]` or `#[derive(WorldQuery)]` macros, the user is required to add the `#[system_param(ignore)]` attribute so that the macro knows to treat that field specially. This is undesirable, since it makes the macro more fragile and less consistent.

## Solution

Implement `SystemParam` and `WorldQuery` for `PhantomData` type. Remove the `ignore` attributes.

This borrows the approach used in #8012 to prevent generated types from conflicting with user-defined types.

---

## Changelog

+ Implemented `SystemParam` and `WorldQuery` for `PhantomData<T>`.
- Removed the attributes `#[system_param(ignore)]` and `#[world_query(ignore)]`.

## Migration Guide

The attribute `#[system_param(ignore)]` has been removed, as it is now unnecessary.

```rust
#[derive(SystemParam)]
struct MyParam<'w, 's, Marker> {
    ...
    // Before:
    #[system_param(ignore)
    _marker: PhantomData<Marker>,

    // After:
    _marker: PhantomData<Marker>,
}
```

The attribute `#[world_query(ignore)]` has been removed, as it is now unnecessary.

```rust
#[derive(WorldQuery)]
struct MyQuery<Marker> {
    ...
    // Before:
    #[world_query(ignore)
    _marker: PhantomData<Marker>,

    // After:
    _marker: PhantomData<Marker>,
}
```