### PR TITLE
Make `SystemSet` marker traits mutually exclusive

### DIFF
--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -1,5 +1,5 @@
 use proc_macro::TokenStream;
-use quote::{format_ident, quote, ToTokens};
+use quote::{quote, ToTokens};
 use syn::parse::{Parse, ParseStream};
 
 use crate::bevy_ecs_path;
@@ -15,14 +15,6 @@ pub static BASE_ATTRIBUTE_NAME: &str = "base";
 /// - `trait_path`: The [`syn::Path`] to the set trait
 pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStream {
     let path = bevy_ecs_path();
-
-    let mut base_trait_path = trait_path.clone();
-    let ident = &mut base_trait_path.segments.last_mut().unwrap().ident;
-    *ident = format_ident!("Base{ident}");
-
-    let mut free_trait_path = trait_path.clone();
-    let ident = &mut free_trait_path.segments.last_mut().unwrap().ident;
-    *ident = format_ident!("Free{ident}");
 
     let ident = input.ident;
 

--- a/crates/bevy_ecs/macros/src/set.rs
+++ b/crates/bevy_ecs/macros/src/set.rs
@@ -78,9 +78,9 @@ pub fn derive_set(input: syn::DeriveInput, trait_path: &syn::Path) -> TokenStrea
     );
 
     let kind = if is_base {
-        quote! { #path::schedule::Base }
+        quote! { #path::schedule::BaseSystemSetMarker }
     } else {
-        quote! { #path::schedule::Free }
+        quote! { #path::schedule::FreeSystemSetMarker }
     };
 
     (quote! {


### PR DESCRIPTION
# Objective

Fix an issue discussed in #7882. The problem comes down to the fact that `BaseSystemSet` and `FreeSystemSet` can both be implemented for the same type, which opens the door for misuse and results in actively harmful error messages.

## Solution

Use an associated type to determine whether a system set is base or not. Add blanket implementations to the marker traits based on the value of the associated type. Users are disallowed from manually implementing either marker trait due to blanket implementations, which ensures that the two traits are disjoint.

---

## Migration Guide

The marker traits `BaseSystemSet` and `FreeSystemSet` can no longer be implemented manually. Instead, implement `KindedSystemSet`:

```rust
use bevy_ecs::schedule;

// Before:
impl schedule::BaseSystemSet for MySet {}

// After:
impl schedule::KindedSystemSet for MySet {
    // This will automatically implement `BaseSystemSet` for `MySet` due to a blanket implementation.
    type Kind = schedule::BaseSystemSetMarker;
}
```