### PR TITLE
Color::Lcha constructors

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -253,6 +253,45 @@ impl Color {
         }
     }
 
+    /// New `Color` with LCH representation in sRGB colorspace.
+    ///
+    /// # Arguments
+    ///
+    /// * `lightness` - Lightness channel. [0.0, 1.5]
+    /// * `chroma` - Chroma channel. [0.0, 1.5]
+    /// * `hue` - Hue channel. [0.0, 360.0]
+    ///
+    /// See also [`Color::lcha`].
+    ///
+    pub const fn lch(lightness: f32, chroma: f32, hue: f32) -> Color {
+        Color::Lcha {
+            lightness,
+            chroma,
+            hue,
+            alpha: 1.0,
+        }
+    }
+
+    /// New `Color` with LCH representation in sRGB colorspace.
+    ///
+    /// # Arguments
+    ///
+    /// * `lightness` - Lightness channel. [0.0, 1.5]
+    /// * `chroma` - Chroma channel. [0.0, 1.5]
+    /// * `hue` - Hue channel. [0.0, 360.0]
+    /// * `alpha` - Alpha channel. [0.0, 1.0]
+    ///
+    /// See also [`Color::lch`].
+    ///
+    pub const fn lcha(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Color {
+        Color::Lcha {
+            lightness,
+            chroma,
+            hue,
+            alpha,
+        }
+    }
+
     /// New `Color` from sRGB colorspace.
     ///
     /// # Examples
@@ -1865,12 +1904,7 @@ mod tests {
         let rgba = Color::rgba(0., 0., 0., 0.);
         let rgba_l = Color::rgba_linear(0., 0., 0., 0.);
         let hsla = Color::hsla(0., 0., 0., 0.);
-        let lcha = Color::Lcha {
-            lightness: 0.0,
-            chroma: 0.0,
-            hue: 0.0,
-            alpha: 0.0,
-        };
+        let lcha = Color::lcha(0., 0., 0., 0.);
         assert_eq!(rgba_l, rgba_l.as_rgba_linear());
         let Color::RgbaLinear { .. } = rgba.as_rgba_linear() else { panic!("from Rgba") };
         let Color::RgbaLinear { .. } = hsla.as_rgba_linear() else { panic!("from Hsla") };

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -262,7 +262,6 @@ impl Color {
     /// * `hue` - Hue channel. [0.0, 360.0]
     ///
     /// See also [`Color::lcha`].
-    ///
     pub const fn lch(lightness: f32, chroma: f32, hue: f32) -> Color {
         Color::Lcha {
             lightness,
@@ -282,7 +281,6 @@ impl Color {
     /// * `alpha` - Alpha channel. [0.0, 1.0]
     ///
     /// See also [`Color::lch`].
-    ///
     pub const fn lcha(lightness: f32, chroma: f32, hue: f32, alpha: f32) -> Color {
         Color::Lcha {
             lightness,


### PR DESCRIPTION
# Objective

- With 0.10.0 the Color enum got an additional Lcha variant but misses function constructors for it similar to `Color::rgb(r, g, b)`

## Solution

- Added `Color::lch` and `Color::lcha` functions

⚠️  There is the PR #8040 which needs to be merged first because of this test and a refactoring in it.

---

## Changelog

### Added

- Added `Color::lch` and `Color::lcha` functions