### PR TITLE
Doc and test `get_many(_mut)` ordering

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -302,13 +302,13 @@ mod tests {
         fn query_system_mut(
             mut ran: ResMut<SystemRan>,
             entities_array: Res<EntitiesArray>,
-            q: Query<&mut W<usize>>,
+            mut q: Query<&mut W<usize>>,
         ) {
             let entities_array: [Entity; ENTITIES_COUNT] =
                 entities_array.0.clone().try_into().unwrap();
 
             #[allow(unused_mut)]
-            for (i, mut w) in (0..ENTITIES_COUNT).zip(q.get_many(entities_array).unwrap()) {
+            for (i, mut w) in (0..ENTITIES_COUNT).zip(q.get_many_mut(entities_array).unwrap()) {
                 assert_eq!(i, w.0);
             }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -277,6 +277,60 @@ mod tests {
     }
 
     #[test]
+    fn get_many_is_ordered() {
+        use crate::system::Resource;
+        const ENTITIES_COUNT: usize = 1000;
+
+        #[derive(Resource)]
+        struct EntitiesArray(Vec<Entity>);
+
+        fn query_system(
+            mut ran: ResMut<SystemRan>,
+            entities_array: Res<EntitiesArray>,
+            q: Query<&W<usize>>,
+        ) {
+            let entities_array: [Entity; ENTITIES_COUNT] =
+                entities_array.0.clone().try_into().unwrap();
+
+            for (i, w) in (0..ENTITIES_COUNT).zip(q.get_many(entities_array).unwrap()) {
+                assert_eq!(i, w.0);
+            }
+
+            *ran = SystemRan::Yes;
+        }
+
+        fn query_system_mut(
+            mut ran: ResMut<SystemRan>,
+            entities_array: Res<EntitiesArray>,
+            q: Query<&mut W<usize>>,
+        ) {
+            let entities_array: [Entity; ENTITIES_COUNT] =
+                entities_array.0.clone().try_into().unwrap();
+
+            #[allow(unused_mut)]
+            for (i, mut w) in (0..ENTITIES_COUNT).zip(q.get_many(entities_array).unwrap()) {
+                assert_eq!(i, w.0);
+            }
+
+            *ran = SystemRan::Yes;
+        }
+
+        let mut world = World::default();
+        world.insert_resource(SystemRan::No);
+        let entity_ids = (0..ENTITIES_COUNT)
+            .map(|i| world.spawn(W(i)).id())
+            .collect();
+        world.insert_resource(EntitiesArray(entity_ids));
+
+        run_system(&mut world, query_system);
+        assert_eq!(*world.resource::<SystemRan>(), SystemRan::Yes);
+
+        world.insert_resource(SystemRan::No);
+        run_system(&mut world, query_system_mut);
+        assert_eq!(*world.resource::<SystemRan>(), SystemRan::Yes);
+    }
+
+    #[test]
     fn or_param_set_system() {
         // Regression test for issue #762
         fn query_system(

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -793,6 +793,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// Returns the read-only query items for the given array of [`Entity`].
     ///
+    /// The returned query items are in the same order as the input.
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
     /// The elements of the array do not need to be unique, unlike `get_many_mut`.
     ///
@@ -897,6 +898,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// Returns the query items for the given array of [`Entity`].
     ///
+    /// The returned query items are in the same order as the input.
     /// In case of a nonexisting entity, duplicate entities or mismatched component, a [`QueryEntityError`] is returned instead.
     ///
     /// # See also


### PR DESCRIPTION
# Objective

- Document and test that `Query::get_many` and `Query::get_many_mut` results are in the same order as the input.

## Solution

- Added a line to the doc comment of `get_many` and `get_many_mut` documenting that the order of result is same as input.
- Created a new test, `system::tests::get_many_ordering`, to verify that fact.