### PR TITLE
Fix CubicCurve::iter_samples iteration count

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -483,7 +483,7 @@ impl<P: Point> CubicCurve<P> {
         subdivisions: usize,
         sample_function: fn(&Self, f32) -> P,
     ) -> impl Iterator<Item = P> + '_ {
-        (0..subdivisions).map(move |i| {
+        (0..=subdivisions).map(move |i| {
             let segments = self.segments.len() as f32;
             let t = i as f32 / subdivisions as f32 * segments;
             sample_function(self, t)


### PR DESCRIPTION
# Objective

Fix `CubicCurve::iter_samples` iteration count.

## Solution

If I understand the function and the docs correctly, this should iterate over `0..=subdivisions` instead of `0..subdivisions`.
For example: Now the iteration returns 3 points at `subdivisions = 2`, as indicated in the documentation.