### PR TITLE
Add `EventProcessor` `SystemParam` that gives mutable access to events

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -525,7 +525,7 @@ impl<'a, E: Event> Iterator for ManualEventIteratorWithId<'a, E> {
         event_trace(instance.event_id);
         self.reader.last_event_count += 1;
         self.unread -= 1;
-        return Some((&instance.event, instance.event_id));
+        Some((&instance.event, instance.event_id))
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {
@@ -644,7 +644,7 @@ impl<'a, E: Event> Iterator for ManualEventIteratorMutWithId<'a, E> {
         event_trace(instance.event_id);
         self.reader.last_event_count += 1;
         self.unread -= 1;
-        return Some((&mut instance.event, instance.event_id));
+        Some((&mut instance.event, instance.event_id))
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {


### PR DESCRIPTION
# Objective
Allow events to be modified 'in-flight'.

## Solution

Add a new `EventProcessor` `SystemParam` that contains `ResMut<Events<E>>` that gives an iterator over mutable references to the events.

New code is 95% identical to the existing immutable code, but I'm not sure if a macro is warranted to reduce code duplication.

## Changelog

 - Added `EventProcessor`
 - Added `iter_mut` and `iter_mut_with_id` to `ManualEventReader`
