### PR TITLE
smoother loops in repeating animations

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -489,25 +489,39 @@ fn apply_animation(
 
                 // Find the current keyframe
                 // PERF: finding the current keyframe can be optimised
-                let step_start = match curve
+                let has_step_start = match curve
                     .keyframe_timestamps
                     .binary_search_by(|probe| probe.partial_cmp(&elapsed).unwrap())
                 {
                     Ok(n) if n >= curve.keyframe_timestamps.len() - 1 => continue, // this curve is finished
-                    Ok(i) => i,
-                    Err(0) => continue, // this curve isn't started yet
+                    Ok(i) => Some(i),
+                    Err(0) if !animation.repeat => continue, // this curve isn't started yet
                     Err(n) if n > curve.keyframe_timestamps.len() - 1 => continue, // this curve is finished
-                    Err(i) => i - 1,
+                    Err(i) => i.checked_sub(1),
                 };
-                let ts_start = curve.keyframe_timestamps[step_start];
-                let ts_end = curve.keyframe_timestamps[step_start + 1];
-                let lerp = (elapsed - ts_start) / (ts_end - ts_start);
+                let step_start;
+                let step_end;
+                let lerp;
+                if let Some(step_start_found) = has_step_start {
+                    step_start = step_start_found;
+                    step_end = step_start + 1;
+                    let ts_start = curve.keyframe_timestamps[step_start];
+                    let ts_end = curve.keyframe_timestamps[step_end];
+                    lerp = (elapsed - ts_start) / (ts_end - ts_start);
+                } else {
+                    // Before the first step, in a looping animation
+                    // lerp between the last frame of the animation and the first
+                    step_start = curve.keyframe_timestamps.len() - 1;
+                    step_end = 0;
+                    let ts_end = curve.keyframe_timestamps[0];
+                    lerp = elapsed / ts_end;
+                };
 
                 // Apply the keyframe
                 match &curve.keyframes {
                     Keyframes::Rotation(keyframes) => {
                         let rot_start = keyframes[step_start];
-                        let mut rot_end = keyframes[step_start + 1];
+                        let mut rot_end = keyframes[step_end];
                         // Choose the smallest angle for the rotation
                         if rot_end.dot(rot_start) < 0.0 {
                             rot_end = -rot_end;
@@ -518,13 +532,13 @@ fn apply_animation(
                     }
                     Keyframes::Translation(keyframes) => {
                         let translation_start = keyframes[step_start];
-                        let translation_end = keyframes[step_start + 1];
+                        let translation_end = keyframes[step_end];
                         let result = translation_start.lerp(translation_end, lerp);
                         transform.translation = transform.translation.lerp(result, weight);
                     }
                     Keyframes::Scale(keyframes) => {
                         let scale_start = keyframes[step_start];
-                        let scale_end = keyframes[step_start + 1];
+                        let scale_end = keyframes[step_end];
                         let result = scale_start.lerp(scale_end, lerp);
                         transform.scale = transform.scale.lerp(result, weight);
                     }


### PR DESCRIPTION
# Objective

- When looping animations, there are some cases with a small difference between the last frame and the first. This can result in a small jump. It is very hard to unsee

https://user-images.githubusercontent.com/8672791/224546509-6f3950d0-93fe-4983-9e3e-9b52d0a61e7c.mp4

Here the animation has keyframes at 30 FPS, when played at 120 FPS the jump is 4 frames long

## Solution

- lerp between the last frame and the first when the first doesn't start at timestamp 0
