### PR TITLE
UI example scrolling list Fix

### DIFF
--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -129,7 +129,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         style: Style {
                                             flex_direction: FlexDirection::Column,
                                             flex_grow: 1.0,
-                                            max_size: Size::UNDEFINED,
+                                            size: Size::height(Val::Px(0.)),
                                             align_items: AlignItems::Center,
                                             ..default()
                                         },


### PR DESCRIPTION
# Objective
Fix for the scrolling list in the UI example.

The upgrade to Taffy 3 broke the scrolling list because in Taffy 3 `Dimension::Undefined` is removed and `Val::Undefined` is mapped to `Dimension::Auto`. The example was giving the list container a max height of `Val::Undefined `which previously in Taffy internally would have been translated to `Dimension::Points(0.)` but now becomes `Dimension::Auto` which means that instead of taking the height of its parent, the list container takes the height of its content, that is the height of the entire list. So the list widget believes that the list fits inside the container and can't be scrolled.

Fixes #8056

## Solution

Set the height constraint of the list's container to zero so it doesn't automatically take the height of its content and break the list widget.

# Changelog
* Changed the height constraint of the node containing the list to `Val::Px(0.)`, so it doesn't take the height of its content and break the list widget.