### PR TITLE
Reorder render sets

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -249,7 +249,7 @@ impl Plugin for PbrPlugin {
         render_app
             .configure_set(RenderLightSystems::PrepareLights.in_set(RenderSet::ManageViews))
             .configure_set(RenderLightSystems::PrepareClusters.in_set(RenderSet::ManageViews))
-            .configure_set(RenderLightSystems::QueueShadows.in_set(RenderSet::Queue))
+            .configure_set(RenderLightSystems::QueueShadows.in_set(RenderSet::QueueMeshes))
             .add_systems(
                 (
                     render::extract_clusters.in_set(RenderLightSystems::ExtractClusters),

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -269,7 +269,13 @@ impl Plugin for PbrPlugin {
                     .before(ViewSet::PrepareUniforms),
                 render::prepare_clusters
                     .after(render::prepare_lights)
-                    .in_set(RenderLightSystems::PrepareClusters),
+                    .in_set(ViewSet::PrepareUniforms),
+                // A sync is needed after prepare_clusters, before prepare_mesh_view_bind_groups,
+                // because prepare_clusters inserts ViewClusterBindings on views
+                apply_system_buffers
+                    .in_set(RenderSet::Prepare)
+                    .after(render::prepare_clusters)
+                    .before(prepare_mesh_view_bind_groups),
                 sort_phase_system::<Shadow>.in_set(RenderSet::PhaseSort),
             ))
             .init_resource::<ShadowSamplers>()

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -247,8 +247,8 @@ impl Plugin for PbrPlugin {
 
         // Extract the required data from the main world
         render_app
-            .configure_set(RenderLightSystems::PrepareLights.in_set(RenderSet::Prepare))
-            .configure_set(RenderLightSystems::PrepareClusters.in_set(RenderSet::Prepare))
+            .configure_set(RenderLightSystems::PrepareLights.in_set(RenderSet::ManageViews))
+            .configure_set(RenderLightSystems::PrepareClusters.in_set(RenderSet::ManageViews))
             .configure_set(RenderLightSystems::QueueShadows.in_set(RenderSet::Queue))
             .add_systems(
                 (

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -205,7 +205,7 @@ where
                         .in_set(RenderSet::Prepare)
                         .after(PrepareAssetSet::PreAssetPrepare),
                     render::queue_shadows::<M>.in_set(RenderLightSystems::QueueShadows),
-                    queue_material_meshes::<M>.in_set(RenderSet::Queue),
+                    queue_material_meshes::<M>.in_set(RenderSet::QueueMeshes),
                 ));
         }
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -134,7 +134,7 @@ where
                 prepare_prepass_textures
                     .in_set(RenderSet::Prepare)
                     .after(bevy_render::view::prepare_windows),
-                queue_prepass_material_meshes::<M>.in_set(RenderSet::Queue),
+                queue_prepass_material_meshes::<M>.in_set(RenderSet::QueueMeshes),
                 sort_phase_system::<Opaque3dPrepass>.in_set(RenderSet::PhaseSort),
                 sort_phase_system::<AlphaMask3dPrepass>.in_set(RenderSet::PhaseSort),
             ))

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -35,7 +35,7 @@ use bevy_render::{
         BevyDefault, DefaultImageSampler, FallbackImageCubemap, FallbackImagesDepth,
         FallbackImagesMsaa, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
     },
-    view::{ComputedVisibility, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
+    view::{ComputedVisibility, ViewSet, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::components::GlobalTransform;
@@ -110,8 +110,12 @@ impl Plugin for MeshRenderPlugin {
                 .add_systems((extract_meshes, extract_skinned_meshes).in_schedule(ExtractSchedule))
                 .add_systems((
                     prepare_skinned_meshes.in_set(RenderSet::Prepare),
-                    queue_mesh_bind_group.in_set(RenderSet::Queue),
-                    queue_mesh_view_bind_groups.in_set(RenderSet::Queue),
+                    prepare_mesh_bind_group
+                        .in_set(RenderSet::Prepare)
+                        .after(ViewSet::PrepareUniforms),
+                    prepare_mesh_view_bind_groups
+                        .in_set(RenderSet::Prepare)
+                        .after(ViewSet::PrepareUniforms),
                 ));
         }
     }
@@ -848,7 +852,7 @@ pub struct MeshBindGroup {
     pub skinned: Option<BindGroup>,
 }
 
-pub fn queue_mesh_bind_group(
+pub fn prepare_mesh_bind_group(
     mut commands: Commands,
     mesh_pipeline: Res<MeshPipeline>,
     render_device: Res<RenderDevice>,
@@ -933,7 +937,7 @@ pub struct MeshViewBindGroup {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn queue_mesh_view_bind_groups(
+pub fn prepare_mesh_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     mesh_pipeline: Res<MeshPipeline>,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -115,7 +115,7 @@ pub struct Camera {
     /// If this is enabled, a previous camera exists that shares this camera's render target, and this camera has MSAA enabled, then the previous camera's
     /// outputs will be written to the intermediate multi-sampled render target textures for this camera. This enables cameras with MSAA enabled to
     /// "write their results on top" of previous camera results, and include them as a part of their render results. This is enabled by default to ensure
-    /// cameras with MSAA enabled layer their results in the same way as cameras without MSAA enabled by default.  
+    /// cameras with MSAA enabled layer their results in the same way as cameras without MSAA enabled by default.
     pub msaa_writeback: bool,
 }
 

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -30,7 +30,7 @@ impl Plugin for CameraPlugin {
             render_app
                 .init_resource::<SortedCameras>()
                 .add_system(extract_cameras.in_schedule(ExtractSchedule))
-                .add_system(sort_cameras.in_set(RenderSet::Prepare));
+                .add_system(sort_cameras.in_set(RenderSet::ManageViews));
             let camera_driver_node = CameraDriverNode::new(&mut render_app.world);
             let mut render_graph = render_app.world.resource_mut::<RenderGraph>();
             render_graph.add_node(crate::main_graph::node::CAMERA_DRIVER, camera_driver_node);

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -1,8 +1,8 @@
 use crate::{
     render_resource::{encase::internal::WriteInto, DynamicUniformBuffer, ShaderType},
     renderer::{RenderDevice, RenderQueue},
-    view::ComputedVisibility,
-    Extract, ExtractSchedule, RenderApp, RenderSet,
+    view::{ComputedVisibility, ViewSet},
+    Extract, ExtractSchedule, RenderApp,
 };
 use bevy_app::{App, IntoSystemAppConfig, Plugin};
 use bevy_asset::{Asset, Handle};
@@ -83,7 +83,7 @@ impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentP
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(ComponentUniforms::<C>::default())
-                .add_system(prepare_uniform_components::<C>.in_set(RenderSet::Prepare));
+                .add_system(prepare_uniform_components::<C>.in_set(ViewSet::PrepareUniforms));
         }
     }
 }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -3,7 +3,8 @@ use crate::{
     prelude::Shader,
     render_resource::{ShaderType, UniformBuffer},
     renderer::{RenderDevice, RenderQueue},
-    Extract, ExtractSchedule, RenderApp, RenderSet,
+    view::ViewSet,
+    Extract, ExtractSchedule, RenderApp,
 };
 use bevy_app::{App, IntoSystemAppConfigs, Plugin};
 use bevy_asset::{load_internal_asset, HandleUntyped};
@@ -27,7 +28,7 @@ impl Plugin for GlobalsPlugin {
                 .init_resource::<GlobalsBuffer>()
                 .init_resource::<Time>()
                 .add_systems((extract_frame_count, extract_time).in_schedule(ExtractSchedule))
-                .add_system(prepare_globals_buffer.in_set(RenderSet::Prepare));
+                .add_system(prepare_globals_buffer.in_set(ViewSet::PrepareUniforms));
         }
     }
 }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -134,7 +134,6 @@ impl RenderSet {
         schedule.configure_sets(
             (
                 ExtractCommands,
-                PrepareAssets,
                 ManageViews,
                 ManageViewsFlush,
                 Queue,
@@ -150,6 +149,7 @@ impl RenderSet {
             )
                 .chain(),
         );
+        schedule.configure_sets((ExtractCommands, PrepareAssets).chain());
         schedule.configure_set(
             QueueMeshes
                 .in_set(RenderSet::Queue)

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -42,10 +42,12 @@ pub mod prelude {
 use bevy_window::{PrimaryWindow, RawHandleWrapper};
 use globals::GlobalsPlugin;
 pub use once_cell;
+use prelude::Mesh;
 
 use crate::{
     camera::CameraPlugin,
     mesh::MeshPlugin,
+    render_asset::prepare_assets,
     render_resource::{PipelineCache, Shader, ShaderLoader},
     renderer::{render_system, RenderInstance},
     settings::WgpuSettings,
@@ -84,6 +86,8 @@ pub enum RenderSet {
     /// Queue drawable entities to phase items in [`RenderPhase`](crate::render_phase::RenderPhase)s
     /// ready for sorting
     Queue,
+    /// A sub-set within Queue where mesh entity queue systems are executed
+    QueueMeshes,
     /// The copy of [`apply_system_buffers`] that runs immediately after `Queue`.
     QueueFlush,
     // TODO: This could probably be moved in favor of a system ordering abstraction in Render or Queue
@@ -145,6 +149,11 @@ impl RenderSet {
                 CleanupFlush,
             )
                 .chain(),
+        );
+        schedule.configure_set(
+            QueueMeshes
+                .in_set(RenderSet::Queue)
+                .after(prepare_assets::<Mesh>),
         );
 
         schedule

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -20,7 +20,7 @@ pub enum PrepareAssetError<E: Send + Sync + 'static> {
 /// Therefore it is converted into a [`RenderAsset::ExtractedAsset`], which may be the same type
 /// as the render asset itself.
 ///
-/// After that in the [`RenderSet::Prepare`](crate::RenderSet::Prepare) step the extracted asset
+/// After that in the [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) step the extracted asset
 /// is transformed into its GPU-representation of type [`RenderAsset::PreparedAsset`].
 pub trait RenderAsset: Asset {
     /// The representation of the asset in the "render world".
@@ -52,7 +52,7 @@ pub enum PrepareAssetSet {
 /// and prepares them for the GPU. They can then be accessed from the [`RenderAssets`] resource.
 ///
 /// Therefore it sets up the [`ExtractSchedule`](crate::ExtractSchedule) and
-/// [`RenderSet::Prepare`](crate::RenderSet::Prepare) steps for the specified [`RenderAsset`].
+/// [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) steps for the specified [`RenderAsset`].
 pub struct RenderAssetPlugin<A: RenderAsset> {
     prepare_asset_set: PrepareAssetSet,
     phantom: PhantomData<fn() -> A>,
@@ -87,7 +87,7 @@ impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
                         PrepareAssetSet::PostAssetPrepare,
                     )
                         .chain()
-                        .in_set(RenderSet::Prepare),
+                        .in_set(RenderSet::PrepareAssets),
                 )
                 .init_resource::<ExtractedAssets<A>>()
                 .init_resource::<RenderAssets<A>>()

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -60,7 +60,7 @@ impl Plugin for ViewPlugin {
                     prepare_view_uniforms.in_set(ViewSet::PrepareUniforms),
                     prepare_view_targets
                         .after(WindowSystem::Prepare)
-                        .in_set(RenderSet::Prepare)
+                        .in_set(RenderSet::ManageViews)
                         .after(crate::render_asset::prepare_assets::<Image>),
                 ));
         }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -6,7 +6,7 @@ pub use visibility::*;
 pub use window::*;
 
 use crate::{
-    camera::ExtractedCamera,
+    camera::{sort_cameras, ExtractedCamera},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::{Image, Shader},
     render_asset::RenderAssets,
@@ -61,7 +61,8 @@ impl Plugin for ViewPlugin {
                     prepare_view_targets
                         .after(WindowSystem::Prepare)
                         .in_set(RenderSet::ManageViews)
-                        .after(crate::render_asset::prepare_assets::<Image>),
+                        .after(crate::render_asset::prepare_assets::<Image>)
+                        .after(sort_cameras),
                 ));
         }
     }

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -33,7 +33,7 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<WindowSurfaces>()
                 .init_non_send_resource::<NonSendMarker>()
                 .add_system(extract_windows.in_schedule(ExtractSchedule))
-                .configure_set(WindowSystem::Prepare.in_set(RenderSet::Prepare))
+                .configure_set(WindowSystem::Prepare.in_set(RenderSet::ManageViews))
                 .add_system(prepare_windows.in_set(WindowSystem::Prepare));
         }
     }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -166,7 +166,7 @@ where
                     prepare_materials_2d::<M>
                         .in_set(RenderSet::Prepare)
                         .after(PrepareAssetSet::PreAssetPrepare),
-                    queue_material2d_meshes::<M>.in_set(RenderSet::Queue),
+                    queue_material2d_meshes::<M>.in_set(RenderSet::QueueMeshes),
                 ));
         }
     }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -20,7 +20,8 @@ use bevy_render::{
         BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
     },
     view::{
-        ComputedVisibility, ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
+        ComputedVisibility, ExtractedView, ViewSet, ViewTarget, ViewUniform, ViewUniformOffset,
+        ViewUniforms,
     },
     Extract, ExtractSchedule, RenderApp, RenderSet,
 };
@@ -105,8 +106,12 @@ impl Plugin for Mesh2dRenderPlugin {
                 .init_resource::<SpecializedMeshPipelines<Mesh2dPipeline>>()
                 .add_systems((
                     extract_mesh2d.in_schedule(ExtractSchedule),
-                    queue_mesh2d_bind_group.in_set(RenderSet::Queue),
-                    queue_mesh2d_view_bind_groups.in_set(RenderSet::Queue),
+                    prepare_mesh2d_bind_group
+                        .in_set(RenderSet::Prepare)
+                        .after(ViewSet::PrepareUniforms),
+                    prepare_mesh2d_view_bind_groups
+                        .in_set(RenderSet::Prepare)
+                        .after(ViewSet::PrepareUniforms),
                 ));
         }
     }
@@ -468,7 +473,7 @@ pub struct Mesh2dBindGroup {
     pub value: BindGroup,
 }
 
-pub fn queue_mesh2d_bind_group(
+pub fn prepare_mesh2d_bind_group(
     mut commands: Commands,
     mesh2d_pipeline: Res<Mesh2dPipeline>,
     render_device: Res<RenderDevice>,
@@ -493,7 +498,7 @@ pub struct Mesh2dViewBindGroup {
     pub value: BindGroup,
 }
 
-pub fn queue_mesh2d_view_bind_groups(
+pub fn prepare_mesh2d_view_bind_groups(
     mut commands: Commands,
     render_device: Res<RenderDevice>,
     mesh2d_pipeline: Res<Mesh2dPipeline>,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -285,7 +285,7 @@ impl Plugin for ColoredMesh2dPlugin {
             .init_resource::<SpecializedRenderPipelines<ColoredMesh2dPipeline>>()
             .add_systems((
                 extract_colored_mesh2d.in_schedule(ExtractSchedule),
-                queue_colored_mesh2d.in_set(RenderSet::Queue),
+                queue_colored_mesh2d.in_set(RenderSet::QueueMeshes),
             ));
     }
 }


### PR DESCRIPTION
# Objective

NOTE: This is a draft because `bevy_sprites` needs porting over to the new ordering and the batching there needs to be reworked to fit the new ordering. I have done this pre-schedule v3 but need to redo it now after. It will come soon.

- Reorder render schedule sets to allow data preparation when phase item order is known to support improved batching
- Part of the batching/instancing etc plan from here: https://github.com/bevyengine/bevy/issues/89#issuecomment-1379249074 
- The original idea came from @inodentry and proved to be a good one. Thanks!

## Solution

- Move `Prepare` and `PrepareFlush` after `PhaseSortFlush`
- Add a `PrepareAssets` set that runs in parallel with other systems and sets in the render schedule.
  - Put `prepare_assets` systems in the `PrepareAssets` set
  - If explicit dependencies are needed on `Mesh` or `Material` `RenderAsset`s then depend on the appropriate system.
- Add `ManageViews` and `ManageViewsFlush` sets between `ExtractCommands` and `Queue`
- Move `queue_mesh*_bind_group` to the `Prepare` stage
  - Rename them to `prepare_`
  - Put systems that prepare uniform data into a `PrepareUniforms` set
  - Run the `prepare_..._bind_group` systems after `PrepareUniforms` so that all buffers are ready before creating bind groups from them
- Move `prepare_lights` to the `ManageViews` set
  - `prepare_lights` creates views and this must happen before `Queue`
  - This system needs refactoring to stop handling all responsibilities
    - Gather lights, sort, and create shadow map views. Store sorted light entities in a resource
    - Prepare buffer data in prepare set

---

## Changelog

Changed:
- Reordered and reworked render app schedule sets. The main change is that data is extracted, _queued, sorted,_ and then prepared when the order of data is known.

## Migration Guide

- Queue things to phases in the `Queue` set, prepare data and bind groups in the `Prepare` set