### PR TITLE
add position to scene errors

### DIFF
--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -1,5 +1,5 @@
 use crate::serde::SceneDeserializer;
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};
 use bevy_ecs::world::{FromWorld, World};
@@ -37,7 +37,15 @@ impl AssetLoader for SceneLoader {
             };
             let scene = scene_deserializer
                 .deserialize(&mut deserializer)
-                .map_err(|e| deserializer.span_error(e))?;
+                .map_err(|e| {
+                    let span_error = deserializer.span_error(e);
+                    anyhow!(
+                        "{} at {}:{}",
+                        span_error.code,
+                        load_context.path().to_string_lossy(),
+                        span_error.position,
+                    )
+                })?;
             load_context.set_default_asset(LoadedAsset::new(scene));
             Ok(())
         })

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -35,7 +35,9 @@ impl AssetLoader for SceneLoader {
             let scene_deserializer = SceneDeserializer {
                 type_registry: &self.type_registry.read(),
             };
-            let scene = scene_deserializer.deserialize(&mut deserializer)?;
+            let scene = scene_deserializer
+                .deserialize(&mut deserializer)
+                .map_err(|e| deserializer.span_error(e))?;
             load_context.set_default_asset(LoadedAsset::new(scene));
             Ok(())
         })


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/6760
- adds line and position on line info to scene errors

```text
Before:
2023-03-12T22:38:59.103220Z  WARN bevy_asset::asset_server: encountered an error while loading an asset: Expected closing `)`
After:
2023-03-12T22:38:59.103220Z  WARN bevy_asset::asset_server: encountered an error while loading an asset: Expected closing `)` at scenes/test/scene.scn.ron:10:4
```

## Solution

- use span_error to get position info. This is what the ron crate does internally to get the position info. https://github.com/ron-rs/ron/blob/562963f88733cae0e3ca2a128b590817f0346343/src/options.rs#L158

## Changelog

- added line numbers to scene errors