### PR TITLE
Fix scrolling in UI example

### DIFF
--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -128,8 +128,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     NodeBundle {
                                         style: Style {
                                             flex_direction: FlexDirection::Column,
-                                            flex_grow: 1.0,
-                                            max_size: Size::UNDEFINED,
                                             align_items: AlignItems::Center,
                                             ..default()
                                         },
@@ -150,12 +148,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                                     font_size: 20.,
                                                     color: Color::WHITE,
                                                 },
-                                            )
-                                            .with_style(Style {
-                                                flex_shrink: 0.,
-                                                size: Size::new(Val::Undefined, Val::Px(20.)),
-                                                ..default()
-                                            }),
+                                            ),
                                             Label,
                                             AccessibilityNode(NodeBuilder::new(Role::ListItem)),
                                         ));
@@ -310,21 +303,21 @@ struct ScrollingList {
 
 fn mouse_scroll(
     mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut query_list: Query<(&mut ScrollingList, &mut Style, &Children, &Node)>,
-    query_item: Query<&Node>,
+    mut query_list: Query<(&mut ScrollingList, &mut Style, &Parent, &Node)>,
+    query_node: Query<&Node>,
 ) {
     for mouse_wheel_event in mouse_wheel_events.iter() {
-        for (mut scrolling_list, mut style, children, uinode) in &mut query_list {
-            let items_height: f32 = children
-                .iter()
-                .map(|entity| query_item.get(*entity).unwrap().size().y)
-                .sum();
-            let panel_height = uinode.size().y;
-            let max_scroll = (items_height - panel_height).max(0.);
+        for (mut scrolling_list, mut style, parent, list_node) in &mut query_list {
+            let items_height = list_node.size().y;
+            let container_height = query_node.get(parent.get()).unwrap().size().y;
+
+            let max_scroll = (items_height - container_height).max(0.);
+
             let dy = match mouse_wheel_event.unit {
                 MouseScrollUnit::Line => mouse_wheel_event.y * 20.,
                 MouseScrollUnit::Pixel => mouse_wheel_event.y,
             };
+
             scrolling_list.position += dy;
             scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
             style.position.top = Val::Px(scrolling_list.position);


### PR DESCRIPTION
# Objective

Fixes #8056 
Alternative to #8061

## Solution

Prior to this PR, the inner container was being constrained to the height of the outer container. The scroll range was being determined by the **inner** container's height and a sum obtained by iterating over every list item in the container.

With this PR, I let the inner container stretch to the height of its contents. The scroll range is simple to get from the outer and inner container heights.

I'm not sure why it was implemented this way, but it's possible that this was working around a very old stretch/taffy bug or something.

There's some additional explanation of what is going on and why the old implementation worked in Bevy 0.9 but not Bevy 0.10 in #8061.

```
 Before                After
┌─────Container─────┐ ┌─────Container─────┐
│ ┌─ScrollingList─┐ │ │ ┌─ScrollingList─┐ │
│ │    Item 1     │ │ │ │    Item 1     │ │
│ │    Item 2     │ │ │ │    Item 2     │ │
│ │    Item 3     │ │ │ │    Item 3     │ │
│ │    Item 4     │ │ │ │    Item 4     │ │
└─┴───────────────┴─┘ └─┼───────────────┼─┘
       Item 6           │    Item 6     │
       Item 7           │    Item 7     │
       Item 8           │    Item 8     │
                        └───────────────┘
```

This also cleans up a few unnecessary styles.

