### PR TITLE
Added Globals struct to prepass shader

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -17,6 +17,7 @@ use bevy_ecs::{
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::ExtractedCamera,
+    globals::{GlobalsBuffer, GlobalsUniform},
     mesh::MeshVertexBufferLayout,
     prelude::{Camera, Mesh},
     render_asset::RenderAssets,
@@ -38,7 +39,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::{FallbackImagesDepth, FallbackImagesMsaa, TextureCache},
     view::{ExtractedView, Msaa, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities},
-    Extract, ExtractSchedule, RenderApp, RenderSet, globals::{GlobalsBuffer, GlobalsUniform},
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_utils::{tracing::error, HashMap};
 
@@ -598,8 +599,8 @@ pub fn queue_prepass_view_bind_group<M: Material>(
                 },
                 BindGroupEntry {
                     binding: 1,
-                    resource: globals_binding
-                }
+                    resource: globals_binding,
+                },
             ],
             label: Some("prepass_view_bind_group"),
             layout: &prepass_pipeline.view_layout,

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -6,6 +6,9 @@
 @group(0) @binding(0)
 var<uniform> view: View;
 
+@group(0) @binding(1)
+var<uniform> globals: Globals;
+
 // Material bindings will be in @group(1)
 
 @group(2) @binding(0)

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -19,3 +19,4 @@ var<uniform> mesh: Mesh;
 var<uniform> joint_matrices: SkinnedMesh;
 #import bevy_pbr::skinning
 #endif
+


### PR DESCRIPTION
# Objective

- The bevy prepass shaders should have access to the Globals struct, same as the main pass. This is necessary for effects like wind vertex shaders or any shader that depends on time.

## Solution

- Adding Globals binding to the prepass shader's view bind group and specify it in the prepass pipeline.