### PR TITLE
Disable incremental build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly
+  CARGO_INCREMENTAL: 0
 
 jobs:
   build:


### PR DESCRIPTION
# Objective

Reduce cargo compile times in the CI worflow

## Solution

Disabling incremental build, with the `CARGO_INCREMENTAL` env var should improve compile times

EDIT: It seems that https://github.com/dtolnay/rust-toolchain/pull/27 already does it, so maybe this change is not necessary