### PR TITLE
Include bevy_text feature in bevy_ui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ bevy_sprite = ["bevy_internal/bevy_sprite"]
 bevy_text = ["bevy_internal/bevy_text"]
 
 # A custom ECS-driven UI framework
-bevy_ui = ["bevy_internal/bevy_ui"]
+bevy_ui = ["bevy_internal/bevy_ui", "bevy_text"]
 
 # winit window and input backend
 bevy_winit = ["bevy_internal/bevy_winit"]


### PR DESCRIPTION
Was this intentional? It seems pretty weird to keep them seperate.