### PR TITLE
fix: register Cascade in the TypeRegistry

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -151,6 +151,7 @@ impl Plugin for PbrPlugin {
 
         app.register_asset_reflect::<StandardMaterial>()
             .register_type::<AmbientLight>()
+            .register_type::<Cascade>()
             .register_type::<CascadeShadowConfig>()
             .register_type::<Cascades>()
             .register_type::<CascadesVisibleEntities>()


### PR DESCRIPTION
# Objective

Fixes #8087 

Attempting to serialize an entity containing a `DirectionalLightBundle` fails as the `Cascade` component isn't in the type registry.

## Solution

- Register `Cascade`

---

## Changelog

- Register `Cascade` in the `TypeRegistry` resource
