### PR TITLE
Fix blend_modes example UI positioning

### DIFF
--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -211,6 +211,7 @@ fn setup(
 
     commands.spawn((
         TextBundle::from_section("", text_style).with_style(Style {
+            position_type: PositionType::Absolute,
             top: Val::Px(10.0),
             right: Val::Px(10.0),
             ..default()


### PR DESCRIPTION
# Objective

Fixes #8091

## Solution

A `position_type` property was mistakenly deleted. This PR restores it.