### PR TITLE
Make `Plugin::{build, setup}` take `&mut self` instead of `&self`

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -63,7 +63,7 @@ pub struct Focus(Option<Entity>);
 pub struct AccessibilityPlugin;
 
 impl Plugin for AccessibilityPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         app.init_resource::<AccessibilityRequested>()
             .init_resource::<Focus>();
     }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -546,7 +546,7 @@ fn update_transitions(player: &mut AnimationPlayer, time: &Time) {
 pub struct AnimationPlugin {}
 
 impl Plugin for AnimationPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<AnimationClip>()
             .register_asset_reflect::<AnimationClip>()
             .register_type::<AnimationPlayer>()

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -305,8 +305,8 @@ impl App {
     /// be useful for situations where you want to use [`App::update`].
     pub fn setup(&mut self) {
         // temporarily remove the plugin registry to run each plugin's setup function on app.
-        let plugin_registry = std::mem::take(&mut self.plugin_registry);
-        for plugin in &plugin_registry {
+        let mut plugin_registry = std::mem::take(&mut self.plugin_registry);
+        for plugin in &mut plugin_registry {
             plugin.setup(self);
         }
         self.plugin_registry = plugin_registry;
@@ -733,7 +733,7 @@ impl App {
     /// #     #[derive(Default)]
     /// #     pub struct LogPlugin;
     /// #     impl Plugin for LogPlugin{
-    /// #        fn build(&self, app: &mut App) {}
+    /// #        fn build(&mut self, app: &mut App) {}
     /// #     }
     /// # }
     /// App::new().add_plugin(bevy_log::LogPlugin::default());
@@ -757,7 +757,7 @@ impl App {
     /// Boxed variant of `add_plugin`, can be used from a [`PluginGroup`]
     pub(crate) fn add_boxed_plugin(
         &mut self,
-        plugin: Box<dyn Plugin>,
+        mut plugin: Box<dyn Plugin>,
     ) -> Result<&mut Self, AppError> {
         debug!("added plugin: {}", plugin.name());
         if plugin.is_unique() && !self.plugin_name_added.insert(plugin.name().to_string()) {
@@ -798,7 +798,7 @@ impl App {
     /// #    default_sampler: bool,
     /// # }
     /// # impl Plugin for ImagePlugin {
-    /// #    fn build(&self, app: &mut App) {}
+    /// #    fn build(&mut self, app: &mut App) {}
     /// # }
     /// # let mut app = App::new();
     /// # app.add_plugin(ImagePlugin::default());
@@ -1028,19 +1028,19 @@ mod tests {
 
     struct PluginA;
     impl Plugin for PluginA {
-        fn build(&self, _app: &mut crate::App) {}
+        fn build(&mut self, _app: &mut crate::App) {}
     }
     struct PluginB;
     impl Plugin for PluginB {
-        fn build(&self, _app: &mut crate::App) {}
+        fn build(&mut self, _app: &mut crate::App) {}
     }
     struct PluginC<T>(T);
     impl<T: Send + Sync + 'static> Plugin for PluginC<T> {
-        fn build(&self, _app: &mut crate::App) {}
+        fn build(&mut self, _app: &mut crate::App) {}
     }
     struct PluginD;
     impl Plugin for PluginD {
-        fn build(&self, _app: &mut crate::App) {}
+        fn build(&mut self, _app: &mut crate::App) {}
         fn is_unique(&self) -> bool {
             false
         }
@@ -1072,7 +1072,7 @@ mod tests {
     fn cant_call_app_run_from_plugin_build() {
         struct PluginRun;
         impl Plugin for PluginRun {
-            fn build(&self, app: &mut crate::App) {
+            fn build(&mut self, app: &mut crate::App) {
                 app.run();
             }
         }

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -15,12 +15,12 @@ use std::any::Any;
 /// generic plugins with different type parameters will not be considered duplicates.
 pub trait Plugin: Downcast + Any + Send + Sync {
     /// Configures the [`App`] to which this plugin is added.
-    fn build(&self, app: &mut App);
+    fn build(&mut self, app: &mut App);
 
     /// Runs after all plugins are built, but before the app runner is called.
     /// This can be useful if you have some resource that other plugins need during their build step,
     /// but after build you want to remove it and send it to another thread.
-    fn setup(&self, _app: &mut App) {
+    fn setup(&mut self, _app: &mut App) {
         // do nothing
     }
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -217,17 +217,17 @@ mod tests {
 
     struct PluginA;
     impl Plugin for PluginA {
-        fn build(&self, _: &mut App) {}
+        fn build(&mut self, _: &mut App) {}
     }
 
     struct PluginB;
     impl Plugin for PluginB {
-        fn build(&self, _: &mut App) {}
+        fn build(&mut self, _: &mut App) {}
     }
 
     struct PluginC;
     impl Plugin for PluginC {
-        fn build(&self, _: &mut App) {}
+        fn build(&mut self, _: &mut App) {}
     }
 
     #[test]

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -75,7 +75,7 @@ impl ScheduleRunnerSettings {
 pub struct ScheduleRunnerPlugin;
 
 impl Plugin for ScheduleRunnerPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let settings = app
             .world
             .get_resource_or_insert_with(ScheduleRunnerSettings::default)

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -62,7 +62,7 @@ impl<T: Asset> Default for HandleMap<T> {
 }
 
 impl Plugin for DebugAssetServerPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         IoTaskPool::init(|| {
             TaskPoolBuilder::default()
                 .num_threads(2)

--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -17,7 +17,7 @@ impl<T: Asset> Default for AssetCountDiagnosticsPlugin<T> {
 }
 
 impl<T: Asset> Plugin for AssetCountDiagnosticsPlugin<T> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system);
     }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -99,7 +99,7 @@ impl AssetPlugin {
 }
 
 impl Plugin for AssetPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if !app.world.contains_resource::<AssetServer>() {
             let source = self.create_platform_default_asset_io();
             let asset_server = AssetServer::with_boxed_io(source);

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -56,7 +56,7 @@ use bevy_ecs::prelude::*;
 pub struct AudioPlugin;
 
 impl Plugin for AudioPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<AudioOutput<AudioSource>>()
             .add_asset::<AudioSource>()
             .add_asset::<AudioSink>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -38,7 +38,7 @@ use bevy_tasks::tick_global_task_pools_on_main_thread;
 pub struct TypeRegistrationPlugin;
 
 impl Plugin for TypeRegistrationPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<Entity>().register_type::<Name>();
 
         register_rust_types(app);
@@ -102,7 +102,7 @@ pub struct TaskPoolPlugin {
 }
 
 impl Plugin for TaskPoolPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // Setup the default bevy task pools
         self.task_pool_options.create_default_pools();
 
@@ -140,7 +140,7 @@ pub struct FrameCount(pub u32);
 pub struct FrameCountPlugin;
 
 impl Plugin for FrameCountPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<FrameCount>();
         app.add_system(update_frame_count.in_base_set(CoreSet::Last));
     }

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -13,7 +13,7 @@ pub const BLIT_SHADER_HANDLE: HandleUntyped =
 pub struct BlitPlugin;
 
 impl Plugin for BlitPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, BLIT_SHADER_HANDLE, "blit.wgsl", Shader::from_wgsl);
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -52,7 +52,7 @@ const MAX_MIP_DIMENSION: u32 = 512;
 pub struct BloomPlugin;
 
 impl Plugin for BloomPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, BLOOM_SHADER_HANDLE, "bloom.wgsl", Shader::from_wgsl);
 
         app.register_type::<BloomSettings>();

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -41,7 +41,7 @@ use crate::{tonemapping::TonemappingNode, upscaling::UpscalingNode};
 pub struct Core2dPlugin;
 
 impl Plugin for Core2dPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<Camera2d>()
             .add_plugin(ExtractComponentPlugin::<Camera2d>::default());
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -54,7 +54,7 @@ use crate::{
 pub struct Core3dPlugin;
 
 impl Plugin for Core3dPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<Camera3d>()
             .register_type::<Camera3dDepthLoadOp>()
             .add_plugin(ExtractComponentPlugin::<Camera3d>::default());

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -78,7 +78,7 @@ const FXAA_SHADER_HANDLE: HandleUntyped =
 /// Adds support for Fast Approximate Anti-Aliasing (FXAA)
 pub struct FxaaPlugin;
 impl Plugin for FxaaPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, FXAA_SHADER_HANDLE, "fxaa.wgsl", Shader::from_wgsl);
 
         app.add_plugin(ExtractComponentPlugin::<Fxaa>::default());

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -40,7 +40,7 @@ use bevy_render::{extract_resource::ExtractResourcePlugin, prelude::Shader};
 pub struct CorePipelinePlugin;
 
 impl Plugin for CorePipelinePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(
             app,
             FULLSCREEN_SHADER_HANDLE,

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -15,7 +15,7 @@ use bevy_render::{render_resource::*, RenderApp};
 pub struct MsaaWritebackPlugin;
 
 impl Plugin for MsaaWritebackPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return
         };

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -34,7 +34,7 @@ pub struct TonemappingLuts {
 pub struct TonemappingPlugin;
 
 impl Plugin for TonemappingPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(
             app,
             TONEMAPPING_SHADER_HANDLE,

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -12,7 +12,7 @@ pub use node::UpscalingNode;
 pub struct UpscalingPlugin;
 
 impl Plugin for UpscalingPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system(queue_view_upscaling_pipelines.in_set(RenderSet::Queue));
         }

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -8,7 +8,7 @@ use crate::{Diagnostic, DiagnosticId, Diagnostics};
 pub struct EntityCountDiagnosticsPlugin;
 
 impl Plugin for EntityCountDiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system);
     }

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -9,7 +9,7 @@ use bevy_time::Time;
 pub struct FrameTimeDiagnosticsPlugin;
 
 impl Plugin for FrameTimeDiagnosticsPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         app.add_startup_system(Self::setup_system)
             .add_system(Self::diagnostic_system);
     }

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -16,7 +16,7 @@ pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugi
 pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<Diagnostics>()
             .add_startup_system(system_information_diagnostics_plugin::internal::log_system_info);
     }

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -30,7 +30,7 @@ impl Default for LogDiagnosticsPlugin {
 }
 
 impl Plugin for LogDiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.insert_resource(LogDiagnosticsState {
             timer: Timer::new(self.wait_duration, TimerMode::Repeating),
             filter: self.filter.clone(),

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -13,7 +13,7 @@ use bevy_app::prelude::*;
 #[derive(Default)]
 pub struct SystemInformationDiagnosticsPlugin;
 impl Plugin for SystemInformationDiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_startup_system(internal::setup_system)
             .add_system(internal::diagnostic_system);
     }

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -41,7 +41,7 @@ pub trait DynamicPluginExt {
 
 impl DynamicPluginExt for App {
     unsafe fn load_plugin<P: AsRef<OsStr>>(&mut self, path: P) -> &mut Self {
-        let (lib, plugin) = dynamically_load_plugin(path).unwrap();
+        let (lib, mut plugin) = dynamically_load_plugin(path).unwrap();
         std::mem::forget(lib); // Ensure that the library is not automatically unloaded
         plugin.build(self);
         self

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -12,7 +12,7 @@ use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
 pub struct GilrsPlugin;
 
 impl Plugin for GilrsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         match GilrsBuilder::new()
             .with_default_filters(false)
             .set_update_state(false)

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -18,7 +18,7 @@ use bevy_scene::Scene;
 pub struct GltfPlugin;
 
 impl Plugin for GltfPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_asset_loader::<GltfLoader>()
             .register_type::<GltfExtras>()
             .add_asset::<Gltf>()

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -38,7 +38,7 @@ use bevy_app::prelude::*;
 pub struct HierarchyPlugin;
 
 impl Plugin for HierarchyPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<Children>()
             .register_type::<Parent>()
             .register_type::<smallvec::SmallVec<[bevy_ecs::entity::Entity; 8]>>()

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -95,7 +95,7 @@ impl<T: Component> Default for ValidParentCheckPlugin<T> {
 }
 
 impl<T: Component> Plugin for ValidParentCheckPlugin<T> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<ReportHierarchyIssue<T>>().add_system(
             check_hierarchy_component_has_valid_parent::<T>
                 .run_if(resource_equals(ReportHierarchyIssue::<T>::new(true)))

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -52,7 +52,7 @@ pub struct InputPlugin;
 pub struct InputSystem;
 
 impl Plugin for InputPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.configure_set(InputSystem.in_base_set(CoreSet::PreUpdate))
             // keyboard
             .add_event::<KeyboardInput>()

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -104,7 +104,7 @@ impl Default for LogPlugin {
 
 impl Plugin for LogPlugin {
     #[cfg_attr(not(feature = "tracing-chrome"), allow(unused_variables))]
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         #[cfg(feature = "trace")]
         {
             let old_handler = panic::take_hook();

--- a/crates/bevy_pbr/src/environment_map/mod.rs
+++ b/crates/bevy_pbr/src/environment_map/mod.rs
@@ -19,7 +19,7 @@ pub const ENVIRONMENT_MAP_SHADER_HANDLE: HandleUntyped =
 pub struct EnvironmentMapPlugin;
 
 impl Plugin for EnvironmentMapPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(
             app,
             ENVIRONMENT_MAP_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -97,7 +97,7 @@ impl Default for PbrPlugin {
 }
 
 impl Plugin for PbrPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(
             app,
             PBR_TYPES_SHADER_HANDLE,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -184,7 +184,7 @@ impl<M: Material> Plugin for MaterialPlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible());
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -75,7 +75,7 @@ impl<M: Material> Plugin for PrepassPipelinePlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             PREPASS_SHADER_HANDLE,
@@ -124,7 +124,7 @@ impl<M: Material> Plugin for PrepassPlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -134,7 +134,7 @@ pub const FOG_SHADER_HANDLE: HandleUntyped =
 pub struct FogPlugin;
 
 impl Plugin for FogPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, FOG_SHADER_HANDLE, "fog.wgsl", Shader::from_wgsl);
 
         app.add_plugin(ExtractComponentPlugin::<FogSettings>::default());

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -66,7 +66,7 @@ pub const SKINNING_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 13215291596265391738);
 
 impl Plugin for MeshRenderPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             MESH_VERTEX_OUTPUT,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -28,7 +28,7 @@ pub const WIREFRAME_SHADER_HANDLE: HandleUntyped =
 pub struct WireframePlugin;
 
 impl Plugin for WireframePlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             WIREFRAME_SHADER_HANDLE,

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -15,7 +15,7 @@ use bevy_ecs::schedule::IntoSystemConfig;
 pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<Camera>()
             .register_type::<Viewport>()
             .register_type::<Option<Viewport>>()

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -25,7 +25,7 @@ impl<T: CameraProjection> Default for CameraProjectionPlugin<T> {
 pub struct CameraUpdateSystem;
 
 impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.register_type::<T>()
             .edit_schedule(CoreSchedule::Startup, |schedule| {
                 schedule.configure_set(CameraUpdateSystem.in_base_set(StartupSet::PostStartup));

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -79,7 +79,7 @@ impl<C> Default for UniformComponentPlugin<C> {
 }
 
 impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .insert_resource(ComponentUniforms::<C>::default())
@@ -177,7 +177,7 @@ impl<C, F> ExtractComponentPlugin<C, F> {
 }
 
 impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             if self.only_extract_visible {
                 render_app.add_system(extract_visible_components::<C>.in_schedule(ExtractSchedule));

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -30,7 +30,7 @@ impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {
 }
 
 impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.add_system(extract_resource::<R>.in_schedule(ExtractSchedule));
         }

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -18,7 +18,7 @@ pub const GLOBALS_TYPE_HANDLE: HandleUntyped =
 pub struct GlobalsPlugin;
 
 impl Plugin for GlobalsPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, GLOBALS_TYPE_HANDLE, "globals.wgsl", Shader::from_wgsl);
         app.register_type::<GlobalsUniform>();
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -184,7 +184,7 @@ pub struct RenderApp;
 
 impl Plugin for RenderPlugin {
     /// Initializes the renderer, sets up the [`RenderSet`](RenderSet) and creates the rendering sub-app.
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<Shader>()
             .add_debug_asset::<Shader>()
             .init_asset_loader::<ShaderLoader>()

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -14,7 +14,7 @@ use bevy_ecs::entity::Entity;
 pub struct MeshPlugin;
 
 impl Plugin for MeshPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<Mesh>()
             .add_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_type::<skinning::SkinnedMesh>()

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -64,7 +64,7 @@ pub struct RenderToMainAppReceiver(pub Receiver<SubApp>);
 pub struct PipelinedRenderingPlugin;
 
 impl Plugin for PipelinedRenderingPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // Don't add RenderExtractApp if RenderApp isn't initialized.
         if app.get_sub_app(RenderApp).is_err() {
             return;
@@ -78,7 +78,7 @@ impl Plugin for PipelinedRenderingPlugin {
     }
 
     // Sets up the render thread and inserts resources into the main app used for controlling the render thread.
-    fn setup(&self, app: &mut App) {
+    fn setup(&mut self, app: &mut App) {
         // skip setting up when headless
         if app.get_sub_app(RenderExtractApp).is_err() {
             return;

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -77,7 +77,7 @@ impl<A: RenderAsset> Default for RenderAssetPlugin<A> {
 }
 
 impl<A: RenderAsset> Plugin for RenderAssetPlugin<A> {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .configure_sets(

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -69,7 +69,7 @@ impl ImagePlugin {
 }
 
 impl Plugin for ImagePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         #[cfg(any(
             feature = "png",
             feature = "dds",

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -37,7 +37,7 @@ pub const VIEW_TYPE_HANDLE: HandleUntyped =
 pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(app, VIEW_TYPE_HANDLE, "view.wgsl", Shader::from_wgsl);
 
         app.register_type::<ComputedVisibility>()

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -207,7 +207,7 @@ pub enum VisibilitySystems {
 pub struct VisibilityPlugin;
 
 impl Plugin for VisibilityPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         use VisibilitySystems::*;
 
         app.configure_set(CalculateBounds.in_base_set(CoreSet::PostUpdate))

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -26,7 +26,7 @@ pub enum WindowSystem {
 }
 
 impl Plugin for WindowRenderPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .init_resource::<ExtractedWindows>()

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -31,7 +31,7 @@ pub struct ScenePlugin;
 
 #[cfg(feature = "serialize")]
 impl Plugin for ScenePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<DynamicScene>()
             .add_asset::<Scene>()
             .init_asset_loader::<SceneLoader>()
@@ -44,5 +44,5 @@ impl Plugin for ScenePlugin {
 
 #[cfg(not(feature = "serialize"))]
 impl Plugin for ScenePlugin {
-    fn build(&self, _: &mut App) {}
+    fn build(&mut self, _: &mut App) {}
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -49,7 +49,7 @@ pub enum SpriteSystem {
 }
 
 impl Plugin for SpritePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         let sprite_shader = Shader::from_wgsl(include_str!("render/sprite.wgsl"));
         shaders.set_untracked(SPRITE_SHADER_HANDLE, sprite_shader);

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -15,7 +15,7 @@ pub const COLOR_MATERIAL_SHADER_HANDLE: HandleUntyped =
 pub struct ColorMaterialPlugin;
 
 impl Plugin for ColorMaterialPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         load_internal_asset!(
             app,
             COLOR_MATERIAL_SHADER_HANDLE,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -150,7 +150,7 @@ impl<M: Material2d> Plugin for Material2dPlugin<M>
 where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible());
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -58,7 +58,7 @@ pub const MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 2971387252468633715);
 
 impl Plugin for Mesh2dRenderPlugin {
-    fn build(&self, app: &mut bevy_app::App) {
+    fn build(&mut self, app: &mut bevy_app::App) {
         load_internal_asset!(
             app,
             MESH2D_VERTEX_OUTPUT,

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -66,7 +66,7 @@ pub enum YAxisOrientation {
 }
 
 impl Plugin for TextPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .register_type::<Text>()

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -34,7 +34,7 @@ pub struct TimePlugin;
 pub struct TimeSystem;
 
 impl Plugin for TimePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<Time>()
             .init_resource::<TimeUpdateStrategy>()
             .register_type::<Timer>()

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -89,7 +89,7 @@ pub enum TransformSystem {
 pub struct TransformPlugin;
 
 impl Plugin for TransformPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // A set for `propagate_transforms` to mark it as ambiguous with `sync_simple_transforms`.
         // Used instead of the `SystemTypeSet` as that would not allow multiple instances of the system.
         #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -148,7 +148,7 @@ fn label_changed(
 pub(crate) struct AccessibilityPlugin;
 
 impl Plugin for AccessibilityPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_systems((calc_bounds, button_changed, image_changed, label_changed));
     }
 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -75,7 +75,7 @@ impl Default for UiScale {
 }
 
 impl Plugin for UiPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_plugin(ExtractComponentPlugin::<UiCameraConfig>::default())
             .init_resource::<FlexSurface>()
             .init_resource::<UiScale>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -67,7 +67,7 @@ pub struct WindowPlugin {
 }
 
 impl Plugin for WindowPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // User convenience events
         app.add_event::<WindowResized>()
             .add_event::<WindowCreated>()

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -159,7 +159,7 @@ fn update_accessibility_nodes(
 pub struct AccessibilityPlugin;
 
 impl Plugin for AccessibilityPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_non_send_resource::<AccessKitAdapters>()
             .init_resource::<WinitActionHandlers>()
             .add_event::<ActionRequest>()

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -53,7 +53,7 @@ pub static ANDROID_APP: once_cell::sync::OnceCell<AndroidApp> = once_cell::sync:
 pub struct WinitPlugin;
 
 impl Plugin for WinitPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let mut event_loop_builder = EventLoopBuilder::<()>::with_user_event();
 
         #[cfg(target_os = "android")]

--- a/crates/bevy_winit/src/web_resize.rs
+++ b/crates/bevy_winit/src/web_resize.rs
@@ -8,7 +8,7 @@ use winit::dpi::LogicalSize;
 pub(crate) struct CanvasParentResizePlugin;
 
 impl Plugin for CanvasParentResizePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<CanvasParentResizeEventChannel>()
             .add_system(canvas_parent_resize_event_handler);
     }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -269,7 +269,7 @@ pub const COLORED_MESH2D_SHADER_HANDLE: HandleUntyped =
     HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 13828845428412094821);
 
 impl Plugin for ColoredMesh2dPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // Load our custom shader
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         shaders.set_untracked(

--- a/examples/app/plugin.rs
+++ b/examples/app/plugin.rs
@@ -26,7 +26,7 @@ pub struct PrintMessagePlugin {
 
 impl Plugin for PrintMessagePlugin {
     // this is where we set up our plugin
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let state = PrintMessageState {
             message: self.message.clone(),
             timer: Timer::new(self.wait_duration, TimerMode::Repeating),

--- a/examples/app/plugin_group.rs
+++ b/examples/app/plugin_group.rs
@@ -35,7 +35,7 @@ impl PluginGroup for HelloWorldPlugins {
 pub struct PrintHelloPlugin;
 
 impl Plugin for PrintHelloPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_system(print_hello_system);
     }
 }
@@ -47,7 +47,7 @@ fn print_hello_system() {
 pub struct PrintWorldPlugin;
 
 impl Plugin for PrintWorldPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_system(print_world_system);
     }
 }

--- a/examples/asset/custom_asset_io.rs
+++ b/examples/asset/custom_asset_io.rs
@@ -54,7 +54,7 @@ impl AssetIo for CustomAssetIo {
 struct CustomAssetIoPlugin;
 
 impl Plugin for CustomAssetIoPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let default_io = AssetPlugin::default().create_platform_default_asset_io();
 
         // create the custom asset io instance

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -56,7 +56,7 @@ mod splash {
     pub struct SplashPlugin;
 
     impl Plugin for SplashPlugin {
-        fn build(&self, app: &mut App) {
+        fn build(&mut self, app: &mut App) {
             // As this plugin is managing the splash screen, it will focus on the state `GameState::Splash`
             app.add_systems((
                 // When entering the state, spawn everything needed for this screen
@@ -130,7 +130,7 @@ mod game {
     pub struct GamePlugin;
 
     impl Plugin for GamePlugin {
-        fn build(&self, app: &mut App) {
+        fn build(&mut self, app: &mut App) {
             app.add_systems((
                 game_setup.in_schedule(OnEnter(GameState::Game)),
                 game.in_set(OnUpdate(GameState::Game)),
@@ -262,7 +262,7 @@ mod menu {
     pub struct MenuPlugin;
 
     impl Plugin for MenuPlugin {
-        fn build(&self, app: &mut App) {
+        fn build(&mut self, app: &mut App) {
             app
                 // At start, the menu is not enabled. This will be changed in `menu_setup` when
                 // entering the `GameState::Menu` state.

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -67,7 +67,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
 pub struct GameOfLifeComputePlugin;
 
 impl Plugin for GameOfLifeComputePlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         // Extract the game of life image resource from the main world into the render world
         // for operation on by the compute shader and display on the sprite.
         app.add_plugin(ExtractResourcePlugin::<GameOfLifeImage>::default());

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -79,7 +79,7 @@ impl ExtractComponent for InstanceMaterialData {
 pub struct CustomMaterialPlugin;
 
 impl Plugin for CustomMaterialPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_plugin(ExtractComponentPlugin::<InstanceMaterialData>::default());
         app.sub_app_mut(RenderApp)
             .add_render_command::<Transparent3d, DrawCustom>()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -148,7 +148,7 @@ fn print_light_count(time: Res<Time>, mut timer: Local<PrintingTimer>, lights: Q
 struct LogVisibleLights;
 
 impl Plugin for LogVisibleLights {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         let render_app = match app.get_sub_app_mut(RenderApp) {
             Ok(render_app) => render_app,
             Err(_) => return,

--- a/examples/tools/scene_viewer/camera_controller_plugin.rs
+++ b/examples/tools/scene_viewer/camera_controller_plugin.rs
@@ -90,7 +90,7 @@ Freecam Controls:
 pub struct CameraControllerPlugin;
 
 impl Plugin for CameraControllerPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.add_system(camera_controller);
     }
 }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -55,7 +55,7 @@ Scene Controls:
 pub struct SceneViewerPlugin;
 
 impl Plugin for SceneViewerPlugin {
-    fn build(&self, app: &mut App) {
+    fn build(&mut self, app: &mut App) {
         app.init_resource::<CameraTracker>().add_systems((
             scene_load_check.in_base_set(CoreSet::PreUpdate),
             update_lights,


### PR DESCRIPTION
# Objective

- Allow `Plugins` to mutate themselves during `build` and `setup`.
  - Helps #7682.
  - Makes transferring data from `Plugin` to `App` easier.

## Solution

- Change `Plugin::build` and `Plugin::setup` to take `&mut self` instead of `&self`.

---

## Changelog

### Changed

- `Plugin::build` and `Plugin::setup` now take  `&mut self` instead of `&self`.

## Migration Guide

- Implementers of `Plugin` need to change their `build` and `setup` implementations to take `&mut self` instead of `&self`.
