### PR TITLE
WIP: Support scrolling (`Overflow::Scroll`) in `bevy_ui`

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -324,13 +324,12 @@ pub fn ui_layout_system(
             }
 
             // Adjust position by the scroll offset of the parent
-            let x_scroll_position = 0.0; // TODO: implement horizontal scrolling
-            new_position.x += x_scroll_position;
-            let y_scroll_position = scroll_position_query
+            let (x_scroll_position, y_scroll_position) = scroll_position_query
                 .get(**parent)
                 .ok()
-                .and_then(|(_, p)| p.map(|p| p.offset_y))
-                .unwrap_or(0.0);
+                .and_then(|(_, p)| p.map(|p| (p.offset_x, p.offset_y)))
+                .unwrap_or((0.0, 0.0));
+            new_position.x += x_scroll_position;
             new_position.y += y_scroll_position;
         }
         // only trigger change detection when the new value is different

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -325,13 +325,13 @@ pub fn ui_layout_system(
 
             // Adjust position by the scroll offset of the parent
             let x_scroll_position = 0.0; // TODO: implement horizontal scrolling
-            new_position.x += to_logical(x_scroll_position);
+            new_position.x += x_scroll_position;
             let y_scroll_position = scroll_position_query
                 .get(**parent)
                 .ok()
                 .and_then(|(_, p)| p.map(|p| p.offset_y))
                 .unwrap_or(0.0);
-            new_position.y += to_logical(y_scroll_position);
+            new_position.y += y_scroll_position;
         }
         // only trigger change detection when the new value is different
         if transform.translation != new_position {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,6 +1,6 @@
 mod convert;
 
-use crate::{ContentSize, Node, Style, UiScale};
+use crate::{ContentSize, Node, ScrollPosition, Style, UiScale};
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
@@ -221,6 +221,7 @@ pub fn ui_layout_system(
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
     mut measure_query: Query<(Entity, &mut ContentSize)>,
+    scroll_position_query: Query<(Entity, Option<&ScrollPosition>), With<Node>>,
     children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,
     mut removed_children: RemovedComponents<Children>,
     mut removed_content_sizes: RemovedComponents<ContentSize>,
@@ -321,6 +322,16 @@ pub fn ui_layout_system(
                 new_position.x -= to_logical(parent_layout.size.width / 2.0);
                 new_position.y -= to_logical(parent_layout.size.height / 2.0);
             }
+
+            // Adjust position by the scroll offset of the parent
+            let x_scroll_position = 0.0; // TODO: implement horizontal scrolling
+            new_position.x += to_logical(x_scroll_position);
+            let y_scroll_position = scroll_position_query
+                .get(**parent)
+                .ok()
+                .and_then(|(_, p)| p.map(|p| p.offset_y))
+                .unwrap_or(0.0);
+            new_position.y += to_logical(y_scroll_position);
         }
         // only trigger change detection when the new value is different
         if transform.translation != new_position {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -46,7 +46,7 @@ use bevy_input::InputSystem;
 use bevy_transform::TransformSystem;
 use stack::ui_stack_system;
 pub use stack::UiStack;
-use update::{update_clipping_system, update_scroll_position};
+use update::{update_clipping_system, update_scroll_interaction, update_scroll_position};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -59,6 +59,8 @@ pub enum UiSystem {
     Layout,
     /// After this label, input interactions with UI entities have been updated for this frame
     Focus,
+    /// After this label, scroll positions have been updated
+    Scroll,
     /// After this label, the [`UiStack`] resource has been updated
     Stack,
 }
@@ -164,7 +166,8 @@ impl Plugin for UiPlugin {
                     .before(TransformSystem::TransformPropagate),
                 ui_stack_system.in_set(UiSystem::Stack),
                 update_clipping_system.after(TransformSystem::TransformPropagate),
-                update_scroll_position,
+                update_scroll_interaction.in_set(UiSystem::Focus),
+                update_scroll_position.in_set(UiSystem::Scroll),
             ),
         );
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -46,7 +46,7 @@ use bevy_input::InputSystem;
 use bevy_transform::TransformSystem;
 use stack::ui_stack_system;
 pub use stack::UiStack;
-use update::update_clipping_system;
+use update::{update_clipping_system, update_scroll_position};
 
 /// The basic plugin for Bevy UI
 #[derive(Default)]
@@ -164,6 +164,7 @@ impl Plugin for UiPlugin {
                     .before(TransformSystem::TransformPropagate),
                 ui_stack_system.in_set(UiSystem::Stack),
                 update_clipping_system.after(TransformSystem::TransformPropagate),
+                update_scroll_position,
             ),
         );
 

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -28,6 +28,8 @@ pub struct NodeBundle {
     pub background_color: BackgroundColor,
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
+    /// Describes whether and how the button has been interacted with by the input
+    pub interaction: Interaction,
     /// Scroll position
     pub scroll_position: ScrollPosition,
     /// The transform of the node
@@ -56,6 +58,7 @@ impl Default for NodeBundle {
             node: Default::default(),
             style: Default::default(),
             focus_policy: Default::default(),
+            interaction: Interaction::default(),
             scroll_position: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     widget::{Button, UiImageSize},
-    BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
+    BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, ScrollPosition, Style, UiImage,
+    ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
@@ -27,6 +28,8 @@ pub struct NodeBundle {
     pub background_color: BackgroundColor,
     /// Whether this node should block interaction with lower nodes
     pub focus_policy: FocusPolicy,
+    /// Scroll position
+    pub scroll_position: ScrollPosition,
     /// The transform of the node
     ///
     /// This field is automatically managed by the UI layout system.
@@ -53,6 +56,7 @@ impl Default for NodeBundle {
             node: Default::default(),
             style: Default::default(),
             focus_policy: Default::default(),
+            scroll_position: Default::default(),
             transform: Default::default(),
             global_transform: Default::default(),
             visibility: Default::default(),

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -64,6 +64,8 @@ impl Default for Node {
 #[reflect(Component, Default)]
 pub struct ScrollPosition {
     pub is_hovered: bool,
+    /// How far accross the node is scrolled (0 = not scrolled / scrolled to right)
+    pub offset_x: f32,
     /// How far down the node is scrolled (0 = not scrolled / scrolled to top)
     pub offset_y: f32,
 }
@@ -71,6 +73,7 @@ pub struct ScrollPosition {
 impl ScrollPosition {
     pub const DEFAULT: Self = Self {
         is_hovered: false,
+        offset_x: 0.0,
         offset_y: 0.0,
     };
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -63,12 +63,16 @@ impl Default for Node {
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct ScrollPosition {
+    pub is_hovered: bool,
     /// How far down the node is scrolled (0 = not scrolled / scrolled to top)
     pub offset_y: f32,
 }
 
 impl ScrollPosition {
-    pub const DEFAULT: Self = Self { offset_y: 0.0 };
+    pub const DEFAULT: Self = Self {
+        is_hovered: false,
+        offset_y: 0.0,
+    };
 }
 
 impl Default for ScrollPosition {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -59,6 +59,24 @@ impl Default for Node {
     }
 }
 
+/// The scroll position on the node
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
+pub struct ScrollPosition {
+    /// How far down the node is scrolled (0 = not scrolled / scrolled to top)
+    pub offset_y: f32,
+}
+
+impl ScrollPosition {
+    pub const DEFAULT: Self = Self { offset_y: 0.0 };
+}
+
+impl Default for ScrollPosition {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
 /// Represents the possible value types for layout properties.
 ///
 /// This enum allows specifying values for various [`Style`] properties in different units,
@@ -922,6 +940,30 @@ impl Overflow {
         }
     }
 
+    /// Scroll overflowing items on both axes
+    pub const fn scroll() -> Self {
+        Self {
+            x: OverflowAxis::Scroll,
+            y: OverflowAxis::Scroll,
+        }
+    }
+
+    /// Scroll overflowing items on the x axis
+    pub const fn scroll_x() -> Self {
+        Self {
+            x: OverflowAxis::Scroll,
+            y: OverflowAxis::Visible,
+        }
+    }
+
+    /// Scroll overflowing items on the y axis
+    pub const fn scroll_y() -> Self {
+        Self {
+            x: OverflowAxis::Visible,
+            y: OverflowAxis::Scroll,
+        }
+    }
+
     /// Overflow is visible on both axes
     pub const fn is_visible(&self) -> bool {
         self.x.is_visible() && self.y.is_visible()
@@ -942,6 +984,8 @@ pub enum OverflowAxis {
     Visible,
     /// Hide overflowing items.
     Clip,
+    /// Scroll overflowing items.
+    Scroll,
 }
 
 impl OverflowAxis {

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -122,7 +122,6 @@ pub fn update_scroll_position(
                     .map(|child| query_node.get(*child).unwrap().size().y)
                     .sum();
 
-                // TODO: Fix scroll clamping too soon
                 let max_scroll = (items_height - container_height).max(0.);
 
                 let dy = match mouse_wheel_event.unit {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -84,7 +84,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         flex_direction: FlexDirection::Column,
                                         align_self: AlignSelf::Stretch,
                                         size: Size::height(Val::Percent(50.)),
-                                        overflow: Overflow::Scroll,
+                                        overflow: Overflow::scroll_y(),
                                         ..default()
                                     },
                                     background_color: Color::rgb(0.10, 0.10, 0.10).into(),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -135,7 +135,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     for i in 0..100 {
                                         parent.spawn((
                                             TextBundle::from_section(
-                                                format!("Item {i}"),
+                                                format!("Item {}", i + 1),
                                                 TextStyle {
                                                     font: asset_server
                                                         .load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -84,7 +84,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         flex_direction: FlexDirection::Column,
                                         align_self: AlignSelf::Stretch,
                                         size: Size::height(Val::Percent(50.)),
-                                        overflow: Overflow::scroll_y(),
+                                        align_items: AlignItems::Start,
+                                        overflow: Overflow::scroll(),
                                         ..default()
                                     },
                                     background_color: Color::rgb(0.10, 0.10, 0.10).into(),
@@ -97,7 +98,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                             NodeBundle {
                                                 style: Style {
                                                     flex_direction: FlexDirection::Column,
-                                                    align_items: AlignItems::Center,
+                                                    align_items: AlignItems::Start,
+                                                    size: Size::width(Val::Px(600.)),
                                                     ..default()
                                                 },
                                                 ..default()
@@ -109,7 +111,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                             for i in 0..100 {
                                                 parent.spawn((
                                                     TextBundle::from_section(
-                                                        format!("Item {}", i + 1),
+                                                        format!("Item {} rhgiuherwiofhioewhfgioewhgioewhioghweioghiowhewiohgio", i + 1),
                                                         TextStyle {
                                                             font: asset_server
                                                                 .load("fonts/FiraSans-Bold.ttf"),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -49,6 +49,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     parent
                         .spawn(NodeBundle {
                             style: Style {
+                                flex_direction: FlexDirection::Column,
                                 size: Size::width(Val::Percent(100.)),
                                 ..default()
                             },
@@ -75,6 +76,55 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 // for accessibility to treat the text accordingly.
                                 Label,
                             ));
+
+                            // Scrolling list
+                            parent
+                                .spawn(NodeBundle {
+                                    style: Style {
+                                        flex_direction: FlexDirection::Column,
+                                        align_self: AlignSelf::Stretch,
+                                        size: Size::height(Val::Percent(50.)),
+                                        overflow: Overflow::Scroll,
+                                        ..default()
+                                    },
+                                    background_color: Color::rgb(0.10, 0.10, 0.10).into(),
+                                    ..default()
+                                })
+                                .with_children(|parent| {
+                                    // Moving panel
+                                    parent
+                                        .spawn((
+                                            NodeBundle {
+                                                style: Style {
+                                                    flex_direction: FlexDirection::Column,
+                                                    align_items: AlignItems::Center,
+                                                    ..default()
+                                                },
+                                                ..default()
+                                            },
+                                            AccessibilityNode(NodeBuilder::new(Role::List)),
+                                        ))
+                                        .with_children(|parent| {
+                                            // List items
+                                            for i in 0..100 {
+                                                parent.spawn((
+                                                    TextBundle::from_section(
+                                                        format!("Item {}", i + 1),
+                                                        TextStyle {
+                                                            font: asset_server
+                                                                .load("fonts/FiraSans-Bold.ttf"),
+                                                            font_size: 20.,
+                                                            color: Color::WHITE,
+                                                        },
+                                                    ),
+                                                    Label,
+                                                    AccessibilityNode(NodeBuilder::new(
+                                                        Role::ListItem,
+                                                    )),
+                                                ));
+                                            }
+                                        });
+                                });
                         });
                 });
             // right vertical fill
@@ -103,7 +153,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ),
                         Label,
                     ));
-                    // List with hidden overflow
+                    // Scrolling list
                     parent
                         .spawn(NodeBundle {
                             style: Style {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -5,7 +5,6 @@ use bevy::{
         accesskit::{NodeBuilder, Role},
         AccessibilityNode,
     },
-    input::mouse::{MouseScrollUnit, MouseWheel},
     prelude::*,
     winit::WinitSettings,
 };
@@ -16,7 +15,6 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
-        .add_systems(Update, mouse_scroll)
         .run();
 }
 
@@ -112,7 +110,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 flex_direction: FlexDirection::Column,
                                 align_self: AlignSelf::Stretch,
                                 size: Size::height(Val::Percent(50.)),
-                                overflow: Overflow::clip_y(),
+                                overflow: Overflow::scroll_y(),
                                 ..default()
                             },
                             background_color: Color::rgb(0.10, 0.10, 0.10).into(),
@@ -130,7 +128,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         },
                                         ..default()
                                     },
-                                    ScrollingList::default(),
                                     AccessibilityNode(NodeBuilder::new(Role::List)),
                                 ))
                                 .with_children(|parent| {
@@ -277,33 +274,4 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         });
                 });
         });
-}
-
-#[derive(Component, Default)]
-struct ScrollingList {
-    position: f32,
-}
-
-fn mouse_scroll(
-    mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut query_list: Query<(&mut ScrollingList, &mut Style, &Parent, &Node)>,
-    query_node: Query<&Node>,
-) {
-    for mouse_wheel_event in mouse_wheel_events.iter() {
-        for (mut scrolling_list, mut style, parent, list_node) in &mut query_list {
-            let items_height = list_node.size().y;
-            let container_height = query_node.get(parent.get()).unwrap().size().y;
-
-            let max_scroll = (items_height - container_height).max(0.);
-
-            let dy = match mouse_wheel_event.unit {
-                MouseScrollUnit::Line => mouse_wheel_event.y * 20.,
-                MouseScrollUnit::Pixel => mouse_wheel_event.y,
-            };
-
-            scrolling_list.position += dy;
-            scrolling_list.position = scrolling_list.position.clamp(-max_scroll, 0.);
-            style.top = Val::Px(scrolling_list.position);
-        }
-    }
 }

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -132,7 +132,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ))
                                 .with_children(|parent| {
                                     // List items
-                                    for i in 0..30 {
+                                    for i in 0..100 {
                                         parent.spawn((
                                             TextBundle::from_section(
                                                 format!("Item {i}"),


### PR DESCRIPTION
# Objective

Allow users to create scrollable regions using `bevy_ui`.
Fixes #8074 

## Prior Art

https://github.com/Piefayth/bevy_ui_scroll

## Solution

This is adapted from the scrolling implementation in the `examples/ui/ui.rs` example, but is improved in that it does not use the style system in order to apply offsets (which requires a relayout each time the scroll position changes, and interferes with users wanting to use that same style):

- A new `Overflow::Scroll` variant has been added to the `Overflow` enum to mark nodes that should be scrollable
- A system has been added that responds to mousewheel events and updates the scroll position
- Nodes are laid out like usual (layout using Taffy is not affected)
- The position of nodes is offset by the scroll position of their parent *after* layout while performing transform change detection

## Requirements from Taffy:

- [x] https://github.com/DioxusLabs/taffy/pull/424 (Correctly lay out `Overflow::Scroll`/`Overflow::Hidden` nodes)
- [x] https://github.com/DioxusLabs/taffy/pull/446 (Support reserving space for scrollbars for `Overflow::Scroll` nodes)
- [x] https://github.com/DioxusLabs/taffy/issues/470
- [ ] Track which nodes' scroll heights have changed in a given layout computation (for efficiently updating scroll_height in bevy on relayout only when actually necessary)
- [x] Release new version

## Tasks

- [x] Add `Overflow::Scroll` variant to `Overflow` enum
- [x] Add `ScrollPosition` component
- [x] Add `update_scroll_position` system
- [x] Only scroll the item under the cursor
- [x] Horizontal scrolling
- [x] Separate `Overflow` in each axis (https://github.com/bevyengine/bevy/pull/8095)
- [ ] Update scrolling on relayout (height of node or contents may have changed)
- [ ] Make `ScrollPosition` component optional for ui nodes to avoid checking every node on scroll
- [ ] AccessKit (need to export scroll_x/scroll_y and scroll_x_max/scroll_y_max to accessibility tree)
- [ ] Touch-based scrolling for mobile platforms
- [ ] Nested scrollviews

---

## Changelog

- Add support for `Overflow::Scroll`