### PR TITLE
change not implemation to custom system struct

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -137,7 +137,7 @@ mod sealed {
 pub mod common_conditions {
     use std::borrow::Cow;
 
-    use super::{Condition, ConditionInverter};
+    use super::{Condition, NotSystem};
     use crate::{
         change_detection::DetectChanges,
         event::{Event, EventReader},
@@ -921,13 +921,13 @@ pub mod common_conditions {
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// ```
-    pub fn not<Marker, T>(condition: T) -> ConditionInverter<T::System>
+    pub fn not<Marker, T>(condition: T) -> NotSystem<T::System>
     where
         T: Condition<Marker>,
     {
         let condition = IntoSystem::into_system(condition);
         let name = format!("!{}", condition.name());
-        ConditionInverter::<T::System> {
+        NotSystem::<T::System> {
             condition,
             name: Cow::Owned(name),
         }
@@ -938,16 +938,16 @@ pub mod common_conditions {
 ///
 /// See [`common_conditions::not`] for examples.
 #[derive(Clone)]
-pub struct ConditionInverter<T>
+pub struct NotSystem<T>
 where
-    T: System<In = (), Out = bool> + ReadOnlySystem,
+    T: System<In = (), Out = bool>,
 {
     condition: T,
     name: Cow<'static, str>,
 }
-impl<T> System for ConditionInverter<T>
+impl<T> System for NotSystem<T>
 where
-    T: System<In = (), Out = bool> + ReadOnlySystem,
+    T: System<In = (), Out = bool>,
 {
     type In = ();
     type Out = bool;
@@ -1011,10 +1011,7 @@ where
 }
 
 // SAFETY: The inner condition asserts its own safety.
-unsafe impl<T> ReadOnlySystem for ConditionInverter<T> where
-    T: System<In = (), Out = bool> + ReadOnlySystem
-{
-}
+unsafe impl<T> ReadOnlySystem for NotSystem<T> where T: System<In = (), Out = bool> + ReadOnlySystem {}
 
 /// Combines the outputs of two systems using the `&&` operator.
 pub type AndThen<A, B> = CombinatorSystem<AndThenMarker, A, B>;

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -940,7 +940,7 @@ pub mod common_conditions {
 /// Inverts the output of a [`Condition`].
 ///
 /// See [`common_conditions::not`] for examples.
-#[derive(Clone)]
+
 pub struct ConditionInverter<Marker, T>
 where
     T: System<In = (), Out = bool> + ReadOnlySystem,
@@ -1021,6 +1021,19 @@ where
     Marker: 'static,
     T: System<In = (), Out = bool> + ReadOnlySystem,
 {
+}
+
+impl<Marker, T> Clone for ConditionInverter<Marker, T>
+where
+    T: System<In = (), Out = bool> + ReadOnlySystem + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            _marker: PhantomData,
+            condition: self.condition.clone(),
+            name: self.name.clone(),
+        }
+    }
 }
 
 /// Combines the outputs of two systems using the `&&` operator.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -394,8 +394,8 @@ where
 
     /// Add a run condition to each contained system.
     ///
-    /// Each system will receive its own clone of the [`Condition`] and will only run
-    /// if the `Condition` is true.
+    /// The [`Condition`] must be [`Clone`]. Each system will receive its own clone
+    /// of the `Condition` and will only run if the `Condition` is true.
     ///
     /// Each individual condition will be evaluated at most once (per schedule run),
     /// right before the corresponding system prepares to run.
@@ -422,6 +422,9 @@ where
     /// Use [`run_if`](IntoSystemSetConfig::run_if) on a [`SystemSet`] if you want to make sure
     /// that either all or none of the systems are run, or you don't want to evaluate the run
     /// condition for each contained system separately.
+    ///
+    /// The [`Condition`] is cloned for each system.
+    /// Cloned instances of [`FunctionSystem`](crate::system::FunctionSystem) will be de-initialized.
     fn distributive_run_if<M>(self, condition: impl Condition<M> + Clone) -> SystemConfigs {
         self.into_configs().distributive_run_if(condition)
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -380,6 +380,7 @@ where
     marker: PhantomData<fn() -> Marker>,
 }
 
+// De-initializes the cloned system.
 impl<Marker, F> Clone for FunctionSystem<Marker, F>
 where
     F: SystemParamFunction<Marker> + Clone,
@@ -387,10 +388,10 @@ where
     fn clone(&self) -> Self {
         Self {
             func: self.func.clone(),
-            system_meta: self.system_meta.clone(),
+            system_meta: SystemMeta::new::<F>(),
             param_state: None,
-            world_id: self.world_id,
-            archetype_generation: self.archetype_generation,
+            world_id: None,
+            archetype_generation: ArchetypeGeneration::initial(),
             marker: PhantomData,
         }
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -389,8 +389,8 @@ where
             func: self.func.clone(),
             system_meta: self.system_meta.clone(),
             param_state: None,
-            world_id: self.world_id.clone(),
-            archetype_generation: self.archetype_generation.clone(),
+            world_id: self.world_id,
+            archetype_generation: self.archetype_generation,
             marker: PhantomData,
         }
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -388,8 +388,8 @@ where
     fn clone(&self) -> Self {
         Self {
             func: self.func.clone(),
-            system_meta: SystemMeta::new::<F>(),
             param_state: None,
+            system_meta: SystemMeta::new::<F>(),
             world_id: None,
             archetype_generation: ArchetypeGeneration::initial(),
             marker: PhantomData,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -380,6 +380,23 @@ where
     marker: PhantomData<fn() -> Marker>,
 }
 
+impl<Marker, F> Clone for FunctionSystem<Marker, F>
+where
+    F: SystemParamFunction<Marker> + Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            func: self.func.clone(),
+            system_meta: self.system_meta.clone(),
+            param_state: None,
+            world_id: self.world_id.clone(),
+            archetype_generation: self.archetype_generation.clone(),
+            marker: PhantomData,
+        }
+    }
+}
+
+#[derive(Clone)]
 pub struct IsFunctionSystem;
 
 impl<Marker, F> IntoSystem<F::In, F::Out, (IsFunctionSystem, Marker)> for F

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -367,6 +367,9 @@ pub struct In<In>(pub In);
 /// becomes the functions [`In`] tagged parameter or `()` if no such parameter exists.
 ///
 /// [`FunctionSystem`] must be `.initialized` before they can be run.
+///
+/// The [`Clone`] implementation for [`FunctionSystem`] returns a new instance which
+/// is NOT initialized. The cloned system must also be `.initialized` before it can be run.
 pub struct FunctionSystem<Marker, F>
 where
     F: SystemParamFunction<Marker>,

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -396,7 +396,6 @@ where
     }
 }
 
-#[derive(Clone)]
 pub struct IsFunctionSystem;
 
 impl<Marker, F> IntoSystem<F::In, F::Out, (IsFunctionSystem, Marker)> for F

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -120,6 +120,11 @@ impl Transform {
 
     /// Returns this [`Transform`] with a new rotation so that [`Transform::forward`]
     /// points towards the `target` position and [`Transform::up`] points towards `up`.
+    ///
+    /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
+    /// * if `target` is the same as the transform translation, `Vec3::Z` is used instead
+    /// * if `up` is zero, `Vec3::Y` is used instead
+    /// * if the resulting forward direction is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]
     #[must_use]
     pub fn looking_at(mut self, target: Vec3, up: Vec3) -> Self {
@@ -129,6 +134,11 @@ impl Transform {
 
     /// Returns this [`Transform`] with a new rotation so that [`Transform::forward`]
     /// points in the given `direction` and [`Transform::up`] points towards `up`.
+    ///
+    /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
+    /// * if `direction` is zero, `Vec3::Z` is used instead
+    /// * if `up` is zero, `Vec3::Y` is used instead
+    /// * if `direction` is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]
     #[must_use]
     pub fn looking_to(mut self, direction: Vec3, up: Vec3) -> Self {
@@ -325,6 +335,11 @@ impl Transform {
 
     /// Rotates this [`Transform`] so that [`Transform::forward`] points towards the `target` position,
     /// and [`Transform::up`] points towards `up`.
+    ///
+    /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
+    /// * if `target` is the same as the transtorm translation, `Vec3::Z` is used instead
+    /// * if `up` is zero, `Vec3::Y` is used instead
+    /// * if the resulting forward direction is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]
     pub fn look_at(&mut self, target: Vec3, up: Vec3) {
         self.look_to(target - self.translation, up);
@@ -332,10 +347,19 @@ impl Transform {
 
     /// Rotates this [`Transform`] so that [`Transform::forward`] points in the given `direction`
     /// and [`Transform::up`] points towards `up`.
+    ///
+    /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
+    /// * if `direction` is zero, `Vec3::Z` is used instead
+    /// * if `up` is zero, `Vec3::Y` is used instead
+    /// * if `direction` is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]
     pub fn look_to(&mut self, direction: Vec3, up: Vec3) {
-        let forward = -direction.normalize();
-        let right = up.cross(forward).normalize();
+        let forward = -direction.try_normalize().unwrap_or(Vec3::Z);
+        let up = up.try_normalize().unwrap_or(Vec3::Y);
+        let right = up
+            .cross(forward)
+            .try_normalize()
+            .unwrap_or_else(|| up.any_orthonormal_vector());
         let up = forward.cross(right);
         self.rotation = Quat::from_mat3(&Mat3::from_cols(right, up, forward));
     }


### PR DESCRIPTION
# Objective

The function `common_conditions::not` can't be used with the system configuration `distributive_run_if`, because the returned closure is typed as `impl Condition<()>`. Fixes another part of #8058.

## Solution

Changes to `not`:
- Add a custom `NotSystem` struct which wraps a `Condition` and inverts its output whenever it's run. Implements `Clone`.
- Return the concrete `NotSystem<_, T>` type from `not<_, T>`, so that the return type is `Clone` when the input system is `Clone`.

Changes to `FunctionSystem`:
- Add a `Clone` implementation for `FunctionSystem<Marker, F>` where `F` is `Clone`. Note: this implementation does _not_ clone the `param_state` field, so the cloned system instance doesn't have the original's state. Let me know if this is a problem.
- ~~`#[derive(Clone)]` for the `IsFunctionSystem` marker. The compiler didn't like it when I tried to remove this. Is it really necessary to implement `Clone` for the marker types?~~

---

## Changelog

- Added `NotSystem` system type
- Changed `common_conditions::not` to return a concrete type
- Changed `FunctionSystem` to implement `Clone` for `Clone` functions
