### PR TITLE
Remove redundant bounds check in `Entities::get`

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -571,8 +571,7 @@ impl Entities {
     /// Returns the location of an [`Entity`].
     /// Note: for pending entities, returns `Some(EntityLocation::INVALID)`.
     pub fn get(&self, entity: Entity) -> Option<EntityLocation> {
-        if (entity.index as usize) < self.meta.len() {
-            let meta = &self.meta[entity.index as usize];
+        if let Some(meta) = self.meta.get(entity.index as usize) {
             if meta.generation != entity.generation
                 || meta.location.archetype_id == ArchetypeId::INVALID
             {


### PR DESCRIPTION
# Objective

`Entities::get` does a manual bounds check of a `Vec` before taking a reference to that slot using brackets, which does the same bounds check again to see if it needs to panic (which of course it can't). This is wasteful.

## Solution

Use `Vec::get` to both bounds check and create a reference in one step.  Although the redundant bounds check should be optimized away in release mode, using `Vec::get` is shorter and more idiomatic, and potentially faster in debug builds.