### PR TITLE
Add documentation specifying behavior of app::runner when WinitPlugin is disabled

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -11,7 +11,10 @@ use bevy_ecs::{
         ScheduleLabel,
     },
 };
-use bevy_utils::{tracing::debug, HashMap, HashSet};
+use bevy_utils::{
+    tracing::{debug, warn},
+    HashMap, HashSet,
+};
 use std::{
     fmt::Debug,
     panic::{catch_unwind, resume_unwind, AssertUnwindSafe},

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1007,6 +1007,7 @@ impl App {
 }
 
 fn run_once(mut app: App) {
+    trace!("no app runner detected, defaulting to run_once");
     app.update();
 }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1007,7 +1007,7 @@ impl App {
 }
 
 fn run_once(mut app: App) {
-    trace!("no app runner detected, defaulting to run_once");
+    warn!("No app runner detected. defaulting to `run_once`. If this is intentional, consider using `App::update` directly instead.");
     app.update();
 }
 

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -14,7 +14,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// * [`AssetPlugin`](crate::asset::AssetPlugin) - with feature `bevy_asset`
 /// * [`DebugAssetPlugin`](crate::asset::debug_asset_server::DebugAssetServerPlugin) - with feature `debug_asset_server`
 /// * [`ScenePlugin`](crate::scene::ScenePlugin) - with feature `bevy_scene`
-/// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit`
+/// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit` (this also sets the [`app::runner`])
 /// * [`RenderPlugin`](crate::render::RenderPlugin) - with feature `bevy_render`
 /// * [`ImagePlugin`](crate::render::texture::ImagePlugin) - with feature `bevy_render`
 /// * [`PipelinedRenderingPlugin`](crate::render::pipelined_rendering::PipelinedRenderingPlugin) - with feature `bevy_render` when not targeting `wasm32`
@@ -35,6 +35,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// [`DefaultPlugins`] contains all the plugins typically required to build
 /// a *Bevy* application which includes a *window* and presentation components.
 /// For *headless* cases – without a *window* or presentation, see [`MinimalPlugins`].
+/// If [`WinitPlugin`] is disabled from this bundle, then the [`app::runner`] will not be set.
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -14,7 +14,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// * [`AssetPlugin`](crate::asset::AssetPlugin) - with feature `bevy_asset`
 /// * [`DebugAssetPlugin`](crate::asset::debug_asset_server::DebugAssetServerPlugin) - with feature `debug_asset_server`
 /// * [`ScenePlugin`](crate::scene::ScenePlugin) - with feature `bevy_scene`
-/// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit` (this also sets the [`app::runner`])
+/// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit` (this also sets the app's [runner](crate::app::App::runner))
 /// * [`RenderPlugin`](crate::render::RenderPlugin) - with feature `bevy_render`
 /// * [`ImagePlugin`](crate::render::texture::ImagePlugin) - with feature `bevy_render`
 /// * [`PipelinedRenderingPlugin`](crate::render::pipelined_rendering::PipelinedRenderingPlugin) - with feature `bevy_render` when not targeting `wasm32`
@@ -35,7 +35,7 @@ use bevy_app::{PluginGroup, PluginGroupBuilder};
 /// [`DefaultPlugins`] contains all the plugins typically required to build
 /// a *Bevy* application which includes a *window* and presentation components.
 /// For *headless* cases – without a *window* or presentation, see [`MinimalPlugins`].
-/// If [`WinitPlugin`] is disabled from this bundle, then the [`app::runner`] will not be set.
+/// If [`WinitPlugin`](crate::winit::WinitPlugin) is disabled from this bundle, then the app's [runner](crate::app::App::runner) will not be set.
 pub struct DefaultPlugins;
 
 impl PluginGroup for DefaultPlugins {


### PR DESCRIPTION
# Objective

Closes #8110 by adding more documentation and a log message.

## Solution

- [x] Add documentation to `DefaultPlugins` specifying behavior of app:runner when `WinitPlugin` is disabled
- [x] Add log message to `App::run_once` that no runner has been set

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

### Added
- More documentation in `DefaultPlugins` specifying behavior of `App::runner`
- A `trace!` log message when no `App::runner` is set

