### PR TITLE
Allow `many_buttons` to be run without text

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -76,7 +76,15 @@ fn setup(mut commands: Commands, font: Res<UiFont>) {
             for i in 0..count {
                 for j in 0..count {
                     let color = as_rainbow(j % i.max(1)).into();
-                    spawn_button(commands, font.0.clone_weak(), color, count_f, i, j, spawn_text);
+                    spawn_button(
+                        commands,
+                        font.0.clone_weak(),
+                        color,
+                        count_f,
+                        i,
+                        j,
+                        spawn_text,
+                    );
                 }
             }
         });

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -1,5 +1,5 @@
 //! This example shows what happens when there is a lot of buttons on screen.
-//! 
+//!
 //! To start the demo without text run
 //! `cargo run --example many_buttons --release no-text`
 
@@ -89,26 +89,24 @@ fn spawn_button(
     j: usize,
 ) {
     let width = 90.0 / total;
-    let mut builder = commands
-        .spawn((
-            ButtonBundle {
-                style: Style {
-                    size: Size::new(Val::Percent(width), Val::Percent(width)),
-                    bottom: Val::Percent(100.0 / total * i as f32),
-                    left: Val::Percent(100.0 / total * j as f32),
-                    align_items: AlignItems::Center,
-                    position_type: PositionType::Absolute,
-                    ..default()
-                },
-                background_color: color,
+    let mut builder = commands.spawn((
+        ButtonBundle {
+            style: Style {
+                size: Size::new(Val::Percent(width), Val::Percent(width)),
+                bottom: Val::Percent(100.0 / total * i as f32),
+                left: Val::Percent(100.0 / total * j as f32),
+                align_items: AlignItems::Center,
+                position_type: PositionType::Absolute,
                 ..default()
             },
-            IdleColor(color),
-        ));
+            background_color: color,
+            ..default()
+        },
+        IdleColor(color),
+    ));
 
     if std::env::args().nth(1).as_deref() != Some("no-text") {
-        builder
-        .with_children(|commands| {
+        builder.with_children(|commands| {
             commands.spawn(TextBundle::from_section(
                 format!("{i}, {j}"),
                 TextStyle {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -5,20 +5,13 @@ use bevy::{
 };
 
 // For a total of 110 * 110 = 12100 buttons with text
-#[cfg(feature = "bevy_text")]
 const ROW_COLUMN_COUNT: usize = 110;
-
-// For a total of 220 * 220 = 48400 buttons without text
-#[cfg(not(feature = "bevy_text"))]
-const ROW_COLUMN_COUNT: usze = 220;
-
-#[cfg(feature = "bevy_text")]
 const FONT_SIZE: f32 = 7.0;
 
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
-    let mut app = App::new();
-    app.add_plugins(DefaultPlugins.set(WindowPlugin {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::Immediate,
                 ..default()
@@ -27,12 +20,9 @@ fn main() {
         }))
         .add_plugin(FrameTimeDiagnosticsPlugin::default())
         .add_plugin(LogDiagnosticsPlugin::default())
-        .add_systems((setup.on_startup(), button_system));
-
-    #[cfg(feature = "bevy_text")]
-    app.init_resource::<UiFont>();
-
-    app.run();
+        .init_resource::<UiFont>()
+        .add_systems((setup.on_startup(), button_system))
+        .run();
 }
 
 #[derive(Component)]
@@ -53,11 +43,9 @@ fn button_system(
     }
 }
 
-#[cfg(feature = "bevy_text")]
 #[derive(Resource)]
 struct UiFont(Handle<Font>);
 
-#[cfg(feature = "bevy_text")]
 impl FromWorld for UiFont {
     fn from_world(world: &mut World) -> Self {
         let asset_server = world.resource::<AssetServer>();
@@ -65,11 +53,7 @@ impl FromWorld for UiFont {
     }
 }
 
-fn setup(
-    mut commands: Commands, 
-    #[cfg(feature = "bevy_text")]
-    font: Res<UiFont>
-) {
+fn setup(mut commands: Commands, font: Res<UiFont>) {
     let count = ROW_COLUMN_COUNT;
     let count_f = count as f32;
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);
@@ -86,20 +70,13 @@ fn setup(
             for i in 0..count {
                 for j in 0..count {
                     let color = as_rainbow(j % i.max(1)).into();
-                    spawn_button(
-                        commands, 
-                        #[cfg(feature = "bevy_text")]
-                        font.0.clone_weak(), 
-                        color, 
-                        count_f, i, j);
+                    spawn_button(commands, font.0.clone_weak(), color, count_f, i, j);
                 }
             }
         });
 }
-
 fn spawn_button(
     commands: &mut ChildBuilder,
-    #[cfg(feature = "bevy_text")]
     font: Handle<Font>,
     color: BackgroundColor,
     total: f32,
@@ -107,7 +84,6 @@ fn spawn_button(
     j: usize,
 ) {
     let width = 90.0 / total;
-    #[cfg(feature = "bevy_text")]
     commands
         .spawn((
             ButtonBundle {
@@ -134,22 +110,4 @@ fn spawn_button(
                 },
             ));
         });
-
-    #[cfg(not(feature = "bevy_text"))]
-    commands
-        .spawn((
-            ButtonBundle {
-                style: Style {
-                    size: Size::new(Val::Percent(width), Val::Percent(width)),
-                    bottom: Val::Percent(100.0 / total * i as f32),
-                    left: Val::Percent(100.0 / total * j as f32),
-                    align_items: AlignItems::Center,
-                    position_type: PositionType::Absolute,
-                    ..default()
-                },
-                background_color: color,
-                ..default()
-            },
-            IdleColor(color),
-        ));    
 }

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -11,20 +11,10 @@ use bevy::{
 
 // For a total of 110 * 110 = 12100 buttons with text
 const ROW_COLUMN_COUNT: usize = 110;
-<<<<<<< HEAD
-=======
-
-// For a total of 220 * 220 = 48400 buttons without text
-#[cfg(not(feature = "bevy_text"))]
-const ROW_COLUMN_COUNT: usize = 220;
-
-#[cfg(feature = "bevy_text")]
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
 const FONT_SIZE: f32 = 7.0;
 
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
-<<<<<<< HEAD
     App::new()
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
@@ -38,24 +28,6 @@ fn main() {
         .init_resource::<UiFont>()
         .add_systems((setup.on_startup(), button_system))
         .run();
-=======
-    let mut app = App::new();
-    app.add_plugins(DefaultPlugins.set(WindowPlugin {
-        primary_window: Some(Window {
-            present_mode: PresentMode::Immediate,
-            ..default()
-        }),
-        ..default()
-    }))
-    .add_plugin(FrameTimeDiagnosticsPlugin::default())
-    .add_plugin(LogDiagnosticsPlugin::default())
-    .add_systems((setup.on_startup(), button_system));
-
-    #[cfg(feature = "bevy_text")]
-    app.init_resource::<UiFont>();
-
-    app.run();
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
 }
 
 #[derive(Component)]
@@ -86,11 +58,7 @@ impl FromWorld for UiFont {
     }
 }
 
-<<<<<<< HEAD
 fn setup(mut commands: Commands, font: Res<UiFont>) {
-=======
-fn setup(mut commands: Commands, #[cfg(feature = "bevy_text")] font: Res<UiFont>) {
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
     let count = ROW_COLUMN_COUNT;
     let count_f = count as f32;
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);
@@ -107,30 +75,14 @@ fn setup(mut commands: Commands, #[cfg(feature = "bevy_text")] font: Res<UiFont>
             for i in 0..count {
                 for j in 0..count {
                     let color = as_rainbow(j % i.max(1)).into();
-<<<<<<< HEAD
                     spawn_button(commands, font.0.clone_weak(), color, count_f, i, j);
-=======
-                    spawn_button(
-                        commands,
-                        #[cfg(feature = "bevy_text")]
-                        font.0.clone_weak(),
-                        color,
-                        count_f,
-                        i,
-                        j,
-                    );
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
                 }
             }
         });
 }
 fn spawn_button(
     commands: &mut ChildBuilder,
-<<<<<<< HEAD
     font: Handle<Font>,
-=======
-    #[cfg(feature = "bevy_text")] font: Handle<Font>,
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
     color: BackgroundColor,
     total: f32,
     i: usize,
@@ -166,25 +118,5 @@ fn spawn_button(
                 },
             ));
         });
-<<<<<<< HEAD
     }
-=======
-
-    #[cfg(not(feature = "bevy_text"))]
-    commands.spawn((
-        ButtonBundle {
-            style: Style {
-                size: Size::new(Val::Percent(width), Val::Percent(width)),
-                bottom: Val::Percent(100.0 / total * i as f32),
-                left: Val::Percent(100.0 / total * j as f32),
-                align_items: AlignItems::Center,
-                position_type: PositionType::Absolute,
-                ..default()
-            },
-            background_color: color,
-            ..default()
-        },
-        IdleColor(color),
-    ));
->>>>>>> 85773ce157abe4f35a977aff70a09ec59baec2a7
 }

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -72,14 +72,16 @@ fn setup(mut commands: Commands, font: Res<UiFont>) {
             ..default()
         })
         .with_children(|commands| {
+            let spawn_text = std::env::args().nth(1).as_deref() != Some("no-text");
             for i in 0..count {
                 for j in 0..count {
                     let color = as_rainbow(j % i.max(1)).into();
-                    spawn_button(commands, font.0.clone_weak(), color, count_f, i, j);
+                    spawn_button(commands, font.0.clone_weak(), color, count_f, i, j, spawn_text);
                 }
             }
         });
 }
+
 fn spawn_button(
     commands: &mut ChildBuilder,
     font: Handle<Font>,
@@ -87,6 +89,7 @@ fn spawn_button(
     total: f32,
     i: usize,
     j: usize,
+    spawn_text: bool,
 ) {
     let width = 90.0 / total;
     let mut builder = commands.spawn((
@@ -105,7 +108,7 @@ fn spawn_button(
         IdleColor(color),
     ));
 
-    if std::env::args().nth(1).as_deref() != Some("no-text") {
+    if spawn_text {
         builder.with_children(|commands| {
             commands.spawn(TextBundle::from_section(
                 format!("{i}, {j}"),

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -1,3 +1,8 @@
+//! This example shows what happens when there is a lot of buttons on screen.
+//! 
+//! To start the demo without text run
+//! `cargo run --example many_buttons --release no-text`
+
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
@@ -84,7 +89,7 @@ fn spawn_button(
     j: usize,
 ) {
     let width = 90.0 / total;
-    commands
+    let mut builder = commands
         .spawn((
             ButtonBundle {
                 style: Style {
@@ -99,7 +104,10 @@ fn spawn_button(
                 ..default()
             },
             IdleColor(color),
-        ))
+        ));
+
+    if std::env::args().nth(1).as_deref() != Some("no-text") {
+        builder
         .with_children(|commands| {
             commands.spawn(TextBundle::from_section(
                 format!("{i}, {j}"),
@@ -110,4 +118,5 @@ fn spawn_button(
                 },
             ));
         });
+    }
 }


### PR DESCRIPTION
# Objective

`many_buttons` isn't a good benchmark in all cases because it draws so much text. Allow `many_buttons` to be run without text.

## Solution

If the command-line flag `no-text` is specified, don't draw any text.

## Changelog

* `many_buttons` can now be run without text. To start without text run: `cargo run --example many_buttons --release no-text`
