### PR TITLE
Derive Copy and Clone for Collision

### DIFF
--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -2,7 +2,7 @@
 
 use bevy_math::{Vec2, Vec3};
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Collision {
     Left,
     Right,


### PR DESCRIPTION
# Objective

Fixes #8120 

## Solution

Derives `Copy` and `Clone` for the `Collision` enum.

Apologies if I chose the wrong branch to merge into, this is my first contribution to Bevy.