### PR TITLE
Simplify hex method by using trim_start_matches

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -304,10 +304,7 @@ impl Color {
     /// ```
     ///
     pub fn hex<T: AsRef<str>>(hex: T) -> Result<Color, HexColorError> {
-        let hex = hex.as_ref();
-        let hex = hex.strip_prefix('#').unwrap_or(hex);
-
-        match *hex.as_bytes() {
+        match *hex.as_ref().trim_start_matches('#').as_bytes() {
             // RGB
             [r, g, b] => {
                 let [r, g, b, ..] = decode_hex([r, r, g, g, b, b])?;


### PR DESCRIPTION
# Objective

Simplify hex method by using trim_start_matches

## Solution

Using `trim_start_matches` to remove the 'number sign' if it exists instead of using `unwrap_or`