### PR TITLE
AddVal Viewport unit variants

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -1,4 +1,4 @@
-use taffy::style::LengthPercentageAuto;
+use bevy_math::Vec2;
 
 use crate::{
     AlignContent, AlignItems, AlignSelf, Display, FlexDirection, FlexWrap, JustifyContent,
@@ -6,94 +6,72 @@ use crate::{
 };
 
 impl Val {
-    fn scaled(self, scale_factor: f64) -> Self {
+    fn scaled(self, scale_factor: f64, physical_size: Vec2) -> Self {
         match self {
             Val::Auto => Val::Auto,
             Val::Percent(value) => Val::Percent(value),
             Val::Px(value) => Val::Px((scale_factor * value as f64) as f32),
+            Val::VMin(value) => Val::Px(physical_size.x.min(physical_size.y) * value / 100.),
+            Val::VMax(value) => Val::Px(physical_size.x.max(physical_size.y) * value / 100.),
+            Val::Vw(value) => Val::Px(physical_size.x * value / 100.),
+            Val::Vh(value) => Val::Px(physical_size.y * value / 100.),
         }
     }
-
-    fn to_inset(self) -> LengthPercentageAuto {
-        match self {
+    fn into_dimension(self, scale_factor: f64, physical_size: Vec2) -> taffy::style::Dimension {
+        match self.scaled(scale_factor, physical_size) {
+            Val::Auto => taffy::style::Dimension::Auto,
+            Val::Percent(value) => taffy::style::Dimension::Percent(value / 100.0),
+            Val::Px(value) => taffy::style::Dimension::Points(value),
+            _ => unreachable!(),
+        }
+    }
+    fn into_length_percentage(
+        self,
+        scale_factor: f64,
+        physical_size: Vec2,
+    ) -> taffy::style::LengthPercentage {
+        match self.scaled(scale_factor, physical_size) {
+            Val::Auto => taffy::style::LengthPercentage::Points(0.0),
+            Val::Percent(value) => taffy::style::LengthPercentage::Percent(value / 100.0),
+            Val::Px(value) => taffy::style::LengthPercentage::Points(value),
+            _ => unreachable!(),
+        }
+    }
+    fn into_length_percentage_auto(
+        self,
+        scale_factor: f64,
+        physical_size: Vec2,
+    ) -> taffy::style::LengthPercentageAuto {
+        match self.scaled(scale_factor, physical_size) {
             Val::Auto => taffy::style::LengthPercentageAuto::Auto,
             Val::Percent(value) => taffy::style::LengthPercentageAuto::Percent(value / 100.0),
             Val::Px(value) => taffy::style::LengthPercentageAuto::Points(value),
+            _ => unreachable!(),
         }
     }
 }
 
 impl UiRect {
-    fn scaled(self, scale_factor: f64) -> Self {
-        Self {
-            left: self.left.scaled(scale_factor),
-            right: self.right.scaled(scale_factor),
-            top: self.top.scaled(scale_factor),
-            bottom: self.bottom.scaled(scale_factor),
+    fn map_to_taffy_rect<T>(self, map_fn: impl Fn(Val) -> T) -> taffy::geometry::Rect<T> {
+        taffy::geometry::Rect {
+            left: map_fn(self.left),
+            right: map_fn(self.right),
+            top: map_fn(self.top),
+            bottom: map_fn(self.bottom),
         }
     }
 }
 
 impl Size {
-    fn scaled(self, scale_factor: f64) -> Self {
-        Self {
-            width: self.width.scaled(scale_factor),
-            height: self.height.scaled(scale_factor),
+    fn map_to_taffy_size<T>(self, map_fn: impl Fn(Val) -> T) -> taffy::geometry::Size<T> {
+        taffy::geometry::Size {
+            width: map_fn(self.width),
+            height: map_fn(self.height),
         }
     }
 }
 
-impl<T: From<Val>> From<UiRect> for taffy::prelude::Rect<T> {
-    fn from(value: UiRect) -> Self {
-        Self {
-            left: value.left.into(),
-            right: value.right.into(),
-            top: value.top.into(),
-            bottom: value.bottom.into(),
-        }
-    }
-}
-
-impl<T: From<Val>> From<Size> for taffy::prelude::Size<T> {
-    fn from(value: Size) -> Self {
-        Self {
-            width: value.width.into(),
-            height: value.height.into(),
-        }
-    }
-}
-
-impl From<Val> for taffy::style::Dimension {
-    fn from(value: Val) -> Self {
-        match value {
-            Val::Auto => taffy::style::Dimension::Auto,
-            Val::Percent(value) => taffy::style::Dimension::Percent(value / 100.0),
-            Val::Px(value) => taffy::style::Dimension::Points(value),
-        }
-    }
-}
-
-impl From<Val> for taffy::style::LengthPercentage {
-    fn from(value: Val) -> Self {
-        match value {
-            Val::Auto => taffy::style::LengthPercentage::Points(0.0),
-            Val::Percent(value) => taffy::style::LengthPercentage::Percent(value / 100.0),
-            Val::Px(value) => taffy::style::LengthPercentage::Points(value),
-        }
-    }
-}
-
-impl From<Val> for taffy::style::LengthPercentageAuto {
-    fn from(value: Val) -> Self {
-        match value {
-            Val::Auto => taffy::style::LengthPercentageAuto::Auto,
-            Val::Percent(value) => taffy::style::LengthPercentageAuto::Percent(value / 100.0),
-            Val::Px(value) => taffy::style::LengthPercentageAuto::Points(value),
-        }
-    }
-}
-
-pub fn from_style(scale_factor: f64, style: &Style) -> taffy::style::Style {
+pub fn from_style(scale_factor: f64, physical_size: Vec2, style: &Style) -> taffy::style::Style {
     taffy::style::Style {
         display: style.display.into(),
         position: style.position_type.into(),
@@ -104,22 +82,44 @@ pub fn from_style(scale_factor: f64, style: &Style) -> taffy::style::Style {
         align_content: Some(style.align_content.into()),
         justify_content: Some(style.justify_content.into()),
         inset: taffy::prelude::Rect {
-            left: style.left.scaled(scale_factor).to_inset(),
-            right: style.right.scaled(scale_factor).to_inset(),
-            top: style.top.scaled(scale_factor).to_inset(),
-            bottom: style.bottom.scaled(scale_factor).to_inset(),
+            left: style
+                .left
+                .into_length_percentage_auto(scale_factor, physical_size),
+            right: style
+                .right
+                .into_length_percentage_auto(scale_factor, physical_size),
+            top: style
+                .top
+                .into_length_percentage_auto(scale_factor, physical_size),
+            bottom: style
+                .bottom
+                .into_length_percentage_auto(scale_factor, physical_size),
         },
-        margin: style.margin.scaled(scale_factor).into(),
-        padding: style.padding.scaled(scale_factor).into(),
-        border: style.border.scaled(scale_factor).into(),
+        margin: style
+            .margin
+            .map_to_taffy_rect(|m| m.into_length_percentage_auto(scale_factor, physical_size)),
+        padding: style
+            .padding
+            .map_to_taffy_rect(|m| m.into_length_percentage(scale_factor, physical_size)),
+        border: style
+            .border
+            .map_to_taffy_rect(|m| m.into_length_percentage(scale_factor, physical_size)),
         flex_grow: style.flex_grow,
         flex_shrink: style.flex_shrink,
-        flex_basis: style.flex_basis.scaled(scale_factor).into(),
-        size: style.size.scaled(scale_factor).into(),
-        min_size: style.min_size.scaled(scale_factor).into(),
-        max_size: style.max_size.scaled(scale_factor).into(),
+        flex_basis: style.flex_basis.into_dimension(scale_factor, physical_size),
+        size: style
+            .size
+            .map_to_taffy_size(|s| s.into_dimension(scale_factor, physical_size)),
+        min_size: style
+            .min_size
+            .map_to_taffy_size(|s| s.into_dimension(scale_factor, physical_size)),
+        max_size: style
+            .max_size
+            .map_to_taffy_size(|s| s.into_dimension(scale_factor, physical_size)),
         aspect_ratio: style.aspect_ratio,
-        gap: style.gap.scaled(scale_factor).into(),
+        gap: style
+            .gap
+            .map_to_taffy_size(|s| s.into_length_percentage(scale_factor, physical_size)),
         justify_self: None,
     }
 }
@@ -283,7 +283,7 @@ mod tests {
                 height: Val::Percent(0.),
             },
         };
-        let taffy_style = from_style(1.0, &bevy_style);
+        let taffy_style = from_style(1.0, Vec2::new(800., 600.), &bevy_style);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.position, taffy::style::Position::Absolute);
         assert!(matches!(

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -67,6 +67,14 @@ pub enum Val {
     Px(f32),
     /// Set this value in percent
     Percent(f32),
+    /// Set this value in percent of the viewport width
+    Vw(f32),
+    /// Set this value in percent of the viewport height
+    Vh(f32),
+    /// Set this value in percent of the viewport's smaller dimension.
+    VMin(f32),
+    /// Set this value in percent of the viewport's larger dimension.
+    VMax(f32),
 }
 
 impl Val {
@@ -87,6 +95,10 @@ impl Mul<f32> for Val {
             Val::Auto => Val::Auto,
             Val::Px(value) => Val::Px(value * rhs),
             Val::Percent(value) => Val::Percent(value * rhs),
+            Val::Vw(value) => Val::Vw(value * rhs),
+            Val::Vh(value) => Val::Vh(value * rhs),
+            Val::VMin(value) => Val::VMin(value * rhs),
+            Val::VMax(value) => Val::VMax(value * rhs),
         }
     }
 }
@@ -95,7 +107,12 @@ impl MulAssign<f32> for Val {
     fn mul_assign(&mut self, rhs: f32) {
         match self {
             Val::Auto => {}
-            Val::Px(value) | Val::Percent(value) => *value *= rhs,
+            Val::Px(value)
+            | Val::Percent(value)
+            | Val::Vw(value)
+            | Val::Vh(value)
+            | Val::VMin(value)
+            | Val::VMax(value) => *value *= rhs,
         }
     }
 }
@@ -108,6 +125,10 @@ impl Div<f32> for Val {
             Val::Auto => Val::Auto,
             Val::Px(value) => Val::Px(value / rhs),
             Val::Percent(value) => Val::Percent(value / rhs),
+            Val::Vw(value) => Val::Vw(value / rhs),
+            Val::Vh(value) => Val::Vh(value / rhs),
+            Val::VMin(value) => Val::VMin(value / rhs),
+            Val::VMax(value) => Val::VMax(value / rhs),
         }
     }
 }
@@ -116,7 +137,12 @@ impl DivAssign<f32> for Val {
     fn div_assign(&mut self, rhs: f32) {
         match self {
             Val::Auto => {}
-            Val::Px(value) | Val::Percent(value) => *value /= rhs,
+            Val::Px(value)
+            | Val::Percent(value)
+            | Val::Vw(value)
+            | Val::Vh(value)
+            | Val::VMin(value)
+            | Val::VMax(value) => *value /= rhs,
         }
     }
 }


### PR DESCRIPTION
* Added `Val` viewport unit variants `Vw`, `Vh`, `VMin` and `VMax`.
* Modified `convert` module to support the new `Val` variants.
* Changed `flex_node_system` to support the new `Val` variants.
* Perform full layout update on screen resizing, to propagate the new viewport size to all nodes.

# Objective

- Describe the objective or issue this PR addresses.
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Describe the solution used to achieve the objective above.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
