### PR TITLE
Improve UI `update_clipping_system` comments

### DIFF
--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -37,35 +37,46 @@ fn update_clipping(
     entity: Entity,
     clip: Option<Rect>,
 ) {
-    let (node, global_transform, style, calculated_clip) = node_query.get_mut(entity).unwrap();
-    // Update this node's CalculatedClip component
-    match (clip, calculated_clip) {
+    let (node, global_transform, style, old_clip) = node_query.get_mut(entity).unwrap();
+
+    // Update current node's CalculatedClip component
+    match (old_clip, clip) {
         (None, None) => {}
-        (None, Some(_)) => {
+        (Some(_), None) => {
             commands.entity(entity).remove::<CalculatedClip>();
         }
-        (Some(clip), None) => {
+        (None, Some(clip)) => {
             commands.entity(entity).insert(CalculatedClip { clip });
         }
-        (Some(clip), Some(mut old_clip)) => {
+        (Some(mut old_clip), Some(clip)) => {
             if old_clip.clip != clip {
                 *old_clip = CalculatedClip { clip };
             }
         }
     }
 
-    // Calculate new clip for its children
+    // Calculate new clip rectangle for children nodes
     let children_clip = match style.overflow {
+        // When `Visible`, children will be visible even when they are outside
+        // the current node's "area". In this case they inherit the current
+        // node's parent clip. If an ancestor is set as `Hidden`, that clip will
+        // be used; otherwise this will be `None`.
         Overflow::Visible => clip,
         Overflow::Hidden => {
+            // Calculate current node clip rectangle from: posisition + calculated_size
             let node_center = global_transform.translation().truncate();
-            let node_rect = Rect::from_center_size(node_center, node.calculated_size);
-            Some(clip.map_or(node_rect, |c| c.intersect(node_rect)))
+            let node_clip = Rect::from_center_size(node_center, node.calculated_size);
+
+            // If `clip` is `Some`, use the intersection between current node's
+            // clip and the ancestor `clip`. This handles the case of nested
+            // `Overflow::Hidden` nodes. If parent `clip` is not defined, use
+            // the current node's clip (pos + calculated size).
+            Some(clip.map_or(node_clip, |c| c.intersect(node_clip)))
         }
     };
 
     if let Ok(children) = children_query.get(entity) {
-        for child in children.iter().cloned() {
+        for &child in children.into_iter() {
             update_clipping(commands, children_query, node_query, child, children_clip);
         }
     }


### PR DESCRIPTION
# Objective

- Improve `update_clipping_system` comments

## Solution

- Add extra comments
- Reorder `CalculatedClip` updating `match` so it's reads `(old, new)` vs previous `(new, old)`
- Remove `clone` on children iteration