### PR TITLE
Improve render asset

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -8,7 +8,7 @@ use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
 use bevy_render::extract_resource::{ExtractResource, ExtractResourcePlugin};
 use bevy_render::render_asset::RenderAssets;
 use bevy_render::renderer::RenderDevice;
-use bevy_render::texture::{CompressedImageFormats, Image, ImageSampler, ImageType};
+use bevy_render::texture::{CompressedImageFormats, GpuImage, Image, ImageSampler, ImageType};
 use bevy_render::view::{ViewTarget, ViewUniform};
 use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
 
@@ -317,7 +317,7 @@ pub enum DebandDither {
 }
 
 pub fn get_lut_bindings<'a>(
-    images: &'a RenderAssets<Image>,
+    images: &'a RenderAssets<GpuImage>,
     tonemapping_luts: &'a TonemappingLuts,
     tonemapping: &Tonemapping,
     bindings: [u32; 2],

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -13,7 +13,7 @@ use bevy_render::{
         SamplerDescriptor, TextureViewId,
     },
     renderer::RenderContext,
-    texture::Image,
+    texture::GpuImage,
     view::{ExtractedView, ViewTarget, ViewUniformOffset, ViewUniforms},
 };
 
@@ -63,7 +63,7 @@ impl Node for TonemappingNode {
         let view_entity = graph.get_input_entity(Self::IN_VIEW)?;
         let pipeline_cache = world.resource::<PipelineCache>();
         let tonemapping_pipeline = world.resource::<TonemappingPipeline>();
-        let gpu_images = world.get_resource::<RenderAssets<Image>>().unwrap();
+        let gpu_images = world.get_resource::<RenderAssets<GpuImage>>().unwrap();
         let view_uniforms_resource = world.resource::<ViewUniforms>();
         let view_uniforms = &view_uniforms_resource.uniforms;
         let view_uniforms_id = view_uniforms.buffer().unwrap().id();

--- a/crates/bevy_pbr/src/environment_map/mod.rs
+++ b/crates/bevy_pbr/src/environment_map/mod.rs
@@ -10,7 +10,7 @@ use bevy_render::{
         BindGroupEntry, BindGroupLayoutEntry, BindingResource, BindingType, SamplerBindingType,
         Shader, ShaderStages, TextureSampleType, TextureViewDimension,
     },
-    texture::{FallbackImageCubemap, Image, GpuImage},
+    texture::{FallbackImageCubemap, GpuImage, Image},
 };
 
 pub const ENVIRONMENT_MAP_SHADER_HANDLE: HandleUntyped =

--- a/crates/bevy_pbr/src/environment_map/mod.rs
+++ b/crates/bevy_pbr/src/environment_map/mod.rs
@@ -10,7 +10,7 @@ use bevy_render::{
         BindGroupEntry, BindGroupLayoutEntry, BindingResource, BindingType, SamplerBindingType,
         Shader, ShaderStages, TextureSampleType, TextureViewDimension,
     },
-    texture::{FallbackImageCubemap, Image},
+    texture::{FallbackImageCubemap, Image, GpuImage},
 };
 
 pub const ENVIRONMENT_MAP_SHADER_HANDLE: HandleUntyped =
@@ -55,7 +55,7 @@ pub struct EnvironmentMapLight {
 impl EnvironmentMapLight {
     /// Whether or not all textures necessary to use the environment map
     /// have been loaded by the asset server.
-    pub fn is_loaded(&self, images: &RenderAssets<Image>) -> bool {
+    pub fn is_loaded(&self, images: &RenderAssets<GpuImage>) -> bool {
         images.get(&self.diffuse_map).is_some() && images.get(&self.specular_map).is_some()
     }
 }
@@ -72,7 +72,7 @@ impl ExtractComponent for EnvironmentMapLight {
 
 pub fn get_bindings<'a>(
     environment_map_light: Option<&EnvironmentMapLight>,
-    images: &'a RenderAssets<Image>,
+    images: &'a RenderAssets<GpuImage>,
     fallback_image_cubemap: &'a FallbackImageCubemap,
     bindings: [u32; 3],
 ) -> [BindGroupEntry<'a>; 3] {

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -530,7 +530,7 @@ pub struct PreparedMaterial<T: Material> {
 }
 
 impl<M: Material> RenderAsset for PreparedMaterial<M> {
-    type Asset = M;
+    type SourceAsset = M;
     type ExtractedAsset = M;
     type Param = (
         SRes<RenderDevice>,
@@ -538,7 +538,7 @@ impl<M: Material> RenderAsset for PreparedMaterial<M> {
         SRes<FallbackImage>,
         SRes<MaterialPipeline<M>>,
     );
-    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
         asset.clone()
     }
     fn prepare_asset(

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -20,8 +20,7 @@ use bevy_ecs::{
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
-    mesh::{Mesh, MeshVertexBufferLayout},
-    prelude::Image,
+    mesh::{Mesh, GpuMesh, MeshVertexBufferLayout},
     render_asset::{PrepareAssetSet, RenderAssets},
     render_phase::{
         AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
@@ -33,7 +32,7 @@ use bevy_render::{
         SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
-    texture::FallbackImage,
+    texture::{FallbackImage, GpuImage},
     view::{ExtractedView, Msaa, VisibleEntities},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -370,10 +369,10 @@ pub fn queue_material_meshes<M: Material>(
     mut pipelines: ResMut<SpecializedMeshPipelines<MaterialPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     render_materials: Res<RenderMaterials<M>>,
     material_meshes: Query<(&Handle<M>, &Handle<Mesh>, &MeshUniform)>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     mut views: Query<(
         &ExtractedView,
         &VisibleEntities,
@@ -614,7 +613,7 @@ pub fn prepare_materials<M: Material>(
     mut extracted_assets: ResMut<ExtractedMaterials<M>>,
     mut render_materials: ResMut<RenderMaterials<M>>,
     render_device: Res<RenderDevice>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>,
     pipeline: Res<MaterialPipeline<M>>,
 ) {
@@ -661,7 +660,7 @@ pub fn prepare_materials<M: Material>(
 fn prepare_material<M: Material>(
     material: &M,
     render_device: &RenderDevice,
-    images: &RenderAssets<Image>,
+    images: &RenderAssets<GpuImage>,
     fallback_image: &FallbackImage,
     pipeline: &MaterialPipeline<M>,
 ) -> Result<PreparedMaterial<M>, AsBindGroupError> {

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -6,8 +6,11 @@ use bevy_asset::Handle;
 use bevy_math::Vec4;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect, TypeUuid};
 use bevy_render::{
-    color::Color, mesh::MeshVertexBufferLayout, render_asset::RenderAssets, render_resource::*,
-    texture::{Image, GpuImage},
+    color::Color,
+    mesh::MeshVertexBufferLayout,
+    render_asset::RenderAssets,
+    render_resource::*,
+    texture::{GpuImage, Image},
 };
 
 /// A material with "standard" properties used in PBR lighting
@@ -344,7 +347,10 @@ pub struct StandardMaterialUniform {
 }
 
 impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
-    fn as_bind_group_shader_type(&self, images: &RenderAssets<GpuImage>) -> StandardMaterialUniform {
+    fn as_bind_group_shader_type(
+        &self,
+        images: &RenderAssets<GpuImage>,
+    ) -> StandardMaterialUniform {
         let mut flags = StandardMaterialFlags::NONE;
         if self.base_color_texture.is_some() {
             flags |= StandardMaterialFlags::BASE_COLOR_TEXTURE;

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -7,7 +7,7 @@ use bevy_math::Vec4;
 use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect, TypeUuid};
 use bevy_render::{
     color::Color, mesh::MeshVertexBufferLayout, render_asset::RenderAssets, render_resource::*,
-    texture::Image,
+    texture::{Image, GpuImage},
 };
 
 /// A material with "standard" properties used in PBR lighting
@@ -344,7 +344,7 @@ pub struct StandardMaterialUniform {
 }
 
 impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
-    fn as_bind_group_shader_type(&self, images: &RenderAssets<Image>) -> StandardMaterialUniform {
+    fn as_bind_group_shader_type(&self, images: &RenderAssets<GpuImage>) -> StandardMaterialUniform {
         let mut flags = StandardMaterialFlags::NONE;
         if self.base_color_texture.is_some() {
             flags |= StandardMaterialFlags::BASE_COLOR_TEXTURE;

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -45,7 +45,7 @@ use bevy_utils::{tracing::error, HashMap};
 
 use crate::{
     AlphaMode, DrawMesh, Material, MaterialPipeline, MaterialPipelineKey, MeshPipeline,
-    MeshPipelineKey, MeshUniform, RenderMaterials, SetMaterialBindGroup, SetMeshBindGroup,
+    MeshPipelineKey, MeshUniform, PreparedMaterial, SetMaterialBindGroup, SetMeshBindGroup,
     MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS,
 };
 
@@ -622,7 +622,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<GpuMesh>>,
-    render_materials: Res<RenderMaterials<M>>,
+    render_materials: Res<RenderAssets<PreparedMaterial<M>>>,
     material_meshes: Query<(&Handle<M>, &Handle<Mesh>, &MeshUniform)>,
     mut views: Query<(
         &ExtractedView,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -18,7 +18,7 @@ use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::ExtractedCamera,
     globals::{GlobalsBuffer, GlobalsUniform},
-    mesh::{Mesh, GpuMesh, MeshVertexBufferLayout},
+    mesh::{GpuMesh, Mesh, MeshVertexBufferLayout},
     prelude::Camera,
     render_asset::RenderAssets,
     render_phase::{

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -18,8 +18,8 @@ use bevy_reflect::TypeUuid;
 use bevy_render::{
     camera::ExtractedCamera,
     globals::{GlobalsBuffer, GlobalsUniform},
-    mesh::MeshVertexBufferLayout,
-    prelude::{Camera, Mesh},
+    mesh::{Mesh, GpuMesh, MeshVertexBufferLayout},
+    prelude::Camera,
     render_asset::RenderAssets,
     render_phase::{
         sort_phase_system, AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand,
@@ -621,7 +621,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
     mut pipelines: ResMut<SpecializedMeshPipelines<PrepassPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     render_materials: Res<RenderMaterials<M>>,
     material_meshes: Query<(&Handle<M>, &Handle<Mesh>, &MeshUniform)>,
     mut views: Query<(

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -3,7 +3,7 @@ use crate::{
     CascadeShadowConfig, Cascades, CascadesVisibleEntities, Clusters, CubemapVisibleEntities,
     DirectionalLight, DirectionalLightShadowMap, DrawPrepass, EnvironmentMapLight,
     GlobalVisiblePointLights, Material, MaterialPipelineKey, MeshPipeline, MeshPipelineKey,
-    NotShadowCaster, PointLight, PointLightShadowMap, PrepassPipeline, PreparedMaterial, SpotLight,
+    NotShadowCaster, PointLight, PointLightShadowMap, PreparedMaterial, PrepassPipeline, SpotLight,
     VisiblePointLights,
 };
 use bevy_asset::Handle;
@@ -13,7 +13,7 @@ use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles
 use bevy_render::{
     camera::Camera,
     color::Color,
-    mesh::{Mesh, GpuMesh},
+    mesh::{GpuMesh, Mesh},
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -13,7 +13,7 @@ use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles
 use bevy_render::{
     camera::Camera,
     color::Color,
-    mesh::Mesh,
+    mesh::{Mesh, GpuMesh},
     render_asset::RenderAssets,
     render_graph::{Node, NodeRunError, RenderGraphContext, SlotInfo, SlotType},
     render_phase::{
@@ -649,7 +649,7 @@ pub(crate) fn spot_light_projection_matrix(angle: f32) -> Mat4 {
 pub fn prepare_lights(
     mut commands: Commands,
     mut texture_cache: ResMut<TextureCache>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
     mut global_light_meta: ResMut<GlobalLightMeta>,
@@ -1554,7 +1554,7 @@ pub fn queue_shadows<M: Material>(
     shadow_draw_functions: Res<DrawFunctions<Shadow>>,
     prepass_pipeline: Res<PrepassPipeline<M>>,
     casting_meshes: Query<(&Handle<Mesh>, &Handle<M>), Without<NotShadowCaster>>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     render_materials: Res<RenderMaterials<M>>,
     mut pipelines: ResMut<SpecializedMeshPipelines<PrepassPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -3,7 +3,7 @@ use crate::{
     CascadeShadowConfig, Cascades, CascadesVisibleEntities, Clusters, CubemapVisibleEntities,
     DirectionalLight, DirectionalLightShadowMap, DrawPrepass, EnvironmentMapLight,
     GlobalVisiblePointLights, Material, MaterialPipelineKey, MeshPipeline, MeshPipelineKey,
-    NotShadowCaster, PointLight, PointLightShadowMap, PrepassPipeline, RenderMaterials, SpotLight,
+    NotShadowCaster, PointLight, PointLightShadowMap, PrepassPipeline, PreparedMaterial, SpotLight,
     VisiblePointLights,
 };
 use bevy_asset::Handle;
@@ -1555,7 +1555,7 @@ pub fn queue_shadows<M: Material>(
     prepass_pipeline: Res<PrepassPipeline<M>>,
     casting_meshes: Query<(&Handle<Mesh>, &Handle<M>), Without<NotShadowCaster>>,
     render_meshes: Res<RenderAssets<GpuMesh>>,
-    render_materials: Res<RenderMaterials<M>>,
+    render_materials: Res<RenderAssets<PreparedMaterial<M>>>,
     mut pipelines: ResMut<SpecializedMeshPipelines<PrepassPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
     view_lights: Query<(Entity, &ViewLightEntities)>,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -24,7 +24,7 @@ use bevy_render::{
     globals::{GlobalsBuffer, GlobalsUniform},
     mesh::{
         skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-        GpuBufferInfo, Mesh, MeshVertexBufferLayout,
+        GpuBufferInfo, GpuMesh, Mesh, MeshVertexBufferLayout,
     },
     prelude::Msaa,
     render_asset::RenderAssets,
@@ -546,7 +546,7 @@ impl FromWorld for MeshPipeline {
 impl MeshPipeline {
     pub fn get_image_texture<'a>(
         &'a self,
-        gpu_images: &'a RenderAssets<Image>,
+        gpu_images: &'a RenderAssets<GpuImage>,
         handle_option: &Option<Handle<Image>>,
     ) -> Option<(&'a TextureView, &'a Sampler)> {
         if let Some(handle) = handle_option {
@@ -953,7 +953,7 @@ pub fn queue_mesh_view_bind_groups(
         Option<&EnvironmentMapLight>,
         &Tonemapping,
     )>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     mut fallback_images: FallbackImagesMsaa,
     mut fallback_depths: FallbackImagesDepth,
     fallback_cubemap: Res<FallbackImageCubemap>,
@@ -1143,7 +1143,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
 
 pub struct DrawMesh;
 impl<P: PhaseItem> RenderCommand<P> for DrawMesh {
-    type Param = SRes<RenderAssets<Mesh>>;
+    type Param = SRes<RenderAssets<GpuMesh>>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = Read<Handle<Mesh>>;
     #[inline]

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -10,7 +10,7 @@ use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
 use bevy_render::Render;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    mesh::{Mesh, MeshVertexBufferLayout},
+    mesh::{Mesh, GpuMesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::{
@@ -99,7 +99,7 @@ impl SpecializedMeshPipeline for WireframePipeline {
 #[allow(clippy::too_many_arguments)]
 fn queue_wireframes(
     opaque_3d_draw_functions: Res<DrawFunctions<Opaque3d>>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     wireframe_config: Res<WireframeConfig>,
     wireframe_pipeline: Res<WireframePipeline>,
     mut pipelines: ResMut<SpecializedMeshPipelines<WireframePipeline>>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -10,7 +10,7 @@ use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
 use bevy_render::Render;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    mesh::{Mesh, GpuMesh, MeshVertexBufferLayout},
+    mesh::{GpuMesh, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::{

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -425,7 +425,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                 &self,
                 layout: &#render_path::render_resource::BindGroupLayout,
                 render_device: &#render_path::renderer::RenderDevice,
-                images: &#render_path::render_asset::RenderAssets<#render_path::texture::Image>,
+                images: &#render_path::render_asset::RenderAssets<#render_path::texture::GpuImage>,
                 fallback_image: &#render_path::texture::FallbackImage,
             ) -> Result<#render_path::render_resource::PreparedBindGroup<Self::Data>, #render_path::render_resource::AsBindGroupError> {
                 let bindings = vec![#(#binding_impls,)*];

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,8 +1,8 @@
 use crate::{
     camera::CameraProjection,
-    texture::{Image, GpuImage},
     render_asset::RenderAssets,
     render_resource::TextureView,
+    texture::{GpuImage, Image},
     view::{ColorGrading, ExtractedView, ExtractedWindows, VisibleEntities},
     Extract,
 };

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -1,6 +1,6 @@
 use crate::{
     camera::CameraProjection,
-    prelude::Image,
+    texture::{Image, GpuImage},
     render_asset::RenderAssets,
     render_resource::TextureView,
     view::{ColorGrading, ExtractedView, ExtractedWindows, VisibleEntities},
@@ -411,7 +411,7 @@ impl NormalizedRenderTarget {
     pub fn get_texture_view<'a>(
         &self,
         windows: &'a ExtractedWindows,
-        images: &'a RenderAssets<Image>,
+        images: &'a RenderAssets<GpuImage>,
     ) -> Option<&'a TextureView> {
         match self {
             NormalizedRenderTarget::Window(window_ref) => windows
@@ -427,7 +427,7 @@ impl NormalizedRenderTarget {
     pub fn get_texture_format<'a>(
         &self,
         windows: &'a ExtractedWindows,
-        images: &'a RenderAssets<Image>,
+        images: &'a RenderAssets<GpuImage>,
     ) -> Option<TextureFormat> {
         match self {
             NormalizedRenderTarget::Window(window_ref) => windows

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -829,12 +829,12 @@ pub enum GpuBufferInfo {
 }
 
 impl RenderAsset for GpuMesh {
-    type Asset = Mesh;
+    type SourceAsset = Mesh;
     type ExtractedAsset = Mesh;
     type Param = SRes<RenderDevice>;
 
     /// Clones the mesh.
-    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
         asset.clone()
     }
 

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -828,21 +828,21 @@ pub enum GpuBufferInfo {
     },
 }
 
-impl RenderAsset for Mesh {
+impl RenderAsset for GpuMesh {
+    type Asset = Mesh;
     type ExtractedAsset = Mesh;
-    type PreparedAsset = GpuMesh;
     type Param = SRes<RenderDevice>;
 
     /// Clones the mesh.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        self.clone()
+    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+        asset.clone()
     }
 
     /// Converts the extracted mesh a into [`GpuMesh`].
     fn prepare_asset(
         mesh: Self::ExtractedAsset,
         render_device: &mut SystemParamItem<Self::Param>,
-    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
+    ) -> Result<Self, PrepareAssetError<Self::ExtractedAsset>> {
         let vertex_buffer_data = mesh.get_vertex_buffer_data();
         let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
             usage: BufferUsages::VERTEX,

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -834,8 +834,8 @@ impl RenderAsset for GpuMesh {
     type Param = SRes<RenderDevice>;
 
     /// Clones the mesh.
-    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
-        asset.clone()
+    fn extract_asset(source_asset: &Self::SourceAsset) -> Self::ExtractedAsset {
+        source_asset.clone()
     }
 
     /// Converts the extracted mesh a into [`GpuMesh`].

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -19,6 +19,6 @@ impl Plugin for MeshPlugin {
             .add_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_type::<skinning::SkinnedMesh>()
             .register_type::<Vec<Entity>>()
-            .add_plugin(RenderAssetPlugin::<Mesh>::default());
+            .add_plugin(RenderAssetPlugin::<GpuMesh>::default());
     }
 }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -30,10 +30,10 @@ pub trait RenderAsset: Send + Sync + 'static + Sized {
     /// Specifies all ECS data required by [`RenderAsset::prepare_asset`].
     /// For convenience use the [`lifetimeless`](bevy_ecs::system::lifetimeless) [`SystemParam`].
     type Param: SystemParam;
-    /// Converts the asset into a [`RenderAsset::ExtractedAsset`].
-    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset;
+    /// Converts the `source_asset` into a [`RenderAsset::ExtractedAsset`].
+    fn extract_asset(source_asset: &Self::SourceAsset) -> Self::ExtractedAsset;
     /// Prepares the `extracted asset` for the GPU by transforming it into
-    /// a [`RenderAsset::PreparedAsset`]. Therefore ECS data may be accessed via the `param`.
+    /// a [`RenderAsset`]. Therefore ECS data may be accessed via the `param`.
     fn prepare_asset(
         extracted_asset: Self::ExtractedAsset,
         param: &mut SystemParamItem<Self::Param>,
@@ -118,8 +118,8 @@ impl<A: RenderAsset> Default for ExtractedAssets<A> {
     }
 }
 
-/// Stores all GPU representations ([`RenderAsset::PreparedAssets`](RenderAsset::PreparedAsset))
-/// of [`RenderAssets`](RenderAsset) as long as they exist.
+/// Stores all GPU representations ([`RenderAsset`](RenderAsset))
+/// of [`RenderAssets::SourceAsset`](RenderAsset::SourceAsset) as long as they exist.
 #[derive(Resource, Deref, DerefMut)]
 pub struct RenderAssets<A: RenderAsset>(HashMap<Handle<A::SourceAsset>, A>);
 
@@ -129,7 +129,7 @@ impl<A: RenderAsset> Default for RenderAssets<A> {
     }
 }
 
-/// This system extracts all crated or modified assets of the corresponding [`RenderAsset`] type
+/// This system extracts all created or modified assets of the corresponding [`RenderAsset`] type
 /// into the "render world".
 fn extract_render_asset<A: RenderAsset>(
     mut commands: Commands,
@@ -153,7 +153,7 @@ fn extract_render_asset<A: RenderAsset>(
     let mut extracted_assets = Vec::new();
     for handle in changed_assets.drain() {
         if let Some(asset) = assets.get(&handle) {
-            extracted_assets.push((handle, A::extract_asset(&asset)));
+            extracted_assets.push((handle, A::extract_asset(asset)));
         }
     }
 

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -3,7 +3,7 @@ use crate::{
     render_asset::RenderAssets,
     render_resource::{resource_macros::*, BindGroupLayout, Buffer, Sampler, TextureView},
     renderer::RenderDevice,
-    texture::{GpuImage, FallbackImage},
+    texture::{FallbackImage, GpuImage},
 };
 pub use bevy_render_macros::AsBindGroup;
 use encase::ShaderType;
@@ -56,14 +56,14 @@ impl Deref for BindGroup {
 ///
 /// This is an opinionated trait that is intended to make it easy to generically
 /// convert a type into a [`BindGroup`]. It provides access to specific render resources,
-/// such as [`RenderAssets<GpuImage>`] and [`FallbackImage`]. If a type has a [`Handle<Image>`](bevy_asset::Handle),
+/// such as [`RenderAssets<GpuImage>`] and [`FallbackImage`]. If a type has a [`Handle<crate::texture::Image>`](bevy_asset::Handle),
 /// these can be used to retrieve the corresponding [`Texture`](crate::render_resource::Texture) resource.
 ///
 /// [`AsBindGroup::as_bind_group`] is intended to be called once, then the result cached somewhere. It is generally
 /// ok to do "expensive" work here, such as creating a [`Buffer`] for a uniform.
 ///
 /// If for some reason a [`BindGroup`] cannot be created yet (for example, the [`Texture`](crate::render_resource::Texture)
-/// for an [`Image`] hasn't loaded yet), just return [`AsBindGroupError::RetryNextUpdate`], which signals that the caller
+/// for an [`crate::texture::Image`] hasn't loaded yet), just return [`AsBindGroupError::RetryNextUpdate`], which signals that the caller
 /// should retry again later.
 ///
 /// # Deriving
@@ -115,7 +115,7 @@ impl Deref for BindGroup {
 ///     GPU resource, which will be bound as a texture in shaders. The field will be assumed to implement [`Into<Option<Handle<Image>>>`]. In practice,
 ///     most fields should be a [`Handle<Image>`](bevy_asset::Handle) or [`Option<Handle<Image>>`]. If the value of an [`Option<Handle<Image>>`] is
 ///     [`None`], the [`FallbackImage`] resource will be used instead. This attribute can be used in conjunction with a `sampler` binding attribute
-///    (with a different binding index) if a binding of the sampler for the [`Image`] is also required.
+///    (with a different binding index) if a binding of the sampler for the [`crate::texture::Image`] is also required.
 ///
 /// | Arguments             | Values                                                                  | Default              |
 /// |-----------------------|-------------------------------------------------------------------------|----------------------|
@@ -130,7 +130,7 @@ impl Deref for BindGroup {
 ///     resource, which will be bound as a sampler in shaders. The field will be assumed to implement [`Into<Option<Handle<Image>>>`]. In practice,
 ///     most fields should be a [`Handle<Image>`](bevy_asset::Handle) or [`Option<Handle<Image>>`]. If the value of an [`Option<Handle<Image>>`] is
 ///     [`None`], the [`FallbackImage`] resource will be used instead. This attribute can be used in conjunction with a `texture` binding attribute
-///     (with a different binding index) if a binding of the texture for the [`Image`] is also required.
+///     (with a different binding index) if a binding of the texture for the [`crate::texture::Image`] is also required.
 ///
 /// | Arguments              | Values                                                                  | Default                |
 /// |------------------------|-------------------------------------------------------------------------|------------------------|

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -1,10 +1,9 @@
 use crate::{
     define_atomic_id,
-    prelude::Image,
     render_asset::RenderAssets,
     render_resource::{resource_macros::*, BindGroupLayout, Buffer, Sampler, TextureView},
     renderer::RenderDevice,
-    texture::FallbackImage,
+    texture::{GpuImage, FallbackImage},
 };
 pub use bevy_render_macros::AsBindGroup;
 use encase::ShaderType;
@@ -57,7 +56,7 @@ impl Deref for BindGroup {
 ///
 /// This is an opinionated trait that is intended to make it easy to generically
 /// convert a type into a [`BindGroup`]. It provides access to specific render resources,
-/// such as [`RenderAssets<Image>`] and [`FallbackImage`]. If a type has a [`Handle<Image>`](bevy_asset::Handle),
+/// such as [`RenderAssets<GpuImage>`] and [`FallbackImage`]. If a type has a [`Handle<Image>`](bevy_asset::Handle),
 /// these can be used to retrieve the corresponding [`Texture`](crate::render_resource::Texture) resource.
 ///
 /// [`AsBindGroup::as_bind_group`] is intended to be called once, then the result cached somewhere. It is generally
@@ -204,7 +203,7 @@ impl Deref for BindGroup {
 ///     much like the field-level `uniform` attribute. The difference is that the entire [`AsBindGroup`] value is converted to `ConvertedShaderType`,
 ///     which must implement [`ShaderType`], instead of a specific field implementing [`ShaderType`]. This is useful if more complicated conversion
 ///     logic is required. The conversion is done using the [`AsBindGroupShaderType<ConvertedShaderType>`] trait, which is automatically implemented
-///     if `&Self` implements [`Into<ConvertedShaderType>`]. Only use [`AsBindGroupShaderType`] if access to resources like [`RenderAssets<Image>`] is
+///     if `&Self` implements [`Into<ConvertedShaderType>`]. Only use [`AsBindGroupShaderType`] if access to resources like [`RenderAssets<GpuImage>`] is
 ///     required.
 /// * `bind_group_data(DataType)`
 ///     * The [`AsBindGroup`] type will be converted to some `DataType` using [`Into<DataType>`] and stored
@@ -272,7 +271,7 @@ pub trait AsBindGroup {
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        images: &RenderAssets<Image>,
+        images: &RenderAssets<GpuImage>,
         fallback_image: &FallbackImage,
     ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError>;
 
@@ -322,7 +321,7 @@ impl OwnedBindingResource {
 pub trait AsBindGroupShaderType<T: ShaderType> {
     /// Return the `T` [`ShaderType`] for `self`. When used in [`AsBindGroup`]
     /// derives, it is safe to assume that all images in `self` exist.
-    fn as_bind_group_shader_type(&self, images: &RenderAssets<Image>) -> T;
+    fn as_bind_group_shader_type(&self, images: &RenderAssets<GpuImage>) -> T;
 }
 
 impl<T, U: ShaderType> AsBindGroupShaderType<U> for T
@@ -330,7 +329,7 @@ where
     for<'a> &'a T: Into<U>,
 {
     #[inline]
-    fn as_bind_group_shader_type(&self, _images: &RenderAssets<Image>) -> U {
+    fn as_bind_group_shader_type(&self, _images: &RenderAssets<GpuImage>) -> U {
         self.into()
     }
 }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -503,9 +503,9 @@ pub struct GpuImage {
     pub mip_level_count: u32,
 }
 
-impl RenderAsset for Image {
+impl RenderAsset for GpuImage {
+    type Asset = Image;
     type ExtractedAsset = Image;
-    type PreparedAsset = GpuImage;
     type Param = (
         SRes<RenderDevice>,
         SRes<RenderQueue>,
@@ -513,15 +513,15 @@ impl RenderAsset for Image {
     );
 
     /// Clones the Image.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
-        self.clone()
+    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+        asset.clone()
     }
 
     /// Converts the extracted image into a [`GpuImage`].
     fn prepare_asset(
         image: Self::ExtractedAsset,
         (render_device, render_queue, default_sampler): &mut SystemParamItem<Self::Param>,
-    ) -> Result<Self::PreparedAsset, PrepareAssetError<Self::ExtractedAsset>> {
+    ) -> Result<Self, PrepareAssetError<Self::ExtractedAsset>> {
         let texture = render_device.create_texture_with_data(
             render_queue,
             &image.texture_descriptor,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -504,7 +504,7 @@ pub struct GpuImage {
 }
 
 impl RenderAsset for GpuImage {
-    type Asset = Image;
+    type SourceAsset = Image;
     type ExtractedAsset = Image;
     type Param = (
         SRes<RenderDevice>,
@@ -513,7 +513,7 @@ impl RenderAsset for GpuImage {
     );
 
     /// Clones the Image.
-    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
         asset.clone()
     }
 

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -513,8 +513,8 @@ impl RenderAsset for GpuImage {
     );
 
     /// Clones the Image.
-    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
-        asset.clone()
+    fn extract_asset(source_asset: &Self::SourceAsset) -> Self::ExtractedAsset {
+        source_asset.clone()
     }
 
     /// Converts the extracted image into a [`GpuImage`].

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -93,7 +93,7 @@ impl Plugin for ImagePlugin {
             app.init_asset_loader::<HdrTextureLoader>();
         }
 
-        app.add_plugin(RenderAssetPlugin::<Image>::with_prepare_asset_set(
+        app.add_plugin(RenderAssetPlugin::<GpuImage>::with_prepare_asset_set(
             PrepareAssetSet::PreAssetPrepare,
         ))
         .register_type::<Image>()

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -8,13 +8,12 @@ pub use window::*;
 use crate::{
     camera::ExtractedCamera,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    texture::GpuImage,
     prelude::Shader,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
     renderer::{RenderDevice, RenderQueue},
-    texture::{BevyDefault, TextureCache},
+    texture::{BevyDefault, GpuImage, TextureCache},
     Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -8,7 +8,8 @@ pub use window::*;
 use crate::{
     camera::ExtractedCamera,
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    prelude::{Image, Shader},
+    texture::GpuImage,
+    prelude::Shader,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
@@ -63,7 +64,7 @@ impl Plugin for ViewPlugin {
                         prepare_view_targets
                             .after(WindowSystem::Prepare)
                             .in_set(RenderSet::Prepare)
-                            .after(crate::render_asset::prepare_assets::<Image>),
+                            .after(crate::render_asset::prepare_assets::<GpuImage>),
                     ),
                 );
         }
@@ -358,7 +359,7 @@ struct MainTargetTextures {
 fn prepare_view_targets(
     mut commands: Commands,
     windows: Res<ExtractedWindows>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     msaa: Res<Msaa>,
     render_device: Res<RenderDevice>,
     mut texture_cache: ResMut<TextureCache>,

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -3,7 +3,8 @@ use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_math::Vec4;
 use bevy_reflect::{prelude::*, TypeUuid};
 use bevy_render::{
-    color::Color, prelude::Shader, render_asset::RenderAssets, render_resource::*, texture::Image, texture::GpuImage,
+    color::Color, prelude::Shader, render_asset::RenderAssets, render_resource::*,
+    texture::GpuImage, texture::Image,
 };
 
 use crate::{Material2d, Material2dPlugin, MaterialMesh2dBundle};

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -3,7 +3,7 @@ use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_math::Vec4;
 use bevy_reflect::{prelude::*, TypeUuid};
 use bevy_render::{
-    color::Color, prelude::Shader, render_asset::RenderAssets, render_resource::*, texture::Image,
+    color::Color, prelude::Shader, render_asset::RenderAssets, render_resource::*, texture::Image, texture::GpuImage,
 };
 
 use crate::{Material2d, Material2dPlugin, MaterialMesh2dBundle};
@@ -95,7 +95,7 @@ pub struct ColorMaterialUniform {
 }
 
 impl AsBindGroupShaderType<ColorMaterialUniform> for ColorMaterial {
-    fn as_bind_group_shader_type(&self, _images: &RenderAssets<Image>) -> ColorMaterialUniform {
+    fn as_bind_group_shader_type(&self, _images: &RenderAssets<GpuImage>) -> ColorMaterialUniform {
         let mut flags = ColorMaterialFlags::NONE;
         if self.texture.is_some() {
             flags |= ColorMaterialFlags::TEXTURE;

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -1,10 +1,9 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
+use bevy_asset::{AddAsset, AssetServer, Handle};
 use bevy_core_pipeline::{
     core_2d::Transparent2d,
     tonemapping::{DebandDither, Tonemapping},
 };
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::*,
     query::ROQueryItem,
@@ -18,7 +17,7 @@ use bevy_reflect::TypeUuid;
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
     mesh::{GpuMesh, MeshVertexBufferLayout},
-    render_asset::{PrepareAssetSet, RenderAssets},
+    render_asset::{RenderAssets, RenderAsset, RenderAssetPlugin, PrepareAssetError},
     render_phase::{
         AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
         RenderPhase, SetItemPipeline, TrackedRenderPass,
@@ -31,10 +30,10 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::{FallbackImage, GpuImage},
     view::{ComputedVisibility, ExtractedView, Msaa, Visibility, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::{FloatOrd, HashMap, HashSet};
+use bevy_utils::{FloatOrd};
 use std::hash::Hash;
 use std::marker::PhantomData;
 
@@ -153,20 +152,16 @@ where
         app.add_asset::<M>()
             .add_plugin(ExtractComponentPlugin::<Handle<M>>::extract_visible());
 
+        app.add_plugin(RenderAssetPlugin::<PreparedMaterial2d<M>>::default());
+
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
                 .add_render_command::<Transparent2d, DrawMaterial2d<M>>()
                 .init_resource::<Material2dPipeline<M>>()
-                .init_resource::<ExtractedMaterials2d<M>>()
-                .init_resource::<RenderMaterials2d<M>>()
                 .init_resource::<SpecializedMeshPipelines<Material2dPipeline<M>>>()
-                .add_systems(ExtractSchedule, extract_materials_2d::<M>)
                 .add_systems(
                     Render,
                     (
-                        prepare_materials_2d::<M>
-                            .in_set(RenderSet::Prepare)
-                            .after(PrepareAssetSet::PreAssetPrepare),
                         queue_material2d_meshes::<M>.in_set(RenderSet::Queue),
                     ),
                 );
@@ -300,7 +295,7 @@ pub struct SetMaterial2dBindGroup<M: Material2d, const I: usize>(PhantomData<M>)
 impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
     for SetMaterial2dBindGroup<M, I>
 {
-    type Param = SRes<RenderMaterials2d<M>>;
+    type Param = SRes<RenderAssets<PreparedMaterial2d<M>>>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = Read<Handle<M>>;
 
@@ -326,7 +321,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<GpuMesh>>,
-    render_materials: Res<RenderMaterials2d<M>>,
+    render_materials: Res<RenderAssets<PreparedMaterial2d<M>>>,
     material2d_meshes: Query<(&Handle<M>, &Mesh2dHandle, &Mesh2dUniform)>,
     mut views: Query<(
         &ExtractedView,
@@ -425,147 +420,36 @@ pub struct PreparedMaterial2d<T: Material2d> {
     pub key: T::Data,
 }
 
-#[derive(Resource)]
-struct ExtractedMaterials2d<M: Material2d> {
-    extracted: Vec<(Handle<M>, M)>,
-    removed: Vec<Handle<M>>,
-}
-
-impl<M: Material2d> Default for ExtractedMaterials2d<M> {
-    fn default() -> Self {
-        Self {
-            extracted: Default::default(),
-            removed: Default::default(),
-        }
+impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
+    type Asset = M;
+    type ExtractedAsset = M;
+    type Param = (
+        SRes<RenderDevice>,
+        SRes<RenderAssets<GpuImage>>,
+        SRes<FallbackImage>,
+        SRes<Material2dPipeline<M>>,
+    );
+    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+        asset.clone()
     }
-}
-
-/// Stores all prepared representations of [`Material2d`] assets for as long as they exist.
-#[derive(Resource, Deref, DerefMut)]
-pub struct RenderMaterials2d<T: Material2d>(HashMap<Handle<T>, PreparedMaterial2d<T>>);
-
-impl<T: Material2d> Default for RenderMaterials2d<T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-
-/// This system extracts all created or modified assets of the corresponding [`Material2d`] type
-/// into the "render world".
-fn extract_materials_2d<M: Material2d>(
-    mut commands: Commands,
-    mut events: Extract<EventReader<AssetEvent<M>>>,
-    assets: Extract<Res<Assets<M>>>,
-) {
-    let mut changed_assets = HashSet::default();
-    let mut removed = Vec::new();
-    for event in events.iter() {
-        match event {
-            AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
-                changed_assets.insert(handle.clone_weak());
-            }
-            AssetEvent::Removed { handle } => {
-                changed_assets.remove(handle);
-                removed.push(handle.clone_weak());
-            }
-        }
-    }
-
-    let mut extracted_assets = Vec::new();
-    for handle in changed_assets.drain() {
-        if let Some(asset) = assets.get(&handle) {
-            extracted_assets.push((handle, asset.clone()));
-        }
-    }
-
-    commands.insert_resource(ExtractedMaterials2d {
-        extracted: extracted_assets,
-        removed,
-    });
-}
-
-/// All [`Material2d`] values of a given type that should be prepared next frame.
-pub struct PrepareNextFrameMaterials<M: Material2d> {
-    assets: Vec<(Handle<M>, M)>,
-}
-
-impl<M: Material2d> Default for PrepareNextFrameMaterials<M> {
-    fn default() -> Self {
-        Self {
-            assets: Default::default(),
-        }
-    }
-}
-
-/// This system prepares all assets of the corresponding [`Material2d`] type
-/// which where extracted this frame for the GPU.
-fn prepare_materials_2d<M: Material2d>(
-    mut prepare_next_frame: Local<PrepareNextFrameMaterials<M>>,
-    mut extracted_assets: ResMut<ExtractedMaterials2d<M>>,
-    mut render_materials: ResMut<RenderMaterials2d<M>>,
-    render_device: Res<RenderDevice>,
-    images: Res<RenderAssets<GpuImage>>,
-    fallback_image: Res<FallbackImage>,
-    pipeline: Res<Material2dPipeline<M>>,
-) {
-    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
-    for (handle, material) in queued_assets {
-        match prepare_material2d(
-            &material,
-            &render_device,
-            &images,
-            &fallback_image,
-            &pipeline,
+    fn prepare_asset(
+        material: Self::ExtractedAsset,
+        (render_device, images, fallback_image, pipeline): &mut SystemParamItem<Self::Param>,
+    ) -> Result<Self, PrepareAssetError<Self::ExtractedAsset>> {
+        match material.as_bind_group(
+            &pipeline.material2d_layout,
+            render_device,
+            images,
+            fallback_image,
         ) {
-            Ok(prepared_asset) => {
-                render_materials.insert(handle, prepared_asset);
-            }
-            Err(AsBindGroupError::RetryNextUpdate) => {
-                prepare_next_frame.assets.push((handle, material));
-            }
+            Err(AsBindGroupError::RetryNextUpdate) => Err(PrepareAssetError::RetryNextUpdate(material)),
+            Ok(prepared) => Ok(PreparedMaterial2d {
+                bindings: prepared.bindings,
+                bind_group: prepared.bind_group,
+                key: prepared.data,
+            })
         }
     }
-
-    for removed in std::mem::take(&mut extracted_assets.removed) {
-        render_materials.remove(&removed);
-    }
-
-    for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
-        match prepare_material2d(
-            &material,
-            &render_device,
-            &images,
-            &fallback_image,
-            &pipeline,
-        ) {
-            Ok(prepared_asset) => {
-                render_materials.insert(handle, prepared_asset);
-            }
-            Err(AsBindGroupError::RetryNextUpdate) => {
-                prepare_next_frame.assets.push((handle, material));
-            }
-        }
-    }
-}
-
-fn prepare_material2d<M: Material2d>(
-    material: &M,
-    render_device: &RenderDevice,
-    images: &RenderAssets<GpuImage>,
-    fallback_image: &FallbackImage,
-    pipeline: &Material2dPipeline<M>,
-) -> Result<PreparedMaterial2d<M>, AsBindGroupError> {
-    let prepared = material.as_bind_group(
-        &pipeline.material2d_layout,
-        render_device,
-        images,
-        fallback_image,
-    )?;
-    Ok(PreparedMaterial2d {
-        bindings: prepared.bindings,
-        bind_group: prepared.bind_group,
-        key: prepared.data,
-    })
 }
 
 /// A component bundle for entities with a [`Mesh2dHandle`] and a [`Material2d`].

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -17,8 +17,7 @@ use bevy_log::error;
 use bevy_reflect::TypeUuid;
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
-    mesh::{Mesh, MeshVertexBufferLayout},
-    prelude::Image,
+    mesh::{GpuMesh, MeshVertexBufferLayout},
     render_asset::{PrepareAssetSet, RenderAssets},
     render_phase::{
         AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
@@ -30,7 +29,7 @@ use bevy_render::{
         SpecializedMeshPipelineError, SpecializedMeshPipelines,
     },
     renderer::RenderDevice,
-    texture::FallbackImage,
+    texture::{FallbackImage, GpuImage},
     view::{ComputedVisibility, ExtractedView, Msaa, Visibility, VisibleEntities},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -326,7 +325,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
     mut pipelines: ResMut<SpecializedMeshPipelines<Material2dPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     render_materials: Res<RenderMaterials2d<M>>,
     material2d_meshes: Query<(&Handle<M>, &Mesh2dHandle, &Mesh2dUniform)>,
     mut views: Query<(
@@ -505,7 +504,7 @@ fn prepare_materials_2d<M: Material2d>(
     mut extracted_assets: ResMut<ExtractedMaterials2d<M>>,
     mut render_materials: ResMut<RenderMaterials2d<M>>,
     render_device: Res<RenderDevice>,
-    images: Res<RenderAssets<Image>>,
+    images: Res<RenderAssets<GpuImage>>,
     fallback_image: Res<FallbackImage>,
     pipeline: Res<Material2dPipeline<M>>,
 ) {
@@ -552,7 +551,7 @@ fn prepare_materials_2d<M: Material2d>(
 fn prepare_material2d<M: Material2d>(
     material: &M,
     render_device: &RenderDevice,
-    images: &RenderAssets<Image>,
+    images: &RenderAssets<GpuImage>,
     fallback_image: &FallbackImage,
     pipeline: &Material2dPipeline<M>,
 ) -> Result<PreparedMaterial2d<M>, AsBindGroupError> {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -421,7 +421,7 @@ pub struct PreparedMaterial2d<T: Material2d> {
 }
 
 impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
-    type Asset = M;
+    type SourceAsset = M;
     type ExtractedAsset = M;
     type Param = (
         SRes<RenderDevice>,
@@ -429,7 +429,7 @@ impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
         SRes<FallbackImage>,
         SRes<Material2dPipeline<M>>,
     );
-    fn extract_asset(asset: &Self::Asset) -> Self::ExtractedAsset {
+    fn extract_asset(asset: &Self::SourceAsset) -> Self::ExtractedAsset {
         asset.clone()
     }
     fn prepare_asset(

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -11,7 +11,7 @@ use bevy_reflect::{Reflect, TypeUuid};
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex, UniformComponentPlugin},
     globals::{GlobalsBuffer, GlobalsUniform},
-    mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
+    mesh::{GpuBufferInfo, GpuMesh, Mesh, MeshVertexBufferLayout},
     render_asset::RenderAssets,
     render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
@@ -267,7 +267,7 @@ impl FromWorld for Mesh2dPipeline {
 impl Mesh2dPipeline {
     pub fn get_image_texture<'a>(
         &'a self,
-        gpu_images: &'a RenderAssets<Image>,
+        gpu_images: &'a RenderAssets<GpuImage>,
         handle_option: &Option<Handle<Image>>,
     ) -> Option<(&'a TextureView, &'a Sampler)> {
         if let Some(handle) = handle_option {
@@ -576,7 +576,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dBindGroup<I> {
 
 pub struct DrawMesh2d;
 impl<P: PhaseItem> RenderCommand<P> for DrawMesh2d {
-    type Param = SRes<RenderAssets<Mesh>>;
+    type Param = SRes<RenderAssets<GpuMesh>>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = Read<Mesh2dHandle>;
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -486,7 +486,7 @@ pub fn queue_sprites(
     mut pipelines: ResMut<SpecializedRenderPipelines<SpritePipeline>>,
     pipeline_cache: Res<PipelineCache>,
     mut image_bind_groups: ResMut<ImageBindGroups>,
-    gpu_images: Res<RenderAssets<Image>>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
     msaa: Res<Msaa>,
     mut extracted_sprites: ResMut<ExtractedSprites>,
     mut views: Query<(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions, RenderPhase},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{Image, GpuImage},
+    texture::{GpuImage, Image},
     view::{ComputedVisibility, ExtractedView, ViewUniforms},
     Extract, RenderApp, RenderSet,
 };

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -23,7 +23,7 @@ use bevy_render::{
     render_phase::{sort_phase_system, AddRenderCommand, DrawFunctions, RenderPhase},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::Image,
+    texture::{Image, GpuImage},
     view::{ComputedVisibility, ExtractedView, ViewUniforms},
     Extract, RenderApp, RenderSet,
 };
@@ -565,7 +565,7 @@ pub fn queue_uinodes(
     mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
     pipeline_cache: Res<PipelineCache>,
     mut image_bind_groups: ResMut<UiImageBindGroups>,
-    gpu_images: Res<RenderAssets<Image>>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
     ui_batches: Query<(Entity, &UiBatch)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
     events: Res<SpriteAssetEvents>,

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -10,7 +10,7 @@ use bevy::{
     prelude::*,
     reflect::TypeUuid,
     render::{
-        mesh::{Indices, MeshVertexAttribute},
+        mesh::{GpuMesh, Indices, MeshVertexAttribute},
         render_asset::RenderAssets,
         render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
         render_resource::{
@@ -315,7 +315,7 @@ pub fn queue_colored_mesh2d(
     mut pipelines: ResMut<SpecializedRenderPipelines<ColoredMesh2dPipeline>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
-    render_meshes: Res<RenderAssets<Mesh>>,
+    render_meshes: Res<RenderAssets<GpuMesh>>,
     colored_mesh2d: Query<(&Mesh2dHandle, &Mesh2dUniform), With<ColoredMesh2d>>,
     mut views: Query<(
         &VisibleEntities,

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -19,7 +19,7 @@ use bevy::{
             TextureViewDescriptor, TextureViewDimension,
         },
         renderer::RenderDevice,
-        texture::{CompressedImageFormats, FallbackImage},
+        texture::{CompressedImageFormats, FallbackImage, GpuImage},
     },
 };
 
@@ -230,7 +230,7 @@ impl AsBindGroup for CubemapMaterial {
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        images: &RenderAssets<Image>,
+        images: &RenderAssets<GpuImage>,
         _fallback_image: &FallbackImage,
     ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError> {
         let base_color_texture = self

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,6 +8,7 @@ use bevy::{
     render::{
         extract_resource::{ExtractResource, ExtractResourcePlugin},
         render_asset::RenderAssets,
+        texture::GpuImage,
         render_graph::{self, RenderGraph},
         render_resource::*,
         renderer::{RenderContext, RenderDevice},
@@ -94,7 +95,7 @@ struct GameOfLifeImageBindGroup(BindGroup);
 fn queue_bind_group(
     mut commands: Commands,
     pipeline: Res<GameOfLifePipeline>,
-    gpu_images: Res<RenderAssets<Image>>,
+    gpu_images: Res<RenderAssets<GpuImage>>,
     game_of_life_image: Res<GameOfLifeImage>,
     render_device: Res<RenderDevice>,
 ) {

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -8,10 +8,10 @@ use bevy::{
     render::{
         extract_resource::{ExtractResource, ExtractResourcePlugin},
         render_asset::RenderAssets,
-        texture::GpuImage,
         render_graph::{self, RenderGraph},
         render_resource::*,
         renderer::{RenderContext, RenderDevice},
+        texture::GpuImage,
         Render, RenderApp, RenderSet,
     },
     window::WindowPlugin,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -10,7 +10,7 @@ use bevy::{
     prelude::*,
     render::{
         extract_component::{ExtractComponent, ExtractComponentPlugin},
-        mesh::{GpuBufferInfo, MeshVertexBufferLayout, GpuMesh},
+        mesh::{GpuBufferInfo, GpuMesh, MeshVertexBufferLayout},
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -10,7 +10,7 @@ use bevy::{
     prelude::*,
     render::{
         extract_component::{ExtractComponent, ExtractComponentPlugin},
-        mesh::{GpuBufferInfo, MeshVertexBufferLayout},
+        mesh::{GpuBufferInfo, MeshVertexBufferLayout, GpuMesh},
         render_asset::RenderAssets,
         render_phase::{
             AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
@@ -110,7 +110,7 @@ fn queue_custom(
     msaa: Res<Msaa>,
     mut pipelines: ResMut<SpecializedMeshPipelines<CustomPipeline>>,
     pipeline_cache: Res<PipelineCache>,
-    meshes: Res<RenderAssets<Mesh>>,
+    meshes: Res<RenderAssets<GpuMesh>>,
     material_meshes: Query<(Entity, &MeshUniform, &Handle<Mesh>), With<InstanceMaterialData>>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
 ) {
@@ -224,7 +224,7 @@ type DrawCustom = (
 pub struct DrawMeshInstanced;
 
 impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
-    type Param = SRes<RenderAssets<Mesh>>;
+    type Param = SRes<RenderAssets<GpuMesh>>;
     type ViewWorldQuery = ();
     type ItemWorldQuery = (Read<Handle<Mesh>>, Read<InstanceBuffer>);
 

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -8,7 +8,7 @@ use bevy::{
         render_asset::RenderAssets,
         render_resource::{AsBindGroupError, PreparedBindGroup, *},
         renderer::RenderDevice,
-        texture::FallbackImage,
+        texture::{FallbackImage, GpuImage},
     },
 };
 use std::num::NonZeroU32;
@@ -83,7 +83,7 @@ impl AsBindGroup for BindlessMaterial {
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        image_assets: &RenderAssets<Image>,
+        image_assets: &RenderAssets<GpuImage>,
         fallback_image: &FallbackImage,
     ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError> {
         // retrieve the render resources from handles


### PR DESCRIPTION
# Objective

- Remove duplicated implementation of asset extraction/preparation in material/material2d
- Allow to have multiple GPU representations for the same "main world" asset.

## Solution

Remove one to one correlation between "main world" asset and GPU asset, by swapping base type that implements `RenderAsset` to be the GPU asset type. That would make `RenderAssetPlugin` more flexible, being able to prepare different data based on same source asset *(example: effect plugin could preprocess mesh buffer data for specialized rendering, without affecting main render flow)*.
That also makes `RenderAssets<GPUType>` more explicit.

## Changelog
#### Changed
- `RenderAsset` trait definition
- `Material` and `Material2d` now use `RenderAssetPlugin`
- `RenderMaterials` and `RenderMaterials2d` were replaced with more generic `RenderAssets`

## Migration Guide

- `RenderMaterials<M>` can now be accesed as `RenderAssets<PreparedMaterial<M>>`
- `RenderMaterials2d<M>` can now be accesed as `RenderAssets<PreparedMaterial2d<M>>`
- `RenderAssets<Image>` is now `RenderAssets<GpuImage>`
- `RenderAssets<Mesh>` is now `RenderAssets<GpuMesh>`
- `RenderAsset` trait should now be implemented on prev `RenderAsset::PreparedAsset` type, while source asset type is defined as `RenderAsset::SourceAsset`

#### Before
```rust
impl RenderAsset for Image {
    type ExtractedAsset = Image;
    type PreparedAsset = GpuImage;

    fn extract_asset(&self) -> Self::ExtractedAsset {
        self.clone()
    }
}
```
#### After
```rust
impl RenderAsset for GpuImage {
    type SourceAsset = Image;
    type ExtractedAsset = Image;

    fn extract_asset(source_asset: &Self::SourceAsset) -> Self::ExtractedAsset {
        source_asset.clone()
    }
}
```