### PR TITLE
UI- Interaction Released state for nodes

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -199,7 +199,7 @@ pub fn ui_focus_system(
     // prepare an iterator that contains all the nodes that have the cursor in their rect,
     // from the top node to the bottom one. this will also reset the interaction to `None`
     // for all nodes encountered that are no longer hovered.
-    let mut moused_over_nodes = ui_stack
+    let mut hovered_nodes = ui_stack
         .uinodes
         .iter()
         // reverse the iterator to traverse the tree from closest nodes to furthest
@@ -252,7 +252,7 @@ pub fn ui_focus_system(
 
     // set Clicked or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
     // the iteration will stop on it because it "captures" the interaction.
-    let mut iter = node_query.iter_many_mut(moused_over_nodes.by_ref());
+    let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref());
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             if mouse_clicked {
@@ -278,8 +278,8 @@ pub fn ui_focus_system(
         }
     }
     // reset `Interaction` for the remaining lower nodes to `None`. those are the nodes that remain in
-    // `moused_over_nodes` after the previous loop is exited.
-    let mut iter = node_query.iter_many_mut(moused_over_nodes);
+    // `hovered_nodes` after the previous loop is exited.
+    let mut iter = node_query.iter_many_mut(hovered_nodes);
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             // don't reset clicked nodes because they're handled separately

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -41,6 +41,8 @@ pub enum Interaction {
     Hovered,
     /// Nothing has happened
     None,
+    /// The node has just been released
+    Released,
 }
 
 impl Interaction {
@@ -151,15 +153,6 @@ pub fn ui_focus_system(
 
     let mouse_released =
         mouse_button_input.just_released(MouseButton::Left) || touches_input.any_just_released();
-    if mouse_released {
-        for node in node_query.iter_mut() {
-            if let Some(mut interaction) = node.interaction {
-                if *interaction == Interaction::Clicked {
-                    *interaction = Interaction::None;
-                }
-            }
-        }
-    }
 
     let mouse_clicked =
         mouse_button_input.just_pressed(MouseButton::Left) || touches_input.any_just_pressed();
@@ -171,10 +164,10 @@ pub fn ui_focus_system(
         .iter()
         .filter(|(_, camera_ui)| !is_ui_disabled(*camera_ui))
         .filter_map(|(camera, _)| {
-            if let Some(NormalizedRenderTarget::Window(window_ref)) =
+            if let Some(NormalizedRenderTarget::Window(window_id)) =
                 camera.target.normalize(primary_window)
             {
-                Some(window_ref)
+                Some(window_id)
             } else {
                 None
             }
@@ -188,11 +181,25 @@ pub fn ui_focus_system(
             })
         })
         .or_else(|| touches_input.first_pressed_position());
+    if mouse_released {
+        for node in node_query.iter_mut() {
+            let contains_cursor = get_mouse_relative_to_node(&node, cursor_position).mouse_over();
+            if let Some(mut interaction) = node.interaction {
+                if *interaction == Interaction::Clicked {
+                    *interaction = if contains_cursor {
+                        Interaction::Released
+                    } else {
+                        Interaction::None
+                    };
+                }
+            }
+        }
+    }
 
     // prepare an iterator that contains all the nodes that have the cursor in their rect,
     // from the top node to the bottom one. this will also reset the interaction to `None`
     // for all nodes encountered that are no longer hovered.
-    let mut hovered_nodes = ui_stack
+    let mut moused_over_nodes = ui_stack
         .uinodes
         .iter()
         // reverse the iterator to traverse the tree from closest nodes to furthest
@@ -211,29 +218,8 @@ pub fn ui_focus_system(
                         return None;
                     }
                 }
-
-                let position = node.global_transform.translation();
-                let ui_position = position.truncate();
-                let extents = node.node.size() / 2.0;
-                let mut min = ui_position - extents;
-                if let Some(clip) = node.calculated_clip {
-                    min = Vec2::max(min, clip.clip.min);
-                }
-
-                // The mouse position relative to the node
-                // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
-                let relative_cursor_position = cursor_position.map(|cursor_position| {
-                    Vec2::new(
-                        (cursor_position.x - min.x) / node.node.size().x,
-                        (cursor_position.y - min.y) / node.node.size().y,
-                    )
-                });
-
-                // If the current cursor position is within the bounds of the node, consider it for
-                // clicking
-                let relative_cursor_position_component = RelativeCursorPosition {
-                    normalized: relative_cursor_position,
-                };
+                let relative_cursor_position_component =
+                    get_mouse_relative_to_node(&node, cursor_position);
 
                 let contains_cursor = relative_cursor_position_component.mouse_over();
 
@@ -248,7 +234,10 @@ pub fn ui_focus_system(
                     Some(*entity)
                 } else {
                     if let Some(mut interaction) = node.interaction {
-                        if *interaction == Interaction::Hovered || (cursor_position.is_none()) {
+                        if *interaction == Interaction::Hovered
+                            || *interaction == Interaction::Released
+                            || (cursor_position.is_none())
+                        {
                             interaction.set_if_neq(Interaction::None);
                         }
                     }
@@ -263,7 +252,7 @@ pub fn ui_focus_system(
 
     // set Clicked or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
     // the iteration will stop on it because it "captures" the interaction.
-    let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref());
+    let mut iter = node_query.iter_many_mut(moused_over_nodes.by_ref());
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             if mouse_clicked {
@@ -290,7 +279,7 @@ pub fn ui_focus_system(
     }
     // reset `Interaction` for the remaining lower nodes to `None`. those are the nodes that remain in
     // `moused_over_nodes` after the previous loop is exited.
-    let mut iter = node_query.iter_many_mut(hovered_nodes);
+    let mut iter = node_query.iter_many_mut(moused_over_nodes);
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             // don't reset clicked nodes because they're handled separately
@@ -298,5 +287,34 @@ pub fn ui_focus_system(
                 interaction.set_if_neq(Interaction::None);
             }
         }
+    }
+}
+
+/// helper functions for calculating cursor relative position to node
+fn get_mouse_relative_to_node(
+    node: &NodeQueryItem,
+    cursor_position: Option<Vec2>,
+) -> RelativeCursorPosition {
+    let position = node.global_transform.translation();
+    let ui_position = position.truncate();
+    let extents = node.node.size() / 2.0;
+    let mut min = ui_position - extents;
+    if let Some(clip) = node.calculated_clip {
+        min = Vec2::max(min, clip.clip.min);
+    }
+
+    // The mouse position relative to the node
+    // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
+    let relative_cursor_position = cursor_position.map(|cursor_position| {
+        Vec2::new(
+            (cursor_position.x - min.x) / node.node.size().x,
+            (cursor_position.y - min.y) / node.node.size().y,
+        )
+    });
+
+    // If the current cursor position is within the bounds of the node, consider it for
+    // clicking
+    RelativeCursorPosition {
+        normalized: relative_cursor_position,
     }
 }

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -98,7 +98,7 @@ fn menu(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Clicked | Interaction::Released => {
                 *color = PRESSED_BUTTON.into();
                 next_state.set(AppState::InGame);
             }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -366,10 +366,12 @@ mod menu {
     ) {
         for (interaction, mut color, selected) in &mut interaction_query {
             *color = match (*interaction, selected) {
-                (Interaction::Clicked, _) | (Interaction::None, Some(_)) => PRESSED_BUTTON.into(),
+                (Interaction::Clicked, _)
+                | (Interaction::Released, _)
+                | (Interaction::None, Some(_)) => PRESSED_BUTTON.into(),
                 (Interaction::Hovered, Some(_)) => HOVERED_PRESSED_BUTTON.into(),
                 (Interaction::Hovered, None) => HOVERED_BUTTON.into(),
-                (Interaction::None, None) => NORMAL_BUTTON.into(),
+                (_, _) => NORMAL_BUTTON.into(),
             }
         }
     }
@@ -796,7 +798,7 @@ mod menu {
         mut game_state: ResMut<NextState<GameState>>,
     ) {
         for (interaction, menu_button_action) in &interaction_query {
-            if *interaction == Interaction::Clicked {
+            if *interaction == Interaction::Released {
                 match menu_button_action {
                     MenuButtonAction::Quit => app_exit_events.send(AppExit),
                     MenuButtonAction::Play => {

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -131,7 +131,7 @@ fn button_handler(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Clicked | Interaction::Released => {
                 *color = Color::BLUE.into();
             }
             Interaction::Hovered => {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -35,7 +35,7 @@ fn button_system(
                 text.sections[0].value = "Hover".to_string();
                 *color = HOVERED_BUTTON.into();
             }
-            Interaction::None => {
+            _ => {
                 text.sections[0].value = "Button".to_string();
                 *color = NORMAL_BUTTON.into();
             }

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -27,6 +27,10 @@ fn button_system(
     for (interaction, mut color, children) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
+            Interaction::Released => {
+                text.sections[0].value = "Released".to_string();
+                *color = PRESSED_BUTTON.into();
+            }
             Interaction::Clicked => {
                 text.sections[0].value = "Press".to_string();
                 *color = PRESSED_BUTTON.into();
@@ -35,7 +39,7 @@ fn button_system(
                 text.sections[0].value = "Hover".to_string();
                 *color = HOVERED_BUTTON.into();
             }
-            _ => {
+            Interaction::None => {
                 text.sections[0].value = "Button".to_string();
                 *color = NORMAL_BUTTON.into();
             }


### PR DESCRIPTION
# Objective
Fixes #5769

## Solution

Instead of changing node state from `Pressed` to `None` on click release, it first checks if pointer is still above element. If not, just go to `None` state. If yes changes it to `Released` state allowing for more familiar user experience (users expect action to happen on release, not click, also if we start pressing on button but release it with cursor outside of it we don't want to make action happened).

---

## Changelog

Added `Released` state to nodes `Interaction` enum

## Migration Guide

- user would need to cover one more case, so I guess it is a breaking change (?)
```rust
// 0.10
fn button_system(
    mut interaction_query: Query<
        (&Interaction, &mut BackgroundColor, &Children),
        (Changed<Interaction>, With<Button>),
    >,
    mut text_query: Query<&mut Text>,
) {
    for (interaction, mut color, children) in &mut interaction_query {
        let mut text = text_query.get_mut(children[0]).unwrap();
        match *interaction {
            Interaction::Clicked => {
                text.sections[0].value = "Press".to_string();
                *color = PRESSED_BUTTON.into();
            }
            Interaction::Hovered => {
                text.sections[0].value = "Hover".to_string();
                *color = HOVERED_BUTTON.into();
            }
            Interaction::None => {
                text.sections[0].value = "Button".to_string();
                *color = NORMAL_BUTTON.into();
            }
        }
    }
}
// 0.11
fn button_system(
    mut interaction_query: Query<
        (&Interaction, &mut BackgroundColor, &Children),
        (Changed<Interaction>, With<Button>),
    >,
    mut text_query: Query<&mut Text>,
) {
    for (interaction, mut color, children) in &mut interaction_query {
        let mut text = text_query.get_mut(children[0]).unwrap();
        match *interaction {
            Interaction::Released => {
                text.sections[0].value = "Released".to_string();
                *color = PRESSED_BUTTON.into();
            }
            Interaction::Clicked => {
                text.sections[0].value = "Press".to_string();
                *color = PRESSED_BUTTON.into();
            }
            Interaction::Hovered => {
                text.sections[0].value = "Hover".to_string();
                *color = HOVERED_BUTTON.into();
            }
            Interaction::None => {
                text.sections[0].value = "Button".to_string();
                *color = NORMAL_BUTTON.into();
            }
        }
    }
}

```