### PR TITLE
Fix documentation on RegularPolygon

### DIFF
--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -5,7 +5,7 @@ use wgpu::PrimitiveTopology;
 #[derive(Debug, Copy, Clone)]
 pub struct RegularPolygon {
     /// Circumscribed radius in the `XY` plane.
-    /// 
+    ///
     /// In other words, the vertices of this polygon will all touch a circle of this radius.
     pub radius: f32,
     /// Number of sides.

--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -4,7 +4,7 @@ use wgpu::PrimitiveTopology;
 /// A regular polygon in the `XY` plane
 #[derive(Debug, Copy, Clone)]
 pub struct RegularPolygon {
-    /// Inscribed radius in the `XY` plane.
+    /// Circumscribed radius in the `XY` plane.
     pub radius: f32,
     /// Number of sides.
     pub sides: usize,

--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -5,6 +5,8 @@ use wgpu::PrimitiveTopology;
 #[derive(Debug, Copy, Clone)]
 pub struct RegularPolygon {
     /// Circumscribed radius in the `XY` plane.
+    /// 
+    /// In other words, the vertices of this polygon will all touch a circle of this radius.
     pub radius: f32,
     /// Number of sides.
     pub sides: usize,


### PR DESCRIPTION
A `RegularPolygon` is described by the circumscribed radius, not the inscribed radius.

## Objective

- Correct documentation for `RegularPolygon`

## Solution

- Use the correct term
