### PR TITLE
Update/FixedUpdate Stepping

### DIFF
--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -1,6 +1,7 @@
 //! A simplified implementation of the classic game "Breakout".
 
 use bevy::{
+    app::Stepping,
     prelude::*,
     sprite::collide_aabb::{collide, Collision},
     sprite::MaterialMesh2dBundle,
@@ -47,14 +48,22 @@ const WALL_COLOR: Color = Color::rgb(0.8, 0.8, 0.8);
 const TEXT_COLOR: Color = Color::rgb(0.5, 0.5, 1.0);
 const SCORE_COLOR: Color = Color::rgb(1.0, 0.5, 0.5);
 
+fn step_on_press(input: Res<Input<KeyCode>>, mut stepping: ResMut<Stepping>) {
+    if input.pressed(KeyCode::Space) {
+        *stepping = Stepping::Enabled { frames: 1 };
+    }
+}
+
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .insert_resource(Stepping::Enabled { frames: 0 })
         .insert_resource(Scoreboard { score: 0 })
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_event::<CollisionEvent>()
         // Configure how frequently our gameplay systems are run
         .insert_resource(FixedTime::new_from_secs(1.0 / 60.0))
+        .add_systems(PreUpdate, step_on_press)
         .add_systems(Startup, setup)
         // Add our gameplay simulation systems to the fixed timestep schedule
         .add_systems(


### PR DESCRIPTION
# Objective

Alternative to #8063

Note that this is a draft PR and only exists to illustrate an idea. It is not intended to be a final API.

It would be nice if users could "step through" their app logic to debug on a frame-by-frame basis (and in the future ... system-by-system).

This aims to illustrate an alternative to the system stepping impl in #8063 that accomplishes the following goals:
* Illustrate that stepping Update and FixedUpdate globally is a simple and effective solution. We can step "user logic" transparently without the need to manually opt engine systems out of stepping logic or user logic into stepping logic. We can step every example "out of the box" by just adding the Stepping resource and defining a step system in PreUpdate (to determine what inputs will result in a user logic step, and how many steps to take). Update / FixedUpdate exist to be the "simple place to drop user logic". We can use (and rely on) those boundaries.
* Support arbitrary app logic such as state transitions (because we do full frame stepping)
* Significantly simpler / less invasive impl that exists entirely in "userspace" (no bevy_ecs scheduler changes need). The current change set is an extremely uncontroversial impl that we could merge now to unlock a subset of the value in #8063 without any negative UX implications for our users.
* Note that this does not (yet) support per-system stepping (which would introduce more complexity and caveats), but I think we can expand this general idea with run conditions or the schedule-internal stepping introduced in #8063 (see Next Steps).

Note that this type of "conditional update/fixedupdate" logic running is how engines like Godot implement their pausing functionality.

Like #8063, this would benefit from event buffers that aren't cleared every other frame.

## Next Steps

* Explore granular per-system run-condition based stepping. A new run condition would be implicitly added to systems in Update/FixedUpdate (when granular stepping enabled). It would run / not run systems based on the current execution state (ex: which system are we currently breaking on, which systems have run for this "frame", which systems still need to run). This would be configured on each SystemConfig with override-able defaults. We would have a "stepped virtual frame" resource that each criteria would track itself relative to (which in combination with the step state would allow the system to decide if it should/should not run on a given frame).
* We can still explore the "internal schedule executor stepping" route introduced in #8063. Very possible that the added complexity in the schedule executor is worth it relative to whatever run-condition impl we implement. Run conditions might not even be viable at all! The point is we could still use the "only step Update/FixedUpdate" approach (without any need to opt bevy internals or user systems in or out).
* Consider just using debuggers for per system stepping. Users can drop breakpoints on whatever systems they want. This can be combined with global per-frame stepping for something close to a best of both worlds solution:
  1. Enable per-frame stepping with `KeyCode::Space` to advance by one frame
  2. Drop breakpoints on the systems you want
  3. Press space to begin a new frame. Execution breaks on each system you selected (and you have a full debugger at your disposal). After stepping through every system / breakpoint you have set, the stepped user logic ends and the engine internals start looping again (doing rendering PreUpdate/PostUpdate, etc).
  4. Note that we'd need to rethink `Time:delta()` in the context of breakpoints, otherwise things will jump around a lot (and FixedUpdate will have a ton of updates each frame). We would want to clamp it to some max value in this context (or maybe all contexts?). 