### PR TITLE
Provide access to world storages when using `UnsafeWorldCell`

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -291,8 +291,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub unsafe fn get_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         // SAFETY: caller ensures that `self` has permission to access `R`
         //  caller ensures that no mutable reference exists to `R`
-        unsafe { self.unsafe_world() }
-            .storages
+        unsafe { self.storages() }
             .resources
             .get(component_id)?
             .get_data()
@@ -334,8 +333,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub unsafe fn get_non_send_resource_by_id(self, component_id: ComponentId) -> Option<Ptr<'w>> {
         // SAFETY: we only access data on world that the caller has ensured is unaliased and we have
         //  permission to access.
-        unsafe { self.unsafe_world() }
-            .storages
+        unsafe { self.storages() }
             .non_send_resources
             .get(component_id)?
             .get_data()
@@ -378,8 +376,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<MutUntyped<'w>> {
         // SAFETY: we only access data that the caller has ensured is unaliased and `self`
         //  has permission to access.
-        let (ptr, ticks) = unsafe { self.unsafe_world() }
-            .storages
+        let (ptr, ticks) = unsafe { self.storages() }
             .resources
             .get(component_id)?
             .get_with_ticks()?;
@@ -439,8 +436,7 @@ impl<'w> UnsafeWorldCell<'w> {
         let change_tick = self.read_change_tick();
         // SAFETY: we only access data that the caller has ensured is unaliased and `self`
         //  has permission to access.
-        let (ptr, ticks) = unsafe { self.unsafe_world() }
-            .storages
+        let (ptr, ticks) = unsafe { self.storages() }
             .non_send_resources
             .get(component_id)?
             .get_with_ticks()?;
@@ -473,8 +469,7 @@ impl<'w> UnsafeWorldCell<'w> {
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
         // - caller ensures that we have permission to access this resource
-        unsafe { self.unsafe_world() }
-            .storages
+        unsafe { self.storages() }
             .resources
             .get(component_id)?
             .get_with_ticks()
@@ -498,8 +493,7 @@ impl<'w> UnsafeWorldCell<'w> {
         // - caller ensures there is no `&mut World`
         // - caller ensures there are no mutable borrows of this resource
         // - caller ensures that we have permission to access this resource
-        unsafe { self.unsafe_world() }
-            .storages
+        unsafe { self.storages() }
             .non_send_resources
             .get(component_id)?
             .get_with_ticks()
@@ -769,7 +763,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ) -> Option<&'w Column> {
         // SAFETY: caller ensures returned data is not misused and we have not created any borrows
         // of component/resource data
-        unsafe { self.unsafe_world() }.storages.tables[location.table_id].get_column(component_id)
+        unsafe { self.storages() }.tables[location.table_id].get_column(component_id)
     }
 
     #[inline]
@@ -780,10 +774,7 @@ impl<'w> UnsafeWorldCell<'w> {
     unsafe fn fetch_sparse_set(self, component_id: ComponentId) -> Option<&'w ComponentSparseSet> {
         // SAFETY: caller ensures returned data is not misused and we have not created any borrows
         // of component/resource data
-        unsafe { self.unsafe_world() }
-            .storages
-            .sparse_sets
-            .get(component_id)
+        unsafe { self.storages() }.sparse_sets.get(component_id)
     }
 }
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -189,8 +189,9 @@ impl<'w> UnsafeWorldCell<'w> {
     /// The caller must only access world data that this [`UnsafeWorldCell`]
     /// was given access to on construction.
     pub unsafe fn storages(self) -> &'w Storages {
-        // SAFETY: Caller ensures they will only access world
-        // data that this instance is allowed to access.
+        // SAFETY:
+        // - Caller ensures they will only access world
+        //   data that this instance is allowed to access.
         unsafe { self.unsafe_world() }.storages()
     }
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -200,10 +200,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub fn read_change_tick(self) -> Tick {
         // SAFETY:
         // - we only access world metadata
-        let tick = unsafe { self.world_metadata() }
-            .change_tick
-            .load(Ordering::Acquire);
-        Tick::new(tick)
+        unsafe { self.world_metadata() }.read_change_tick()
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -187,7 +187,7 @@ impl<'w> UnsafeWorldCell<'w> {
     ///
     /// # Safety
     /// The caller must only access world data that this [`UnsafeWorldCell`]
-    /// was given access to on construction.
+    /// has been given access to.
     pub unsafe fn storages(self) -> &'w Storages {
         // SAFETY:
         // - Caller ensures they will only access world

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     entity::{Entities, Entity, EntityLocation},
     prelude::Component,
-    storage::{Column, ComponentSparseSet},
+    storage::{Column, ComponentSparseSet, Storages},
     system::Resource,
 };
 use bevy_ptr::Ptr;
@@ -181,6 +181,17 @@ impl<'w> UnsafeWorldCell<'w> {
         // SAFETY:
         // - we only access world metadata
         &unsafe { self.world_metadata() }.bundles
+    }
+
+    /// Provides access to the underlying data storages of the world.
+    ///
+    /// # Safety
+    /// The caller must only access world data that this [`UnsafeWorldCell`]
+    /// was given access to on construction.
+    pub unsafe fn storages(self) -> &'w Storages {
+        // SAFETY: Caller ensures they will only access world
+        // data that this instance is allowed to access.
+        unsafe { self.unsafe_world() }.storages()
     }
 
     /// Reads the current change tick of this world.


### PR DESCRIPTION
# Objective

`UnsafeWorldCell` is a type used to provide interior mutable access to a world, meant to be a replacement for `&World`. However, it is not currently possible to directly access the world's underlying storages, which means `UnsafeWorldCell` is not enough for every case where you need interior mutable world access.

## Solution

Provide access to world storages. Make the function unsafe, requiring the user to only use world accesses allowed by the `UnsafeWorldCell`.

---

## Changelog

+ Added the function `UnsafeWorldCell::storages`, which gives low-level access to the underlying data storages of the `World`.