### PR TITLE
add `monitor_selection` to window

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1908,6 +1908,13 @@ hidden = true
 name = "window_resizing"
 path = "examples/window/window_resizing.rs"
 
+[[example]]
+name = "monitor_selection"
+path = "examples/window/monitor_selection.rs"
+
+[package.metadata.example.monitor_selection]
+hidden = true
+
 [package.metadata.example.window_resizing]
 name = "Window Resizing"
 description = "Demonstrates resizing and responding to resizing a window"

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -100,6 +100,8 @@ pub struct Window {
     pub present_mode: PresentMode,
     /// Which fullscreen or windowing mode should be used?
     pub mode: WindowMode,
+    /// The preferred monitor this window should be spawned at. Cannot be changed after the window is spawned.
+    pub monitor_selection: MonitorSelection,
     /// Where the window should be placed.
     pub position: WindowPosition,
     /// What resolution the window should have.
@@ -194,6 +196,7 @@ impl Default for Window {
             cursor: Default::default(),
             present_mode: Default::default(),
             mode: Default::default(),
+            monitor_selection: MonitorSelection::Primary,
             position: Default::default(),
             resolution: Default::default(),
             internal: Default::default(),

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -159,6 +159,11 @@ pub(crate) fn changed_window(
                     winit_window.set_fullscreen(new_mode);
                 }
             }
+
+            if window.monitor_selection != cache.window.monitor_selection {
+                warn!("changing monitor_selection after the window is spawned is not supported!");
+            }
+
             if window.resolution != cache.window.resolution {
                 let physical_size = PhysicalSize::new(
                     window.resolution.physical_width(),

--- a/examples/window/monitor_selection.rs
+++ b/examples/window/monitor_selection.rs
@@ -1,0 +1,17 @@
+use bevy::{prelude::*, window::WindowMode};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Update, bevy::window::close_on_esc)
+        .add_systems(Startup, spawn_window)
+        .run();
+}
+
+fn spawn_window(mut commands: Commands) {
+    commands.spawn(Window {
+        monitor_selection: MonitorSelection::Index(1),
+        mode: WindowMode::BorderlessFullscreen,
+        ..default()
+    });
+}


### PR DESCRIPTION
# Objective

make
```rust
    commands.spawn(Window {
        monitor_selection: MonitorSelection::Index(1),
        mode: WindowMode::BorderlessFullscreen,
        ..default()
    });
```
work


## Solution

- add `monitor_selection` field to `Window`
- respect that solution for non-`Windowed` modes

## Open questions
- should `WindowPosition::Centered(MonitorSelection)` change? we could
  1. remove the `MonitorSelection` and always use the `MonitorSelection` from the window itself
  2. keep `MonitorSelection` so that you can spawn on `Primary`, then later move to `Centered(MonitorSelection::At(1))`.
- should we try to make changing the selection work after the window is spawned by moving it to another monitor? I don't know how to do this with winit.

## Changelog

- add `monitor_selection` to `Window`. Windows can now specify which monitor they want to be spawned on.

## Migration Guide

- nnothing if we keep `WindowPosition::Centered(MonitorSelection)`