### PR TITLE
Avoid spawning gizmo meshes when no gizmos are being drawn

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -18,6 +18,7 @@ pub(crate) struct GizmoStorage {
     pub list_colors: Vec<ColorItem>,
     pub strip_positions: Vec<PositionItem>,
     pub strip_colors: Vec<ColorItem>,
+    pub in_use: bool,
 }
 
 pub type Gizmos<'s> = Deferred<'s, GizmoBuffer>;

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -177,7 +177,7 @@ fn extract_gizmo_data(
             GizmoMesh,
             #[cfg(feature = "bevy_pbr")]
             (
-                handle.clone(),
+                handle.clone_weak(),
                 MeshUniform {
                     flags: 0,
                     transform,
@@ -186,7 +186,7 @@ fn extract_gizmo_data(
             ),
             #[cfg(feature = "bevy_sprite")]
             (
-                Mesh2dHandle(handle.clone()),
+                Mesh2dHandle(handle.clone_weak()),
                 Mesh2dUniform {
                     flags: 0,
                     transform,

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -131,31 +131,42 @@ fn update_gizmo_meshes(
 ) {
     let list_mesh = meshes.get_mut(&handles.list).unwrap();
 
-    let positions = mem::take(&mut storage.list_positions);
-    list_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+    storage.in_use = false;
 
-    let colors = mem::take(&mut storage.list_colors);
-    list_mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    if !storage.list_positions.is_empty() {
+        storage.in_use = true;
 
-    let strip_mesh = meshes.get_mut(&handles.strip).unwrap();
+        let positions = mem::take(&mut storage.list_positions);
+        list_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
 
-    let positions = mem::take(&mut storage.strip_positions);
-    strip_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+        let colors = mem::take(&mut storage.list_colors);
+        list_mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    }
 
-    let colors = mem::take(&mut storage.strip_colors);
-    strip_mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    if !storage.strip_positions.is_empty() {
+        storage.in_use = true;
+
+        let strip_mesh = meshes.get_mut(&handles.strip).unwrap();
+
+        let positions = mem::take(&mut storage.strip_positions);
+        strip_mesh.insert_attribute(Mesh::ATTRIBUTE_POSITION, positions);
+
+        let colors = mem::take(&mut storage.strip_colors);
+        strip_mesh.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+    }
 }
 
 fn extract_gizmo_data(
     mut commands: Commands,
     handles: Extract<Res<MeshHandles>>,
     config: Extract<Res<GizmoConfig>>,
+    storage: Extract<Res<GizmoStorage>>,
 ) {
     if config.is_changed() {
         commands.insert_resource(**config);
     }
 
-    if !config.enabled {
+    if !config.enabled || !storage.in_use {
         return;
     }
 


### PR DESCRIPTION
# Objective

Avoid queuing empty meshes for rendering.
Should prevent #8144 from triggering when no gizmos are in use. Not a real fix, unfortunately.

## Solution

Add an `in_use` field to `GizmoStorage` and only set it to true when there are gizmos to draw.