### PR TITLE
Fix size of clipped text glyphs.

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -296,7 +296,8 @@ pub fn extract_text_uinodes(
         .map(|window| window.resolution.scale_factor() as f32)
         .unwrap_or(1.0);
 
-    let scaling = Mat4::from_scale(Vec3::splat(scale_factor.recip()));
+        let inverse_scale_factor = scale_factor.recip();
+    
 
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
         if let Ok((uinode, global_transform, text, text_layout_info, visibility, clip)) =
@@ -306,10 +307,8 @@ pub fn extract_text_uinodes(
             if !visibility.is_visible() || uinode.size().x == 0. || uinode.size().y == 0. {
                 continue;
             }
-
             let transform = global_transform.compute_matrix()
-                * Mat4::from_translation(-0.5 * uinode.size().extend(0.))
-                * scaling;
+                * Mat4::from_translation(-0.5 * uinode.size().extend(0.));
 
             let mut color = Color::WHITE;
             let mut current_section = usize::MAX;
@@ -326,13 +325,16 @@ pub fn extract_text_uinodes(
                 }
                 let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
+                let mut rect = atlas.textures[atlas_info.glyph_index];
+                rect.min *= inverse_scale_factor;
+                rect.max *= inverse_scale_factor;
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,
-                    transform: transform * Mat4::from_translation(position.extend(0.)),
+                    transform: transform * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
                     color,
-                    rect: atlas.textures[atlas_info.glyph_index],
+                    rect,
                     image: atlas.texture.clone_weak(),
-                    atlas_size: Some(atlas.size),
+                    atlas_size: Some(atlas.size * inverse_scale_factor),
                     clip: clip.map(|clip| clip.clip),
                     flip_x: false,
                     flip_y: false,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -296,8 +296,7 @@ pub fn extract_text_uinodes(
         .map(|window| window.resolution.scale_factor() as f32)
         .unwrap_or(1.0);
 
-        let inverse_scale_factor = scale_factor.recip();
-    
+    let inverse_scale_factor = scale_factor.recip();
 
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
         if let Ok((uinode, global_transform, text, text_layout_info, visibility, clip)) =
@@ -330,7 +329,8 @@ pub fn extract_text_uinodes(
                 rect.max *= inverse_scale_factor;
                 extracted_uinodes.uinodes.push(ExtractedUiNode {
                     stack_index,
-                    transform: transform * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
+                    transform: transform
+                        * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
                     color,
                     rect,
                     image: atlas.texture.clone_weak(),


### PR DESCRIPTION
# Objective

Text glyphs that were clipped were not sized correctly because the transform extracted from the `extract_text_uinodes` had a scaling on it that wasn't accounted for. 

fixes #8167

## Solution

Remove the scaling from the transform and multiply the size of the glyphs by the inverse of the scale factor.