### PR TITLE
`UiImage` helper functions

### DIFF
--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -758,6 +758,20 @@ impl UiImage {
             ..Default::default()
         }
     }
+
+    /// flip the image along its x-axis
+    #[must_use]
+    pub const fn with_flip_x(mut self) -> Self {
+        self.flip_x = true;
+        self
+    }
+
+    /// flip the image along its y-axis
+    #[must_use]
+    pub const fn with_flip_y(mut self) -> Self {
+        self.flip_y = true;
+        self
+    }
 }
 
 impl From<Handle<Image>> for UiImage {


### PR DESCRIPTION
# Objective

Add helper functions to `UiImage` for creating flipped images.

## Changelog

* Added `with_flip_x` and `with_flip_y` methods to `UiImage` that return the `UiImage` flipped along the respective axis.
