### PR TITLE
add option for far plane culling (#8173)

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -50,7 +50,7 @@ impl Camera2dBundle {
         // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
-            far,
+            far: Some(far),
             ..Default::default()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -728,7 +728,7 @@ fn load_node(
                 let xmag = orthographic.xmag();
                 let orthographic_projection = OrthographicProjection {
                     near: orthographic.znear(),
-                    far: orthographic.zfar(),
+                    far: Some(orthographic.zfar()),
                     scaling_mode: ScalingMode::FixedHorizontal(1.0),
                     scale: xmag,
                     ..Default::default()
@@ -743,7 +743,7 @@ fn load_node(
                     ..Default::default()
                 };
                 if let Some(zfar) = perspective.zfar() {
-                    perspective_projection.far = zfar;
+                    perspective_projection.far = Some(zfar);
                 }
                 if let Some(aspect_ratio) = perspective.aspect_ratio() {
                     perspective_projection.aspect_ratio = aspect_ratio;

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1865,7 +1865,7 @@ pub fn update_point_light_frusta(
                 &view_projection,
                 &transform.translation(),
                 &view_backward,
-                point_light.range,
+                Some(point_light.range),
             );
         }
     }
@@ -1900,7 +1900,7 @@ pub fn update_spot_light_frusta(
             &view_projection,
             &transform.translation(),
             &view_backward,
-            spot_light.range,
+            Some(spot_light.range),
         );
     }
 }

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -150,10 +150,10 @@ impl Frustum {
         view_projection: &Mat4,
         view_translation: &Vec3,
         view_backward: &Vec3,
-        far: f32,
+        far: Option<f32>,
     ) -> Self {
         let mut frustum = Frustum::from_view_projection_no_far(view_projection);
-        let far_center = *view_translation - far * *view_backward;
+        let far_center = *view_translation - far.unwrap_or_default() * *view_backward;
         frustum.planes[5] = Plane::new(view_backward.extend(-view_backward.dot(far_center)));
         frustum
     }

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -352,7 +352,15 @@ fn propagate_recursive(
 /// for that view.
 pub fn check_visibility(
     mut thread_queues: Local<ThreadLocal<Cell<Vec<Entity>>>>,
-    mut view_query: Query<(&mut VisibleEntities, &Frustum, Option<&RenderLayers>), With<Camera>>,
+    mut view_query: Query<
+        (
+            &mut VisibleEntities,
+            &Frustum,
+            Option<&RenderLayers>,
+            Option<&Projection>,
+        ),
+        With<Camera>,
+    >,
     mut visible_aabb_query: Query<(
         Entity,
         &mut ComputedVisibility,
@@ -366,7 +374,7 @@ pub fn check_visibility(
         Without<Aabb>,
     >,
 ) {
-    for (mut visible_entities, frustum, maybe_view_mask) in &mut view_query {
+    for (mut visible_entities, frustum, maybe_view_mask, maybe_projection) in &mut view_query {
         let view_mask = maybe_view_mask.copied().unwrap_or_default();
 
         visible_entities.entities.clear();
@@ -390,6 +398,11 @@ pub fn check_visibility(
                     return;
                 }
 
+                let use_far_culling = match maybe_projection {
+                    Some(p) => p.far().is_some(),
+                    None => false,
+                };
+
                 // If we have an aabb and transform, do frustum culling
                 if maybe_no_frustum_culling.is_none() {
                     let model = transform.compute_matrix();
@@ -398,11 +411,11 @@ pub fn check_visibility(
                         radius: transform.radius_vec3a(model_aabb.half_extents),
                     };
                     // Do quick sphere-based frustum culling
-                    if !frustum.intersects_sphere(&model_sphere, false) {
+                    if !frustum.intersects_sphere(&model_sphere, use_far_culling) {
                         return;
                     }
                     // If we have an aabb, do aabb-based frustum culling
-                    if !frustum.intersects_obb(model_aabb, &model, true, false) {
+                    if !frustum.intersects_obb(model_aabb, &model, true, use_far_culling) {
                         return;
                     }
                 }


### PR DESCRIPTION
# Objective

- Adds option to `Projection` for far plane culling, and updates `check_visibility` to perform culling based on this property
- Before this change Frustum Culling would only account for near, left, right, top, and bottom planes with no trivial user facing overrides
- "Fixes #8173"

## Solution

- In addition to providing the option and updating check visibility, the new `use_far_culling: bool` defaults to false to prevent breaking changes
- with the use_far_culling option enabled, the perspective projection will behave more like the defaults in Godot, Unity, and Unreal where all 6 planes of the frustum are used for visibility tests
- this can lead to performance improvements on weaker targets like mobile with minimal effort

---

## Changelog

- Added use_far_culling option for camera_3d projections. Consider enabling this option for a quick performance boost for weaker targets until occlusion culling is ready.

## Example
Checkout https://github.com/NotoriousENG/bevy_cull_bug/tree/feature/fix_example and build against this PR for bevy to see in action
 
Image Showing Far Plane culling is working
![image](https://user-images.githubusercontent.com/32341612/227695870-f1a0bd56-9f5d-429e-bfb1-04545bf918d4.png)
