### PR TITLE
Add ReflectComponent registration for Sprite

### DIFF
--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,9 +1,6 @@
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Rect, Vec2};
-use bevy_reflect::{
-    prelude::{FromReflect, ReflectDefault},
-    Reflect,
-};
+use bevy_reflect::{std_traits::ReflectDefault, FromReflect, Reflect};
 use bevy_render::color::Color;
 
 #[derive(Component, Debug, Default, Clone, Reflect, FromReflect)]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,9 +1,13 @@
-use bevy_ecs::component::Component;
+use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Rect, Vec2};
-use bevy_reflect::Reflect;
+use bevy_reflect::{
+    prelude::{FromReflect, ReflectDefault},
+    Reflect,
+};
 use bevy_render::color::Color;
 
-#[derive(Component, Debug, Default, Clone, Reflect)]
+#[derive(Component, Debug, Default, Clone, Reflect, FromReflect)]
+#[reflect(Component, Default)]
 #[repr(C)]
 pub struct Sprite {
     /// The sprite's color tint
@@ -24,7 +28,7 @@ pub struct Sprite {
 
 /// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).
 /// It defaults to `Anchor::Center`.
-#[derive(Component, Debug, Clone, Default, Reflect)]
+#[derive(Component, Debug, Clone, Default, Reflect, FromReflect)]
 #[doc(alias = "pivot")]
 pub enum Anchor {
     #[default]


### PR DESCRIPTION
# Objective

- `Sprite` components are not included in scene (de)serialization.
- Fixes #8206

## Solution

- Add `#[reflect(Component, Default)]` to `Sprite`
- Add `#[derive(FromReflect)]` to `Sprite` and `Anchor`
