### PR TITLE
Update 3d_scene.rs

### DIFF
--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -5,7 +5,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_systems(Startup, setup)
+        .add_startup_system(setup)
         .run();
 }
 


### PR DESCRIPTION
# Objective

Fix the error of cargo not finding "Startup"

## Solution

using `add_startup_system` instead of `add_systems(Startup, setup)` 
