### PR TITLE
Make bevy_winit/trace optional in trace feature

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -17,7 +17,7 @@ trace = [
     "bevy_log/trace",
     "bevy_render?/trace",
     "bevy_hierarchy/trace",
-    "bevy_winit/trace"
+    "bevy_winit?/trace"
 ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]


### PR DESCRIPTION
# Objective

Bevy with
```
default-features = false
features = [
   "trace_tracy"
]
```
will fail due to `error: The platform you're compiling for is not supported by winit`

## Solution

- Make bevy_winit/trace optional in trace feature