### PR TITLE
Simplify `Clone` for `ThinSlicePtr`

### DIFF
--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -368,12 +368,7 @@ impl<'a, T> ThinSlicePtr<'a, T> {
 
 impl<'a, T> Clone for ThinSlicePtr<'a, T> {
     fn clone(&self) -> Self {
-        Self {
-            ptr: self.ptr,
-            #[cfg(debug_assertions)]
-            len: self.len,
-            _marker: PhantomData,
-        }
+        *self
     }
 }
 


### PR DESCRIPTION
# Objective

The type `ThinSlicePtr` has a manual implementation of `Clone` that manually clones each field. Since this type implements `Copy`, we can change this implementation to simply dereference `&self`.