### PR TITLE
Make standard commands more ergonomic (in niche cases)

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1000,7 +1000,7 @@ impl<R: Resource> Command for RemoveResource<R> {
 
 impl<R: Resource> RemoveResource<R> {
     /// Creates a [`Command`] which will remove a [`Resource`] from the [`World`]
-    fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             _phantom: PhantomData::<R>,
         }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -950,7 +950,8 @@ where
 }
 
 impl<T> Remove<T> {
-    fn new(entity: Entity) -> Self {
+    /// Creates a [`Command`] which will remove the specified [`Entity`] when flushed
+    pub const fn new(entity: Entity) -> Self {
         Self {
             entity,
             _phantom: PhantomData::<T>,
@@ -969,7 +970,8 @@ impl<R: Resource + FromWorld> Command for InitResource<R> {
 }
 
 impl<R: Resource + FromWorld> InitResource<R> {
-    fn new() -> Self {
+    /// Creates a [`Command`] which will insert a default created [`Resource`] into the [`World`]
+    pub const fn new() -> Self {
         Self {
             _phantom: PhantomData::<R>,
         }
@@ -997,6 +999,7 @@ impl<R: Resource> Command for RemoveResource<R> {
 }
 
 impl<R: Resource> RemoveResource<R> {
+    /// Creates a [`Command`] which will remove a [`Resource`] from the [`World`]
     fn new() -> Self {
         Self {
             _phantom: PhantomData::<R>,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -444,7 +444,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # bevy_ecs::system::assert_is_system(initialise_scoreboard);
     /// ```
     pub fn init_resource<R: Resource + FromWorld>(&mut self) {
-        self.queue.push(InitResource::<R>::default());
+        self.queue.push(InitResource::<R>::new());
     }
 
     /// Pushes a [`Command`] to the queue for inserting a [`Resource`] in the [`World`] with a specific value.
@@ -497,7 +497,7 @@ impl<'w, 's> Commands<'w, 's> {
     /// # bevy_ecs::system::assert_is_system(system);
     /// ```
     pub fn remove_resource<R: Resource>(&mut self) {
-        self.queue.push(RemoveResource::<R>::default());
+        self.queue.push(RemoveResource::<R>::new());
     }
 
     /// Pushes a generic [`Command`] to the command queue.
@@ -744,7 +744,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     where
         T: Bundle,
     {
-        self.commands.add(Remove::<T>::from(self.entity));
+        self.commands.add(Remove::<T>::new(self.entity));
         self
     }
 
@@ -949,8 +949,8 @@ where
     }
 }
 
-impl<T> From<Entity> for Remove<T> {
-    fn from(entity: Entity) -> Self {
+impl<T> Remove<T> {
+    fn new(entity: Entity) -> Self {
         Self {
             entity,
             _phantom: PhantomData::<T>,
@@ -968,8 +968,8 @@ impl<R: Resource + FromWorld> Command for InitResource<R> {
     }
 }
 
-impl<R: Resource + FromWorld> Default for InitResource<R> {
-    fn default() -> Self {
+impl<R: Resource + FromWorld> InitResource<R> {
+    fn new() -> Self {
         Self {
             _phantom: PhantomData::<R>,
         }
@@ -996,8 +996,8 @@ impl<R: Resource> Command for RemoveResource<R> {
     }
 }
 
-impl<R: Resource> Default for RemoveResource<R> {
-    fn default() -> Self {
+impl<R: Resource> RemoveResource<R> {
+    fn new() -> Self {
         Self {
             _phantom: PhantomData::<R>,
         }

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -935,7 +935,7 @@ where
 #[derive(Debug)]
 pub struct Remove<T> {
     pub entity: Entity,
-    pub _phantom: PhantomData<T>,
+    pub phantom: PhantomData<T>,
 }
 
 impl<T> Command for Remove<T>
@@ -954,7 +954,7 @@ impl<T> Remove<T> {
     pub const fn new(entity: Entity) -> Self {
         Self {
             entity,
-            _phantom: PhantomData::<T>,
+            phantom: PhantomData::<T>,
         }
     }
 }
@@ -989,7 +989,7 @@ impl<R: Resource> Command for InsertResource<R> {
 }
 
 pub struct RemoveResource<R: Resource> {
-    pub _phantom: PhantomData<R>,
+    pub phantom: PhantomData<R>,
 }
 
 impl<R: Resource> Command for RemoveResource<R> {
@@ -1002,7 +1002,7 @@ impl<R: Resource> RemoveResource<R> {
     /// Creates a [`Command`] which will remove a [`Resource`] from the [`World`]
     pub const fn new() -> Self {
         Self {
-            _phantom: PhantomData::<R>,
+            phantom: PhantomData::<R>,
         }
     }
 }


### PR DESCRIPTION
# Objective

I ran into a case where I need to create a `CommandQueue` and push standard `Command` actions like `Insert` or `Remove` to it manually. I saw that `Remove` looked as follows:

```rust
struct Remove<T> {
  entity: Entity,
  phantom: PhantomData<T>
}
```

so naturally, I tried to use `Remove::<Foo>::from(entity)` but it didn't exist. We need to specify the `PhantomData` explicitly when creating this command action. The same goes for `RemoveResource` and `InitResource`

## Solution

This PR implements the following:

- `From<Entity>` for `Remove<T>`
- `Default` for `RemoveResource` and `InitResource`
- use these traits in the implementation of methods of `Commands`
- rename `phantom` field on the structs above to `_phantom` to have a more uniform field naming scheme for the command actions

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

-  Added: implemented `From<Entity>` for `Remove<T>` and `Default` for `RemoveResource` and `InitResource` for ergonomics