### PR TITLE
Basic event benchmarks

### DIFF
--- a/benches/benches/bevy_ecs/benches.rs
+++ b/benches/benches/bevy_ecs/benches.rs
@@ -1,9 +1,9 @@
 use criterion::criterion_main;
 
 mod components;
+mod events;
 mod iteration;
 mod scheduling;
-mod events;
 mod world;
 
 criterion_main!(

--- a/benches/benches/bevy_ecs/benches.rs
+++ b/benches/benches/bevy_ecs/benches.rs
@@ -3,11 +3,13 @@ use criterion::criterion_main;
 mod components;
 mod iteration;
 mod scheduling;
+mod events;
 mod world;
 
 criterion_main!(
-    iteration::iterations_benches,
     components::components_benches,
+    events::event_benches,
+    iteration::iterations_benches,
     scheduling::scheduling_benches,
     world::world_benches,
 );

--- a/benches/benches/bevy_ecs/events/iter.rs
+++ b/benches/benches/bevy_ecs/events/iter.rs
@@ -1,0 +1,24 @@
+use bevy_ecs::prelude::*;
+
+struct A(f32);
+
+pub struct Benchmark(Events<A>);
+
+impl Benchmark {
+    pub fn new(count: usize) -> Self {
+        let mut events = Events::default();
+        
+        for _ in 0..count {
+            events.send(A(0.0));
+        }
+
+        Self(events)
+    }
+
+    pub fn run(&mut self) {
+        let mut reader = self.0.get_reader();
+        for evt in reader.iter(&self.0) {
+            std::hint::black_box(evt);
+        }
+    }
+}

--- a/benches/benches/bevy_ecs/events/iter.rs
+++ b/benches/benches/bevy_ecs/events/iter.rs
@@ -1,15 +1,13 @@
 use bevy_ecs::prelude::*;
 
-struct A(f32);
+pub struct Benchmark<const SIZE: usize>(Events<[u8; SIZE]>);
 
-pub struct Benchmark(Events<A>);
-
-impl Benchmark {
+impl<const SIZE: usize> Benchmark<SIZE> {
     pub fn new(count: usize) -> Self {
         let mut events = Events::default();
 
         for _ in 0..count {
-            events.send(A(0.0));
+            events.send([0u8; SIZE]);
         }
 
         Self(events)

--- a/benches/benches/bevy_ecs/events/iter.rs
+++ b/benches/benches/bevy_ecs/events/iter.rs
@@ -7,7 +7,7 @@ pub struct Benchmark(Events<A>);
 impl Benchmark {
     pub fn new(count: usize) -> Self {
         let mut events = Events::default();
-        
+
         for _ in 0..count {
             events.send(A(0.0));
         }

--- a/benches/benches/bevy_ecs/events/mod.rs
+++ b/benches/benches/bevy_ecs/events/mod.rs
@@ -1,13 +1,9 @@
 use criterion::*;
 
-mod send;
 mod iter;
+mod send;
 
-criterion_group!(
-    event_benches,
-    send,
-    iter,
-);
+criterion_group!(event_benches, send, iter,);
 
 fn send(c: &mut Criterion) {
     let mut group = c.benchmark_group("events_send");

--- a/benches/benches/bevy_ecs/events/mod.rs
+++ b/benches/benches/bevy_ecs/events/mod.rs
@@ -10,8 +10,20 @@ fn send(c: &mut Criterion) {
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
     for count in [100, 1000, 10000, 50000] {
-        group.bench_function(format!("{}", count), |b| {
-            let mut bench = send::Benchmark::new(count);
+        group.bench_function(format!("size_4_events_{}", count), |b| {
+            let mut bench = send::Benchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_16_events_{}", count), |b| {
+            let mut bench = send::Benchmark::<16>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_512_events_{}", count), |b| {
+            let mut bench = send::Benchmark::<512>::new(count);
             b.iter(move || bench.run());
         });
     }
@@ -23,8 +35,20 @@ fn iter(c: &mut Criterion) {
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
     for count in [100, 1000, 10000, 50000] {
-        group.bench_function(format!("{}", count), |b| {
-            let mut bench = iter::Benchmark::new(count);
+        group.bench_function(format!("size_4_events_{}", count), |b| {
+            let mut bench = iter::Benchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_16_events_{}", count), |b| {
+            let mut bench = iter::Benchmark::<4>::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("size_512_events_{}", count), |b| {
+            let mut bench = iter::Benchmark::<512>::new(count);
             b.iter(move || bench.run());
         });
     }

--- a/benches/benches/bevy_ecs/events/mod.rs
+++ b/benches/benches/bevy_ecs/events/mod.rs
@@ -1,0 +1,36 @@
+use criterion::*;
+
+mod send;
+mod iter;
+
+criterion_group!(
+    event_benches,
+    send,
+    iter,
+);
+
+fn send(c: &mut Criterion) {
+    let mut group = c.benchmark_group("events_send");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("{}", count), |b| {
+            let mut bench = send::Benchmark::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    group.finish();
+}
+
+fn iter(c: &mut Criterion) {
+    let mut group = c.benchmark_group("events_iter");
+    group.warm_up_time(std::time::Duration::from_millis(500));
+    group.measurement_time(std::time::Duration::from_secs(4));
+    for count in [100, 1000, 10000, 50000] {
+        group.bench_function(format!("{}", count), |b| {
+            let mut bench = iter::Benchmark::new(count);
+            b.iter(move || bench.run());
+        });
+    }
+    group.finish();
+}

--- a/benches/benches/bevy_ecs/events/send.rs
+++ b/benches/benches/bevy_ecs/events/send.rs
@@ -2,7 +2,10 @@ use bevy_ecs::prelude::*;
 
 struct A(f32);
 
-pub struct Benchmark(Events<A>, usize);
+pub struct Benchmark {
+    events: Events<A>,
+    count: usize,
+}
 
 impl Benchmark {
     pub fn new(count: usize) -> Self {
@@ -16,13 +19,13 @@ impl Benchmark {
             events.update();
         }
 
-        Self(events, count)
+        Self { events, count }
     }
 
     pub fn run(&mut self) {
-        for _ in 0..self.1 {
-            self.0.send(std::hint::black_box(A(0.0)));
+        for _ in 0..self.count {
+            self.events.send(std::hint::black_box(A(0.0)));
         }
-        self.0.update();
+        self.events.update();
     }
 }

--- a/benches/benches/bevy_ecs/events/send.rs
+++ b/benches/benches/bevy_ecs/events/send.rs
@@ -8,7 +8,7 @@ impl Benchmark {
     pub fn new(count: usize) -> Self {
         let mut events = Events::default();
         
-        // Force the internal buffers to be allocated
+        // Force both internal buffers to be allocated.
         for _ in 0..2 {
             for _ in 0..count {
                 events.send(A(0.0));
@@ -21,7 +21,7 @@ impl Benchmark {
 
     pub fn run(&mut self) {
         for _ in 0..self.1 {
-            self.0.send(A(0.0));
+            self.0.send(std::hint::black_box(A(0.0)));
         }
         self.0.update();
     }

--- a/benches/benches/bevy_ecs/events/send.rs
+++ b/benches/benches/bevy_ecs/events/send.rs
@@ -1,0 +1,28 @@
+use bevy_ecs::prelude::*;
+
+struct A(f32);
+
+pub struct Benchmark(Events<A>, usize);
+
+impl Benchmark {
+    pub fn new(count: usize) -> Self {
+        let mut events = Events::default();
+        
+        // Force the internal buffers to be allocated
+        for _ in 0..2 {
+            for _ in 0..count {
+                events.send(A(0.0));
+            }
+            events.update();
+        }
+
+        Self(events, count)
+    }
+
+    pub fn run(&mut self) {
+        for _ in 0..self.1 {
+            self.0.send(A(0.0));
+        }
+        self.0.update();
+    }
+}

--- a/benches/benches/bevy_ecs/events/send.rs
+++ b/benches/benches/bevy_ecs/events/send.rs
@@ -1,20 +1,18 @@
 use bevy_ecs::prelude::*;
 
-struct A(f32);
-
-pub struct Benchmark {
-    events: Events<A>,
+pub struct Benchmark<const SIZE: usize> {
+    events: Events<[u8; SIZE]>,
     count: usize,
 }
 
-impl Benchmark {
+impl<const SIZE: usize> Benchmark<SIZE> {
     pub fn new(count: usize) -> Self {
         let mut events = Events::default();
         
         // Force both internal buffers to be allocated.
         for _ in 0..2 {
             for _ in 0..count {
-                events.send(A(0.0));
+                events.send([0u8; SIZE]);
             }
             events.update();
         }
@@ -24,7 +22,7 @@ impl Benchmark {
 
     pub fn run(&mut self) {
         for _ in 0..self.count {
-            self.events.send(std::hint::black_box(A(0.0)));
+            self.events.send(std::hint::black_box([0u8; SIZE]));
         }
         self.events.update();
     }


### PR DESCRIPTION
# Objective
Fix #7731. Add basic Event sending and iteration benchmarks to bevy_ecs's benchmark suite.

## Solution
Add said benchmarks scaling from 100 to 50,000 events.

Not sure if I want to include a randomization of the events going in, the current implementation might be too easy for the compiler to optimize.