### PR TITLE
Bootstrap trait docs for derive macros by JSON sniffing

### DIFF
--- a/crates/bevy_ecs/macros/build.rs
+++ b/crates/bevy_ecs/macros/build.rs
@@ -1,6 +1,7 @@
 use std::{io::Write, path::PathBuf, process::Command};
 
 fn main() {
+    println!("cargo:rerun-if-changed=../src/");
     // TODO: this needs to run once
     // cargo +nightly rustdoc --target-dir target -- -Z unstable-options --output-format json
     // cargo +nightly rustdoc -p bevy_ecs -- -Z unstable-options -w json
@@ -28,42 +29,66 @@ fn main() {
     // Optional: Resource
     // Component
     // States
-    //
-    // jq -r '.. | objects | select(.name == "SystemParam" and has("docs")) | .docs' target/doc/bevy_ecs.json > system_param.md
 
+    // jq -r '.. | objects | select(.name == "SystemParam" and has("docs")) | .docs' target/doc/bevy_ecs.json > system_param.md
+    let traits_to_document = [
+        "Bundle",
+        "SystemParam",
+        "WorldQuery",
+        "ScheduleLabel",
+        "SystemSet",
+        // "Resource",
+        "Component",
+        "States",
+    ];
+    let traits_doc_filenames = [
+        "bundle.md",
+        "system_param.md",
+        "world_query.md",
+        "schedule_label.md",
+        "system_set.md",
+        // "resource.md",
+        "component.md",
+        "states.md",
+    ];
     use std::env;
     let out_dir = env::var("OUT_DIR").unwrap();
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let mut jq_command = Command::new("jq");
-    let system_param_doc = jq_command
-        .arg("-r")
-        .arg(r#".. | objects | select(.name == "SystemParam" and has("docs")) | .docs"#)
-        .arg(format!("{out_dir}/../../../../doc/bevy_ecs.json"));
-    assert!(system_param_doc.status().unwrap().success());
 
-    let system_param_doc = system_param_doc
-        //TODO: do something so it doesn't output it
-        .output()
-        .expect("failed to extract SystemParam");
-    // assert!(system_param_doc.status.success());
-    //TODO: Add # to all headings
-    //TODO: Remove links at the bottom, as they won't work.
+    let trait_docs = traits_to_document
+        .into_iter()
+        .flat_map(|x| {
+            Command::new("jq")
+                .arg("-r")
+                .arg(format!(
+                    r#".. | objects | select(.name == "{x}" and has("docs")) | .docs"#
+                ))
+                .arg(format!("{out_dir}/../../../../doc/bevy_ecs.json"))
+                //TODO: do something so it doesn't output it
+                .output()
+            //TODO: Add # to all headings
+            //TODO: Remove links at the bottom, as they won't work.
+        })
+        .map(|x| x.stdout);
 
-    let system_param_doc = system_param_doc.stdout;
-    let system_param_doc_path = format!("{manifest_dir}/../doc/{}", "system_param.md");
-    let system_param_doc_path = PathBuf::from(system_param_doc_path);
+    let traits_doc_paths = traits_doc_filenames
+        .into_iter()
+        .map(|x| PathBuf::from(format!("{manifest_dir}/../doc/{x}")))
+        .collect::<Vec<_>>();
 
-    std::fs::create_dir_all(system_param_doc_path.parent().unwrap()).unwrap();
-    if !std::path::Path::exists(&system_param_doc_path) {
-        std::fs::File::create(&system_param_doc_path).unwrap();
+    std::fs::create_dir_all(traits_doc_paths[0].parent().unwrap()).unwrap();
+    for (trait_doc_path, trait_doc) in traits_doc_paths.into_iter().zip(trait_docs.into_iter()) {
+        if !std::path::Path::exists(&trait_doc_path) {
+            std::fs::File::create(&trait_doc_path).unwrap();
+        }
+        std::fs::File::options()
+            .append(false)
+            .truncate(true)
+            .write(true)
+            .open(trait_doc_path)
+            //TODO
+            .expect("ERROR")
+            .write_all(trait_doc.as_slice())
+            .unwrap();
     }
-    std::fs::File::options()
-        .append(false)
-        .truncate(true)
-        .write(true)
-        .open(system_param_doc_path)
-        //TODO
-        .expect("ERROR")
-        .write_all(system_param_doc.as_slice())
-        .unwrap();
 }

--- a/crates/bevy_ecs/macros/build.rs
+++ b/crates/bevy_ecs/macros/build.rs
@@ -1,0 +1,69 @@
+use std::{io::Write, path::PathBuf, process::Command};
+
+fn main() {
+    // TODO: this needs to run once
+    // cargo +nightly rustdoc --target-dir target -- -Z unstable-options --output-format json
+    // cargo +nightly rustdoc -p bevy_ecs -- -Z unstable-options -w json
+    Command::new("cargo")
+        .args([
+            "+nightly",
+            "rustdoc",
+            "--manifest-path",
+            "../",
+            // "-p",
+            // "bevy_ecs",
+            "--",
+            "-Zunstable-options",
+            "-w",
+            "json",
+        ])
+        .output()
+        //TODO
+        .expect("failed to generate json rustdocs -- did you install `rustup component add --toolchain nightly rust-docs-json`");
+    // Bundle
+    // SystemParam
+    // WorldQuery
+    // ScheduleLabel
+    // SystemSet
+    // Optional: Resource
+    // Component
+    // States
+    //
+    // jq -r '.. | objects | select(.name == "SystemParam" and has("docs")) | .docs' target/doc/bevy_ecs.json > system_param.md
+
+    use std::env;
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let mut jq_command = Command::new("jq");
+    let system_param_doc = jq_command
+        .arg("-r")
+        .arg(r#".. | objects | select(.name == "SystemParam" and has("docs")) | .docs"#)
+        .arg(format!("{out_dir}/../../../../doc/bevy_ecs.json"));
+    assert!(system_param_doc.status().unwrap().success());
+
+    let system_param_doc = system_param_doc
+        //TODO: do something so it doesn't output it
+        .output()
+        .expect("failed to extract SystemParam");
+    // assert!(system_param_doc.status.success());
+    //TODO: Add # to all headings
+    //TODO: Remove links at the bottom, as they won't work.
+
+    let system_param_doc = system_param_doc.stdout;
+    let system_param_doc_path = format!("{manifest_dir}/../doc/{}", "system_param.md");
+    let system_param_doc_path = PathBuf::from(system_param_doc_path);
+
+    std::fs::create_dir_all(system_param_doc_path.parent().unwrap()).unwrap();
+    if !std::path::Path::exists(&system_param_doc_path) {
+        std::fs::File::create(&system_param_doc_path).unwrap();
+    }
+    std::fs::File::options()
+        .append(false)
+        .truncate(true)
+        .write(true)
+        .open(system_param_doc_path)
+        //TODO
+        .expect("ERROR")
+        .write_all(system_param_doc.as_slice())
+        .unwrap();
+}

--- a/crates/bevy_ecs/macros/build.rs
+++ b/crates/bevy_ecs/macros/build.rs
@@ -1,5 +1,14 @@
 use std::{io::Write, path::PathBuf, process::Command};
 
+// - [ ] Bundle
+// - [ ] SystemParam
+// - [ ] WorldQuery
+// - [ ] ScheduleLabel
+// - [ ] SystemSet
+// - [ ] Optional: Resource
+// - [ ] Component
+// - [ ] States
+
 fn main() {
     println!("cargo:rerun-if-changed=../src/");
     // TODO: this needs to run once
@@ -21,14 +30,6 @@ fn main() {
         .output()
         //TODO
         .expect("failed to generate json rustdocs -- did you install `rustup component add --toolchain nightly rust-docs-json`");
-    // Bundle
-    // SystemParam
-    // WorldQuery
-    // ScheduleLabel
-    // SystemSet
-    // Optional: Resource
-    // Component
-    // States
 
     // jq -r '.. | objects | select(.name == "SystemParam" and has("docs")) | .docs' target/doc/bevy_ecs.json > system_param.md
     let traits_to_document = [

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -26,6 +26,7 @@ enum BundleFieldKind {
 const BUNDLE_ATTRIBUTE_NAME: &str = "bundle";
 const BUNDLE_ATTRIBUTE_IGNORE_NAME: &str = "ignore";
 
+#[doc = include_str!("../../doc/bundle.md")]
 #[proc_macro_derive(Bundle, attributes(bundle))]
 pub fn derive_bundle(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);
@@ -457,12 +458,14 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
 }
 
 /// Implement `WorldQuery` to use a struct as a parameter in a query
+#[doc = include_str!("../../doc/world_query.md")]
 #[proc_macro_derive(WorldQuery, attributes(world_query))]
 pub fn derive_world_query(input: TokenStream) -> TokenStream {
     derive_world_query_impl(input)
 }
 
 /// Derive macro generating an impl of the trait `ScheduleLabel`.
+#[doc = include_str!("../../doc/schedule_label.md")]
 #[proc_macro_derive(ScheduleLabel)]
 pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -475,6 +478,7 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
 }
 
 /// Derive macro generating an impl of the trait `SystemSet`.
+#[doc = include_str!("../../doc/system_set.md")]
 #[proc_macro_derive(SystemSet)]
 pub fn derive_system_set(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -493,11 +497,13 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }
 
+#[doc = include_str!("../../doc/component.md")]
 #[proc_macro_derive(Component, attributes(component))]
 pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
+#[doc = include_str!("../../doc/states.md")]
 #[proc_macro_derive(States)]
 pub fn derive_states(input: TokenStream) -> TokenStream {
     states::derive_states(input)

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -260,6 +260,7 @@ struct SystemParamFieldAttributes {
 static SYSTEM_PARAM_ATTRIBUTE_NAME: &str = "system_param";
 
 /// Implement `SystemParam` to use a struct as a parameter in a system
+#[doc = include_str!("../../doc/system_param.md")]
 #[proc_macro_derive(SystemParam, attributes(system_param))]
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let token_stream = input.clone();


### PR DESCRIPTION
# Objective

Tries to address documentation issues #6195.

## Solution

- Added a `build.rs` file to `bevy_ecs/macros` that uses `nightly` to produce a `JSON` of the
`rustdoc`, and then use a tool like `jq` to sniff out the docs for the traits; Place those in `.md`-files
and use them in `bevy_ecs`-crate.
- [ ] Use something else than `jq`, as that is not required to run the build
- [ ] Remove links as all intra-links in the sniffed markdown files point nowhere now.
- [ ] Possibly add another `#` to all the headings in the markdown files, as to be able to put them in
- [ ] doc tests don't work anymore, thus all code blocks needs to have a `ignore` added to them.
a subsection in the derive-macro documentation.
- [ ] Important use `CARGO` environment variable to find the *right* cargo.
- **Alternative**: Just have proc-macro-derive traits have their documentation in `.md`-files and then
include those in the `bevy_ecs/macros` proc-macro package.
