### PR TITLE
Format SystemState doc example code

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -81,17 +81,17 @@ impl SystemMeta {
 ///
 /// Basic usage:
 /// ```rust
-/// use bevy_ecs::prelude::*;
-/// use bevy_ecs::{system::SystemState};
-/// use bevy_ecs::event::Events;
-///
-/// struct MyEvent;
-/// #[derive(Resource)]
-/// struct MyResource(u32);
-///
-/// #[derive(Component)]
-/// struct MyComponent;
-///
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::system::SystemState;
+/// # use bevy_ecs::event::Events;
+/// #
+/// # struct MyEvent;
+/// # #[derive(Resource)]
+/// # struct MyResource(u32);
+/// #
+/// # #[derive(Component)]
+/// # struct MyComponent;
+/// #
 /// // Work directly on the `World`
 /// let mut world = World::new();
 /// world.init_resource::<Events<MyEvent>>();
@@ -102,34 +102,36 @@ impl SystemMeta {
 ///     EventWriter<MyEvent>,
 ///     Option<ResMut<MyResource>>,
 ///     Query<&MyComponent>,
-///     )> = SystemState::new(&mut world);
+/// )> = SystemState::new(&mut world);
 ///
 /// // Use system_state.get_mut(&mut world) and unpack your system parameters into variables!
 /// // system_state.get(&world) provides read-only versions of your system parameters instead.
 /// let (event_writer, maybe_resource, query) = system_state.get_mut(&mut world);
 ///
-/// // If you are using [`Commands`], you can choose when you want to apply them to the world.
-/// // You need to manually call `.apply(world)` on the [`SystemState`] to apply them.
+/// // If you are using `Commands`, you can choose when you want to apply them to the world.
+/// // You need to manually call `.apply(world)` on the `SystemState` to apply them.
 /// ```
 /// Caching:
 /// ```rust
-/// use bevy_ecs::prelude::*;
-/// use bevy_ecs::{system::SystemState};
-/// use bevy_ecs::event::Events;
-///
-/// struct MyEvent;
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_ecs::system::SystemState;
+/// # use bevy_ecs::event::Events;
+/// #
+/// # struct MyEvent;
 /// #[derive(Resource)]
 /// struct CachedSystemState {
-///    event_state: SystemState<EventReader<'static, 'static, MyEvent>>
+///     event_state: SystemState<EventReader<'static, 'static, MyEvent>>,
 /// }
 ///
 /// // Create and store a system state once
 /// let mut world = World::new();
 /// world.init_resource::<Events<MyEvent>>();
-/// let initial_state: SystemState<EventReader<MyEvent>>  = SystemState::new(&mut world);
+/// let initial_state: SystemState<EventReader<MyEvent>> = SystemState::new(&mut world);
 ///
 /// // The system state is cached in a resource
-/// world.insert_resource(CachedSystemState{event_state: initial_state});
+/// world.insert_resource(CachedSystemState {
+///     event_state: initial_state,
+/// });
 ///
 /// // Later, fetch the cached system state, saving on overhead
 /// world.resource_scope(|world, mut cached_state: Mut<CachedSystemState>| {
@@ -137,7 +139,7 @@ impl SystemMeta {
 ///
 ///     for events in event_reader.iter() {
 ///         println!("Hello World!");
-///     };
+///     }
 /// });
 /// ```
 pub struct SystemState<Param: SystemParam + 'static> {
@@ -566,7 +568,6 @@ where
 /// use std::num::ParseIntError;
 ///
 /// use bevy_ecs::prelude::*;
-/// use bevy_ecs::system::{SystemParam, SystemParamItem};
 ///
 /// /// Pipe creates a new system which calls `a`, then calls `b` with the output of `a`
 /// pub fn pipe<A, B, AMarker, BMarker>(


### PR DESCRIPTION
# Objective

I noticed some funky whitespace in the examples in the [`SystemState`](https://docs.rs/bevy/latest/bevy/ecs/system/struct.SystemState.html#example) doc examples.

## Solution

Semi-manually reformatted these particular code blocks and hid some of the imports and boilerplate not relevant to the example.

([format_code_in_doc_comments](https://rust-lang.github.io/rustfmt/?version=v1.5.1&search=#format_code_in_doc_comments) seemingly has a bunch of issues and has not been stabilized) 
