### PR TITLE
Remove base set error variants of `ScheduleBuildError`

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1495,20 +1495,6 @@ pub enum ScheduleBuildError {
     /// Tried to run a schedule before all of its systems have been initialized.
     #[error("Systems in schedule have not been initialized.")]
     Uninitialized,
-    /// Tried to add a system to multiple base sets.
-    #[error("System `{system:?}` is in the base sets {first_set:?} and {second_set:?}, but systems can only belong to one base set.")]
-    SystemInMultipleBaseSets {
-        system: String,
-        first_set: String,
-        second_set: String,
-    },
-    /// Tried to add a set to multiple base sets.
-    #[error("Set `{set:?}` is in the base sets {first_set:?} and {second_set:?}, but sets can only belong to one base set.")]
-    SetInMultipleBaseSets {
-        set: String,
-        first_set: String,
-        second_set: String,
-    },
 }
 
 /// Specifies how schedule construction should respond to detecting a certain kind of issue.

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -68,7 +68,7 @@ pub struct OnTransition<S: States> {
 
 /// A [`SystemSet`] that will run within `CoreSet::Update` when this state is active.
 ///
-/// This set, when created via `App::add_state`, is configured with both a base set and a run condition.
+/// This set, when created via `App::add_state`, is configured with a run condition.
 /// If all you want is the run condition, use the [`in_state`](crate::schedule::common_conditions::in_state)
 /// [condition](super::Condition) directly.
 #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]


### PR DESCRIPTION
# Objective

With the removal of base sets, some variants of `ScheduleBuildError` can never occur and should be removed.

## Solution

- Remove the obsolete variants of `ScheduleBuildError`.
- Also fix a doc comment which mentioned base sets.

---

## Changelog

### Removed

- Remove `ScheduleBuildError::SystemInMultipleBaseSets` and `ScheduleBuildError::SetInMultipleBaseSets`.
