### PR TITLE
add get_texture_handle method to TextureAtlas

### DIFF
--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -152,4 +152,16 @@ impl TextureAtlas {
             .as_ref()
             .and_then(|texture_handles| texture_handles.get(texture).cloned())
     }
+
+    /// Returns the image handle of the texture corresponding to the given index in the [`TextureAtlas`]
+    ///
+    /// This runs in `O(n)` time.
+    pub fn get_texture_handle(&self, index: usize) -> Option<&Handle<Image>> {
+        self.texture_handles.as_ref().and_then(|texture_handles| {
+            texture_handles
+                .iter()
+                .find(|(_, i)| **i == index)
+                .map(|(handle, _)| handle)
+        })
+    }
 }


### PR DESCRIPTION
# Objective

In Bevy 0.10.0, the visibility of `TextureAtlas`'s `pub texture_handles: Option<HashMap<Handle<Image>, usize>>` field is changed to `pub(crate)`, which removed the ability to search  image handle by index.

## Solution

Add a method, `get_texture_handle`, which iterates the HashMap, finds value(index), and returns key(image handle).
