### PR TITLE
add a feature for memory tracing with tracy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,9 @@ trace_chrome = ["trace", "bevy_internal/trace_chrome"]
 # Tracing support, exposing a port for Tracy
 trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 
+# Tracing support, with memory profiling, exposing a port for Tracy
+trace_tracy_memory = ["trace", "bevy_internal/trace_tracy", "bevy_internal/trace_tracy_memory"]
+
 # Tracing support
 trace = ["bevy_internal/trace"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -21,6 +21,7 @@ trace = [
 ]
 trace_chrome = [ "bevy_log/tracing-chrome" ]
 trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]
+trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
 detailed_trace = ["bevy_utils/detailed_trace"]

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bevy"]
 
 [features]
 trace = [ "tracing-error" ]
+trace_tracy_memory = ["dep:tracy-client"]
 
 [dependencies]
 bevy_app = { path = "../bevy_app", version = "0.11.0-dev" }
@@ -21,6 +22,7 @@ tracing-chrome = { version = "0.7.0", optional = true }
 tracing-tracy = { version = "0.10.0", optional = true }
 tracing-log = "0.1.2"
 tracing-error = { version = "0.2.0", optional = true }
+tracy-client = { version = "0.15", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.2.0"

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -17,6 +17,11 @@ use std::panic;
 #[cfg(target_os = "android")]
 mod android_tracing;
 
+#[cfg(feature = "trace_tracy_memory")]
+#[global_allocator]
+static GLOBAL: tracy_client::ProfiledAllocator<std::alloc::System> =
+    tracy_client::ProfiledAllocator::new(std::alloc::System, 100);
+
 pub mod prelude {
     //! The Bevy Log Prelude.
     #[doc(hidden)]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -67,6 +67,7 @@ The default feature set enables most of the expected features of a game engine, 
 |trace|Tracing support|
 |trace_chrome|Tracing support, saving a file in Chrome Tracing format|
 |trace_tracy|Tracing support, exposing a port for Tracy|
+|trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
 |wav|WAV audio format support|
 |wayland|Wayland display server support|
 |webp|WebP image format support|


### PR DESCRIPTION
# Objective

- Expose a feature for tracing with Tracy to profile memory (https://docs.rs/tracy-client/0.15.2/tracy_client/struct.ProfiledAllocator.html)
- This is a separate feature than just tracing as it can have an additional cost

<img width="1912" alt="Screenshot 2023-03-30 at 08 39 49" src="https://user-images.githubusercontent.com/8672791/228985566-dd62fff8-1cbf-4f59-8a10-80c796daba0c.png">
