### PR TITLE
Fix inaccurate documentation on `QueryState::for_each_unchecked

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -788,8 +788,6 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
     /// iter() method, but cannot be chained like a normal [`Iterator`].
     ///
-    /// This can only be called for read-only queries.
-    ///
     /// # Safety
     ///
     /// This does not check for mutable query correctness. To be safe, make sure mutable queries


### PR DESCRIPTION
# Objective

The documentation on `QueryState::for_each_unchecked` incorrectly says that it can only be used with read-only queries.

## Solution

Remove the inaccurate sentence.