### PR TITLE
Add a performance regression issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -1,0 +1,52 @@
+---
+name: Performance Regression
+about: Bevy running slowly after upgrading? Report a performance regression.
+title: ''
+labels: C-Bug, C-Performance, C-Regression, S-Needs-Triage
+assignees: ''
+---
+
+## Bevy version
+
+* Original: The release number or commit hash of the version you last tested your app against.
+* Current: The release number or commit hash of the version you're currently using.
+
+## \[Optional\] Relevant system information
+
+If you cannot get Bevy to build or run on your machine, please include:
+
+- the Rust version you're using (you can get this by running `cargo --version`)
+  - Bevy relies on the "latest stable release" of Rust
+  - nightly should generally work, but there are sometimes regressions: please let us know!
+- the operating system or browser used, including its version
+  - e.g. Windows 10, Ubuntu 18.04, iOS 14
+
+## What's running slowly?
+
+Describe how you arrived at the problem. If you can, consider providing a code snippet or link
+to help reproduce the regression. For more information on how to get these traces, please see
+https://github.com/bevyengine/bevy/blob/main/docs/profiling.md.
+
+If the exact scenario is not immediately reproducible, please include a set list of steps
+
+## Before and After Traces
+
+To best help us investigate the regression, it's best to provide profiler traces before and after
+the change.
+
+If this is about a compile-time regression, please provide the full output of `cargo build --timings`,
+for more information see https://doc.rust-lang.org/cargo/reference/timings.html.
+
+* Before:
+* After:
+
+## Additional information
+
+Other information that can be used to further reproduce or isolate the problem.
+This commonly includes:
+
+- screenshots
+- logs
+- theories about what might be going wrong
+- workarounds that you used
+- links to related bugs, PRs or discussions

--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -26,7 +26,7 @@ Please include:
 Describe how you arrived at the problem. If you can, consider providing a code snippet or link
 to help reproduce the regression. 
 
-If the exact scenario is not immediately reproducible, please include a set list of steps
+If the exact scenario is not immediately reproducible on `cargo run`, please include a set list of steps to produce the correct setup.
 
 ## Before and After Traces
 

--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -11,9 +11,9 @@ assignees: ''
 * Original: The release number or commit hash of the version you last tested your app against.
 * Current: The release number or commit hash of the version you're currently using.
 
-## \[Optional\] Relevant system information
+## Relevant system information
 
-If you cannot get Bevy to build or run on your machine, please include:
+Please include:
 
 - the Rust version you're using (you can get this by running `cargo --version`)
   - Bevy relies on the "latest stable release" of Rust

--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -21,18 +21,21 @@ If you cannot get Bevy to build or run on your machine, please include:
 - the operating system or browser used, including its version
   - e.g. Windows 10, Ubuntu 18.04, iOS 14
 
-## What's running slowly?
+## What's performing poorly?
 
 Describe how you arrived at the problem. If you can, consider providing a code snippet or link
-to help reproduce the regression. For more information on how to get these traces, please see
-https://github.com/bevyengine/bevy/blob/main/docs/profiling.md.
+to help reproduce the regression. 
 
 If the exact scenario is not immediately reproducible, please include a set list of steps
 
 ## Before and After Traces
 
-To best help us investigate the regression, it's best to provide profiler traces before and after
-the change.
+To best help us investigate the regression, it's best to provide as much detailed profiling 
+data as possible.
+
+If your app is running slowly, please show profiler traces before and after the change. 
+For more information on how to get these traces, see
+https://github.com/bevyengine/bevy/blob/main/docs/profiling.md.
 
 If this is about a compile-time regression, please provide the full output of `cargo build --timings`,
 for more information see https://doc.rust-lang.org/cargo/reference/timings.html.

--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -15,25 +15,25 @@ assignees: ''
 
 Please include:
 
-- the Rust version you're using (you can get this by running `cargo --version`)
-  - Bevy relies on the "latest stable release" of Rust
-  - nightly should generally work, but there are sometimes regressions: please let us know!
-- the operating system or browser used, including its version
-  - e.g. Windows 10, Ubuntu 18.04, iOS 14
+* the Rust version you're using (you can get this by running `cargo --version`)
+  * Bevy relies on the "latest stable release" of Rust
+  * nightly should generally work, but there are sometimes regressions: please let us know!
+* the operating system or browser used, including its version
+  * e.g. Windows 10, Ubuntu 18.04, iOS 14
 
 ## What's performing poorly?
 
 Describe how you arrived at the problem. If you can, consider providing a code snippet or link
-to help reproduce the regression. 
+to help reproduce the regression.
 
 If the exact scenario is not immediately reproducible on `cargo run`, please include a set list of steps to produce the correct setup.
 
 ## Before and After Traces
 
-To best help us investigate the regression, it's best to provide as much detailed profiling 
+To best help us investigate the regression, it's best to provide as much detailed profiling
 data as possible.
 
-If your app is running slowly, please show profiler traces before and after the change. 
+If your app is running slowly, please show profiler traces before and after the change.
 For more information on how to get these traces, see
 https://github.com/bevyengine/bevy/blob/main/docs/profiling.md.
 
@@ -48,8 +48,8 @@ for more information see https://doc.rust-lang.org/cargo/reference/timings.html.
 Other information that can be used to further reproduce or isolate the problem.
 This commonly includes:
 
-- screenshots
-- logs
-- theories about what might be going wrong
-- workarounds that you used
-- links to related bugs, PRs or discussions
+* screenshots
+* logs
+* theories about what might be going wrong
+* workarounds that you used
+* links to related bugs, PRs or discussions

--- a/.github/ISSUE_TEMPLATE/performance_regression.md
+++ b/.github/ISSUE_TEMPLATE/performance_regression.md
@@ -35,10 +35,10 @@ data as possible.
 
 If your app is running slowly, please show profiler traces before and after the change.
 For more information on how to get these traces, see
-https://github.com/bevyengine/bevy/blob/main/docs/profiling.md.
+<https://github.com/bevyengine/bevy/blob/main/docs/profiling.md>.
 
 If this is about a compile-time regression, please provide the full output of `cargo build --timings`,
-for more information see https://doc.rust-lang.org/cargo/reference/timings.html.
+for more information see <https://doc.rust-lang.org/cargo/reference/timings.html>.
 
 * Before:
 * After:


### PR DESCRIPTION
# Objective
Closes #7821. A good chunk of performance related issues filed are tough to take action on without much deeper investigation by the author, who may or may not be responsive after filing the issue.

## Solution
Add a performance regression issue template and use it to direct users to take a more proactive role in investigating the source of the regression.