### PR TITLE
Add an API for accessing world storages from `UnsafeWorldCell`

### DIFF
--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -84,6 +84,7 @@ impl<'a> UnsafeStorages<'a> {
     }
 }
 
+/// A view into the [`ComponentSparseSet`] collection of [`UnsafeStorages`].
 #[derive(Clone, Copy)]
 pub struct UnsafeSparseSets<'a> {
     sparse_sets: &'a SparseSets,
@@ -97,6 +98,7 @@ impl<'a> UnsafeSparseSets<'a> {
     }
 }
 
+/// A view into the [`Table`] collection of [`UnsafeStorages`].
 #[derive(Clone, Copy)]
 pub struct UnsafeTables<'a> {
     tables: &'a Tables,

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -91,7 +91,8 @@ pub struct UnsafeSparseSets<'a> {
 }
 
 impl<'a> UnsafeSparseSets<'a> {
-    /// Gets a view into the [`ComponentSparseSet`] associated with `component_id`.
+    /// Gets a view into the [`ComponentSparseSet`] associated with `component_id`,
+    /// if one exists.
     pub fn get(self, component_id: ComponentId) -> Option<UnsafeComponentSparseSet<'a>> {
         self.sparse_sets
             .get(component_id)
@@ -106,7 +107,7 @@ pub struct UnsafeTables<'a> {
 }
 
 impl<'a> UnsafeTables<'a> {
-    /// Gets a view into the [`Table`] associated with `id`.
+    /// Gets a view into the [`Table`] associated with `id`, if one exists.
     pub fn get(self, id: TableId) -> Option<UnsafeTable<'a>> {
         self.tables.get(id).map(|table| UnsafeTable { table })
     }

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -89,12 +89,21 @@ pub struct UnsafeSparseSets<'a> {
     sparse_sets: &'a SparseSets,
 }
 
+impl<'a> UnsafeSparseSets<'a> {
+    pub fn get(self, component_id: ComponentId) -> Option<UnsafeComponentSparseSet<'a>> {
+        self.sparse_sets
+            .get(component_id)
+            .map(|sparse_set| UnsafeComponentSparseSet { sparse_set })
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct UnsafeTables<'a> {
     tables: &'a Tables,
 }
 
-#[derive(Clone, Copy)]
-pub struct UnsafeResources<'a, const SEND: bool> {
-    resources: &'a Resources<SEND>,
+impl<'a> UnsafeTables<'a> {
+    pub fn get(self, id: TableId) -> Option<UnsafeTable<'a>> {
+        self.tables.get(id).map(|table| UnsafeTable { table })
+    }
 }

--- a/crates/bevy_ecs/src/storage/mod.rs
+++ b/crates/bevy_ecs/src/storage/mod.rs
@@ -91,6 +91,7 @@ pub struct UnsafeSparseSets<'a> {
 }
 
 impl<'a> UnsafeSparseSets<'a> {
+    /// Gets a view into the [`ComponentSparseSet`] associated with `component_id`.
     pub fn get(self, component_id: ComponentId) -> Option<UnsafeComponentSparseSet<'a>> {
         self.sparse_sets
             .get(component_id)
@@ -105,6 +106,7 @@ pub struct UnsafeTables<'a> {
 }
 
 impl<'a> UnsafeTables<'a> {
+    /// Gets a view into the [`Table`] associated with `id`.
     pub fn get(self, id: TableId) -> Option<UnsafeTable<'a>> {
         self.tables.get(id).map(|table| UnsafeTable { table })
     }

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -286,25 +286,3 @@ impl<const SEND: bool> Resources<SEND> {
         }
     }
 }
-
-/// A view into a [`Resources`] collection of [`UnsafeStorages`].
-///
-/// [`UnsafeStorages`]: super::UnsafeStorages
-#[derive(Clone, Copy)]
-pub struct UnsafeResources<'a, const SEND: bool> {
-    pub(super) resources: &'a Resources<SEND>,
-}
-
-impl<'a, const SEND: bool> UnsafeResources<'a, SEND> {
-    /// Gets access to the resource's data store, if it is registered.
-    ///
-    /// # Safety
-    /// It is the callers responsibility to ensure that
-    /// - the [`UnsafeWorldCell`] self as obtained from has permission to access the resource mutably
-    /// - no mutable reference to the resource exists at the same time
-    ///
-    /// [`UnsafeWorldCell`]: crate::world::unsafe_world_cell::UnsafeWorldCell
-    pub unsafe fn get(self, component_id: ComponentId) -> Option<&'a ResourceData<SEND>> {
-        self.resources.get(component_id)
-    }
-}

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -286,3 +286,20 @@ impl<const SEND: bool> Resources<SEND> {
         }
     }
 }
+
+#[derive(Clone, Copy)]
+pub struct UnsafeResources<'a, const SEND: bool> {
+    pub(super) resources: &'a Resources<SEND>,
+}
+
+impl<'a, const SEND: bool> UnsafeResources<'a, SEND> {
+    /// Returns the entity's component and associated ticks.
+    ///
+    /// # Safety
+    ///
+    /// The [`UnsafeWorldCell`] that this instance was obtained from
+    /// must be allowed to read the resource associated with `component_id`.
+    pub unsafe fn get(self, component_id: ComponentId) -> Option<&'a ResourceData<SEND>> {
+        self.resources.get(component_id)
+    }
+}

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -296,7 +296,7 @@ pub struct UnsafeResources<'a, const SEND: bool> {
 }
 
 impl<'a, const SEND: bool> UnsafeResources<'a, SEND> {
-    /// Returns the entity's component and associated ticks.
+    /// Gets access to the resource's data store, if it is registered.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -287,6 +287,9 @@ impl<const SEND: bool> Resources<SEND> {
     }
 }
 
+/// A view into a [`Resources`] collection of [`UnsafeStorages`].
+///
+/// [`UnsafeStorages`]: super::UnsafeStorages
 #[derive(Clone, Copy)]
 pub struct UnsafeResources<'a, const SEND: bool> {
     pub(super) resources: &'a Resources<SEND>,

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -299,9 +299,11 @@ impl<'a, const SEND: bool> UnsafeResources<'a, SEND> {
     /// Returns the entity's component and associated ticks.
     ///
     /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`UnsafeWorldCell`] self as obtained from has permission to access the resource mutably
+    /// - no mutable reference to the resource exists at the same time
     ///
-    /// The [`UnsafeWorldCell`] that this instance was obtained from
-    /// must be allowed to read the resource associated with `component_id`.
+    /// [`UnsafeWorldCell`]: crate::world::unsafe_world_cell::UnsafeWorldCell
     pub unsafe fn get(self, component_id: ComponentId) -> Option<&'a ResourceData<SEND>> {
         self.resources.get(component_id)
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -643,6 +643,26 @@ impl<'a> UnsafeComponentSparseSet<'a> {
     pub unsafe fn get(self, entity: Entity) -> Option<(Ptr<'a>, TickCells<'a>)> {
         self.sparse_set.get_with_ticks(entity)
     }
+
+    /// If `entity` has a component in this sparse set, returns the tick
+    /// indicating when it was added.
+    ///
+    /// Before dereferencing this, take care to ensure that the instance
+    /// of [`UnsafeStorages`] that this `UnsafeComponentSparseSet` was
+    /// obtained from has permission to access this component's data.
+    pub fn get_added_tick(self, entity: Entity) -> Option<&'a UnsafeCell<Tick>> {
+        self.sparse_set.get_added_ticks(entity)
+    }
+
+    /// If `entity` has a component in this sparse set, returns the tick
+    /// indicating when it was last changed.
+    ///
+    /// Before dereferencing this, take care to ensure that the instance
+    /// of [`UnsafeStorages`] that this `UnsafeComponentSparseSet` was
+    /// obtained from has permission to access this component's data.
+    pub fn get_changed_tick(self, entity: Entity) -> Option<&'a UnsafeCell<Tick>> {
+        self.sparse_set.get_changed_ticks(entity)
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -626,6 +626,9 @@ impl SparseSets {
     }
 }
 
+/// A view into a [`ComponentSparseSet`] from [`UnsafeStorages`].
+///
+/// [`UnsafeStorages`]: super::UnsafeStorages
 #[derive(Clone, Copy)]
 pub struct UnsafeComponentSparseSet<'a> {
     pub(super) sparse_set: &'a ComponentSparseSet,

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -638,11 +638,12 @@ impl<'a> UnsafeComponentSparseSet<'a> {
     /// Returns the entity's component and associated ticks.
     ///
     /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`UnsafeWorldCell`] self was obtianed from has permission
+    ///   to access the component.
+    /// - no other mutable references to the component exist at the same time.
     ///
-    /// The [`UnsafeStorages`]) that this instance was obtained from
-    /// must be allowed to read `entity`'s component from this sparse set.
-    ///
-    /// [`UnsafeStorages`]: super::UnsafeStorages
+    /// [`UnsafeWorldCell`]: crate::world::unsafe_world_cell::UnsafeWorldCell
     pub unsafe fn get(self, entity: Entity) -> Option<(Ptr<'a>, TickCells<'a>)> {
         self.sparse_set.get_with_ticks(entity)
     }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -626,6 +626,25 @@ impl SparseSets {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct UnsafeComponentSparseSet<'a> {
+    pub(super) sparse_set: &'a ComponentSparseSet,
+}
+
+impl<'a> UnsafeComponentSparseSet<'a> {
+    /// Returns the entity's component and associated ticks.
+    ///
+    /// # Safety
+    ///
+    /// The [`UnsafeStorages`]) that this instance was obtained from
+    /// must be allowed to read `entity`'s component from this sparse set.
+    ///
+    /// [`UnsafeStorages`]: super::UnsafeStorages
+    pub unsafe fn get(self, entity: Entity) -> Option<(Ptr<'a>, TickCells<'a>)> {
+        self.sparse_set.get_with_ticks(entity)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::SparseSets;

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -635,7 +635,8 @@ pub struct UnsafeComponentSparseSet<'a> {
 }
 
 impl<'a> UnsafeComponentSparseSet<'a> {
-    /// Returns the entity's component and associated ticks.
+    /// If `entity` has a component stored in this sparse set,
+    /// returns the component's value and associated change [`Tick`]s.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -654,6 +654,8 @@ impl<'a> UnsafeComponentSparseSet<'a> {
     /// Before dereferencing this, take care to ensure that the instance
     /// of [`UnsafeStorages`] that this `UnsafeComponentSparseSet` was
     /// obtained from has permission to access this component's data.
+    ///
+    /// [`UnsafeStorages`]: super::UnsafeStorages
     pub fn get_added_tick(self, entity: Entity) -> Option<&'a UnsafeCell<Tick>> {
         self.sparse_set.get_added_ticks(entity)
     }
@@ -664,6 +666,8 @@ impl<'a> UnsafeComponentSparseSet<'a> {
     /// Before dereferencing this, take care to ensure that the instance
     /// of [`UnsafeStorages`] that this `UnsafeComponentSparseSet` was
     /// obtained from has permission to access this component's data.
+    ///
+    /// [`UnsafeStorages`]: super::UnsafeStorages
     pub fn get_changed_tick(self, entity: Entity) -> Option<&'a UnsafeCell<Tick>> {
         self.sparse_set.get_changed_ticks(entity)
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -918,7 +918,7 @@ pub struct UnsafeTable<'a> {
 }
 
 impl<'a> UnsafeTable<'a> {
-    /// Gets access to the data for a specific component in this table.
+    /// Gets access to the data for a specific component type in this table.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -909,6 +909,9 @@ impl IndexMut<TableId> for Tables {
     }
 }
 
+/// A view into a [`Table`] from [`UnsafeStorages`].
+///
+/// [`UnsafeStorages`]: super::UnsafeStorages
 #[derive(Clone, Copy)]
 pub struct UnsafeTable<'a> {
     pub(super) table: &'a Table,

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -918,7 +918,8 @@ pub struct UnsafeTable<'a> {
 }
 
 impl<'a> UnsafeTable<'a> {
-    /// Gets access to the data for a specific component type in this table.
+    /// If this table stores components of type `component_id`,
+    /// gets access to the [`Column`] storing those components.
     ///
     /// # Safety
     /// It is the callers responsibility to ensure that

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -921,12 +921,13 @@ impl<'a> UnsafeTable<'a> {
     /// Gets access to the data for a specific component in this table.
     ///
     /// # Safety
+    /// It is the callers responsibility to ensure that
+    /// - the [`UnsafeWorldCell`] self was obtained from has permission
+    ///   to access the component in this table's archetype.
+    /// - no other mutable references to components of this type
+    ///   exist in this table at the same time.
     ///
-    /// The [`UnsafeStorages`]) that this instance was obtained from
-    /// must be allowed to access the data associated with `component_id`
-    /// in this table's archetype.
-    ///
-    /// [`UnsafeStorages`]: super::UnsafeStorages
+    /// [`UnsafeWorldCell`]: crate::world::unsafe_world_cell::UnsafeWorldCell
     pub unsafe fn get_column(self, component_id: ComponentId) -> Option<&'a Column> {
         self.table.get_column(component_id)
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -909,6 +909,26 @@ impl IndexMut<TableId> for Tables {
     }
 }
 
+#[derive(Clone, Copy)]
+pub struct UnsafeTable<'a> {
+    pub(super) table: &'a Table,
+}
+
+impl<'a> UnsafeTable<'a> {
+    /// Gets access to the data for a specific component in this table.
+    ///
+    /// # Safety
+    ///
+    /// The [`UnsafeStorages`]) that this instance was obtained from
+    /// must be allowed to access the data associated with `component_id`
+    /// in this table's archetype.
+    ///
+    /// [`UnsafeStorages`]: super::UnsafeStorages
+    pub unsafe fn get_column(self, component_id: ComponentId) -> Option<&'a Column> {
+        self.table.get_column(component_id)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -559,7 +559,7 @@ pub struct Table {
 }
 
 impl Table {
-    /// Fetches a read-only slice of the entities stored within the [`Table`].
+    /// Returns the entities stored in this table.
     #[inline]
     pub fn entities(&self) -> &[Entity] {
         &self.entities
@@ -926,6 +926,17 @@ impl<'a> UnsafeTable<'a> {
     /// [`UnsafeStorages`]: super::UnsafeStorages
     pub unsafe fn get_column(self, component_id: ComponentId) -> Option<&'a Column> {
         self.table.get_column(component_id)
+    }
+
+    /// Returns `true` if this table has a column associated with `component_id`.
+    /// Otherwise, this returns `false`.
+    pub fn has_column(self, component_id: ComponentId) -> bool {
+        self.table.has_column(component_id)
+    }
+
+    /// Returns the entities stored in this table.
+    pub fn entities(self) -> &'a [Entity] {
+        self.table.entities()
     }
 }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -932,8 +932,11 @@ impl<'a> UnsafeTable<'a> {
         self.table.get_column(component_id)
     }
 
-    /// Returns `true` if this table has a column associated with `component_id`.
-    /// Otherwise, this returns `false`.
+    /// Checks if the table contains a [`Column`] for a given [`Component`].
+    ///
+    /// Returns `true` if the column is present, `false` otherwise.
+    ///
+    /// [`Component`]: crate::component::Component
     pub fn has_column(self, component_id: ComponentId) -> bool {
         self.table.has_column(component_id)
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -559,7 +559,7 @@ pub struct Table {
 }
 
 impl Table {
-    /// Returns the entities stored in this table.
+    /// Returns the entities with components stored in this table.
     #[inline]
     pub fn entities(&self) -> &[Entity] {
         &self.entities
@@ -938,7 +938,7 @@ impl<'a> UnsafeTable<'a> {
         self.table.has_column(component_id)
     }
 
-    /// Returns the entities stored in this table.
+    /// Returns the entities with components stored in this table.
     pub fn entities(self) -> &'a [Entity] {
         self.table.entities()
     }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     entity::{Entities, Entity, EntityLocation},
     prelude::Component,
-    storage::{Column, ComponentSparseSet},
+    storage::{Column, ComponentSparseSet, UnsafeStorages},
     system::Resource,
 };
 use bevy_ptr::Ptr;
@@ -149,6 +149,16 @@ impl<'w> UnsafeWorldCell<'w> {
         // - caller ensures that the returned `&World` is not used in a way that would conflict
         //   with any existing mutable borrows of world data
         unsafe { &*self.0 }
+    }
+
+    /// Returns interior-mutable access to the world's internal data stores.
+    /// The returned [`UnsafeStorages`] can only be used to access data
+    /// that this `UnsafeWorldCell` has permission to access.
+    pub fn storages(self) -> UnsafeStorages<'w> {
+        // SAFETY: Interior mutable access to the world is hidden behind
+        // `UnsafeStorages`, which will require any data access to be valid.
+        let storages = unsafe { self.unsafe_world().storages() };
+        UnsafeStorages::new(storages)
     }
 
     /// Retrieves this world's [Entities] collection


### PR DESCRIPTION
# Objective

Re-do of #8175.

`UnsafeWorldCell` is a type that provides interior mutable access to a world. Currently, the only way to access world data is through high-level methods. In order to make `UnsafeWorldCell` a full replacement for the interior-mutable-ish version of `&World`, we need a way of accessing the world's internal data storages.

## Solution

Provide an API for accessing a world's internal data stores via `UnsafeWorldCell`. World accesses are gated behind unsafe, with the unsafe code deferred as late as possible to encourage clean code.

```rust
/// # Safety
/// `world` must have access to the `Score` resource.
unsafe fn get_score_unchecked(world: UnsafeWorldCell) -> Ptr {
    let score_id = world.components().resource_id::<Score>().unwrap();
    // SAFETY: Caller ensures we have access to `Score`.
    world.storages().resources.get(score_id).unwrap().get_data().unwrap()
                               ^^^^^^^^^^^^^ this is the unsafe part
}
```

---

## Changelog

+ Added the `UnsafeStorages` API, for interior mutable access to a World's internal data stores via `UnsafeWorldCell`.

## Future Work

Use this API in the engine. In particular, it will be useful when porting `Query` and `WorldQuery` over to using `UnsafeWorldCell`.
