### PR TITLE
Fix typo in bevy_reflect README

### DIFF
--- a/crates/bevy_reflect/README.md
+++ b/crates/bevy_reflect/README.md
@@ -153,8 +153,8 @@ let my_trait: &dyn DoThing = reflect_do_thing.get(&*reflect_value).unwrap();
 println!("{}", my_trait.do_thing());
 
 // This works because the #[reflect(MyTrait)] we put on MyType informed the Reflect derive to insert a new instance
-// of ReflectDoThing into MyType's registration. The instance knows how to cast &dyn Reflect to &dyn MyType, because it
-// knows that &dyn Reflect should first be downcasted to &MyType, which can then be safely casted to &dyn MyType
+// of ReflectDoThing into MyType's registration. The instance knows how to cast &dyn Reflect to &dyn DoThing, because it
+// knows that &dyn Reflect should first be downcasted to &MyType, which can then be safely casted to &dyn DoThing
 ```
 
 ## Why make this?


### PR DESCRIPTION
# Objective

Fix typo in bevy_reflect README: `MyType` is a struct and not a trait, so `&dyn MyType` is incorrect.

## Solution

Replace `&dyn MyType` with `&dyn DoThing`