### PR TITLE
Reflect `Component` and `Default` of `BloomSettings`

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -1,7 +1,7 @@
 use super::downsampling_pipeline::BloomUniforms;
-use bevy_ecs::{prelude::Component, query::QueryItem};
+use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
 use bevy_math::{UVec4, Vec4};
-use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 
 /// Applies a bloom effect to an HDR-enabled 2d or 3d camera.
@@ -26,6 +26,7 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
 #[allow(clippy::doc_markdown)]
 #[derive(Component, Reflect, Clone)]
+#[reflect(Component, Default)]
 pub struct BloomSettings {
     /// Controls the baseline of how much the image is scattered (default: 0.15).
     ///


### PR DESCRIPTION
These traits are both implemented, but not reflected, requiring user code to do `app.register_type_data::<BloomSettings, ReflectDefault>().register_type_data::<BloomSettings, ReflectComponent>()` to make these usable via reflection.