### PR TITLE
Changed spelling linebreak_behaviour to linebreak_behavior

### DIFF
--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -231,7 +231,7 @@ pub struct Touches {
     /// A collection of every [`Touch`] that just got released.
     just_released: HashMap<u64, Touch>,
     /// A collection of every [`Touch`] that just got cancelled.
-    just_cancelled: HashMap<u64, Touch>,
+    just_canceled: HashMap<u64, Touch>,
 }
 
 impl Touches {
@@ -281,18 +281,18 @@ impl Touches {
     }
 
     /// Checks if any touch input was just cancelled.
-    pub fn any_just_cancelled(&self) -> bool {
-        !self.just_cancelled.is_empty()
+    pub fn any_just_canceled(&self) -> bool {
+        !self.just_canceled.is_empty()
     }
 
     /// Returns `true` if the input corresponding to the `id` has just been cancelled.
-    pub fn just_cancelled(&self, id: u64) -> bool {
-        self.just_cancelled.contains_key(&id)
+    pub fn just_canceled(&self, id: u64) -> bool {
+        self.just_canceled.contains_key(&id)
     }
 
     /// An iterator visiting every just cancelled [`Touch`] input in arbitrary order.
-    pub fn iter_just_cancelled(&self) -> impl Iterator<Item = &Touch> {
-        self.just_cancelled.values()
+    pub fn iter_just_canceled(&self) -> impl Iterator<Item = &Touch> {
+        self.just_canceled.values()
     }
 
     /// Retrieves the position of the first currently pressed touch, if any
@@ -301,7 +301,7 @@ impl Touches {
     }
 
     /// Processes a [`TouchInput`] event by updating the `pressed`, `just_pressed`,
-    /// `just_released`, and `just_cancelled` collections.
+    /// `just_released`, and `just_canceled` collections.
     fn process_touch_event(&mut self, event: &TouchInput) {
         match event.phase {
             TouchPhase::Started => {
@@ -327,18 +327,18 @@ impl Touches {
                 }
             }
             TouchPhase::Canceled => {
-                // if touch `just_cancelled`, add related event to it
+                // if touch `just_canceled`, add related event to it
                 // the event position info is inside `pressed`, so use it unless not found
                 if let Some((_, v)) = self.pressed.remove_entry(&event.id) {
-                    self.just_cancelled.insert(event.id, v);
+                    self.just_canceled.insert(event.id, v);
                 } else {
-                    self.just_cancelled.insert(event.id, event.into());
+                    self.just_canceled.insert(event.id, event.into());
                 }
             }
         };
     }
 
-    /// Clears the `just_pressed`, `just_released`, and `just_cancelled` collections.
+    /// Clears the `just_pressed`, `just_released`, and `just_canceled` collections.
     ///
     /// This is not clearing the `pressed` collection, because it could incorrectly mark
     /// a touch input as not pressed even though it is pressed. This could happen if the
@@ -348,7 +348,7 @@ impl Touches {
     fn update(&mut self) {
         self.just_pressed.clear();
         self.just_released.clear();
-        self.just_cancelled.clear();
+        self.just_canceled.clear();
     }
 }
 
@@ -393,14 +393,14 @@ mod test {
 
         touches.just_pressed.insert(4, touch_event);
         touches.just_released.insert(4, touch_event);
-        touches.just_cancelled.insert(4, touch_event);
+        touches.just_canceled.insert(4, touch_event);
 
         touches.update();
 
         // Verify that all the `just_x` maps are cleared
         assert!(touches.just_pressed.is_empty());
         assert!(touches.just_released.is_empty());
-        assert!(touches.just_cancelled.is_empty());
+        assert!(touches.just_canceled.is_empty());
     }
 
     #[test]
@@ -458,7 +458,7 @@ mod test {
         touches.update();
         touches.process_touch_event(&cancel_touch_event);
 
-        assert!(touches.just_cancelled.get(&touch_event.id).is_some());
+        assert!(touches.just_canceled.get(&touch_event.id).is_some());
         assert!(touches.pressed.get(&touch_event.id).is_none());
 
         // Test ending an event
@@ -543,7 +543,7 @@ mod test {
         // Register the touch and test that it was registered correctly
         touches.process_touch_event(&touch_event);
 
-        assert!(touches.just_cancelled(touch_event.id));
-        assert_eq!(touches.iter_just_cancelled().count(), 1);
+        assert!(touches.just_canceled(touch_event.id));
+        assert_eq!(touches.iter_just_canceled().count(), 1);
     }
 }

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -527,7 +527,7 @@ mod test {
     }
 
     #[test]
-    fn touch_cancelled() {
+    fn touch_canceled() {
         use crate::{touch::TouchPhase, TouchInput, Touches};
         use bevy_math::Vec2;
 

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -22,7 +22,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// should assume that a new [`TouchPhase::Started`] event received with the same id has nothing
 /// to do with the old finger and is a new finger.
 ///
-/// A [`TouchPhase::Cancelled`] event is emitted when the system has canceled tracking this
+/// A [`TouchPhase::Canceled`] event is emitted when the system has canceled tracking this
 /// touch, such as when the window loses focus, or on iOS if the user moves the
 /// device against their face.
 ///
@@ -116,7 +116,7 @@ pub enum TouchPhase {
     ///
     /// This occurs when the window loses focus, or on iOS if the user moves the
     /// device against their face.
-    Cancelled,
+    Canceled,
 }
 
 /// A touch input.
@@ -326,7 +326,7 @@ impl Touches {
                     self.just_released.insert(event.id, event.into());
                 }
             }
-            TouchPhase::Cancelled => {
+            TouchPhase::Canceled => {
                 // if touch `just_cancelled`, add related event to it
                 // the event position info is inside `pressed`, so use it unless not found
                 if let Some((_, v)) = self.pressed.remove_entry(&event.id) {
@@ -449,7 +449,7 @@ mod test {
         // Test cancelling an event
 
         let cancel_touch_event = TouchInput {
-            phase: TouchPhase::Cancelled,
+            phase: TouchPhase::Canceled,
             position: Vec2::ONE,
             force: None,
             id: touch_event.id,
@@ -534,7 +534,7 @@ mod test {
         let mut touches = Touches::default();
 
         let touch_event = TouchInput {
-            phase: TouchPhase::Cancelled,
+            phase: TouchPhase::Canceled,
             position: Vec2::splat(4.0),
             force: None,
             id: 4,

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -36,14 +36,14 @@ impl GlyphBrush {
         sections: &[S],
         bounds: Vec2,
         text_alignment: TextAlignment,
-        linebreak_behaviour: BreakLineOn,
+        linebreak_behavior: BreakLineOn,
     ) -> Result<Vec<SectionGlyph>, TextError> {
         let geom = SectionGeometry {
             bounds: (bounds.x, bounds.y),
             ..Default::default()
         };
 
-        let lbb: BuiltInLineBreaker = linebreak_behaviour.into();
+        let lbb: BuiltInLineBreaker = linebreak_behavior.into();
 
         let section_glyphs = Layout::default()
             .h_align(text_alignment.into())

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -45,7 +45,7 @@ impl TextPipeline {
         sections: &[TextSection],
         scale_factor: f64,
         text_alignment: TextAlignment,
-        linebreak_behaviour: BreakLineOn,
+        linebreak_behavior: BreakLineOn,
         bounds: Vec2,
         font_atlas_set_storage: &mut Assets<FontAtlasSet>,
         texture_atlases: &mut Assets<TextureAtlas>,
@@ -78,7 +78,7 @@ impl TextPipeline {
 
         let section_glyphs =
             self.brush
-                .compute_glyphs(&sections, bounds, text_alignment, linebreak_behaviour)?;
+                .compute_glyphs(&sections, bounds, text_alignment, linebreak_behavior)?;
 
         if section_glyphs.is_empty() {
             return Ok(TextLayoutInfo::default());

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -15,7 +15,7 @@ pub struct Text {
     /// Should not affect its position within a container.
     pub alignment: TextAlignment,
     /// How the text should linebreak when running out of the bounds determined by max_size
-    pub linebreak_behaviour: BreakLineOn,
+    pub linebreak_behavior: BreakLineOn,
 }
 
 impl Default for Text {
@@ -23,7 +23,7 @@ impl Default for Text {
         Self {
             sections: Default::default(),
             alignment: TextAlignment::Left,
-            linebreak_behaviour: BreakLineOn::WordBoundary,
+            linebreak_behavior: BreakLineOn::WordBoundary,
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -187,7 +187,7 @@ pub fn update_text2d_layout(
                 &text.sections,
                 scale_factor,
                 text.alignment,
-                text.linebreak_behaviour,
+                text.linebreak_behavior,
                 text_bounds,
                 &mut font_atlas_set_storage,
                 &mut texture_atlases,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -115,7 +115,7 @@ pub fn text_system(
                 &text.sections,
                 scale_factor,
                 text.alignment,
-                text.linebreak_behaviour,
+                text.linebreak_behavior,
                 node_size,
                 &mut font_atlas_set_storage,
                 &mut texture_atlases,

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -270,7 +270,7 @@ pub enum FileDragAndDrop {
     },
 
     /// File hovering was cancelled.
-    HoveredFileCancelled {
+    HoveredFileCanceled {
         /// Window that had a cancelled file drop.
         window: Entity,
     },

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -40,7 +40,7 @@ pub fn convert_touch_input(
             winit::event::TouchPhase::Started => TouchPhase::Started,
             winit::event::TouchPhase::Moved => TouchPhase::Moved,
             winit::event::TouchPhase::Ended => TouchPhase::Ended,
-            winit::event::TouchPhase::Cancelled => TouchPhase::Cancelled,
+            winit::event::TouchPhase::Canceled => TouchPhase::Canceled,
         },
         position: Vec2::new(location.x as f32, location.y as f32),
         force: touch_input.force.map(|f| match f {

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -40,7 +40,7 @@ pub fn convert_touch_input(
             winit::event::TouchPhase::Started => TouchPhase::Started,
             winit::event::TouchPhase::Moved => TouchPhase::Moved,
             winit::event::TouchPhase::Ended => TouchPhase::Ended,
-            winit::event::TouchPhase::Canceled => TouchPhase::Canceled,
+            winit::event::TouchPhase::Cancelled => TouchPhase::Canceled,
         },
         position: Vec2::new(location.x as f32, location.y as f32),
         force: touch_input.force.map(|f| match f {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -566,8 +566,8 @@ pub fn winit_runner(mut app: App) {
                             path_buf,
                         });
                     }
-                    WindowEvent::HoveredFileCancelled => {
-                        file_drag_and_drop_events.send(FileDragAndDrop::HoveredFileCancelled {
+                    WindowEvent::HoveredFileCanceled => {
+                        file_drag_and_drop_events.send(FileDragAndDrop::HoveredFileCanceled {
                             window: window_entity,
                         });
                     }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -566,7 +566,7 @@ pub fn winit_runner(mut app: App) {
                             path_buf,
                         });
                     }
-                    WindowEvent::HoveredFileCanceled => {
+                    WindowEvent::HoveredFileCancelled => {
                         file_drag_and_drop_events.send(FileDragAndDrop::HoveredFileCanceled {
                             window: window_entity,
                         });

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -92,7 +92,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         slightly_smaller_text_style.clone(),
                     )],
                     alignment: TextAlignment::Left,
-                    linebreak_behaviour: BreakLineOn::WordBoundary,
+                    linebreak_behavior: BreakLineOn::WordBoundary,
                 },
                 text_2d_bounds: Text2dBounds {
                     // Wrap text in the rectangle
@@ -124,7 +124,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         slightly_smaller_text_style.clone(),
                     )],
                     alignment: TextAlignment::Left,
-                    linebreak_behaviour: BreakLineOn::AnyCharacter,
+                    linebreak_behavior: BreakLineOn::AnyCharacter,
                 },
                 text_2d_bounds: Text2dBounds {
                     // Wrap text in the rectangle

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -313,7 +313,7 @@ fn update_image_viewer(
                 *drop_hovered = false;
             }
             FileDragAndDrop::HoveredFile { .. } => *drop_hovered = true,
-            FileDragAndDrop::HoveredFileCancelled { .. } => *drop_hovered = false,
+            FileDragAndDrop::HoveredFileCanceled { .. } => *drop_hovered = false,
         }
     }
 

--- a/examples/input/touch_input.rs
+++ b/examples/input/touch_input.rs
@@ -26,7 +26,7 @@ fn touch_system(touches: Res<Touches>) {
         );
     }
 
-    for touch in touches.iter_just_cancelled() {
+    for touch in touches.iter_just_canceled() {
         info!("cancelled touch with id: {:?}", touch.id());
     }
 

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -36,7 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             },
         }],
         alignment: TextAlignment::Left,
-        linebreak_behaviour: BreakLineOn::AnyCharacter,
+        linebreak_behavior: BreakLineOn::AnyCharacter,
     };
 
     commands

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -53,7 +53,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
         text: Text {
             sections,
             alignment: TextAlignment::Center,
-            linebreak_behaviour: BreakLineOn::AnyCharacter,
+            linebreak_behavior: BreakLineOn::AnyCharacter,
         },
         ..Default::default()
     });


### PR DESCRIPTION
# Objective

In the [`Text`](https://github.com/bevyengine/bevy/blob/3442a13d2cb4b2d77c9f7bf8b6dad25742bd21d7/crates/bevy_text/src/text.rs#L18) struct the field is named: `linebreak_behaviour`, the British spelling of _behavior_. 
**Update**, also found: 
- `FileDragAndDrop::HoveredFileCancelled` 
- `TouchPhase::Cancelled`
- `Touches.just_cancelled`

The majority of all spelling is in the US but when you have a lot of contributors across the world, sometimes 
spelling differences can pop up in APIs such as in this case. 

For consistency, I think it would be worth a while to ensure that the API is persistent.

Some examples:
`from_reflect.rs` has `DefaultBehavior`
TextStyle has `color` and uses the `Color` struct.
In `bevy_input/src/Touch.rs` `TouchPhase::Cancelled` and _canceled_ are used interchangeably in the documentation

I've found that there is also the same type of discrepancies in the documentation, though this is a low priority but is worth checking. 
**Update**: I've now checked the documentation (See #8291)

## Solution

I've only renamed the inconsistencies that have breaking changes and documentation pertaining to them. The rest of the documentation will be changed via #8291.

Do note that the winit API is written with UK spelling, thus this may be a cause for confusion:
`winit::event::TouchPhase::Cancelled => TouchPhase::Canceled`
`winit::event::WindowEvent::HoveredFileCancelled` -> Related to `FileDragAndDrop::HoveredFileCanceled`

But I'm hoping to maybe outline other spelling inconsistencies in the API, and maybe an addition to the contribution guide.

---

## Changelog

- `Text` field `linebreak_behaviour` has been renamed to `linebreak_behavior`.
- Event `FileDragAndDrop::HoveredFileCancelled` has been renamed to `HoveredFileCanceled`
- Function `Touches.just_cancelled` has been renamed to `Touches.just_canceled`
- Event `TouchPhase::Cancelled` has been renamed to `TouchPhase::Canceled` 

## Migration Guide

Update where `linebreak_behaviour` is used to `linebreak_behavior`
Updated the event `FileDragAndDrop::HoveredFileCancelled` where used to `HoveredFileCanceled`
Update `Touches.just_cancelled` where used as `Touches.just_canceled`
The event `TouchPhase::Cancelled` is now called `TouchPhase::Canceled` 
