### PR TITLE
make the examples use the States derive macro

### DIFF
--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -14,20 +14,14 @@ fn main() {
         .run();
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, States)]
 enum AppState {
     #[default]
     Setup,
     Finished,
 }
 
-impl States for AppState {
-    type Iter = std::array::IntoIter<AppState, 2>;
 
-    fn variants() -> Self::Iter {
-        [AppState::Setup, AppState::Finished].into_iter()
-    }
-}
 
 #[derive(Resource, Default)]
 struct RpgSpriteHandles {

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -21,8 +21,6 @@ enum AppState {
     Finished,
 }
 
-
-
 #[derive(Resource, Default)]
 struct RpgSpriteHandles {
     handles: Vec<HandleUntyped>,

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -11,19 +11,11 @@
 
 use bevy::prelude::*;
 
-#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Hash, States)]
 enum AppState {
     #[default]
     MainMenu,
     InGame,
-}
-
-impl States for AppState {
-    type Iter = std::array::IntoIter<AppState, 2>;
-
-    fn variants() -> Self::Iter {
-        [AppState::MainMenu, AppState::InGame].into_iter()
-    }
 }
 
 #[derive(Component)]


### PR DESCRIPTION
# Objective
Some examples still manually implement the States trait, even though manual implementation is no longer needed as there is now the derive macro for that.