### PR TITLE
Update `increment_change_tick` to return a strongly-typed `Tick`

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -202,12 +202,10 @@ impl<'w> UnsafeWorldCell<'w> {
     }
 
     #[inline]
-    pub fn increment_change_tick(self) -> u32 {
+    pub fn increment_change_tick(self) -> Tick {
         // SAFETY:
         // - we only access world metadata
-        unsafe { self.world_metadata() }
-            .change_tick
-            .fetch_add(1, Ordering::AcqRel)
+        unsafe { self.world_metadata() }.increment_change_tick()
     }
 
     /// Shorthand helper function for getting the [`ArchetypeComponentId`] for a resource.


### PR DESCRIPTION
# Objective

While migrating the engine to use the `Tick` type in #7905, I forgot to update `UnsafeWorldCell::increment_change_tick`.

## Solution

Update the function.

---

## Changelog

- The function `UnsafeWorldCell::increment_change_tick` is now strongly-typed, returning a value of type `Tick` instead of a raw `u32`.

## Migration Guide

The function `UnsafeWorldCell::increment_change_tick` is now strongly-typed, returning a value of type `Tick` instead of a raw `u32`.
