### PR TITLE
bevy_reflect: newtype struct special case (de)serialization

### DIFF
--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1179,6 +1179,7 @@ mod tests {
         array_value: [i32; 5],
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
+        newtype_struct_value: SomeNewtypeStruct,
         tuple_struct_value: SomeTupleStruct,
         unit_struct: SomeUnitStruct,
         unit_enum: SomeEnum,
@@ -1198,7 +1199,10 @@ mod tests {
     }
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
-    struct SomeTupleStruct(String);
+    struct SomeNewtypeStruct(String);
+
+    #[derive(Reflect, FromReflect, Debug, PartialEq)]
+    struct SomeTupleStruct(String, u32);
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct SomeUnitStruct;
@@ -1249,6 +1253,7 @@ mod tests {
         let mut registry = TypeRegistry::default();
         registry.register::<MyStruct>();
         registry.register::<SomeStruct>();
+        registry.register::<SomeNewtypeStruct>();
         registry.register::<SomeTupleStruct>();
         registry.register::<SomeUnitStruct>();
         registry.register::<SomeIgnoredStruct>();
@@ -1288,7 +1293,8 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -1330,7 +1336,8 @@ mod tests {
                 struct_value: (
                     foo: 999999999,
                 ),
-                tuple_struct_value: ("Tuple Struct"),
+                newtype_struct_value: ("Newtype Struct"),
+                tuple_struct_value: ("Tuple Struct", 2),
                 unit_struct: (),
                 unit_enum: Unit,
                 newtype_enum: NewType(123),
@@ -1547,7 +1554,8 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -1577,12 +1585,13 @@ mod tests {
             0, 0, 219, 15, 73, 64, 57, 5, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 254, 255, 255,
             255, 255, 255, 255, 255, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 254, 255, 255, 255, 255,
             255, 255, 255, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 64, 32, 0,
-            0, 0, 0, 0, 0, 0, 255, 201, 154, 59, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 84, 117, 112,
-            108, 101, 32, 83, 116, 114, 117, 99, 116, 0, 0, 0, 0, 1, 0, 0, 0, 123, 0, 0, 0, 0, 0,
-            0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20, 0, 0, 0, 0, 0,
-            0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97,
-            108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0,
-            0,
+            0, 0, 0, 0, 0, 0, 255, 201, 154, 59, 0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 78, 101, 119,
+            116, 121, 112, 101, 32, 83, 116, 114, 117, 99, 116, 12, 0, 0, 0, 0, 0, 0, 0, 84, 117,
+            112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 2, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 123,
+            0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20,
+            0, 0, 0, 0, 0, 0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116,
+            32, 118, 97, 108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0,
+            0, 0, 0, 0, 0, 0
         ];
 
         let deserializer = UntypedReflectDeserializer::new(&registry);
@@ -1610,7 +1619,8 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -1635,15 +1645,16 @@ mod tests {
         let input = vec![
             129, 217, 40, 98, 101, 118, 121, 95, 114, 101, 102, 108, 101, 99, 116, 58, 58, 115,
             101, 114, 100, 101, 58, 58, 100, 101, 58, 58, 116, 101, 115, 116, 115, 58, 58, 77, 121,
-            83, 116, 114, 117, 99, 116, 220, 0, 19, 123, 172, 72, 101, 108, 108, 111, 32, 119, 111,
+            83, 116, 114, 117, 99, 116, 220, 0, 20, 123, 172, 72, 101, 108, 108, 111, 32, 119, 111,
             114, 108, 100, 33, 145, 123, 146, 202, 64, 73, 15, 219, 205, 5, 57, 149, 254, 255, 0,
-            1, 2, 149, 254, 255, 0, 1, 2, 129, 64, 32, 145, 206, 59, 154, 201, 255, 172, 84, 117,
-            112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 144, 164, 85, 110, 105, 116, 129, 167,
-            78, 101, 119, 84, 121, 112, 101, 123, 129, 165, 84, 117, 112, 108, 101, 146, 202, 63,
-            157, 112, 164, 202, 64, 77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145, 180,
-            83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108, 117,
-            101, 144, 144, 129, 166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112, 108,
-            101, 144, 146, 100, 145, 101,
+            1, 2, 149, 254, 255, 0, 1, 2, 129, 64, 32, 145, 206, 59, 154, 201, 255, 174, 78, 101,
+            119, 116, 121, 112, 101, 32, 83, 116, 114, 117, 99, 116, 146, 172, 84, 117, 112, 108,
+            101, 32, 83, 116, 114, 117, 99, 116, 2, 144, 164, 85, 110, 105, 116, 129, 167, 78, 101,
+            119, 84, 121, 112, 101, 123, 129, 165, 84, 117, 112, 108, 101, 146, 202, 63, 157, 112,
+            164, 202, 64, 77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145, 180, 83, 116,
+            114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108, 117, 101,
+            144, 144, 129, 166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112, 108, 101,
+            144, 146, 100, 145, 101
         ];
 
         let mut reader = std::io::BufReader::new(input.as_slice());

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -589,19 +589,14 @@ impl<'a, 'de> Visitor<'de> for NewtypeStructVisitor<'a> {
             .field_len()
             .saturating_sub(ignored_len);
 
-        if field_len > 1 {
+        if field_len != 1 {
             return Err(Error::custom(format_args!(
-                "Tried to deserialize a struct {} with more than 1 field as a newtype.",
+                "tried to deserialize {} as a newtype struct, but it doesn't have exactly 1 field.",
                 self.tuple_struct_info.type_name(),
             )));
         }
 
-        let field = self.tuple_struct_info.field_at(0).ok_or_else(|| {
-            de::Error::custom(format_args!(
-                "no fields on supposedly newtype struct {}",
-                self.tuple_struct_info.type_name(),
-            ))
-        })?;
+        let field = self.tuple_struct_info.field_at(0).unwrap();
         let registration = get_registration(field.type_id(), field.type_name(), self.registry)?;
 
         let de = TypedReflectDeserializer {
@@ -1591,7 +1586,7 @@ mod tests {
             0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20,
             0, 0, 0, 0, 0, 0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116,
             32, 118, 97, 108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0,
-            0, 0, 0, 0, 0, 0
+            0, 0, 0, 0, 0, 0,
         ];
 
         let deserializer = UntypedReflectDeserializer::new(&registry);
@@ -1654,7 +1649,7 @@ mod tests {
             164, 202, 64, 77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145, 180, 83, 116,
             114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108, 117, 101,
             144, 144, 129, 166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112, 108, 101,
-            144, 146, 100, 145, 101
+            144, 146, 100, 145, 101,
         ];
 
         let mut reader = std::io::BufReader::new(input.as_slice());

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -133,7 +133,6 @@ impl<'a> Serialize for TypedReflectSerializer<'a> {
                     .map(|data| data.len())
                     .unwrap_or(0);
                 let field_len = value.field_len().saturating_sub(ignored_len);
-
                 if value.field_len() == 1 && field_len == 1 {
                     NewtypeStructSerializer {
                         tuple_struct: value,
@@ -552,7 +551,9 @@ mod tests {
         array_value: [i32; 5],
         map_value: HashMap<u8, usize>,
         struct_value: SomeStruct,
+        newtype_struct_value: SomeNewtypeStruct,
         tuple_struct_value: SomeTupleStruct,
+        partial_tuple_struct_value: SomePartialTupleStruct,
         unit_struct: SomeUnitStruct,
         unit_enum: SomeEnum,
         newtype_enum: SomeEnum,
@@ -571,7 +572,13 @@ mod tests {
     }
 
     #[derive(Reflect, Debug, PartialEq)]
-    struct SomeTupleStruct(String);
+    struct SomeNewtypeStruct(String);
+
+    #[derive(Reflect, Debug, PartialEq)]
+    struct SomeTupleStruct(String, u32);
+
+    #[derive(Reflect, Debug, PartialEq)]
+    struct SomePartialTupleStruct(String, #[reflect(skip_serializing)] u32);
 
     #[derive(Reflect, FromReflect, Debug, PartialEq)]
     struct SomeUnitStruct;
@@ -622,7 +629,9 @@ mod tests {
         let mut registry = TypeRegistry::default();
         registry.register::<MyStruct>();
         registry.register::<SomeStruct>();
+        registry.register::<SomeNewtypeStruct>();
         registry.register::<SomeTupleStruct>();
+        registry.register::<SomePartialTupleStruct>();
         registry.register::<SomeUnitStruct>();
         registry.register::<SomeIgnoredStruct>();
         registry.register::<SomeIgnoredTupleStruct>();
@@ -651,7 +660,9 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
+            partial_tuple_struct_value: SomePartialTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -701,7 +712,9 @@ mod tests {
         struct_value: (
             foo: 999999999,
         ),
-        tuple_struct_value: ("Tuple Struct"),
+        newtype_struct_value: ("Newtype Struct"),
+        tuple_struct_value: ("Tuple Struct", 2),
+        partial_tuple_struct_value: ("Tuple Struct"),
         unit_struct: (),
         unit_enum: Unit,
         newtype_enum: NewType(123),
@@ -851,7 +864,9 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
+            partial_tuple_struct_value: SomePartialTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -884,12 +899,14 @@ mod tests {
             0, 0, 0, 0, 219, 15, 73, 64, 57, 5, 0, 0, 0, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 254, 255,
             255, 255, 255, 255, 255, 255, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 254, 255, 255, 255,
             255, 255, 255, 255, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 64, 32,
-            0, 0, 0, 0, 0, 0, 0, 255, 201, 154, 59, 0, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0, 0, 84, 117,
-            112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 0, 0, 0, 0, 1, 0, 0, 0, 123, 0, 0, 0, 0,
-            0, 0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20, 0, 0, 0, 0,
-            0, 0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97,
-            108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0, 0, 0, 0, 0, 0,
-            0,
+            0, 0, 0, 0, 0, 0, 0, 255, 201, 154, 59, 0, 0, 0, 0, 14, 0, 0, 0, 0, 0, 0, 0, 78, 101,
+            119, 116, 121, 112, 101, 32, 83, 116, 114, 117, 99, 116, 12, 0, 0, 0, 0, 0, 0, 0, 84,
+            117, 112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 2, 0, 0, 0, 12, 0, 0, 0, 0, 0, 0,
+            0, 84, 117, 112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 0, 0, 0, 0, 1, 0, 0, 0, 123,
+            0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20,
+            0, 0, 0, 0, 0, 0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116,
+            32, 118, 97, 108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0,
+            0, 0, 0, 0, 0, 0
         ];
 
         assert_eq!(expected, bytes);
@@ -909,7 +926,9 @@ mod tests {
             array_value: [-2, -1, 0, 1, 2],
             map_value: map,
             struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            newtype_struct_value: SomeNewtypeStruct(String::from("Newtype Struct")),
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct"), 2),
+            partial_tuple_struct_value: SomePartialTupleStruct(String::from("Tuple Struct"), 2),
             unit_struct: SomeUnitStruct,
             unit_enum: SomeEnum::Unit,
             newtype_enum: SomeEnum::NewType(123),
@@ -927,6 +946,7 @@ mod tests {
                 value: 100,
                 inner_struct: SomeSerializableStruct { foo: 101 },
             },
+
         };
 
         let registry = get_registry();
@@ -937,15 +957,17 @@ mod tests {
         let expected: Vec<u8> = vec![
             129, 217, 41, 98, 101, 118, 121, 95, 114, 101, 102, 108, 101, 99, 116, 58, 58, 115,
             101, 114, 100, 101, 58, 58, 115, 101, 114, 58, 58, 116, 101, 115, 116, 115, 58, 58, 77,
-            121, 83, 116, 114, 117, 99, 116, 220, 0, 19, 123, 172, 72, 101, 108, 108, 111, 32, 119,
+            121, 83, 116, 114, 117, 99, 116, 220, 0, 21, 123, 172, 72, 101, 108, 108, 111, 32, 119,
             111, 114, 108, 100, 33, 145, 123, 146, 202, 64, 73, 15, 219, 205, 5, 57, 149, 254, 255,
-            0, 1, 2, 149, 254, 255, 0, 1, 2, 129, 64, 32, 145, 206, 59, 154, 201, 255, 172, 84,
-            117, 112, 108, 101, 32, 83, 116, 114, 117, 99, 116, 144, 164, 85, 110, 105, 116, 129,
-            167, 78, 101, 119, 84, 121, 112, 101, 123, 129, 165, 84, 117, 112, 108, 101, 146, 202,
-            63, 157, 112, 164, 202, 64, 77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145,
-            180, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108,
-            117, 101, 144, 144, 129, 166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112,
-            108, 101, 144, 146, 100, 145, 101,
+            0, 1, 2, 149, 254, 255, 0, 1, 2, 129, 64, 32, 145, 206, 59, 154, 201, 255, 174, 78,
+            101, 119, 116, 121, 112, 101, 32, 83, 116, 114, 117, 99, 116, 146, 172, 84, 117, 112,
+            108, 101, 32, 83, 116, 114, 117, 99, 116, 2, 145, 172, 84, 117, 112, 108, 101, 32, 83,
+            116, 114, 117, 99, 116, 144, 164, 85, 110, 105, 116, 129, 167, 78, 101, 119, 84, 121,
+            112, 101, 123, 129, 165, 84, 117, 112, 108, 101, 146, 202, 63, 157, 112, 164, 202, 64,
+            77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145, 180, 83, 116, 114, 117, 99,
+            116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108, 117, 101, 144, 144, 129,
+            166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112, 108, 101, 144, 146, 100,
+            145, 101
         ];
 
         assert_eq!(expected, bytes);

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -275,19 +275,14 @@ impl<'a> Serialize for NewtypeStructSerializer<'a> {
         let ignored_len = serialization_data.map(|data| data.len()).unwrap_or(0);
         let field_len = self.tuple_struct.field_len().saturating_sub(ignored_len);
 
-        if field_len > 1 {
+        if field_len != 1 {
             return Err(Error::custom(format_args!(
-                "Tried to serialize a struct {} with more than 1 field as a newtype.",
+                "tried to serialize {} as a newtype struct, but it doesn't have exactly 1 field.",
                 type_info.type_name(),
             )));
         }
 
-        let field = self.tuple_struct.field(0).ok_or_else(|| {
-            Error::custom(format_args!(
-                "no fields on supposedly newtype struct {}",
-                self.tuple_struct.type_name(),
-            ))
-        })?;
+        let field = self.tuple_struct.field(0).unwrap();
         serializer.serialize_newtype_struct(
             tuple_struct_info.name(),
             &TypedReflectSerializer::new(field, self.registry),
@@ -906,7 +901,7 @@ mod tests {
             0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 164, 112, 157, 63, 164, 112, 77, 64, 3, 0, 0, 0, 20,
             0, 0, 0, 0, 0, 0, 0, 83, 116, 114, 117, 99, 116, 32, 118, 97, 114, 105, 97, 110, 116,
             32, 118, 97, 108, 117, 101, 1, 0, 0, 0, 0, 0, 0, 0, 100, 0, 0, 0, 0, 0, 0, 0, 101, 0,
-            0, 0, 0, 0, 0, 0
+            0, 0, 0, 0, 0, 0,
         ];
 
         assert_eq!(expected, bytes);
@@ -946,7 +941,6 @@ mod tests {
                 value: 100,
                 inner_struct: SomeSerializableStruct { foo: 101 },
             },
-
         };
 
         let registry = get_registry();
@@ -967,7 +961,7 @@ mod tests {
             77, 112, 164, 129, 166, 83, 116, 114, 117, 99, 116, 145, 180, 83, 116, 114, 117, 99,
             116, 32, 118, 97, 114, 105, 97, 110, 116, 32, 118, 97, 108, 117, 101, 144, 144, 129,
             166, 83, 116, 114, 117, 99, 116, 144, 129, 165, 84, 117, 112, 108, 101, 144, 146, 100,
-            145, 101
+            145, 101,
         ];
 
         assert_eq!(expected, bytes);


### PR DESCRIPTION
# Objective

When (de)serializing with `serde` directly, tuple structs with exactly one field are serialized/deserialized through the `serialize_newtype_struct`/`deserialize_tuple_struct` methods (respectively). Depending on the serialization format, this results in the sequence that wraps the field of the tuple struct being elided. For example, consider the following structs:

```rust
use serde::Serialize;

#[derive(Serialize)]
struct Wrapper {
    newtype: Newtype,
    skipped_field: SkippedField,
}

#[derive(Serialize)]
struct Newtype(String);
#[derive(Serialize)]
struct SkippedField(String, #[serde(skip)] u32);
```

When serialized with `serde_yaml` the result is:

```yaml
newtype: One
skipedfield:
- Two
```

<details>
  <summary>Code used to serialize</summary>

  ```rust
  let s = serde_yaml::to_string(&Wrapper {
      newtype: Newtype("One".to_string()),
      skipped_field: SkippedField("Two".to_string(), 5),
  }).unwrap();
  println!(s);
  ```

</details>

When doing the equivalent serialization through `bevy_reflect`, newtype structs don't get such special treatment:

```rust
use bevy::prelude::*;

#[derive(Reflect)]
struct Wrapper {
    newtype: Newtype,
    skipped_field: SkippedField,
}

#[derive(Reflect)]
struct Newtype(String);
#[derive(Reflect)]
struct SkippedField(String, #[reflect(skip_serialization)] u32);
// Note that this is skip_serialization, not ignore
```

```yaml
newtype:
- One
skipped_filed:
- Two
```

<details>
  <summary>Code used to serialize</summary>

  ```rust
  use bevy::reflect::{serde::TypedReflectSerializer, TypeRegistryInternal};
  let mut registry = TypeRegistryInternal::new();
  registry.register::<Wrapper>();
  registry.register::<Newtype>();
  registry.register::<SkippedField>();

  let v = &Wrapper {
      newtype: Newtype("One".to_string()),
      skipped_field: SkippedField("Two".to_string(), 5),
  };
  let serializer = TypedReflectSerializer::new(v, &registry);
  println!(serde_yaml::to_string(&serializer).unwrap());
  ```

</details>


To my knowledge, it isn't a stated goal of the serialization format for it exactly match `serde`'s output (in fact, I suspect this is a non-goal). That said, it seems to me since the two are already quite similar, taking easy steps to minimize the difference is beneficial. Aside from the relationship to `serde`, this can lead to slightly more compact serialization in certain situations.

## Solution

After this PR, the serialization format more closely resembles the direct `serde` serialization:

```yaml
newtype: One
skipedfield:
- Two
```

This is implemented by adding a special in the (de)serialization code for tuple structs when they have exactly 1 field and that field is not ignored. In that case, the struct is (de)serialized as a newtype struct instead of a tuple struct.

