### PR TITLE
WorldQuery::Config for dynamic queries

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -245,6 +245,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                 type Fetch<'__w> = #fetch_struct_name #user_ty_generics_with_world;
                 type ReadOnly = #read_only_struct_name #user_ty_generics;
                 type State = #state_struct_name #user_ty_generics;
+                type Config = ();
 
                 fn shrink<'__wlong: '__wshort, '__wshort>(
                     item: <#struct_name #user_ty_generics as #path::query::WorldQuery>::Item<'__wlong>
@@ -347,9 +348,11 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                     )*
                 }
 
-                fn init_state(world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {
+                fn init_state(_config: Self::Config, world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {
                     #state_struct_name {
-                        #(#named_field_idents: <#field_types>::init_state(world),)*
+                        // TODO: instead of using `Default::default` for the config (and thus failing to compile on query types needing configuration like `Ptr<'_>`)
+                        // we could have a tuple with configuration for each field, or generate a mirror struct with the same field names but storing the configuration values
+                        #(#named_field_idents: <#field_types>::init_state(Default::default(), world),)*
                     }
                 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -907,7 +907,10 @@ mod tests {
             }
         }
 
-        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity> {
+        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity>
+        where
+            F::Config: Default,
+        {
             world
                 .query_filtered::<Entity, F>()
                 .iter(world)
@@ -990,7 +993,10 @@ mod tests {
             }
         }
 
-        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity> {
+        fn get_filtered<F: ReadOnlyWorldQuery>(world: &mut World) -> Vec<Entity>
+        where
+            F::Config: Default,
+        {
             world
                 .query_filtered::<Entity, F>()
                 .iter(world)

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -328,20 +328,22 @@ pub unsafe trait WorldQuery {
     /// constructing [`Self::Fetch`](crate::query::WorldQuery::Fetch).
     type State: Send + Sync + Sized;
 
-    /// Runtime config value passed to [`WorldQuery::init_state`]
+    /// This associated type defines how a query can be configured at runtime.
     ///
-    /// This is used to pass runtime information that is necessary to construct
-    /// [`WorldQuery`].
+    /// [`QueryState::new_with_config`](crate::query::state::QueryState::new_with_config) uses this
+    /// associated type to construct [`QueryState`](crate::query::state::QueryState).
+    /// When this associated type implements the `Default` trait,
+    /// [`QueryState::new`](crate::query::state::QueryState::new) can be used instead.
     ///
-    /// Statically defined queries for types such as `&T` may obtain a
-    /// [`ComponentId`] statically, however, a dynamic query would require that
-    /// [`ComponentId`] is passed at runtime, such that
-    /// `Self::Config = ComponentId`.
+    /// In the case where no config is required, `()` is conventionally chosen
+    /// as the type for `Config`. This is the case for statically defined
+    /// queries, for types such as `&T`, since they can obtain a
+    /// [`ComponentId`] without any runtime information.
     ///
-    /// [`QueryState::new`](crate::query::state::QueryState::new) can be used when
-    /// `Self::Config: Default` otherwise
-    /// [`QueryState::new_with_config`](crate::query::state::QueryState::new_with_config)
-    /// is used to construct [`QueryState`](crate::query::state::QueryState).
+    /// However, for dynamic queries, the [`ComponentId`] varies at runtime and
+    /// mut be additionally provided. By supplying `Config = ComponentId` we
+    /// can vary the component requested each time we construct a new query,
+    /// even for the same underlying Rust type.
     type Config;
 
     /// This function manually implements subtyping for the query items.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -329,6 +329,19 @@ pub unsafe trait WorldQuery {
     type State: Send + Sync + Sized;
 
     /// Runtime config value passed to [`WorldQuery::init_state`]
+    ///
+    /// This is used to pass runtime information that is necessary to construct
+    /// [`WorldQuery`].
+    ///
+    /// Statically defined queries for types such as `&T` may obtain a
+    /// [`ComponentId`] statically, however, a dynamic query would require that
+    /// [`ComponentId`] is passed at runtime, such that
+    /// `Self::Config = ComponentId`.
+    ///
+    /// [`QueryState::new`](crate::query::state::QueryState::new) can be used when
+    /// `Self::Config: Default` otherwise
+    /// [`QueryState::new_with_config`](crate::query::state::QueryState::new_with_config)
+    /// is used to construct [`QueryState`](crate::query::state::QueryState).
     type Config;
 
     /// This function manually implements subtyping for the query items.

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -47,6 +47,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     type Item<'w> = ();
     type ReadOnly = Self;
     type State = ComponentId;
+    type Config = ();
 
     fn shrink<'wlong: 'wshort, 'wshort>(_: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
@@ -97,7 +98,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     ) {
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: (), world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -144,6 +145,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     type Item<'w> = ();
     type ReadOnly = Self;
     type State = ComponentId;
+    type Config = ();
 
     fn shrink<'wlong: 'wshort, 'wshort>(_: Self::Item<'wlong>) -> Self::Item<'wshort> {}
 
@@ -194,7 +196,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     ) {
     }
 
-    fn init_state(world: &mut World) -> ComponentId {
+    fn init_state(_config: (), world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
 
@@ -258,6 +260,7 @@ macro_rules! impl_query_filter_tuple {
             type Item<'w> = bool;
             type ReadOnly = Or<($($filter::ReadOnly,)*)>;
             type State = ($($filter::State,)*);
+            type Config = ($($filter::Config,)*);
 
             fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 item
@@ -361,8 +364,9 @@ macro_rules! impl_query_filter_tuple {
                 $($filter::update_archetype_component_access($filter, archetype, access);)*
             }
 
-            fn init_state(world: &mut World) -> Self::State {
-                ($($filter::init_state(world),)*)
+            fn init_state(config: Self::Config, world: &mut World) -> Self::State {
+                let ($($state,)*) = config;
+                ($($filter::init_state($state, world),)*)
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -406,6 +410,7 @@ macro_rules! impl_tick_filter {
             type Item<'w> = bool;
             type ReadOnly = Self;
             type State = ComponentId;
+            type Config = ();
 
             fn shrink<'wlong: 'wshort, 'wshort>(item: Self::Item<'wlong>) -> Self::Item<'wshort> {
                 item
@@ -532,7 +537,7 @@ macro_rules! impl_tick_filter {
                 }
             }
 
-            fn init_state(world: &mut World) -> ComponentId {
+            fn init_state(_config: (), world: &mut World) -> ComponentId {
                 world.init_component::<T>()
             }
 

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -114,6 +114,8 @@ mod tests {
             Q: ReadOnlyWorldQuery,
             F: ReadOnlyWorldQuery,
             F::ReadOnly: ArchetypeFilter,
+            Q::Config: Default,
+            F::Config: Default,
         {
             let mut query = world.query_filtered::<Q, F>();
             let query_type = type_name::<QueryCombinationIter<Q, F, K>>();
@@ -129,6 +131,8 @@ mod tests {
             Q: ReadOnlyWorldQuery,
             F: ReadOnlyWorldQuery,
             F::ReadOnly: ArchetypeFilter,
+            Q::Config: Default,
+            F::Config: Default,
         {
             let mut query = world.query_filtered::<Q, F>();
             let query_type = type_name::<QueryState<Q, F>>();

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -104,7 +104,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         <Q as WorldQuery>::Config: Default,
         <F as WorldQuery>::Config: Default,
     {
-        QueryState::new_with_config(world, Default::default(), Default::default())
+        let fetch_config = Default::default();
+        let filter_config = Default::default();
+        QueryState::new_with_config(world, fetch_config, filter_config)
     }
 
     /// Creates a new [`QueryState`] from a given [`World`], config, and inherits the result of `world.id()`.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -49,7 +49,11 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for QueryState<Q, F> 
     }
 }
 
-impl<Q: WorldQuery, F: ReadOnlyWorldQuery> FromWorld for QueryState<Q, F> {
+impl<Q: WorldQuery, F: ReadOnlyWorldQuery> FromWorld for QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
+{
     fn from_world(world: &mut World) -> Self {
         world.query_filtered()
     }
@@ -95,9 +99,22 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
 impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Creates a new [`QueryState`] from a given [`World`] and inherits the result of `world.id()`.
-    pub fn new(world: &mut World) -> Self {
-        let fetch_state = Q::init_state(world);
-        let filter_state = F::init_state(world);
+    pub fn new(world: &mut World) -> Self
+    where
+        <Q as WorldQuery>::Config: Default,
+        <F as WorldQuery>::Config: Default,
+    {
+        QueryState::new_with_config(world, Default::default(), Default::default())
+    }
+
+    /// Creates a new [`QueryState`] from a given [`World`], config, and inherits the result of `world.id()`.
+    pub fn new_with_config(
+        world: &mut World,
+        fetch_config: <Q as WorldQuery>::Config,
+        filter_config: <F as WorldQuery>::Config,
+    ) -> Self {
+        let fetch_state = Q::init_state(fetch_config, world);
+        let filter_state = F::init_state(filter_config, world);
 
         let mut component_access = FilteredAccess::default();
         Q::update_component_access(&fetch_state, &mut component_access);

--- a/crates/bevy_ecs/src/system/exclusive_system_param.rs
+++ b/crates/bevy_ecs/src/system/exclusive_system_param.rs
@@ -31,6 +31,9 @@ pub type ExclusiveSystemParamItem<'s, P> = <P as ExclusiveSystemParam>::Item<'s>
 
 impl<'a, Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> ExclusiveSystemParam
     for &'a mut QueryState<Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type State = QueryState<Q, F>;
     type Item<'s> = &'s mut QueryState<Q, F>;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -154,6 +154,9 @@ pub type SystemParamItem<'w, 's, P> = <P as SystemParam>::Item<'w, 's>;
 // SAFETY: QueryState is constrained to read-only fetches, so it only reads World.
 unsafe impl<'w, 's, Q: ReadOnlyWorldQuery + 'static, F: ReadOnlyWorldQuery + 'static>
     ReadOnlySystemParam for Query<'w, 's, Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
 }
 
@@ -161,6 +164,9 @@ unsafe impl<'w, 's, Q: ReadOnlyWorldQuery + 'static, F: ReadOnlyWorldQuery + 'st
 // this Query conflicts with any prior access, a panic will occur.
 unsafe impl<Q: WorldQuery + 'static, F: ReadOnlyWorldQuery + 'static> SystemParam
     for Query<'_, '_, Q, F>
+where
+    <Q as WorldQuery>::Config: Default,
+    <F as WorldQuery>::Config: Default,
 {
     type State = QueryState<Q, F>;
     type Item<'w, 's> = Query<'w, 's, Q, F>;
@@ -1586,7 +1592,11 @@ mod tests {
             's,
             Q: WorldQuery + Send + Sync + 'static,
             F: ReadOnlyWorldQuery + Send + Sync + 'static = (),
-        > {
+        >
+        where
+            Q::Config: Default,
+            F::Config: Default,
+        {
             _query: Query<'w, 's, Q, F>,
         }
 
@@ -1707,6 +1717,7 @@ mod tests {
         pub struct WhereParam<'w, 's, Q>
         where
             Q: 'static + WorldQuery,
+            Q::Config: Default,
         {
             _q: Query<'w, 's, Q, ()>,
         }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -748,7 +748,10 @@ impl World {
     /// ]);
     /// ```
     #[inline]
-    pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()> {
+    pub fn query<Q: WorldQuery>(&mut self) -> QueryState<Q, ()>
+    where
+        <Q as WorldQuery>::Config: Default,
+    {
         self.query_filtered::<Q, ()>()
     }
 
@@ -772,7 +775,11 @@ impl World {
     /// assert_eq!(matching_entities, vec![e2]);
     /// ```
     #[inline]
-    pub fn query_filtered<Q: WorldQuery, F: ReadOnlyWorldQuery>(&mut self) -> QueryState<Q, F> {
+    pub fn query_filtered<Q: WorldQuery, F: ReadOnlyWorldQuery>(&mut self) -> QueryState<Q, F>
+    where
+        <Q as WorldQuery>::Config: Default,
+        <F as WorldQuery>::Config: Default,
+    {
         QueryState::new(self)
     }
 

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -179,7 +179,11 @@ impl<C, F> ExtractComponentPlugin<C, F> {
     }
 }
 
-impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C> {
+impl<C: ExtractComponent> Plugin for ExtractComponentPlugin<C>
+where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             if self.only_extract_visible {
@@ -207,7 +211,10 @@ fn extract_components<C: ExtractComponent>(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, C::Query), C::Filter>>,
-) {
+) where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, query_item) in &query {
         if let Some(component) = C::extract_component(query_item) {
@@ -223,7 +230,10 @@ fn extract_visible_components<C: ExtractComponent>(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     query: Extract<Query<(Entity, &ComputedVisibility, C::Query), C::Filter>>,
-) {
+) where
+    <C::Query as WorldQuery>::Config: Default,
+    <C::Filter as WorldQuery>::Config: Default,
+{
     let mut values = Vec::with_capacity(*previous_len);
     for (entity, computed_visibility, query_item) in &query {
         if computed_visibility.is_visible() {

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -7,7 +7,7 @@ use crate::{
     renderer::RenderContext,
 };
 use bevy_ecs::{
-    query::{QueryItem, QueryState, ReadOnlyWorldQuery},
+    query::{QueryItem, QueryState, ReadOnlyWorldQuery, WorldQuery},
     world::{FromWorld, World},
 };
 use downcast_rs::{impl_downcast, Downcast};
@@ -368,7 +368,10 @@ pub struct ViewNodeRunner<N: ViewNode> {
     node: N,
 }
 
-impl<N: ViewNode> ViewNodeRunner<N> {
+impl<N: ViewNode> ViewNodeRunner<N>
+where
+    <N::ViewQuery as WorldQuery>::Config: Default,
+{
     pub fn new(node: N, world: &mut World) -> Self {
         Self {
             view_query: world.query_filtered(),
@@ -377,7 +380,10 @@ impl<N: ViewNode> ViewNodeRunner<N> {
     }
 }
 
-impl<N: ViewNode + FromWorld> FromWorld for ViewNodeRunner<N> {
+impl<N: ViewNode + FromWorld> FromWorld for ViewNodeRunner<N>
+where
+    <N::ViewQuery as WorldQuery>::Config: Default,
+{
     fn from_world(world: &mut World) -> Self {
         Self::new(N::from_world(world), world)
     }

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -2,7 +2,7 @@ use crate::render_phase::{PhaseItem, TrackedRenderPass};
 use bevy_app::App;
 use bevy_ecs::{
     entity::Entity,
-    query::{QueryState, ROQueryItem, ReadOnlyWorldQuery},
+    query::{QueryState, ROQueryItem, ReadOnlyWorldQuery, WorldQuery},
     system::{ReadOnlySystemParam, Resource, SystemParam, SystemParamItem, SystemState},
     world::World,
 };
@@ -233,7 +233,11 @@ pub struct RenderCommandState<P: PhaseItem + 'static, C: RenderCommand<P>> {
     entity: QueryState<C::ItemWorldQuery>,
 }
 
-impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C> {
+impl<P: PhaseItem, C: RenderCommand<P>> RenderCommandState<P, C>
+where
+    <C::ViewWorldQuery as WorldQuery>::Config: Default,
+    <C::ItemWorldQuery as WorldQuery>::Config: Default,
+{
     /// Creates a new [`RenderCommandState`] for the [`RenderCommand`].
     pub fn new(world: &mut World) -> Self {
         Self {
@@ -280,7 +284,9 @@ pub trait AddRenderCommand {
         &mut self,
     ) -> &mut Self
     where
-        C::Param: ReadOnlySystemParam;
+        C::Param: ReadOnlySystemParam,
+        <C::ViewWorldQuery as WorldQuery>::Config: Default,
+        <C::ItemWorldQuery as WorldQuery>::Config: Default;
 }
 
 impl AddRenderCommand for App {
@@ -289,6 +295,8 @@ impl AddRenderCommand for App {
     ) -> &mut Self
     where
         C::Param: ReadOnlySystemParam,
+        <C::ViewWorldQuery as WorldQuery>::Config: Default,
+        <C::ItemWorldQuery as WorldQuery>::Config: Default,
     {
         let draw_function = RenderCommandState::<P, C>::new(&mut self.world);
         let draw_functions = self


### PR DESCRIPTION
# Objective

Allows providing runtime state to QueryState allowing users to implement dynamic queries which cannot be derived from type definition.

This PR is a cut-down and rebased version of https://github.com/bevyengine/bevy/pull/6390.

https://github.com/bevyengine/bevy/pull/6390 is itself an alternative proposal to https://github.com/bevyengine/bevy/pull/6240 which I believe to be a simpler approach due to no type magic.

I am making this cut-down PR as neither of the prior PRs received much attention in the way of reviews but both provide a powerful feature.

## Solution

- introduce a `Config` associated type to `WorldQuery`
    - this is `Config = ()` for current query types `&T`, `&mut T`, `Q::Config` for `Option<Q>` and `(A::Config, B::Config, ..)` for `(A, B, ..)`
- Make `QueryState::new` require `Q::Config: Default` and `F::Config: Default`. This propagates quite far, to `world.query`, `Query: SystemParam` and `ExtractComponentPlugin`
