### PR TITLE
fix invalid bone weights

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -120,17 +120,14 @@ impl Mesh {
         }
 
         // validate attributes
-        match attribute.id {
-            id if id == Self::ATTRIBUTE_JOINT_WEIGHT.id => {
-                let VertexAttributeValues::Float32x4(ref mut values) = values else {
-                    unreachable!() // we confirmed the format above
-                };
-                for value in values.iter_mut().filter(|v| *v == &[0.0, 0.0, 0.0, 0.0]) {
-                    // zero weights are invalid
-                    value[0] = 1.0;
-                }
+        if attribute.id == Self::ATTRIBUTE_JOINT_WEIGHT.id {
+            let VertexAttributeValues::Float32x4(ref mut values) = values else {
+                unreachable!() // we confirmed the format above
+            };
+            for value in values.iter_mut().filter(|v| *v == &[0.0, 0.0, 0.0, 0.0]) {
+                // zero weights are invalid
+                value[0] = 1.0;
             }
-            _ => (),
         }
 
         self.attributes

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -123,7 +123,7 @@ impl Mesh {
         match attribute.id {
             id if id == Self::ATTRIBUTE_JOINT_WEIGHT.id => {
                 let VertexAttributeValues::Float32x4(ref mut values) = values else {
-                    panic!() // we confirmed the format above
+                    unreachable!() // we confirmed the format above
                 };
                 for value in values.iter_mut().filter(|v| *v == &[0.0, 0.0, 0.0, 0.0]) {
                     // zero weights are invalid

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -110,13 +110,27 @@ impl Mesh {
         attribute: MeshVertexAttribute,
         values: impl Into<VertexAttributeValues>,
     ) {
-        let values = values.into();
+        let mut values = values.into();
         let values_format = VertexFormat::from(&values);
         if values_format != attribute.format {
             panic!(
                 "Failed to insert attribute. Invalid attribute format for {}. Given format is {values_format:?} but expected {:?}",
                 attribute.name, attribute.format
             );
+        }
+
+        // validate attributes
+        match attribute.id {
+            id if id == Self::ATTRIBUTE_JOINT_WEIGHT.id => {
+                let VertexAttributeValues::Float32x4(ref mut values) = values else {
+                    panic!() // we confirmed the format above
+                };
+                for value in values.iter_mut().filter(|v| *v == &[0.0, 0.0, 0.0, 0.0]) {
+                    // zero weights are invalid
+                    value[0] = 1.0;
+                }
+            }
+            _ => (),
         }
 
         self.attributes


### PR DESCRIPTION
# Objective

when a mesh uses zero for all bone weights, vertices end up in the middle of the screen.

## Solution

we can address this by explicitly setting the first bone weight to 1 when the weights are given as zero. this is the approach taken by [unity](https://forum.unity.com/threads/whats-the-problem-with-this-import-fbx-warning.133736/) (although that also sets the bone index to zero) and [three.js](https://github.com/mrdoob/three.js/blob/94c1a4b86f53c91b61ec4ca3299b4ad02422ddb8/src/objects/SkinnedMesh.js#L98), and likely other engines.

## Alternatives

it does add a bit of overhead, and users can always fix this themselves, though it's a bit awkward particularly with gltfs.

(note - this is for work so my sme status shouldn't apply)
