### PR TITLE
Fix viewport change detection

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -555,6 +555,8 @@ pub fn camera_system<T: CameraProjection + Component>(
                 }
             }
         }
+
+        camera.computed.old_viewport_size = viewport_size;
     }
 }
 


### PR DESCRIPTION
# Objective

Fix #8322

## Solution

The `old_viewport_size` that is used to detect whether the viewport has changed was not being updated and thus always `None`.