### PR TITLE
Handle vertex_uvs if they are present in default prepass fragment shader

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -109,7 +109,7 @@ struct FragmentOutput {
 }
 
 @fragment
-fn fragment(in: VertexOutput) -> FragmentOutput {
+fn fragment(in: FragmentInput) -> FragmentOutput {
     var out: FragmentOutput;
 
 #ifdef NORMAL_PREPASS

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -84,6 +84,10 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 
 #ifdef PREPASS_FRAGMENT
 struct FragmentInput {
+#ifdef VERTEX_UVS
+    @location(0) uv: vec2<f32>,
+#endif // VERTEX_UVS
+
 #ifdef NORMAL_PREPASS
     @location(1) world_normal: vec3<f32>,
 #endif // NORMAL_PREPASS
@@ -105,7 +109,7 @@ struct FragmentOutput {
 }
 
 @fragment
-fn fragment(in: FragmentInput) -> FragmentOutput {
+fn fragment(in: VertexOutput) -> FragmentOutput {
     var out: FragmentOutput;
 
 #ifdef NORMAL_PREPASS

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -63,7 +63,8 @@ fn setup(
     });
 
     // A quad that shows the outputs of the prepass
-    // To make it easy, we just draw a big quad right in front of the camera. For a real application, this isn't ideal.
+    // To make it easy, we just draw a big quad right in front of the camera.
+    // For a real application, this isn't ideal.
     commands.spawn((
         MaterialMeshBundle {
             mesh: meshes.add(shape::Quad::new(Vec2::new(20.0, 20.0)).into()),
@@ -79,9 +80,13 @@ fn setup(
 
     // Opaque cube using the StandardMaterial
     commands.spawn((
-        PbrBundle {
+        MaterialMeshBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: std_materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            material: materials.add(CustomMaterial {
+                color: Color::WHITE,
+                color_texture: Some(asset_server.load("branding/icon.png")),
+                alpha_mode: AlphaMode::Opaque,
+            }),
             transform: Transform::from_xyz(-1.0, 0.5, 0.0),
             ..default()
         },
@@ -96,7 +101,6 @@ fn setup(
             base_color_texture: Some(asset_server.load("branding/icon.png")),
             ..default()
         }),
-
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -78,7 +78,7 @@ fn setup(
         NotShadowCaster,
     ));
 
-    // Opaque cube using the StandardMaterial
+    // Opaque cube
     commands.spawn((
         MaterialMeshBundle {
             mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),


### PR DESCRIPTION
# Objective

- Enabling AlphaMode::Opaque in the shader_prepass example crashes. The issue seems to be that enabling opaque also generates vertex_uvs

Fixes https://github.com/bevyengine/bevy/issues/8273

## Solution

- Use the vertex_uvs in the shader if they are present