### PR TITLE
Make UiNode render pass respect render layers.

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -3,7 +3,7 @@ use crate::{
     prelude::Image,
     render_asset::RenderAssets,
     render_resource::TextureView,
-    view::{ColorGrading, ExtractedView, ExtractedWindows, VisibleEntities},
+    view::{ColorGrading, ExtractedView, ExtractedWindows, RenderLayers, VisibleEntities},
     Extract,
 };
 use bevy_asset::{AssetEvent, Assets, Handle};
@@ -582,6 +582,7 @@ pub fn extract_cameras(
             &VisibleEntities,
             Option<&ColorGrading>,
             Option<&TemporalJitter>,
+            Option<&RenderLayers>,
         )>,
     >,
     primary_window: Extract<Query<Entity, With<PrimaryWindow>>>,
@@ -595,6 +596,7 @@ pub fn extract_cameras(
         visible_entities,
         color_grading,
         temporal_jitter,
+        render_layers,
     ) in query.iter()
     {
         let color_grading = *color_grading.unwrap_or(&ColorGrading::default());
@@ -642,6 +644,10 @@ pub fn extract_cameras(
                 },
                 visible_entities.clone(),
             ));
+
+            if let Some(render_layers) = render_layers {
+                commands.insert(*render_layers);
+            }
 
             if let Some(temporal_jitter) = temporal_jitter {
                 commands.insert(temporal_jitter.clone());


### PR DESCRIPTION
# Objective

Ensures that UiNodes are only rendered to views with matching render layer configurations. Fixes #6069.

## Solution

When UiNodes are queued, they are queued indiscriminately for each extracted view that exists. Since render layers can be a component of both the camera as well as the UiNode, we need to propagate the layer information in two ways:
* by adding render layer components to those extracted view entities so they can be queried later
* by adding render layer data to the UiBatches, so a batch of nodes all reference the same layer data

With this data propagated, we can perform a layer intersection check when queueing UiNodes against a particular view.

---

## Changelog

### Fixed

UI components only render in views with matching render layers.