### PR TITLE
Added documentation to the fields within derived read-only types

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -365,7 +365,12 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
             #[doc = "`]."]
             #[automatically_derived]
             #visibility struct #read_only_struct_name #user_impl_generics #user_where_clauses {
-                #( #field_visibilities #named_field_idents: #read_only_field_types, )*
+                #( 
+                    #[doc = "Automatically generated read-only field for accessing `"]
+                    #[doc = stringify!(#field_types)]
+                    #[doc = "`."]
+                    #field_visibilities #named_field_idents: #read_only_field_types, 
+                )*
             }
 
             #readonly_state

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -365,11 +365,11 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
             #[doc = "`]."]
             #[automatically_derived]
             #visibility struct #read_only_struct_name #user_impl_generics #user_where_clauses {
-                #( 
+                #(
                     #[doc = "Automatically generated read-only field for accessing `"]
                     #[doc = stringify!(#field_types)]
                     #[doc = "`."]
-                    #field_visibilities #named_field_idents: #read_only_field_types, 
+                    #field_visibilities #named_field_idents: #read_only_field_types,
                 )*
             }
 


### PR DESCRIPTION
Fixes #8333

# Objective

Fixes issue which causes failure to compile if using `#![deny(missing_docs)]`.

## Solution

Added some very basic commenting to the generated read-only fields. honestly I feel this to be up for debate since the comments are very basic and give very little useful information but the purpose of this PR is to fix the issue at hand.

---

## Changelog

Added comments to the derive macro and the projects now successfully compile.
