### PR TITLE
Awaiting asset dependencies

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -456,12 +456,7 @@ impl AssetServer {
         let server = self.clone();
         let owned_path = asset_path.to_owned();
 
-        let handle_id = asset_path.get_id().into();
-        self.server
-            .handle_to_path
-            .write()
-            .entry(handle_id)
-            .or_insert_with(|| asset_path.to_owned());
+        self.insert_asset_key(asset_path);
 
         Box::pin(async move {
             if let Err(err) = server.load_async(owned_path, force).await {
@@ -481,14 +476,18 @@ impl AssetServer {
             })
             .detach();
 
+        self.insert_asset_key(asset_path.clone());
+
+        asset_path.into()
+    }
+
+    fn insert_asset_key(&self, asset_path: AssetPath<'_>) {
         let handle_id = asset_path.get_id().into();
         self.server
             .handle_to_path
             .write()
             .entry(handle_id)
             .or_insert_with(|| asset_path.to_owned());
-
-        asset_path.into()
     }
 
     /// Loads assets from the specified folder recursively.

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_log::warn;
 use bevy_tasks::IoTaskPool;
-use bevy_utils::{Entry, HashMap, Uuid, BoxedFuture};
+use bevy_utils::{BoxedFuture, Entry, HashMap, Uuid};
 use crossbeam_channel::TryRecvError;
 use parking_lot::{Mutex, RwLock};
 use std::{path::Path, sync::Arc};

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -479,7 +479,7 @@ impl AssetServer {
     ) -> bool {
         let mut asset_sources = self.server.asset_sources.write();
         let source_info = asset_sources
-            .get_mut(&source_path_id)
+            .get_mut(source_path_id)
             .expect("`AssetSource` should exist at this point.");
         if version != source_info.version {
             return false;

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -8,10 +8,10 @@ use anyhow::Result;
 use bevy_ecs::system::{Res, ResMut, Resource};
 use bevy_log::warn;
 use bevy_tasks::IoTaskPool;
-use bevy_utils::{Entry, HashMap, Uuid};
+use bevy_utils::{Entry, HashMap, Uuid, BoxedFuture};
 use crossbeam_channel::TryRecvError;
 use parking_lot::{Mutex, RwLock};
-use std::{path::Path, pin::Pin, sync::Arc};
+use std::{path::Path, sync::Arc};
 use thiserror::Error;
 
 /// Errors that occur while loading assets with an `AssetServer`.
@@ -452,7 +452,7 @@ impl AssetServer {
         &self,
         asset_path: AssetPath<'_>,
         force: bool,
-    ) -> Pin<Box<dyn std::future::Future<Output = ()> + Send>> {
+    ) -> BoxedFuture<'_, ()> {
         let server = self.clone();
         let owned_path = asset_path.to_owned();
         let task = IoTaskPool::get().spawn(async move {


### PR DESCRIPTION
# Objective

This PR is aimed to fix #5297

## Solution

The solution uses `IoTaskPool::scope`, where all the tasks for loading dependencies are spawned. In order to avoid creating a recursive type, the futures for dependencies are `Box`-ed.

## Changelog

This PR changes the behaviour of asset loading. The behaviour change is minimal -- if the dependency task fails, the "parent" asset task will not fail as did the original implementation.

## Migration Guide

The original issue has been marked as a bug. 

Some projects might be avoiding the issue by forcing things like `bevy_asset_loader` to wait for dependencies explicitly. This PR should free people from doing that and make loading assets easier.
