### PR TITLE
fix panic when moving child

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -657,6 +657,22 @@ mod tests {
     }
 
     #[test]
+    fn set_parent_of_orphan() {
+        let world = &mut World::new();
+
+        let [a, b, c] = std::array::from_fn(|_| world.spawn_empty().id());
+        world.entity_mut(a).set_parent(b);
+        assert_parent(world, a, Some(b));
+        assert_children(world, b, Some(&[a]));
+
+        world.entity_mut(b).despawn();
+        world.entity_mut(a).set_parent(c);
+
+        assert_parent(world, a, Some(c));
+        assert_children(world, c, Some(&[a]));
+    }
+
+    #[test]
     fn remove_parent() {
         let world = &mut World::new();
         world.insert_resource(Events::<HierarchyEvent>::default());

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -42,7 +42,7 @@ fn update_parent(world: &mut World, child: Entity, new_parent: Entity) -> Option
 /// Removes the [`Children`] component from the parent if it's empty.
 fn remove_from_children(world: &mut World, parent: Entity, child: Entity) {
     let Some(mut parent) = world.get_entity_mut(parent) else { 
-        return; 
+        return;
     };
     let Some(mut children) = parent.get_mut::<Children>() else {
         return;

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -656,6 +656,7 @@ mod tests {
         );
     }
 
+    // regression test for https://github.com/bevyengine/bevy/pull/8346
     #[test]
     fn set_parent_of_orphan() {
         let world = &mut World::new();

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -41,13 +41,15 @@ fn update_parent(world: &mut World, child: Entity, new_parent: Entity) -> Option
 ///
 /// Removes the [`Children`] component from the parent if it's empty.
 fn remove_from_children(world: &mut World, parent: Entity, child: Entity) {
-    if let Some(mut parent) = world.get_entity_mut(parent) {
-        if let Some(mut children) = parent.get_mut::<Children>() {
-            children.0.retain(|x| *x != child);
-            if children.is_empty() {
-                parent.remove::<Children>();
-            }
-        }
+    let Some(mut parent) = world.get_entity_mut(parent) else { 
+        return; 
+    };
+    let Some(mut children) = parent.get_mut::<Children>() else {
+        return;
+    };
+    children.0.retain(|x| *x != child);
+    if children.is_empty() {
+        parent.remove::<Children>();
     }
 }
 

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -41,7 +41,7 @@ fn update_parent(world: &mut World, child: Entity, new_parent: Entity) -> Option
 ///
 /// Removes the [`Children`] component from the parent if it's empty.
 fn remove_from_children(world: &mut World, parent: Entity, child: Entity) {
-    let Some(mut parent) = world.get_entity_mut(parent) else { 
+    let Some(mut parent) = world.get_entity_mut(parent) else {
         return;
     };
     let Some(mut children) = parent.get_mut::<Children>() else {

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -41,11 +41,12 @@ fn update_parent(world: &mut World, child: Entity, new_parent: Entity) -> Option
 ///
 /// Removes the [`Children`] component from the parent if it's empty.
 fn remove_from_children(world: &mut World, parent: Entity, child: Entity) {
-    let mut parent = world.entity_mut(parent);
-    if let Some(mut children) = parent.get_mut::<Children>() {
-        children.0.retain(|x| *x != child);
-        if children.is_empty() {
-            parent.remove::<Children>();
+    if let Some(mut parent) = world.get_entity_mut(parent) {
+        if let Some(mut children) = parent.get_mut::<Children>() {
+            children.0.retain(|x| *x != child);
+            if children.is_empty() {
+                parent.remove::<Children>();
+            }
         }
     }
 }


### PR DESCRIPTION
# Objective
When changing an Entity's `Parent` to a new one from an old `Parent` that doesn't exist, Bevy panics. Fixes #8337.

## Solution

Use `get_entity_mut` instead of `entity_mut` in `remove_from_children`.
