### PR TITLE
added multi-line string formatting

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -141,16 +141,23 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
                 Ok(*entry.insert(match layout_map.entry(key) {
                     Entry::Occupied(entry) => {
                         if cfg!(debug_assertions) {
-                            let stored_descriptor = cache.get_render_pipeline_descriptor(*entry.get());
+                            let stored_descriptor =
+                                cache.get_render_pipeline_descriptor(*entry.get());
                             if stored_descriptor != &descriptor {
-                                error!("The cached pipeline descriptor for {} is not equal to the generated descriptor for the given key. This means the SpecializePipeline implementation uses 'unused' MeshVertexBufferLayout information to specialize the pipeline. This is not allowed because it would invalidate the pipeline cache.", std::any::type_name::<S>());
+                                error!(
+                                    "The cached pipeline descriptor for {} is not \
+                                equal to the generated descriptor for the given key. \
+                                This means the SpecializePipeline implementation uses \ 
+                                unused' MeshVertexBufferLayout information to specialize \
+                                the pipeline. This is not allowed because it would invalidate \
+                                the pipeline cache.",
+                                    std::any::type_name::<S>()
+                                );
                             }
                         }
                         *entry.into_mut()
                     }
-                    Entry::Vacant(entry) => {
-                        *entry.insert(cache.queue_render_pipeline(descriptor))
-                    }
+                    Entry::Vacant(entry) => *entry.insert(cache.queue_render_pipeline(descriptor)),
                 }))
             }
         }

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -147,7 +147,7 @@ impl<S: SpecializedMeshPipeline> SpecializedMeshPipelines<S> {
                                 error!(
                                     "The cached pipeline descriptor for {} is not \
                                 equal to the generated descriptor for the given key. \
-                                This means the SpecializePipeline implementation uses \ 
+                                This means the SpecializePipeline implementation uses \
                                 unused' MeshVertexBufferLayout information to specialize \
                                 the pipeline. This is not allowed because it would invalidate \
                                 the pipeline cache.",


### PR DESCRIPTION
# Objective

fixes #8348

## Solution

- Uses multi-line string with backslashes allowing rustfmt to work properly in the surrounding area.