### PR TITLE
Constrain values in uniform buffers to `ShaderSize`.

### DIFF
--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -1,5 +1,5 @@
 use crate::{
-    render_resource::{encase::internal::WriteInto, DynamicUniformBuffer, ShaderType},
+    render_resource::{encase::internal::WriteInto, DynamicUniformBuffer, ShaderSize},
     renderer::{RenderDevice, RenderQueue},
     view::ComputedVisibility,
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
@@ -78,7 +78,7 @@ impl<C> Default for UniformComponentPlugin<C> {
     }
 }
 
-impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
+impl<C: Component + ShaderSize + WriteInto + Clone> Plugin for UniformComponentPlugin<C> {
     fn build(&self, app: &mut App) {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app
@@ -93,11 +93,11 @@ impl<C: Component + ShaderType + WriteInto + Clone> Plugin for UniformComponentP
 
 /// Stores all uniforms of the component type.
 #[derive(Resource)]
-pub struct ComponentUniforms<C: Component + ShaderType> {
+pub struct ComponentUniforms<C: Component + ShaderSize> {
     uniforms: DynamicUniformBuffer<C>,
 }
 
-impl<C: Component + ShaderType> Deref for ComponentUniforms<C> {
+impl<C: Component + ShaderSize> Deref for ComponentUniforms<C> {
     type Target = DynamicUniformBuffer<C>;
 
     #[inline]
@@ -106,14 +106,14 @@ impl<C: Component + ShaderType> Deref for ComponentUniforms<C> {
     }
 }
 
-impl<C: Component + ShaderType> ComponentUniforms<C> {
+impl<C: Component + ShaderSize> ComponentUniforms<C> {
     #[inline]
     pub fn uniforms(&self) -> &DynamicUniformBuffer<C> {
         &self.uniforms
     }
 }
 
-impl<C: Component + ShaderType> Default for ComponentUniforms<C> {
+impl<C: Component + ShaderSize> Default for ComponentUniforms<C> {
     fn default() -> Self {
         Self {
             uniforms: Default::default(),
@@ -130,7 +130,7 @@ fn prepare_uniform_components<C: Component>(
     mut component_uniforms: ResMut<ComponentUniforms<C>>,
     components: Query<(Entity, &C)>,
 ) where
-    C: ShaderType + WriteInto + Clone,
+    C: ShaderSize + WriteInto + Clone,
 {
     component_uniforms.uniforms.clear();
     let entities = components

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -5,7 +5,7 @@ use crate::{
     renderer::{RenderDevice, RenderQueue},
 };
 use encase::{
-    internal::WriteInto, DynamicUniformBuffer as DynamicUniformBufferWrapper, ShaderType,
+    internal::WriteInto, DynamicUniformBuffer as DynamicUniformBufferWrapper, ShaderSize,
     UniformBuffer as UniformBufferWrapper,
 };
 use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsages};
@@ -29,7 +29,7 @@ use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsa
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std140 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-uniform
-pub struct UniformBuffer<T: ShaderType> {
+pub struct UniformBuffer<T: ShaderSize> {
     value: T,
     scratch: UniformBufferWrapper<Vec<u8>>,
     buffer: Option<Buffer>,
@@ -38,7 +38,7 @@ pub struct UniformBuffer<T: ShaderType> {
     buffer_usage: BufferUsages,
 }
 
-impl<T: ShaderType> From<T> for UniformBuffer<T> {
+impl<T: ShaderSize> From<T> for UniformBuffer<T> {
     fn from(value: T) -> Self {
         Self {
             value,
@@ -51,7 +51,7 @@ impl<T: ShaderType> From<T> for UniformBuffer<T> {
     }
 }
 
-impl<T: ShaderType + Default> Default for UniformBuffer<T> {
+impl<T: ShaderSize + Default> Default for UniformBuffer<T> {
     fn default() -> Self {
         Self {
             value: T::default(),
@@ -64,7 +64,7 @@ impl<T: ShaderType + Default> Default for UniformBuffer<T> {
     }
 }
 
-impl<T: ShaderType + WriteInto> UniformBuffer<T> {
+impl<T: ShaderSize + WriteInto> UniformBuffer<T> {
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
@@ -154,7 +154,7 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
 /// * [`Texture`](crate::render_resource::Texture)
 ///
 /// [std140 alignment/padding requirements]: https://www.w3.org/TR/WGSL/#address-spaces-uniform
-pub struct DynamicUniformBuffer<T: ShaderType> {
+pub struct DynamicUniformBuffer<T: ShaderSize> {
     scratch: DynamicUniformBufferWrapper<Vec<u8>>,
     buffer: Option<Buffer>,
     label: Option<String>,
@@ -163,7 +163,7 @@ pub struct DynamicUniformBuffer<T: ShaderType> {
     _marker: PhantomData<fn() -> T>,
 }
 
-impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
+impl<T: ShaderSize> Default for DynamicUniformBuffer<T> {
     fn default() -> Self {
         Self {
             scratch: DynamicUniformBufferWrapper::new(Vec::new()),
@@ -176,7 +176,7 @@ impl<T: ShaderType> Default for DynamicUniformBuffer<T> {
     }
 }
 
-impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
+impl<T: ShaderSize + WriteInto> DynamicUniformBuffer<T> {
     #[inline]
     pub fn buffer(&self) -> Option<&Buffer> {
         self.buffer.as_ref()
@@ -197,6 +197,9 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     }
 
     /// Push data into the `DynamicUniformBuffer`'s internal vector (residing on system RAM).
+    ///
+    /// Returns the dynamic offset of the pushed value in this buffer, which may later be passed to
+    /// [set_bind_group](wgpu::RenderPass::set_bind_group) as the `offsets` parameter, in bind order.
     #[inline]
     pub fn push(&mut self, value: T) -> u32 {
         self.scratch.write(&value).unwrap() as u32

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -199,7 +199,7 @@ impl<T: ShaderSize + WriteInto> DynamicUniformBuffer<T> {
     /// Push data into the `DynamicUniformBuffer`'s internal vector (residing on system RAM).
     ///
     /// Returns the dynamic offset of the pushed value in this buffer, which may later be passed to
-    /// [set_bind_group](wgpu::RenderPass::set_bind_group) as the `offsets` parameter, in bind order.
+    /// [`set_bind_group`](wgpu::RenderPass::set_bind_group) as the `offsets` parameter, in bind order.
     #[inline]
     pub fn push(&mut self, value: T) -> u32 {
         self.scratch.write(&value).unwrap() as u32


### PR DESCRIPTION
# Objective

Fixes #8351 

## Solution

- Replace ShaderType with ShaderSize in relevant files.

---

## Changelog

- Values written to uniform buffers are checked to ensure they are fixed-size at compile time.

## Migration Guide

- If you `#[derive(ShaderType)]`, no changes are needed because this derive automatically implements `ShaderSize` on acceptable types.
- If you explicitly use `ShaderType` as a trait bound, this should be changed to `ShaderSize` if the type will be written to a uniform buffer, as appropriate.
