### PR TITLE
fix collide_aabb

### DIFF
--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -23,8 +23,8 @@ pub enum Collision {
 /// If all sides are involved, `Inside` is returned.
 pub fn collide(a_pos: Vec3, a_size: Vec2, b_pos: Vec3, b_size: Vec2) -> Option<Collision> {
     let Vec2 { x: xa, y: ya } = a_pos.truncate(); // x and y of center of a
-    let Vec2 { x: wa, y: ha } = a_size * 0.5;  // half width and height of a
-    let Vec2 { x: xb, y: yb } = b_pos.truncate(); 
+    let Vec2 { x: wa, y: ha } = a_size * 0.5; // half width and height of a
+    let Vec2 { x: xb, y: yb } = b_pos.truncate();
     let Vec2 { x: wb, y: hb } = b_size * 0.5;
     let dis_x = (xa - xb).abs();
     let dis_y = (ya - yb).abs();
@@ -33,7 +33,7 @@ pub fn collide(a_pos: Vec3, a_size: Vec2, b_pos: Vec3, b_size: Vec2) -> Option<C
 
     if dis_x >= (wa + wb).abs() || dis_y >= (ha + hb).abs() {
         return None; // a is separated from b or is tangent to b
-    } 
+    }
 
     let (x_collision, x_depth) = if dis_x <= (wa - wb).abs() {
         (Collision::Inside, 0.0)

--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -51,7 +51,8 @@ pub fn collide(a_pos: Vec3, a_size: Vec2, b_pos: Vec3, b_size: Vec2) -> Option<C
         (Collision::Top, (yb + hb) - (ya - ha)) // top_b - bottom_a
     };
 
-    if y_depth > x_depth { // choose deepest
+    // choose deepest
+    if y_depth > x_depth {
         Some(y_collision)
     } else {
         Some(x_collision)

--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -51,7 +51,7 @@ pub fn collide(a_pos: Vec3, a_size: Vec2, b_pos: Vec3, b_size: Vec2) -> Option<C
         };
 
         // if we had an "x" and a "y" collision, pick the "primary" side using penetration depth
-        if y_depth.abs() < x_depth.abs() {
+        if y_depth.abs() > x_depth.abs() {
             Some(y_collision)
         } else {
             Some(x_collision)
@@ -179,13 +179,13 @@ mod test {
             (3., 3., 2., 2.),
             (2.5, 2.,2., 2.),
         );
-        assert_eq!(res, Some(Collision::Top));
+        assert_eq!(res, Some(Collision::Right));
         // Top-right collision
         #[rustfmt::skip]
         let res = collide_two_rectangles(
             (3., 3., 2., 2.),
             (2., 2.5, 2., 2.),
         );
-        assert_eq!(res, Some(Collision::Right));
+        assert_eq!(res, Some(Collision::Top));
     }
 }


### PR DESCRIPTION
# Objective

It says in comments, "If the collision occurs on multiple sides, the side with the deepest penetration is returned." But it did the opposite: when x_depth is more than y_depth, it chooses y_collision.  And the unit test did the same.

## Solution

Choose y_collision when y_depth is more than y_depth.
