### PR TITLE
Use let else

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -512,18 +512,19 @@ impl AssetServer {
             let asset_sources = self.server.asset_sources.read();
             let asset_lifecycles = self.server.asset_lifecycles.read();
             for potential_free in potential_frees.drain(..) {
-                if let Some(&0) = ref_counts.get(&potential_free) {
-                    let type_uuid = match potential_free {
-                        HandleId::Id(type_uuid, _) => Some(type_uuid),
-                        HandleId::AssetPathId(id) => asset_sources
-                            .get(&id.source_path_id())
-                            .and_then(|source_info| source_info.get_asset_type(id.label_id())),
-                    };
+                let Some(&0) = ref_counts.get(&potential_free) else {
+                    continue;
+                };
+                let type_uuid = match potential_free {
+                    HandleId::Id(type_uuid, _) => Some(type_uuid),
+                    HandleId::AssetPathId(id) => asset_sources
+                        .get(&id.source_path_id())
+                        .and_then(|source_info| source_info.get_asset_type(id.label_id())),
+                };
 
-                    if let Some(type_uuid) = type_uuid {
-                        if let Some(asset_lifecycle) = asset_lifecycles.get(&type_uuid) {
-                            asset_lifecycle.free_asset(potential_free);
-                        }
+                if let Some(type_uuid) = type_uuid {
+                    if let Some(asset_lifecycle) = asset_lifecycles.get(&type_uuid) {
+                        asset_lifecycle.free_asset(potential_free);
                     }
                 }
             }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -175,12 +175,9 @@ impl AssetIo for FileAssetIo {
     all(not(target_arch = "wasm32"), not(target_os = "android"))
 ))]
 pub fn filesystem_watcher_system(asset_server: Res<AssetServer>) {
-    let asset_io =
-        if let Some(asset_io) = asset_server.server.asset_io.downcast_ref::<FileAssetIo>() {
-            asset_io
-        } else {
-            return;
-        };
+    let Some(asset_io) = asset_server.server.asset_io.downcast_ref::<FileAssetIo>() else {
+        return;
+    };
     let watcher = asset_io.filesystem_watcher.read();
     if let Some(ref watcher) = *watcher {
         let mut changed = HashSet::<&PathBuf>::default();

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -320,35 +320,35 @@ fn prepare_bloom_textures(
     views: Query<(Entity, &ExtractedCamera), With<BloomSettings>>,
 ) {
     for (entity, camera) in &views {
-        if let Some(UVec2 {
+        let Some(UVec2 {
             x: width,
             y: height,
-        }) = camera.physical_viewport_size
-        {
-            // How many times we can halve the resolution minus one so we don't go unnecessarily low
-            let mip_count = MAX_MIP_DIMENSION.ilog2().max(2) - 1;
-            let mip_height_ratio = MAX_MIP_DIMENSION as f32 / height as f32;
+        }) = camera.physical_viewport_size else {
+            continue;
+        };
+        // How many times we can halve the resolution minus one so we don't go unnecessarily low
+        let mip_count = MAX_MIP_DIMENSION.ilog2().max(2) - 1;
+        let mip_height_ratio = MAX_MIP_DIMENSION as f32 / height as f32;
 
-            let texture_descriptor = TextureDescriptor {
-                label: Some("bloom_texture"),
-                size: Extent3d {
-                    width: ((width as f32 * mip_height_ratio).round() as u32).max(1),
-                    height: ((height as f32 * mip_height_ratio).round() as u32).max(1),
-                    depth_or_array_layers: 1,
-                },
-                mip_level_count: mip_count,
-                sample_count: 1,
-                dimension: TextureDimension::D2,
-                format: BLOOM_TEXTURE_FORMAT,
-                usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
-                view_formats: &[],
-            };
+        let texture_descriptor = TextureDescriptor {
+            label: Some("bloom_texture"),
+            size: Extent3d {
+                width: ((width as f32 * mip_height_ratio).round() as u32).max(1),
+                height: ((height as f32 * mip_height_ratio).round() as u32).max(1),
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: mip_count,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: BLOOM_TEXTURE_FORMAT,
+            usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+            view_formats: &[],
+        };
 
-            commands.entity(entity).insert(BloomTexture {
-                texture: texture_cache.get(&render_device, texture_descriptor),
-                mip_count,
-            });
-        }
+        commands.entity(entity).insert(BloomTexture {
+            texture: texture_cache.get(&render_device, texture_descriptor),
+            mip_count,
+        });
     }
 }
 

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -56,10 +56,7 @@ impl Plugin for BloomPlugin {
         app.add_plugin(ExtractComponentPlugin::<BloomSettings>::default());
         app.add_plugin(UniformComponentPlugin::<BloomUniforms>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
         render_app
             .init_resource::<BloomDownsamplingPipeline>()

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -111,10 +111,7 @@ impl Plugin for CASPlugin {
         app.add_plugin(ExtractComponentPlugin::<ContrastAdaptiveSharpeningSettings>::default());
         app.add_plugin(UniformComponentPlugin::<CASUniform>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
         render_app
             .init_resource::<CASPipeline>()
             .init_resource::<SpecializedRenderPipelines<CASPipeline>>()

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -46,13 +46,11 @@ impl Node for MainPass2dNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
-        let (camera, transparent_phase, target, camera_2d) =
-            if let Ok(result) = self.query.get_manual(world, view_entity) {
-                result
-            } else {
-                // no target
-                return Ok(());
-            };
+        let Ok(components) = self.query.get_manual(world, view_entity) else {
+            // no target
+            return Ok(());
+        };
+        let (camera, transparent_phase, target, camera_2d) = components;
         {
             #[cfg(feature = "trace")]
             let _main_pass_2d = info_span!("main_pass_2d").entered();

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -47,10 +47,7 @@ impl Plugin for Core2dPlugin {
         app.register_type::<Camera2d>()
             .add_plugin(ExtractComponentPlugin::<Camera2d>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
         render_app
             .init_resource::<DrawFunctions<Transparent2d>>()

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -68,10 +68,7 @@ impl Plugin for Core3dPlugin {
             .add_plugin(SkyboxPlugin)
             .add_plugin(ExtractComponentPlugin::<Camera3d>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
         render_app
             .init_resource::<DrawFunctions<Opaque3d>>()

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -87,10 +87,8 @@ impl Plugin for FxaaPlugin {
 
         app.add_plugin(ExtractComponentPlugin::<Fxaa>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+
         render_app
             .init_resource::<FxaaPipeline>()
             .init_resource::<SpecializedRenderPipelines<FxaaPipeline>>()

--- a/crates/bevy_core_pipeline/src/fxaa/node.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/node.rs
@@ -51,10 +51,7 @@ impl Node for FxaaNode {
         let pipeline_cache = world.resource::<PipelineCache>();
         let fxaa_pipeline = world.resource::<FxaaPipeline>();
 
-        let (target, pipeline, fxaa) = match self.query.get_manual(world, view_entity) {
-            Ok(result) => result,
-            Err(_) => return Ok(()),
-        };
+        let Ok((target, pipeline, fxaa)) = self.query.get_manual(world, view_entity) else { return Ok(()) };
 
         if !fxaa.enabled {
             return Ok(());

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -207,29 +207,28 @@ fn queue_skybox_bind_groups(
     views: Query<(Entity, &Skybox)>,
 ) {
     for (entity, skybox) in &views {
-        if let (Some(skybox), Some(view_uniforms)) =
-            (images.get(&skybox.0), view_uniforms.uniforms.binding())
-        {
-            let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
-                label: Some("skybox_bind_group"),
-                layout: &pipeline.bind_group_layout,
-                entries: &[
-                    BindGroupEntry {
-                        binding: 0,
-                        resource: BindingResource::TextureView(&skybox.texture_view),
-                    },
-                    BindGroupEntry {
-                        binding: 1,
-                        resource: BindingResource::Sampler(&skybox.sampler),
-                    },
-                    BindGroupEntry {
-                        binding: 2,
-                        resource: view_uniforms,
-                    },
-                ],
-            });
+        let (Some(skybox), Some(view_uniforms)) = (images.get(&skybox.0), view_uniforms.uniforms.binding()) else {
+            continue;
+        };
+        let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+            label: Some("skybox_bind_group"),
+            layout: &pipeline.bind_group_layout,
+            entries: &[
+                BindGroupEntry {
+                    binding: 0,
+                    resource: BindingResource::TextureView(&skybox.texture_view),
+                },
+                BindGroupEntry {
+                    binding: 1,
+                    resource: BindingResource::Sampler(&skybox.sampler),
+                },
+                BindGroupEntry {
+                    binding: 2,
+                    resource: view_uniforms,
+                },
+            ],
+        });
 
-            commands.entity(entity).insert(SkyboxBindGroup(bind_group));
-        }
+        commands.entity(entity).insert(SkyboxBindGroup(bind_group));
     }
 }

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -36,10 +36,7 @@ impl Plugin for SkyboxPlugin {
 
         app.add_plugin(ExtractComponentPlugin::<Skybox>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
         let render_device = render_app.world.resource::<RenderDevice>().clone();
 

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -480,46 +480,47 @@ fn prepare_taa_history_textures(
     views: Query<(Entity, &ExtractedCamera, &ExtractedView), With<TemporalAntiAliasSettings>>,
 ) {
     for (entity, camera, view) in &views {
-        if let Some(physical_viewport_size) = camera.physical_viewport_size {
-            let mut texture_descriptor = TextureDescriptor {
-                label: None,
-                size: Extent3d {
-                    depth_or_array_layers: 1,
-                    width: physical_viewport_size.x,
-                    height: physical_viewport_size.y,
-                },
-                mip_level_count: 1,
-                sample_count: 1,
-                dimension: TextureDimension::D2,
-                format: if view.hdr {
-                    ViewTarget::TEXTURE_FORMAT_HDR
-                } else {
-                    TextureFormat::bevy_default()
-                },
-                usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
-                view_formats: &[],
-            };
-
-            texture_descriptor.label = Some("taa_history_1_texture");
-            let history_1_texture = texture_cache.get(&render_device, texture_descriptor.clone());
-
-            texture_descriptor.label = Some("taa_history_2_texture");
-            let history_2_texture = texture_cache.get(&render_device, texture_descriptor);
-
-            let textures = if frame_count.0 % 2 == 0 {
-                TAAHistoryTextures {
-                    write: history_1_texture,
-                    read: history_2_texture,
-                }
+        let Some(physical_viewport_size) = camera.physical_viewport_size else {
+            continue;
+        };
+        let mut texture_descriptor = TextureDescriptor {
+            label: None,
+            size: Extent3d {
+                depth_or_array_layers: 1,
+                width: physical_viewport_size.x,
+                height: physical_viewport_size.y,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: TextureDimension::D2,
+            format: if view.hdr {
+                ViewTarget::TEXTURE_FORMAT_HDR
             } else {
-                TAAHistoryTextures {
-                    write: history_2_texture,
-                    read: history_1_texture,
-                }
-            };
+                TextureFormat::bevy_default()
+            },
+            usage: TextureUsages::TEXTURE_BINDING | TextureUsages::RENDER_ATTACHMENT,
+            view_formats: &[],
+        };
 
-            commands.entity(entity).insert(textures);
-        }
+        texture_descriptor.label = Some("taa_history_1_texture");
+        let history_1_texture = texture_cache.get(&render_device, texture_descriptor.clone());
+
+        texture_descriptor.label = Some("taa_history_2_texture");
+        let history_2_texture = texture_cache.get(&render_device, texture_descriptor);
+
+        let textures = if frame_count.0 % 2 == 0 {
+            TAAHistoryTextures {
+                write: history_1_texture,
+                read: history_2_texture,
+            }
+        } else {
+            TAAHistoryTextures {
+                write: history_2_texture,
+                read: history_1_texture,
+            }
+        };
+
+        commands.entity(entity).insert(textures);
     }
 }
 

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -62,19 +62,18 @@ impl Node for TonemappingNode {
         let view_uniforms = &view_uniforms_resource.uniforms;
         let view_uniforms_id = view_uniforms.buffer().unwrap().id();
 
-        let (view_uniform_offset, target, view_tonemapping_pipeline, tonemapping) =
-            match self.query.get_manual(world, view_entity) {
-                Ok(result) => result,
-                Err(_) => return Ok(()),
-            };
+        let Ok(components) = self.query.get_manual(world, view_entity) else {
+            return Ok(());
+        };
+
+        let (view_uniform_offset, target, view_tonemapping_pipeline, tonemapping) = components;
 
         if !target.is_hdr() {
             return Ok(());
         }
 
-        let pipeline = match pipeline_cache.get_render_pipeline(view_tonemapping_pipeline.0) {
-            Some(pipeline) => pipeline,
-            None => return Ok(()),
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(view_tonemapping_pipeline.0) else {
+            return Ok(());
         };
 
         let post_process = target.post_process_write();

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -51,9 +51,8 @@ impl Node for UpscalingNode {
         let pipeline_cache = world.get_resource::<PipelineCache>().unwrap();
         let blit_pipeline = world.get_resource::<BlitPipeline>().unwrap();
 
-        let (target, upscaling_target, camera) = match self.query.get_manual(world, view_entity) {
-            Ok(query) => query,
-            Err(_) => return Ok(()),
+        let Ok((target, upscaling_target, camera)) = self.query.get_manual(world, view_entity) else {
+            return Ok(());
         };
 
         let color_attachment_load_op = if let Some(camera) = camera {
@@ -101,9 +100,8 @@ impl Node for UpscalingNode {
             }
         };
 
-        let pipeline = match pipeline_cache.get_render_pipeline(upscaling_target.0) {
-            Some(pipeline) => pipeline,
-            None => return Ok(()),
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(upscaling_target.0) else {
+            return Ok(());
         };
 
         let pass_descriptor = RenderPassDescriptor {

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -53,31 +53,32 @@ impl LogDiagnosticsPlugin {
     }
 
     fn log_diagnostic(diagnostic: &Diagnostic) {
-        if let Some(value) = diagnostic.smoothed() {
-            if diagnostic.get_max_history_length() > 1 {
-                if let Some(average) = diagnostic.average() {
-                    info!(
-                        target: "bevy diagnostic",
-                        // Suffix is only used for 's' or 'ms' currently,
-                        // so we reserve two columns for it; however,
-                        // Do not reserve columns for the suffix in the average
-                        // The ) hugging the value is more aesthetically pleasing
-                        "{name:<name_width$}: {value:>11.6}{suffix:2} (avg {average:>.6}{suffix:})",
-                        name = diagnostic.name,
-                        suffix = diagnostic.suffix,
-                        name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
-                    );
-                    return;
-                }
+        let Some(value) = diagnostic.smoothed() else {
+            return;
+        };
+        if diagnostic.get_max_history_length() > 1 {
+            if let Some(average) = diagnostic.average() {
+                info!(
+                    target: "bevy diagnostic",
+                    // Suffix is only used for 's' or 'ms' currently,
+                    // so we reserve two columns for it; however,
+                    // Do not reserve columns for the suffix in the average
+                    // The ) hugging the value is more aesthetically pleasing
+                    "{name:<name_width$}: {value:>11.6}{suffix:2} (avg {average:>.6}{suffix:})",
+                    name = diagnostic.name,
+                    suffix = diagnostic.suffix,
+                    name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+                );
+                return;
             }
-            info!(
-                target: "bevy diagnostic",
-                "{name:<name_width$}: {value:>.6}{suffix:}",
-                name = diagnostic.name,
-                suffix = diagnostic.suffix,
-                name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
-            );
         }
+        info!(
+            target: "bevy diagnostic",
+            "{name:<name_width$}: {value:>.6}{suffix:}",
+            name = diagnostic.name,
+            suffix = diagnostic.suffix,
+            name_width = crate::MAX_DIAGNOSTIC_NAME_WIDTH,
+        );
     }
 
     fn log_diagnostics_system(

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -125,10 +125,7 @@ where
     unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<Q::Item<'w>> {
         for entity in self.entity_iter.by_ref() {
             let entity = *entity.borrow();
-            let location = match self.entities.get(entity) {
-                Some(location) => location,
-                None => continue,
-            };
+            let Some(location) = self.entities.get(entity) else { continue };
 
             if !self
                 .query_state

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -126,21 +126,22 @@ pub fn apply_state_transition<S: States>(world: &mut World) {
     // We want to take the `NextState` resource,
     // but only mark it as changed if it wasn't empty.
     let mut next_state_resource = world.resource_mut::<NextState<S>>();
-    if let Some(entered) = next_state_resource.bypass_change_detection().0.take() {
-        next_state_resource.set_changed();
+    let Some(entered) = next_state_resource.bypass_change_detection().0.take() else {
+        return;
+    };
+    next_state_resource.set_changed();
 
-        let mut state_resource = world.resource_mut::<State<S>>();
-        if *state_resource != entered {
-            let exited = mem::replace(&mut state_resource.0, entered.clone());
-            // Try to run the schedules if they exist.
-            world.try_run_schedule(OnExit(exited.clone())).ok();
-            world
-                .try_run_schedule(OnTransition {
-                    from: exited,
-                    to: entered.clone(),
-                })
-                .ok();
-            world.try_run_schedule(OnEnter(entered)).ok();
-        }
+    let mut state_resource = world.resource_mut::<State<S>>();
+    if *state_resource != entered {
+        let exited = mem::replace(&mut state_resource.0, entered.clone());
+        // Try to run the schedules if they exist.
+        world.try_run_schedule(OnExit(exited.clone())).ok();
+        world
+            .try_run_schedule(OnTransition {
+                from: exited,
+                to: entered.clone(),
+            })
+            .ok();
+        world.try_run_schedule(OnEnter(entered)).ok();
     }
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -315,26 +315,25 @@ impl ComponentSparseSet {
     ///
     /// Returns `true` if `entity` had a component value in the sparse set.
     pub(crate) fn remove(&mut self, entity: Entity) -> bool {
-        if let Some(dense_index) = self.sparse.remove(entity.index()) {
-            let dense_index = dense_index as usize;
+        let Some(dense_index) = self.sparse.remove(entity.index()) else {
+            return false;
+        };
+        let dense_index = dense_index as usize;
+        #[cfg(debug_assertions)]
+        assert_eq!(entity, self.entities[dense_index]);
+        self.entities.swap_remove(dense_index);
+        let is_last = dense_index == self.dense.len() - 1;
+        // SAFETY: if the sparse index points to something in the dense vec, it exists
+        unsafe { self.dense.swap_remove_unchecked(TableRow::new(dense_index)) }
+        if !is_last {
+            let swapped_entity = self.entities[dense_index];
+            #[cfg(not(debug_assertions))]
+            let index = swapped_entity;
             #[cfg(debug_assertions)]
-            assert_eq!(entity, self.entities[dense_index]);
-            self.entities.swap_remove(dense_index);
-            let is_last = dense_index == self.dense.len() - 1;
-            // SAFETY: if the sparse index points to something in the dense vec, it exists
-            unsafe { self.dense.swap_remove_unchecked(TableRow::new(dense_index)) }
-            if !is_last {
-                let swapped_entity = self.entities[dense_index];
-                #[cfg(not(debug_assertions))]
-                let index = swapped_entity;
-                #[cfg(debug_assertions)]
-                let index = swapped_entity.index();
-                *self.sparse.get_mut(index).unwrap() = dense_index as u32;
-            }
-            true
-        } else {
-            false
+            let index = swapped_entity.index();
+            *self.sparse.get_mut(index).unwrap() = dense_index as u32;
         }
+        true
     }
 
     pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -555,10 +555,7 @@ impl<'w> UnsafeEntityCell<'w> {
 
     #[inline]
     pub fn contains_type_id(self, type_id: TypeId) -> bool {
-        let id = match self.world.components().get_id(type_id) {
-            Some(id) => id,
-            None => return false,
-        };
+        let Some(id) = self.world.components().get_id(type_id) else { return false };
         self.contains_id(id)
     }
 

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -142,23 +142,24 @@ pub(crate) fn queue_gizmos_3d(
     for (view, mut phase) in &mut views {
         let key = key | MeshPipelineKey::from_hdr(view.hdr);
         for (entity, mesh_handle) in &mesh_handles {
-            if let Some(mesh) = render_meshes.get(mesh_handle) {
-                let key = key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                let pipeline = pipelines
-                    .specialize(
-                        &pipeline_cache,
-                        &pipeline,
-                        (!config.on_top, key),
-                        &mesh.layout,
-                    )
-                    .unwrap();
-                phase.add(Opaque3d {
-                    entity,
-                    pipeline,
-                    draw_function,
-                    distance: 0.,
-                });
-            }
+            let Some(mesh) = render_meshes.get(mesh_handle) else {
+                continue;
+            };
+            let key = key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let pipeline = pipelines
+                .specialize(
+                    &pipeline_cache,
+                    &pipeline,
+                    (!config.on_top, key),
+                    &mesh.layout,
+                )
+                .unwrap();
+            phase.add(Opaque3d {
+                entity,
+                pipeline,
+                draw_function,
+                distance: 0.,
+            });
         }
     }
 }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -242,10 +242,7 @@ impl Plugin for PbrPlugin {
                 },
             );
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
-        };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
         // Extract the required data from the main world
         render_app

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1185,10 +1185,7 @@ pub(crate) fn assign_lights_to_clusters(
     mut max_point_lights_warning_emitted: Local<bool>,
     render_device: Option<Res<RenderDevice>>,
 ) {
-    let render_device = match render_device {
-        Some(render_device) => render_device,
-        None => return,
-    };
+    let Some(render_device) = render_device else { return };
 
     global_lights.entities.clear();
     lights.clear();

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -119,29 +119,26 @@ fn queue_wireframes(
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let add_render_phase =
             |(entity, mesh_handle, mesh_uniform): (Entity, &Handle<Mesh>, &MeshUniform)| {
-                if let Some(mesh) = render_meshes.get(mesh_handle) {
-                    let key = view_key
-                        | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                    let pipeline_id = pipelines.specialize(
-                        &pipeline_cache,
-                        &wireframe_pipeline,
-                        key,
-                        &mesh.layout,
-                    );
-                    let pipeline_id = match pipeline_id {
-                        Ok(id) => id,
-                        Err(err) => {
-                            error!("{}", err);
-                            return;
-                        }
-                    };
-                    opaque_phase.add(Opaque3d {
-                        entity,
-                        pipeline: pipeline_id,
-                        draw_function: draw_custom,
-                        distance: rangefinder.distance(&mesh_uniform.transform),
-                    });
-                }
+                let Some(mesh) = render_meshes.get(mesh_handle) else {
+                    return;
+                };
+                let key =
+                    view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+                let pipeline_id =
+                    pipelines.specialize(&pipeline_cache, &wireframe_pipeline, key, &mesh.layout);
+                let pipeline_id = match pipeline_id {
+                    Ok(id) => id,
+                    Err(err) => {
+                        error!("{}", err);
+                        return;
+                    }
+                };
+                opaque_phase.add(Opaque3d {
+                    entity,
+                    pipeline: pipeline_id,
+                    draw_function: draw_custom,
+                    distance: rangefinder.distance(&mesh_uniform.transform),
+                });
             };
 
         if wireframe_config.global {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -29,10 +29,7 @@ pub(crate) fn type_uuid_derive(input: proc_macro::TokenStream) -> proc_macro::To
             continue;
         }
 
-        let uuid_str = match name_value.lit {
-            Lit::Str(lit_str) => lit_str,
-            _ => panic!("`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"`."),
-        };
+        let Lit::Str(uuid_str) = name_value.lit else { panic!("`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"`.") };
 
         uuid = Some(
             Uuid::parse_str(&uuid_str.value())

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -607,49 +607,51 @@ pub fn extract_cameras(
             continue;
         }
 
-        if let (Some((viewport_origin, _)), Some(viewport_size), Some(target_size)) = (
+        let (Some((viewport_origin, _)), Some(viewport_size), Some(target_size)) = (
             camera.physical_viewport_rect(),
             camera.physical_viewport_size(),
             camera.physical_target_size(),
-        ) {
-            if target_size.x == 0 || target_size.y == 0 {
-                continue;
-            }
+        ) else {
+            continue;
+        };
 
-            let mut commands = commands.get_or_spawn(entity);
+        if target_size.x == 0 || target_size.y == 0 {
+            continue;
+        }
 
-            commands.insert((
-                ExtractedCamera {
-                    target: camera.target.normalize(primary_window),
-                    viewport: camera.viewport.clone(),
-                    physical_viewport_size: Some(viewport_size),
-                    physical_target_size: Some(target_size),
-                    render_graph: camera_render_graph.0.clone(),
-                    order: camera.order,
-                    output_mode: camera.output_mode,
-                    msaa_writeback: camera.msaa_writeback,
-                    // this will be set in sort_cameras
-                    sorted_camera_index_for_target: 0,
-                },
-                ExtractedView {
-                    projection: camera.projection_matrix(),
-                    transform: *transform,
-                    view_projection: None,
-                    hdr: camera.hdr,
-                    viewport: UVec4::new(
-                        viewport_origin.x,
-                        viewport_origin.y,
-                        viewport_size.x,
-                        viewport_size.y,
-                    ),
-                    color_grading,
-                },
-                visible_entities.clone(),
-            ));
+        let mut commands = commands.get_or_spawn(entity);
 
-            if let Some(temporal_jitter) = temporal_jitter {
-                commands.insert(temporal_jitter.clone());
-            }
+        commands.insert((
+            ExtractedCamera {
+                target: camera.target.normalize(primary_window),
+                viewport: camera.viewport.clone(),
+                physical_viewport_size: Some(viewport_size),
+                physical_target_size: Some(target_size),
+                render_graph: camera_render_graph.0.clone(),
+                order: camera.order,
+                output_mode: camera.output_mode,
+                msaa_writeback: camera.msaa_writeback,
+                // this will be set in sort_cameras
+                sorted_camera_index_for_target: 0,
+            },
+            ExtractedView {
+                projection: camera.projection_matrix(),
+                transform: *transform,
+                view_projection: None,
+                hdr: camera.hdr,
+                viewport: UVec4::new(
+                    viewport_origin.x,
+                    viewport_origin.y,
+                    viewport_size.x,
+                    viewport_size.y,
+                ),
+                color_grading,
+            },
+            visible_entities.clone(),
+        ));
+
+        if let Some(temporal_jitter) = temporal_jitter {
+            commands.insert(temporal_jitter.clone());
         }
     }
 }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -303,10 +303,7 @@ impl Mesh {
             indices.map(|i| values[i]).collect()
         }
 
-        let indices = match self.indices.take() {
-            Some(indices) => indices,
-            None => return,
-        };
+        let Some(indices) = self.indices.take() else { return };
 
         for attributes in self.attributes.values_mut() {
             let indices = indices.iter();
@@ -954,39 +951,30 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
         other => return Err(GenerateTangentsError::UnsupportedTopology(other)),
     };
 
-    let positions = match mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
+    let VertexAttributeValues::Float32x3(positions) = mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
-    )? {
-        VertexAttributeValues::Float32x3(vertices) => vertices,
-        _ => {
+    )? else {
             return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
                 Mesh::ATTRIBUTE_POSITION.name,
                 VertexFormat::Float32x3,
             ))
-        }
-    };
-    let normals = match mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
+        };
+    let VertexAttributeValues::Float32x3(normals) = mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_NORMAL.name),
-    )? {
-        VertexAttributeValues::Float32x3(vertices) => vertices,
-        _ => {
+    )? else {
             return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
                 Mesh::ATTRIBUTE_NORMAL.name,
                 VertexFormat::Float32x3,
             ))
-        }
-    };
-    let uvs = match mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
+        };
+    let VertexAttributeValues::Float32x2(uvs) = mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_UV_0.name),
-    )? {
-        VertexAttributeValues::Float32x2(vertices) => vertices,
-        _ => {
+    )? else {
             return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
                 Mesh::ATTRIBUTE_UV_0.name,
                 VertexFormat::Float32x2,
             ))
-        }
-    };
+        };
     let indices = mesh
         .indices()
         .ok_or(GenerateTangentsError::MissingIndices)?;

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -381,24 +381,24 @@ impl Mesh {
 
     /// Compute the Axis-Aligned Bounding Box of the mesh vertices in model space
     pub fn compute_aabb(&self) -> Option<Aabb> {
-        if let Some(VertexAttributeValues::Float32x3(values)) =
-            self.attribute(Mesh::ATTRIBUTE_POSITION)
+        let Some(VertexAttributeValues::Float32x3(values)) = self.attribute(Mesh::ATTRIBUTE_POSITION) else {
+            return None;
+        };
+
+        let mut minimum = VEC3_MAX;
+        let mut maximum = VEC3_MIN;
+        for p in values {
+            minimum = minimum.min(Vec3::from_slice(p));
+            maximum = maximum.max(Vec3::from_slice(p));
+        }
+        if minimum.x != std::f32::MAX
+            && minimum.y != std::f32::MAX
+            && minimum.z != std::f32::MAX
+            && maximum.x != std::f32::MIN
+            && maximum.y != std::f32::MIN
+            && maximum.z != std::f32::MIN
         {
-            let mut minimum = VEC3_MAX;
-            let mut maximum = VEC3_MIN;
-            for p in values {
-                minimum = minimum.min(Vec3::from_slice(p));
-                maximum = maximum.max(Vec3::from_slice(p));
-            }
-            if minimum.x != std::f32::MAX
-                && minimum.y != std::f32::MAX
-                && minimum.z != std::f32::MAX
-                && maximum.x != std::f32::MIN
-                && maximum.y != std::f32::MIN
-                && maximum.z != std::f32::MIN
-            {
-                return Some(Aabb::from_min_max(minimum, maximum));
-            }
+            return Some(Aabb::from_min_max(minimum, maximum));
         }
 
         None

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -144,41 +144,44 @@ impl RenderGraph {
         name: impl Into<Cow<'static, str>>,
     ) -> Result<(), RenderGraphError> {
         let name = name.into();
-        if let Some(id) = self.node_names.remove(&name) {
-            if let Some(node_state) = self.nodes.remove(&id) {
-                // Remove all edges from other nodes to this one. Note that as we're removing this
-                // node, we don't need to remove its input edges
-                for input_edge in node_state.edges.input_edges().iter() {
-                    match input_edge {
-                        Edge::SlotEdge { output_node, .. }
-                        | Edge::NodeEdge {
-                            input_node: _,
-                            output_node,
-                        } => {
-                            if let Ok(output_node) = self.get_node_state_mut(*output_node) {
-                                output_node.edges.remove_output_edge(input_edge.clone())?;
-                            }
-                        }
+        let Some(id) = self.node_names.remove(&name) else {
+            return Ok(());
+        };
+        let Some(node_state) = self.nodes.remove(&id) else {
+            return Ok(());
+        };
+
+        // Remove all edges from other nodes to this one. Note that as we're removing this
+        // node, we don't need to remove its input edges
+        for input_edge in node_state.edges.input_edges().iter() {
+            match input_edge {
+                Edge::SlotEdge { output_node, .. }
+                | Edge::NodeEdge {
+                    input_node: _,
+                    output_node,
+                } => {
+                    if let Ok(output_node) = self.get_node_state_mut(*output_node) {
+                        output_node.edges.remove_output_edge(input_edge.clone())?;
                     }
                 }
-                // Remove all edges from this node to other nodes. Note that as we're removing this
-                // node, we don't need to remove its output edges
-                for output_edge in node_state.edges.output_edges().iter() {
-                    match output_edge {
-                        Edge::SlotEdge {
-                            output_node: _,
-                            output_index: _,
-                            input_node,
-                            input_index: _,
-                        }
-                        | Edge::NodeEdge {
-                            output_node: _,
-                            input_node,
-                        } => {
-                            if let Ok(input_node) = self.get_node_state_mut(*input_node) {
-                                input_node.edges.remove_input_edge(output_edge.clone())?;
-                            }
-                        }
+            }
+        }
+        // Remove all edges from this node to other nodes. Note that as we're removing this
+        // node, we don't need to remove its output edges
+        for output_edge in node_state.edges.output_edges().iter() {
+            match output_edge {
+                Edge::SlotEdge {
+                    output_node: _,
+                    output_index: _,
+                    input_node,
+                    input_index: _,
+                }
+                | Edge::NodeEdge {
+                    output_node: _,
+                    input_node,
+                } => {
+                    if let Ok(input_node) = self.get_node_state_mut(*input_node) {
+                        input_node.edges.remove_input_edge(output_edge.clone())?;
                     }
                 }
             }

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -377,87 +377,90 @@ fn prepare_view_targets(
 ) {
     let mut textures = HashMap::default();
     for (entity, camera, view) in cameras.iter() {
-        if let (Some(target_size), Some(target)) = (camera.physical_target_size, &camera.target) {
-            if let (Some(out_texture_view), Some(out_texture_format)) = (
-                target.get_texture_view(&windows, &images),
-                target.get_texture_format(&windows, &images),
-            ) {
-                let size = Extent3d {
-                    width: target_size.x,
-                    height: target_size.y,
-                    depth_or_array_layers: 1,
+        let (Some(target_size), Some(target)) = (camera.physical_target_size, &camera.target) else {
+            continue;
+        };
+
+        let (Some(out_texture_view), Some(out_texture_format)) = (
+            target.get_texture_view(&windows, &images),
+            target.get_texture_format(&windows, &images),
+        ) else {
+            continue;
+        };
+
+        let size = Extent3d {
+            width: target_size.x,
+            height: target_size.y,
+            depth_or_array_layers: 1,
+        };
+
+        let main_texture_format = if view.hdr {
+            ViewTarget::TEXTURE_FORMAT_HDR
+        } else {
+            TextureFormat::bevy_default()
+        };
+
+        let main_textures = textures
+            .entry((camera.target.clone(), view.hdr))
+            .or_insert_with(|| {
+                let descriptor = TextureDescriptor {
+                    label: None,
+                    size,
+                    mip_level_count: 1,
+                    sample_count: 1,
+                    dimension: TextureDimension::D2,
+                    format: main_texture_format,
+                    usage: TextureUsages::RENDER_ATTACHMENT | TextureUsages::TEXTURE_BINDING,
+                    // TODO: Consider changing this if main_texture_format is not sRGB
+                    view_formats: &[],
                 };
+                MainTargetTextures {
+                    a: texture_cache
+                        .get(
+                            &render_device,
+                            TextureDescriptor {
+                                label: Some("main_texture_a"),
+                                ..descriptor
+                            },
+                        )
+                        .default_view,
+                    b: texture_cache
+                        .get(
+                            &render_device,
+                            TextureDescriptor {
+                                label: Some("main_texture_b"),
+                                ..descriptor
+                            },
+                        )
+                        .default_view,
+                    sampled: (msaa.samples() > 1).then(|| {
+                        texture_cache
+                            .get(
+                                &render_device,
+                                TextureDescriptor {
+                                    label: Some("main_texture_sampled"),
+                                    size,
+                                    mip_level_count: 1,
+                                    sample_count: msaa.samples(),
+                                    dimension: TextureDimension::D2,
+                                    format: main_texture_format,
+                                    usage: TextureUsages::RENDER_ATTACHMENT,
+                                    view_formats: &[],
+                                },
+                            )
+                            .default_view
+                    }),
+                    main_texture: Arc::new(AtomicUsize::new(0)),
+                }
+            });
 
-                let main_texture_format = if view.hdr {
-                    ViewTarget::TEXTURE_FORMAT_HDR
-                } else {
-                    TextureFormat::bevy_default()
-                };
-
-                let main_textures = textures
-                    .entry((camera.target.clone(), view.hdr))
-                    .or_insert_with(|| {
-                        let descriptor = TextureDescriptor {
-                            label: None,
-                            size,
-                            mip_level_count: 1,
-                            sample_count: 1,
-                            dimension: TextureDimension::D2,
-                            format: main_texture_format,
-                            usage: TextureUsages::RENDER_ATTACHMENT
-                                | TextureUsages::TEXTURE_BINDING,
-                            // TODO: Consider changing this if main_texture_format is not sRGB
-                            view_formats: &[],
-                        };
-                        MainTargetTextures {
-                            a: texture_cache
-                                .get(
-                                    &render_device,
-                                    TextureDescriptor {
-                                        label: Some("main_texture_a"),
-                                        ..descriptor
-                                    },
-                                )
-                                .default_view,
-                            b: texture_cache
-                                .get(
-                                    &render_device,
-                                    TextureDescriptor {
-                                        label: Some("main_texture_b"),
-                                        ..descriptor
-                                    },
-                                )
-                                .default_view,
-                            sampled: (msaa.samples() > 1).then(|| {
-                                texture_cache
-                                    .get(
-                                        &render_device,
-                                        TextureDescriptor {
-                                            label: Some("main_texture_sampled"),
-                                            size,
-                                            mip_level_count: 1,
-                                            sample_count: msaa.samples(),
-                                            dimension: TextureDimension::D2,
-                                            format: main_texture_format,
-                                            usage: TextureUsages::RENDER_ATTACHMENT,
-                                            view_formats: &[],
-                                        },
-                                    )
-                                    .default_view
-                            }),
-                            main_texture: Arc::new(AtomicUsize::new(0)),
-                        }
-                    });
-
-                commands.entity(entity).insert(ViewTarget {
-                    main_textures: main_textures.clone(),
-                    main_texture_format,
-                    main_texture: main_textures.main_texture.clone(),
-                    out_texture: out_texture_view.clone(),
-                    out_texture_format,
-                });
-            }
-        }
+        commands.entity(entity).insert(ViewTarget {
+            main_textures: main_textures.clone(),
+            main_texture_format,
+            main_texture: main_textures.main_texture.clone(),
+            out_texture: out_texture_view.clone(),
+            out_texture_format,
+        });
     }
 }
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -192,15 +192,16 @@ impl SceneSpawner {
         scene_handles: &[Handle<DynamicScene>],
     ) -> Result<(), SceneSpawnError> {
         for scene_handle in scene_handles {
-            if let Some(spawned_instances) = self.spawned_dynamic_scenes.get(scene_handle) {
-                for instance_id in spawned_instances {
-                    if let Some(instance_info) = self.spawned_instances.get_mut(instance_id) {
-                        Self::spawn_dynamic_internal(
-                            world,
-                            scene_handle,
-                            &mut instance_info.entity_map,
-                        )?;
-                    }
+            let Some(spawned_instances) = self.spawned_dynamic_scenes.get(scene_handle) else {
+                continue;
+            };
+            for instance_id in spawned_instances {
+                if let Some(instance_info) = self.spawned_instances.get_mut(instance_id) {
+                    Self::spawn_dynamic_internal(
+                        world,
+                        scene_handle,
+                        &mut instance_info.entity_map,
+                    )?;
                 }
             }
         }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -373,48 +373,49 @@ pub fn queue_material2d_meshes<M: Material2d>(
         }
 
         for visible_entity in &visible_entities.entities {
-            if let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) =
-                material2d_meshes.get(*visible_entity)
-            {
-                if let Some(material2d) = render_materials.get(material2d_handle) {
-                    if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
-                        let mesh_key = view_key
-                            | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let Ok((material2d_handle, mesh2d_handle, mesh2d_uniform)) = material2d_meshes.get(*visible_entity) else {
+                continue;
+            };
+            let Some(material2d) = render_materials.get(material2d_handle) else {
+                continue;
+            };
+            let Some(mesh) = render_meshes.get(&mesh2d_handle.0) else {
+                continue;
+            };
+            let mesh_key =
+                view_key | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
 
-                        let pipeline_id = pipelines.specialize(
-                            &pipeline_cache,
-                            &material2d_pipeline,
-                            Material2dKey {
-                                mesh_key,
-                                bind_group_data: material2d.key.clone(),
-                            },
-                            &mesh.layout,
-                        );
+            let pipeline_id = pipelines.specialize(
+                &pipeline_cache,
+                &material2d_pipeline,
+                Material2dKey {
+                    mesh_key,
+                    bind_group_data: material2d.key.clone(),
+                },
+                &mesh.layout,
+            );
 
-                        let pipeline_id = match pipeline_id {
-                            Ok(id) => id,
-                            Err(err) => {
-                                error!("{}", err);
-                                continue;
-                            }
-                        };
-
-                        let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                        transparent_phase.add(Transparent2d {
-                            entity: *visible_entity,
-                            draw_function: draw_transparent_pbr,
-                            pipeline: pipeline_id,
-                            // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
-                            // lowest sort key and getting closer should increase. As we have
-                            // -z in front of the camera, the largest distance is -far with values increasing toward the
-                            // camera. As such we can just use mesh_z as the distance
-                            sort_key: FloatOrd(mesh_z),
-                            // This material is not batched
-                            batch_range: None,
-                        });
-                    }
+            let pipeline_id = match pipeline_id {
+                Ok(id) => id,
+                Err(err) => {
+                    error!("{}", err);
+                    continue;
                 }
-            }
+            };
+
+            let mesh_z = mesh2d_uniform.transform.w_axis.z;
+            transparent_phase.add(Transparent2d {
+                entity: *visible_entity,
+                draw_function: draw_transparent_pbr,
+                pipeline: pipeline_id,
+                // NOTE: Back-to-front ordering for transparent with ascending sort means far should have the
+                // lowest sort key and getting closer should increase. As we have
+                // -z in front of the camera, the largest distance is -far with values increasing toward the
+                // camera. As such we can just use mesh_z as the distance
+                sort_key: FloatOrd(mesh_z),
+                // This material is not batched
+                batch_range: None,
+            });
         }
     }
 }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -510,236 +510,227 @@ pub fn queue_sprites(
 
     let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples());
 
-    if let Some(view_binding) = view_uniforms.uniforms.binding() {
-        let sprite_meta = &mut sprite_meta;
+    let Some(view_binding) = view_uniforms.uniforms.binding() else {
+        return;
+    };
 
-        // Clear the vertex buffers
-        sprite_meta.vertices.clear();
-        sprite_meta.colored_vertices.clear();
+    let sprite_meta = &mut sprite_meta;
 
-        sprite_meta.view_bind_group = Some(render_device.create_bind_group(&BindGroupDescriptor {
-            entries: &[BindGroupEntry {
-                binding: 0,
-                resource: view_binding,
-            }],
-            label: Some("sprite_view_bind_group"),
-            layout: &sprite_pipeline.view_layout,
-        }));
+    // Clear the vertex buffers
+    sprite_meta.vertices.clear();
+    sprite_meta.colored_vertices.clear();
 
-        let draw_sprite_function = draw_functions.read().id::<DrawSprite>();
+    sprite_meta.view_bind_group = Some(render_device.create_bind_group(&BindGroupDescriptor {
+        entries: &[BindGroupEntry {
+            binding: 0,
+            resource: view_binding,
+        }],
+        label: Some("sprite_view_bind_group"),
+        layout: &sprite_pipeline.view_layout,
+    }));
 
-        // Vertex buffer indices
-        let mut index = 0;
-        let mut colored_index = 0;
+    let draw_sprite_function = draw_functions.read().id::<DrawSprite>();
 
-        // FIXME: VisibleEntities is ignored
+    // Vertex buffer indices
+    let mut index = 0;
+    let mut colored_index = 0;
 
-        let extracted_sprites = &mut extracted_sprites.sprites;
-        // Sort sprites by z for correct transparency and then by handle to improve batching
-        // NOTE: This can be done independent of views by reasonably assuming that all 2D views look along the negative-z axis in world space
-        extracted_sprites.sort_unstable_by(|a, b| {
-            match a
-                .transform
-                .translation()
-                .z
-                .partial_cmp(&b.transform.translation().z)
-            {
-                Some(Ordering::Equal) | None => a.image_handle_id.cmp(&b.image_handle_id),
-                Some(other) => other,
-            }
-        });
-        let image_bind_groups = &mut *image_bind_groups;
+    // FIXME: VisibleEntities is ignored
 
-        for (mut transparent_phase, visible_entities, view, tonemapping, dither) in &mut views {
-            let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
+    let extracted_sprites = &mut extracted_sprites.sprites;
+    // Sort sprites by z for correct transparency and then by handle to improve batching
+    // NOTE: This can be done independent of views by reasonably assuming that all 2D views look along the negative-z axis in world space
+    extracted_sprites.sort_unstable_by(|a, b| {
+        match a
+            .transform
+            .translation()
+            .z
+            .partial_cmp(&b.transform.translation().z)
+        {
+            Some(Ordering::Equal) | None => a.image_handle_id.cmp(&b.image_handle_id),
+            Some(other) => other,
+        }
+    });
+    let image_bind_groups = &mut *image_bind_groups;
 
-            if !view.hdr {
-                if let Some(tonemapping) = tonemapping {
-                    view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
-                    view_key |= match tonemapping {
-                        Tonemapping::None => SpritePipelineKey::TONEMAP_METHOD_NONE,
-                        Tonemapping::Reinhard => SpritePipelineKey::TONEMAP_METHOD_REINHARD,
-                        Tonemapping::ReinhardLuminance => {
-                            SpritePipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
-                        }
-                        Tonemapping::AcesFitted => SpritePipelineKey::TONEMAP_METHOD_ACES_FITTED,
-                        Tonemapping::AgX => SpritePipelineKey::TONEMAP_METHOD_AGX,
-                        Tonemapping::SomewhatBoringDisplayTransform => {
-                            SpritePipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
-                        }
-                        Tonemapping::TonyMcMapface => {
-                            SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE
-                        }
-                        Tonemapping::BlenderFilmic => {
-                            SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC
-                        }
-                    };
-                }
-                if let Some(DebandDither::Enabled) = dither {
-                    view_key |= SpritePipelineKey::DEBAND_DITHER;
-                }
-            }
+    for (mut transparent_phase, visible_entities, view, tonemapping, dither) in &mut views {
+        let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
 
-            let pipeline = pipelines.specialize(
-                &pipeline_cache,
-                &sprite_pipeline,
-                view_key | SpritePipelineKey::from_colored(false),
-            );
-            let colored_pipeline = pipelines.specialize(
-                &pipeline_cache,
-                &sprite_pipeline,
-                view_key | SpritePipelineKey::from_colored(true),
-            );
-
-            view_entities.clear();
-            view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
-            transparent_phase.items.reserve(extracted_sprites.len());
-
-            // Impossible starting values that will be replaced on the first iteration
-            let mut current_batch = SpriteBatch {
-                image_handle_id: HandleId::Id(Uuid::nil(), u64::MAX),
-                colored: false,
-            };
-            let mut current_batch_entity = Entity::PLACEHOLDER;
-            let mut current_image_size = Vec2::ZERO;
-            // Add a phase item for each sprite, and detect when successive items can be batched.
-            // Spawn an entity with a `SpriteBatch` component for each possible batch.
-            // Compatible items share the same entity.
-            // Batches are merged later (in `batch_phase_system()`), so that they can be interrupted
-            // by any other phase item (and they can interrupt other items from batching).
-            for extracted_sprite in extracted_sprites.iter() {
-                if !view_entities.contains(extracted_sprite.entity.index() as usize) {
-                    continue;
-                }
-                let new_batch = SpriteBatch {
-                    image_handle_id: extracted_sprite.image_handle_id,
-                    colored: extracted_sprite.color != Color::WHITE,
+        if !view.hdr {
+            if let Some(tonemapping) = tonemapping {
+                view_key |= SpritePipelineKey::TONEMAP_IN_SHADER;
+                view_key |= match tonemapping {
+                    Tonemapping::None => SpritePipelineKey::TONEMAP_METHOD_NONE,
+                    Tonemapping::Reinhard => SpritePipelineKey::TONEMAP_METHOD_REINHARD,
+                    Tonemapping::ReinhardLuminance => {
+                        SpritePipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE
+                    }
+                    Tonemapping::AcesFitted => SpritePipelineKey::TONEMAP_METHOD_ACES_FITTED,
+                    Tonemapping::AgX => SpritePipelineKey::TONEMAP_METHOD_AGX,
+                    Tonemapping::SomewhatBoringDisplayTransform => {
+                        SpritePipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM
+                    }
+                    Tonemapping::TonyMcMapface => SpritePipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE,
+                    Tonemapping::BlenderFilmic => SpritePipelineKey::TONEMAP_METHOD_BLENDER_FILMIC,
                 };
-                if new_batch != current_batch {
-                    // Set-up a new possible batch
-                    if let Some(gpu_image) =
-                        gpu_images.get(&Handle::weak(new_batch.image_handle_id))
-                    {
-                        current_batch = new_batch;
-                        current_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
-                        current_batch_entity = commands.spawn(current_batch).id();
-
-                        image_bind_groups
-                            .values
-                            .entry(Handle::weak(current_batch.image_handle_id))
-                            .or_insert_with(|| {
-                                render_device.create_bind_group(&BindGroupDescriptor {
-                                    entries: &[
-                                        BindGroupEntry {
-                                            binding: 0,
-                                            resource: BindingResource::TextureView(
-                                                &gpu_image.texture_view,
-                                            ),
-                                        },
-                                        BindGroupEntry {
-                                            binding: 1,
-                                            resource: BindingResource::Sampler(&gpu_image.sampler),
-                                        },
-                                    ],
-                                    label: Some("sprite_material_bind_group"),
-                                    layout: &sprite_pipeline.material_layout,
-                                })
-                            });
-                    } else {
-                        // Skip this item if the texture is not ready
-                        continue;
-                    }
-                }
-
-                // Calculate vertex data for this item
-
-                let mut uvs = QUAD_UVS;
-                if extracted_sprite.flip_x {
-                    uvs = [uvs[1], uvs[0], uvs[3], uvs[2]];
-                }
-                if extracted_sprite.flip_y {
-                    uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
-                }
-
-                // By default, the size of the quad is the size of the texture
-                let mut quad_size = current_image_size;
-
-                // If a rect is specified, adjust UVs and the size of the quad
-                if let Some(rect) = extracted_sprite.rect {
-                    let rect_size = rect.size();
-                    for uv in &mut uvs {
-                        *uv = (rect.min + *uv * rect_size) / current_image_size;
-                    }
-                    quad_size = rect_size;
-                }
-
-                // Override the size if a custom one is specified
-                if let Some(custom_size) = extracted_sprite.custom_size {
-                    quad_size = custom_size;
-                }
-
-                // Apply size and global transform
-                let positions = QUAD_VERTEX_POSITIONS.map(|quad_pos| {
-                    extracted_sprite
-                        .transform
-                        .transform_point(
-                            ((quad_pos - extracted_sprite.anchor) * quad_size).extend(0.),
-                        )
-                        .into()
-                });
-
-                // These items will be sorted by depth with other phase items
-                let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
-
-                // Store the vertex data and add the item to the render phase
-                if current_batch.colored {
-                    let vertex_color = extracted_sprite.color.as_linear_rgba_f32();
-                    for i in QUAD_INDICES {
-                        sprite_meta.colored_vertices.push(ColoredSpriteVertex {
-                            position: positions[i],
-                            uv: uvs[i].into(),
-                            color: vertex_color,
-                        });
-                    }
-                    let item_start = colored_index;
-                    colored_index += QUAD_INDICES.len() as u32;
-                    let item_end = colored_index;
-
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
-                        pipeline: colored_pipeline,
-                        entity: current_batch_entity,
-                        sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
-                } else {
-                    for i in QUAD_INDICES {
-                        sprite_meta.vertices.push(SpriteVertex {
-                            position: positions[i],
-                            uv: uvs[i].into(),
-                        });
-                    }
-                    let item_start = index;
-                    index += QUAD_INDICES.len() as u32;
-                    let item_end = index;
-
-                    transparent_phase.add(Transparent2d {
-                        draw_function: draw_sprite_function,
-                        pipeline,
-                        entity: current_batch_entity,
-                        sort_key,
-                        batch_range: Some(item_start..item_end),
-                    });
-                }
+            }
+            if let Some(DebandDither::Enabled) = dither {
+                view_key |= SpritePipelineKey::DEBAND_DITHER;
             }
         }
-        sprite_meta
-            .vertices
-            .write_buffer(&render_device, &render_queue);
-        sprite_meta
-            .colored_vertices
-            .write_buffer(&render_device, &render_queue);
+
+        let pipeline = pipelines.specialize(
+            &pipeline_cache,
+            &sprite_pipeline,
+            view_key | SpritePipelineKey::from_colored(false),
+        );
+        let colored_pipeline = pipelines.specialize(
+            &pipeline_cache,
+            &sprite_pipeline,
+            view_key | SpritePipelineKey::from_colored(true),
+        );
+
+        view_entities.clear();
+        view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
+        transparent_phase.items.reserve(extracted_sprites.len());
+
+        // Impossible starting values that will be replaced on the first iteration
+        let mut current_batch = SpriteBatch {
+            image_handle_id: HandleId::Id(Uuid::nil(), u64::MAX),
+            colored: false,
+        };
+        let mut current_batch_entity = Entity::PLACEHOLDER;
+        let mut current_image_size = Vec2::ZERO;
+        // Add a phase item for each sprite, and detect when successive items can be batched.
+        // Spawn an entity with a `SpriteBatch` component for each possible batch.
+        // Compatible items share the same entity.
+        // Batches are merged later (in `batch_phase_system()`), so that they can be interrupted
+        // by any other phase item (and they can interrupt other items from batching).
+        for extracted_sprite in extracted_sprites.iter() {
+            if !view_entities.contains(extracted_sprite.entity.index() as usize) {
+                continue;
+            }
+            let new_batch = SpriteBatch {
+                image_handle_id: extracted_sprite.image_handle_id,
+                colored: extracted_sprite.color != Color::WHITE,
+            };
+            if new_batch != current_batch {
+                // Set-up a new possible batch
+                let Some(gpu_image) = gpu_images.get(&Handle::weak(new_batch.image_handle_id)) else {
+                    // Skip this item if the texture is not ready
+                    continue;
+                };
+                current_batch = new_batch;
+                current_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
+                current_batch_entity = commands.spawn(current_batch).id();
+
+                image_bind_groups
+                    .values
+                    .entry(Handle::weak(current_batch.image_handle_id))
+                    .or_insert_with(|| {
+                        render_device.create_bind_group(&BindGroupDescriptor {
+                            entries: &[
+                                BindGroupEntry {
+                                    binding: 0,
+                                    resource: BindingResource::TextureView(&gpu_image.texture_view),
+                                },
+                                BindGroupEntry {
+                                    binding: 1,
+                                    resource: BindingResource::Sampler(&gpu_image.sampler),
+                                },
+                            ],
+                            label: Some("sprite_material_bind_group"),
+                            layout: &sprite_pipeline.material_layout,
+                        })
+                    });
+            }
+
+            // Calculate vertex data for this item
+
+            let mut uvs = QUAD_UVS;
+            if extracted_sprite.flip_x {
+                uvs = [uvs[1], uvs[0], uvs[3], uvs[2]];
+            }
+            if extracted_sprite.flip_y {
+                uvs = [uvs[3], uvs[2], uvs[1], uvs[0]];
+            }
+
+            // By default, the size of the quad is the size of the texture
+            let mut quad_size = current_image_size;
+
+            // If a rect is specified, adjust UVs and the size of the quad
+            if let Some(rect) = extracted_sprite.rect {
+                let rect_size = rect.size();
+                for uv in &mut uvs {
+                    *uv = (rect.min + *uv * rect_size) / current_image_size;
+                }
+                quad_size = rect_size;
+            }
+
+            // Override the size if a custom one is specified
+            if let Some(custom_size) = extracted_sprite.custom_size {
+                quad_size = custom_size;
+            }
+
+            // Apply size and global transform
+            let positions = QUAD_VERTEX_POSITIONS.map(|quad_pos| {
+                extracted_sprite
+                    .transform
+                    .transform_point(((quad_pos - extracted_sprite.anchor) * quad_size).extend(0.))
+                    .into()
+            });
+
+            // These items will be sorted by depth with other phase items
+            let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
+
+            // Store the vertex data and add the item to the render phase
+            if current_batch.colored {
+                let vertex_color = extracted_sprite.color.as_linear_rgba_f32();
+                for i in QUAD_INDICES {
+                    sprite_meta.colored_vertices.push(ColoredSpriteVertex {
+                        position: positions[i],
+                        uv: uvs[i].into(),
+                        color: vertex_color,
+                    });
+                }
+                let item_start = colored_index;
+                colored_index += QUAD_INDICES.len() as u32;
+                let item_end = colored_index;
+
+                transparent_phase.add(Transparent2d {
+                    draw_function: draw_sprite_function,
+                    pipeline: colored_pipeline,
+                    entity: current_batch_entity,
+                    sort_key,
+                    batch_range: Some(item_start..item_end),
+                });
+            } else {
+                for i in QUAD_INDICES {
+                    sprite_meta.vertices.push(SpriteVertex {
+                        position: positions[i],
+                        uv: uvs[i].into(),
+                    });
+                }
+                let item_start = index;
+                index += QUAD_INDICES.len() as u32;
+                let item_end = index;
+
+                transparent_phase.add(Transparent2d {
+                    draw_function: draw_sprite_function,
+                    pipeline,
+                    entity: current_batch_entity,
+                    sort_key,
+                    batch_range: Some(item_start..item_end),
+                });
+            }
+        }
     }
+    sprite_meta
+        .vertices
+        .write_buffer(&render_device, &render_queue);
+    sprite_meta
+        .colored_vertices
+        .write_buffer(&render_device, &render_queue);
 }
 
 pub type DrawSprite = (

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -111,48 +111,49 @@ impl GlyphBrush {
             let glyph_position = glyph.position;
             let adjust = GlyphPlacementAdjuster::new(&mut glyph);
             let section_data = sections_data[sg.section_index];
-            if let Some(outlined_glyph) = section_data.1.font.outline_glyph(glyph) {
-                let bounds = outlined_glyph.px_bounds();
-                let handle_font_atlas: Handle<FontAtlasSet> = section_data.0.cast_weak();
-                let font_atlas_set = font_atlas_set_storage
-                    .get_or_insert_with(handle_font_atlas, FontAtlasSet::default);
+            let Some(outlined_glyph) = section_data.1.font.outline_glyph(glyph) else {
+                continue;
+            };
+            let bounds = outlined_glyph.px_bounds();
+            let handle_font_atlas: Handle<FontAtlasSet> = section_data.0.cast_weak();
+            let font_atlas_set =
+                font_atlas_set_storage.get_or_insert_with(handle_font_atlas, FontAtlasSet::default);
 
-                let atlas_info = font_atlas_set
-                    .get_glyph_atlas_info(section_data.2, glyph_id, glyph_position)
-                    .map(Ok)
-                    .unwrap_or_else(|| {
-                        font_atlas_set.add_glyph_to_atlas(texture_atlases, textures, outlined_glyph)
-                    })?;
+            let atlas_info = font_atlas_set
+                .get_glyph_atlas_info(section_data.2, glyph_id, glyph_position)
+                .map(Ok)
+                .unwrap_or_else(|| {
+                    font_atlas_set.add_glyph_to_atlas(texture_atlases, textures, outlined_glyph)
+                })?;
 
-                if !text_settings.allow_dynamic_font_size
-                    && !font_atlas_warning.warned
-                    && font_atlas_set.num_font_atlases() > text_settings.max_font_atlases.get()
-                {
-                    warn!("warning[B0005]: Number of font atlases has exceeded the maximum of {}. Performance and memory usage may suffer.", text_settings.max_font_atlases.get());
-                    font_atlas_warning.warned = true;
-                }
-
-                let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                let glyph_rect = texture_atlas.textures[atlas_info.glyph_index];
-                let size = Vec2::new(glyph_rect.width(), glyph_rect.height());
-
-                let x = bounds.min.x + size.x / 2.0 - min_x;
-
-                let y = match y_axis_orientation {
-                    YAxisOrientation::BottomToTop => max_y - bounds.max.y + size.y / 2.0,
-                    YAxisOrientation::TopToBottom => bounds.min.y + size.y / 2.0 - min_y,
-                };
-
-                let position = adjust.position(Vec2::new(x, y));
-
-                positioned_glyphs.push(PositionedGlyph {
-                    position,
-                    size,
-                    atlas_info,
-                    section_index: sg.section_index,
-                    byte_index,
-                });
+            if !text_settings.allow_dynamic_font_size
+                && !font_atlas_warning.warned
+                && font_atlas_set.num_font_atlases() > text_settings.max_font_atlases.get()
+            {
+                warn!("warning[B0005]: Number of font atlases has exceeded the maximum of {}. Performance and memory usage may suffer.", text_settings.max_font_atlases.get());
+                font_atlas_warning.warned = true;
             }
+
+            let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
+            let glyph_rect = texture_atlas.textures[atlas_info.glyph_index];
+            let size = Vec2::new(glyph_rect.width(), glyph_rect.height());
+
+            let x = bounds.min.x + size.x / 2.0 - min_x;
+
+            let y = match y_axis_orientation {
+                YAxisOrientation::BottomToTop => max_y - bounds.max.y + size.y / 2.0,
+                YAxisOrientation::TopToBottom => bounds.min.y + size.y / 2.0 - min_y,
+            };
+
+            let position = adjust.position(Vec2::new(x, y));
+
+            positioned_glyphs.push(PositionedGlyph {
+                position,
+                size,
+                atlas_info,
+                section_index: sg.section_index,
+                byte_index,
+            });
         }
         Ok(positioned_glyphs)
     }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -196,63 +196,61 @@ pub fn ui_focus_system(
         // reverse the iterator to traverse the tree from closest nodes to furthest
         .rev()
         .filter_map(|entity| {
-            if let Ok(node) = node_query.get_mut(*entity) {
-                // Nodes that are not rendered should not be interactable
-                if let Some(computed_visibility) = node.computed_visibility {
-                    if !computed_visibility.is_visible() {
-                        // Reset their interaction to None to avoid strange stuck state
-                        if let Some(mut interaction) = node.interaction {
-                            // We cannot simply set the interaction to None, as that will trigger change detection repeatedly
-                            interaction.set_if_neq(Interaction::None);
-                        }
-
-                        return None;
-                    }
-                }
-
-                let position = node.global_transform.translation();
-                let ui_position = position.truncate();
-                let extents = node.node.size() / 2.0;
-                let mut min = ui_position - extents;
-                if let Some(clip) = node.calculated_clip {
-                    min = Vec2::max(min, clip.clip.min);
-                }
-
-                // The mouse position relative to the node
-                // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
-                let relative_cursor_position = cursor_position.map(|cursor_position| {
-                    Vec2::new(
-                        (cursor_position.x - min.x) / node.node.size().x,
-                        (cursor_position.y - min.y) / node.node.size().y,
-                    )
-                });
-
-                // If the current cursor position is within the bounds of the node, consider it for
-                // clicking
-                let relative_cursor_position_component = RelativeCursorPosition {
-                    normalized: relative_cursor_position,
-                };
-
-                let contains_cursor = relative_cursor_position_component.mouse_over();
-
-                // Save the relative cursor position to the correct component
-                if let Some(mut node_relative_cursor_position_component) =
-                    node.relative_cursor_position
-                {
-                    *node_relative_cursor_position_component = relative_cursor_position_component;
-                }
-
-                if contains_cursor {
-                    Some(*entity)
-                } else {
+            let Ok(node) = node_query.get_mut(*entity) else {
+                return None;
+            };
+            // Nodes that are not rendered should not be interactable
+            if let Some(computed_visibility) = node.computed_visibility {
+                if !computed_visibility.is_visible() {
+                    // Reset their interaction to None to avoid strange stuck state
                     if let Some(mut interaction) = node.interaction {
-                        if *interaction == Interaction::Hovered || (cursor_position.is_none()) {
-                            interaction.set_if_neq(Interaction::None);
-                        }
+                        // We cannot simply set the interaction to None, as that will trigger change detection repeatedly
+                        interaction.set_if_neq(Interaction::None);
                     }
-                    None
+
+                    return None;
                 }
+            }
+
+            let position = node.global_transform.translation();
+            let ui_position = position.truncate();
+            let extents = node.node.size() / 2.0;
+            let mut min = ui_position - extents;
+            if let Some(clip) = node.calculated_clip {
+                min = Vec2::max(min, clip.clip.min);
+            }
+
+            // The mouse position relative to the node
+            // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
+            let relative_cursor_position = cursor_position.map(|cursor_position| {
+                Vec2::new(
+                    (cursor_position.x - min.x) / node.node.size().x,
+                    (cursor_position.y - min.y) / node.node.size().y,
+                )
+            });
+
+            // If the current cursor position is within the bounds of the node, consider it for
+            // clicking
+            let relative_cursor_position_component = RelativeCursorPosition {
+                normalized: relative_cursor_position,
+            };
+
+            let contains_cursor = relative_cursor_position_component.mouse_over();
+
+            // Save the relative cursor position to the correct component
+            if let Some(mut node_relative_cursor_position_component) = node.relative_cursor_position
+            {
+                *node_relative_cursor_position_component = relative_cursor_position_component;
+            }
+
+            if contains_cursor {
+                Some(*entity)
             } else {
+                if let Some(mut interaction) = node.interaction {
+                    if *interaction == Interaction::Hovered || (cursor_position.is_none()) {
+                        interaction.set_if_neq(Interaction::None);
+                    }
+                }
                 None
             }
         })

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -60,10 +60,7 @@ pub enum RenderUiSystem {
 pub fn build_ui_render(app: &mut App) {
     load_internal_asset!(app, UI_SHADER_HANDLE, "ui.wgsl", Shader::from_wgsl);
 
-    let render_app = match app.get_sub_app_mut(RenderApp) {
-        Ok(render_app) => render_app,
-        Err(_) => return,
-    };
+    let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
 
     render_app
         .init_resource::<UiPipeline>()

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -98,63 +98,66 @@ fn update_accessibility_nodes(
     if !accessibility_requested.load(Ordering::SeqCst) {
         return;
     }
-    if let Ok((primary_window_id, primary_window)) = primary_window.get_single() {
-        if let Some(adapter) = adapters.get(&primary_window_id) {
-            let should_run = focus.is_changed() || !nodes.is_empty();
-            if should_run {
-                adapter.update_if_active(|| {
-                    let mut to_update = vec![];
-                    let mut has_focus = false;
-                    let mut name = None;
-                    if primary_window.focused {
-                        has_focus = true;
-                        let title = primary_window.title.clone();
-                        name = Some(title.into_boxed_str());
-                    }
-                    let focus_id = if has_focus {
-                        (*focus).or_else(|| Some(primary_window_id))
-                    } else {
-                        None
-                    };
-                    let mut root_children = vec![];
-                    for (entity, node, children, parent) in &nodes {
-                        let mut node = (**node).clone();
-                        if let Some(parent) = parent {
-                            if node_entities.get(**parent).is_err() {
-                                root_children.push(entity.to_node_id());
-                            }
-                        } else {
-                            root_children.push(entity.to_node_id());
-                        }
-                        if let Some(children) = children {
-                            for child in children.iter() {
-                                if node_entities.get(*child).is_ok() {
-                                    node.push_child(child.to_node_id());
-                                }
-                            }
-                        }
-                        to_update.push((
-                            entity.to_node_id(),
-                            node.build(&mut NodeClassSet::lock_global()),
-                        ));
-                    }
-                    let mut root = NodeBuilder::new(Role::Window);
-                    if let Some(name) = name {
-                        root.set_name(name);
-                    }
-                    root.set_children(root_children);
-                    let root = root.build(&mut NodeClassSet::lock_global());
-                    let window_update = (primary_window_id.to_node_id(), root);
-                    to_update.insert(0, window_update);
-                    TreeUpdate {
-                        nodes: to_update,
-                        focus: focus_id.map(|v| v.to_node_id()),
-                        ..default()
-                    }
-                });
-            }
-        }
+    let Ok((primary_window_id, primary_window)) = primary_window.get_single() else {
+        return;
+    };
+    let Some(adapter) = adapters.get(&primary_window_id) else {
+        return;
+    };
+    let should_run = focus.is_changed() || !nodes.is_empty();
+    if !should_run {
+        return;
     }
+    adapter.update_if_active(|| {
+        let mut to_update = vec![];
+        let mut has_focus = false;
+        let mut name = None;
+        if primary_window.focused {
+            has_focus = true;
+            let title = primary_window.title.clone();
+            name = Some(title.into_boxed_str());
+        }
+        let focus_id = if has_focus {
+            (*focus).or_else(|| Some(primary_window_id))
+        } else {
+            None
+        };
+        let mut root_children = vec![];
+        for (entity, node, children, parent) in &nodes {
+            let mut node = (**node).clone();
+            if let Some(parent) = parent {
+                if node_entities.get(**parent).is_err() {
+                    root_children.push(entity.to_node_id());
+                }
+            } else {
+                root_children.push(entity.to_node_id());
+            }
+            if let Some(children) = children {
+                for child in children.iter() {
+                    if node_entities.get(*child).is_ok() {
+                        node.push_child(child.to_node_id());
+                    }
+                }
+            }
+            to_update.push((
+                entity.to_node_id(),
+                node.build(&mut NodeClassSet::lock_global()),
+            ));
+        }
+        let mut root = NodeBuilder::new(Role::Window);
+        if let Some(name) = name {
+            root.set_name(name);
+        }
+        root.set_children(root_children);
+        let root = root.build(&mut NodeClassSet::lock_global());
+        let window_update = (primary_window_id.to_node_id(), root);
+        to_update.insert(0, window_update);
+        TreeUpdate {
+            nodes: to_update,
+            focus: focus_id.map(|v| v.to_node_id()),
+            ..default()
+        }
+    });
 }
 
 /// Implements winit-specific `AccessKit` functionality.

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -386,27 +386,21 @@ pub fn winit_runner(mut app: App) {
                 ) = system_state.get_mut(&mut app.world);
 
                 // Entity of this window
-                let window_entity =
-                    if let Some(entity) = winit_windows.get_window_entity(winit_window_id) {
-                        entity
-                    } else {
-                        warn!(
-                            "Skipped event {:?} for unknown winit Window Id {:?}",
-                            event, winit_window_id
-                        );
-                        return;
-                    };
+                let Some(window_entity) = winit_windows.get_window_entity(winit_window_id) else {
+                    warn!(
+                        "Skipped event {:?} for unknown winit Window Id {:?}",
+                        event, winit_window_id
+                    );
+                    return;
+                };
 
-                let (mut window, mut cache) =
-                    if let Ok((window, info)) = window_query.get_mut(window_entity) {
-                        (window, info)
-                    } else {
-                        warn!(
-                            "Window {:?} is missing `Window` component, skipping event {:?}",
-                            window_entity, event
-                        );
-                        return;
-                    };
+                let Ok((mut window, mut cache)) =  window_query.get_mut(window_entity) else {
+                    warn!(
+                        "Window {:?} is missing `Window` component, skipping event {:?}",
+                        window_entity, event
+                    );
+                    return;
+                };
 
                 winit_state.low_power_event = true;
 

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -130,173 +130,170 @@ pub(crate) fn changed_window(
     winit_windows: NonSendMut<WinitWindows>,
 ) {
     for (entity, mut window, mut cache) in &mut changed_windows {
-        if let Some(winit_window) = winit_windows.get_window(entity) {
-            if window.title != cache.window.title {
-                winit_window.set_title(window.title.as_str());
-            }
-
-            if window.mode != cache.window.mode {
-                let new_mode = match window.mode {
-                    bevy_window::WindowMode::BorderlessFullscreen => {
-                        Some(winit::window::Fullscreen::Borderless(None))
-                    }
-                    bevy_window::WindowMode::Fullscreen => {
-                        Some(winit::window::Fullscreen::Exclusive(get_best_videomode(
-                            &winit_window.current_monitor().unwrap(),
-                        )))
-                    }
-                    bevy_window::WindowMode::SizedFullscreen => {
-                        Some(winit::window::Fullscreen::Exclusive(get_fitting_videomode(
-                            &winit_window.current_monitor().unwrap(),
-                            window.width() as u32,
-                            window.height() as u32,
-                        )))
-                    }
-                    bevy_window::WindowMode::Windowed => None,
-                };
-
-                if winit_window.fullscreen() != new_mode {
-                    winit_window.set_fullscreen(new_mode);
-                }
-            }
-            if window.resolution != cache.window.resolution {
-                let physical_size = PhysicalSize::new(
-                    window.resolution.physical_width(),
-                    window.resolution.physical_height(),
-                );
-                winit_window.set_inner_size(physical_size);
-            }
-
-            if window.physical_cursor_position() != cache.window.physical_cursor_position() {
-                if let Some(physical_position) = window.physical_cursor_position() {
-                    let inner_size = winit_window.inner_size();
-
-                    let position = PhysicalPosition::new(
-                        physical_position.x,
-                        // Flip the coordinate space back to winit's context.
-                        inner_size.height as f32 - physical_position.y,
-                    );
-
-                    if let Err(err) = winit_window.set_cursor_position(position) {
-                        error!("could not set cursor position: {:?}", err);
-                    }
-                }
-            }
-
-            if window.cursor.icon != cache.window.cursor.icon {
-                winit_window.set_cursor_icon(converters::convert_cursor_icon(window.cursor.icon));
-            }
-
-            if window.cursor.grab_mode != cache.window.cursor.grab_mode {
-                crate::winit_windows::attempt_grab(winit_window, window.cursor.grab_mode);
-            }
-
-            if window.cursor.visible != cache.window.cursor.visible {
-                winit_window.set_cursor_visible(window.cursor.visible);
-            }
-
-            if window.cursor.hit_test != cache.window.cursor.hit_test {
-                if let Err(err) = winit_window.set_cursor_hittest(window.cursor.hit_test) {
-                    window.cursor.hit_test = cache.window.cursor.hit_test;
-                    warn!(
-                        "Could not set cursor hit test for window {:?}: {:?}",
-                        window.title, err
-                    );
-                }
-            }
-
-            if window.decorations != cache.window.decorations
-                && window.decorations != winit_window.is_decorated()
-            {
-                winit_window.set_decorations(window.decorations);
-            }
-
-            if window.resizable != cache.window.resizable
-                && window.resizable != winit_window.is_resizable()
-            {
-                winit_window.set_resizable(window.resizable);
-            }
-
-            if window.resize_constraints != cache.window.resize_constraints {
-                let constraints = window.resize_constraints.check_constraints();
-                let min_inner_size = LogicalSize {
-                    width: constraints.min_width,
-                    height: constraints.min_height,
-                };
-                let max_inner_size = LogicalSize {
-                    width: constraints.max_width,
-                    height: constraints.max_height,
-                };
-
-                winit_window.set_min_inner_size(Some(min_inner_size));
-                if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
-                    winit_window.set_max_inner_size(Some(max_inner_size));
-                }
-            }
-
-            if window.position != cache.window.position {
-                if let Some(position) = crate::winit_window_position(
-                    &window.position,
-                    &window.resolution,
-                    winit_window.available_monitors(),
-                    winit_window.primary_monitor(),
-                    winit_window.current_monitor(),
-                ) {
-                    let should_set = match winit_window.outer_position() {
-                        Ok(current_position) => current_position != position,
-                        _ => true,
-                    };
-
-                    if should_set {
-                        winit_window.set_outer_position(position);
-                    }
-                }
-            }
-
-            if let Some(maximized) = window.internal.take_maximize_request() {
-                winit_window.set_maximized(maximized);
-            }
-
-            if let Some(minimized) = window.internal.take_minimize_request() {
-                winit_window.set_minimized(minimized);
-            }
-
-            if window.focused != cache.window.focused && window.focused {
-                winit_window.focus_window();
-            }
-
-            if window.window_level != cache.window.window_level {
-                winit_window.set_window_level(convert_window_level(window.window_level));
-            }
-
-            // Currently unsupported changes
-            if window.transparent != cache.window.transparent {
-                window.transparent = cache.window.transparent;
-                warn!(
-                    "Winit does not currently support updating transparency after window creation."
-                );
-            }
-
-            #[cfg(target_arch = "wasm32")]
-            if window.canvas != cache.window.canvas {
-                window.canvas = cache.window.canvas.clone();
-                warn!(
-                    "Bevy currently doesn't support modifying the window canvas after initialization."
-                );
-            }
-
-            if window.ime_enabled != cache.window.ime_enabled {
-                winit_window.set_ime_allowed(window.ime_enabled);
-            }
-
-            if window.ime_position != cache.window.ime_position {
-                winit_window.set_ime_position(LogicalPosition::new(
-                    window.ime_position.x,
-                    window.ime_position.y,
-                ));
-            }
-
-            cache.window = window.clone();
+        let Some(winit_window) = winit_windows.get_window(entity) else {
+            continue;
+        };
+        if window.title != cache.window.title {
+            winit_window.set_title(window.title.as_str());
         }
+
+        if window.mode != cache.window.mode {
+            let new_mode = match window.mode {
+                bevy_window::WindowMode::BorderlessFullscreen => {
+                    Some(winit::window::Fullscreen::Borderless(None))
+                }
+                bevy_window::WindowMode::Fullscreen => Some(winit::window::Fullscreen::Exclusive(
+                    get_best_videomode(&winit_window.current_monitor().unwrap()),
+                )),
+                bevy_window::WindowMode::SizedFullscreen => {
+                    Some(winit::window::Fullscreen::Exclusive(get_fitting_videomode(
+                        &winit_window.current_monitor().unwrap(),
+                        window.width() as u32,
+                        window.height() as u32,
+                    )))
+                }
+                bevy_window::WindowMode::Windowed => None,
+            };
+
+            if winit_window.fullscreen() != new_mode {
+                winit_window.set_fullscreen(new_mode);
+            }
+        }
+        if window.resolution != cache.window.resolution {
+            let physical_size = PhysicalSize::new(
+                window.resolution.physical_width(),
+                window.resolution.physical_height(),
+            );
+            winit_window.set_inner_size(physical_size);
+        }
+
+        if window.physical_cursor_position() != cache.window.physical_cursor_position() {
+            if let Some(physical_position) = window.physical_cursor_position() {
+                let inner_size = winit_window.inner_size();
+
+                let position = PhysicalPosition::new(
+                    physical_position.x,
+                    // Flip the coordinate space back to winit's context.
+                    inner_size.height as f32 - physical_position.y,
+                );
+
+                if let Err(err) = winit_window.set_cursor_position(position) {
+                    error!("could not set cursor position: {:?}", err);
+                }
+            }
+        }
+
+        if window.cursor.icon != cache.window.cursor.icon {
+            winit_window.set_cursor_icon(converters::convert_cursor_icon(window.cursor.icon));
+        }
+
+        if window.cursor.grab_mode != cache.window.cursor.grab_mode {
+            crate::winit_windows::attempt_grab(winit_window, window.cursor.grab_mode);
+        }
+
+        if window.cursor.visible != cache.window.cursor.visible {
+            winit_window.set_cursor_visible(window.cursor.visible);
+        }
+
+        if window.cursor.hit_test != cache.window.cursor.hit_test {
+            if let Err(err) = winit_window.set_cursor_hittest(window.cursor.hit_test) {
+                window.cursor.hit_test = cache.window.cursor.hit_test;
+                warn!(
+                    "Could not set cursor hit test for window {:?}: {:?}",
+                    window.title, err
+                );
+            }
+        }
+
+        if window.decorations != cache.window.decorations
+            && window.decorations != winit_window.is_decorated()
+        {
+            winit_window.set_decorations(window.decorations);
+        }
+
+        if window.resizable != cache.window.resizable
+            && window.resizable != winit_window.is_resizable()
+        {
+            winit_window.set_resizable(window.resizable);
+        }
+
+        if window.resize_constraints != cache.window.resize_constraints {
+            let constraints = window.resize_constraints.check_constraints();
+            let min_inner_size = LogicalSize {
+                width: constraints.min_width,
+                height: constraints.min_height,
+            };
+            let max_inner_size = LogicalSize {
+                width: constraints.max_width,
+                height: constraints.max_height,
+            };
+
+            winit_window.set_min_inner_size(Some(min_inner_size));
+            if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
+                winit_window.set_max_inner_size(Some(max_inner_size));
+            }
+        }
+
+        if window.position != cache.window.position {
+            if let Some(position) = crate::winit_window_position(
+                &window.position,
+                &window.resolution,
+                winit_window.available_monitors(),
+                winit_window.primary_monitor(),
+                winit_window.current_monitor(),
+            ) {
+                let should_set = match winit_window.outer_position() {
+                    Ok(current_position) => current_position != position,
+                    _ => true,
+                };
+
+                if should_set {
+                    winit_window.set_outer_position(position);
+                }
+            }
+        }
+
+        if let Some(maximized) = window.internal.take_maximize_request() {
+            winit_window.set_maximized(maximized);
+        }
+
+        if let Some(minimized) = window.internal.take_minimize_request() {
+            winit_window.set_minimized(minimized);
+        }
+
+        if window.focused != cache.window.focused && window.focused {
+            winit_window.focus_window();
+        }
+
+        if window.window_level != cache.window.window_level {
+            winit_window.set_window_level(convert_window_level(window.window_level));
+        }
+
+        // Currently unsupported changes
+        if window.transparent != cache.window.transparent {
+            window.transparent = cache.window.transparent;
+            warn!("Winit does not currently support updating transparency after window creation.");
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        if window.canvas != cache.window.canvas {
+            window.canvas = cache.window.canvas.clone();
+            warn!(
+                "Bevy currently doesn't support modifying the window canvas after initialization."
+            );
+        }
+
+        if window.ime_enabled != cache.window.ime_enabled {
+            winit_window.set_ime_allowed(window.ime_enabled);
+        }
+
+        if window.ime_position != cache.window.ime_position {
+            winit_window.set_ime_position(LogicalPosition::new(
+                window.ime_position.x,
+                window.ime_position.y,
+            ));
+        }
+
+        cache.window = window.clone();
     }
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -335,29 +335,29 @@ pub fn queue_colored_mesh2d(
 
         // Queue all entities visible to that view
         for visible_entity in &visible_entities.entities {
-            if let Ok((mesh2d_handle, mesh2d_uniform)) = colored_mesh2d.get(*visible_entity) {
-                // Get our specialized pipeline
-                let mut mesh2d_key = mesh_key;
-                if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
-                    mesh2d_key |=
-                        Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
-                }
-
-                let pipeline_id =
-                    pipelines.specialize(&pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
-
-                let mesh_z = mesh2d_uniform.transform.w_axis.z;
-                transparent_phase.add(Transparent2d {
-                    entity: *visible_entity,
-                    draw_function: draw_colored_mesh2d,
-                    pipeline: pipeline_id,
-                    // The 2d render items are sorted according to their z value before rendering,
-                    // in order to get correct transparency
-                    sort_key: FloatOrd(mesh_z),
-                    // This material is not batched
-                    batch_range: None,
-                });
+            let Ok((mesh2d_handle, mesh2d_uniform)) = colored_mesh2d.get(*visible_entity) else {
+                continue;
+            };
+            // Get our specialized pipeline
+            let mut mesh2d_key = mesh_key;
+            if let Some(mesh) = render_meshes.get(&mesh2d_handle.0) {
+                mesh2d_key |= Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
             }
+
+            let pipeline_id =
+                pipelines.specialize(&pipeline_cache, &colored_mesh2d_pipeline, mesh2d_key);
+
+            let mesh_z = mesh2d_uniform.transform.w_axis.z;
+            transparent_phase.add(Transparent2d {
+                entity: *visible_entity,
+                draw_function: draw_colored_mesh2d,
+                pipeline: pipeline_id,
+                // The 2d render items are sorted according to their z value before rendering,
+                // in order to get correct transparency
+                sort_key: FloatOrd(mesh_z),
+                // This material is not batched
+                batch_range: None,
+            });
         }
     }
 }

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -231,77 +231,78 @@ pub fn camera_controller(
     mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
 ) {
     let dt = time.delta_seconds();
+    let Ok((mut transform, mut options)) = query.get_single_mut() else {
+        return;
+    };
 
-    if let Ok((mut transform, mut options)) = query.get_single_mut() {
-        if !options.initialized {
-            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
-            options.yaw = yaw;
-            options.pitch = pitch;
-            options.initialized = true;
-        }
-        if !options.enabled {
-            return;
-        }
+    if !options.initialized {
+        let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
+        options.yaw = yaw;
+        options.pitch = pitch;
+        options.initialized = true;
+    }
+    if !options.enabled {
+        return;
+    }
 
-        // Handle key input
-        let mut axis_input = Vec3::ZERO;
-        if key_input.pressed(options.key_forward) {
-            axis_input.z += 1.0;
-        }
-        if key_input.pressed(options.key_back) {
-            axis_input.z -= 1.0;
-        }
-        if key_input.pressed(options.key_right) {
-            axis_input.x += 1.0;
-        }
-        if key_input.pressed(options.key_left) {
-            axis_input.x -= 1.0;
-        }
-        if key_input.pressed(options.key_up) {
-            axis_input.y += 1.0;
-        }
-        if key_input.pressed(options.key_down) {
-            axis_input.y -= 1.0;
-        }
-        if key_input.just_pressed(options.keyboard_key_enable_mouse) {
-            *move_toggled = !*move_toggled;
-        }
+    // Handle key input
+    let mut axis_input = Vec3::ZERO;
+    if key_input.pressed(options.key_forward) {
+        axis_input.z += 1.0;
+    }
+    if key_input.pressed(options.key_back) {
+        axis_input.z -= 1.0;
+    }
+    if key_input.pressed(options.key_right) {
+        axis_input.x += 1.0;
+    }
+    if key_input.pressed(options.key_left) {
+        axis_input.x -= 1.0;
+    }
+    if key_input.pressed(options.key_up) {
+        axis_input.y += 1.0;
+    }
+    if key_input.pressed(options.key_down) {
+        axis_input.y -= 1.0;
+    }
+    if key_input.just_pressed(options.keyboard_key_enable_mouse) {
+        *move_toggled = !*move_toggled;
+    }
 
-        // Apply movement update
-        if axis_input != Vec3::ZERO {
-            let max_speed = if key_input.pressed(options.key_run) {
-                options.run_speed
-            } else {
-                options.walk_speed
-            };
-            options.velocity = axis_input.normalize() * max_speed;
+    // Apply movement update
+    if axis_input != Vec3::ZERO {
+        let max_speed = if key_input.pressed(options.key_run) {
+            options.run_speed
         } else {
-            let friction = options.friction.clamp(0.0, 1.0);
-            options.velocity *= 1.0 - friction;
-            if options.velocity.length_squared() < 1e-6 {
-                options.velocity = Vec3::ZERO;
-            }
+            options.walk_speed
+        };
+        options.velocity = axis_input.normalize() * max_speed;
+    } else {
+        let friction = options.friction.clamp(0.0, 1.0);
+        options.velocity *= 1.0 - friction;
+        if options.velocity.length_squared() < 1e-6 {
+            options.velocity = Vec3::ZERO;
         }
-        let forward = transform.forward();
-        let right = transform.right();
-        transform.translation += options.velocity.x * dt * right
-            + options.velocity.y * dt * Vec3::Y
-            + options.velocity.z * dt * forward;
+    }
+    let forward = transform.forward();
+    let right = transform.right();
+    transform.translation += options.velocity.x * dt * right
+        + options.velocity.y * dt * Vec3::Y
+        + options.velocity.z * dt * forward;
 
-        // Handle mouse input
-        let mut mouse_delta = Vec2::ZERO;
-        if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            for mouse_event in mouse_events.iter() {
-                mouse_delta += mouse_event.delta;
-            }
+    // Handle mouse input
+    let mut mouse_delta = Vec2::ZERO;
+    if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
+        for mouse_event in mouse_events.iter() {
+            mouse_delta += mouse_event.delta;
         }
+    }
 
-        if mouse_delta != Vec2::ZERO {
-            // Apply look update
-            options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
-                .clamp(-PI / 2., PI / 2.);
-            options.yaw -= mouse_delta.x * options.sensitivity * dt;
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
-        }
+    if mouse_delta != Vec2::ZERO {
+        // Apply look update
+        options.pitch = (options.pitch - mouse_delta.y * 0.5 * options.sensitivity * dt)
+            .clamp(-PI / 2., PI / 2.);
+        options.yaw -= mouse_delta.x * options.sensitivity * dt;
+        transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
     }
 }

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -318,28 +318,29 @@ fn update_image_viewer(
     }
 
     for (mat_h, mesh_h) in &image_mesh {
-        if let Some(mat) = materials.get_mut(mat_h) {
-            if let Some(ref new_image) = new_image {
-                mat.base_color_texture = Some(new_image.clone());
+        let Some(mat) = materials.get_mut(mat_h) else {
+            continue;
+        };
+        if let Some(ref new_image) = new_image {
+            mat.base_color_texture = Some(new_image.clone());
 
-                if let Ok(text_entity) = text.get_single() {
-                    commands.entity(text_entity).despawn();
-                }
+            if let Ok(text_entity) = text.get_single() {
+                commands.entity(text_entity).despawn();
             }
+        }
 
-            for event in image_events.iter() {
-                let image_changed_h = match event {
-                    AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
-                    _ => continue,
-                };
-                if let Some(base_color_texture) = mat.base_color_texture.clone() {
-                    if image_changed_h == &base_color_texture {
-                        if let Some(image_changed) = images.get(image_changed_h) {
-                            let size = image_changed.size().normalize_or_zero() * 1.4;
-                            // Resize Mesh
-                            let quad = Mesh::from(shape::Quad::new(size));
-                            let _ = meshes.set(mesh_h, quad);
-                        }
+        for event in image_events.iter() {
+            let image_changed_h = match event {
+                AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
+                _ => continue,
+            };
+            if let Some(base_color_texture) = mat.base_color_texture.clone() {
+                if image_changed_h == &base_color_texture {
+                    if let Some(image_changed) = images.get(image_changed_h) {
+                        let size = image_changed.size().normalize_or_zero() * 1.4;
+                        // Resize Mesh
+                        let quad = Mesh::from(shape::Quad::new(size));
+                        let _ = meshes.set(mesh_h, quad);
                     }
                 }
             }

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -100,43 +100,44 @@ fn keyboard_animation_control(
     animations: Res<Animations>,
     mut current_animation: Local<usize>,
 ) {
-    if let Ok(mut player) = animation_player.get_single_mut() {
-        if keyboard_input.just_pressed(KeyCode::Space) {
-            if player.is_paused() {
-                player.resume();
-            } else {
-                player.pause();
-            }
+    let Ok(mut player) = animation_player.get_single_mut() else {
+        return;
+    };
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        if player.is_paused() {
+            player.resume();
+        } else {
+            player.pause();
         }
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Up) {
-            let speed = player.speed();
-            player.set_speed(speed * 1.2);
-        }
+    if keyboard_input.just_pressed(KeyCode::Up) {
+        let speed = player.speed();
+        player.set_speed(speed * 1.2);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Down) {
-            let speed = player.speed();
-            player.set_speed(speed * 0.8);
-        }
+    if keyboard_input.just_pressed(KeyCode::Down) {
+        let speed = player.speed();
+        player.set_speed(speed * 0.8);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Left) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed - 0.1);
-        }
+    if keyboard_input.just_pressed(KeyCode::Left) {
+        let elapsed = player.elapsed();
+        player.set_elapsed(elapsed - 0.1);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Right) {
-            let elapsed = player.elapsed();
-            player.set_elapsed(elapsed + 0.1);
-        }
+    if keyboard_input.just_pressed(KeyCode::Right) {
+        let elapsed = player.elapsed();
+        player.set_elapsed(elapsed + 0.1);
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Return) {
-            *current_animation = (*current_animation + 1) % animations.0.len();
-            player
-                .play_with_transition(
-                    animations.0[*current_animation].clone_weak(),
-                    Duration::from_millis(250),
-                )
-                .repeat();
-        }
+    if keyboard_input.just_pressed(KeyCode::Return) {
+        *current_animation = (*current_animation + 1) % animations.0.len();
+        player
+            .play_with_transition(
+                animations.0[*current_animation].clone_weak(),
+                Duration::from_millis(250),
+            )
+            .repeat();
     }
 }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -360,45 +360,45 @@ fn check_for_collisions(
 
     // check collision with walls
     for (collider_entity, transform, maybe_brick) in &collider_query {
-        let collision = collide(
+        let Some(collision) = collide(
             ball_transform.translation,
             ball_size,
             transform.translation,
             transform.scale.truncate(),
-        );
-        if let Some(collision) = collision {
-            // Sends a collision event so that other systems can react to the collision
-            collision_events.send_default();
+        ) else {
+            continue;
+        };
+        // Sends a collision event so that other systems can react to the collision
+        collision_events.send_default();
 
-            // Bricks should be despawned and increment the scoreboard on collision
-            if maybe_brick.is_some() {
-                scoreboard.score += 1;
-                commands.entity(collider_entity).despawn();
-            }
+        // Bricks should be despawned and increment the scoreboard on collision
+        if maybe_brick.is_some() {
+            scoreboard.score += 1;
+            commands.entity(collider_entity).despawn();
+        }
 
-            // reflect the ball when it collides
-            let mut reflect_x = false;
-            let mut reflect_y = false;
+        // reflect the ball when it collides
+        let mut reflect_x = false;
+        let mut reflect_y = false;
 
-            // only reflect if the ball's velocity is going in the opposite direction of the
-            // collision
-            match collision {
-                Collision::Left => reflect_x = ball_velocity.x > 0.0,
-                Collision::Right => reflect_x = ball_velocity.x < 0.0,
-                Collision::Top => reflect_y = ball_velocity.y < 0.0,
-                Collision::Bottom => reflect_y = ball_velocity.y > 0.0,
-                Collision::Inside => { /* do nothing */ }
-            }
+        // only reflect if the ball's velocity is going in the opposite direction of the
+        // collision
+        match collision {
+            Collision::Left => reflect_x = ball_velocity.x > 0.0,
+            Collision::Right => reflect_x = ball_velocity.x < 0.0,
+            Collision::Top => reflect_y = ball_velocity.y < 0.0,
+            Collision::Bottom => reflect_y = ball_velocity.y > 0.0,
+            Collision::Inside => { /* do nothing */ }
+        }
 
-            // reflect velocity on the x-axis if we hit something on the x-axis
-            if reflect_x {
-                ball_velocity.x = -ball_velocity.x;
-            }
+        // reflect velocity on the x-axis if we hit something on the x-axis
+        if reflect_x {
+            ball_velocity.x = -ball_velocity.x;
+        }
 
-            // reflect velocity on the y-axis if we hit something on the y-axis
-            if reflect_y {
-                ball_velocity.y = -ball_velocity.y;
-            }
+        // reflect velocity on the y-axis if we hit something on the y-axis
+        if reflect_y {
+            ball_velocity.y = -ball_velocity.y;
         }
     }
 }

--- a/examples/tools/scene_viewer/camera_controller_plugin.rs
+++ b/examples/tools/scene_viewer/camera_controller_plugin.rs
@@ -105,92 +105,93 @@ fn camera_controller(
     mut query: Query<(&mut Transform, &mut CameraController), With<Camera>>,
 ) {
     let dt = time.delta_seconds();
+    let Ok((mut transform, mut options)) = query.get_single_mut() else {
+        return;
+    };
 
-    if let Ok((mut transform, mut options)) = query.get_single_mut() {
-        if !options.initialized {
-            let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
-            options.yaw = yaw;
-            options.pitch = pitch;
-            options.initialized = true;
-        }
-        if !options.enabled {
-            return;
-        }
+    if !options.initialized {
+        let (yaw, pitch, _roll) = transform.rotation.to_euler(EulerRot::YXZ);
+        options.yaw = yaw;
+        options.pitch = pitch;
+        options.initialized = true;
+    }
+    if !options.enabled {
+        return;
+    }
 
-        // Handle key input
-        let mut axis_input = Vec3::ZERO;
-        if key_input.pressed(options.key_forward) {
-            axis_input.z += 1.0;
-        }
-        if key_input.pressed(options.key_back) {
-            axis_input.z -= 1.0;
-        }
-        if key_input.pressed(options.key_right) {
-            axis_input.x += 1.0;
-        }
-        if key_input.pressed(options.key_left) {
-            axis_input.x -= 1.0;
-        }
-        if key_input.pressed(options.key_up) {
-            axis_input.y += 1.0;
-        }
-        if key_input.pressed(options.key_down) {
-            axis_input.y -= 1.0;
-        }
-        if key_input.just_pressed(options.keyboard_key_enable_mouse) {
-            *move_toggled = !*move_toggled;
-        }
+    // Handle key input
+    let mut axis_input = Vec3::ZERO;
+    if key_input.pressed(options.key_forward) {
+        axis_input.z += 1.0;
+    }
+    if key_input.pressed(options.key_back) {
+        axis_input.z -= 1.0;
+    }
+    if key_input.pressed(options.key_right) {
+        axis_input.x += 1.0;
+    }
+    if key_input.pressed(options.key_left) {
+        axis_input.x -= 1.0;
+    }
+    if key_input.pressed(options.key_up) {
+        axis_input.y += 1.0;
+    }
+    if key_input.pressed(options.key_down) {
+        axis_input.y -= 1.0;
+    }
+    if key_input.just_pressed(options.keyboard_key_enable_mouse) {
+        *move_toggled = !*move_toggled;
+    }
 
-        // Apply movement update
-        if axis_input != Vec3::ZERO {
-            let max_speed = if key_input.pressed(options.key_run) {
-                options.run_speed
-            } else {
-                options.walk_speed
-            };
-            options.velocity = axis_input.normalize() * max_speed;
+    // Apply movement update
+    if axis_input != Vec3::ZERO {
+        let max_speed = if key_input.pressed(options.key_run) {
+            options.run_speed
         } else {
-            let friction = options.friction.clamp(0.0, 1.0);
-            options.velocity *= 1.0 - friction;
-            if options.velocity.length_squared() < 1e-6 {
-                options.velocity = Vec3::ZERO;
-            }
+            options.walk_speed
+        };
+        options.velocity = axis_input.normalize() * max_speed;
+    } else {
+        let friction = options.friction.clamp(0.0, 1.0);
+        options.velocity *= 1.0 - friction;
+        if options.velocity.length_squared() < 1e-6 {
+            options.velocity = Vec3::ZERO;
         }
-        let forward = transform.forward();
-        let right = transform.right();
-        transform.translation += options.velocity.x * dt * right
-            + options.velocity.y * dt * Vec3::Y
-            + options.velocity.z * dt * forward;
+    }
+    let forward = transform.forward();
+    let right = transform.right();
+    transform.translation += options.velocity.x * dt * right
+        + options.velocity.y * dt * Vec3::Y
+        + options.velocity.z * dt * forward;
 
-        // Handle mouse input
-        let mut mouse_delta = Vec2::ZERO;
-        if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            for mut window in &mut windows {
-                if !window.focused {
-                    continue;
-                }
-
-                window.cursor.grab_mode = CursorGrabMode::Locked;
-                window.cursor.visible = false;
+    // Handle mouse input
+    let mut mouse_delta = Vec2::ZERO;
+    if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
+        for mut window in &mut windows {
+            if !window.focused {
+                continue;
             }
 
-            for mouse_event in mouse_events.iter() {
-                mouse_delta += mouse_event.delta;
-            }
-        }
-        if mouse_button_input.just_released(options.mouse_key_enable_mouse) {
-            for mut window in &mut windows {
-                window.cursor.grab_mode = CursorGrabMode::None;
-                window.cursor.visible = true;
-            }
+            window.cursor.grab_mode = CursorGrabMode::Locked;
+            window.cursor.visible = false;
         }
 
-        if mouse_delta != Vec2::ZERO {
-            // Apply look update
-            options.pitch = (options.pitch - mouse_delta.y * RADIANS_PER_DOT * options.sensitivity)
-                .clamp(-PI / 2., PI / 2.);
-            options.yaw -= mouse_delta.x * RADIANS_PER_DOT * options.sensitivity;
-            transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
+        for mouse_event in mouse_events.iter() {
+            mouse_delta += mouse_event.delta;
         }
+    }
+    if mouse_button_input.just_released(options.mouse_key_enable_mouse) {
+        for mut window in &mut windows {
+            window.cursor.grab_mode = CursorGrabMode::None;
+            window.cursor.visible = true;
+        }
+    }
+
+    if mouse_delta != Vec2::ZERO {
+        // Apply look update
+        options.pitch = (options.pitch - mouse_delta.y * RADIANS_PER_DOT * options.sensitivity)
+            .clamp(-PI / 2., PI / 2.);
+        options.yaw -= mouse_delta.x * RADIANS_PER_DOT * options.sensitivity;
+        transform.rotation = Quat::from_euler(EulerRot::ZYX, 0.0, options.yaw, options.pitch);
     }
 }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -170,31 +170,32 @@ fn keyboard_animation_control(
     if scene_handle.animations.is_empty() {
         return;
     }
+    let Ok(mut player) = animation_player.get_single_mut() else {
+        return;
+    };
 
-    if let Ok(mut player) = animation_player.get_single_mut() {
-        if keyboard_input.just_pressed(KeyCode::Space) {
-            if player.is_paused() {
-                player.resume();
-            } else {
-                player.pause();
-            }
+    if keyboard_input.just_pressed(KeyCode::Space) {
+        if player.is_paused() {
+            player.resume();
+        } else {
+            player.pause();
         }
+    }
 
-        if *changing {
-            // change the animation the frame after return was pressed
-            *current_animation = (*current_animation + 1) % scene_handle.animations.len();
-            player
-                .play(scene_handle.animations[*current_animation].clone_weak())
-                .repeat();
-            *changing = false;
-        }
+    if *changing {
+        // change the animation the frame after return was pressed
+        *current_animation = (*current_animation + 1) % scene_handle.animations.len();
+        player
+            .play(scene_handle.animations[*current_animation].clone_weak())
+            .repeat();
+        *changing = false;
+    }
 
-        if keyboard_input.just_pressed(KeyCode::Return) {
-            // delay the animation change for one frame
-            *changing = true;
-            // set the current animation to its start and pause it to reset to its starting state
-            player.set_elapsed(0.0).pause();
-        }
+    if keyboard_input.just_pressed(KeyCode::Return) {
+        // delay the animation change for one frame
+        *changing = true;
+        // set the current animation to its start and pause it to reset to its starting state
+        player.set_elapsed(0.0).pause();
     }
 }
 

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -36,28 +36,30 @@ fn atlas_render_system(
     font_atlas_sets: Res<Assets<FontAtlasSet>>,
     texture_atlases: Res<Assets<TextureAtlas>>,
 ) {
-    if let Some(set) = font_atlas_sets.get(&state.handle.cast_weak::<FontAtlasSet>()) {
-        if let Some((_size, font_atlas)) = set.iter().next() {
-            let x_offset = state.atlas_count as f32;
-            if state.atlas_count == font_atlas.len() as u32 {
-                return;
-            }
-            let texture_atlas = texture_atlases
-                .get(&font_atlas[state.atlas_count as usize].texture_atlas)
-                .unwrap();
-            state.atlas_count += 1;
-            commands.spawn(ImageBundle {
-                image: texture_atlas.texture.clone().into(),
-                style: Style {
-                    position_type: PositionType::Absolute,
-                    top: Val::Px(0.0),
-                    left: Val::Px(512.0 * x_offset),
-                    ..default()
-                },
-                ..default()
-            });
-        }
+    let Some(set) = font_atlas_sets.get(&state.handle.cast_weak::<FontAtlasSet>()) else {
+        return;
+    };
+    let Some((_size, font_atlas)) = set.iter().next() else {
+        return;
+    };
+    let x_offset = state.atlas_count as f32;
+    if state.atlas_count == font_atlas.len() as u32 {
+        return;
     }
+    let texture_atlas = texture_atlases
+        .get(&font_atlas[state.atlas_count as usize].texture_atlas)
+        .unwrap();
+    state.atlas_count += 1;
+    commands.spawn(ImageBundle {
+        image: texture_atlas.texture.clone().into(),
+        style: Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(0.0),
+            left: Val::Px(512.0 * x_offset),
+            ..default()
+        },
+        ..default()
+    });
 }
 
 fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Query<&mut Text>) {


### PR DESCRIPTION
# Objective

Now that `let...else` is stable, we can improve legibility and reduce indentation in code that currently uses `if let`, followed by large blocks of code.

## Solution

Replace instances of `if let` or `match...return` to use `let...else`.

The first commit in this PR fixes instances of `clippy::manual_let_else`, which detects basic instances of `match` that we can replace easily. The second commit in this PR additionally changes large function and loop blocks to return or continue early when a value is not matched. This unfortunately causes a lot of changed lines in the PR.

We can just cherry pick the first commit if we don't want to change beyond the pedantic clippy lint, or break these changes up into multiple PRs.

EDIT: For any potential reviewers, you might consider viewing the changes in your local editor or somewhere else that ignores indentation changes when highlighting lines.