### PR TITLE
Fix panics and docs when using World schedules

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1708,9 +1708,11 @@ impl World {
 
 // Schedule-related methods
 impl World {
-    /// Runs the [`Schedule`] associated with the `label` a single time.
+    /// Adds the specified [`Schedule`] to the world. The schedule can later be run
+    /// by calling [`.run_schedule(label)`](Self::run_schedule) or by directly
+    /// accessing the [`Schedules`] resource.
     ///
-    /// The [`Schedule`] is fetched from the
+    /// The `Schedules` resource will be initialized if it does not already exist.
     pub fn add_schedule(&mut self, schedule: Schedule, label: impl ScheduleLabel) {
         let mut schedules = self.get_resource_or_insert_with(Schedules::default);
         schedules.insert(label, schedule);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1712,7 +1712,7 @@ impl World {
     ///
     /// The [`Schedule`] is fetched from the
     pub fn add_schedule(&mut self, schedule: Schedule, label: impl ScheduleLabel) {
-        let mut schedules = self.resource_mut::<Schedules>();
+        let mut schedules = self.get_resource_or_insert_with(Schedules::default);
         schedules.insert(label, schedule);
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1743,7 +1743,9 @@ impl World {
         &mut self,
         label: &dyn ScheduleLabel,
     ) -> Result<(), TryRunScheduleError> {
-        let Some((extracted_label, mut schedule)) = self.resource_mut::<Schedules>().remove_entry(label) else {
+        let Some((extracted_label, mut schedule))
+            = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
+        else {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };
 


### PR DESCRIPTION
# Objective

The method `World::try_run_schedule` currently panics if the `Schedules` resource does not exist, but it should just return an `Err`. Similarly, `World::add_schedule` panics unnecessarily if the resource does not exist.

Also, the documentation for `World::add_schedule` is completely wrong.

## Solution

When the `Schedules` resource does not exist, we now treat it the same as if it did exist but was empty. When calling `add_schedule`, we initialize it if it does not exist.
