### PR TITLE
Explain why default_nearest is used in pixel_perfect example

### DIFF
--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(DefaultPlugins.set(
             // This sets image filtering to nearest
             // This is done to prevent textures with low resolution (e.g. pixel art) from being blurred
-            // by nearest filtering.
+            // by linear filtering.
             ImagePlugin::default_nearest(),
         ))
         .add_systems(Startup, setup)

--- a/examples/2d/pixel_perfect.rs
+++ b/examples/2d/pixel_perfect.rs
@@ -4,7 +4,12 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(ImagePlugin::default_nearest()))
+        .add_plugins(DefaultPlugins.set(
+            // This sets image filtering to nearest
+            // This is done to prevent textures with low resolution (e.g. pixel art) from being blurred
+            // by nearest filtering.
+            ImagePlugin::default_nearest(),
+        ))
         .add_systems(Startup, setup)
         .add_systems(Update, sprite_movement)
         .run();


### PR DESCRIPTION
# Objective

Fixes #8367 

## Solution

Added a comment explaining why linear filtering is required in this example, with formatting focused specifically on `ImagePlugin` to avoid confusion