### PR TITLE
Support for user defined log formatting

### DIFF
--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -8,6 +8,7 @@ fn main() {
             // Uncomment this to override the default log settings:
             // level: bevy::log::Level::TRACE,
             // filter: "wgpu=warn,bevy_ecs=info".to_string(),
+            // layer: Box::new(|| Box::new(bevy::log::tracing_subscriber::fmt::Layer::default())),
             ..default()
         }))
         .add_systems(Update, log_system)


### PR DESCRIPTION
# Objective

Adopted #3778.

This pr allows to configure how the bevy log is formatted. The default bevy log can be a bit verbose for some projects, specially the timestamp. The objective is to allow developers to select the format that best suits them.

```
Example of original bevy log:
2023-04-13T14:19:53.674653Z INFO bevy_render::renderer: [important text!]
```

## Solution

Using `tracing_subscriber::fmt::Subscriber`, adds the attribute `layer` to `LogPlugin`. This allows to pass a `tracing_subscriber::fmt::Layer` when creating the plugin and modifying the output.

For example this

```rust
App::new()
    .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
        layer: Box::new(|| Box::new(bevy::log::tracing_subscriber::fmt::Layer::default())),
        ..default()
    }))
    .run()
```

prints

```
INFO bevy_render::renderer: [important text!]
```

The main idea comes from @SonicZentropy and their pull request #3778, but it was stale since may. This has all the changes and a fix since now `LogSettings` are included in the plugin and not in a resource.

Since plugin builders are stateless and not mutable (#8101), the old solution of using an `Option<Box<Layer>>` no longer works. One solution to fix this is to use a `Box<Fn() -> Box<Layer>>`. I am unaware of another more idiomatic fix, so if you have something better please revise it. Should plugins builders be mutable in the future, this can be changed back to the original approach.

---

## Changelog

- Adds field `layer` to `LogPlugin` that takes a function returning a `tracing_subscriber` custom layer.
- Reexports `tracing_subscriber` from log so it can be used to configure the plugin.
- Modifies the `logs.rs` example to include the new configuration.

## Migration Guide

No breaking changes
