### PR TITLE
Add a `scope` API for world schedules

### DIFF
--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -7,4 +7,4 @@ use crate::schedule::BoxedScheduleLabel;
 /// [`World::try_run_schedule`]: crate::world::World::try_run_schedule
 #[derive(Error, Debug)]
 #[error("The schedule with the label {0:?} was not found.")]
-pub struct ScheduleNotFoundError(pub BoxedScheduleLabel);
+pub struct TryRunScheduleError(pub BoxedScheduleLabel);

--- a/crates/bevy_ecs/src/world/error.rs
+++ b/crates/bevy_ecs/src/world/error.rs
@@ -7,4 +7,4 @@ use crate::schedule::BoxedScheduleLabel;
 /// [`World::try_run_schedule`]: crate::world::World::try_run_schedule
 #[derive(Error, Debug)]
 #[error("The schedule with the label {0:?} was not found.")]
-pub struct TryRunScheduleError(pub BoxedScheduleLabel);
+pub struct ScheduleNotFoundError(pub BoxedScheduleLabel);

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1762,7 +1762,7 @@ impl World {
     }
 
     /// Attempts to run the [`Schedule`] associated with the `label` a single time,
-    /// and returns a [`TryRunScheduleError`] if the schedule does not exist.
+    /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
@@ -1776,7 +1776,7 @@ impl World {
     }
 
     /// Attempts to run the [`Schedule`] associated with the `label` a single time,
-    /// and returns a [`TryRunScheduleError`] if the schedule does not exist.
+    /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
     ///
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1827,7 +1827,7 @@ impl World {
     /// Temporarily removes the schedule associated with `label` from the world,
     /// runs user code, and finally re-adds the schedule.
     ///
-    /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
+    /// Unlike the `run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1724,8 +1724,9 @@ impl World {
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
     ///
-    /// For simple cases where you just need to call the schedule,
+    /// For simple cases where you just need to call the schedule once,
     /// consider using [`World::try_run_schedule`] instead.
+    /// For other use cases, see the example on [`World::schedule_scope`].
     pub fn try_schedule_scope<R>(
         &mut self,
         label: impl ScheduleLabel,
@@ -1744,8 +1745,9 @@ impl World {
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
     ///
-    /// For simple cases where you just need to call the schedule,
+    /// For simple cases where you just need to call the schedule once,
     /// consider using [`World::try_run_schedule_ref`] instead.
+    /// For other use cases, see the example on [`World::schedule_scope`].
     pub fn try_schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,
@@ -1772,9 +1774,6 @@ impl World {
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
     ///
-    /// For simple cases where you just need to call the schedule,
-    /// consider using [`World::run_schedule`] instead.
-    ///
     /// # Examples
     ///
     /// ```
@@ -1800,6 +1799,9 @@ impl World {
     /// # assert_eq!(world.resource::<Counter>().0, 5);
     /// ```
     ///
+    /// For simple cases where you just need to call the schedule once,
+    /// consider using [`World::run_schedule`] instead.
+    ///
     /// # Panics
     ///
     /// If the requested schedule does not exist.
@@ -1821,6 +1823,7 @@ impl World {
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule_ref`] instead.
+    /// For other use cases, see the example on [`World::schedule_scope`].
     ///
     /// # Panics
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1762,8 +1762,12 @@ impl World {
         let _span = bevy_utils::tracing::info_span!("schedule", name = ?extracted_label).entered();
         let value = f(self, &mut schedule);
 
-        self.resource_mut::<Schedules>()
+        let old = self
+            .resource_mut::<Schedules>()
             .insert(extracted_label, schedule);
+        if old.is_some() {
+            warn!("Schedule `{label:?}` was inserted during a call to `World::schedule_scope`: its value has been overwritten")
+        }
 
         Ok(value)
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1716,6 +1716,16 @@ impl World {
         schedules.insert(label, schedule);
     }
 
+    /// Temporarily removes the schedule associated with `label` from the world,
+    /// runs user code, and finally re-adds the schedule.
+    /// This returns a [`ScheduleNotFoundError`] if there is no schedule
+    /// associated with `label`.
+    ///
+    /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
+    /// and system state is cached.
+    ///
+    /// For simple cases where you just need to call the schedule,
+    /// consider using [`World::try_run_schedule`] instead.
     pub fn try_schedule_scope<R>(
         &mut self,
         label: impl ScheduleLabel,
@@ -1724,6 +1734,18 @@ impl World {
         self.try_schedule_scope_ref(&label, f)
     }
 
+    /// Temporarily removes the schedule associated with `label` from the world,
+    /// runs user code, and finally re-adds the schedule.
+    /// This returns a [`ScheduleNotFoundError`] if there is no schedule
+    /// associated with `label`.
+    ///
+    /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
+    ///
+    /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
+    /// and system state is cached.
+    ///
+    /// For simple cases where you just need to call the schedule,
+    /// consider using [`World::try_run_schedule`] instead.
     pub fn try_schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,
@@ -1744,6 +1766,18 @@ impl World {
         Ok(value)
     }
 
+    /// Temporarily removes the schedule associated with `label` from the world,
+    /// runs user code, and finally re-adds the schedule.
+    ///
+    /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
+    /// and system state is cached.
+    ///
+    /// For simple cases where you just need to call the schedule,
+    /// consider using [`World::try_run_schedule`] instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
     pub fn schedule_scope<R>(
         &mut self,
         label: impl ScheduleLabel,
@@ -1752,6 +1786,20 @@ impl World {
         self.schedule_scope_ref(&label, f)
     }
 
+    /// Temporarily removes the schedule associated with `label` from the world,
+    /// runs user code, and finally re-adds the schedule.
+    ///
+    /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
+    ///
+    /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
+    /// and system state is cached.
+    ///
+    /// For simple cases where you just need to call the schedule,
+    /// consider using [`World::try_run_schedule`] instead.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
     pub fn schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1777,7 +1777,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist.
+    /// If the requested schedule does not exist.
     pub fn schedule_scope<R>(
         &mut self,
         label: impl ScheduleLabel,
@@ -1799,7 +1799,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist.
+    /// If the requested schedule does not exist.
     pub fn schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,
@@ -1848,7 +1848,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist.
+    /// If the requested schedule does not exist.
     pub fn run_schedule(&mut self, label: impl ScheduleLabel) {
         self.run_schedule_ref(&label);
     }
@@ -1864,7 +1864,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist.
+    /// If the requested schedule does not exist.
     pub fn run_schedule_ref(&mut self, label: &dyn ScheduleLabel) {
         self.schedule_scope_ref(label, |world, sched| sched.run(world));
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1751,7 +1751,9 @@ impl World {
         label: &dyn ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, ScheduleNotFoundError> {
-        let Some((extracted_label, mut schedule)) = self.resource_mut::<Schedules>().remove_entry(label) else {
+        let Some((extracted_label, mut schedule))
+            = self.get_resource_or_insert_with(Schedules::default).remove_entry(label)
+        else {
             return Err(ScheduleNotFoundError(label.dyn_clone()));
         };
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1718,7 +1718,7 @@ impl World {
 
     /// Temporarily removes the schedule associated with `label` from the world,
     /// runs user code, and finally re-adds the schedule.
-    /// This returns a [`ScheduleNotFoundError`] if there is no schedule
+    /// This returns a [`TryRunScheduleError`] if there is no schedule
     /// associated with `label`.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
@@ -1737,7 +1737,7 @@ impl World {
 
     /// Temporarily removes the schedule associated with `label` from the world,
     /// runs user code, and finally re-adds the schedule.
-    /// This returns a [`ScheduleNotFoundError`] if there is no schedule
+    /// This returns a [`TryRunScheduleError`] if there is no schedule
     /// associated with `label`.
     ///
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
@@ -1838,7 +1838,7 @@ impl World {
     }
 
     /// Attempts to run the [`Schedule`] associated with the `label` a single time,
-    /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
+    /// and returns a [`TryRunScheduleError`] if the schedule does not exist.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
@@ -1852,7 +1852,7 @@ impl World {
     }
 
     /// Attempts to run the [`Schedule`] associated with the `label` a single time,
-    /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
+    /// and returns a [`TryRunScheduleError`] if the schedule does not exist.
     ///
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1775,6 +1775,31 @@ impl World {
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule`] instead.
     ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, schedule::ScheduleLabel};
+    /// # #[derive(ScheduleLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    /// # pub struct MySchedule;
+    /// # #[derive(Resource)]
+    /// # struct Counter(usize);
+    /// #
+    /// # let mut world = World::new();
+    /// # world.insert_resource(Counter(0));
+    /// # let mut schedule = Schedule::new();
+    /// # schedule.add_systems(tick_counter);
+    /// # world.init_resource::<Schedules>();
+    /// # world.add_schedule(schedule, MySchedule);
+    /// # fn tick_counter(mut counter: ResMut<Counter>) { counter.0 += 1; }
+    /// // Run the schedule five times.
+    /// world.schedule_scope(MySchedule, |world, schedule| {
+    ///     for _ in 0..5 {
+    ///         schedule.run(world);
+    ///     }
+    /// });
+    /// # assert_eq!(world.resource::<Counter>().0, 5);
+    /// ```
+    ///
     /// # Panics
     ///
     /// If the requested schedule does not exist.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1751,9 +1751,7 @@ impl World {
         label: &dyn ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
-        let Some((extracted_label, mut schedule))
-            = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
-        else {
+        let Some((extracted_label, mut schedule)) = self.resource_mut::<Schedules>().remove_entry(label) else {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
-    world::error::ScheduleNotFoundError,
+    world::error::TryRunScheduleError,
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::warn;
@@ -1730,7 +1730,7 @@ impl World {
         &mut self,
         label: impl ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
-    ) -> Result<R, ScheduleNotFoundError> {
+    ) -> Result<R, TryRunScheduleError> {
         self.try_schedule_scope_ref(&label, f)
     }
 
@@ -1750,11 +1750,11 @@ impl World {
         &mut self,
         label: &dyn ScheduleLabel,
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
-    ) -> Result<R, ScheduleNotFoundError> {
+    ) -> Result<R, TryRunScheduleError> {
         let Some((extracted_label, mut schedule))
             = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
         else {
-            return Err(ScheduleNotFoundError(label.dyn_clone()));
+            return Err(TryRunScheduleError(label.dyn_clone()));
         };
 
         // TODO: move this span to Schedule::run
@@ -1821,7 +1821,7 @@ impl World {
     pub fn try_run_schedule(
         &mut self,
         label: impl ScheduleLabel,
-    ) -> Result<(), ScheduleNotFoundError> {
+    ) -> Result<(), TryRunScheduleError> {
         self.try_run_schedule_ref(&label)
     }
 
@@ -1837,7 +1837,7 @@ impl World {
     pub fn try_run_schedule_ref(
         &mut self,
         label: &dyn ScheduleLabel,
-    ) -> Result<(), ScheduleNotFoundError> {
+    ) -> Result<(), TryRunScheduleError> {
         self.try_schedule_scope_ref(label, |world, sched| sched.run(world))
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1773,7 +1773,7 @@ impl World {
             .resource_mut::<Schedules>()
             .insert(extracted_label, schedule);
         if old.is_some() {
-            warn!("Schedule `{label:?}` was inserted during a call to `World::schedule_scope`: its value has been overwritten")
+            warn!("Schedule `{label:?}` was inserted during a call to `World::schedule_scope`: its value has been overwritten");
         }
 
         Ok(value)

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1752,7 +1752,7 @@ impl World {
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, ScheduleNotFoundError> {
         let Some((extracted_label, mut schedule))
-            = self.get_resource_or_insert_with(Schedules::default).remove_entry(label)
+            = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
         else {
             return Err(ScheduleNotFoundError(label.dyn_clone()));
         };

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -21,7 +21,7 @@ use crate::{
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
-    world::error::TryRunScheduleError,
+    world::error::ScheduleNotFoundError,
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use bevy_utils::tracing::warn;
@@ -1726,7 +1726,7 @@ impl World {
     pub fn try_run_schedule(
         &mut self,
         label: impl ScheduleLabel,
-    ) -> Result<(), TryRunScheduleError> {
+    ) -> Result<(), ScheduleNotFoundError> {
         self.try_run_schedule_ref(&label)
     }
 
@@ -1742,9 +1742,9 @@ impl World {
     pub fn try_run_schedule_ref(
         &mut self,
         label: &dyn ScheduleLabel,
-    ) -> Result<(), TryRunScheduleError> {
+    ) -> Result<(), ScheduleNotFoundError> {
         let Some((extracted_label, mut schedule)) = self.resource_mut::<Schedules>().remove_entry(label) else {
-            return Err(TryRunScheduleError(label.dyn_clone()));
+            return Err(ScheduleNotFoundError(label.dyn_clone()));
         };
 
         // TODO: move this span to Schedule::run

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1722,7 +1722,7 @@ impl World {
     /// associated with `label`.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::try_run_schedule`] instead.
@@ -1742,7 +1742,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::try_run_schedule_ref`] instead.
@@ -1772,7 +1772,7 @@ impl World {
     /// runs user code, and finally re-adds the schedule.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule`] instead.
@@ -1794,7 +1794,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule_ref`] instead.
@@ -1815,7 +1815,7 @@ impl World {
     /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     pub fn try_run_schedule(
@@ -1831,7 +1831,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     pub fn try_run_schedule_ref(
@@ -1844,7 +1844,7 @@ impl World {
     /// Runs the [`Schedule`] associated with the `label` a single time.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     ///
@@ -1860,7 +1860,7 @@ impl World {
     /// Unlike the `run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached.
+    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     ///

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1745,7 +1745,7 @@ impl World {
     /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
-    /// consider using [`World::try_run_schedule`] instead.
+    /// consider using [`World::try_run_schedule_ref`] instead.
     pub fn try_schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,
@@ -1775,11 +1775,11 @@ impl World {
     /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
-    /// consider using [`World::try_run_schedule`] instead.
+    /// consider using [`World::run_schedule`] instead.
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
+    /// Panics if the requested schedule does not exist.
     pub fn schedule_scope<R>(
         &mut self,
         label: impl ScheduleLabel,
@@ -1797,11 +1797,11 @@ impl World {
     /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
-    /// consider using [`World::try_run_schedule`] instead.
+    /// consider using [`World::run_schedule_ref`] instead.
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
+    /// Panics if the requested schedule does not exist.
     pub fn schedule_scope_ref<R>(
         &mut self,
         label: &dyn ScheduleLabel,
@@ -1850,7 +1850,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
+    /// Panics if the requested schedule does not exist.
     pub fn run_schedule(&mut self, label: impl ScheduleLabel) {
         self.run_schedule_ref(&label);
     }
@@ -1866,7 +1866,7 @@ impl World {
     ///
     /// # Panics
     ///
-    /// Panics if the requested schedule does not exist, or the [`Schedules`] resource was not added.
+    /// Panics if the requested schedule does not exist.
     pub fn run_schedule_ref(&mut self, label: &dyn ScheduleLabel) {
         self.schedule_scope_ref(label, |world, sched| sched.run(world));
     }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1722,7 +1722,7 @@ impl World {
     /// associated with `label`.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::try_run_schedule`] instead.
@@ -1742,7 +1742,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::try_run_schedule_ref`] instead.
@@ -1772,7 +1772,7 @@ impl World {
     /// runs user code, and finally re-adds the schedule.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule`] instead.
@@ -1794,7 +1794,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple cases where you just need to call the schedule,
     /// consider using [`World::run_schedule_ref`] instead.
@@ -1815,7 +1815,7 @@ impl World {
     /// and returns a [`ScheduleNotFoundError`] if the schedule does not exist.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     pub fn try_run_schedule(
@@ -1831,7 +1831,7 @@ impl World {
     /// Unlike the `try_run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     pub fn try_run_schedule_ref(
@@ -1844,7 +1844,7 @@ impl World {
     /// Runs the [`Schedule`] associated with the `label` a single time.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     ///
@@ -1860,7 +1860,7 @@ impl World {
     /// Unlike the `run_schedule` method, this method takes the label by reference, which can save a clone.
     ///
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
-    /// and system state is cached. The `Schedules` resource will be initialized if it does not exist.
+    /// and system state is cached.
     ///
     /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
     ///

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -106,16 +106,11 @@ pub fn run_fixed_update_schedule(world: &mut World) {
     fixed_time.tick(delta_time);
 
     // Run the schedule until we run out of accumulated time
-    let mut check_again = true;
-    while check_again {
-        let mut fixed_time = world.resource_mut::<FixedTime>();
-        let fixed_time_run = fixed_time.expend().is_ok();
-        if fixed_time_run {
-            let _ = world.try_run_schedule(FixedUpdate);
-        } else {
-            check_again = false;
+    let _ = world.try_schedule_scope(FixedUpdate, |world, schedule| {
+        while world.resource_mut::<FixedTime>().expend().is_ok() {
+            schedule.run(world);
         }
-    }
+    });
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Objective

If you want to execute a schedule on the world using arbitrarily complex behavior, you currently need to use "hokey-pokey strats": remove the schedule from the world, do your thing, and add it back to the world. Not only is this cumbersome, it's potentially error-prone as one might forget to re-insert the schedule.

## Solution

Add the `World::{try}schedule_scope{ref}` family of functions, which is a convenient abstraction over hokey pokey strats. This method essentially works the same way as `World::resource_scope`.

### Example

```rust
// Run the schedule five times.
world.schedule_scope(MySchedule, |world, schedule| {
    for _ in 0..5 {
        schedule.run(world);
    }
});
```

---

## Changelog

Added the `World::schedule_scope` family of methods, which provide a way to get mutable access to a world and one of its schedules at the same time.
