### PR TITLE
Add vertex based ambient occlusion

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -703,6 +703,11 @@ impl SpecializedMeshPipeline for MeshPipeline {
             vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(4));
         }
 
+        if layout.contains(Mesh::ATTRIBUTE_OCCLUSION) {
+            shader_defs.push("VERTEX_OCCLUSION".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_OCCLUSION.at_shader_location(5));
+        }
+
         let mut bind_group_layout = match key.msaa_samples() {
             1 => vec![self.view_layout.clone()],
             _ => {
@@ -715,8 +720,8 @@ impl SpecializedMeshPipeline for MeshPipeline {
             && layout.contains(Mesh::ATTRIBUTE_JOINT_WEIGHT)
         {
             shader_defs.push("SKINNED".into());
-            vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_INDEX.at_shader_location(5));
-            vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_WEIGHT.at_shader_location(6));
+            vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_INDEX.at_shader_location(6));
+            vertex_attributes.push(Mesh::ATTRIBUTE_JOINT_WEIGHT.at_shader_location(7));
             bind_group_layout.push(self.skinned_mesh_layout.clone());
         } else {
             bind_group_layout.push(self.mesh_layout.clone());

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -20,9 +20,12 @@ struct Vertex {
 #ifdef VERTEX_COLORS
     @location(4) color: vec4<f32>,
 #endif
+#ifdef VERTEX_OCCLUSION
+    @location(5) occlusion: f32,
+#endif
 #ifdef SKINNED
-    @location(5) joint_indices: vec4<u32>,
-    @location(6) joint_weights: vec4<f32>,
+    @location(6) joint_indices: vec4<u32>,
+    @location(7) joint_weights: vec4<f32>,
 #endif
 };
 
@@ -64,6 +67,10 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 
 #ifdef VERTEX_COLORS
     out.color = vertex.color;
+#endif
+
+#ifdef VERTEX_OCCLUSION
+    out.occlusion = vertex.occlusion;
 #endif
 
     return out;

--- a/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
@@ -11,3 +11,6 @@
 #ifdef VERTEX_COLORS
 @location(4) color: vec4<f32>,
 #endif
+#ifdef VERTEX_OCCLUSION
+@location(5) occlusion: f32,
+#endif

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -89,9 +89,12 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         pbr_input.material.perceptual_roughness = perceptual_roughness;
 
         var occlusion: f32 = 1.0;
+#ifdef VERTEX_OCCLUSION
+        occlusion = in.occlusion;
+#endif
 #ifdef VERTEX_UVS
         if ((material.flags & STANDARD_MATERIAL_FLAGS_OCCLUSION_TEXTURE_BIT) != 0u) {
-            occlusion = textureSample(occlusion_texture, occlusion_sampler, uv).r;
+            occlusion = occlusion * textureSample(occlusion_texture, occlusion_sampler, uv).r;
         }
 #endif
         pbr_input.frag_coord = in.frag_coord;

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -76,12 +76,16 @@ impl Mesh {
     pub const ATTRIBUTE_COLOR: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Color", 4, VertexFormat::Float32x4);
 
+    /// Per vertex ambient occlusion. Use in conjunction with [`Mesh::insert_attribute`]
+    pub const ATTRIBUTE_OCCLUSION: MeshVertexAttribute =
+        MeshVertexAttribute::new("Vertex_Occlusion", 5, VertexFormat::Float32);
+
     /// Per vertex joint transform matrix weight. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_JOINT_WEIGHT: MeshVertexAttribute =
-        MeshVertexAttribute::new("Vertex_JointWeight", 5, VertexFormat::Float32x4);
+        MeshVertexAttribute::new("Vertex_JointWeight", 6, VertexFormat::Float32x4);
     /// Per vertex joint transform matrix index. Use in conjunction with [`Mesh::insert_attribute`]
     pub const ATTRIBUTE_JOINT_INDEX: MeshVertexAttribute =
-        MeshVertexAttribute::new("Vertex_JointIndex", 6, VertexFormat::Uint16x4);
+        MeshVertexAttribute::new("Vertex_JointIndex", 7, VertexFormat::Uint16x4);
 
     /// Construct a new mesh. You need to provide a [`PrimitiveTopology`] so that the
     /// renderer knows how to treat the vertex data. Most of the time this will be

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -1,4 +1,4 @@
-//! Illustrates the use of vertex colors.
+//! Illustrates the use of vertex colors and ambient occlusion factors.
 
 use bevy::{prelude::*, render::mesh::VertexAttributeValues};
 
@@ -31,7 +31,9 @@ fn setup(
             .iter()
             .map(|[r, g, b]| [(1. - *r) / 2., (1. - *g) / 2., (1. - *b) / 2., 1.])
             .collect();
+        let occlusions: Vec<f32> = positions.iter().map(|[_, y, _]| y + 0.5).collect();
         colorful_cube.insert_attribute(Mesh::ATTRIBUTE_COLOR, colors);
+        colorful_cube.insert_attribute(Mesh::ATTRIBUTE_OCCLUSION, occlusions);
     }
     commands.spawn(PbrBundle {
         mesh: meshes.add(colorful_cube),


### PR DESCRIPTION
# Objective

Add the feature to specify ambient occlusion values on a per-vertex basis, enhancing the lighting quality of scenes without using a separate texture.

## Solution

- Add a new `MeshVertexAttribute`.
- Add a new field to the vertex shader input and output and pass its value through.
- Use the new value in the fragment shader.
- Update the `vertex_colors` example to showcase the new attribute.

## Changelog

- Add the `ATTRIBUTE_OCCLUSION` vertex attribute to support specifying ambient occlusion values on a per-vertex basis.