### PR TITLE
Better error message when index does not exist in texture atlas

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -396,7 +396,17 @@ pub fn extract_sprites(
             continue;
         }
         if let Some(texture_atlas) = texture_atlases.get(texture_atlas_handle) {
-            let rect = Some(texture_atlas.textures[atlas_sprite.index]);
+            let rect = Some(
+                *texture_atlas
+                    .textures
+                    .get(atlas_sprite.index)
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "Sprite index {} does not exist for texture atlas.",
+                            atlas_sprite.index
+                        )
+                    }),
+            );
             extracted_sprites.sprites.push(ExtractedSprite {
                 entity,
                 color: atlas_sprite.color,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -402,8 +402,9 @@ pub fn extract_sprites(
                     .get(atlas_sprite.index)
                     .unwrap_or_else(|| {
                         panic!(
-                            "Sprite index {} does not exist for texture atlas.",
-                            atlas_sprite.index
+                            "Sprite index {:?} does not exist for texture atlas handle {:?}.",
+                            atlas_sprite.index,
+                            texture_atlas_handle.id(),
                         )
                     }),
             );


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/8210

## Changelog

- Improve error message when `TextureAtlasSprite::index` does not exist in texture atlas