### PR TITLE
Exposure settings

### DIFF
--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -854,18 +854,6 @@ pub fn prepare_lights(
             flags |= DirectionalLightFlags::SHADOWS_ENABLED;
         }
 
-        // convert from illuminance (lux) to candelas
-        //
-        // exposure is hard coded at the moment but should be replaced
-        // by values coming from the camera
-        // see: https://google.github.io/filament/Filament.html#imagingpipeline/physicallybasedcamera/exposuresettings
-        const APERTURE: f32 = 4.0;
-        const SHUTTER_SPEED: f32 = 1.0 / 250.0;
-        const SENSITIVITY: f32 = 100.0;
-        let ev100 = f32::log2(APERTURE * APERTURE / SHUTTER_SPEED) - f32::log2(SENSITIVITY / 100.0);
-        let exposure = 1.0 / (f32::powf(2.0, ev100) * 1.2);
-        let intensity = light.illuminance * exposure;
-
         let num_cascades = light
             .cascade_shadow_config
             .bounds
@@ -876,7 +864,7 @@ pub fn prepare_lights(
             cascades: [GpuDirectionalCascade::default(); MAX_CASCADES_PER_LIGHT],
             // premultiply color by intensity
             // we don't use the alpha at all, so no reason to multiply only [0..3]
-            color: Vec4::from_slice(&light.color.as_linear_rgba_f32()) * intensity,
+            color: Vec4::from_slice(&light.color.as_linear_rgba_f32()) * light.illuminance,
             // direction is negated to be ready for N.L
             dir_to_light: light.transform.back(),
             flags: flags.bits,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -254,7 +254,7 @@ fn pbr(
 
     // Total light
     output_color = vec4<f32>(
-        direct_light + indirect_light + emissive_light,
+        view.exposure * (direct_light + indirect_light + emissive_light),
         output_color.a
     );
 

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -16,6 +16,7 @@ struct View {
     projection: mat4x4<f32>,
     inverse_projection: mat4x4<f32>,
     world_position: vec3<f32>,
+    exposure: f32,
     // viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,
     color_grading: ColorGrading,

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -3,13 +3,13 @@
 
 use std::f32::consts::PI;
 
-use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*};
+use bevy::{pbr::CascadeShadowConfigBuilder, prelude::*, render::camera::ExposureSettings};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (movement, animate_light_direction))
+        .add_systems(Update, (update_exposure, movement, animate_light_direction))
         .run();
 }
 
@@ -207,6 +207,7 @@ fn setup(
     // directional 'sun' light
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
+            illuminance: 1000.0,
             shadows_enabled: true,
             ..default()
         },
@@ -227,11 +228,101 @@ fn setup(
         ..default()
     });
 
+    let exposure_settings = ExposureSettings::default();
+    let style = TextStyle {
+        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+        font_size: 18.0,
+        color: Color::WHITE,
+    };
+
+    commands.spawn(
+        TextBundle::from_sections(vec![
+            TextSection::new(
+                format!("Aperture: f/{:.0}\n", exposure_settings.aperture_f_stops),
+                style.clone(),
+            ),
+            TextSection::new(
+                format!(
+                    "Shutter speed: 1/{:.0}s\n",
+                    1.0 / exposure_settings.shutter_speed_s
+                ),
+                style.clone(),
+            ),
+            TextSection::new(
+                format!(
+                    "Sensitivity: ISO {:.0}\n",
+                    exposure_settings.sensitivity_iso
+                ),
+                style.clone(),
+            ),
+            TextSection::new("\n\n", style.clone()),
+            TextSection::new("Controls\n", style.clone()),
+            TextSection::new("---------------\n", style.clone()),
+            TextSection::new("1/2 - Decrease/Increase aperture\n", style.clone()),
+            TextSection::new("3/4 - Decrease/Increase shutter speed\n", style.clone()),
+            TextSection::new("5/6 - Decrease/Increase sensitivity\n", style),
+        ])
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            top: Val::Px(10.0),
+            left: Val::Px(10.0),
+            ..default()
+        }),
+    );
+
     // camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+    commands.spawn((
+        Camera3dBundle {
+            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+            ..default()
+        },
+        exposure_settings,
+    ));
+}
+
+fn update_exposure(
+    key_input: Res<Input<KeyCode>>,
+    mut query: Query<&mut ExposureSettings>,
+    mut text: Query<&mut Text>,
+) {
+    let mut text = text.single_mut();
+    let mut exposure_settings = query.single_mut();
+    if key_input.just_pressed(KeyCode::Key2) {
+        exposure_settings.aperture_f_stops *= 2.0;
+        text.sections[0].value = format!("Aperture: f/{:.0}\n", exposure_settings.aperture_f_stops);
+    } else if key_input.just_pressed(KeyCode::Key1) {
+        exposure_settings.aperture_f_stops *= 0.5;
+        text.sections[0].value = format!("Aperture: f/{:.0}\n", exposure_settings.aperture_f_stops);
+    }
+    if key_input.just_pressed(KeyCode::Key4) {
+        exposure_settings.shutter_speed_s *= 2.0;
+        text.sections[1].value = format!(
+            "Shutter speed: 1/{:.0}s\n",
+            1.0 / exposure_settings.shutter_speed_s
+        );
+    } else if key_input.just_pressed(KeyCode::Key3) {
+        exposure_settings.shutter_speed_s *= 0.5;
+        text.sections[1].value = format!(
+            "Shutter speed: 1/{:.0}s\n",
+            1.0 / exposure_settings.shutter_speed_s
+        );
+    }
+    if key_input.just_pressed(KeyCode::Key6) {
+        exposure_settings.sensitivity_iso += 100.0;
+        text.sections[2].value = format!(
+            "Sensitivity: ISO {:.0}\n",
+            exposure_settings.sensitivity_iso
+        );
+    } else if key_input.just_pressed(KeyCode::Key5) {
+        exposure_settings.sensitivity_iso -= 100.0;
+        text.sections[2].value = format!(
+            "Sensitivity: ISO {:.0}\n",
+            exposure_settings.sensitivity_iso
+        );
+    }
+    if key_input.just_pressed(KeyCode::D) {
+        *exposure_settings = ExposureSettings::default();
+    }
 }
 
 fn animate_light_direction(


### PR DESCRIPTION
# Objective

- Add basic exposure settings for aperture in f-stops, shutter speed in seconds, and sensitivity in ISO units as per Google's Filament: https://google.github.io/filament/Filament.html#physicallybasedcamera
- Fixes #8369 

## Solution

- Add basic exposure settings for aperture in f-stops, shutter speed in seconds, and sensitivity in ISO units as per Google's Filament: https://google.github.io/filament/Filament.html#physicallybasedcamera

---

## Changelog

- Added: ExposureSettings component that can be added to an entity with a Camera to configure PBR exposure settings

## Migration Guide

- The `ExposureSettings` component on an `Camera` entity will be used to configure exposure for PBR rendering. Previously only directional lights were using hard-coded exposure, but now all light has exposure applied. This will mean that all light sources other than directional lights will be significantly darker. Adjust the exposure settings and light intensities as necessary.