### PR TITLE
Add examples page build instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,6 +265,7 @@ Examples in Bevy should be:
 4. **Minimal:** They should be no larger or complex than is needed to meet the goals of the example.
 
 When you add a new example, be sure to update `examples/README.md` with the new example and add it to the root `Cargo.toml` file.
+Run `cargo run -p build-templated-pages -- build-example-page` to do this automatically.
 Use a generous sprinkling of keywords in your description: these are commonly used to search for a specific example.
 See the [example style guide](.github/contributing/example_style_guide.md) to help make sure the style of your example matches what we're already using.
 

--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -1,4 +1,5 @@
 <!-- MD024 - The Headers from the Platform-Specific Examples should be identical  -->
+<!-- Use 'cargo run -p build-templated-pages -- build-example-page' to generate the final example README.md -->
 <!-- markdownlint-disable-file MD024 -->
 
 # Examples

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,4 +1,5 @@
 <!-- MD024 - The Headers from the Platform-Specific Examples should be identical  -->
+<!-- Use 'cargo run -p build-templated-pages -- build-example-page' to generate the final example README.md -->
 <!-- markdownlint-disable-file MD024 -->
 
 # Examples


### PR DESCRIPTION
# Objective

Bevy provides an easy way to build the `examples/README.md` page, but it's difficult to discover.
By adding instructions in `CONTRIBUTING.md`, it's easier to find that it's possible to avoid this error-prone manual process.

Precisely: #8405 took me about 1 additional hour searching what command to use to generate automatically the file. (I could have manually edited the README, but that's beyond the point…)