### PR TITLE
Use logical coordinates for the UI layout

### DIFF
--- a/crates/bevy_ui/src/flex/convert.rs
+++ b/crates/bevy_ui/src/flex/convert.rs
@@ -13,9 +13,7 @@ impl Val {
         match self {
             Val::Auto => taffy::style::LengthPercentageAuto::Auto,
             Val::Percent(value) => taffy::style::LengthPercentageAuto::Percent(value / 100.),
-            Val::Px(value) => taffy::style::LengthPercentageAuto::Points(
-                (context.scale_factor * value as f64) as f32,
-            ),
+            Val::Px(value) => taffy::style::LengthPercentageAuto::Points(value),
             Val::VMin(value) => {
                 taffy::style::LengthPercentageAuto::Points(context.min_size * value / 100.)
             }
@@ -23,10 +21,10 @@ impl Val {
                 taffy::style::LengthPercentageAuto::Points(context.max_size * value / 100.)
             }
             Val::Vw(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.physical_size.x * value / 100.)
+                taffy::style::LengthPercentageAuto::Points(context.logical_size.x * value / 100.)
             }
             Val::Vh(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.physical_size.y * value / 100.)
+                taffy::style::LengthPercentageAuto::Points(context.logical_size.y * value / 100.)
             }
         }
     }

--- a/crates/bevy_ui/src/flex/mod.rs
+++ b/crates/bevy_ui/src/flex/mod.rs
@@ -188,12 +188,8 @@ without UI components as a child of an entity with UI components, results may be
                 *node,
                 taffy::style::Style {
                     size: taffy::geometry::Size {
-                        width: taffy::style::Dimension::Points(
-                            logical_size.x
-                        ),
-                        height: taffy::style::Dimension::Points(
-                            logical_size.y
-                        ),
+                        width: taffy::style::Dimension::Points(logical_size.x),
+                        height: taffy::style::Dimension::Points(logical_size.y),
                     },
                     ..Default::default()
                 },
@@ -351,10 +347,7 @@ pub fn flex_node_system(
     // PERF: try doing this incrementally
     for (entity, mut node, mut transform, parent) in &mut node_transform_query {
         let layout = flex_surface.get_layout(entity).unwrap();
-        let new_size = Vec2::new(
-            layout.size.width,
-            layout.size.height,
-        );
+        let new_size = Vec2::new(layout.size.width, layout.size.height);
         // only trigger change detection when the new value is different
         if node.calculated_size != new_size {
             node.calculated_size = new_size;


### PR DESCRIPTION
# Objective

It would be a lot more efficient and less complicated if the UI layout systems only used logical coordinates.

## Solution

Just use logical coordinates everywhere except where we can't.
Change `flex_node_system` and `FlexSurface` to use logical coordinates.

---

## Changelog

* Modified `flex_node_system` and `FlexSurface` to use logical coordinates.
* Changed the size paramter of `update_window` to a `Vec2` and renamed it to `logical_size`.

## Migration Guide

