### PR TITLE
Add Reflection Macros to TextureAtlasSprite

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -58,6 +58,7 @@ impl Plugin for SpritePlugin {
         app.add_asset::<TextureAtlas>()
             .register_asset_reflect::<TextureAtlas>()
             .register_type::<Sprite>()
+            .register_type::<TextureAtlasSprite>()
             .register_type::<Anchor>()
             .register_type::<Mesh2dHandle>()
             .add_plugin(Mesh2dRenderPlugin)

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,6 +1,6 @@
 use crate::Anchor;
 use bevy_asset::Handle;
-use bevy_ecs::component::Component;
+use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::{FromReflect, Reflect, TypeUuid};
 use bevy_render::{color::Color, texture::Image};
@@ -23,7 +23,8 @@ pub struct TextureAtlas {
     pub(crate) texture_handles: Option<HashMap<Handle<Image>, usize>>,
 }
 
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Component, Debug, Clone, Reflect, FromReflect)]
+#[reflect(Component)]
 pub struct TextureAtlasSprite {
     /// The tint color used to draw the sprite, defaulting to [`Color::WHITE`]
     pub color: Color,


### PR DESCRIPTION
# Objective

Add Reflection to `TextureAtlasSprite` to bring it inline with `Sprite`

## Solution

Addition of appropriate macros to the type

---

## Changelog

`#[reflect(Component)]` and derive `FromReflect` for `TextureAtlasSprite`
Added `TextureAtlasSprite` to the TypeRegistry