### PR TITLE
Add debug gradient function to bevy_core_pipeline

### DIFF
--- a/crates/bevy_core_pipeline/src/debug_gradient.wgsl
+++ b/crates/bevy_core_pipeline/src/debug_gradient.wgsl
@@ -3,7 +3,10 @@
 // Define a function to map a range of values to a high contrast color gradient
 // optimized for representational clarity.
 // this uses the matplotlib plasma color map.
-fn get_color(value: f32) -> vec3<f32> {
+
+// Color from the plasma gradient quantized to six colors, for value between
+// 0 and 5, clamped.
+fn plasma_color_at_index(value: f32) -> vec3<f32> {
     let plasma_colors = array(
         vec3(0.868,0.941,0.011), // #f0f921
         vec3(0.966,0.386,0.0326), // #fca636
@@ -12,6 +15,9 @@ fn get_color(value: f32) -> vec3<f32> {
         vec3(0.144,0.0,0.396), // #6a00a8
         vec3(0.00142,0.000488,0.245), // #0d0887
     );
+    // There is no way to index an array in wgsl from a dynamic value,
+    // the index (between square brackets) must be a const value.
+    // So we implement array indexing as a series of if/else
     if value < 1.0 {
         return plasma_colors[0];
     } else if value < 2.0 {
@@ -27,14 +33,15 @@ fn get_color(value: f32) -> vec3<f32> {
     }
 }
 
-// Return color sampled from the plasma color map
+// Return the color sampled from the plasma color map,
+// `value` is clamped between 0 and 1.
 fn debug_gradient(value: f32) -> vec4<f32> {
     let colors_offset = clamp(value, 0.0, 1.0) * 5.0;
     let low_ratio = fract(colors_offset);
 
     let low_color_index = u32(floor(colors_offset));
-    let low_color = get_color(colors_offset);
-    let high_color = get_color(colors_offset + 1.0);
+    let low_color = plasma_color_at_index(colors_offset);
+    let high_color = plasma_color_at_index(colors_offset + 1.0);
 
     return vec4(mix(low_color, high_color, low_ratio), 1.0);
 }

--- a/crates/bevy_core_pipeline/src/debug_gradient.wgsl
+++ b/crates/bevy_core_pipeline/src/debug_gradient.wgsl
@@ -1,0 +1,41 @@
+#define_import_path bevy_core_pipeline::debug_gradient
+
+// Define a function to map a range of values to a high contrast color gradient
+// optimized for representational clarity.
+// this uses the matplotlib plasma color map.
+fn get_color(value: f32) -> vec3<f32> {
+    let plasma_colors = array(
+        vec3(0.868,0.941,0.011), // #f0f921
+        vec3(0.966,0.386,0.0326), // #fca636
+        vec3(0.753,0.126,0.121), // #e16462
+        vec3(0.444,0.0188,0.282), // #b12a90
+        vec3(0.144,0.0,0.396), // #6a00a8
+        vec3(0.00142,0.000488,0.245), // #0d0887
+    );
+    if value < 1.0 {
+        return plasma_colors[0];
+    } else if value < 2.0 {
+        return plasma_colors[1];
+    } else if value < 3.0 {
+        return plasma_colors[2];
+    } else if value < 4.0 {
+        return plasma_colors[3];
+    } else if value < 5.0 {
+        return plasma_colors[4];
+    } else {
+        return plasma_colors[5];
+    }
+}
+
+// Return color sampled from the plasma color map
+fn debug_gradient(value: f32) -> vec4<f32> {
+    let colors_offset = clamp(value, 0.0, 1.0) * 5.0;
+    let low_ratio = fract(colors_offset);
+
+    let low_color_index = u32(floor(colors_offset));
+    let low_color = get_color(colors_offset);
+    let high_color = get_color(colors_offset + 1.0);
+
+    return vec4(mix(low_color, high_color, low_ratio), 1.0);
+}
+

--- a/crates/bevy_core_pipeline/src/debug_gradient.wgsl
+++ b/crates/bevy_core_pipeline/src/debug_gradient.wgsl
@@ -36,7 +36,7 @@ fn plasma_color_at_index(value: f32) -> vec3<f32> {
 // Return the color sampled from the plasma color map,
 // `value` is clamped between 0 and 1.
 fn debug_gradient(value: f32) -> vec4<f32> {
-    let colors_offset = clamp(value, 0.0, 1.0) * 5.0;
+    let colors_offset = saturate(value) * 5.0;
     let low_ratio = fract(colors_offset);
 
     let low_color_index = u32(floor(colors_offset));

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -15,6 +15,7 @@ mod taa;
 pub mod tonemapping;
 pub mod upscaling;
 
+use bevy_reflect::TypeUuid;
 pub use skybox::Skybox;
 
 /// Experimental features that are not yet finished. Please report any issues you encounter!
@@ -48,8 +49,11 @@ use crate::{
     upscaling::UpscalingPlugin,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::load_internal_asset;
+use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_render::{extract_resource::ExtractResourcePlugin, prelude::Shader};
+
+pub const DEBUG_GRADIENT_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 17293936987160423658);
 
 #[derive(Default)]
 pub struct CorePipelinePlugin;
@@ -60,6 +64,12 @@ impl Plugin for CorePipelinePlugin {
             app,
             FULLSCREEN_SHADER_HANDLE,
             "fullscreen_vertex_shader/fullscreen.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            DEBUG_GRADIENT_HANDLE,
+            "debug_gradient.wgsl",
             Shader::from_wgsl
         );
 


### PR DESCRIPTION
# Objective

When debugging shaders, overwriting a fragment's color with any arbitrary value can be useful. Usually, this is done by using a grayscale gradient, by replacing each color channel with the given value.

However, distinguishing between different shades of grey can be strenuous.

## Solution

A [color map] is often used to represent values with colors, color maps give much better contrast between even similar values.

I adopted the matplotlib "plasma" color map, and implemented it as a shader function that can be imported with `#import bevy_core_pipeline::debug_gradient`.

![parallax mapping example with depth represented with the plasma colormap](https://user-images.githubusercontent.com/26321040/233394855-0a84bab3-377e-4054-9ab0-7aeef4a38909.png)


[color map]: https://matplotlib.org/stable/tutorials/colors/colormaps.html
---

## Changelog

- Add the `bevy_core_pipeline::debug_gradient` shader to convert a value between [0, 1] into the "plasma" gradient.