### PR TITLE
Fix 1.69 CI clippy lints

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1157,8 +1157,8 @@ macro_rules! impl_tuple_fetch {
             }
 
             #[inline(always)]
-            unsafe fn filter_fetch<'w>(
-                _fetch: &mut Self::Fetch<'w>,
+            unsafe fn filter_fetch(
+                _fetch: &mut Self::Fetch<'_>,
                 _entity: Entity,
                 _table_row: TableRow
             ) -> bool {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -328,8 +328,8 @@ macro_rules! impl_query_filter_tuple {
             }
 
             #[inline(always)]
-            unsafe fn filter_fetch<'w>(
-                fetch: &mut Self::Fetch<'w>,
+            unsafe fn filter_fetch(
+                fetch: &mut Self::Fetch<'_>,
                 entity: Entity,
                 table_row: TableRow
             ) -> bool {
@@ -504,8 +504,8 @@ macro_rules! impl_tick_filter {
             }
 
             #[inline(always)]
-            unsafe fn filter_fetch<'w>(
-                fetch: &mut Self::Fetch<'w>,
+            unsafe fn filter_fetch(
+                fetch: &mut Self::Fetch<'_>,
                 entity: Entity,
                 table_row: TableRow
             ) -> bool {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -722,7 +722,7 @@ mod tests {
         );
 
         fn init_component<T: Component>(sets: &mut SparseSets, id: usize) {
-            let descriptor = ComponentDescriptor::new::<TestComponent1>();
+            let descriptor = ComponentDescriptor::new::<T>();
             let id = ComponentId::new(id);
             let info = ComponentInfo::new(id, descriptor);
             sets.get_or_insert(&info);

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
@@ -21,6 +21,9 @@ error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
 error[E0505]: cannot move out of `e_mut` because it is borrowed
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:33:9
    |
+13 |     let mut e_mut = world.entity_mut(e);
+   |         --------- binding `e_mut` declared here
+...
 32 |         let gotten: &A = e_mut.get::<A>().unwrap();
    |                          ---------------- borrow of `e_mut` occurs here
 33 |         e_mut.despawn();

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -30,7 +30,7 @@ note: required by a bound in `assert_readonly`
   --> tests/ui/system_param_derive_readonly.rs:23:8
    |
 21 | fn assert_readonly<P>()
-   |    --------------- required by a bound in this
+   |    --------------- required by a bound in this function
 22 | where
 23 |     P: ReadOnlySystemParam,
    |        ^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_readonly`

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -2,7 +2,7 @@ error[E0599]: no method named `get_field` found for struct `Box<(dyn Reflect + '
   --> tests/reflect_derive/generics.fail.rs:14:9
    |
 14 |     foo.get_field::<NoReflect>("a").unwrap();
-   |         ^^^^^^^^^ method not found in `Box<(dyn Reflect + 'static)>`
+   |         ^^^^^^^^^ method not found in `Box<dyn Reflect>`
 
 error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
   --> tests/reflect_derive/generics.fail.rs:12:37


### PR DESCRIPTION
- Fix CI by implementing changes recommended by clippy
- It uncovered a bug in a `bevy_ecs` test. Nice!

