### PR TITLE
blend_modes example: fix label position

### DIFF
--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -34,6 +34,7 @@ fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
+    asset_server: Res<AssetServer>,
 ) {
     let base_color = Color::rgba(0.9, 0.2, 0.3, 1.0);
     let icosphere_mesh = meshes.add(
@@ -185,15 +186,15 @@ fn setup(
 
     // Controls Text
     let text_style = TextStyle {
+        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 18.0,
         color: Color::BLACK,
-        ..default()
     };
 
     let label_text_style = TextStyle {
+        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 25.0,
         color: Color::ORANGE,
-        ..default()
     };
 
     commands.spawn(

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -234,12 +234,13 @@ fn setup(
             ))
             .with_children(|parent| {
                 parent.spawn(
-                    TextBundle::from_section(label, label_text_style.clone()).with_style(Style {
-                        position_type: PositionType::Absolute,
-                        bottom: Val::Px(0.),
-                        size: Size::new(Val::Px(label.len() as f32 * 10.0), Val::Auto),
-                        ..default()
-                    }),
+                    TextBundle::from_section(label, label_text_style.clone())
+                        .with_style(Style {
+                            position_type: PositionType::Absolute,
+                            bottom: Val::Px(0.),
+                            ..default()
+                        })
+                        .with_no_wrap(),
                 );
             });
     };

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -236,6 +236,7 @@ fn setup(
                     TextBundle::from_section(label, label_text_style.clone()).with_style(Style {
                         position_type: PositionType::Absolute,
                         bottom: Val::Px(0.),
+                        size: Size::new(Val::Px(label.len() as f32 * 10.0), Val::Auto),
                         ..default()
                     }),
                 );


### PR DESCRIPTION
# Objective

- Labels are not correctly placed
<img width="1392" alt="Screenshot 2023-04-22 at 00 12 54" src="https://user-images.githubusercontent.com/8672791/233742996-0189b3c2-ea6b-4f3f-b2e8-68fdbf74f52f.png">

## Solution

- Set a width in the UI so that text doesn't try to wrap
<img width="1392" alt="Screenshot 2023-04-22 at 00 13 04" src="https://user-images.githubusercontent.com/8672791/233743064-8d6045e5-3936-4c22-be07-ac618399c093.png">
