### PR TITLE
`measure_text_system` text query fix

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -68,7 +68,7 @@ pub fn measure_text_system(
     ui_scale: Res<UiScale>,
     mut text_pipeline: ResMut<TextPipeline>,
     mut text_queries: ParamSet<(
-        Query<Entity, Changed<Text>>,
+        Query<Entity, (Changed<Text>, With<Node>)>,
         Query<Entity, (With<Text>, With<Node>)>,
         Query<(&Text, &mut CalculatedSize)>,
     )>,
@@ -82,7 +82,7 @@ pub fn measure_text_system(
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
-        // Adds all entities where the text or the style has changed to the local queue
+        // Adds all entities where the text has changed to the local queue
         for entity in text_queries.p0().iter() {
             if !queued_text.contains(&entity) {
                 queued_text.push(entity);


### PR DESCRIPTION
# Objective

The first query of `measure_text_system`'s `text_queries` `ParamSet` queries for all changed `Text` meaning that non-UI `Text` entities could be added to its queue.

## Solution

Add a `With<Node>` query filter.

---

## Changelog
changes:
* Added a `With<Node>` query filter to first query of `measure_text_system`'s `text_queries` `ParamSet` to ensure that only UI node entities are added to its local queue.
* Fixed comment (text is not computed on changes to style).
