### PR TITLE
Add a bounding box gizmo

### DIFF
--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -21,3 +21,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.11.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.11.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.11.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.11.0-dev" }
+bevy_transform = { path = "../bevy_transform", version = "0.11.0-dev" }

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -18,22 +18,31 @@
 
 use std::mem;
 
-use bevy_app::{Last, Plugin};
+use bevy_app::{Last, Plugin, Update};
 use bevy_asset::{load_internal_asset, Assets, Handle, HandleUntyped};
 use bevy_ecs::{
-    prelude::{Component, DetectChanges},
+    change_detection::DetectChanges,
+    component::Component,
+    entity::Entity,
+    query::Without,
+    reflect::ReflectComponent,
     schedule::IntoSystemConfigs,
-    system::{Commands, Res, ResMut, Resource},
+    system::{Commands, Query, Res, ResMut, Resource},
     world::{FromWorld, World},
 };
 use bevy_math::Mat4;
-use bevy_reflect::TypeUuid;
+use bevy_reflect::{
+    std_traits::ReflectDefault, FromReflect, Reflect, ReflectFromReflect, TypeUuid,
+};
 use bevy_render::{
+    color::Color,
     mesh::Mesh,
+    primitives::Aabb,
     render_phase::AddRenderCommand,
     render_resource::{PrimitiveTopology, Shader, SpecializedMeshPipelines},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
+use bevy_transform::components::GlobalTransform;
 
 #[cfg(feature = "bevy_pbr")]
 use bevy_pbr::MeshUniform;
@@ -47,12 +56,12 @@ mod pipeline_2d;
 #[cfg(feature = "bevy_pbr")]
 mod pipeline_3d;
 
-use crate::gizmos::GizmoStorage;
+use gizmos::{GizmoStorage, Gizmos};
 
 /// The `bevy_gizmos` prelude.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{gizmos::Gizmos, GizmoConfig};
+    pub use crate::{gizmos::Gizmos, AabbGizmo, AabbGizmoConfig, GizmoConfig};
 }
 
 const LINE_SHADER_HANDLE: HandleUntyped =
@@ -68,7 +77,14 @@ impl Plugin for GizmoPlugin {
         app.init_resource::<MeshHandles>()
             .init_resource::<GizmoConfig>()
             .init_resource::<GizmoStorage>()
-            .add_systems(Last, update_gizmo_meshes);
+            .add_systems(Last, update_gizmo_meshes)
+            .add_systems(
+                Update,
+                (
+                    draw_aabbs,
+                    draw_all_aabbs.run_if(|config: Res<GizmoConfig>| config.aabb.draw_all),
+                ),
+            );
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return; };
 
@@ -101,7 +117,7 @@ impl Plugin for GizmoPlugin {
 }
 
 /// A [`Resource`] that stores configuration for gizmos.
-#[derive(Resource, Clone, Copy)]
+#[derive(Resource, Clone)]
 pub struct GizmoConfig {
     /// Set to `false` to stop drawing gizmos.
     ///
@@ -113,6 +129,8 @@ pub struct GizmoConfig {
     ///
     /// Defaults to `false`.
     pub on_top: bool,
+    /// Configuration for the [`AabbGizmo`].
+    pub aabb: AabbGizmoConfig,
 }
 
 impl Default for GizmoConfig {
@@ -120,7 +138,68 @@ impl Default for GizmoConfig {
         Self {
             enabled: true,
             on_top: false,
+            aabb: Default::default(),
         }
+    }
+}
+
+/// Configuration for bounding box gizmos.
+#[derive(Clone, Default)]
+pub struct AabbGizmoConfig {
+    /// Draws all bounding boxes in the scene when set to `true`.
+    ///
+    /// To draw a specific entity's bounding box, you can add the [`AabbGizmo`] component.
+    ///
+    /// Defaults to `false`.
+    pub draw_all: bool,
+    /// The default color for bounding box gizmos.
+    ///
+    /// A random color is chosen per box if `None`.
+    ///
+    /// Defaults to `None`.
+    pub default_color: Option<Color>,
+}
+
+fn color_from_entity(entity: Entity) -> Color {
+    let hue = entity.to_bits() as f32 * 100_000. % 360.;
+    Color::hsl(hue, 1., 0.5)
+}
+
+/// Add this [`Component`] to an entity to draw its [`Aabb`] component.
+#[derive(Component, Reflect, FromReflect, Default, Debug)]
+#[reflect(Component, FromReflect, Default)]
+pub struct AabbGizmo {
+    /// The color of the box.
+    ///
+    /// The default color from the [`GizmoConfig`] resource is used if `None`,
+    pub color: Option<Color>,
+}
+
+fn draw_aabbs(
+    query: Query<(Entity, &Aabb, &GlobalTransform, &AabbGizmo)>,
+    config: Res<GizmoConfig>,
+    mut gizmos: Gizmos,
+) {
+    for (entity, &aabb, &transform, gizmo) in &query {
+        let color = gizmo
+            .color
+            .or(config.aabb.default_color)
+            .unwrap_or_else(|| color_from_entity(entity));
+        gizmos.bounding_box(aabb, transform, color);
+    }
+}
+
+fn draw_all_aabbs(
+    query: Query<(Entity, &Aabb, &GlobalTransform), Without<AabbGizmo>>,
+    config: Res<GizmoConfig>,
+    mut gizmos: Gizmos,
+) {
+    for (entity, &aabb, &transform) in &query {
+        let color = config
+            .aabb
+            .default_color
+            .unwrap_or_else(|| color_from_entity(entity));
+        gizmos.bounding_box(aabb, transform, color);
     }
 }
 
@@ -198,7 +277,7 @@ fn extract_gizmo_data(
     config: Extract<Res<GizmoConfig>>,
 ) {
     if config.is_changed() {
-        commands.insert_resource(**config);
+        commands.insert_resource(config.clone());
     }
 
     if !config.enabled {

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -3,7 +3,10 @@
 //! - Copy the code for the `SceneViewerPlugin` and add the plugin to your App.
 //! - Insert an initialized `SceneHandle` resource into your App's `AssetServer`.
 
-use bevy::{asset::LoadState, gltf::Gltf, prelude::*, scene::InstanceId};
+use bevy::{
+    asset::LoadState, gltf::Gltf, input::common_conditions::input_just_pressed, prelude::*,
+    scene::InstanceId,
+};
 
 use std::f32::consts::*;
 use std::fmt;
@@ -43,6 +46,7 @@ impl fmt::Display for SceneHandle {
 Scene Controls:
     L           - animate light direction
     U           - toggle shadows
+    B           - toggle bounding boxes
     C           - cycle through the camera controller and any cameras loaded from the scene
 
     Space       - Play/Pause animation
@@ -63,11 +67,16 @@ impl Plugin for SceneViewerPlugin {
                 (
                     update_lights,
                     camera_tracker,
+                    toggle_bounding_boxes.run_if(input_just_pressed(KeyCode::B)),
                     #[cfg(feature = "animation")]
                     (start_animation, keyboard_animation_control),
                 ),
             );
     }
+}
+
+fn toggle_bounding_boxes(mut config: ResMut<GizmoConfig>) {
+    config.aabb.draw_all ^= true;
 }
 
 fn scene_load_check(


### PR DESCRIPTION
# Objective

Add a bounding box gizmo

![Screenshot from 2023-04-22 23-49-40](https://user-images.githubusercontent.com/29694403/233808825-7593dc38-0623-48a9-b0d7-a4ca24a9e071.png)

## Changelog

- Added the `Gizmos::bounding_box` method for drawing `Aabb`s.
- Added the `AabbGizmo` component that will draw the `Aabb` component on that entity.
- Added an option to draw all bounding boxes in a scene on the `GizmoConfig` resource.
