### PR TITLE
stress test examples: add missing warns

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -69,6 +69,8 @@ fn button_system(
 }
 
 fn setup(mut commands: Commands) {
+    warn!(include_str!("warning_string.txt"));
+
     let count = ROW_COLUMN_COUNT;
     let count_f = count as f32;
     let as_rainbow = |i: usize| Color::hsl((i as f32 / count_f) * 360.0, 0.9, 0.8);

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -25,6 +25,8 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
+    warn!(include_str!("warning_string.txt"));
+
     commands.spawn(Camera2dBundle::default());
     let mut text = Text {
         sections: vec![TextSection {

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -26,6 +26,8 @@ fn main() {
 }
 
 fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
+    warn!(include_str!("warning_string.txt"));
+
     commands.spawn(Camera2dBundle::default());
     let sections = (1..=50)
         .flat_map(|i| {


### PR DESCRIPTION
# Objective

- Some stress test examples don't have the warning about performances

## Solution

- Add it
