### PR TITLE
docs(bevy_render): Remove copy-pasted docstring

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -230,7 +230,6 @@ impl Image {
     ///
     /// # Panics
     /// Panics if the size of the `format` is not a multiple of the length of the `pixel` data.
-    /// do not match.
     pub fn new_fill(
         size: Extent3d,
         dimension: TextureDimension,


### PR DESCRIPTION
This line does not appear to be an intended part of the `Panics` section, but instead looks like it was missed when copy-pasting a `Panics` section from above.

It confused me when I was reading the docs. At first I read it as if it was an imperative statement saying not to use `match` statements which seemed odd and out of place.  Once I saw the code it was clearly in err.

# Objective

- Cleanup documentation string to reduce end-user confusion.
