### PR TITLE
Colored wireframe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -698,6 +698,19 @@ description = "Showcases wireframe rendering"
 category = "3D Rendering"
 wasm = true
 
+
+[[example]]
+name = "colored_wireframe"
+path = "examples/3d/colored_wireframe.rs"
+
+
+[package.metadata.example.colored_wireframe]
+name = "Colored wireframe"
+description = "Showcases wireframe rendering with colors"
+category = "3D Rendering"
+wasm = true
+
+
 [[example]]
 name = "no_prepass"
 path = "tests/3d/no_prepass.rs"

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -4,6 +4,9 @@
 @group(1) @binding(0)
 var<uniform> mesh: Mesh;
 
+@group(2) @binding(0)
+var<uniform> color: vec4<f32>;
+
 #ifdef SKINNED
 @group(1) @binding(1)
 var<uniform> joint_matrices: SkinnedMesh;
@@ -40,5 +43,5 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 
 @fragment
 fn fragment() -> @location(0) vec4<f32> {
-    return vec4<f32>(1.0, 1.0, 1.0, 1.0);
+    return color;
 }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -3,10 +3,21 @@ use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshVie
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_core_pipeline::core_3d::Opaque3d;
+use bevy_ecs::query::ROQueryItem;
+use bevy_ecs::system::lifetimeless::Read;
+use bevy_ecs::system::SystemParamItem;
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{Reflect, TypeUuid};
 use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+use bevy_render::prelude::Color;
+use bevy_render::render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass};
+use bevy_render::render_resource::{
+    BindGroup, BindGroupDescriptor, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
+    BindGroupLayoutEntry, BindingType, BufferBindingType, BufferInitDescriptor, BufferUsages,
+    ShaderStages,
+};
+use bevy_render::renderer::RenderDevice;
 use bevy_render::Render;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -48,6 +59,7 @@ impl Plugin for WireframePlugin {
                 .add_render_command::<Opaque3d, DrawWireframes>()
                 .init_resource::<WireframePipeline>()
                 .init_resource::<SpecializedMeshPipelines<WireframePipeline>>()
+                .add_systems(Render, wireframes_bind_group.in_set(RenderSet::Prepare))
                 .add_systems(Render, queue_wireframes.in_set(RenderSet::Queue));
         }
     }
@@ -56,25 +68,48 @@ impl Plugin for WireframePlugin {
 /// Controls whether an entity should rendered in wireframe-mode if the [`WireframePlugin`] is enabled
 #[derive(Component, Debug, Clone, Default, ExtractComponent, Reflect)]
 #[reflect(Component, Default)]
-pub struct Wireframe;
+pub struct Wireframe {
+    pub color: Color,
+}
 
 #[derive(Resource, Debug, Clone, Default, ExtractResource, Reflect)]
 #[reflect(Resource)]
 pub struct WireframeConfig {
     /// Whether to show wireframes for all meshes. If `false`, only meshes with a [Wireframe] component will be rendered.
     pub global: bool,
+    pub color: Color,
 }
+
+#[derive(Component)]
+pub struct WireframeBindgroup(BindGroup);
 
 #[derive(Resource, Clone)]
 pub struct WireframePipeline {
     mesh_pipeline: MeshPipeline,
     shader: Handle<Shader>,
+    layout: BindGroupLayout,
 }
 impl FromWorld for WireframePipeline {
     fn from_world(render_world: &mut World) -> Self {
+        let render_device = render_world.resource::<RenderDevice>();
+
         WireframePipeline {
             mesh_pipeline: render_world.resource::<MeshPipeline>().clone(),
             shader: WIREFRAME_SHADER_HANDLE.typed(),
+            layout: render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                label: None,
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        //TODO: set a min_binding_size
+                        min_binding_size: None,
+                    },
+                    count: None,
+                }],
+            }),
         }
     }
 }
@@ -92,7 +127,68 @@ impl SpecializedMeshPipeline for WireframePipeline {
         descriptor.fragment.as_mut().unwrap().shader = self.shader.clone_weak();
         descriptor.primitive.polygon_mode = PolygonMode::Line;
         descriptor.depth_stencil.as_mut().unwrap().bias.slope_scale = 1.0;
+        descriptor.layout.push(self.layout.clone());
         Ok(descriptor)
+    }
+}
+
+fn wireframes_bind_group(
+    mut commands: Commands,
+    wireframe_config: Res<WireframeConfig>,
+    render_device: Res<RenderDevice>,
+    pipeline: Res<WireframePipeline>,
+    mut q_wireframes: ParamSet<(
+        Query<Entity, With<MeshUniform>>,
+        Query<(Entity, &Wireframe), With<MeshUniform>>,
+    )>,
+) {
+    if wireframe_config.global {
+        let color = wireframe_config.color;
+        let query = q_wireframes.p0();
+
+        let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+            label: None,
+            contents: bytemuck::cast_slice(&[color.as_rgba_f32()]),
+            usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+        });
+
+        let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.layout,
+            entries: &[BindGroupEntry {
+                binding: 0,
+                resource: buffer.as_entire_binding(),
+            }],
+        });
+
+        for entity in &query {
+            commands
+                .entity(entity)
+                .insert(WireframeBindgroup(bind_group.clone()));
+        }
+    } else {
+        let query = q_wireframes.p1();
+
+        for (entity, wireframe) in &query {
+            let buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
+                label: None,
+                contents: bytemuck::cast_slice(&[wireframe.color.as_rgba_f32()]),
+                usage: BufferUsages::UNIFORM | BufferUsages::COPY_DST,
+            });
+
+            let bind_group = render_device.create_bind_group(&BindGroupDescriptor {
+                label: None,
+                layout: &pipeline.layout,
+                entries: &[BindGroupEntry {
+                    binding: 0,
+                    resource: buffer.as_entire_binding(),
+                }],
+            });
+
+            commands
+                .entity(entity)
+                .insert(WireframeBindgroup(bind_group));
+        }
     }
 }
 
@@ -166,5 +262,25 @@ type DrawWireframes = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
     SetMeshBindGroup<1>,
+    SetWireframeBindGroup<2>,
     DrawMesh,
 );
+
+pub struct SetWireframeBindGroup<const I: usize>;
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetWireframeBindGroup<I> {
+    type Param = ();
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<WireframeBindgroup>;
+    #[inline]
+    fn render<'w>(
+        _item: &P,
+        _view: (),
+        wireframe_bindgroup: ROQueryItem<'w, Self::ItemWorldQuery>,
+        (): SystemParamItem<'_, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        pass.set_bind_group(I, &wireframe_bindgroup.0, &[]);
+
+        RenderCommandResult::Success
+    }
+}

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroU64;
-
 use crate::MeshPipeline;
 use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup};
 use bevy_app::Plugin;
@@ -107,7 +105,9 @@ impl FromWorld for WireframePipeline {
                     ty: BindingType::Buffer {
                         ty: BufferBindingType::Uniform,
                         has_dynamic_offset: false,
-                        min_binding_size: Some(SizeValue::new((std::mem::size_of::<f32>() * 4) as u64).0),
+                        min_binding_size: Some(
+                            SizeValue::new((std::mem::size_of::<f32>() * 4) as u64).0,
+                        ),
                     },
                     count: None,
                 }],

--- a/examples/3d/colored_wireframe.rs
+++ b/examples/3d/colored_wireframe.rs
@@ -1,0 +1,68 @@
+//! Showcases wireframe rendering with colors.
+
+use bevy::{
+    pbr::wireframe::{Wireframe, WireframeConfig, WireframePlugin},
+    prelude::*,
+    render::{render_resource::WgpuFeatures, settings::WgpuSettings, RenderPlugin},
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(RenderPlugin {
+            wgpu_settings: WgpuSettings {
+                features: WgpuFeatures::POLYGON_MODE_LINE,
+                ..default()
+            },
+        }))
+        .add_plugin(WireframePlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+/// set up a simple 3D scene
+fn setup(
+    mut commands: Commands,
+    mut wireframe_config: ResMut<WireframeConfig>,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // Draw the wireframe on all entities.
+    wireframe_config.global = true;
+
+    // Set the default color to green
+    wireframe_config.color = Color::GREEN;
+
+    // a row of cubes
+    for i in 0..10 {
+        commands.spawn(PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            transform: Transform::from_xyz(i as f32 * 2. - 9., 0.5, 0.0),
+            ..default()
+        });
+    }
+
+    // a second row of cubes, with a specific wireframe color
+    for i in 0..5 {
+        commands.spawn((
+            PbrBundle {
+                mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                transform: Transform::from_xyz(i as f32 * 2. - 4., 2., 0.0),
+                ..default()
+            },
+            Wireframe { color: Color::RED },
+        ));
+    }
+
+    // light
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(0.0, 2.5, 15.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -43,7 +43,7 @@ fn setup(
             ..default()
         },
         // This enables wireframe drawing on this entity
-        Wireframe,
+        Wireframe::default(),
     ));
     // light
     commands.spawn(PointLightBundle {

--- a/examples/README.md
+++ b/examples/README.md
@@ -115,6 +115,7 @@ Example | Description
 [Anti-aliasing](../examples/3d/anti_aliasing.rs) | Compares different anti-aliasing methods
 [Atmospheric Fog](../examples/3d/atmospheric_fog.rs) | A scene showcasing the atmospheric fog effect
 [Blend Modes](../examples/3d/blend_modes.rs) | Showcases different blend modes
+[Colored wireframe](../examples/3d/colored_wireframe.rs) | Showcases wireframe rendering with colors
 [Fog](../examples/3d/fog.rs) | A scene showcasing the distance fog effect
 [Lighting](../examples/3d/lighting.rs) | Illustrates various lighting options in a simple scene
 [Lines](../examples/3d/lines.rs) | Create a custom material to draw 3d lines


### PR DESCRIPTION
# Objective

Add the ability to draw colored wireframes to ease debugging.

## Solution

- Changed `wireframe.rs` in `bevy_pbr` to have the ability to change colors. 

## Migration Guide

- Replace `Wireframe` with `Wireframe::default()` in commands when inserting a `Wireframe` component.