### PR TITLE
Fix panic when using debug_asset_server

### DIFF
--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     texture::Image,
 };
 
-#[derive(Debug, TypeUuid)]
+#[derive(Debug, TypeUuid, Clone)]
 #[uuid = "97059ac6-c9ba-4da9-95b6-bed82c3ce198"]
 pub struct Font {
     pub font: FontArc,

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -76,6 +76,7 @@ pub const DEFAULT_FONT_HANDLE: HandleUntyped =
 impl Plugin for TextPlugin {
     fn build(&self, app: &mut App) {
         app.add_asset::<Font>()
+            .add_debug_asset::<Font>()
             .add_asset::<FontAtlasSet>()
             .register_type::<Text>()
             .register_type::<Text2dBounds>()


### PR DESCRIPTION
# Objective

- Fixes #8484

## Solution

Since #8445 fonts need to register a debug asset, otherwise the `debug_asset_server` feature doesn't work. This adds the debug asset registration
