### PR TITLE
WIP: Update depth buffer with parallax mapping result

### DIFF
--- a/crates/bevy_core_pipeline/src/debug_gradient.wgsl
+++ b/crates/bevy_core_pipeline/src/debug_gradient.wgsl
@@ -1,0 +1,41 @@
+#define_import_path bevy_core_pipeline::debug_gradient
+
+// Define a function to map a range of values to a high contrast color gradient
+// optimized for representational clarity.
+// this uses the matplotlib plasma color map.
+fn get_color(value: f32) -> vec3<f32> {
+    let plasma_colors = array(
+        vec3(0.868,0.941,0.011), // #f0f921
+        vec3(0.966,0.386,0.0326), // #fca636
+        vec3(0.753,0.126,0.121), // #e16462
+        vec3(0.444,0.0188,0.282), // #b12a90
+        vec3(0.144,0.0,0.396), // #6a00a8
+        vec3(0.00142,0.000488,0.245), // #0d0887
+    );
+    if value < 1.0 {
+        return plasma_colors[0];
+    } else if value < 2.0 {
+        return plasma_colors[1];
+    } else if value < 3.0 {
+        return plasma_colors[2];
+    } else if value < 4.0 {
+        return plasma_colors[3];
+    } else if value < 5.0 {
+        return plasma_colors[4];
+    } else {
+        return plasma_colors[5];
+    }
+}
+
+// Return color sampled from the plasma color map
+fn debug_gradient(value: f32) -> vec4<f32> {
+    let colors_offset = clamp(value, 0.0, 1.0) * 5.0;
+    let low_ratio = fract(colors_offset);
+
+    let low_color_index = u32(floor(colors_offset));
+    let low_color = get_color(colors_offset);
+    let high_color = get_color(colors_offset + 1.0);
+
+    return vec4(mix(low_color, high_color, low_ratio), 1.0);
+}
+

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -15,6 +15,7 @@ mod taa;
 pub mod tonemapping;
 pub mod upscaling;
 
+use bevy_reflect::TypeUuid;
 pub use skybox::Skybox;
 
 /// Experimental features that are not yet finished. Please report any issues you encounter!
@@ -48,8 +49,11 @@ use crate::{
     upscaling::UpscalingPlugin,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::load_internal_asset;
+use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_render::{extract_resource::ExtractResourcePlugin, prelude::Shader};
+
+pub const DEBUG_GRADIENT_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 17293936987160423658);
 
 #[derive(Default)]
 pub struct CorePipelinePlugin;
@@ -60,6 +64,12 @@ impl Plugin for CorePipelinePlugin {
             app,
             FULLSCREEN_SHADER_HANDLE,
             "fullscreen_vertex_shader/fullscreen.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            DEBUG_GRADIENT_HANDLE,
+            "debug_gradient.wgsl",
             Shader::from_wgsl
         );
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -393,7 +393,7 @@ where
             vertex_attributes.push(Mesh::ATTRIBUTE_UV_0.at_shader_location(1));
         }
 
-        if key.mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS) {
+        if true || key.mesh_key.contains(MeshPipelineKey::NORMAL_PREPASS) {
             vertex_attributes.push(Mesh::ATTRIBUTE_NORMAL.at_shader_location(2));
             shader_defs.push("NORMAL_PREPASS".into());
 
@@ -428,7 +428,7 @@ where
         let has_motion_vectors = key
             .mesh_key
             .contains(MeshPipelineKey::MOTION_VECTOR_PREPASS);
-        let has_prepass_fragment = has_normal || has_motion_vectors;
+        let has_prepass_fragment = true || has_normal || has_motion_vectors;
         let mut targets = vec![];
         targets.push(has_normal.then_some(ColorTargetState {
             format: NORMAL_PREPASS_FORMAT,
@@ -440,6 +440,9 @@ where
             blend: Some(BlendState::REPLACE),
             write_mask: ColorWrites::ALL,
         }));
+        if targets.iter().all(|opt| opt.is_none()) {
+            targets.clear();
+        }
 
         // The fragment shader is only used when the normal prepass or motion vectors prepass
         // is enabled or the material uses alpha cutoff values and doesn't rely on the standard

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -1,7 +1,6 @@
 #import bevy_pbr::prepass_bindings
 #import bevy_pbr::mesh_functions
 #import bevy_pbr::pbr_bindings
-#import bevy_pbr::parallax_mapping
 
 // Most of these attributes are not used in the default prepass fragment shader, but they are still needed so we can
 // pass them to custom prepass shaders like pbr_prepass.wgsl.
@@ -91,6 +90,7 @@ struct FragmentInput {
 #endif // VERTEX_UVS
 #ifdef NORMAL_PREPASS
     @location(1) world_normal: vec3<f32>,
+    @location(2) world_tangent: vec4<f32>,
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
@@ -113,28 +113,6 @@ struct FragmentOutput {
 @fragment
 fn fragment(in: FragmentInput) -> FragmentOutput {
     var out: FragmentOutput;
-#ifdef VERTEX_UVS
-#ifdef VERTEX_TANGENTS
-    if ((material.flags & STANDARD_MATERIAL_FLAGS_DEPTH_MAP_BIT) != 0u) {
-        let N = in.world_normal;
-        let T = in.world_tangent.xyz;
-        let B = in.world_tangent.w * cross(N, T);
-        // Transform V from fragment to camera in world space to tangent space.
-        let Vt = vec3(dot(V, T), dot(V, B), dot(V, N));
-        let parallaxed = parallaxed_uv(
-            material.parallax_depth_scale,
-            material.max_parallax_layer_count,
-            material.max_relief_mapping_search_steps,
-            in.uv,
-            // Flip the direction of Vt to go toward the surface to make the
-            // parallax mapping algorithm easier to understand and reason
-            // about.
-            -Vt,
-        );
-        out.depth = parallaxed.z;
-    }
-#endif
-#endif
 
 #ifdef NORMAL_PREPASS
     out.normal = vec4(in.world_normal * 0.5 + vec3(0.5), 1.0);

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -26,6 +26,7 @@ struct Vertex {
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,
+    @location(3) world_position: vec4<f32>,
 
 #ifdef VERTEX_UVS
     @location(0) uv: vec2<f32>,
@@ -39,7 +40,6 @@ struct VertexOutput {
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    @location(3) world_position: vec4<f32>,
     @location(4) previous_world_position: vec4<f32>,
 #endif // MOTION_VECTOR_PREPASS
 }
@@ -54,6 +54,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     var model = mesh.model;
 #endif // SKINNED
 
+    out.world_position = mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
     out.clip_position = mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
 #ifdef DEPTH_CLAMP_ORTHO
         out.clip_position.z = min(out.clip_position.z, 1.0);
@@ -76,7 +77,6 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    out.world_position = mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
     out.previous_world_position = mesh_position_local_to_world(mesh.previous_model, vec4<f32>(vertex.position, 1.0));
 #endif // MOTION_VECTOR_PREPASS
 

--- a/crates/bevy_pbr/src/render/parallax_mapping.wgsl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wgsl
@@ -110,5 +110,13 @@ fn parallaxed_uv(
     current_layer_depth += mix(next_depth, previous_depth, weight);
 #endif
 
-    return vec3<f32>(uv, current_layer_depth);
+    return vec3<f32>(uv, sample_depth_map(uv));
+}
+
+/// Additional depth in tangent space resulting from parallaxing.
+///
+/// This is a simple pythagorean theorem.
+fn additional_depth(old_uv: vec2<f32>, new_uv: vec2<f32>, depth: f32) -> f32 {
+    let traversed = distance(old_uv, new_uv);
+    return sqrt(traversed*traversed + depth*depth);
 }

--- a/crates/bevy_pbr/src/render/parallax_mapping.wgsl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wgsl
@@ -110,13 +110,12 @@ fn parallaxed_uv(
     current_layer_depth += mix(next_depth, previous_depth, weight);
 #endif
 
-    return vec3<f32>(uv, sample_depth_map(uv));
+    return vec3<f32>(uv, sample_depth_map(uv) * depth_scale);
 }
 
 /// Additional depth in tangent space resulting from parallaxing.
 ///
 /// This is a simple pythagorean theorem.
 fn additional_depth(old_uv: vec2<f32>, new_uv: vec2<f32>, depth: f32) -> f32 {
-    let traversed = distance(old_uv, new_uv);
-    return sqrt(traversed*traversed + depth*depth);
+    return length(vec3(new_uv - old_uv, depth));
 }

--- a/crates/bevy_pbr/src/render/parallax_mapping.wgsl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wgsl
@@ -24,9 +24,9 @@ fn parallaxed_uv(
     uv: vec2<f32>,
     // The vector from the camera to the fragment at the surface in tangent space
     Vt: vec3<f32>,
-) -> vec2<f32> {
+) -> vec3<f32> {
     if max_layer_count < 1.0 {
-        return uv;
+        return vec3(uv, 0.0);
     }
     var uv = uv;
 
@@ -110,7 +110,5 @@ fn parallaxed_uv(
     current_layer_depth += mix(next_depth, previous_depth, weight);
 #endif
 
-    // Note: `current_layer_depth` is not returned, but may be useful
-    // for light computation later on in future improvements of the pbr shader.
-    return uv;
+    return vec3<f32>(uv, current_layer_depth);
 }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -10,6 +10,7 @@
 #import bevy_pbr::fog
 #import bevy_pbr::pbr_functions
 #import bevy_pbr::parallax_mapping
+#import bevy_core_pipeline::debug_gradient
 
 #import bevy_pbr::prepass_utils
 
@@ -32,7 +33,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         let B = in.world_tangent.w * cross(N, T);
         // Transform V from fragment to camera in world space to tangent space.
         let Vt = vec3(dot(V, T), dot(V, B), dot(V, N));
-        uv = parallaxed_uv(
+        let parallaxed = parallaxed_uv(
             material.parallax_depth_scale,
             material.max_parallax_layer_count,
             material.max_relief_mapping_search_steps,
@@ -42,6 +43,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
             // about.
             -Vt,
         );
+        uv = parallaxed.xy;
     }
 #endif
 #endif
@@ -151,5 +153,6 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
 #ifdef PREMULTIPLY_ALPHA
     output_color = premultiply_alpha(material.flags, output_color);
 #endif
+    output_color = vec4(debug_gradient(pow(in.frag_coord.z, 0.1)), 1.0);
     return output_color;
 }

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -92,9 +92,9 @@ fn prepass_alpha_discard(in: FragmentInput) {
 @fragment
 fn fragment(in: FragmentInput) -> FragmentOutput {
     var out: FragmentOutput;
-    out.depth = in.frag_coord.z;
-
     prepass_alpha_discard(in);
+
+    out.depth = in.frag_coord.z;
 
 #ifdef VERTEX_TANGENTS
     if ((material.flags & STANDARD_MATERIAL_FLAGS_DEPTH_MAP_BIT) != 0u) {
@@ -116,13 +116,13 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
             // about.
             -Vt,
         );
-        if parallaxed.z != 0.0 {
-        let NBT = transpose(mat3x3(T, B, N));
-        let tangent_extra_depth = Vt * additional_depth(in.uv, parallaxed.xy, parallaxed.z);
-        let extra_depth = tangent_extra_depth * NBT;
-        let parallaxed_view_position = view.view_proj * (in.world_position - vec4(extra_depth, 0.0));
-        // let parallaxed_view_position = view.view_proj * in.world_position;
-        out.depth = (parallaxed_view_position.z / parallaxed_view_position.w)  * 0.9999;
+        if parallaxed.z > 0.0001 {
+            let NBT = transpose(mat3x3(T, B, N));
+            let tangent_extra_depth = Vt * additional_depth(in.uv, parallaxed.xy, parallaxed.z);
+            let extra_depth = tangent_extra_depth * NBT;
+            let parallaxed_view_position = view.view_proj * (in.world_position - vec4(extra_depth, 0.0));
+            // let parallaxed_view_position = view.view_proj * in.world_position;
+            out.depth = parallaxed_view_position.z / parallaxed_view_position.w;
         }
     }
 #endif

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -3,7 +3,12 @@
 
 use std::fmt;
 
-use bevy::{prelude::*, render::render_resource::TextureFormat, window::close_on_esc};
+use bevy::{
+    core_pipeline::prepass::{DepthPrepass, MotionVectorPrepass, NormalPrepass},
+    prelude::*,
+    render::render_resource::TextureFormat,
+    window::close_on_esc,
+};
 
 fn main() {
     App::new()
@@ -218,6 +223,7 @@ fn setup(
             ..default()
         },
         CameraController,
+        DepthPrepass,
     ));
 
     // light

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -4,7 +4,9 @@
 use std::fmt;
 
 use bevy::{
-    core_pipeline::prepass::DepthPrepass, prelude::*, render::render_resource::TextureFormat,
+    core_pipeline::{core_3d::Camera3dDepthLoadOp, prepass::DepthPrepass},
+    prelude::*,
+    render::render_resource::TextureFormat,
     window::close_on_esc,
 };
 
@@ -219,6 +221,10 @@ fn setup(
     commands.spawn((
         Camera3dBundle {
             transform: Transform::from_xyz(1.5, 1.5, 1.5).looking_at(Vec3::ZERO, Vec3::Y),
+            camera_3d: Camera3d {
+                depth_load_op: Camera3dDepthLoadOp::Load,
+                ..default()
+            },
             ..default()
         },
         CameraController,

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -4,9 +4,7 @@
 use std::fmt;
 
 use bevy::{
-    core_pipeline::prepass::{DepthPrepass, MotionVectorPrepass, NormalPrepass},
-    prelude::*,
-    render::render_resource::TextureFormat,
+    core_pipeline::prepass::DepthPrepass, prelude::*, render::render_resource::TextureFormat,
     window::close_on_esc,
 };
 
@@ -14,6 +12,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(Normal(None))
+        .insert_resource(Msaa::Off)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -266,7 +265,7 @@ fn setup(
             reflectance: 0.18,
             ..Color::rgb_u8(0, 80, 0).into()
         }),
-        transform: Transform::from_xyz(0.0, -1.0, 0.0),
+        transform: Transform::from_xyz(0.0, -0.1, 0.0),
         ..default()
     });
 

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -6,6 +6,7 @@
 //! With no arguments it will load the `FlightHelmet` glTF model from the repository assets subdirectory.
 
 use bevy::{
+    core_pipeline::prepass::{DepthPrepass, MotionVectorPrepass, NormalPrepass},
     math::Vec3A,
     prelude::*,
     render::primitives::{Aabb, Sphere},
@@ -63,6 +64,7 @@ fn parse_scene(scene_path: String) -> (String, usize) {
 }
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.insert_resource(Msaa::Off);
     let scene_path = std::env::args()
         .nth(1)
         .unwrap_or_else(|| "assets/models/FlightHelmet/FlightHelmet.gltf".to_string());
@@ -135,6 +137,9 @@ fn setup_scene_after_load(
                     .load("assets/environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
             },
             camera_controller,
+            DepthPrepass,
+            NormalPrepass,
+            MotionVectorPrepass,
         ));
 
         // Spawn a default light if the scene does not have one


### PR DESCRIPTION
## Objective

The current parallax mapping implementation doesn't play well with depth-based feature, since it only updates the fragment color in the main pass. 

Effects that depend on depth will not work properly. This includes existing and future rendering features, such as:

- Shadow mapping
- Screen space ambient occlusion
- Fog
- Temporal anti-aliasing
- Screen space reflection
- etc.

### Solution

We update `pbr_prepass` to account for depth evaluated by parallax mapping

### TODO

Everything is broken, the code is full of debug stuff :sweat_smile:
