### PR TITLE
Just print out name string, not the entire Name struct

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -107,7 +107,7 @@ impl<'a> std::fmt::Debug for DebugNameItem<'a> {
     #[inline(always)]
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self.name {
-            Some(name) => write!(f, "{:?} ({:?})", &name, &self.entity),
+            Some(name) => write!(f, "{:?} ({:?})", name.as_str(), &self.entity),
             None => std::fmt::Debug::fmt(&self.entity, f),
         }
     }


### PR DESCRIPTION
# Objective
This is just an oversight on my part when I implemented this, there isn't much reason to print out the hash of a `Name` like it does currently:
```
Name { hash: 1608798714325729304, name: "Suzanne" } (7v0)
```

## Solution
Instead it would be better if we just printed out the string like so:
```
"Suzanne" (7v0)
```

As it conveys all of the information in a less cluttered way and immediately intuitive way which was the original purpose of `DebugName`.