### PR TITLE
shader_prepass example: disable MSAA for maximum compatibility 

### DIFF
--- a/assets/shaders/show_prepass.wgsl
+++ b/assets/shaders/show_prepass.wgsl
@@ -15,9 +15,14 @@ var<uniform> settings: ShowPrepassSettings;
 @fragment
 fn fragment(
     @builtin(position) frag_coord: vec4<f32>,
+#ifdef MULTISAMPLED
     @builtin(sample_index) sample_index: u32,
+#endif
     #import bevy_pbr::mesh_vertex_output
 ) -> @location(0) vec4<f32> {
+#ifndef MULTISAMPLED
+    let sample_index = 0u;
+#endif
     if settings.show_depth == 1u {
         let depth = prepass_depth(frag_coord, sample_index);
         return vec4(depth, depth, depth, 1.0);

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -28,6 +28,8 @@ fn main() {
         })
         .add_systems(Startup, setup)
         .add_systems(Update, (rotate, toggle_prepass_view))
+        // Disabling MSAA for maximum compatibility. Shader prepass with MSAA needs GPU capability MULTISAMPLED_SHADING
+        .insert_resource(Msaa::Off)
         .run();
 }
 


### PR DESCRIPTION
# Objective


Since #8446, example `shader_prepass` logs the following error on my mac m1:
```
ERROR bevy_render::render_resource::pipeline_cache: failed to process shader:
error: Entry point fragment at Fragment is invalid
 = Argument 1 varying error
 = Capability MULTISAMPLED_SHADING is not supported
```
The example display the 3d scene but doesn't change with the preps selected

Maybe related to this update in naga: https://github.com/gfx-rs/naga/commit/cc3a8ac73773e2223c3d45fbc1b22607026e2ec0

## Solution

- Disable MSAA in the example, and check if it's enabled in the shader
