### PR TITLE
avoid panic with parented scenes on deleted entities

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     world::{Mut, World},
 };
 use bevy_hierarchy::{AddChild, Parent};
-use bevy_utils::{tracing::error, HashMap};
+use bevy_utils::{tracing::error, HashMap, HashSet};
 use thiserror::Error;
 use uuid::Uuid;
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -267,6 +267,12 @@ impl SceneSpawner {
         let scenes_with_parent = std::mem::take(&mut self.scenes_with_parent);
 
         for (instance_id, parent) in scenes_with_parent {
+            if world.get_entity(parent).is_none() {
+                // parent has been deleted, despawn the instance
+                self.instances_to_despawn.push(instance_id);
+                continue;
+            }
+
             if let Some(instance) = self.spawned_instances.get(&instance_id) {
                 for entity in instance.entity_map.values() {
                     // Add the `Parent` component to the scene root, and update the `Children` component of


### PR DESCRIPTION
# Objective

after calling `SceneSpawner::spawn_as_child`, the scene spawner system will always try to attach the scene instance to the parent once it is loaded, even if the parent has been deleted, causing a panic.

## Solution

check if the parent is still alive, and don't spawn the scene instance if not.