### PR TITLE
Serialize `Entity` in `DynamicScene`

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -26,7 +26,7 @@ thread_local = "1.1.4"
 fixedbitset = "0.4.2"
 rustc-hash = "1.1"
 downcast-rs = "1.2"
-serde = { version = "1", features = ["derive"] }
+serde = "1"
 thiserror = "1.0"
 
 [dev-dependencies]

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -115,7 +115,7 @@ type IdCursor = isize;
 /// [`EntityCommands`]: crate::system::EntityCommands
 /// [`Query::get`]: crate::system::Query::get
 /// [`World`]: crate::world::World
-#[derive(Clone, Copy, Deserialize, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Entity {
     generation: u32,
     index: u32,
@@ -230,6 +230,25 @@ impl Entity {
 impl fmt::Debug for Entity {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}v{}", self.index, self.generation)
+    }
+}
+
+impl Serialize for Entity {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u64(self.to_bits())
+    }
+}
+
+impl<'de> Deserialize<'de> for Entity {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let id: u64 = serde::de::Deserialize::deserialize(deserializer)?;
+        Ok(Entity::from_bits(id))
     }
 }
 

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -36,8 +36,10 @@ pub struct DynamicScene {
 
 /// A reflection-powered serializable representation of an entity and its components.
 pub struct DynamicEntity {
-    /// The transiently unique identifier of a corresponding [`Entity`](bevy_ecs::entity::Entity).
-    pub entity: u32,
+    /// The identifier of the entity, unique within a scene (and the world it may have been generated from).
+    ///
+    /// Components that reference this entity must consistently use this identifier.
+    pub entity: Entity,
     /// A vector of boxed components that belong to the given entity and
     /// implement the [`Reflect`] trait.
     pub components: Vec<Box<dyn Reflect>>,
@@ -101,7 +103,7 @@ impl DynamicScene {
             // or spawn a new entity with a transiently unique id if there is
             // no corresponding entry.
             let entity = *entity_map
-                .entry(bevy_ecs::entity::Entity::from_raw(scene_entity.entity))
+                .entry(scene_entity.entity)
                 .or_insert_with(|| world.spawn_empty().id());
             let entity_mut = &mut world.entity_mut(entity);
 

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -38,7 +38,7 @@ use std::collections::BTreeMap;
 /// ```
 pub struct DynamicSceneBuilder<'w> {
     extracted_resources: BTreeMap<ComponentId, Box<dyn Reflect>>,
-    extracted_scene: BTreeMap<u32, DynamicEntity>,
+    extracted_scene: BTreeMap<Entity, DynamicEntity>,
     type_registry: AppTypeRegistry,
     original_world: &'w World,
 }
@@ -123,14 +123,12 @@ impl<'w> DynamicSceneBuilder<'w> {
         let type_registry = self.type_registry.read();
 
         for entity in entities {
-            let index = entity.index();
-
-            if self.extracted_scene.contains_key(&index) {
+            if self.extracted_scene.contains_key(&entity) {
                 continue;
             }
 
             let mut entry = DynamicEntity {
-                entity: index,
+                entity,
                 components: Vec::new(),
             };
 
@@ -151,7 +149,7 @@ impl<'w> DynamicSceneBuilder<'w> {
                 };
                 extract_and_push();
             }
-            self.extracted_scene.insert(index, entry);
+            self.extracted_scene.insert(entity.id(), entry);
         }
 
         drop(type_registry);
@@ -243,7 +241,7 @@ mod tests {
         let scene = builder.build();
 
         assert_eq!(scene.entities.len(), 1);
-        assert_eq!(scene.entities[0].entity, entity.index());
+        assert_eq!(scene.entities[0].entity, entity);
         assert_eq!(scene.entities[0].components.len(), 1);
         assert!(scene.entities[0].components[0].represents::<ComponentA>());
     }
@@ -264,7 +262,7 @@ mod tests {
         let scene = builder.build();
 
         assert_eq!(scene.entities.len(), 1);
-        assert_eq!(scene.entities[0].entity, entity.index());
+        assert_eq!(scene.entities[0].entity, entity);
         assert_eq!(scene.entities[0].components.len(), 1);
         assert!(scene.entities[0].components[0].represents::<ComponentA>());
     }
@@ -288,7 +286,7 @@ mod tests {
         let scene = builder.build();
 
         assert_eq!(scene.entities.len(), 1);
-        assert_eq!(scene.entities[0].entity, entity.index());
+        assert_eq!(scene.entities[0].entity, entity);
         assert_eq!(scene.entities[0].components.len(), 2);
         assert!(scene.entities[0].components[0].represents::<ComponentA>());
         assert!(scene.entities[0].components[1].represents::<ComponentB>());
@@ -315,10 +313,10 @@ mod tests {
         let mut entities = builder.build().entities.into_iter();
 
         // Assert entities are ordered
-        assert_eq!(entity_a.index(), entities.next().map(|e| e.entity).unwrap());
-        assert_eq!(entity_b.index(), entities.next().map(|e| e.entity).unwrap());
-        assert_eq!(entity_c.index(), entities.next().map(|e| e.entity).unwrap());
-        assert_eq!(entity_d.index(), entities.next().map(|e| e.entity).unwrap());
+        assert_eq!(entity_a, entities.next().map(|e| e.entity).unwrap());
+        assert_eq!(entity_b, entities.next().map(|e| e.entity).unwrap());
+        assert_eq!(entity_c, entities.next().map(|e| e.entity).unwrap());
+        assert_eq!(entity_d, entities.next().map(|e| e.entity).unwrap());
     }
 
     #[test]
@@ -345,7 +343,7 @@ mod tests {
         assert_eq!(scene.entities.len(), 2);
         let mut scene_entities = vec![scene.entities[0].entity, scene.entities[1].entity];
         scene_entities.sort();
-        assert_eq!(scene_entities, [entity_a_b.index(), entity_a.index()]);
+        assert_eq!(scene_entities, [entity_a_b, entity_a]);
     }
 
     #[test]
@@ -365,7 +363,7 @@ mod tests {
         let scene = builder.build();
 
         assert_eq!(scene.entities.len(), 1);
-        assert_eq!(scene.entities[0].entity, entity_a.index());
+        assert_eq!(scene.entities[0].entity, entity_a);
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Extracted part of #7335. I used this mainly to [patch my game](https://github.com/lifescapegame/lifescape/blob/cbd78b048c128d8117df27265168435122e6d185/Cargo.toml#L51), but this may also simplify the merging process since this PR fixes only one major.

If `DynamicScene` scene is serialized with a component that refers to an entity whose `generation` != 0, then this will cause a panic when mapping entities:
https://github.com/bevyengine/bevy/blob/ee697f820c0b164cf2825b9c8e932fc8cee24a2c/crates/bevy_scene/src/dynamic_scene.rs#L143-L147
It's because entities are compared with `generation` taken into account and since entities from `DynamicScene` have only `id`, their `generation` will be 0 and it causes mismatch.

## Solution

Serialize `Entity` in `DynamicScene` instead of just `u32`. And change `Entity` serialization to `u64` to avoid making scene format longer. This way comparsion when mapping entities will be correct and the serialized ron will store plain numbers for dynamic entities as before. The serialized text become even shorter since entities inside components now also plain numbers.

I believe it the simplest change and it's was [one of the suggestions from `@cart`](https://github.com/bevyengine/bevy/pull/7335#issuecomment-1399661706).

---

## Changelog

### Changed

- Serialize `Entity` as `u64`.

### Fixed

- Fix `DynamicScene` deserialization with a component that references entity with `generation` != 0.

## Migration Guide

- Store `Entity` instead of `u32` in `DynamicScene`.
