### PR TITLE
UI layout tree debug print

### DIFF
--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -55,9 +55,9 @@ fn print_node(
     } else {
         "└── "
     };
-    write!(
+    writeln!(
         acc,
-        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?}) {measured}\n",
+        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?}) {measured}",
         lines = lines_string,
         fork = fork_string,
         display = display_variant,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -69,7 +69,7 @@ fn print_node(
         let child_entity = taffy_to_entity.get(child_node).unwrap();
         print_node(
             ui_surface,
-            &taffy_to_entity,
+            taffy_to_entity,
             *child_entity,
             *child_node,
             has_sibling,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -1,21 +1,36 @@
+use crate::UiSurface;
 use bevy_ecs::prelude::Entity;
 use bevy_utils::HashMap;
 use taffy::prelude::Node;
 use taffy::tree::LayoutTree;
-use crate::UiSurface;
 
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
-    let taffy_to_entity: HashMap<Node, Entity> =
-        ui_surface.entity_to_taffy.iter()
+    let taffy_to_entity: HashMap<Node, Entity> = ui_surface
+        .entity_to_taffy
+        .iter()
         .map(|(entity, node)| (*node, *entity))
         .collect();
     for (&entity, &node) in ui_surface.window_nodes.iter() {
         println!("Layout tree for window entity: {entity:?}");
-        print_node(ui_surface, &taffy_to_entity, entity, node, false, String::new());
+        print_node(
+            ui_surface,
+            &taffy_to_entity,
+            entity,
+            node,
+            false,
+            String::new(),
+        );
     }
 }
 
-fn print_node(ui_surface: &UiSurface, taffy_to_entity: &HashMap<Node, Entity>, entity: Entity, node: Node, has_sibling: bool, lines_string: String) {
+fn print_node(
+    ui_surface: &UiSurface,
+    taffy_to_entity: &HashMap<Node, Entity>,
+    entity: Entity,
+    node: Node,
+    has_sibling: bool,
+    lines_string: String,
+) {
     let tree = &ui_surface.taffy;
     let layout = tree.layout(node).unwrap();
     let style = tree.style(node).unwrap();
@@ -29,7 +44,11 @@ fn print_node(ui_surface: &UiSurface, taffy_to_entity: &HashMap<Node, Entity>, e
         (_, taffy::style::Display::Grid) => "GRID",
     };
 
-    let fork_string = if has_sibling { "├── " } else { "└── " };
+    let fork_string = if has_sibling {
+        "├── "
+    } else {
+        "└── "
+    };
     println!(
         "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?}) {measured}",
         lines = lines_string,
@@ -48,6 +67,13 @@ fn print_node(ui_surface: &UiSurface, taffy_to_entity: &HashMap<Node, Entity>, e
     for (index, child_node) in tree.children(node).unwrap().iter().enumerate() {
         let has_sibling = index < num_children - 1;
         let child_entity = taffy_to_entity.get(child_node).unwrap();
-        print_node(ui_surface, &taffy_to_entity, *child_entity, *child_node, has_sibling, new_string.clone());
+        print_node(
+            ui_surface,
+            &taffy_to_entity,
+            *child_entity,
+            *child_node,
+            has_sibling,
+            new_string.clone(),
+        );
     }
 }

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -1,0 +1,41 @@
+
+pub fn print_tree(tree: &impl LayoutTree, root: Node) {
+    println!("TREE");
+    print_node(tree, root, false, String::new());
+}
+
+fn print_node(tree: &impl LayoutTree, node: Node, has_sibling: bool, lines_string: String) {
+    let layout = tree.layout(node);
+    let style = tree.style(node);
+
+    let num_children = tree.child_count(node);
+
+    let display = match (num_children, style.display) {
+        (_, style::Display::None) => "NONE",
+        (0, _) => "LEAF",
+        (_, style::Display::Flex) => "FLEX",
+        #[cfg(feature = "grid")]
+        (_, style::Display::Grid) => "GRID",
+    };
+
+    let fork_string = if has_sibling { "├── " } else { "└── " };
+    println!(
+        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({key:?})",
+        lines = lines_string,
+        fork = fork_string,
+        display = display,
+        x = layout.location.x,
+        y = layout.location.y,
+        width = layout.size.width,
+        height = layout.size.height,
+        key = node.data(),
+    );
+    let bar = if has_sibling { "│   " } else { "    " };
+    let new_string = lines_string + bar;
+
+    // Recurse into children
+    for (index, child) in tree.children(node).enumerate() {
+        let has_sibling = index < num_children - 1;
+        print_node(tree, *child, has_sibling, new_string.clone());
+    }
+}

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -4,6 +4,7 @@ use bevy_utils::HashMap;
 use taffy::prelude::Node;
 use taffy::tree::LayoutTree;
 
+/// Prints a debug representation of the computed layout of the UI layout tree for each window.
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     let taffy_to_entity: HashMap<Node, Entity> = ui_surface
         .entity_to_taffy
@@ -23,6 +24,7 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
     }
 }
 
+/// Recursively navigates the layout tree printing each node's information.
 fn print_node(
     ui_surface: &UiSurface,
     taffy_to_entity: &HashMap<Node, Entity>,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,4 +1,5 @@
 mod convert;
+pub mod debug;
 
 use crate::{CalculatedSize, Node, Style, UiScale};
 use bevy_ecs::{


### PR DESCRIPTION
# Objective

Copy the `debug::print_tree` function from Taffy except display entity ids instead of Taffy's node ids and indicate which ui nodes have a measure func.