### PR TITLE
Expose sorting methods in `Children`

### DIFF
--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -50,6 +50,83 @@ impl Children {
     pub fn swap(&mut self, a_index: usize, b_index: usize) {
         self.0.swap(a_index, b_index);
     }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided comparator function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by`].
+    ///
+    /// For the unstable version, see [`sort_unstable_by`](Children::sort_unstable_by).
+    ///
+    /// See also [`sort_by_key`](Children::sort_by_key), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    pub fn sort_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity, &Entity) -> std::cmp::Ordering,
+    {
+        self.0.sort_by(compare)
+    }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by_key`].
+    ///
+    /// For the unstable version, see [`sort_unstable_by_key`](Children::sort_unstable_by_key).
+    ///
+    /// See also [`sort_by`](Children::sort_by), [`sort_by_cached_key`](Children::sort_by_cached_key).
+    pub fn sort_by_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_key(compare)
+    }
+
+    /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function. Only evaluates each key at most
+    /// once per sort, caching the intermediate results in memory.
+    ///
+    /// For the underlying implementation, see [`slice::sort_by_cached_key`].
+    ///
+    /// See also [`sort_by`](Children::sort_by), [`sort_by_key`](Children::sort_by_key).
+    pub fn sort_by_cached_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_by_cached_key(compare)
+    }
+
+    /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided comparator function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_unstable_by`].
+    ///
+    /// For the stable version, see [`sort_by`](Children::sort_by).
+    ///
+    /// See also [`sort_unstable_by_key`](Children::sort_unstable_by_key).
+    pub fn sort_unstable_by<F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity, &Entity) -> std::cmp::Ordering,
+    {
+        self.0.sort_unstable_by(compare)
+    }
+
+    /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
+    /// in place using the provided key extraction function.
+    ///
+    /// For the underlying implementation, see [`slice::sort_unstable_by_key`].
+    ///
+    /// For the stable version, see [`sort_by_key`](Children::sort_by_key).
+    ///
+    /// See also [`sort_unstable_by`](Children::sort_unstable_by).
+    pub fn sort_unstable_by_key<K, F>(&mut self, compare: F)
+    where
+        F: FnMut(&Entity) -> K,
+        K: Ord,
+    {
+        self.0.sort_unstable_by_key(compare)
+    }
 }
 
 impl Deref for Children {

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -63,7 +63,7 @@ impl Children {
     where
         F: FnMut(&Entity, &Entity) -> std::cmp::Ordering,
     {
-        self.0.sort_by(compare)
+        self.0.sort_by(compare);
     }
 
     /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
@@ -79,7 +79,7 @@ impl Children {
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_by_key(compare)
+        self.0.sort_by_key(compare);
     }
 
     /// Sorts children [stably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
@@ -94,7 +94,7 @@ impl Children {
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_by_cached_key(compare)
+        self.0.sort_by_cached_key(compare);
     }
 
     /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
@@ -109,7 +109,7 @@ impl Children {
     where
         F: FnMut(&Entity, &Entity) -> std::cmp::Ordering,
     {
-        self.0.sort_unstable_by(compare)
+        self.0.sort_unstable_by(compare);
     }
 
     /// Sorts children [unstably](https://en.wikipedia.org/wiki/Sorting_algorithm#Stability)
@@ -125,7 +125,7 @@ impl Children {
         F: FnMut(&Entity) -> K,
         K: Ord,
     {
-        self.0.sort_unstable_by_key(compare)
+        self.0.sort_unstable_by_key(compare);
     }
 }
 


### PR DESCRIPTION
# Objective

- For many UI use cases (e.g. tree views, lists), it is important to be able to imperatively sort child nodes.
- This also enables us to eventually support something like the [`order`](https://developer.mozilla.org/en-US/docs/Web/CSS/order) CSS property, that declaratively re-orders flex box items by a numeric value, similar to z-index, but in space.

## Solution

We removed the ability to directly construct `Children` from `&[Entity]` some time ago (#4197 #5532) to enforce consistent hierarchies ([RFC 53](https://github.com/bevyengine/rfcs/blob/main/rfcs/53-consistent-hierarchy.md)). If I understand it correctly, it's currently possible to re-order children by using `Children::swap()` or `commands.entity(id).replace_children(...)`, however these are either too cumbersome, needlessly inefficient, and/or don't take effect immediately.

This PR exposes the in-place sorting methods from the `slice` primitive in `Children`, enabling imperatively sorting children in place via `&mut Children`, while still preserving consistent hierarchies.

---

## Changelog
### Added
- The sorting methods from the `slice` primitive are now exposed by the `Children` component, allowing imperatively sorting children in place (Useful for UI scenarios such as lists)
