### PR TITLE
Add Reflect and FromReflect for AssetPath

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -104,8 +104,10 @@ impl Plugin for AssetPlugin {
             app.insert_resource(asset_server);
         }
 
-        app.register_type::<HandleId>()
-            .add_systems(PreUpdate, asset_server::free_unused_assets_system);
+        app.register_type::<HandleId>();
+        app.register_type::<AssetPath>();
+
+        app.add_systems(PreUpdate, asset_server::free_unused_assets_system);
         app.init_schedule(LoadAssets);
         app.init_schedule(AssetEvents);
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,4 +1,4 @@
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize, FromReflect};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_utils::AHasher;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,4 +1,6 @@
-use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, ReflectFromReflect};
+use bevy_reflect::{
+    FromReflect, Reflect, ReflectDeserialize, ReflectFromReflect, ReflectSerialize,
+};
 use bevy_utils::AHasher;
 use serde::{Deserialize, Serialize};
 use std::{

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,4 +1,4 @@
-use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize, FromReflect};
 use bevy_utils::AHasher;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -8,7 +8,7 @@ use std::{
 };
 
 /// Represents a path to an asset in the file system.
-#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize)]
+#[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct AssetPath<'a> {
     path: Cow<'a, Path>,
     label: Option<Cow<'a, str>>,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,4 +1,4 @@
-use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize};
+use bevy_reflect::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, ReflectFromReflect};
 use bevy_utils::AHasher;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -9,6 +9,7 @@ use std::{
 
 /// Represents a path to an asset in the file system.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, Reflect, FromReflect)]
+#[reflect(Debug, PartialEq, Hash, Serialize, Deserialize, FromReflect)]
 pub struct AssetPath<'a> {
     path: Cow<'a, Path>,
     label: Option<Cow<'a, str>>,

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -28,7 +28,7 @@ use std::borrow::Cow;
 use std::ffi::OsString;
 use std::marker::PhantomData;
 use std::ops::Range;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
 #[cfg(not(target_arch = "wasm32"))]
@@ -59,6 +59,7 @@ fn register_rust_types(app: &mut App) {
         .register_type::<Option<bool>>()
         .register_type::<Option<f64>>()
         .register_type::<Cow<'static, str>>()
+        .register_type::<Cow<'static, Path>>()
         .register_type::<Duration>()
         .register_type::<Instant>();
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,5 +1,5 @@
 use crate::std_traits::ReflectDefault;
-use crate::{self as bevy_reflect, ReflectFromPtr, ReflectOwned};
+use crate::{self as bevy_reflect, ReflectFromPtr, ReflectOwned, ReflectFromReflect};
 use crate::{
     map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum, DynamicMap, Enum,
     EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter,
@@ -12,6 +12,7 @@ use crate::utility::{reflect_hasher, GenericTypeInfoCell, NonGenericTypeInfoCell
 use bevy_reflect_derive::{impl_from_reflect_value, impl_reflect_value};
 use bevy_utils::HashSet;
 use bevy_utils::{Duration, Instant};
+use std::fmt;
 use std::{
     any::Any,
     borrow::Cow,
@@ -1247,6 +1248,10 @@ impl Reflect for Cow<'static, Path> {
             Some(false)
         }
     }
+
+    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fmt::Debug::fmt(&self, f)
+    }
 }
 
 impl Typed for Cow<'static, Path> {
@@ -1257,7 +1262,7 @@ impl Typed for Cow<'static, Path> {
 }
 
 impl FromReflect for Cow<'static, Path> {
-    fn from_reflect(reflect: &dyn crate::Reflect) -> Option<Self> {
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
         Some(
             reflect
                 .as_any()
@@ -1269,10 +1274,11 @@ impl FromReflect for Cow<'static, Path> {
 
 impl GetTypeRegistration for Cow<'static, Path> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Cow<'static, Path>>();
-        registration.insert::<ReflectDeserialize>(FromType::<Cow<'static, Path>>::from_type());
-        registration.insert::<ReflectFromPtr>(FromType::<Cow<'static, Path>>::from_type());
-        registration.insert::<ReflectSerialize>(FromType::<Cow<'static, Path>>::from_type());
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectDeserialize>(FromType::<Self>::from_type());
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration.insert::<ReflectSerialize>(FromType::<Self>::from_type());
+        registration.insert::<ReflectFromReflect>(FromType::<Self>::from_type());
         registration
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1263,12 +1263,7 @@ impl Typed for Cow<'static, Path> {
 
 impl FromReflect for Cow<'static, Path> {
     fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        Some(
-            reflect
-                .as_any()
-                .downcast_ref::<Cow<'static, Path>>()?
-                .clone(),
-        )
+        Some(reflect.as_any().downcast_ref::<Self>()?.clone())
     }
 }
 

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,5 +1,5 @@
 use crate::std_traits::ReflectDefault;
-use crate::{self as bevy_reflect, ReflectFromPtr, ReflectOwned, ReflectFromReflect};
+use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwned};
 use crate::{
     map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum, DynamicMap, Enum,
     EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, Map, MapInfo, MapIter,


### PR DESCRIPTION
# Objective

- Add Reflect and FromReflect for AssetPath
- Fixes #8458

## Solution

- Straightforward derive of `Reflect` and `FromReflect` for `AssetPath`
- Implement `Reflect` and `FromReflect` for `Cow<'static, Path>` as to satisfy the 'static lifetime requierments of bevy_reflect. Implementation is a direct copy of that for `Cow<'static, str>` so maybe it begs the question that was already asked in #7429 - maybe it would be benefitial to write a general implementation for `Reflect` for `Cow<'static, T>`.
