### PR TITLE
Add a failsafe for cascading `FixedUpdate` time accumulation

### DIFF
--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -40,12 +40,12 @@ pub struct FixedTime {
     /// If this value is set to `None`, the schedule will run as many times as possible.
     /// Be careful when setting this value to `None`, as it can cause the app to stop rendering
     /// as the fixed update schedule will run an increasing number of times per frame as it falls behind.
-    pub max_ticks_per_frame: Option<u8>,
+    pub max_ticks_per_frame: Option<usize>,
 }
 
 impl FixedTime {
     /// Sets the default maximum number of times that the [`FixedUpdate`] schedule will be allowed to run per main schedule pass.
-    const DEFAULT_MAX_TICKS_PER_FRAME: u8 = 20;
+    const DEFAULT_MAX_TICKS_PER_FRAME: usize = 20;
 
     /// Creates a new [`FixedTime`] struct
     pub fn new(period: Duration) -> Self {

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -24,7 +24,7 @@
 use crate::Time;
 use bevy_app::FixedUpdate;
 use bevy_ecs::{system::Resource, world::World};
-use bevy_utils::{Duration, tracing::warn};
+use bevy_utils::{tracing::warn, Duration};
 use thiserror::Error;
 
 /// The amount of time that must pass before the fixed timestep schedule is run again.
@@ -113,7 +113,7 @@ pub fn run_fixed_update_schedule(world: &mut World) {
     fixed_time.tick(delta_time);
 
     let mut ticks_this_frame = 0;
-    
+
     // Copy this out to appease the borrow checker
     let maybe_max_ticks = fixed_time.max_ticks_per_frame;
 

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -35,7 +35,7 @@ pub struct FixedTime {
     /// To configure this value, simply mutate or overwrite this resource.
     pub period: Duration,
     /// The maximum number of times that the [`FixedUpdate`] schedule will be allowed to run per main schedule pass.
-    /// Defaults to 3.
+    /// Defaults to 20: this may be too high for your game and will result in very low (but stable) FPS with a long fixed update period.
     ///
     /// If this value is set to `None`, the schedule will run as many times as possible.
     /// Be careful when setting this value to `None`, as it can cause the app to stop rendering
@@ -44,12 +44,15 @@ pub struct FixedTime {
 }
 
 impl FixedTime {
+    /// Sets the default maximum number of times that the [`FixedUpdate`] schedule will be allowed to run per main schedule pass.
+    const DEFAULT_MAX_TICKS_PER_FRAME: u8 = 20;
+
     /// Creates a new [`FixedTime`] struct
     pub fn new(period: Duration) -> Self {
         FixedTime {
             accumulated: Duration::ZERO,
             period,
-            max_ticks_per_frame: Some(3),
+            max_ticks_per_frame: Some(Self::DEFAULT_MAX_TICKS_PER_FRAME),
         }
     }
 
@@ -58,7 +61,7 @@ impl FixedTime {
         FixedTime {
             accumulated: Duration::ZERO,
             period: Duration::from_secs_f32(period),
-            max_ticks_per_frame: Some(3),
+            max_ticks_per_frame: Some(Self::DEFAULT_MAX_TICKS_PER_FRAME),
         }
     }
 

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -121,14 +121,14 @@ pub fn run_fixed_update_schedule(world: &mut World) {
     let _ = world.try_schedule_scope(FixedUpdate, |world, schedule| {
         while world.resource_mut::<FixedTime>().expend().is_ok() {
             ticks_this_frame +=  1;
-            
+
             // This is required to avoid entering a death spiral where the fixed update schedule falls behind
             // and needs to run more and more times per frame to catch up.
             if let Some(max_ticks) = maybe_max_ticks {
                 if ticks_this_frame > max_ticks {
                     warn!("The fixed update schedule is falling behind. Consider increasing the period or decreasing the amount of work done in the fixed update schedule.");
                     break;
-                }                
+                }
             }
 
             schedule.run(world);


### PR DESCRIPTION
# Objective

- If a fixed update schedule takes longer to run than its allocated period, more time will build up. This will required the fixed update to be run multiple times in the future, worsening the problem.
- Fixes #8543.

## Solution

- Adds a `max_ticks_per_frame` field to `FixedTime`. If this is set to `Some`, the fixed update schedule will give up after that many runs of the schedule in a single pass of the main schedule.
- This defaults to 3.

## Changelog

The `FixedUpdate` schedule will no longer fall further and further behind when too much work is requested.
Instead, time will begin to accumulate and a warning will be emitted.

You can configure this behavior by setting the `max_ticks_per_frame` field of the `FixedTime` resource.
