### PR TITLE
Simplify text system queries

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -94,7 +94,7 @@ pub fn measure_text_system(
         return;
     }
 
-    let mut new_queue = Vec::new();
+    let mut new_text_queue = Vec::new();
     for entity in text_queue.drain(..) {
         if let Ok((_, text, mut content_size)) = text_query.get_mut(entity) {
             match text_pipeline.create_text_measure(
@@ -108,7 +108,7 @@ pub fn measure_text_system(
                     content_size.set(TextMeasure { info: measure });
                 }
                 Err(TextError::NoSuchFont) => {
-                    new_queue.push(entity);
+                    new_text_queue.push(entity);
                 }
                 Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
@@ -116,7 +116,7 @@ pub fn measure_text_system(
             };
         }
     }
-    *text_queue = new_queue;
+    *text_queue = new_text_queue;
 }
 
 /// Updates the layout and size information whenever the text or style is changed.
@@ -165,7 +165,7 @@ pub fn text_system(
         *last_scale_factor = scale_factor;
     }
 
-    let mut new_queue = Vec::new();
+    let mut new_text_queue = Vec::new();
     for entity in text_queue.drain(..) {
         if let Ok((_, node, text, mut text_layout_info)) = text_query.get_mut(entity) {
             let node_size = Vec2::new(
@@ -190,7 +190,7 @@ pub fn text_system(
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the
                     // queue for further processing
-                    new_queue.push(entity);
+                    new_text_queue.push(entity);
                 }
                 Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
@@ -201,5 +201,5 @@ pub fn text_system(
             }
         }
     }
-    *text_queue = new_queue;
+    *text_queue = new_text_queue;
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -148,12 +148,13 @@ pub fn text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
+    let n = queued_text.len();
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
         // Adds all entities where the text or the style has changed to the local queue
         for (entity, node, text, ..) in text_query.iter() {
-            if node.is_changed() || text.is_changed() || !queued_text.contains(&entity) {
+            if (node.is_changed() || text.is_changed()) && !queued_text.contains(&entity) {
                 queued_text.push(entity);
             }
         }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -3,8 +3,8 @@ use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
     prelude::DetectChanges,
-    query::{Changed, Or, With},
-    system::{Local, ParamSet, Query, Res, ResMut},
+    query::With,
+    system::{Local, Query, Res, ResMut},
     world::Ref,
 };
 use bevy_math::Vec2;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -2,8 +2,10 @@ use crate::{ContentSize, Measure, Node, UiScale};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
+    prelude::DetectChanges,
     query::{Changed, Or, With},
-    system::{Local, ParamSet, Query, Res, ResMut}, world::Ref, prelude::DetectChanges,
+    system::{Local, ParamSet, Query, Res, ResMut},
+    world::Ref,
 };
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
@@ -63,9 +65,7 @@ pub fn measure_text_system(
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut text_query: 
-        Query<(Entity, Ref<Text>, &mut ContentSize), With<Node>>,
-
+    mut text_query: Query<(Entity, Ref<Text>, &mut ContentSize), With<Node>>,
 ) {
     let window_scale_factor = windows
         .get_single()
@@ -139,10 +139,7 @@ pub fn text_system(
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut font_atlas_set_storage: ResMut<Assets<FontAtlasSet>>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut text_query: 
-        // Query<Entity, Or<(Changed<Text>, Changed<Node>)>>,
-        // Query<Entity, (With<Text>, With<Node>)>,
-        Query<(Entity, Ref<Node>, Ref<Text>, &mut TextLayoutInfo)>,
+    mut text_query: Query<(Entity, Ref<Node>, Ref<Text>, &mut TextLayoutInfo)>,
 ) {
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let window_scale_factor = windows

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -148,7 +148,6 @@ pub fn text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
-    let n = queued_text.len();
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {


### PR DESCRIPTION
# Objective

Both `measure_text_system` and `text_system` have `ParamSet` parameters each with three text queries. This complexity doesn't seem necessary and the `ParamSet` queries can be replaced with a single combined query. 

## Solution

Replace the `ParamSet`s in `measure_text_system` and `text_system` with single combined queries.

---

## Changelog

* Replaced the `measure_texture_system` and `text_system` `ParamSet` parameters with single combined queries.


