### PR TITLE
Replace the local text queues in the text systems with flags stored in a component

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,7 +1,7 @@
 //! This module contains basic node bundles used to build UIs
 
 use crate::{
-    widget::{Button, UiImageSize},
+    widget::{Button, UiImageSize, TextFlags},
     BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
@@ -118,6 +118,8 @@ pub struct TextBundle {
     pub text: Text,
     /// Text layout information
     pub text_layout_info: TextLayoutInfo,
+    /// Text system flags 
+    pub text_flags: TextFlags,
     /// The calculated size based on the given image
     pub calculated_size: ContentSize,
     /// Whether this node should block interaction with lower nodes
@@ -148,6 +150,7 @@ impl Default for TextBundle {
         Self {
             text: Default::default(),
             text_layout_info: Default::default(),
+            text_flags: Default::default(),
             calculated_size: Default::default(),
             // Transparent background
             background_color: BackgroundColor(Color::NONE),

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -1,7 +1,7 @@
 //! This module contains basic node bundles used to build UIs
 
 use crate::{
-    widget::{Button, UiImageSize, TextFlags},
+    widget::{Button, TextFlags, UiImageSize},
     BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
@@ -118,7 +118,7 @@ pub struct TextBundle {
     pub text: Text,
     /// Text layout information
     pub text_layout_info: TextLayoutInfo,
-    /// Text system flags 
+    /// Text system flags
     pub text_flags: TextFlags,
     /// The calculated size based on the given image
     pub calculated_size: ContentSize,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -254,3 +254,4 @@ pub fn text_system(
         }
     }
 }
+    

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -125,6 +125,7 @@ pub fn measure_text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
+    
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
         // scale factor unchanged, only create new measures for modified text
@@ -192,7 +193,6 @@ fn queue_text(
         }
     }
 }
-
 
 /// Updates the layout and size information whenever the text or style is changed.
 /// This information is computed by the `TextPipeline` on insertion, then stored.

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -94,7 +94,7 @@ pub fn measure_text_system(
         return;
     }
 
-    let mut new_queue = Vec::new();
+    let mut new_text_queue = Vec::new();
     for entity in text_queue.drain(..) {
         if let Ok((_, text, mut content_size)) = text_query.get_mut(entity) {
             match text_pipeline.create_text_measure(
@@ -108,7 +108,7 @@ pub fn measure_text_system(
                     content_size.set(TextMeasure { info: measure });
                 }
                 Err(TextError::NoSuchFont) => {
-                    new_queue.push(entity);
+                    new_text_queue.push(entity);
                 }
                 Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
@@ -116,7 +116,7 @@ pub fn measure_text_system(
             };
         }
     }
-    *text_queue = new_queue;
+    *text_queue = new_text_queue;
 }
 
 /// Updates the layout and size information whenever the text or style is changed.
@@ -165,7 +165,7 @@ pub fn text_system(
         *last_scale_factor = scale_factor;
     }
 
-    let mut new_queue = Vec::new();
+    let mut new_text_queue = Vec::new();
     for entity in text_queue.drain(..) {
         if let Ok((_, node, text, mut text_layout_info)) = text_query.get_mut(entity) {
             let node_size = Vec2::new(
@@ -190,7 +190,7 @@ pub fn text_system(
                 Err(TextError::NoSuchFont) => {
                     // There was an error processing the text layout, let's add this entity to the
                     // queue for further processing
-                    new_queue.push(entity);
+                    new_text_queue.push(entity);
                 }
                 Err(e @ TextError::FailedToAddGlyph(_)) => {
                     panic!("Fatal error when processing text: {e}.");
@@ -201,5 +201,5 @@ pub fn text_system(
             }
         }
     }
-    *text_queue = new_queue;
+    *text_queue = new_text_queue;
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -148,12 +148,13 @@ pub fn text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
+    let n = queued_text.len();
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
         // Adds all entities where the text or the style has changed to the local queue
         for (entity, node, text, ..) in text_query.iter() {
-            if node.is_changed() || text.is_changed() || !queued_text.contains(&entity) {
+            if (node.is_changed() || text.is_changed()) && !queued_text.contains(&entity) {
                 queued_text.push(entity);
             }
         }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     query::With,
     reflect::ReflectComponent,
     system::{Local, Query, Res, ResMut},
-    world::{Ref, Mut},
+    world::{Mut, Ref},
 };
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
@@ -23,7 +23,7 @@ fn scale_value(value: f32, factor: f64) -> f32 {
 }
 
 /// Text system flags
-/// 
+///
 /// Used internally by [`measure_text_system`] and [`text_system`] to schedule text for processing.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
@@ -127,13 +127,20 @@ pub fn measure_text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
-    
+
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
         // scale factor unchanged, only create new measures for modified text
         for (text, content_size, text_flags) in text_query.iter_mut() {
             if text.is_changed() || text_flags.remeasure {
-                create_text_measure(&fonts, &mut text_pipeline, scale_factor, text, content_size, text_flags);
+                create_text_measure(
+                    &fonts,
+                    &mut text_pipeline,
+                    scale_factor,
+                    text,
+                    content_size,
+                    text_flags,
+                );
             }
         }
     } else {
@@ -141,7 +148,14 @@ pub fn measure_text_system(
         *last_scale_factor = scale_factor;
 
         for (text, content_size, text_flags) in text_query.iter_mut() {
-            create_text_measure(&fonts, &mut text_pipeline, scale_factor, text, content_size, text_flags);
+            create_text_measure(
+                &fonts,
+                &mut text_pipeline,
+                scale_factor,
+                text,
+                content_size,
+                text_flags,
+            );
         }
     }
 }
@@ -229,7 +243,20 @@ pub fn text_system(
         // Scale factor unchanged, only recompute text for modified text nodes
         for (node, text, text_layout_info, text_flags) in text_query.iter_mut() {
             if node.is_changed() || text_flags.recompute {
-                queue_text(&fonts, &mut text_pipeline, &mut font_atlas_warning, &mut font_atlas_set_storage, &mut texture_atlases, &mut textures, &text_settings, scale_factor, text, node, text_flags, text_layout_info);
+                queue_text(
+                    &fonts,
+                    &mut text_pipeline,
+                    &mut font_atlas_warning,
+                    &mut font_atlas_set_storage,
+                    &mut texture_atlases,
+                    &mut textures,
+                    &text_settings,
+                    scale_factor,
+                    text,
+                    node,
+                    text_flags,
+                    text_layout_info,
+                );
             }
         }
     } else {
@@ -237,8 +264,20 @@ pub fn text_system(
         *last_scale_factor = scale_factor;
 
         for (node, text, text_layout_info, text_flags) in text_query.iter_mut() {
-            queue_text(&fonts, &mut text_pipeline, &mut font_atlas_warning, &mut font_atlas_set_storage, &mut texture_atlases, &mut textures, &text_settings, scale_factor, text, node, text_flags, text_layout_info);
+            queue_text(
+                &fonts,
+                &mut text_pipeline,
+                &mut font_atlas_warning,
+                &mut font_atlas_set_storage,
+                &mut texture_atlases,
+                &mut textures,
+                &text_settings,
+                scale_factor,
+                text,
+                node,
+                text_flags,
+                text_layout_info,
+            );
         }
     }
 }
-    

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,14 +1,14 @@
 use crate::{ContentSize, Measure, Node, UiScale};
 use bevy_asset::Assets;
 use bevy_ecs::{
-    entity::Entity,
-    prelude::{DetectChanges, Component},
+    prelude::{Component, DetectChanges},
     query::With,
+    reflect::ReflectComponent,
     system::{Local, Query, Res, ResMut},
-    world::Ref, reflect::ReflectComponent,
+    world::Ref,
 };
 use bevy_math::Vec2;
-use bevy_reflect::{Reflect, std_traits::ReflectDefault};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
 use bevy_text::{
@@ -22,7 +22,7 @@ fn scale_value(value: f32, factor: f64) -> f32 {
     (value as f64 * factor) as f32
 }
 
-/// Text system flags 
+/// Text system flags
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct TextFlags {
@@ -93,7 +93,6 @@ pub fn measure_text_system(
 
     let scale_factor = ui_scale.scale * window_scale_factor;
     #[allow(clippy::float_cmp)]
-
     if *last_scale_factor == scale_factor {
         // scale factor unchanged, only create new measures for modified text
         for (text, mut content_size, mut text_flags) in text_query.iter_mut() {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -88,7 +88,7 @@ fn create_text_measure(
     mut text_flags: Mut<TextFlags>,
 ) {
     match text_pipeline.create_text_measure(
-        &fonts,
+        fonts,
         &text.sections,
         scale_factor,
         text.alignment,
@@ -160,6 +160,7 @@ pub fn measure_text_system(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 #[inline]
 fn queue_text(
     fonts: &Assets<Font>,
@@ -182,7 +183,7 @@ fn queue_text(
         );
 
         match text_pipeline.queue_text(
-            &fonts,
+            fonts,
             &text.sections,
             scale_factor,
             text.alignment,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -23,6 +23,8 @@ fn scale_value(value: f32, factor: f64) -> f32 {
 }
 
 /// Text system flags
+/// 
+/// Used internally by [`measure_text_system`] and [`text_system`] to schedule text for processing.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct TextFlags {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -76,6 +76,10 @@ impl Measure for TextMeasure {
     }
 }
 
+#[inline]
+fn create_text_measure() {
+}
+
 /// Creates a `Measure` for text nodes that allows the UI to determine the appropriate amount of space
 /// to provide for the text given the fonts, the text itself and the constraints of the layout.
 pub fn measure_text_system(
@@ -135,8 +139,13 @@ pub fn measure_text_system(
             ) {
                 Ok(measure) => {
                     content_size.set(TextMeasure { info: measure });
+
+                    // Text measured, so set `TextFlags` to schedule a recompute
+                    text_flags.remeasure = false;
+                    text_flags.recompute = true;
                 }
                 Err(TextError::NoSuchFont) => {
+                    // Try again next frame
                     text_flags.remeasure = true;
                 }
                 Err(e @ TextError::FailedToAddGlyph(_)) => {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -3,8 +3,8 @@ use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
     prelude::DetectChanges,
-    query::{Changed, Or, With},
-    system::{Local, ParamSet, Query, Res, ResMut},
+    query::With,
+    system::{Local, Query, Res, ResMut},
     world::Ref,
 };
 use bevy_math::Vec2;

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -2,8 +2,10 @@ use crate::{ContentSize, Measure, Node, UiScale};
 use bevy_asset::Assets;
 use bevy_ecs::{
     entity::Entity,
+    prelude::DetectChanges,
     query::{Changed, Or, With},
-    system::{Local, ParamSet, Query, Res, ResMut}, world::Ref, prelude::DetectChanges,
+    system::{Local, ParamSet, Query, Res, ResMut},
+    world::Ref,
 };
 use bevy_math::Vec2;
 use bevy_render::texture::Image;
@@ -63,9 +65,7 @@ pub fn measure_text_system(
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut text_query: 
-        Query<(Entity, Ref<Text>, &mut ContentSize), With<Node>>,
-
+    mut text_query: Query<(Entity, Ref<Text>, &mut ContentSize), With<Node>>,
 ) {
     let window_scale_factor = windows
         .get_single()
@@ -139,10 +139,7 @@ pub fn text_system(
     mut texture_atlases: ResMut<Assets<TextureAtlas>>,
     mut font_atlas_set_storage: ResMut<Assets<FontAtlasSet>>,
     mut text_pipeline: ResMut<TextPipeline>,
-    mut text_query: 
-        // Query<Entity, Or<(Changed<Text>, Changed<Node>)>>,
-        // Query<Entity, (With<Text>, With<Node>)>,
-        Query<(Entity, Ref<Node>, Ref<Text>, &mut TextLayoutInfo)>,
+    mut text_query: Query<(Entity, Ref<Node>, Ref<Text>, &mut TextLayoutInfo)>,
 ) {
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let window_scale_factor = windows

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -148,7 +148,6 @@ pub fn text_system(
         .unwrap_or(1.);
 
     let scale_factor = ui_scale.scale * window_scale_factor;
-    let n = queued_text.len();
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {


### PR DESCRIPTION
# Objective

`text_system` and `measure_text_system` both keep local queues to keep track of text node entities that need recomputations/remeasurement, which scales very badly with large numbers of text entities (O(n^2)) and makes the code quite difficult to understand. 

Also `text_system` filters for `Changed<Text>`, this isn't something that it should do. When a text node entity fails to be processed by `measure_text_system` because a font can't be found, the text node will still be added to `text_system`'s local queue for recomputation. `Text` should only ever be queued by `text_system` when a text node's geometry is modified or a new measure is added. 

## Solution

Remove the local text queues and use a component `TextFlags` to schedule remeasurements and recomputations.

## Changelog
* Created a component `TextFlags` with fields `remeasure` and `recompute`, which can be used to schedule a text `remeasure` or `recomputation` respectively and added it to `TextBundle`.
*  Removed the local text queues from `measure_text_system` and `text_system` and instead use the `TextFlags` component to schedule remeasurements and recomputations.

## Migration Guide

The component `TextFlags` has been added to `TextBundle`.
