### PR TITLE
Rename all view/proj/view-proj matrices

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -42,7 +42,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         in.is_front,
     );
 
-    pbr_input.is_orthographic = view.projection[3].w == 1.0;
+    pbr_input.is_orthographic = view.view_to_clip[3].w == 1.0;
 
     pbr_input.N = apply_normal_mapping(
         pbr_input.material.flags,

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -36,7 +36,7 @@ fn skybox_vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
     // because the far plane of an infinite reverse projection is at infinity.
     // NOTE: The clip position has a w component equal to 1.0 so we don't need
     // to apply a perspective divide to it before inverse-projecting it.
-    let world_position_homogeneous = view.inverse_view_proj * vec4(clip_position.xy, 1.0, 1.0);
+    let world_position_homogeneous = view.clip_to_world * vec4(clip_position.xy, 1.0, 1.0);
     let world_position = world_position_homogeneous.xyz / world_position_homogeneous.w;
 
     return VertexOutput(clip_position, world_position);

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -5,12 +5,12 @@
 #endif
 
 struct VertexInput {
-    @location(0) pos: vec3<f32>,
+    @location(0) position: vec3<f32>,
     @location(1) color: vec4<f32>,
 }
 
 struct VertexOutput {
-    @builtin(position) pos: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
     @location(0) color: vec4<f32>,
 }
 
@@ -25,7 +25,7 @@ struct FragmentOutput {
 fn vertex(in: VertexInput) -> VertexOutput {
     var out: VertexOutput;
 
-    out.pos = view.view_proj * vec4<f32>(in.pos, 1.0);
+    out.position = view.world_to_clip * vec4<f32>(in.position, 1.0);
     out.color = in.color;
 
     return out;

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -715,7 +715,7 @@ pub fn prepare_previous_view_projection_uniforms(
         let view_projection = match maybe_previous_view_proj {
             Some(previous_view) => previous_view.clone(),
             None => PreviousViewProjection {
-                view_proj: camera.projection * camera.transform.compute_matrix().inverse(),
+                view_proj: camera.view_to_clip * camera.view_to_world_transform.compute_matrix().inverse(),
             },
         };
         commands

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -117,7 +117,7 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #endif
 
 #ifdef MOTION_VECTOR_PREPASS
-    let clip_position_t = view.unjittered_view_proj * in.world_position;
+    let clip_position_t = view.unjittered_world_to_clip * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
     let previous_clip_position_t = previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;

--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -5,7 +5,7 @@ fn mesh_position_local_to_world(model: mat4x4<f32>, vertex_position: vec4<f32>) 
 }
 
 fn mesh_position_world_to_clip(world_position: vec4<f32>) -> vec4<f32> {
-    return view.view_proj * world_position;
+    return view.world_to_clip * world_position;
 }
 
 // NOTE: The intermediate world_position assignment is important

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -21,7 +21,7 @@ struct FragmentInput {
 
 @fragment
 fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
-    let is_orthographic = view.projection[3].w == 1.0;
+    let is_orthographic = view.view_to_clip[3].w == 1.0;
     let V = calculate_view(in.world_position, is_orthographic);
 #ifdef VERTEX_UVS
     var uv = in.uv;

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -112,7 +112,7 @@ fn calculate_view(
     var V: vec3<f32>;
     if is_orthographic {
         // Orthographic view vector
-        V = normalize(vec3<f32>(view.view_proj[0].z, view.view_proj[1].z, view.view_proj[2].z));
+        V = normalize(vec3<f32>(view.world_to_clip[0].z, view.world_to_clip[1].z, view.world_to_clip[2].z));
     } else {
         // Only valid for a perpective projection
         V = normalize(view.world_position.xyz - world_position.xyz);
@@ -194,10 +194,10 @@ fn pbr(
     var direct_light: vec3<f32> = vec3<f32>(0.0);
 
     let view_z = dot(vec4<f32>(
-        view.inverse_view[0].z,
-        view.inverse_view[1].z,
-        view.inverse_view[2].z,
-        view.inverse_view[3].z
+        view.view_to_world[0].z,
+        view.view_to_world[1].z,
+        view.view_to_world[2].z,
+        view.view_to_world[3].z
     ), in.world_position);
     let cluster_index = fragment_cluster_index(in.frag_coord.xy, view_z, in.is_orthographic);
     let offset_and_counts = unpack_offset_and_counts(cluster_index);

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -115,7 +115,7 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    let clip_position_t = view.unjittered_view_proj * in.world_position;
+    let clip_position_t = view.unjittered_world_to_clip * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
     let previous_clip_position_t = previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -635,9 +635,9 @@ pub fn extract_cameras(
                     sorted_camera_index_for_target: 0,
                 },
                 ExtractedView {
-                    projection: camera.projection_matrix(),
-                    transform: *transform,
-                    view_projection: None,
+                    view_to_clip: camera.projection_matrix(),
+                    view_to_world_transform: *transform,
+                    world_to_clip: None,
                     hdr: camera.hdr,
                     viewport: UVec4::new(
                         viewport_origin.x,

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -8,13 +8,13 @@ struct ColorGrading {
 }
 
 struct View {
-    view_proj: mat4x4<f32>,
-    unjittered_view_proj: mat4x4<f32>,
-    inverse_view_proj: mat4x4<f32>,
-    view: mat4x4<f32>,
-    inverse_view: mat4x4<f32>,
-    projection: mat4x4<f32>,
-    inverse_projection: mat4x4<f32>,
+    world_to_clip: mat4x4<f32>,
+    unjittered_world_to_clip: mat4x4<f32>,
+    clip_to_world: mat4x4<f32>,
+    view_to_world: mat4x4<f32>,
+    world_to_view: mat4x4<f32>,
+    view_to_clip: mat4x4<f32>,
+    clip_to_view: mat4x4<f32>,
     world_position: vec3<f32>,
     // viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_functions.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_functions.wgsl
@@ -5,7 +5,7 @@ fn mesh2d_position_local_to_world(model: mat4x4<f32>, vertex_position: vec4<f32>
 }
 
 fn mesh2d_position_world_to_clip(world_position: vec4<f32>) -> vec4<f32> {
-    return view.view_proj * world_position;
+    return view.world_to_clip * world_position;
 }
 
 // NOTE: The intermediate world_position assignment is important

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -8,11 +8,11 @@
 var<uniform> view: View;
 
 struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
 #ifdef COLORED
     @location(1) color: vec4<f32>,
 #endif
-    @builtin(position) position: vec4<f32>,
 };
 
 @vertex
@@ -24,8 +24,8 @@ fn vertex(
 #endif
 ) -> VertexOutput {
     var out: VertexOutput;
+    out.position = view.world_to_clip * vec4<f32>(vertex_position, 1.0);
     out.uv = vertex_uv;
-    out.position = view.view_proj * vec4<f32>(vertex_position, 1.0);
 #ifdef COLORED
     out.color = vertex_color;
 #endif

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -247,13 +247,13 @@ pub fn extract_default_ui_camera_view<T: Component>(
                 Mat4::orthographic_rh(0.0, logical_size.x, logical_size.y, 0.0, 0.0, UI_CAMERA_FAR);
             let default_camera_view = commands
                 .spawn(ExtractedView {
-                    projection: projection_matrix,
-                    transform: GlobalTransform::from_xyz(
+                    view_to_clip: projection_matrix,
+                    view_to_world_transform: GlobalTransform::from_xyz(
                         0.0,
                         0.0,
                         UI_CAMERA_FAR + UI_CAMERA_TRANSFORM_OFFSET,
                     ),
-                    view_projection: None,
+                    world_to_clip: None,
                     hdr: camera.hdr,
                     viewport: UVec4::new(
                         physical_origin.x,

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -4,9 +4,9 @@
 var<uniform> view: View;
 
 struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
     @location(0) uv: vec2<f32>,
     @location(1) color: vec4<f32>,
-    @builtin(position) position: vec4<f32>,
 };
 
 @vertex
@@ -16,8 +16,8 @@ fn vertex(
     @location(2) vertex_color: vec4<f32>,
 ) -> VertexOutput {
     var out: VertexOutput;
+    out.position = view.world_to_clip * vec4<f32>(vertex_position, 1.0);
     out.uv = vertex_uv;
-    out.position = view.view_proj * vec4<f32>(vertex_position, 1.0);
     out.color = vertex_color;
     return out;
 }


### PR DESCRIPTION
# Objective

- Names of used matrices are sometimes confusing, see https://github.com/bevyengine/bevy/issues/8492

## Solution

- Rename matrices to better reflect in which coordinate space they transform vertices. Like world_to_view, view_to_clip, world_to_clip, etc.

---

## Migration Guide

- Rename
  - view_proj: world_to_clip
  - inverse_view_proj: clip_to_world
  - view: view_to_world
  - inverse_view: world_to_view
  - projection: view_to_clip
  - inverse_projection: clip_to_view
  - model: model_to_world