### PR TITLE
Proof of Concept for Required Components: `Require<T>`

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -286,6 +286,10 @@ impl<T: Component> Default for Require<T> {
     }
 }
 
+// SAFETY:
+// - `Bundle::component_ids` does nothing since `Require` doesn't have any components.
+// - `Bundle::get_components` does nothing since `Require` doesn't have any components.
+// - `Bundle::from_components` just returns `Require::default()` since `Require` doesn't have any components.
 unsafe impl<T: Component> Bundle for Require<T> {
     fn component_ids(
         _components: &mut Components,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1708,4 +1708,43 @@ mod tests {
             "new entity was spawned and received C component"
         );
     }
+
+    #[test]
+    #[should_panic]
+    fn bundle_with_missing_require() {
+        use super::bundle::Require;
+        #[derive(Component)]
+        struct A;
+
+        #[derive(Bundle, Default)]
+        struct B {
+            #[bundle(require)]
+            #[allow(unused)]
+            a: Require<A>,
+        }
+
+        let mut world = World::default();
+
+        world.spawn(B::default());
+    }
+
+    #[test]
+    fn bundle_with_require() {
+        use super::bundle::Require;
+        #[derive(Component)]
+        struct A;
+
+        #[derive(Bundle, Default)]
+        struct B {
+            #[bundle(require)]
+            #[allow(unused)]
+            a: Require<A>,
+        }
+
+        let mut world = World::default();
+
+        let entity = world.spawn((A, B::default()));
+
+        assert!(entity.contains::<A>());
+    }
 }


### PR DESCRIPTION
# Objective

An attempt to fix #7272

This is a proposal for a way to express bundle requirements using a bit of macro help.

## Solution

My solution is to leverage the existing `derive_bundle` macro to provide a set of required component IDs for every `Bundle`.

Currently, the syntax looks like this:

```rust
#[derive(Component)]
struct A;

#[derive(Bundle, Default)]
struct B {
    #[bundle(require)]
    #[allow(unused)]
    a: Require<A>,
}
```

`Require<T>` is simply a `PhantomData<T>` which has a custom implementation of `Bundle`.
It is not inserted as a component. Instead, it is used to populate a list of `ComponentId` which is checked during `BundleInfo` construction:

```rust
for id in requires {
    if !component_ids.contains(&id) {
        panic!(
            "Bundle {bundle_type_name} requires missing component: {}",
            components.get_info_unchecked(id).name(),
        );
    }
}
```

This allows us to enforce `Bundle` dependencies by panicking.

There is currently a few issues I'm trying to resolve:
1. Ideally, user shouldn't have to specify `#[bundle(require)]`. If we can parse the type name containing `Require<*>`, I think we can make it less verbose.
2. I'm not sure how to get rid of `#[allow(unused)]`. `Require` is like `PhantomData`, but not. It should be unused, but rust doesn't know that, which causes warnings in user code. I'm open to ideas here.
3. I would like to give the user the option to insert a default if the requirement is missing, instead of always panicking.

I've included two tests with the initial implementation which demonstrates complete usage.

```rust
    #[test]
    #[should_panic]
    fn bundle_with_missing_require() {
        use super::bundle::Require;
        #[derive(Component)]
        struct A;

        #[derive(Bundle, Default)]
        struct B {
            #[bundle(require)]
            #[allow(unused)]
            a: Require<A>,
        }

        let mut world = World::default();

        world.spawn(B::default());
    }

    #[test]
    fn bundle_with_require() {
        use super::bundle::Require;
        #[derive(Component)]
        struct A;

        #[derive(Bundle, Default)]
        struct B {
            #[bundle(require)]
            #[allow(unused)]
            a: Require<A>,
        }

        let mut world = World::default();

        let entity = world.spawn((A, B::default()));

        assert!(entity.contains::<A>());
    }
```

Please note, Currently this PR is just a draft. I'm still new to internals of Bevy, and I'm interested in dialogue with more experienced developers. If there is any way to simplify things further, or if there are any edge cases I'm missing, I'm open to any and all feedback.

Personally, I think this is a major feature missing from Bevy, since it's impossible for bundles to overlap. This means if two bundles depend on a component existing on an entity, there is simply no way to enforce or express that prior to runtime. This is what motivated me to open this PR.

---

## Changelog

### Added
- `Require<T>` type to specify a required component within a bundle
- `BundleFieldKind::Require` to support `#[bundle(require)]`
- `Bundle::requires()` which does nothing on all internal `Bundle` implementations except for `Require<T>`.
- Tests: `bundle_with_missing_require` and `bundle_with_require`

### Changed
- `derive_bundle` to implement `requires()` for deriving Bundles
- `BundleInfo::new` to check for missing required components
