### PR TITLE
Use `cmp` of Self in implementaions of `partial_cmp`

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -279,7 +279,7 @@ impl<T: Asset> Eq for Handle<T> {}
 
 impl<T: Asset> PartialOrd for Handle<T> {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.id.cmp(&other.id))
+        Some(self.cmp(other))
     }
 }
 

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -177,7 +177,7 @@ impl Eq for Name {}
 
 impl PartialOrd for Name {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        self.name.partial_cmp(&other.name)
+        Some(self.cmp(other))
     }
 }
 


### PR DESCRIPTION
# Objective

Ensure future consistency between the two compare functions for all types with manual `Ord` and `PartialOrd` implementations.

## Solution

Use `Self::cpm` in the implementation of `partial_cpm` for types `Handle` and `Name`.