### PR TITLE
gilrs: Add code to unknown buttons and axes

### DIFF
--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -1,31 +1,31 @@
 use bevy_input::gamepad::{GamepadAxis, GamepadButton};
 
-pub fn convert_button(button: gilrs::Button) -> Option<GamepadButton> {
+pub fn convert_button(button: gilrs::Button, code: gilrs::ev::Code) -> GamepadButton {
     match button {
-        gilrs::Button::South => Some(GamepadButton::South),
-        gilrs::Button::East => Some(GamepadButton::East),
-        gilrs::Button::North => Some(GamepadButton::North),
-        gilrs::Button::West => Some(GamepadButton::West),
-        gilrs::Button::C => Some(GamepadButton::C),
-        gilrs::Button::Z => Some(GamepadButton::Z),
-        gilrs::Button::LeftTrigger => Some(GamepadButton::LeftTrigger),
-        gilrs::Button::LeftTrigger2 => Some(GamepadButton::LeftTrigger2),
-        gilrs::Button::RightTrigger => Some(GamepadButton::RightTrigger),
-        gilrs::Button::RightTrigger2 => Some(GamepadButton::RightTrigger2),
-        gilrs::Button::Select => Some(GamepadButton::Select),
-        gilrs::Button::Start => Some(GamepadButton::Start),
-        gilrs::Button::Mode => Some(GamepadButton::Mode),
-        gilrs::Button::LeftThumb => Some(GamepadButton::LeftThumb),
-        gilrs::Button::RightThumb => Some(GamepadButton::RightThumb),
-        gilrs::Button::DPadUp => Some(GamepadButton::DPadUp),
-        gilrs::Button::DPadDown => Some(GamepadButton::DPadDown),
-        gilrs::Button::DPadLeft => Some(GamepadButton::DPadLeft),
-        gilrs::Button::DPadRight => Some(GamepadButton::DPadRight),
-        gilrs::Button::Unknown => None,
+        gilrs::Button::South => GamepadButton::South,
+        gilrs::Button::East => GamepadButton::East,
+        gilrs::Button::North => GamepadButton::North,
+        gilrs::Button::West => GamepadButton::West,
+        gilrs::Button::C => GamepadButton::C,
+        gilrs::Button::Z => GamepadButton::Z,
+        gilrs::Button::LeftTrigger => GamepadButton::LeftTrigger,
+        gilrs::Button::LeftTrigger2 => GamepadButton::LeftTrigger2,
+        gilrs::Button::RightTrigger => GamepadButton::RightTrigger,
+        gilrs::Button::RightTrigger2 => GamepadButton::RightTrigger2,
+        gilrs::Button::Select => GamepadButton::Select,
+        gilrs::Button::Start => GamepadButton::Start,
+        gilrs::Button::Mode => GamepadButton::Mode,
+        gilrs::Button::LeftThumb => GamepadButton::LeftThumb,
+        gilrs::Button::RightThumb => GamepadButton::RightThumb,
+        gilrs::Button::DPadUp => GamepadButton::DPadUp,
+        gilrs::Button::DPadDown => GamepadButton::DPadDown,
+        gilrs::Button::DPadLeft => GamepadButton::DPadLeft,
+        gilrs::Button::DPadRight => GamepadButton::DPadRight,
+        gilrs::Button::Unknown => GamepadButton::Other(code.into_u32()),
     }
 }
 
-pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxis> {
+pub fn convert_axis(axis: gilrs::Axis, code: gilrs::ev::Code) -> Option<GamepadAxis> {
     match axis {
         gilrs::Axis::LeftStickX => Some(GamepadAxis::LeftStickX),
         gilrs::Axis::LeftStickY => Some(GamepadAxis::LeftStickY),
@@ -33,9 +33,10 @@ pub fn convert_axis(axis: gilrs::Axis) -> Option<GamepadAxis> {
         gilrs::Axis::RightStickX => Some(GamepadAxis::RightStickX),
         gilrs::Axis::RightStickY => Some(GamepadAxis::RightStickY),
         gilrs::Axis::RightZ => Some(GamepadAxis::RightZ),
+        gilrs::Axis::Unknown => Some(GamepadAxis::Other(code.into_u32())),
         // The `axis_dpad_to_button` gilrs filter should filter out all DPadX and DPadY events. If
         // it doesn't then we probably need an entry added to the following repo and an update to
         // GilRs to use the updated database: https://github.com/gabomdq/SDL_GameControllerDB
-        gilrs::Axis::Unknown | gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
+        gilrs::Axis::DPadX | gilrs::Axis::DPadY => None,
     }
 }

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -79,10 +79,8 @@ pub fn gilrs_event_system(
                     events.write(event.clone().into());
                     connection_events.write(event);
                 }
-                EventType::ButtonChanged(gilrs_button, raw_value, _) => {
-                    let Some(button) = convert_button(gilrs_button) else {
-                        continue;
-                    };
+                EventType::ButtonChanged(gilrs_button, raw_value, code) => {
+                    let button = convert_button(gilrs_button, code);
                     let gamepad = gamepads
                         .id_to_entity
                         .get(&gilrs_event.id)
@@ -95,8 +93,8 @@ pub fn gilrs_event_system(
                         gamepad, button, raw_value,
                     ));
                 }
-                EventType::AxisChanged(gilrs_axis, raw_value, _) => {
-                    let Some(axis) = convert_axis(gilrs_axis) else {
+                EventType::AxisChanged(gilrs_axis, raw_value, code) => {
+                    let Some(axis) = convert_axis(gilrs_axis, code) else {
                         continue;
                     };
                     let gamepad = gamepads

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -622,7 +622,9 @@ pub enum GamepadButton {
     DPadRight,
 
     /// Miscellaneous buttons, considered non-standard (i.e. Extra buttons on a flight stick that do not have a gamepad equivalent).
-    Other(u8),
+    ///
+    /// Note that the value may not be stable across different platforms.
+    Other(u32),
 }
 
 impl GamepadButton {
@@ -685,7 +687,9 @@ pub enum GamepadAxis {
     /// Refer to [`GamepadButton::RightTrigger2`] for the analog trigger on a gamepad controller.
     RightZ,
     /// Non-standard support for other axis types (i.e. HOTAS sliders, potentiometers, etc).
-    Other(u8),
+    ///
+    /// Note that the value may not be stable across different platforms.
+    Other(u32),
 }
 
 impl GamepadAxis {


### PR DESCRIPTION
# Objective

I'm using a joystick to control my game (a flight simulator), so gilrs has not mapped all of the buttons. As discussed elsewhere, that's intentional by gilrs, and that's fine - but, gilrs does give us the code for the axis/button, which games can use to do their own mapping if we expose it.

Fixes #1916

## Solution

I change the gilrs converter to use the (already existing) `Other` variant of the axis/button types to expose the code, so users can access them through events.

The code is given to us as a u32, but here I store it as a u8 just by casting. The presumption is that joysticks will not typically have more than 256 axes or buttons, indeed as of [2020](https://patchwork.kernel.org/project/linux-input/patch/CACa7zykn0q9XJAUvrqnNATr4DUv3Kc7XujF3vm6sfRB5pE6YNQ@mail.gmail.com/) linux only supported 80 buttons. So I think it should be fine.

---

## Changelog

- Exposed unmapped gamepad events

## Migration Guide

I don't think there should be any action required for users who don't want this functionality.
