### PR TITLE
Replace remaining uses of `&T, Changed<T>` with `Ref` in UI system queries

### DIFF
--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -34,23 +34,22 @@ fn calc_name(texts: &Query<&Text>, children: &Children) -> Option<Box<str>> {
 
 fn calc_bounds(
     camera: Query<(&Camera, &GlobalTransform)>,
-    mut nodes: Query<
-        (&mut AccessibilityNode, &Node, &GlobalTransform),
-        Or<(Changed<Node>, Changed<GlobalTransform>)>,
-    >,
+    mut nodes: Query<(&mut AccessibilityNode, Ref<Node>, Ref<GlobalTransform>)>,
 ) {
     if let Ok((camera, camera_transform)) = camera.get_single() {
         for (mut accessible, node, transform) in &mut nodes {
-            if let Some(translation) =
-                camera.world_to_viewport(camera_transform, transform.translation())
-            {
-                let bounds = Rect::new(
-                    translation.x.into(),
-                    translation.y.into(),
-                    (translation.x + node.calculated_size.x).into(),
-                    (translation.y + node.calculated_size.y).into(),
-                );
-                accessible.set_bounds(bounds);
+            if node.is_changed() || transform.is_changed() {
+                if let Some(translation) =
+                    camera.world_to_viewport(camera_transform, transform.translation())
+                {
+                    let bounds = Rect::new(
+                        translation.x.into(),
+                        translation.y.into(),
+                        (translation.x + node.calculated_size.x).into(),
+                        (translation.y + node.calculated_size.y).into(),
+                    );
+                    accessible.set_bounds(bounds);
+                }
             }
         }
     }

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -9,8 +9,9 @@ use bevy_a11y::{
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
     prelude::Entity,
-    query::{Changed, Or, Without},
+    query::{Changed, Without},
     system::{Commands, Query},
+    world::Ref,
 };
 use bevy_hierarchy::Children;
 use bevy_render::prelude::Camera;

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -8,7 +8,7 @@ use bevy_a11y::{
 };
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
-    prelude::{Entity, DetectChanges},
+    prelude::{DetectChanges, Entity},
     query::{Changed, Without},
     system::{Commands, Query},
     world::Ref,

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -8,7 +8,7 @@ use bevy_a11y::{
 };
 use bevy_app::{App, Plugin, Update};
 use bevy_ecs::{
-    prelude::Entity,
+    prelude::{Entity, DetectChanges},
     query::{Changed, Without},
     system::{Commands, Query},
     world::Ref,

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -221,7 +221,7 @@ pub fn ui_layout_system(
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
     mut measure_query: Query<(Entity, &mut ContentSize)>,
-    children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,
+    children_query: Query<(Entity, Ref<Children>), With<Node>>,
     mut removed_children: RemovedComponents<Children>,
     mut removed_content_sizes: RemovedComponents<ContentSize>,
     mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
@@ -292,7 +292,9 @@ pub fn ui_layout_system(
         ui_surface.try_remove_children(entity);
     }
     for (entity, children) in &children_query {
-        ui_surface.update_children(entity, children);
+        if children.is_changed() {
+            ui_surface.update_children(entity, &children);
+        }
     }
 
     // compute layouts

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
     event::EventReader,
-    query::{Changed, With, Without},
+    query::{With, Without},
     removal_detection::RemovedComponents,
     system::{Query, Res, ResMut, Resource},
     world::Ref,


### PR DESCRIPTION
# Objective

Replace `Query<&T, Changed<T>>` style queries with the more efficient `Query<Ref<T>>` form in two of the UI systems.

---

## Changelog

Replaced use of  `Changed` with `Ref` in queries in the `ui_layout_system` and `calc_bounds` UI systems.