### PR TITLE
UI node order property 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1788,6 +1788,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "node_order"
+path = "examples/ui/node_order.rs"
+
+[package.metadata.example.node_order]
+name = "Node Order"
+description = "Example using `NodeOrder` to reorder UI elements"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "overflow"
 path = "examples/ui/overflow.rs"
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,21 +1,21 @@
 mod convert;
 pub mod debug;
 
-use crate::{ContentSize, Node, Style, UiScale};
+use crate::{ContentSize, Node, NodeOrder, Style, UiScale};
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
     event::EventReader,
     query::{Changed, With, Without},
     removal_detection::RemovedComponents,
-    system::{Query, Res, ResMut, Resource},
+    system::{Local, Query, Res, ResMut, Resource},
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_log::warn;
 use bevy_math::Vec2;
 use bevy_transform::components::Transform;
-use bevy_utils::HashMap;
+use bevy_utils::{HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowResolution, WindowScaleFactorChanged};
 use std::fmt;
 use taffy::{prelude::Size, style_helpers::TaffyMaxContent, Taffy};
@@ -157,16 +157,23 @@ without UI components as a child of an entity with UI components, results may be
     }
 
     /// Set the ui node entities without a [`Parent`] as children to the root node in the taffy layout.
-    pub fn set_window_children(
+    pub fn set_window_children<'a>(
         &mut self,
         parent_window: Entity,
-        children: impl Iterator<Item = Entity>,
+        orphaned_nodes: impl Iterator<Item = (Entity, &'a NodeOrder)>,
     ) {
         let taffy_node = self.window_nodes.get(&parent_window).unwrap();
-        let child_nodes = children
-            .map(|e| *self.entity_to_taffy.get(&e).unwrap())
-            .collect::<Vec<taffy::node::Node>>();
-        self.taffy.set_children(*taffy_node, &child_nodes).unwrap();
+        let mut unordered_orphans = orphaned_nodes
+            .map(|(e, node_order)| (*self.entity_to_taffy.get(&e).unwrap(), node_order.0))
+            .collect::<Vec<_>>();
+        unordered_orphans.sort_by_key(|(_, order)| *order);
+        let ordered_orphans = unordered_orphans
+            .into_iter()
+            .map(|(key, _)| key)
+            .collect::<Vec<_>>();
+        self.taffy
+            .set_children(*taffy_node, &ordered_orphans)
+            .unwrap();
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.
@@ -210,6 +217,27 @@ pub enum LayoutError {
     TaffyError(taffy::error::TaffyError),
 }
 
+/// Sort all ui node children by their `NodeOrder`
+pub fn sort_ui_node_children(
+    mut sorted: Local<HashSet<Entity>>,
+    order_query: Query<(Ref<NodeOrder>, &Parent)>,
+    mut children_query: Query<&mut Children>,
+) {
+    sorted.clear();
+    for (order, parent) in order_query.iter() {
+        if order.is_changed() && !sorted.contains(&parent.get()) {
+            children_query
+                .get_mut(parent.get())
+                .unwrap()
+                .sort_by(|c, d| {
+                    let c_ord = order_query.get_component(*c).unwrap_or(&NodeOrder(0)).0;
+                    let d_ord = order_query.get_component(*d).unwrap_or(&NodeOrder(0)).0;
+                    c_ord.cmp(&d_ord)
+                });
+        }
+    }
+}
+
 /// Updates the UI's layout tree, computes the new layout geometry and then updates the sizes and transforms of all the UI nodes.
 #[allow(clippy::too_many_arguments)]
 pub fn ui_layout_system(
@@ -219,7 +247,7 @@ pub fn ui_layout_system(
     mut scale_factor_events: EventReader<WindowScaleFactorChanged>,
     mut resize_events: EventReader<bevy_window::WindowResized>,
     mut ui_surface: ResMut<UiSurface>,
-    root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
+    root_node_query: Query<(Entity, &NodeOrder), (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
     mut measure_query: Query<(Entity, &mut ContentSize)>,
     children_query: Query<(Entity, &Children), (With<Node>, Changed<Children>)>,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -55,13 +55,14 @@ pub struct UiPlugin;
 /// The label enum labeling the types of systems in the Bevy UI
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum UiSystem {
+    /// After this label, the UI node children will have been sorted according to their `NodeOrder`
+    SortChildren,
     /// After this label, the ui layout state has been updated
     Layout,
     /// After this label, input interactions with UI entities have been updated for this frame
     Focus,
     /// After this label, the [`UiStack`] resource has been updated
     Stack,
-    SortChildren,
 }
 
 /// The current scale of the UI.

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -61,6 +61,7 @@ pub enum UiSystem {
     Focus,
     /// After this label, the [`UiStack`] resource has been updated
     Stack,
+    SortChildren,
 }
 
 /// The current scale of the UI.
@@ -103,6 +104,7 @@ impl Plugin for UiPlugin {
             .register_type::<JustifyItems>()
             .register_type::<JustifySelf>()
             .register_type::<Node>()
+            .register_type::<NodeOrder>()
             .register_type::<ZIndex>()
             // NOTE: used by Style::aspect_ratio
             .register_type::<Option<f32>>()
@@ -159,6 +161,9 @@ impl Plugin for UiPlugin {
         .add_systems(
             PostUpdate,
             (
+                sort_ui_node_children
+                    .in_set(UiSystem::SortChildren)
+                    .before(ui_layout_system),
                 ui_layout_system
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -55,8 +55,6 @@ pub struct UiPlugin;
 /// The label enum labeling the types of systems in the Bevy UI
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum UiSystem {
-    /// After this label, the UI node children will have been sorted according to their `NodeOrder`
-    SortChildren,
     /// After this label, the ui layout state has been updated
     Layout,
     /// After this label, input interactions with UI entities have been updated for this frame
@@ -162,9 +160,6 @@ impl Plugin for UiPlugin {
         .add_systems(
             PostUpdate,
             (
-                sort_ui_node_children
-                    .in_set(UiSystem::SortChildren)
-                    .before(ui_layout_system),
                 ui_layout_system
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -2,7 +2,8 @@
 
 use crate::{
     widget::{Button, TextFlags, UiImageSize},
-    BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage, ZIndex,
+    BackgroundColor, ContentSize, FocusPolicy, Interaction, Node, NodeOrder, Style, UiImage,
+    ZIndex,
 };
 use bevy_ecs::bundle::Bundle;
 use bevy_render::{
@@ -20,6 +21,8 @@ use bevy_transform::prelude::{GlobalTransform, Transform};
 pub struct NodeBundle {
     /// Describes the logical size of the node
     pub node: Node,
+    /// Controls the order in which items are displayed.
+    pub order: NodeOrder,
     /// Styles which control the layout (size and position) of the node and it's children
     /// In some cases these styles also affect how the node drawn/painted.
     pub style: Style,
@@ -51,6 +54,7 @@ impl Default for NodeBundle {
             // Transparent background
             background_color: Color::NONE.into(),
             node: Default::default(),
+            order: Default::default(),
             style: Default::default(),
             focus_policy: Default::default(),
             transform: Default::default(),
@@ -70,6 +74,8 @@ pub struct ImageBundle {
     /// This field is automatically managed by the UI layout system.
     /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
     pub node: Node,
+    /// Controls the order in which items are displayed.
+    pub order: NodeOrder,
     /// Styles which control the layout (size and position) of the node and it's children
     /// In some cases these styles also affect how the node drawn/painted.
     pub style: Style,
@@ -111,6 +117,8 @@ pub struct ImageBundle {
 pub struct TextBundle {
     /// Describes the logical size of the node
     pub node: Node,
+    /// Controls the order in which items are displayed.
+    pub order: NodeOrder,
     /// Styles which control the layout (size and position) of the node and it's children
     /// In some cases these styles also affect how the node drawn/painted.
     pub style: Style,
@@ -155,6 +163,7 @@ impl Default for TextBundle {
             // Transparent background
             background_color: BackgroundColor(Color::NONE),
             node: Default::default(),
+            order: Default::default(),
             style: Default::default(),
             focus_policy: Default::default(),
             transform: Default::default(),

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -221,6 +221,8 @@ impl TextBundle {
 pub struct ButtonBundle {
     /// Describes the logical size of the node
     pub node: Node,
+    /// Controls the order in which items are displayed.
+    pub order: NodeOrder,
     /// Marker component that signals this node is a button
     pub button: Button,
     /// Styles which control the layout (size and position) of the node and it's children
@@ -259,6 +261,7 @@ impl Default for ButtonBundle {
         Self {
             focus_policy: FocusPolicy::Block,
             node: Default::default(),
+            order: Default::default(),
             button: Default::default(),
             style: Default::default(),
             interaction: Default::default(),

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -59,6 +59,11 @@ impl Default for Node {
     }
 }
 
+/// Controls the order in which items are displayed.
+#[derive(Component, Debug, Default, Clone, Reflect)]
+#[reflect(Component, Default)]
+pub struct NodeOrder(pub u32);
+
 /// Represents the possible value types for layout properties.
 ///
 /// This enum allows specifying values for various [`Style`] properties in different units,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -62,7 +62,7 @@ impl Default for Node {
 /// Controls the order in which items are displayed.
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default)]
-pub struct NodeOrder(pub u32);
+pub struct NodeOrder(pub i32);
 
 /// Represents the possible value types for layout properties.
 ///

--- a/examples/README.md
+++ b/examples/README.md
@@ -336,7 +336,7 @@ Example | Description
 [CSS Grid](../examples/ui/grid.rs) | An example for CSS Grid layout
 [Flex Layout](../examples/ui/flex_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout nodes and position text
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
-[NodeOrder](../examples/ui/node_order.rs)| Example using `NodeOrder` to reorder UI elements
+[Node Order](../examples/ui/node_order.rs) | Example using `NodeOrder` to reorder UI elements
 [Overflow](../examples/ui/overflow.rs) | Simple example demonstrating overflow behavior
 [Overflow and Clipping Debug](../examples/ui/overflow_debug.rs) | An example to debug overflow and clipping behavior
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component

--- a/examples/README.md
+++ b/examples/README.md
@@ -336,6 +336,7 @@ Example | Description
 [CSS Grid](../examples/ui/grid.rs) | An example for CSS Grid layout
 [Flex Layout](../examples/ui/flex_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout nodes and position text
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)
+[NodeOrder](../examples/ui/node_order.rs)| Example using `NodeOrder` to reorder UI elements
 [Overflow](../examples/ui/overflow.rs) | Simple example demonstrating overflow behavior
 [Overflow and Clipping Debug](../examples/ui/overflow_debug.rs) | An example to debug overflow and clipping behavior
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -57,12 +57,9 @@ fn update(
     mut button_query: Query<(&Interaction, &mut NodeOrder), Changed<Interaction>>,
 ) {
     for (interaction, mut node_order) in button_query.iter_mut() {
-        match interaction {
-            Interaction::Clicked => {
-                *order = *order - 1;
-                node_order.0 = *order;
-            }
-            _ => {}
+        if *interaction == Interaction::Clicked {
+            *order -= 1;
+            node_order.0 = *order;
         }
     }
 }

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -7,71 +7,180 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
-        .add_systems(Update, update)
+        .add_systems(Update, (update_ordered_buttons, update_direction_button))
         .run();
 }
 
+#[derive(Component)]
+struct OrderedButtonContainer;
+
+#[derive(Component)]
+struct OrderedButton;
+
+#[derive(Component)]
+struct DirectionButton;
+
+#[derive(Component)]
+struct DirectionLabel;
+
 fn setup(mut commands: Commands) {
+    let initial_direction = FlexDirection::Row;
     commands.spawn(Camera2dBundle::default());
     commands
         .spawn(NodeBundle {
             style: Style {
+                flex_direction: FlexDirection::Column,
                 size: Size::width(Val::Percent(100.)),
-                justify_content: JustifyContent::Center,
+                justify_content: JustifyContent::Start,
                 align_items: AlignItems::Center,
-                gap: Size::all(Val::Px(10.)),
+                gap: Size::all(Val::Px(20.)),
+                margin: UiRect::all(Val::Px(10.)),
                 ..Default::default()
             },
-            background_color: Color::BLACK.into(),
+            background_color: Color::GRAY.into(),
             ..Default::default()
         })
         .with_children(|builder| {
-            for (i, color) in [
-                Color::RED,
-                Color::GREEN,
-                Color::YELLOW,
-                Color::CYAN,
-                Color::AQUAMARINE,
-                Color::CRIMSON,
-                Color::FUCHSIA,
-                Color::PINK,
-            ]
-            .into_iter()
-            .enumerate()
-            {
-                builder
-                    .spawn(ButtonBundle {
+            builder
+                .spawn(NodeBundle {
+                    style: Style {
+                        justify_content: JustifyContent::Center,
+                        align_items: AlignItems::Center,
+                        size: Size::all(Val::Px(600.)),
+                        min_size: Size::all(Val::Px(600.)),
+                        max_size: Size::all(Val::Px(600.)),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                })
+                .with_children(|builder| {
+                    builder
+                        .spawn((
+                            OrderedButtonContainer,
+                            NodeBundle {
+                                style: Style {
+                                    padding: UiRect::all(Val::Px(10.)),
+                                    gap: Size::all(Val::Px(10.)),
+                                    flex_direction: initial_direction,
+                                    ..Default::default()
+                                },
+                                background_color: Color::BLACK.into(),
+                                ..Default::default()
+                            },
+                        ))
+                        .with_children(|builder| {
+                            for (i, color) in [
+                                Color::RED,
+                                Color::GREEN,
+                                Color::YELLOW,
+                                Color::CYAN,
+                                Color::AQUAMARINE,
+                                Color::CRIMSON,
+                                Color::FUCHSIA,
+                                Color::PINK,
+                            ]
+                            .into_iter()
+                            .enumerate()
+                            {
+                                builder
+                                    .spawn((
+                                        OrderedButton,
+                                        ButtonBundle {
+                                            style: Style {
+                                                size: Size::all(Val::Px(60.)),
+                                                justify_content: JustifyContent::Center,
+                                                align_items: AlignItems::Center,
+                                                ..Default::default()
+                                            },
+                                            background_color: color.into(),
+                                            ..Default::default()
+                                        },
+                                    ))
+                                    .with_children(|builder| {
+                                        builder.spawn(TextBundle::from_section(
+                                            format!("{i}"),
+                                            TextStyle {
+                                                font_size: 40.,
+                                                color: Color::BLACK,
+                                                ..Default::default()
+                                            },
+                                        ));
+                                    });
+                            }
+                        });
+                });
+
+            builder
+                .spawn((
+                    DirectionButton,
+                    ButtonBundle {
                         style: Style {
-                            size: Size::all(Val::Px(100.)),
-                            justify_content: JustifyContent::Center,
-                            align_items: AlignItems::Center,
+                            padding: UiRect::all(Val::Px(10.)),
                             ..Default::default()
                         },
-                        background_color: color.into(),
+                        background_color: Color::WHITE.into(),
                         ..Default::default()
-                    })
-                    .with_children(|builder| {
-                        builder.spawn(TextBundle::from_section(
-                            format!("{i}"),
+                    },
+                ))
+                .with_children(|builder| {
+                    builder.spawn((
+                        DirectionLabel,
+                        TextBundle::from_section(
+                            format!("FlexDirection::{initial_direction:?}"),
                             TextStyle {
-                                font_size: 60.,
+                                font_size: 30.,
                                 color: Color::BLACK,
                                 ..Default::default()
                             },
-                        ));
-                    });
-            }
+                        ),
+                    ));
+                });
         });
 }
 
-fn update(
+fn update_ordered_buttons(
     mut order: Local<i32>,
-    mut button_query: Query<(&Interaction, &mut NodeOrder), Changed<Interaction>>,
+    mut button_query: Query<
+        (&Interaction, &mut NodeOrder),
+        (Changed<Interaction>, With<OrderedButton>),
+    >,
 ) {
-    for (interaction, mut node_order) in button_query.iter_mut() {
+    for (interaction, mut node_order) in &mut button_query {
         if *interaction == Interaction::Clicked {
             *order -= 1;
             node_order.0 = *order;
+        }
+    }
+}
+
+fn update_direction_button(
+    mut direction_button_query: Query<
+        (&Interaction, &mut BackgroundColor),
+        (Changed<Interaction>, With<DirectionButton>),
+    >,
+    mut direction_label_query: Query<&mut Text, With<DirectionLabel>>,
+    mut button_container_query: Query<&mut Style, With<OrderedButtonContainer>>,
+) {
+    for (interaction, mut color) in &mut direction_button_query {
+        match interaction {
+            Interaction::Clicked => {
+                color.0 = Color::RED;
+                let mut style = button_container_query.single_mut();
+                style.flex_direction = match style.flex_direction {
+                    FlexDirection::Row => FlexDirection::RowReverse,
+                    FlexDirection::RowReverse => FlexDirection::Column,
+                    FlexDirection::Column => FlexDirection::ColumnReverse,
+                    FlexDirection::ColumnReverse => FlexDirection::Row,
+                };
+                let mut text = direction_label_query.single_mut();
+                text.sections[0].value = format!("FlexDirection::{:?}", style.flex_direction);
+            }
+            Interaction::Hovered => {
+                color.0 = Color::YELLOW;
+            }
+            Interaction::None => {
+                color.0 = Color::WHITE;
+            }
         }
     }
 }

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -190,10 +190,10 @@ fn update_ordered_buttons(
 ) {
     let mut n = 0;
     if mouse_buttons.just_pressed(MouseButton::Left) {
-        n += 1;
+        n -= 1;
     }
     if mouse_buttons.just_pressed(MouseButton::Right) {
-        n -= -1;
+        n += 1;
     }
     let cursor_position = primary_window_query.single().cursor_position();
     for (node, global_transform, ordered_button, mut background_color, children, parent) in

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -208,7 +208,7 @@ fn update_ordered_buttons(
         {
             if n != 0 {
                 let mut node_order = order_query.get_mut(parent.get()).unwrap();
-                node_order.0 = (node_order.0 + n).rem_euclid(16);
+                node_order.0 += n;
                 let mut text = label_query.get_mut(children[0]).unwrap();
                 text.sections[0].value = format!("{}", node_order.0);
             } else {

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -190,10 +190,10 @@ fn update_ordered_buttons(
 ) {
     let mut n = 0;
     if mouse_buttons.just_pressed(MouseButton::Left) {
-        n -= 1;
+        n += 1;
     }
     if mouse_buttons.just_pressed(MouseButton::Right) {
-        n += 1;
+        n -= 1;
     }
     let cursor_position = primary_window_query.single().cursor_position();
     for (node, global_transform, ordered_button, mut background_color, children, parent) in

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -26,7 +26,19 @@ fn setup(mut commands: Commands) {
             ..Default::default()
         })
         .with_children(|builder| {
-            for (i, color) in [Color::RED, Color::GREEN, Color::YELLOW, Color::CYAN, Color::AQUAMARINE, Color::CRIMSON, Color::FUCHSIA, Color::PINK].into_iter().enumerate() {
+            for (i, color) in [
+                Color::RED,
+                Color::GREEN,
+                Color::YELLOW,
+                Color::CYAN,
+                Color::AQUAMARINE,
+                Color::CRIMSON,
+                Color::FUCHSIA,
+                Color::PINK,
+            ]
+            .into_iter()
+            .enumerate()
+            {
                 builder
                     .spawn(ButtonBundle {
                         style: Style {

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -1,0 +1,68 @@
+/// An example that uses the `NodeOrder` component to reorder UI elements.
+use bevy::{prelude::*, winit::WinitSettings};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
+        .insert_resource(WinitSettings::desktop_app())
+        .add_systems(Startup, setup)
+        .add_systems(Update, update)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                size: Size::width(Val::Percent(100.)),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                gap: Size::all(Val::Px(10.)),
+                ..Default::default()
+            },
+            background_color: Color::BLACK.into(),
+            ..Default::default()
+        })
+        .with_children(|builder| {
+            for i in 0..5 {
+                builder
+                    .spawn(ButtonBundle {
+                        style: Style {
+                            size: Size::all(Val::Px(100.)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..Default::default()
+                        },
+                        background_color: Color::WHITE.into(),
+                        ..Default::default()
+                    })
+                    .with_children(|builder| {
+                        builder.spawn(TextBundle::from_section(
+                            format!("{i}"),
+                            TextStyle {
+                                font_size: 60.,
+                                color: Color::BLACK,
+                                ..Default::default()
+                            },
+                        ));
+                    });
+            }
+        });
+}
+
+fn update(
+    mut order: Local<i32>,
+    mut button_query: Query<(&Interaction, &mut NodeOrder), Changed<Interaction>>,
+) {
+    for (interaction, mut node_order) in button_query.iter_mut() {
+        match interaction {
+            Interaction::Clicked => {
+                *order = *order - 1;
+                node_order.0 = *order;
+            }
+            _ => {}
+        }
+    }
+}

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -4,8 +4,6 @@ use bevy::{prelude::*, winit::WinitSettings};
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
-        .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
         .add_systems(Update, (update_ordered_buttons, update_direction_button))
         .run();

--- a/examples/ui/node_order.rs
+++ b/examples/ui/node_order.rs
@@ -26,7 +26,7 @@ fn setup(mut commands: Commands) {
             ..Default::default()
         })
         .with_children(|builder| {
-            for i in 0..5 {
+            for (i, color) in [Color::RED, Color::GREEN, Color::YELLOW, Color::CYAN, Color::AQUAMARINE, Color::CRIMSON, Color::FUCHSIA, Color::PINK].into_iter().enumerate() {
                 builder
                     .spawn(ButtonBundle {
                         style: Style {
@@ -35,7 +35,7 @@ fn setup(mut commands: Commands) {
                             align_items: AlignItems::Center,
                             ..Default::default()
                         },
-                        background_color: Color::WHITE.into(),
+                        background_color: color.into(),
                         ..Default::default()
                     })
                     .with_children(|builder| {


### PR DESCRIPTION
# Objective

Implement an order property for UI nodes similar to the CSS order property:

https://developer.mozilla.org/en-US/docs/Web/CSS/order

## Solution

Add a component `NodeOrder` that wraps an `i32` and add it to all the UI node bundles. Then in `ui_layout_system` sort the children of UI nodes by ascending `NodeOrder` value.

* `NodeOrder` needs to be a separate component (instead of a field in the `Style` component) so that it can be queried for changes.

https://github.com/bevyengine/bevy/assets/27962798/9ee2a162-6ad6-4cbe-8a4f-95d6d9b23661

---

## Changelog

* New component `NodeOrder`.
* Added the `NodeOrder` component to all of the UI node bundles.
* In `ui_layout_system` children of UI nodes are sorted by their `NodeOrder` value.
* `ui_layout_system` sorts the root ui nodes by their `NodeOrder` before making them children of the window node.
* New UI example `node_order`.

## Migration Guide
