### PR TITLE
Re-introduce comments about frustum culling

### DIFF
--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -4,8 +4,6 @@
 //! and at different scales in the world,
 //! and moves the camera over them to see how well frustum culling works.
 //!
-//! To measure performance realistically, be sure to run this in release mode.
-//! `cargo run --example many_animated_sprites --release`
 
 use std::time::Duration;
 

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -1,9 +1,7 @@
 //! Renders a lot of animated sprites to allow performance testing.
 //!
-//! It sets up many animated sprites in different sizes and rotations,
-//! and at different scales in the world,
-//! and moves the camera over them to see how well frustum culling works.
-//!
+//! This example sets up many animated sprites in different sizes, rotations, and scales in the world.
+//! It also moves the camera over them to see how well frustum culling works.
 
 use std::time::Duration;
 

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -1,10 +1,11 @@
 //! Renders a lot of animated sprites to allow performance testing.
 //!
 //! It sets up many animated sprites in different sizes and rotations,
-//! and at different scales in the world, and moves the camera over them.
+//! and at different scales in the world,
+//! and moves the camera over them to see how well frustum culling works.
 //!
-//! Having sprites out of the camera's field of view should also help stress
-//! test any future potential 2d frustum culling implementation.
+//! To measure performance realistically, be sure to run this in release mode.
+//! `cargo run --example many_animated_sprites --release`
 
 use std::time::Duration;
 

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -1,7 +1,7 @@
 //! Renders a lot of sprites to allow performance testing.
 //! See <https://github.com/bevyengine/bevy/pull/1492>
 //!
-//! This exampple sets up many sprites in different sizes, rotations, and scales in the world.
+//! This example sets up many sprites in different sizes, rotations, and scales in the world.
 //! It also moves the camera over them to see how well frustum culling works.
 //!
 //! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -1,11 +1,8 @@
 //! Renders a lot of sprites to allow performance testing.
 //! See <https://github.com/bevyengine/bevy/pull/1492>
 //!
-//! It sets up many animated sprites in different sizes and rotations,
-//! and at different scales in the world, and moves the camera over them.
-//!
-//! Having sprites out of the camera's field of view should also help stress
-//! test any future potential 2d frustum culling implementation.
+//! It sets up many animated sprites in different sizes and rotations, and at different scales in the world,
+//! and moves the camera over them to see how well frustum culling works.
 //!
 //! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered
 //! in multiple batches, reducing performance but useful for testing.

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -1,8 +1,8 @@
 //! Renders a lot of sprites to allow performance testing.
 //! See <https://github.com/bevyengine/bevy/pull/1492>
 //!
-//! It sets up many animated sprites in different sizes and rotations, and at different scales in the world,
-//! and moves the camera over them to see how well frustum culling works.
+//! This exampple sets up many sprites in different sizes, rotations, and scales in the world.
+//! It also moves the camera over them to see how well frustum culling works.
 //!
 //! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered
 //! in multiple batches, reducing performance but useful for testing.


### PR DESCRIPTION
# Objective

Frustum culling for 2D components has been enabled since #7885,
Fixes #8490 

## Solution

Re-introduced the comments about frustum culling in the many_animated_sprites.rs and many_sprites.rs examples.
