### PR TITLE
Remove mod.rs in scene_viewer

### DIFF
--- a/examples/tools/scene_viewer/mod.rs
+++ b/examples/tools/scene_viewer/mod.rs
@@ -1,2 +1,0 @@
-pub mod camera_controller_plugin;
-pub mod scene_viewer_plugin;


### PR DESCRIPTION
# Objective

- Cleanup file tree

## Solution

A mysterious mod.rs lies in the scene_viewer directory. It seems completely useless, everything ignores it and it doesn't affect anything.

We cruelly remove it, making the world a less whimsical place. A dystopian drive for pure and complete order compels us to eliminate all that is useless, for clarity and to prevent the wonder and beauty of confusion.