### PR TITLE
Improve animation handling in scene_viewer

### DIFF
--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -1,0 +1,122 @@
+//! Control animations of entities in the loaded scene.
+use bevy::{asset::HandleId, gltf::Gltf, prelude::*};
+
+use crate::scene_viewer_plugin::SceneHandle;
+
+struct Clip {
+    name: Option<String>,
+    handle: Handle<AnimationClip>,
+}
+/// Controls animation clips for a unique entity.
+#[derive(Resource)]
+struct Clips {
+    clips: Vec<Clip>,
+    current: usize,
+}
+impl Clips {
+    fn new(clips: Vec<Clip>) -> Self {
+        Clips { clips, current: 0 }
+    }
+    fn current(&self) -> Option<&Clip> {
+        self.clips.get(self.current)
+    }
+    fn advance_to_next(&mut self) {
+        if !self.clips.is_empty() {
+            self.current = (self.current + 1) % self.clips.len();
+        }
+    }
+}
+
+/// Read [`AnimationClip`]s from the loaded [`Gltf`] and write them to [`Clips`].
+fn assign_clips(
+    mut players: Query<&mut AnimationPlayer>,
+    scene_handle: Res<SceneHandle>,
+    animation_clips: Res<Assets<AnimationClip>>,
+    gltf_assets: Res<Assets<Gltf>>,
+    mut commands: Commands,
+    mut setup: Local<bool>,
+) {
+    if scene_handle.is_loaded && !*setup {
+        *setup = true;
+    } else {
+        return;
+    }
+    let gltf = gltf_assets.get(&scene_handle.gltf_handle).unwrap();
+    let animations = &gltf.animations;
+    if !animations.is_empty() {
+        let count = animations.len();
+        let plural = if count == 1 { "" } else { "s" };
+        info!("Found {count} animation{plural}");
+        let names: Vec<_> = gltf.named_animations.keys().collect();
+        info!("Animation names: {names:?}");
+    }
+    let gltf_animation_name = |id: HandleId| {
+        let named = gltf.named_animations.iter().find(|(_, h)| h.id() == id);
+        Clip {
+            name: named.map(|(name, _)| name.clone()),
+            handle: named.map_or_else(
+                || animation_clips.get_handle(id),
+                |(_, handle)| handle.clone_weak(),
+            ),
+        }
+    };
+    let clips = Clips::new(animation_clips.ids().map(gltf_animation_name).collect());
+    if let Some(current) = clips.current() {
+        for mut player in &mut players {
+            player.play(current.handle.clone_weak()).repeat();
+        }
+        commands.insert_resource(clips);
+    }
+}
+
+fn handle_inputs(
+    keyboard_input: Res<Input<KeyCode>>,
+    mut clips: ResMut<Clips>,
+    mut animation_player: Query<&mut AnimationPlayer>,
+) {
+    for mut player in &mut animation_player {
+        if keyboard_input.just_pressed(KeyCode::Space) {
+            if player.is_paused() {
+                info!("Resuming animations");
+                player.resume();
+            } else {
+                info!("Pausing animations");
+                player.pause();
+            }
+        }
+        if clips.clips.len() <= 1 {
+            continue;
+        }
+
+        if keyboard_input.just_pressed(KeyCode::Return) {
+            let resume = !player.is_paused();
+            // set the current animation to its start and pause it to reset to its starting state
+            player.set_elapsed(0.0).pause();
+
+            clips.advance_to_next();
+            let current_clip = clips.current().unwrap();
+            if let Some(animation_name) = &current_clip.name {
+                info!("Now playing {animation_name}");
+            } else {
+                info!("Switching to new animation");
+            }
+            player.play(current_clip.handle.clone_weak()).repeat();
+            if resume {
+                player.resume();
+            }
+        }
+    }
+}
+
+pub struct AnimationManipulationPlugin;
+impl Plugin for AnimationManipulationPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            Update,
+            (
+                handle_inputs.run_if(resource_exists::<Clips>()),
+                assign_clips,
+            ),
+        );
+    }
+}

--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -12,6 +12,8 @@ use bevy::{
     window::WindowPlugin,
 };
 
+#[cfg(feature = "animation")]
+mod animation_plugin;
 mod camera_controller_plugin;
 mod scene_viewer_plugin;
 
@@ -43,6 +45,9 @@ fn main() {
     .add_plugin(SceneViewerPlugin)
     .add_systems(Startup, setup)
     .add_systems(PreUpdate, setup_scene_after_load);
+
+    #[cfg(feature = "animation")]
+    app.add_plugin(animation_plugin::AnimationManipulationPlugin);
 
     app.run();
 }

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -15,10 +15,8 @@ use super::camera_controller_plugin::*;
 
 #[derive(Resource)]
 pub struct SceneHandle {
-    gltf_handle: Handle<Gltf>,
+    pub gltf_handle: Handle<Gltf>,
     scene_index: usize,
-    #[cfg(feature = "animation")]
-    animations: Vec<Handle<AnimationClip>>,
     instance_id: Option<InstanceId>,
     pub is_loaded: bool,
     pub has_light: bool,
@@ -29,8 +27,6 @@ impl SceneHandle {
         Self {
             gltf_handle,
             scene_index,
-            #[cfg(feature = "animation")]
-            animations: Vec::new(),
             instance_id: None,
             is_loaded: false,
             has_light: false,
@@ -38,21 +34,27 @@ impl SceneHandle {
     }
 }
 
-impl fmt::Display for SceneHandle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "
+const BASE_INSTRUCTIONS: &str = r#"
 Scene Controls:
     L           - animate light direction
     U           - toggle shadows
     B           - toggle bounding boxes
     C           - cycle through the camera controller and any cameras loaded from the scene
+"#;
 
+const ANIMATION_INSTRUCTIONS: &str = if cfg!(feature = "animation") {
+    r#"
     Space       - Play/Pause animation
-    Enter       - Cycle through animations
-"
-        )
+    Enter       - Cycle through animations"#
+} else {
+    r#"
+    compile with "--features animation" for animation controls."#
+};
+
+impl fmt::Display for SceneHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{BASE_INSTRUCTIONS}")?;
+        write!(f, "{ANIMATION_INSTRUCTIONS}")
     }
 }
 
@@ -68,8 +70,6 @@ impl Plugin for SceneViewerPlugin {
                     update_lights,
                     camera_tracker,
                     toggle_bounding_boxes.run_if(input_just_pressed(KeyCode::B)),
-                    #[cfg(feature = "animation")]
-                    (start_animation, keyboard_animation_control),
                 ),
             );
     }
@@ -82,7 +82,7 @@ fn toggle_bounding_boxes(mut config: ResMut<GizmoConfig>) {
 fn scene_load_check(
     asset_server: Res<AssetServer>,
     mut scenes: ResMut<Assets<Scene>>,
-    gltf_assets: ResMut<Assets<Gltf>>,
+    gltf_assets: Res<Assets<Gltf>>,
     mut scene_handle: ResMut<SceneHandle>,
     mut scene_spawner: ResMut<SceneSpawner>,
 ) {
@@ -123,22 +123,6 @@ fn scene_load_check(
                 scene_handle.instance_id =
                     Some(scene_spawner.spawn(gltf_scene_handle.clone_weak()));
 
-                #[cfg(feature = "animation")]
-                {
-                    scene_handle.animations = gltf.animations.clone();
-                    if !scene_handle.animations.is_empty() {
-                        info!(
-                            "Found {} animation{}",
-                            scene_handle.animations.len(),
-                            if scene_handle.animations.len() == 1 {
-                                ""
-                            } else {
-                                "s"
-                            }
-                        );
-                    }
-                }
-
                 info!("Spawning scene...");
             }
         }
@@ -149,61 +133,6 @@ fn scene_load_check(
             }
         }
         Some(_) => {}
-    }
-}
-
-#[cfg(feature = "animation")]
-fn start_animation(
-    mut player: Query<&mut AnimationPlayer>,
-    mut done: Local<bool>,
-    scene_handle: Res<SceneHandle>,
-) {
-    if !*done {
-        if let Ok(mut player) = player.get_single_mut() {
-            if let Some(animation) = scene_handle.animations.first() {
-                player.play(animation.clone_weak()).repeat();
-                *done = true;
-            }
-        }
-    }
-}
-
-#[cfg(feature = "animation")]
-fn keyboard_animation_control(
-    keyboard_input: Res<Input<KeyCode>>,
-    mut animation_player: Query<&mut AnimationPlayer>,
-    scene_handle: Res<SceneHandle>,
-    mut current_animation: Local<usize>,
-    mut changing: Local<bool>,
-) {
-    if scene_handle.animations.is_empty() {
-        return;
-    }
-
-    if let Ok(mut player) = animation_player.get_single_mut() {
-        if keyboard_input.just_pressed(KeyCode::Space) {
-            if player.is_paused() {
-                player.resume();
-            } else {
-                player.pause();
-            }
-        }
-
-        if *changing {
-            // change the animation the frame after return was pressed
-            *current_animation = (*current_animation + 1) % scene_handle.animations.len();
-            player
-                .play(scene_handle.animations[*current_animation].clone_weak())
-                .repeat();
-            *changing = false;
-        }
-
-        if keyboard_input.just_pressed(KeyCode::Return) {
-            // delay the animation change for one frame
-            *changing = true;
-            // set the current animation to its start and pause it to reset to its starting state
-            player.set_elapsed(0.0).pause();
-        }
     }
 }
 


### PR DESCRIPTION
# Objective

Cleanup and improve animation controls in `scene_viewer`

## Solution

1. Print named animations when loading the scene
2. In the instructions printed in the terminal, say how to add animation handling
3. Associate animation with name, so as to display their name in the terminal when switching to a new animation
4. Extract animation code into its own individual module. Mostly to eliminate the `#[cfg()]` peppered over the source.

Note, this was first part of #8158.

---

## Changelog

- Add animation names when switching animation in `scene_viewer`
- Add instructions on how to enable animations in `scene_viewer` when not compiled with the `animation` flag