### PR TITLE
Rename `UnsafeWorldCell::read_change_tick`

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -200,6 +200,14 @@ impl<'w> UnsafeWorldCell<'w> {
         Tick::new(tick)
     }
 
+    /// Gets the current change tick of this world.
+    #[inline]
+    pub fn change_tick(self) -> Tick {
+        // SAFETY:
+        // - we only access world metadata
+        unsafe { self.world_metadata() }.read_change_tick()
+    }
+
     #[inline]
     pub fn last_change_tick(self) -> Tick {
         // SAFETY:

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -191,6 +191,7 @@ impl<'w> UnsafeWorldCell<'w> {
 
     /// Reads the current change tick of this world.
     #[inline]
+    #[deprecated = "renamed to `UnsafeWorldCell::change_tick`"]
     pub fn read_change_tick(self) -> Tick {
         // SAFETY:
         // - we only access world metadata
@@ -390,7 +391,7 @@ impl<'w> UnsafeWorldCell<'w> {
         // - index is in-bounds because the column is initialized and non-empty
         // - the caller promises that no other reference to the ticks of the same row can exist at the same time
         let ticks = unsafe {
-            TicksMut::from_tick_cells(ticks, self.last_change_tick(), self.read_change_tick())
+            TicksMut::from_tick_cells(ticks, self.last_change_tick(), self.change_tick())
         };
 
         Some(MutUntyped {
@@ -438,7 +439,7 @@ impl<'w> UnsafeWorldCell<'w> {
         self,
         component_id: ComponentId,
     ) -> Option<MutUntyped<'w>> {
-        let change_tick = self.read_change_tick();
+        let change_tick = self.change_tick();
         // SAFETY: we only access data that the caller has ensured is unaliased and `self`
         //  has permission to access.
         let (ptr, ticks) = unsafe { self.unsafe_world() }
@@ -658,9 +659,7 @@ impl<'w> UnsafeEntityCell<'w> {
     #[inline]
     pub unsafe fn get_mut<T: Component>(self) -> Option<Mut<'w, T>> {
         // SAFETY: same safety requirements
-        unsafe {
-            self.get_mut_using_ticks(self.world.last_change_tick(), self.world.read_change_tick())
-        }
+        unsafe { self.get_mut_using_ticks(self.world.last_change_tick(), self.world.change_tick()) }
     }
 
     /// # Safety
@@ -752,7 +751,7 @@ impl<'w> UnsafeEntityCell<'w> {
                 ticks: TicksMut::from_tick_cells(
                     cells,
                     self.world.last_change_tick(),
-                    self.world.read_change_tick(),
+                    self.world.change_tick(),
                 ),
             })
         }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -14,7 +14,7 @@ use crate::{
     system::Resource,
 };
 use bevy_ptr::Ptr;
-use std::{any::TypeId, cell::UnsafeCell, marker::PhantomData, sync::atomic::Ordering};
+use std::{any::TypeId, cell::UnsafeCell, marker::PhantomData};
 
 /// Variant of the [`World`] where resource and component accesses take `&self`, and the responsibility to avoid
 /// aliasing violations are given to the caller instead of being checked at compile-time by rust's unique XOR shared rule.
@@ -193,12 +193,7 @@ impl<'w> UnsafeWorldCell<'w> {
     #[inline]
     #[deprecated = "renamed to `UnsafeWorldCell::change_tick`"]
     pub fn read_change_tick(self) -> Tick {
-        // SAFETY:
-        // - we only access world metadata
-        let tick = unsafe { self.world_metadata() }
-            .change_tick
-            .load(Ordering::Acquire);
-        Tick::new(tick)
+        self.change_tick()
     }
 
     /// Gets the current change tick of this world.

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -191,7 +191,7 @@ impl<'w> UnsafeWorldCell<'w> {
 
     /// Reads the current change tick of this world.
     #[inline]
-    #[deprecated = "renamed to `UnsafeWorldCell::change_tick`"]
+    #[deprecated = "this method has been renamed to `UnsafeWorldCell::change_tick`"]
     pub fn read_change_tick(self) -> Tick {
         self.change_tick()
     }


### PR DESCRIPTION
# Objective

The method `UnsafeWorldCell::read_change_tick` is longer than it needs to be. `World` only has a method called this because it has two methods for getting a change tick: one that takes `&self` and one that takes `&mut self`. Since this distinction is not applicable to `UnsafeWorldCell`, we should just call this method `change_tick`.

## Solution

Deprecate the current method and add a new one called `change_tick`.

---

## Changelog

- Renamed `UnsafeWorldCell::read_change_tick` to `change_tick`.

## Migration Guide

The `UnsafeWorldCell` method `read_change_tick` has been renamed to `change_tick`.
