### PR TITLE
Adreno material shader fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ default = [
   "android_shared_stdcxx",
   "tonemapping_luts",
   "default_font",
+  "limit_directional_light",
 ]
 
 # Force dynamic linking, which improves iterative compile times
@@ -81,6 +82,9 @@ bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
 
 # Adds PBR rendering
 bevy_pbr = ["bevy_internal/bevy_pbr", "bevy_asset", "bevy_render", "bevy_core_pipeline"]
+
+# Limit Directional Lights in PBR
+limit_directional_light = ["bevy_internal/limit_directional_light"]
 
 # Provides rendering functionality
 bevy_render = ["bevy_internal/bevy_render"]
@@ -241,7 +245,7 @@ bevy_internal = { path = "crates/bevy_internal", version = "0.11.0-dev", default
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.11.0-dev", default-features = false, features = [
-  "webgl",
+  "webgl"
 ] }
 
 [dev-dependencies]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -76,6 +76,9 @@ subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 # Optimise for WebGL2
 webgl = ["bevy_core_pipeline?/webgl", "bevy_pbr?/webgl", "bevy_render?/webgl"]
 
+# Limit directional light to 1 in PBR
+limit_directional_light = ["bevy_pbr/limit_directional_light"]
+
 # enable systems that allow for automated testing on CI
 bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_render?/ci_limits"]
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bevy"]
 
 [features]
 webgl = []
+limit_directional_light = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -399,7 +399,7 @@ bitflags::bitflags! {
 
 impl StandardMaterialFlags {
     const ALPHA_MODE_MASK_BITS: u32 = 0b111;
-    const ALPHA_MODE_SHIFT_BITS: u32 = 32 - Self::ALPHA_MODE_MASK_BITS.count_ones();
+    const ALPHA_MODE_SHIFT_BITS: u32 = 16 - Self::ALPHA_MODE_MASK_BITS.count_ones();
 }
 
 /// The GPU representation of the uniform data of a [`StandardMaterial`].

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -216,6 +216,9 @@ pub struct GpuLights {
 
 // NOTE: this must be kept in sync with the same constants in pbr.frag
 pub const MAX_UNIFORM_BUFFER_POINT_LIGHTS: usize = 256;
+#[cfg(feature = "limit_directional_light")]
+pub const MAX_DIRECTIONAL_LIGHTS: usize = 1;
+#[cfg(not(feature = "limit_directional_light"))]
 pub const MAX_DIRECTIONAL_LIGHTS: usize = 10;
 #[cfg(not(feature = "webgl"))]
 pub const MAX_CASCADES_PER_LIGHT: usize = 4;

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -24,15 +24,18 @@ const STANDARD_MATERIAL_FLAGS_TWO_COMPONENT_NORMAL_MAP: u32       = 64u;
 const STANDARD_MATERIAL_FLAGS_FLIP_NORMAL_MAP_Y: u32              = 128u;
 const STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT: u32                = 256u;
 const STANDARD_MATERIAL_FLAGS_DEPTH_MAP_BIT: u32                  = 512u;
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS: u32       = 3758096384u; // (0b111u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32              = 0u;          // (0u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32                = 536870912u;  // (1u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32               = 1073741824u; // (2u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_PREMULTIPLIED: u32       = 1610612736u; // (3u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ADD: u32                 = 2147483648u; // (4u32 << 29)
-const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MULTIPLY: u32            = 2684354560u; // (5u32 << 29)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS: u32       = 57344u; // (0b111u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE: u32              = 0u;     // (0u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK: u32                = 8192u;  // (1u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND: u32               = 16384u; // (2u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_PREMULTIPLIED: u32       = 24576u; // (3u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ADD: u32                 = 32768u; // (4u32 << 13)
+const STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MULTIPLY: u32            = 40960u; // (5u32 << 13)
 // ↑ To calculate/verify the values above, use the following playground:
 // https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=7792f8dd6fc6a8d4d0b6b1776898a7f4
+// NOTE: the gist is based on a shift of 29 since the blend modes used to be at
+// the end of a u32. Because this created an issue with Adreno chipsets it has 
+// been moved to 13.
 
 // Creates a StandardMaterial with default values
 fn standard_material_new() -> StandardMaterial {


### PR DESCRIPTION
# Objective

Address some issues afflicting the Adreno series of GPUs, specifically on WebGL. 
Alpha blending is broken for these GPUs since the standard blending changes were merged.
Also there is an issue related to directional lights and fog. 

Fixes #8506 
Fixes #8047  

## Solution

The first issue in relation to alpha blending was a weird one. It could be fixed by moving the flags for the alpha blending from the end of the `u32` to just after the last flag from the beginning instead. This seems to be because of some differences in the memory mapping, probably at a lower level. However this fix should work for all other architectures as well.

The second issue is also weird and potentially also related to some as of yet unknown issue with how data is passed between the CPU and the GPU. My best guess is that it is an issue with the Adreno shader compiler that messes up since `gpu_directional_lights` is an array of 10 by default and it either tries to do some fancy pre-optimization or fumbles when the data is copied over to the gpu here as well. The simplest solution I could think of that works without requiring major changes that would affect all platform is to add a feature that can be passed along if you for some reason need to have your code running specifically on these types of GPUS. Thus I added the `limit_directional_light` feature that limits the directional lights to 1 but by default it still stays at 10.

---

## Changelog

- Added `limit_directional_light` feature that limits the amount of directional lights to one because of issues with the Adreno chipset and fog.