### PR TITLE
Add Command::insert_batch and World::insert_batch

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -821,7 +821,7 @@ pub struct EntityLocation {
 
 impl EntityLocation {
     /// location for **pending entity** and **invalid entity**
-    const INVALID: EntityLocation = EntityLocation {
+    pub const INVALID: EntityLocation = EntityLocation {
         archetype_id: ArchetypeId::INVALID,
         archetype_row: ArchetypeRow::INVALID,
         table_id: TableId::INVALID,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1708,4 +1708,64 @@ mod tests {
             "new entity was spawned and received C component"
         );
     }
+
+    #[test]
+    fn insert_batch() {
+        let mut world = World::default();
+        let e0 = world.spawn(A(0)).id();
+        let e1 = world.spawn(B(1)).id();
+
+        let values = vec![(e0, (B(0), C)), (e1, (B(1), C))];
+
+        world.insert_batch(values);
+
+        assert_eq!(
+            world.get::<A>(e0),
+            Some(&A(0)),
+            "existing component was preserved"
+        );
+        assert_eq!(
+            world.get::<B>(e0),
+            Some(&B(0)),
+            "pre-existing entity received correct B component"
+        );
+        assert_eq!(
+            world.get::<B>(e1),
+            Some(&B(1)),
+            "pre-existing entity received correct B component"
+        );
+        assert_eq!(
+            world.get::<C>(e0),
+            Some(&C),
+            "pre-existing entity received C component"
+        );
+        assert_eq!(
+            world.get::<C>(e1),
+            Some(&C),
+            "pre-existing entity received C component"
+        );
+    }
+
+    #[test]
+    #[should_panic]
+    fn insert_batch_not_spawned() {
+        let mut world = World::default();
+        let e0 = Entity::from_raw(0);
+
+        let values = vec![(e0, (B(0), C))];
+
+        world.insert_batch(values);
+    }
+
+    #[test]
+    #[should_panic]
+    fn insert_batch_invalid() {
+        let mut world = World::default();
+        let e0 = world.spawn_empty().id();
+        let invalid_e0 = Entity::new(e0.index(), 1);
+
+        let values = vec![(invalid_e0, (B(2), C))];
+
+        world.insert_batch(values);
+    }
 }


### PR DESCRIPTION
# Objective

- Fixes #8384 

## Solution

- Instead of checking for Entities being pending via `alloc_with_no_replacement`, this function directly calls `world.entities.get(entity)` to find the current `EntityLocation` (which may be invalid). It panics if it runs into an invalid entity

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
