### PR TITLE
Add support for pnm textures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,6 +150,9 @@ dds = ["bevy_internal/dds"]
 # KTX2 compressed texture support
 ktx2 = ["bevy_internal/ktx2"]
 
+# PNM image format support, includes pam, pbm, pgm and ppm
+pnm = ["bevy_internal/pnm"]
+
 # For KTX2 supercompression
 zlib = ["bevy_internal/zlib"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -36,6 +36,7 @@ bmp = ["bevy_render/bmp"]
 webp = ["bevy_render/webp"]
 basis-universal = ["bevy_render/basis-universal"]
 dds = ["bevy_render/dds"]
+pnm = ["bevy_render/pnm"]
 ktx2 = ["bevy_render/ktx2"]
 # For ktx2 supercompression
 zlib = ["bevy_render/zlib"]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -17,6 +17,7 @@ jpeg = ["image/jpeg"]
 bmp = ["image/bmp"]
 webp = ["image/webp"]
 dds = ["ddsfile"]
+pnm = ["image/pnm"]
 bevy_ci_testing = ["bevy_app/bevy_ci_testing"]
 
 shader_format_glsl = ["naga/glsl-in", "naga/wgsl-out"]

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -36,6 +36,14 @@ const FILE_EXTENSIONS: &[&str] = &[
     "ktx2",
     #[cfg(feature = "webp")]
     "webp",
+    #[cfg(feature = "pnm")]
+    "pam",
+    #[cfg(feature = "pnm")]
+    "pbm",
+    #[cfg(feature = "pnm")]
+    "pgm",
+    #[cfg(feature = "pnm")]
+    "ppm",
 ];
 
 impl AssetLoader for ImageTextureLoader {

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -57,6 +57,7 @@ The default feature set enables most of the expected features of a game engine, 
 |jpeg|JPEG image format support|
 |minimp3|MP3 audio format support (through minimp3)|
 |mp3|MP3 audio format support|
+|pnm|PNM image format support, includes pam, pbm, pgm and ppm|
 |serialize|Enable serialization support through serde|
 |shader_format_glsl|Enable support for shaders in GLSL|
 |shader_format_spirv|Enable support for shaders in SPIR-V|


### PR DESCRIPTION
# Objective

Add support for the [Netpbm](https://en.wikipedia.org/wiki/Netpbm) image formats, behind a `pnm` feature flag.

My personal use case for this was robotics applications, with `pgm` being a popular format used in the field to represent world maps in robots.
I chose the formats and feature name by checking the logic in [image.rs](https://github.com/bevyengine/bevy/blob/a35ed552fafaffce8a28c7d47b3e294d755ff096/crates/bevy_render/src/texture/image.rs#L76)

## Solution

Quite straightforward, the `pnm` feature flag already exists in the `image` crate so it's just creating and exposing a `pnm` feature flag in the root `Cargo.toml` and forwarding it through `bevy_internal` and `bevy_render` all the way to the `image` crate.

---

## Changelog

### Added

`pnm` feature to add support for `pam`, `pbm`, `pgm` and `ppm` image formats.