### PR TITLE
Skip UI updates when UI state unchanged

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -304,7 +304,6 @@ pub fn ui_layout_system(
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.needs_update |= ui_surface
         .set_window_children(primary_window_entity, root_node_query.iter())
-        && !removed_nodes.is_empty()
         && !removed_content_sizes.is_empty();
 
     // clean up removed nodes

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -44,6 +44,7 @@ pub struct UiSurface {
     entity_to_taffy: HashMap<Entity, taffy::node::Node>,
     window_nodes: HashMap<Entity, taffy::node::Node>,
     taffy: Taffy,
+    pub needs_update: bool,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
@@ -68,6 +69,7 @@ impl Default for UiSurface {
             entity_to_taffy: Default::default(),
             window_nodes: Default::default(),
             taffy: Taffy::new(),
+            needs_update: false,
         }
     }
 }
@@ -116,10 +118,14 @@ without UI components as a child of an entity with UI components, results may be
             .unwrap();
     }
 
-    /// Removes children from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_children(&mut self, entity: Entity) {
+    /// Removes children from the entity's taffy node if it exists.
+    /// Returns false if no corresponding taffy node.
+    pub fn try_remove_children(&mut self, entity: Entity) -> bool {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
             self.taffy.set_children(*taffy_node, &[]).unwrap();
+            true
+        } else {
+            false
         }
     }
 
@@ -161,12 +167,17 @@ without UI components as a child of an entity with UI components, results may be
         &mut self,
         parent_window: Entity,
         children: impl Iterator<Item = Entity>,
-    ) {
+    ) -> bool {
         let taffy_node = self.window_nodes.get(&parent_window).unwrap();
         let child_nodes = children
             .map(|e| *self.entity_to_taffy.get(&e).unwrap())
             .collect::<Vec<taffy::node::Node>>();
-        self.taffy.set_children(*taffy_node, &child_nodes).unwrap();
+        if self.taffy.children(*taffy_node).unwrap() != child_nodes {
+            self.taffy.set_children(*taffy_node, &child_nodes).unwrap();
+            true
+        } else {
+            false
+        }
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.
@@ -228,6 +239,8 @@ pub fn ui_layout_system(
     mut node_transform_query: Query<(Entity, &mut Node, &mut Transform, Option<&Parent>)>,
     mut removed_nodes: RemovedComponents<Node>,
 ) {
+    ui_surface.needs_update = false;
+
     // assume one window for time being...
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let (primary_window_entity, logical_to_physical_factor, physical_size) =
@@ -248,24 +261,20 @@ pub fn ui_layout_system(
         .iter()
         .any(|resized_window| resized_window.window == primary_window_entity);
 
-    // update window root nodes
-    for (entity, window) in windows.iter() {
-        ui_surface.update_window(entity, &window.resolution);
-    }
-
     let scale_factor = logical_to_physical_factor * ui_scale.scale;
 
     let layout_context = LayoutContext::new(scale_factor, physical_size);
 
     if !scale_factor_events.is_empty() || ui_scale.is_changed() || resized {
         scale_factor_events.clear();
-        // update all nodes
+        ui_surface.needs_update = true;
         for (entity, style) in style_query.iter() {
             ui_surface.upsert_node(entity, &style, &layout_context);
         }
     } else {
         for (entity, style) in style_query.iter() {
             if style.is_changed() {
+                ui_surface.needs_update = true;
                 ui_surface.upsert_node(entity, &style, &layout_context);
             }
         }
@@ -273,9 +282,23 @@ pub fn ui_layout_system(
 
     for (entity, mut content_size) in measure_query.iter_mut() {
         if let Some(measure_func) = content_size.measure_func.take() {
+            ui_surface.needs_update = true;
             ui_surface.update_measure(entity, measure_func);
         }
     }
+
+    if resized {
+        // update window root nodes
+        for (entity, window) in windows.iter() {
+            ui_surface.update_window(entity, &window.resolution);
+        }
+    }
+
+    // update window children (for now assuming all Nodes live in the primary window)
+    ui_surface.needs_update |= ui_surface
+        .set_window_children(primary_window_entity, root_node_query.iter())
+        && !removed_nodes.is_empty()
+        && !removed_content_sizes.is_empty();
 
     // clean up removed nodes
     ui_surface.remove_entities(removed_nodes.iter());
@@ -285,49 +308,49 @@ pub fn ui_layout_system(
         ui_surface.try_remove_measure(entity);
     }
 
-    // update window children (for now assuming all Nodes live in the primary window)
-    ui_surface.set_window_children(primary_window_entity, root_node_query.iter());
-
     // update and remove children
     for entity in removed_children.iter() {
-        ui_surface.try_remove_children(entity);
+        ui_surface.needs_update |= ui_surface.try_remove_children(entity);
     }
     for (entity, children) in &children_query {
         if children.is_changed() {
+            ui_surface.needs_update = true;
             ui_surface.update_children(entity, &children);
         }
     }
 
-    // compute layouts
-    ui_surface.compute_window_layouts();
+    if ui_surface.needs_update {
+        // compute layouts
+        ui_surface.compute_window_layouts();
 
-    let physical_to_logical_factor = 1. / logical_to_physical_factor;
+        let physical_to_logical_factor = 1. / logical_to_physical_factor;
 
-    let to_logical = |v| (physical_to_logical_factor * v as f64) as f32;
+        let to_logical = |v| (physical_to_logical_factor * v as f64) as f32;
 
-    // PERF: try doing this incrementally
-    for (entity, mut node, mut transform, parent) in &mut node_transform_query {
-        let layout = ui_surface.get_layout(entity).unwrap();
-        let new_size = Vec2::new(
-            to_logical(layout.size.width),
-            to_logical(layout.size.height),
-        );
-        // only trigger change detection when the new value is different
-        if node.calculated_size != new_size {
-            node.calculated_size = new_size;
-        }
-        let mut new_position = transform.translation;
-        new_position.x = to_logical(layout.location.x + layout.size.width / 2.0);
-        new_position.y = to_logical(layout.location.y + layout.size.height / 2.0);
-        if let Some(parent) = parent {
-            if let Ok(parent_layout) = ui_surface.get_layout(**parent) {
-                new_position.x -= to_logical(parent_layout.size.width / 2.0);
-                new_position.y -= to_logical(parent_layout.size.height / 2.0);
+        // PERF: try doing this incrementally
+        for (entity, mut node, mut transform, parent) in &mut node_transform_query {
+            let layout = ui_surface.get_layout(entity).unwrap();
+            let new_size = Vec2::new(
+                to_logical(layout.size.width),
+                to_logical(layout.size.height),
+            );
+            // only trigger change detection when the new value is different
+            if node.calculated_size != new_size {
+                node.calculated_size = new_size;
             }
-        }
-        // only trigger change detection when the new value is different
-        if transform.translation != new_position {
-            transform.translation = new_position;
+            let mut new_position = transform.translation;
+            new_position.x = to_logical(layout.location.x + layout.size.width / 2.0);
+            new_position.y = to_logical(layout.location.y + layout.size.height / 2.0);
+            if let Some(parent) = parent {
+                if let Ok(parent_layout) = ui_surface.get_layout(**parent) {
+                    new_position.x -= to_logical(parent_layout.size.width / 2.0);
+                    new_position.y -= to_logical(parent_layout.size.height / 2.0);
+                }
+            }
+            // only trigger change detection when the new value is different
+            if transform.translation != new_position {
+                transform.translation = new_position;
+            }
         }
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -194,6 +194,7 @@ without UI components as a child of an entity with UI components, results may be
         for entity in entities {
             if let Some(node) = self.entity_to_taffy.remove(&entity) {
                 self.taffy.remove(node).unwrap();
+                self.needs_update = true;
             }
         }
     }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -263,14 +263,12 @@ pub fn ui_layout_system(
             return;
         };
 
-    let primary_window_modified = 
-        window_resize_events
+    let primary_window_modified = window_resize_events
         .iter()
         .any(|resized_window| resized_window.window == primary_window_entity)
-        ||
-        window_created_events
-        .iter()
-        .any(|window_created| window_created.window == primary_window_entity);
+        || window_created_events
+            .iter()
+            .any(|window_created| window_created.window == primary_window_entity);
 
     let scale_factor = logical_to_physical_factor * ui_scale.scale;
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -75,6 +75,10 @@ impl Default for UiSurface {
 }
 
 impl UiSurface {
+    pub fn needs_update(&self) -> bool {
+        self.needs_update
+    }
+
     /// Retrieves the taffy node corresponding to given entity exists, or inserts a new taffy node into the layout if no corresponding node exists.
     /// Then convert the given `Style` and use it update the taffy node's style.
     pub fn upsert_node(&mut self, entity: Entity, style: &Style, context: &LayoutContext) {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -143,7 +143,7 @@ impl Plugin for UiPlugin {
         );
         #[cfg(feature = "bevy_text")]
         app.add_plugin(accessibility::AccessibilityPlugin);
-        app.add_systems(PostUpdate, { 
+        app.add_systems(PostUpdate, {
             let system = widget::update_image_content_size_system.before(UiSystem::Layout);
             // Potential conflicts: `Assets<Image>`
             // They run independently since `widget::image_node_system` will only ever observe

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -162,8 +162,13 @@ impl Plugin for UiPlugin {
                 ui_layout_system
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),
-                ui_stack_system.in_set(UiSystem::Stack),
-                update_clipping_system.after(TransformSystem::TransformPropagate),
+                ui_stack_system
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update)
+                    .after(UiSystem::Layout)
+                    .in_set(UiSystem::Stack),
+                update_clipping_system
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update)
+                    .after(TransformSystem::TransformPropagate),
             ),
         );
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -143,7 +143,7 @@ impl Plugin for UiPlugin {
         );
         #[cfg(feature = "bevy_text")]
         app.add_plugin(accessibility::AccessibilityPlugin);
-        app.add_systems(PostUpdate, {
+        app.add_systems(PostUpdate, { 
             let system = widget::update_image_content_size_system.before(UiSystem::Layout);
             // Potential conflicts: `Assets<Image>`
             // They run independently since `widget::image_node_system` will only ever observe
@@ -163,11 +163,11 @@ impl Plugin for UiPlugin {
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),
                 ui_stack_system
-                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update())
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.layout_updated())
                     .after(UiSystem::Layout)
                     .in_set(UiSystem::Stack),
                 update_clipping_system
-                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update())
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.layout_updated())
                     .after(TransformSystem::TransformPropagate),
             ),
         );

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -163,11 +163,11 @@ impl Plugin for UiPlugin {
                     .in_set(UiSystem::Layout)
                     .before(TransformSystem::TransformPropagate),
                 ui_stack_system
-                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update)
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update())
                     .after(UiSystem::Layout)
                     .in_set(UiSystem::Stack),
                 update_clipping_system
-                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update)
+                    .run_if(|ui_surface: Res<UiSurface>| ui_surface.needs_update())
                     .after(TransformSystem::TransformPropagate),
             ),
         );


### PR DESCRIPTION
# Objective

Updates to the node geometries, the UI stack, and clipping rects can be skipped entirely if the UI node entities, the window resolution, and the scale factor are all unchanged.

## Solution

Add a flag to `UiSurface` `needs_update` that is set by `ui_layout_system` if it makes any changes to the UI layout tree. If the flag is not set, don't update the node geometry, UI stack, or clipping rects.

---

## Changelog

* Added a flag to `UiSurface` `needs_update` that is set by `ui_layout_system` if it makes any changes to the UI layout tree. 
* Added `run_if` conditions to `ui_stack_system` and `update_clipping_system` so they only run if `needs_update` is set.
* `ui_layout_system` only does `compute_window_layouts` and the `Node` and `Transform` updates if `needs_update` is set.

## Migration Guide

