### PR TITLE
WebGPU examples: keep link relative to the current page

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -219,7 +219,7 @@ description = \"{}\"
 
 [extra]
 technical_name = \"{}\"
-link = \"examples-webgpu/{}/{}\"
+link = \"{}/{}\"
 image = \"../static/screenshots/{}/{}.png\"
 code_path = \"content/examples-webgpu/{}\"
 github_code_path = \"{}\"


### PR DESCRIPTION
# Objective

- Fix bad links in the WebGPU example page

## Solution

- Bevy website always add the trailing slash, keep the link relative by removing the current folder from it
