### PR TITLE
Update ruzstd and basis universal

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -78,7 +78,7 @@ ktx2 = { version = "0.3.0", optional = true }
 flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.3.1", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
-basis-universal = { version = "0.2.0", optional = true }
+basis-universal = { version = "0.3.0", optional = true }
 encase = { version = "0.6.1", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = ["profile-with-tracing"], optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -76,7 +76,7 @@ ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
 # For ktx2 supercompression
 flate2 = { version = "1.0.22", optional = true }
-ruzstd = { version = "0.2.4", optional = true }
+ruzstd = { version = "0.3.1", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.2.0", optional = true }
 encase = { version = "0.6.1", features = ["glam"] }

--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -61,7 +61,7 @@ pub fn ktx2_buffer_to_image(
                 SupercompressionScheme::Zstandard => {
                     let mut cursor = std::io::Cursor::new(_level_data);
                     let mut decoder = ruzstd::StreamingDecoder::new(&mut cursor)
-                        .map_err(TextureError::SuperDecompressionError)?;
+                        .map_err(|err| TextureError::SuperDecompressionError(err.to_string()))?;
                     let mut decompressed = Vec::new();
                     decoder.read_to_end(&mut decompressed).map_err(|err| {
                         TextureError::SuperDecompressionError(format!(


### PR DESCRIPTION
# Objective

- Update dependencies `ruzstd` and `basis-universal`
- Alternative to #5278 and #8133

## Solution

- Update the dependencies, fix the code
- Bevy now also depend on `syn@2` so it's not a blocker to update `ruzstd` anymore