### PR TITLE
Fix look_to variable naming

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -354,14 +354,14 @@ impl Transform {
     /// * if `direction` is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]
     pub fn look_to(&mut self, direction: Vec3, up: Vec3) {
-        let forward = -direction.try_normalize().unwrap_or(Vec3::Z);
+        let back = -direction.try_normalize().unwrap_or(Vec3::NEG_Z);
         let up = up.try_normalize().unwrap_or(Vec3::Y);
         let right = up
-            .cross(forward)
+            .cross(back)
             .try_normalize()
             .unwrap_or_else(|| up.any_orthonormal_vector());
-        let up = forward.cross(right);
-        self.rotation = Quat::from_mat3(&Mat3::from_cols(right, up, forward));
+        let up = back.cross(right);
+        self.rotation = Quat::from_mat3(&Mat3::from_cols(right, up, back));
     }
 
     /// Multiplies `self` with `transform` component by component, returning the

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -349,7 +349,7 @@ impl Transform {
     /// and [`Transform::up`] points towards `up`.
     ///
     /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
-    /// * if `direction` is zero, `Vec3::Z` is used instead
+    /// * if `direction` is zero, `Vec3::NEG_Z` is used instead
     /// * if `up` is zero, `Vec3::Y` is used instead
     /// * if `direction` is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]


### PR DESCRIPTION
# Objective

- If I understand correctly, forward points in `direction`, so the negative of `direction` should be back.

## Migration Guide

- `Transform::look_to` method changed default value of `direction.try_normalize()` from `Vec3::Z` to `Vec3::NEG_Z`