### PR TITLE
Fix bloom wasm support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -274,7 +274,7 @@ path = "examples/2d/bloom_2d.rs"
 name = "2D Bloom"
 description = "Illustrates bloom post-processing in 2d"
 category = "2D Rendering"
-wasm = false
+wasm = true
 
 [[example]]
 name = "move_sprite"
@@ -535,7 +535,7 @@ path = "examples/3d/bloom_3d.rs"
 name = "3D Bloom"
 description = "Illustrates bloom configuration using HDR and emissive materials"
 category = "3D Rendering"
-wasm = false
+wasm = true
 
 [[example]]
 name = "load_gltf"

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -304,6 +304,7 @@ struct BloomTexture {
     // First mip is half the screen resolution, successive mips are half the previous
     #[cfg(any(not(feature = "webgl"), not(target_arch = "wasm32")))]
     texture: CachedTexture,
+    // WebGL does not support binding specific mip levels for sampling, fallback to separate textures instead
     #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
     texture: Vec<CachedTexture>,
     mip_count: u32,

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -302,15 +302,15 @@ impl ViewNode for BloomNode {
 #[derive(Component)]
 struct BloomTexture {
     // First mip is half the screen resolution, successive mips are half the previous
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(not(feature = "webgl"), not(target_arch = "wasm32")))]
     texture: CachedTexture,
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
     texture: Vec<CachedTexture>,
     mip_count: u32,
 }
 
 impl BloomTexture {
-    #[cfg(not(target_arch = "wasm32"))]
+    #[cfg(any(not(feature = "webgl"), not(target_arch = "wasm32")))]
     fn view(&self, base_mip_level: u32) -> TextureView {
         self.texture.texture.create_view(&TextureViewDescriptor {
             base_mip_level,
@@ -318,7 +318,7 @@ impl BloomTexture {
             ..Default::default()
         })
     }
-    #[cfg(target_arch = "wasm32")]
+    #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
     fn view(&self, base_mip_level: u32) -> TextureView {
         self.texture[base_mip_level as usize]
             .texture
@@ -361,9 +361,9 @@ fn prepare_bloom_textures(
                 view_formats: &[],
             };
 
-            #[cfg(not(target_arch = "wasm32"))]
+            #[cfg(any(not(feature = "webgl"), not(target_arch = "wasm32")))]
             let texture = texture_cache.get(&render_device, texture_descriptor);
-            #[cfg(target_arch = "wasm32")]
+            #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
             let texture: Vec<CachedTexture> = (0..mip_count)
                 .map(|mip| {
                     texture_cache.get(


### PR DESCRIPTION
# Objective

- Fixes #7352 

## Solution

GLES doesn't support binding specific mip levels for sampling. Fallback to using separate textures instead.
- [wgpu-hal/src/gles/device.rs](https://github.com/gfx-rs/wgpu/blob/628a95cd1c27abce4d4ff2ffe4558cc4ef1e7fd3/wgpu-hal/src/gles/device.rs#L1038)

---