### PR TITLE
Optimize wasm examples for the website

### DIFF
--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -11,3 +11,4 @@ xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }
 ron = "0.8"
 toml_edit = "0.19"
+pbr = "1.1"

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -275,7 +275,7 @@ header_message = \"Examples (WebGPU)\"
                 let example = &to_build.technical_name;
                 cmd!(
                     sh,
-                    "cargo run -p build-wasm-example -- --api webgpu {example}"
+                    "cargo run -p build-wasm-example -- --api webgpu {example} --optimize-size"
                 )
                 .run()
                 .unwrap();
@@ -296,7 +296,7 @@ header_message = \"Examples (WebGPU)\"
                     &example_path.join("wasm_example.js"),
                 );
                 let _ = fs::rename(
-                    Path::new("examples/wasm/target/wasm_example_bg.wasm"),
+                    Path::new("examples/wasm/target/wasm_example_bg.wasm.optimized"),
                     &example_path.join("wasm_example_bg.wasm"),
                 );
             }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -9,6 +9,7 @@ use std::{
 };
 
 use clap::Parser;
+use pbr::ProgressBar;
 use toml_edit::Document;
 use xshell::{cmd, Shell};
 
@@ -175,7 +176,6 @@ header_message = \"Examples (WebGPU)\"
                 .unwrap();
 
             let mut categories = HashMap::new();
-
             for to_show in examples_to_run {
                 if !to_show.wasm {
                     continue;
@@ -266,6 +266,12 @@ header_message = \"Examples (WebGPU)\"
                 cmd!(sh, "sed -i.bak 's/asset_folder: \"assets\"/asset_folder: \"\\/assets\\/examples\\/\"/' crates/bevy_asset/src/lib.rs").run().unwrap();
             }
 
+            let mut pb = ProgressBar::new(
+                examples_to_build
+                    .iter()
+                    .filter(|to_build| to_build.wasm)
+                    .count() as u64,
+            );
             for to_build in examples_to_build {
                 if !to_build.wasm {
                     continue;
@@ -299,7 +305,9 @@ header_message = \"Examples (WebGPU)\"
                     Path::new("examples/wasm/target/wasm_example_bg.wasm.optimized"),
                     &example_path.join("wasm_example_bg.wasm"),
                 );
+                pb.inc();
             }
+            pb.finish_print("done");
         }
     }
 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -256,6 +256,17 @@ header_message = \"Examples (WebGPU)\"
             let _ = fs::create_dir_all(root_path);
 
             if website_hacks {
+                // setting up the headers file for cloudflare for the correct Content-Type
+                let mut headers = File::create(root_path.join("headers")).unwrap();
+                headers
+                    .write_all(
+                        "/*/wasm_example_bg.wasm
+  Content-Type: application/wasm
+"
+                        .as_bytes(),
+                    )
+                    .unwrap();
+
                 let sh = Shell::new().unwrap();
 
                 // setting a canvas by default to help with integration

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -54,6 +54,10 @@ enum Action {
         #[arg(long)]
         /// Enable hacks for Bevy website integration
         website_hacks: bool,
+
+        #[arg(long)]
+        /// Optimize the wasm file for size with wasm-opt
+        optimize_size: bool,
     },
 }
 
@@ -248,6 +252,7 @@ header_message = \"Examples (WebGPU)\"
         Action::BuildWebGPUExamples {
             content_folder,
             website_hacks,
+            optimize_size,
         } => {
             let examples_to_build = parse_examples();
 
@@ -290,12 +295,21 @@ header_message = \"Examples (WebGPU)\"
 
                 let sh = Shell::new().unwrap();
                 let example = &to_build.technical_name;
-                cmd!(
-                    sh,
-                    "cargo run -p build-wasm-example -- --api webgpu {example} --optimize-size"
-                )
-                .run()
-                .unwrap();
+                if optimize_size {
+                    cmd!(
+                        sh,
+                        "cargo run -p build-wasm-example -- --api webgpu {example} --optimize-size"
+                    )
+                    .run()
+                    .unwrap();
+                } else {
+                    cmd!(
+                        sh,
+                        "cargo run -p build-wasm-example -- --api webgpu {example}"
+                    )
+                    .run()
+                    .unwrap();
+                }
 
                 let category_path = root_path.join(&to_build.category);
                 let _ = fs::create_dir_all(&category_path);
@@ -312,10 +326,17 @@ header_message = \"Examples (WebGPU)\"
                     Path::new("examples/wasm/target/wasm_example.js"),
                     &example_path.join("wasm_example.js"),
                 );
-                let _ = fs::rename(
-                    Path::new("examples/wasm/target/wasm_example_bg.wasm.optimized"),
-                    &example_path.join("wasm_example_bg.wasm"),
-                );
+                if optimize_size {
+                    let _ = fs::rename(
+                        Path::new("examples/wasm/target/wasm_example_bg.wasm.optimized"),
+                        &example_path.join("wasm_example_bg.wasm"),
+                    );
+                } else {
+                    let _ = fs::rename(
+                        Path::new("examples/wasm/target/wasm_example_bg.wasm"),
+                        &example_path.join("wasm_example_bg.wasm"),
+                    );
+                }
                 pb.inc();
             }
             pb.finish_print("done");

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -262,7 +262,7 @@ header_message = \"Examples (WebGPU)\"
 
             if website_hacks {
                 // setting up the headers file for cloudflare for the correct Content-Type
-                let mut headers = File::create(root_path.join("headers")).unwrap();
+                let mut headers = File::create(root_path.join("_headers")).unwrap();
                 headers
                     .write_all(
                         "/*/wasm_example_bg.wasm


### PR DESCRIPTION
# Objective

- Improve speed of loading examples on the website
- Triggered by https://news.ycombinator.com/item?id=35996393

## Solution

- Use wasm-opt to optimize files for size. This reduces the files from 22mb to 13mb
- Cloudflare doesn't set the correct `Content-Type` header by default for wasm files, add it manually. This enables wasm streaming and compression, dropping the transfer to 3.9mb

The files with this script are deployed on optimized.wasm-pages.pages.dev if you want to test, you can replace this URL on a website deployed locally.