### PR TITLE
Remove unused field in FontAtlasSet

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -14,9 +14,6 @@ type FontSizeKey = FloatOrd;
 #[uuid = "73ba778b-b6b5-4f45-982d-d21b6b86ace2"]
 pub struct FontAtlasSet {
     font_atlases: HashMap<FontSizeKey, Vec<FontAtlas>>,
-    // TODO unused, remove
-    #[allow(dead_code)]
-    queue: Vec<FontSizeKey>,
 }
 
 #[derive(Debug, Clone)]
@@ -29,7 +26,6 @@ impl Default for FontAtlasSet {
     fn default() -> Self {
         FontAtlasSet {
             font_atlases: HashMap::with_capacity_and_hasher(1, Default::default()),
-            queue: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fulfill TODO about unused member from `FontAtlasSet`

## Solution

- Removed field `queue: Vec<FontSizeKey>` from `FontAtlasSet`