### PR TITLE
Correct RequestRedraw documentation

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -24,7 +24,7 @@ pub struct WindowResized {
     pub height: f32,
 }
 
-/// An event that indicates that all of the application's windows should be redrawn,
+/// An event that indicates all of the application's windows should be redrawn,
 /// even if their control flow is set to `Wait` and there have been no window events.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -24,9 +24,8 @@ pub struct WindowResized {
     pub height: f32,
 }
 
-// TODO: This would redraw all windows ? If yes, update docs to reflect this
-/// An event that indicates the window should redraw, even if its control flow is set to `Wait` and
-/// there have been no window events.
+/// An event that indicates that all of the application's windows should be redrawn,
+/// even if their control flow is set to `Wait` and there have been no window events.
 #[derive(Debug, Clone, PartialEq, Eq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(


### PR DESCRIPTION
# Objective

- Since the `RequestRedraw` event triggers the bevy app to run `update` in `bevy_app::app::App`, the documentation should state that all the windows in the application and its sub-apps are going to get redrawn, rather than a single window.

## Solution

- Change `RequestRedraw` documentation in `bevy_window` to mention every window.
