### PR TITLE
`ui_layout_system` removal detection fix

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -236,7 +236,7 @@ pub fn ui_layout_system(
         ui_surface.try_remove_measure(entity);
     }
 
-    // update and remove children
+    // remove taffy children corresponding to removed `Children`
     for entity in removed_children.iter() {
         ui_surface.try_remove_children(entity);
     }
@@ -293,6 +293,7 @@ pub fn ui_layout_system(
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());
 
+    // update children
     for (entity, children) in &children_query {
         if children.is_changed() {
             ui_surface.update_children(entity, &children);

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -288,7 +288,7 @@ pub fn ui_layout_system(
         if let Some(measure_func) = content_size.measure_func.take() {
             ui_surface.update_measure(entity, measure_func);
         }
-    }        
+    }
 
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -264,7 +264,7 @@ pub fn ui_layout_system(
             return;
         };
 
-        let primary_window_modified = window_resize_events
+    let primary_window_modified = window_resize_events
         .iter()
         .any(|resized_window| resized_window.window == primary_window_entity)
         || window_created_events

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -341,5 +341,4 @@ pub fn ui_layout_system(
             transform.translation = new_position;
         }
     }
-    debug::print_ui_layout_tree(&ui_surface);
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -217,7 +217,8 @@ pub fn ui_layout_system(
     windows: Query<(Entity, &Window)>,
     ui_scale: Res<UiScale>,
     mut scale_factor_events: EventReader<WindowScaleFactorChanged>,
-    mut resize_events: EventReader<bevy_window::WindowResized>,
+    mut window_resize_events: EventReader<bevy_window::WindowResized>,
+    mut window_created_events: EventReader<bevy_window::WindowCreated>,
     mut ui_surface: ResMut<UiSurface>,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
@@ -263,9 +264,12 @@ pub fn ui_layout_system(
             return;
         };
 
-    let resized = resize_events
+        let primary_window_modified = window_resize_events
         .iter()
-        .any(|resized_window| resized_window.window == primary_window_entity);
+        .any(|resized_window| resized_window.window == primary_window_entity)
+        || window_created_events
+            .iter()
+            .any(|window_created| window_created.window == primary_window_entity);
 
     // update window root nodes
     for (entity, window) in windows.iter() {
@@ -276,7 +280,7 @@ pub fn ui_layout_system(
 
     let layout_context = LayoutContext::new(scale_factor, physical_size);
 
-    if !scale_factor_events.is_empty() || ui_scale.is_changed() || resized {
+    if !scale_factor_events.is_empty() || ui_scale.is_changed() || primary_window_modified {
         scale_factor_events.clear();
         // update all nodes
         for (entity, style) in style_query.iter() {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};
-use bevy_log::{warn, info};
+use bevy_log::{info, warn};
 use bevy_math::Vec2;
 use bevy_transform::components::Transform;
 use bevy_utils::HashMap;
@@ -98,13 +98,11 @@ impl UiSurface {
 
     /// Update the children of the taffy node corresponding to the given [`Entity`].
     pub fn update_children(&mut self, entity: Entity, children: &Children) {
-        info!("update children {entity:?} -> {children:?}");
         let mut taffy_children = Vec::with_capacity(children.len());
         for child in children {
             if let Some(taffy_node) = self.entity_to_taffy.get(child) {
                 taffy_children.push(*taffy_node);
             } else {
-                warn!("children {entity:?} -> {children:?}");
                 warn!(
                     "Unstyled child in a UI entity hierarchy. You are using an entity \
 without UI components as a child of an entity with UI components, results may be unexpected."
@@ -184,7 +182,6 @@ without UI components as a child of an entity with UI components, results may be
     pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
             if let Some(node) = self.entity_to_taffy.remove(&entity) {
-                info!("Removed UI node: {entity:?} -> {node:?}");
                 self.taffy.remove(node).unwrap();
             }
         }
@@ -194,7 +191,6 @@ without UI components as a child of an entity with UI components, results may be
     /// Does not compute the layout geometry, `compute_window_layouts` should be run before using this function.
     pub fn get_layout(&self, entity: Entity) -> Result<&taffy::layout::Layout, LayoutError> {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            info!("Get layout node: {entity:?} -> {taffy_node:?}");
             self.taffy
                 .layout(*taffy_node)
                 .map_err(LayoutError::TaffyError)
@@ -309,7 +305,6 @@ pub fn ui_layout_system(
     }
 
     // update children
-    
 
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -304,8 +304,6 @@ pub fn ui_layout_system(
         }
     }
 
-    // update children
-
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -236,9 +236,15 @@ pub fn ui_layout_system(
         ui_surface.try_remove_measure(entity);
     }
 
-    // remove taffy children corresponding to removed `Children`
+    // remove and update children
     for entity in removed_children.iter() {
         ui_surface.try_remove_children(entity);
+    }
+
+    for (entity, children) in &children_query {
+        if children.is_changed() {
+            ui_surface.update_children(entity, &children);
+        }
     }
 
     // assume one window for time being...
@@ -292,13 +298,6 @@ pub fn ui_layout_system(
 
     // update window children (for now assuming all Nodes live in the primary window)
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());
-
-    // update children
-    for (entity, children) in &children_query {
-        if children.is_changed() {
-            ui_surface.update_children(entity, &children);
-        }
-    }
 
     // compute layouts
     ui_surface.compute_window_layouts();

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -12,7 +12,7 @@ use bevy_ecs::{
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};
-use bevy_log::{info, warn};
+use bevy_log::warn;
 use bevy_math::Vec2;
 use bevy_transform::components::Transform;
 use bevy_utils::HashMap;


### PR DESCRIPTION
# Objective
If a `Node` component is removed from a UI node entity and then reinserted before `ui_layout_system` runs again, it will be deleted from `UiSurface` when the `remove_entities` method is called. But then subsequent queries will still find the UI node's components and `ui_layout_system` will try to retrieve the deleted taffy node from the `entity_to_taffy` map and panic.

Example that panics on `set_window_children`:
```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2dBundle::default());
    commands
        .spawn(NodeBundle::default())
        .remove::<Node>()
        .insert(Node::default());
}
```

Also since `RemovedComponents` events aren't retained and the UI doesn't update without a window, deleted nodes will not be cleaned up even once a new window is opened.

There are similar issues with the `ContentSize` and `Children` removal detection.


## Solution

Do the removal detection and clean up first, before any other updates.

## Changelog
Reordered `ui_layout_system` so that it does removal detection and clean-up tasks first before any other updates.
