### PR TITLE
Add required features to manifest for shader_material_glsl example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1510,6 +1510,7 @@ wasm = true
 [[example]]
 name = "shader_material_glsl"
 path = "examples/shader/shader_material_glsl.rs"
+required-features = ["shader_format_glsl"]
 
 [package.metadata.example.shader_material_glsl]
 name = "Material - GLSL"


### PR DESCRIPTION
# Objective

Fixed #8505 

## Solution

Add `required-features` to the cargo manifest for that example.

There's precedent for this with the `tonemapping` example which requires non-default features `ktx2` and `zstd`.

Now when running the example, you see a friendly error message:

```
 cargo run --example shader_material_glsl
error: target `shader_material_glsl` in package `bevy` requires the features: `shader_format_glsl`
Consider enabling them by passing, e.g., `--features="shader_format_glsl"`
```