### PR TITLE
implement `Deref` for `State<S>`

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -1,6 +1,7 @@
 use std::fmt::Debug;
 use std::hash::Hash;
 use std::mem;
+use std::ops::Deref;
 
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
@@ -92,6 +93,14 @@ impl<S: States> State<S> {
 impl<S: States> PartialEq<S> for State<S> {
     fn eq(&self, other: &S) -> bool {
         self.get() == other
+    }
+}
+
+impl<S: States> Deref for State<S> {
+    type Target = S;
+
+    fn deref(&self) -> &Self::Target {
+        self.get()
     }
 }
 


### PR DESCRIPTION
# Objective

- Allow for directly call methods on states without first calling `state.get().my_method()`

## Solution

- Implement `Deref` for `State<S>` with `Target = S`

## Changelog

changes:

- Implemented `Deref` for `State<S>` with `Target = S`
---
*I did not implement `DerefMut` because states hold no data and should only be changed via `NextState::set()`*