### PR TITLE
Allow missing docs on wasm implementation of BoxedFuture

### DIFF
--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -47,6 +47,7 @@ use std::{
 #[cfg(not(target_arch = "wasm32"))]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
+#[allow(missing_docs)]
 #[cfg(target_arch = "wasm32")]
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 


### PR DESCRIPTION
# Objective

Reduce missing docs warning noise when building examples for wasm

## Solution

Added "#[allow(missing_docs)]" on the wasm specific version of BoxedFuture

