### PR TITLE
Disable wasm / webgpu building of wireframe example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -716,7 +716,7 @@ path = "examples/3d/wireframe.rs"
 name = "Wireframe"
 description = "Showcases wireframe rendering"
 category = "3D Rendering"
-wasm = true
+wasm = false
 
 [[example]]
 name = "no_prepass"


### PR DESCRIPTION
# Objective

Remove the wireframe example on the WebGPU examples page as it does not render properly. When run in a browser it will render to all white cube due PolygonMode::LINE not being supported in WebGPU.

Relevant docs:
https://wgpu.rs/doc/wgpu/struct.Features.html#associatedconstant.POLYGON_MODE_LINE

When Rendered with WebGPU:
<img width="675" alt="image" src="https://github.com/bevyengine/bevy/assets/644930/86c7623c-3e18-42d2-8231-099da10cf6c4">

## Solution

Disable this example when building for WebGPU / wasm. 

