### PR TITLE
Add a from_str constructor for DiagnosticId

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -21,6 +21,9 @@ bevy_log = { path = "../bevy_log", version = "0.11.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.11.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.11.0-dev" }
 
+# other
+const-sha1 = "0.2.0"
+
 # MacOS
 [target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices


### PR DESCRIPTION
# Objective

Generating a random `u128` number was a bit of a pain when it comes to creating a new Diagnostic. This adds a new `from_str` constructor which takes an arbitrary string. The new function is simpler to use but same rules apply regarding uniqueness.

e.g.
```rust
const NEW_DIAGNOSTIC_ID: DiagnosticId = DiagnosticId::from_str("new_diagnostic_id");
```

It is possible that in the future this would allow `Diagnostic::new()` to be simplified but I didn't want to go too far down that route in one PR.
