### PR TITLE
Fix: Shaders / Material - GLSL example not working in WebGPU examples page

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -76,6 +76,7 @@ fn main() {
             features.push("android_shared_stdcxx");
             features.push("tonemapping_luts");
             features.push("default_font");
+            features.push("shader_format_glsl");
             default_features = false;
         }
     }


### PR DESCRIPTION
# Objective

Fix the glsl material example not working on the WebGPU examples page. Currently it fails with the following error:

```
panicked at 'not implemented: Enable feature "shader_format_glsl" to use GLSL shaders', crates/bevy_render/src/render_resource/shader.rs:215:21
```

## Solution

Add feature "shader_format_glsl" to builds in the build-wasm-examples tool.
