### PR TITLE
Change present mode on many_buttons and many_glyphs from Immediate to AutoNoVsync

### DIFF
--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -25,7 +25,7 @@ fn main() {
 
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            present_mode: PresentMode::Immediate,
+            present_mode: PresentMode::AutoNoVsync,
             ..default()
         }),
         ..default()

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -16,7 +16,7 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(DefaultPlugins.set(WindowPlugin {
         primary_window: Some(Window {
-            present_mode: PresentMode::Immediate,
+            present_mode: PresentMode::AutoNoVsync,
             ..default()
         }),
         ..default()


### PR DESCRIPTION
# Objective

Fix the examples many_buttons and many_glyphs not working on the WebGPU examples page. Currently they both fail with the follow error:

```
panicked at 'Only FIFO/Auto* is supported on web', ..../wgpu-0.16.0/src/backend/web.rs:1162:13
```

## Solution

Change `present_mode` from `PresentMode::Immediate` to `PresentMode::AutoNoVsync`. AutoNoVsync seems to be common mode used by other examples of this kind.

