### PR TITLE
Fix screenspace_texture example shader compiler error in WebGPU (Browser)

### DIFF
--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -11,7 +11,7 @@ fn fragment(
     @builtin(position) position: vec4<f32>,
     #import bevy_pbr::mesh_vertex_output
 ) -> @location(0) vec4<f32> {
-    let uv = coords_to_viewport_uv(position.xy, view.viewport);
-    let color = textureSample(texture, texture_sampler, uv);
+    let viewport_uv = coords_to_viewport_uv(position.xy, view.viewport);
+    let color = textureSample(texture, texture_sampler, viewport_uv);
     return color;
 }


### PR DESCRIPTION
# Objective

Fix the screenspace_texture example not working on the WebGPU examples page. Currently it fails with the following error in the browser console:

```
1 error(s) generated while compiling the shader:
:213:9 error: redeclaration of 'uv'
    let uv = coords_to_viewport_uv(position.xy, view.viewport);
        ^^

:211:14 note: 'uv' previously declared here
@location(2) uv: vec2<f32>,
```

## Solution

Rename the shader variable `uv` to `viewport_uv` to prevent variable redeclaration error.

