### PR TITLE
Disable asset_loading and texture_atlas examples when building for wasm / WebGPU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,7 +404,7 @@ path = "examples/2d/texture_atlas.rs"
 name = "Texture Atlas"
 description = "Generates a texture atlas (sprite sheet) from individual sprites"
 category = "2D Rendering"
-wasm = true
+wasm = false
 
 [[example]]
 name = "transparency_2d"
@@ -906,7 +906,7 @@ path = "examples/asset/asset_loading.rs"
 name = "Asset Loading"
 description = "Demonstrates various methods to load assets"
 category = "Assets"
-wasm = true
+wasm = false
 
 [[example]]
 name = "custom_asset"


### PR DESCRIPTION
# Objective

Remove the asset_loading and texture_atlas on the WebGPU examples page as they do not function properly. Both examples use folder loading that is not supported in a browser context and currently fail with the follow error:

```
panicked at 'called `Result::unwrap()` on an `Err` value: AssetFolderNotADirectory("textures/rpg")', examples/2d/texture_atlas.rs:31:75
```

## Solution

Disable these examples when building for WebGPU / wasm.
