### PR TITLE
Change default tonemapping method

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -134,9 +134,7 @@ pub enum Tonemapping {
     /// Suffers from lots hue shifting, brights don't desaturate naturally.
     /// Bright primaries and secondaries don't desaturate at all.
     Reinhard,
-    /// Current bevy default. Likely to change in the future.
     /// Suffers from hue shifting. Brights don't desaturate much at all across the spectrum.
-    #[default]
     ReinhardLuminance,
     /// Same base implementation that Godot 4.0 uses for Tonemap ACES.
     /// <https://github.com/TheRealMJP/BakingLab/blob/master/BakingLab/ACES.hlsl>
@@ -156,6 +154,7 @@ pub enum Tonemapping {
     /// Designed as a compromise if you want e.g. decent skin tones in low light, but can't afford to re-do your
     /// VFX to look good without hue shifting.
     SomewhatBoringDisplayTransform,
+    /// Current Bevy default.
     /// By Tomasz Stachowiak
     /// <https://github.com/h3r2tic/tony-mc-mapface>
     /// Very neutral. Subtle but intentional hue shifting. Brights desaturate across the spectrum.
@@ -167,6 +166,7 @@ pub enum Tonemapping {
     /// Color hues are preserved during compression, except for a deliberate [Bezold–Brücke shift](https://en.wikipedia.org/wiki/Bezold%E2%80%93Br%C3%BCcke_shift).
     /// To avoid posterization, selective desaturation is employed, with care to avoid the [Abney effect](https://en.wikipedia.org/wiki/Abney_effect).
     /// NOTE: Requires the `tonemapping_luts` cargo feature.
+    #[default]
     TonyMcMapface,
     /// Default Filmic Display Transform from blender.
     /// Somewhat neutral. Suffers from hue shifting. Brights desaturate across the spectrum.
@@ -328,7 +328,7 @@ pub fn get_lut_bindings<'a>(
     bindings: [u32; 2],
 ) -> [BindGroupEntry<'a>; 2] {
     let image = match tonemapping {
-        //AgX lut texture used when tonemapping doesn't need a texture since it's very small (32x32x32)
+        // AgX lut texture used when tonemapping doesn't need a texture since it's very small (32x32x32)
         Tonemapping::None
         | Tonemapping::Reinhard
         | Tonemapping::ReinhardLuminance


### PR DESCRIPTION
Change the default tonemapping method from ReinhardLuminance to TonyMcMapface, which generally looks nicer and works out of the box with bloom.

---

## Changelog

- TonyMcMapface is now the default tonemapper, instead of ReinhardLuminance.

## Migration Guide

- The default tonemapper has been changed from ReinhardLuminance to TonyMcMapface. Explicitly set ReinhardLuminance on your cameras to get back the previous look.