### PR TITLE
Make function pointers of ecs Reflect* public

### DIFF
--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -211,6 +211,26 @@ impl ReflectComponent {
     pub fn new(fns: ReflectComponentFns) -> Self {
         Self(fns)
     }
+
+    /// The underlying function pointers implementing methods on `ReflectComponent`.
+    ///
+    /// This is useful when you want to keep track locally of an individual
+    /// function pointer.
+    ///
+    /// Calling [`TypeRegistry::get`] followed by
+    /// [`TypeRegistration::data::<ReflectComponent>`] can be costly if done several
+    /// times per frame. Consider cloning [`ReflectComponent`] and keeping it
+    /// between frames, cloning a `ReflectComponent` is very cheap.
+    ///
+    /// If you only need a subset of the methods on `ReflectComponent`,
+    /// use `fn_pointers` to get the underlying [`ReflectComponentFns`]
+    /// and copy the subset of function pointers you care about.
+    ///
+    /// [`TypeRegistration::data::<ReflectComponent>`]: bevy_reflect::TypeRegistration::data
+    /// [`TypeRegistry::get`]: bevy_reflect::TypeRegistry::get
+    pub fn fn_pointers(&self) -> &ReflectComponentFns {
+        &self.0
+    }
 }
 
 impl<C: Component + Reflect + FromWorld> FromType<C> for ReflectComponent {

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -142,6 +142,26 @@ impl ReflectResource {
     pub fn new(&self, fns: ReflectResourceFns) -> Self {
         Self(fns)
     }
+
+    /// The underlying function pointers implementing methods on `ReflectResource`.
+    ///
+    /// This is useful when you want to keep track locally of an individual
+    /// function pointer.
+    ///
+    /// Calling [`TypeRegistry::get`] followed by
+    /// [`TypeRegistration::data::<ReflectResource>`] can be costly if done several
+    /// times per frame. Consider cloning [`ReflectResource`] and keeping it
+    /// between frames, cloning a `ReflectResource` is very cheap.
+    ///
+    /// If you only need a subset of the methods on `ReflectResource`,
+    /// use `fn_pointers` to get the underlying [`ReflectResourceFns`]
+    /// and copy the subset of function pointers you care about.
+    ///
+    /// [`TypeRegistration::data::<ReflectResource>`]: bevy_reflect::TypeRegistration::data
+    /// [`TypeRegistry::get`]: bevy_reflect::TypeRegistry::get
+    pub fn fn_pointers(&self) -> &ReflectResourceFns {
+        &self.0
+    }
 }
 
 impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {


### PR DESCRIPTION
Repetitively fetching ReflectResource and ReflectComponent from the TypeRegistry is costly.

We want to access the underlying `fn`s. to do so, we expose the `ReflectResourceFns` and `ReflectComponentFns` stored in ReflectResource and ReflectComponent.

---

## Changelog

- Add the `fn_pointers` methods to `ReflectResource` and `ReflectComponent` returning the underlying `ReflectResourceFns` and `ReflectComponentFns`