### PR TITLE
fix warning: variable does not need to be mutable

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -144,7 +144,7 @@ impl PluginGroupBuilder {
     /// opt back in to a [`Plugin`] after [disabling](Self::disable) it. If there are no plugins
     /// of type `T` in this group, it will panic.
     pub fn enable<T: Plugin>(mut self) -> Self {
-        let mut plugin_entry = self
+        let plugin_entry = self
             .plugins
             .get_mut(&TypeId::of::<T>())
             .expect("Cannot enable a plugin that does not exist.");
@@ -158,7 +158,7 @@ impl PluginGroupBuilder {
     /// [`add_after`](Self::add_after), or it can be [re-enabled](Self::enable). If there are no
     /// plugins of type `T` in this group, it will panic.
     pub fn disable<T: Plugin>(mut self) -> Self {
-        let mut plugin_entry = self
+        let plugin_entry = self
             .plugins
             .get_mut(&TypeId::of::<T>())
             .expect("Cannot disable a plugin that does not exist.");

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -123,7 +123,7 @@ fn extract_windows(
             window.resolution.physical_height().max(1),
         );
 
-        let mut extracted_window = extracted_windows.entry(entity).or_insert(ExtractedWindow {
+        let extracted_window = extracted_windows.entry(entity).or_insert(ExtractedWindow {
             entity,
             handle: handle.clone(),
             physical_width: new_width,


### PR DESCRIPTION
# Objective

Fix warnings:

```rs
warning: variable does not need to be mutable
   --> /bevy/crates/bevy_app/src/plugin_group.rs:147:13
    |
147 |         let mut plugin_entry = self
    |             ----^^^^^^^^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: variable does not need to be mutable
   --> /bevy/crates/bevy_app/src/plugin_group.rs:161:13
    |
161 |         let mut plugin_entry = self
    |             ----^^^^^^^^^^^^
    |             |
    |             help: remove this `mut`

warning: `bevy_app` (lib) generated 2 warnings (run `cargo fix --lib -p bevy_app` to apply 2 suggestions)
warning: variable does not need to be mutable
   --> /bevy/crates/bevy_render/src/view/window.rs:126:13
    |
126 | ...   let mut extracted_window = extracted_windows.entry(entity).or_insert(Extracte...
    |           ----^^^^^^^^^^^^^^^^
    |
    = note: `#[warn(unused_mut)]` on by default

warning: `bevy_render` (lib) generated 1 warning (run `cargo fix --lib -p bevy_render` to apply 1 suggestion)
```
## Solution

- Remove the mut keyword in those variables.