### PR TITLE
Document query errors

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1167,13 +1167,13 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum QueryEntityError {
     /// The given [`Entity`]'s components do not match the query.
-    /// 
+    ///
     /// Either it does not have a requested component, or it has a component which the query filters out.
     QueryDoesNotMatch(Entity),
     /// The given [`Entity`] does not exist.
     NoSuchEntity(Entity),
     /// The [`Entity`] was requested mutably more than once.
-    /// 
+    ///
     /// See [`QueryState::get_many_mut`] for an example.
     AliasedMutability(Entity),
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1162,7 +1162,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     }
 }
 
-/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`QueryState`].
+/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`Query`](crate::system::Query) or [`QueryState`].
 // TODO: return the type_name as part of this error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum QueryEntityError {
@@ -1303,8 +1303,8 @@ mod tests {
     }
 }
 
-/// An error that occurs when evaluating a [`QueryState`] as a single expected resulted via
-/// [`QueryState::single`] or [`QueryState::single_mut`].
+/// An error that occurs when evaluating a [`Query`](crate::system::Query) or [`QueryState`] as a single expected result via
+/// [`get_single`](crate::system::Query::get_single) or [`get_single_mut`](crate::system::Query::get_single_mut).
 #[derive(Debug)]
 pub enum QuerySingleError {
     /// No entity fits the query.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1307,7 +1307,7 @@ mod tests {
 /// [`QueryState::single`] or [`QueryState::single_mut`].
 #[derive(Debug)]
 pub enum QuerySingleError {
-    /// No entities fit the query.
+    /// No entity fits the query.
     NoEntities(&'static str),
     /// Multiple entities fit the query.
     MultipleEntities(&'static str),

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1162,12 +1162,19 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     }
 }
 
-/// An error that occurs when retrieving a specific [`Entity`]'s query result.
+/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`QueryState`].
 // TODO: return the type_name as part of this error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum QueryEntityError {
+    /// The given [`Entity`]'s components do not match the query.
+    /// 
+    /// Either it does not have a requested component, or it has a component which the query filters out.
     QueryDoesNotMatch(Entity),
+    /// The given [`Entity`] does not exist.
     NoSuchEntity(Entity),
+    /// The [`Entity`] was requested mutably more than once.
+    /// 
+    /// See [`QueryState::get_many_mut`] for an example.
     AliasedMutability(Entity),
 }
 
@@ -1177,7 +1184,7 @@ impl fmt::Display for QueryEntityError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             QueryEntityError::QueryDoesNotMatch(_) => {
-                write!(f, "The given entity does not have the requested component.")
+                write!(f, "The given entity's components do not match the query.")
             }
             QueryEntityError::NoSuchEntity(_) => write!(f, "The requested entity does not exist."),
             QueryEntityError::AliasedMutability(_) => {
@@ -1300,7 +1307,9 @@ mod tests {
 /// [`QueryState::single`] or [`QueryState::single_mut`].
 #[derive(Debug)]
 pub enum QuerySingleError {
+    /// No entities fit the query.
     NoEntities(&'static str),
+    /// Multiple entities fit the query.
     MultipleEntities(&'static str),
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1361,7 +1361,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> IntoIterator for &'w mut Quer
 #[derive(Debug, PartialEq, Eq)]
 pub enum QueryComponentError {
     /// The [`Query`] does not have read access to the requested component.
-    /// 
+    ///
     /// This error occurs when the requested component is not included in the original query.
     ///
     /// # Example
@@ -1388,7 +1388,7 @@ pub enum QueryComponentError {
     /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
     MissingReadAccess,
     /// The [`Query`] does not have write access to the requested component.
-    /// 
+    ///
     /// This error occurs when the requested component is not included in the original query, or the mutability of the requested component is mismatched with the original query.
     ///
     /// # Example

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1389,6 +1389,8 @@ pub enum QueryComponentError {
     MissingReadAccess,
     /// The [`Query`] does not have write access to the requested component.
     /// 
+    /// This error occurs when the requested component is not included in the original query, or the mutability of the requested component is mismatched with the original query.
+    ///
     /// # Example
     ///
     /// ```

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1054,7 +1054,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// Returns a mutable reference to the component `T` of the given entity.
     ///
-    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryComponentError`] is returned instead.
     ///
     /// # Example
     ///
@@ -1090,7 +1090,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// Returns a mutable reference to the component `T` of the given entity.
     ///
-    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
+    /// In case of a nonexisting entity or mismatched component, a [`QueryComponentError`] is returned instead.
     ///
     /// # Safety
     ///
@@ -1357,12 +1357,59 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> IntoIterator for &'w mut Quer
     }
 }
 
-/// An error that occurs when retrieving a specific [`Entity`]'s component from a [`Query`]
+/// An error that occurs when retrieving a specific [`Entity`]'s component from a [`Query`].
 #[derive(Debug, PartialEq, Eq)]
 pub enum QueryComponentError {
+    /// The [`Query`] does not have read access to the requested component.
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, system::QueryComponentError};
+    /// #
+    /// # #[derive(Component)]
+    /// # struct OtherComponent;
+    /// #
+    /// # #[derive(Component)]
+    /// # struct RequestedComponent;
+    /// #
+    /// # #[derive(Resource)]
+    /// # struct SpecificEntity {
+    /// #     entity: Entity,
+    /// # }
+    /// #
+    /// fn get_missing_read_access_error(query: Query<&OtherComponent>, res: Res<SpecificEntity>) {
+    ///     if let Err(QueryComponentError::MissingReadAccess) = query.get_component::<RequestedComponent>(res.entity) {
+    ///         println!("query doesn't have read access to RequestedComponent");
+    ///     }
+    /// }
+    /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
     MissingReadAccess,
+    /// The [`Query`] does not have write access to the requested component.
+    /// 
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, system::QueryComponentError};
+    /// #
+    /// # #[derive(Component)]
+    /// # struct RequestedComponent;
+    /// #
+    /// # #[derive(Resource)]
+    /// # struct SpecificEntity {
+    /// #     entity: Entity,
+    /// # }
+    /// #
+    /// fn get_missing_write_access_error(mut query: Query<&RequestedComponent>, res: Res<SpecificEntity>) {
+    ///     if let Err(QueryComponentError::MissingWriteAccess) = query.get_component_mut::<RequestedComponent>(res.entity) {
+    ///         println!("query doesn't have write access to RequestedComponent");
+    ///     }
+    /// }
+    /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
     MissingWriteAccess,
+    /// The given [`Entity`] does not have the requested component.
     MissingComponent,
+    /// The requested [`Entity`] does not exist.
     NoSuchEntity,
 }
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1362,6 +1362,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> IntoIterator for &'w mut Quer
 pub enum QueryComponentError {
     /// The [`Query`] does not have read access to the requested component.
     /// 
+    /// This error occurs when the requested component is not included in the original query.
+    ///
     /// # Example
     ///
     /// ```

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1386,6 +1386,7 @@ pub enum QueryComponentError {
     ///     }
     /// }
     /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
+    /// ```
     MissingReadAccess,
     /// The [`Query`] does not have write access to the requested component.
     ///
@@ -1409,7 +1410,8 @@ pub enum QueryComponentError {
     ///         println!("query doesn't have write access to RequestedComponent");
     ///     }
     /// }
-    /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
+    /// # bevy_ecs::system::assert_is_system(get_missing_write_access_error);
+    /// ```
     MissingWriteAccess,
     /// The given [`Entity`] does not have the requested component.
     MissingComponent,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1372,7 +1372,7 @@ pub enum QueryComponentError {
     /// # #[derive(Component)]
     /// # struct OtherComponent;
     /// #
-    /// # #[derive(Component)]
+    /// # #[derive(Component, PartialEq, Debug)]
     /// # struct RequestedComponent;
     /// #
     /// # #[derive(Resource)]
@@ -1381,9 +1381,11 @@ pub enum QueryComponentError {
     /// # }
     /// #
     /// fn get_missing_read_access_error(query: Query<&OtherComponent>, res: Res<SpecificEntity>) {
-    ///     if let Err(QueryComponentError::MissingReadAccess) = query.get_component::<RequestedComponent>(res.entity) {
-    ///         println!("query doesn't have read access to RequestedComponent");
-    ///     }
+    ///     assert_eq!(
+    ///         query.get_component::<RequestedComponent>(res.entity),
+    ///         Err(QueryComponentError::MissingReadAccess),
+    ///     );
+    ///     println!("query doesn't have read access to RequestedComponent because it does not appear in Query<&OtherComponent>");
     /// }
     /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
     /// ```
@@ -1397,7 +1399,7 @@ pub enum QueryComponentError {
     /// ```
     /// # use bevy_ecs::{prelude::*, system::QueryComponentError};
     /// #
-    /// # #[derive(Component)]
+    /// # #[derive(Component, PartialEq, Debug)]
     /// # struct RequestedComponent;
     /// #
     /// # #[derive(Resource)]
@@ -1406,9 +1408,11 @@ pub enum QueryComponentError {
     /// # }
     /// #
     /// fn get_missing_write_access_error(mut query: Query<&RequestedComponent>, res: Res<SpecificEntity>) {
-    ///     if let Err(QueryComponentError::MissingWriteAccess) = query.get_component_mut::<RequestedComponent>(res.entity) {
-    ///         println!("query doesn't have write access to RequestedComponent");
-    ///     }
+    ///     assert_eq!(
+    ///         query.get_component::<RequestedComponent>(res.entity),
+    ///         Err(QueryComponentError::MissingWriteAccess),
+    ///     );
+    ///     println!("query doesn't have write access to RequestedComponent because it doesn't have &mut in Query<&RequestedComponent>");
     /// }
     /// # bevy_ecs::system::assert_is_system(get_missing_write_access_error);
     /// ```


### PR DESCRIPTION
# Objective

Add documentation to `Query` and `QueryState` errors in bevy_ecs (`QuerySingleError`, `QueryEntityError`, `QueryComponentError`)

## Solution

- Change display message for `QueryEntityError::QueryDoesNotMatch`: this error can also happen when the entity has a component which is filtered out (with `Without<C>`)
- Fix wrong reference in the documentation of `Query::get_component` and `Query::get_component_mut` from `QueryEntityError` to `QueryComponentError`
- Complete the documentation of the three error enum variants.
- Add examples for `QueryComponentError::MissingReadAccess` and `QueryComponentError::MissingWriteAccess`
- Add reference to `QueryState` in `QueryEntityError`'s documentation.

---

## Migration Guide

Expect `QueryEntityError::QueryDoesNotMatch`'s display message to change? Not sure that counts.
