### PR TITLE
bevy_reflect: Consistent `reflect_hash` and `reflect_partial_eq`

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -9,7 +9,7 @@ use std::{
 
 /// Represents a path to an asset in the file system.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, Reflect)]
-#[reflect(Debug, PartialEq, Serialize, Deserialize)]
+#[reflect(Debug, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
     path: Cow<'a, Path>,
     label: Option<Cow<'a, str>>,

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -9,7 +9,7 @@ use std::{
 
 /// Represents a path to an asset in the file system.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, Serialize, Deserialize, Reflect)]
-#[reflect(Debug, PartialEq, Hash, Serialize, Deserialize)]
+#[reflect(Debug, PartialEq, Serialize, Deserialize)]
 pub struct AssetPath<'a> {
     path: Cow<'a, Path>,
     label: Option<Cow<'a, str>>,

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -25,7 +25,6 @@ mod node;
 pub use node::FxaaNode;
 
 #[derive(Reflect, Eq, PartialEq, Hash, Clone, Copy)]
-#[reflect(PartialEq)]
 pub enum Sensitivity {
     Low,
     Medium,

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -25,7 +25,7 @@ mod node;
 pub use node::FxaaNode;
 
 #[derive(Reflect, Eq, PartialEq, Hash, Clone, Copy)]
-#[reflect(PartialEq, Hash)]
+#[reflect(PartialEq)]
 pub enum Sensitivity {
     Low,
     Medium,

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -15,7 +15,7 @@ use std::ops::Deref;
 /// [`HierarchyQueryExt`]: crate::query_extension::HierarchyQueryExt
 /// [`Query`]: bevy_ecs::system::Query
 #[derive(Component, Debug, Eq, PartialEq, Reflect)]
-#[reflect(Component, MapEntities, PartialEq)]
+#[reflect(Component, MapEntities)]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -73,7 +73,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The `ID` of a gamepad is fixed until the gamepad disconnects or the app is restarted.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -154,7 +154,7 @@ impl Gamepads {
 /// which in turn is used to create the [`Input<GamepadButton>`] or
 /// [`Axis<GamepadButton>`] `bevy` resources.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -219,7 +219,7 @@ pub enum GamepadButtonType {
 ///
 /// The gamepad button resources are updated inside of the [`gamepad_button_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -261,7 +261,7 @@ impl GamepadButton {
 /// [`GamepadAxisChangedEvent`]. It is also used in the [`GamepadAxis`]
 /// which in turn is used to create the [`Axis<GamepadAxis>`] `bevy` resource.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -297,7 +297,7 @@ pub enum GamepadAxisType {
 ///
 /// The gamepad axes resources are updated inside of the [`gamepad_axis_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -73,7 +73,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// The `ID` of a gamepad is fixed until the gamepad disconnects or the app is restarted.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -93,7 +93,7 @@ impl Gamepad {
 
 /// Metadata associated with a [`Gamepad`].
 #[derive(Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -154,7 +154,7 @@ impl Gamepads {
 /// which in turn is used to create the [`Input<GamepadButton>`] or
 /// [`Axis<GamepadButton>`] `bevy` resources.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -219,7 +219,7 @@ pub enum GamepadButtonType {
 ///
 /// The gamepad button resources are updated inside of the [`gamepad_button_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -261,7 +261,7 @@ impl GamepadButton {
 /// [`GamepadAxisChangedEvent`]. It is also used in the [`GamepadAxis`]
 /// which in turn is used to create the [`Axis<GamepadAxis>`] `bevy` resource.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -297,7 +297,7 @@ pub enum GamepadAxisType {
 ///
 /// The gamepad axes resources are updated inside of the [`gamepad_axis_event_system`].
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1026,7 +1026,7 @@ pub fn gamepad_connection_system(
 }
 
 #[derive(Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1040,7 +1040,7 @@ pub enum GamepadConnection {
 /// A Gamepad connection event. Created when a connection to a gamepad
 /// is established and when a gamepad is disconnected.
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1071,7 +1071,7 @@ impl GamepadConnectionEvent {
 }
 
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1096,7 +1096,7 @@ impl GamepadAxisChangedEvent {
 /// Gamepad event for when the "value" (amount of pressure) on the button
 /// changes by an amount larger than the threshold defined in [`GamepadSettings`].
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -1159,7 +1159,7 @@ pub fn gamepad_button_event_system(
 /// [`GamepadButtonChangedEvent`] and [`GamepadAxisChangedEvent`] when
 /// the in-frame relative ordering of events is important.
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -20,7 +20,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -79,7 +79,7 @@ pub fn keyboard_input_system(
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -452,7 +452,7 @@ pub enum KeyCode {
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -79,7 +79,7 @@ pub fn keyboard_input_system(
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -452,7 +452,7 @@ pub enum KeyCode {
 ///
 /// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -141,7 +141,7 @@ impl Plugin for InputPlugin {
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -141,7 +141,7 @@ impl Plugin for InputPlugin {
 
 /// The current "press" state of an element
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -20,7 +20,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -46,7 +46,7 @@ pub struct MouseButtonInput {
 ///
 /// The resource is updated inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system).
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -73,7 +73,7 @@ pub enum MouseButton {
 ///
 /// [`DeviceEvent::MouseMotion`]: https://docs.rs/winit/latest/winit/event/enum.DeviceEvent.html#variant.MouseMotion
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -91,7 +91,7 @@ pub struct MouseMotion {
 /// The value of the event can either be interpreted as the amount of lines or the amount of pixels
 /// to scroll.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -114,7 +114,7 @@ pub enum MouseScrollUnit {
 ///
 /// This event is the translated version of the `WindowEvent::MouseWheel` from the `winit` crate.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -46,7 +46,7 @@ pub struct MouseButtonInput {
 ///
 /// The resource is updated inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system).
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -99,7 +99,7 @@ pub enum ForceTouch {
 /// or that a finger has moved. There is also a canceled phase that indicates that
 /// the system canceled the tracking of the finger.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -31,7 +31,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// This event is the translated version of the `WindowEvent::Touch` from the `winit` crate.
 /// It is available to the end user and can be used for game logic.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -53,7 +53,7 @@ pub struct TouchInput {
 
 /// A force description of a [`Touch`](crate::touch::Touch) input.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -99,7 +99,7 @@ pub enum ForceTouch {
 /// or that a finger has moved. There is also a canceled phase that indicates that
 /// the system canceled the tracking of the finger.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -13,7 +13,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -30,7 +30,7 @@ pub struct TouchpadMagnify(pub f32);
 ///
 /// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -139,7 +139,7 @@ impl FromReflectAttrs {
 /// // `Hash` is a "special trait" and does not need (nor have) a ReflectHash struct
 ///
 /// #[derive(Reflect, Hash)]
-/// #[reflect(Hash)]
+/// #[reflect_value(Hash)]
 /// struct Foo;
 /// ```
 ///
@@ -154,7 +154,7 @@ impl FromReflectAttrs {
 ///
 /// #[derive(Reflect)]
 /// // Register the custom `Hash` function
-/// #[reflect(Hash(get_hash))]
+/// #[reflect_value(Hash(get_hash))]
 /// struct Foo;
 /// ```
 ///
@@ -178,7 +178,7 @@ impl ReflectTraits {
         let mut traits = ReflectTraits::default();
         for meta in &metas {
             match meta {
-                // Handles `#[reflect( Hash, Default, ... )]`
+                // Handles `#[reflect( Default, ... )]`
                 Meta::Path(path) => {
                     // Get the first ident in the path (hopefully the path only contains one and not `std::hash::Hash`)
                     let Some(segment) = path.segments.iter().next() else {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -35,9 +35,9 @@ pub(crate) enum ReflectDerive<'a> {
 ///
 /// ```ignore
 /// #[derive(Reflect)]
-/// //                          traits
-/// //        |----------------------------------------|
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// //                    traits
+/// //        |-----------------------------|
+/// #[reflect(Serialize, Deserialize, Default)]
 /// //            type_name       generics
 /// //     |-------------------||----------|
 /// struct ThingThatImReflecting<T1, T2, T3> {/* ... */}
@@ -60,7 +60,7 @@ pub(crate) struct ReflectMeta<'a> {
 ///
 /// ```ignore
 /// #[derive(Reflect)]
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// #[reflect(Serialize, Deserialize, Default)]
 /// struct ThingThatImReflecting<T1, T2, T3> {
 ///     x: T1, // |
 ///     y: T2, // |- fields
@@ -80,7 +80,7 @@ pub(crate) struct ReflectStruct<'a> {
 ///
 /// ```ignore
 /// #[derive(Reflect)]
-/// #[reflect(PartialEq, Serialize, Deserialize, Default)]
+/// #[reflect(Serialize, Deserialize, Default)]
 /// enum ThingThatImReflecting<T1, T2, T3> {
 ///     A(T1),                  // |
 ///     B,                      // |- variants

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -12,6 +12,7 @@ use syn::{Attribute, Expr, ExprLit, Lit, Meta};
 pub(crate) static IGNORE_SERIALIZATION_ATTR: &str = "skip_serializing";
 pub(crate) static IGNORE_ALL_ATTR: &str = "ignore";
 pub(crate) static SKIP_HASH_ATTR: &str = "skip_hash";
+pub(crate) static SKIP_PARTIAL_EQ_ATTR: &str = "skip_partial_eq";
 
 pub(crate) static DEFAULT_ATTR: &str = "default";
 
@@ -55,6 +56,8 @@ pub(crate) struct ReflectFieldAttr {
     pub default: DefaultBehavior,
     /// Determines if this field should be skipped when hashing.
     pub skip_hash: bool,
+    /// Determines if this field should be skipped when comparing for equality.
+    pub skip_partial_eq: bool,
 }
 
 /// Controls how the default value is determined for a field.
@@ -116,6 +119,10 @@ fn parse_meta(args: &mut ReflectFieldAttr, meta: &Meta) -> Result<(), syn::Error
         }
         Meta::Path(path) if path.is_ident(SKIP_HASH_ATTR) => {
             args.skip_hash = true;
+            Ok(())
+        }
+        Meta::Path(path) if path.is_ident(SKIP_PARTIAL_EQ_ATTR) => {
+            args.skip_partial_eq = true;
             Ok(())
         }
         Meta::Path(path) => Err(syn::Error::new(

--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -11,6 +11,7 @@ use syn::{Attribute, Expr, ExprLit, Lit, Meta};
 
 pub(crate) static IGNORE_SERIALIZATION_ATTR: &str = "skip_serializing";
 pub(crate) static IGNORE_ALL_ATTR: &str = "ignore";
+pub(crate) static SKIP_HASH_ATTR: &str = "skip_hash";
 
 pub(crate) static DEFAULT_ATTR: &str = "default";
 
@@ -52,6 +53,8 @@ pub(crate) struct ReflectFieldAttr {
     pub ignore: ReflectIgnoreBehavior,
     /// Sets the default behavior of this field.
     pub default: DefaultBehavior,
+    /// Determines if this field should be skipped when hashing.
+    pub skip_hash: bool,
 }
 
 /// Controls how the default value is determined for a field.
@@ -109,6 +112,10 @@ fn parse_meta(args: &mut ReflectFieldAttr, meta: &Meta) -> Result<(), syn::Error
         }
         Meta::Path(path) if path.is_ident(DEFAULT_ATTR) => {
             args.default = DefaultBehavior::Default;
+            Ok(())
+        }
+        Meta::Path(path) if path.is_ident(SKIP_HASH_ATTR) => {
+            args.skip_hash = true;
             Ok(())
         }
         Meta::Path(path) => Err(syn::Error::new(

--- a/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/fq_std.rs
@@ -37,6 +37,7 @@ pub(crate) struct FQAny;
 pub(crate) struct FQBox;
 pub(crate) struct FQClone;
 pub(crate) struct FQDefault;
+pub(crate) struct FQHash;
 pub(crate) struct FQOption;
 pub(crate) struct FQResult;
 pub(crate) struct FQSend;
@@ -63,6 +64,12 @@ impl ToTokens for FQClone {
 impl ToTokens for FQDefault {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         quote!(::core::default::Default).to_tokens(tokens);
+    }
+}
+
+impl ToTokens for FQHash {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        quote!(::core::hash::Hash).to_tokens(tokens);
     }
 }
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -36,17 +36,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
 
     let debug_fn = reflect_enum.meta().traits().get_debug_impl();
     let hash_fn = reflect_enum.get_hash_impl();
-    let partial_eq_fn = reflect_enum
-        .meta()
-        .traits()
-        .get_partial_eq_impl(bevy_reflect_path)
-        .unwrap_or_else(|| {
-            quote! {
-                fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> #FQOption<bool> {
-                    #bevy_reflect_path::enum_partial_eq(self, value)
-                }
-            }
-        });
+    let partial_eq_fn = reflect_enum.get_partial_eq_impl();
 
     let typed_impl = impl_typed(
         reflect_enum.meta(),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -329,10 +329,10 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
         }
 
         let mut push_variant =
-            |variant: &EnumVariant, info_args: proc_macro2::TokenStream, field_len: usize| {
+            |_variant: &EnumVariant, info_args: proc_macro2::TokenStream, field_len: usize| {
                 #[cfg(feature = "documentation")]
                 let doc_field = {
-                    let doc = &variant.doc;
+                    let doc = &_variant.doc;
                     quote! {
                         docs: #doc
                     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -58,31 +58,10 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             }
         });
 
-    let string_name = enum_path.get_ident().unwrap().to_string();
-
-    #[cfg(feature = "documentation")]
-    let info_generator = {
-        let doc = reflect_enum.meta().doc();
-        quote! {
-            #bevy_reflect_path::EnumInfo::new::<Self>(#string_name, &variants).with_docs(#doc)
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let info_generator = {
-        quote! {
-            #bevy_reflect_path::EnumInfo::new::<Self>(#string_name, &variants)
-        }
-    };
-
     let typed_impl = impl_typed(
         reflect_enum.meta(),
         &where_clause_options,
-        quote! {
-            let variants = [#(#variant_info),*];
-            let info = #info_generator;
-            #bevy_reflect_path::TypeInfo::Enum(info)
-        },
+        reflect_enum.to_type_info(variant_info),
     );
 
     let type_path_impl = impl_type_path(reflect_enum.meta(), &where_clause_options);
@@ -342,9 +321,9 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
             #unit{..} => #variant_index
         });
 
-        fn get_field_args(
+        fn get_field_infos(
             fields: &[StructField],
-            mut generate_for_field: impl FnMut(usize, usize, &StructField) -> proc_macro2::TokenStream,
+            mut generate_info: impl FnMut(usize, usize, &StructField) -> proc_macro2::TokenStream,
         ) -> Vec<proc_macro2::TokenStream> {
             let mut constructor_argument = Vec::new();
             let mut reflect_idx = 0;
@@ -353,26 +332,35 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                     // Ignored field
                     continue;
                 }
-                constructor_argument.push(generate_for_field(reflect_idx, field.index, field));
+                constructor_argument.push(generate_info(reflect_idx, field.index, field));
                 reflect_idx += 1;
             }
             constructor_argument
         }
 
         let mut push_variant =
-            |_variant: &EnumVariant, arguments: proc_macro2::TokenStream, field_len: usize| {
+            |variant: &EnumVariant, info_args: proc_macro2::TokenStream, field_len: usize| {
                 #[cfg(feature = "documentation")]
-                let with_docs = {
-                    let doc = quote::ToTokens::to_token_stream(&_variant.doc);
-                    Some(quote!(.with_docs(#doc)))
+                let doc_field = {
+                    let doc = &variant.doc;
+                    quote! {
+                        docs: #doc
+                    }
                 };
+
                 #[cfg(not(feature = "documentation"))]
-                let with_docs: Option<proc_macro2::TokenStream> = None;
+                let doc_field = proc_macro2::TokenStream::new();
+
+                let meta = quote! {
+                    #bevy_reflect_path::VariantMeta {
+                        #doc_field
+                    }
+                };
 
                 variant_info.push(quote! {
                     #bevy_reflect_path::VariantInfo::#variant_type_ident(
-                        #bevy_reflect_path::#variant_info_ident::new(#arguments)
-                        #with_docs
+                        #bevy_reflect_path::#variant_info_ident::new(#info_args)
+                            .with_meta(#meta)
                     )
                 });
                 enum_field_len.push(quote! {
@@ -388,32 +376,20 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                 push_variant(variant, quote!(#name), 0);
             }
             EnumVariantFields::Unnamed(fields) => {
-                let args = get_field_args(fields, |reflect_idx, declaration_index, field| {
+                let args = get_field_infos(fields, |reflect_idx, declaration_index, field| {
                     let declare_field = syn::Index::from(declaration_index);
                     enum_field_at.push(quote! {
                         #unit { #declare_field : value, .. } if #ref_index == #reflect_idx => #FQOption::Some(value)
                     });
 
-                    #[cfg(feature = "documentation")]
-                    let with_docs = {
-                        let doc = quote::ToTokens::to_token_stream(&field.doc);
-                        Some(quote!(.with_docs(#doc)))
-                    };
-                    #[cfg(not(feature = "documentation"))]
-                    let with_docs: Option<proc_macro2::TokenStream> = None;
-
-                    let field_ty = &field.data.ty;
-                    quote! {
-                        #bevy_reflect_path::UnnamedField::new::<#field_ty>(#reflect_idx)
-                        #with_docs
-                    }
+                    field.to_field_info(bevy_reflect_path)
                 });
 
                 let field_len = args.len();
                 push_variant(variant, quote!(#name, &[ #(#args),* ]), field_len);
             }
             EnumVariantFields::Named(fields) => {
-                let args = get_field_args(fields, |reflect_idx, _, field| {
+                let args = get_field_infos(fields, |reflect_idx, _, field| {
                     let field_ident = field.data.ident.as_ref().unwrap();
                     let field_name = field_ident.to_string();
                     enum_field.push(quote! {
@@ -429,19 +405,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         #unit{ .. } if #ref_index == #reflect_idx => #FQOption::Some(#field_name)
                     });
 
-                    #[cfg(feature = "documentation")]
-                    let with_docs = {
-                        let doc = quote::ToTokens::to_token_stream(&field.doc);
-                        Some(quote!(.with_docs(#doc)))
-                    };
-                    #[cfg(not(feature = "documentation"))]
-                    let with_docs: Option<proc_macro2::TokenStream> = None;
-
-                    let field_ty = &field.data.ty;
-                    quote! {
-                        #bevy_reflect_path::NamedField::new::<#field_ty>(#field_name)
-                        #with_docs
-                    }
+                    field.to_field_info(bevy_reflect_path)
                 });
 
                 let field_len = args.len();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -34,18 +34,8 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         variant_constructors,
     } = get_variant_constructors(reflect_enum, &ref_value, true);
 
-    let hash_fn = reflect_enum
-        .meta()
-        .traits()
-        .get_hash_impl(bevy_reflect_path)
-        .unwrap_or_else(|| {
-            quote! {
-                fn reflect_hash(&self) -> #FQOption<u64> {
-                    #bevy_reflect_path::enum_hash(self)
-                }
-            }
-        });
     let debug_fn = reflect_enum.meta().traits().get_debug_impl();
+    let hash_fn = reflect_enum.get_hash_impl();
     let partial_eq_fn = reflect_enum
         .meta()
         .traits()

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -26,7 +26,6 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         .active_fields()
         .map(|field| ident_or_index(field.data.ident.as_ref(), field.index))
         .collect::<Vec<_>>();
-    let field_types = reflect_struct.active_types();
     let field_count = field_idents.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
 
@@ -46,49 +45,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             }
         });
 
-    #[cfg(feature = "documentation")]
-    let field_generator = {
-        let docs = reflect_struct
-            .active_fields()
-            .map(|field| quote::ToTokens::to_token_stream(&field.doc));
-        quote! {
-            #(#bevy_reflect_path::NamedField::new::<#field_types>(#field_names).with_docs(#docs) ,)*
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let field_generator = {
-        quote! {
-            #(#bevy_reflect_path::NamedField::new::<#field_types>(#field_names) ,)*
-        }
-    };
-
-    let string_name = struct_path.get_ident().unwrap().to_string();
-
-    #[cfg(feature = "documentation")]
-    let info_generator = {
-        let doc = reflect_struct.meta().doc();
-        quote! {
-            #bevy_reflect_path::StructInfo::new::<Self>(#string_name, &fields).with_docs(#doc)
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let info_generator = {
-        quote! {
-            #bevy_reflect_path::StructInfo::new::<Self>(#string_name, &fields)
-        }
-    };
-
     let where_clause_options = reflect_struct.where_clause_options();
     let typed_impl = impl_typed(
         reflect_struct.meta(),
         &where_clause_options,
-        quote! {
-            let fields = [#field_generator];
-            let info = #info_generator;
-            #bevy_reflect_path::TypeInfo::Struct(info)
-        },
+        reflect_struct.to_type_info(),
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta(), &where_clause_options);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -32,16 +32,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     let debug_fn = reflect_struct.meta().traits().get_debug_impl();
 
     let hash_fn = reflect_struct.get_hash_impl();
-    let partial_eq_fn = reflect_struct.meta()
-        .traits()
-        .get_partial_eq_impl(bevy_reflect_path)
-        .unwrap_or_else(|| {
-            quote! {
-                fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> #FQOption<bool> {
-                    #bevy_reflect_path::struct_partial_eq(self, value)
-                }
-            }
-        });
+    let partial_eq_fn = reflect_struct.get_partial_eq_impl();
 
     let where_clause_options = reflect_struct.where_clause_options();
     let typed_impl = impl_typed(

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -29,11 +29,9 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
     let field_count = field_idents.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
 
-    let hash_fn = reflect_struct
-        .meta()
-        .traits()
-        .get_hash_impl(bevy_reflect_path);
     let debug_fn = reflect_struct.meta().traits().get_debug_impl();
+
+    let hash_fn = reflect_struct.get_hash_impl();
     let partial_eq_fn = reflect_struct.meta()
         .traits()
         .get_partial_eq_impl(bevy_reflect_path)

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -24,17 +24,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
 
     let debug_fn = reflect_struct.meta().traits().get_debug_impl();
     let hash_fn = reflect_struct.get_hash_impl();
-    let partial_eq_fn = reflect_struct
-        .meta()
-        .traits()
-        .get_partial_eq_impl(bevy_reflect_path)
-        .unwrap_or_else(|| {
-            quote! {
-                fn reflect_partial_eq(&self, value: &dyn #bevy_reflect_path::Reflect) -> #FQOption<bool> {
-                    #bevy_reflect_path::tuple_struct_partial_eq(self, value)
-                }
-            }
-        });
+    let partial_eq_fn = reflect_struct.get_partial_eq_impl();
 
     let typed_impl = impl_typed(
         reflect_struct.meta(),

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -22,11 +22,8 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
     let where_clause_options = reflect_struct.where_clause_options();
     let get_type_registration_impl = reflect_struct.get_type_registration(&where_clause_options);
 
-    let hash_fn = reflect_struct
-        .meta()
-        .traits()
-        .get_hash_impl(bevy_reflect_path);
     let debug_fn = reflect_struct.meta().traits().get_debug_impl();
+    let hash_fn = reflect_struct.get_hash_impl();
     let partial_eq_fn = reflect_struct
         .meta()
         .traits()

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -13,23 +13,9 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
     let partial_eq_fn = meta.traits().get_partial_eq_impl(bevy_reflect_path);
     let debug_fn = meta.traits().get_debug_impl();
 
-    #[cfg(feature = "documentation")]
-    let with_docs = {
-        let doc = quote::ToTokens::to_token_stream(meta.doc());
-        Some(quote!(.with_docs(#doc)))
-    };
-    #[cfg(not(feature = "documentation"))]
-    let with_docs: Option<proc_macro2::TokenStream> = None;
-
     let where_clause_options = WhereClauseOptions::new_value(meta);
-    let typed_impl = impl_typed(
-        meta,
-        &where_clause_options,
-        quote! {
-            let info = #bevy_reflect_path::ValueInfo::new::<Self>() #with_docs;
-            #bevy_reflect_path::TypeInfo::Value(info)
-        },
-    );
+
+    let typed_impl = impl_typed(meta, &where_clause_options, meta.to_type_info());
 
     let type_path_impl = impl_type_path(meta, &where_clause_options);
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -422,7 +422,7 @@ pub fn impl_reflect_value(input: TokenStream) -> TokenStream {
 /// use bevy::prelude::Vec3;
 ///
 /// impl_reflect_struct!(
-///     #[reflect(PartialEq, Serialize, Deserialize, Default)]
+///     #[reflect(Serialize, Deserialize, Default)]
 ///     #[type_path = "bevy::prelude"]
 ///     struct Vec3 {
 ///         x: f32,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -157,11 +157,24 @@ pub(crate) static TYPE_NAME_ATTRIBUTE_NAME: &str = "type_name";
 ///
 /// This attribute excludes the field from the hash computation in `Reflect::reflect_hash`.
 ///
+/// It's recommended that when using this attribute, the `#[reflect(skip_partial_eq)]` attribute also be used.
+/// This is to uphold the following [property]:
+/// ```text
+/// a.reflect_partial_eq(b) -> a.reflect_hash() == b.reflect_hash()
+/// ```
+///
 /// ## `#[reflect(skip_partial_eq)]`
 ///
 /// This attribute excludes the field from comparison in `Reflect::reflect_partial_eq`.
 ///
+/// It's recommended that when using this attribute, the `#[reflect(skip_hash)]` attribute also be used.
+/// This is to uphold the following [property]:
+/// ```text
+/// a.reflect_partial_eq(b) -> a.reflect_hash() == b.reflect_hash()
+/// ```
+///
 /// [`reflect_trait`]: macro@reflect_trait
+/// [property]: https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq
 #[proc_macro_derive(Reflect, attributes(reflect, reflect_value, type_path, type_name))]
 pub fn derive_reflect(input: TokenStream) -> TokenStream {
     let ast = parse_macro_input!(input as DeriveInput);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -92,15 +92,17 @@ pub(crate) static TYPE_NAME_ATTRIBUTE_NAME: &str = "type_name";
 ///   A custom implementation may be provided using `#[reflect(Debug(my_debug_func))]` where
 ///   `my_debug_func` is the path to a function matching the signature:
 ///   `(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result`.
-/// * `#[reflect(PartialEq)]` will force the implementation of `Reflect::reflect_partial_eq` to rely on
+/// * `#[reflect_value(PartialEq)]` will force the implementation of `Reflect::reflect_partial_eq` to rely on
 ///   the type's [`PartialEq`] implementation.
-///   A custom implementation may be provided using `#[reflect(PartialEq(my_partial_eq_func))]` where
+///   A custom implementation may be provided using `#[reflect_value(PartialEq(my_partial_eq_func))]` where
 ///   `my_partial_eq_func` is the path to a function matching the signature:
 ///   `(&self, value: &dyn #bevy_reflect_path::Reflect) -> bool`.
-/// * `#[reflect(Hash)]` will force the implementation of `Reflect::reflect_hash` to rely on
+///   This may only be used for values derived with the `#[reflect_value]` attribute.
+/// * `#[reflect_value(Hash)]` will force the implementation of `Reflect::reflect_hash` to rely on
 ///   the type's [`Hash`] implementation.
-///   A custom implementation may be provided using `#[reflect(Hash(my_hash_func))]` where
+///   A custom implementation may be provided using `#[reflect_value(Hash(my_hash_func))]` where
 ///   `my_hash_func` is the path to a function matching the signature: `(&self) -> u64`.
+///   This may only be used for values derived with the `#[reflect_value]` attribute.
 /// * `#[reflect(Default)]` will register the `ReflectDefault` type data as normal.
 ///   However, it will also affect how certain other operations are performed in order
 ///   to improve performance and/or robustness.
@@ -150,6 +152,14 @@ pub(crate) static TYPE_NAME_ATTRIBUTE_NAME: &str = "type_name";
 ///
 /// What this does is register the `SerializationData` type within the `GetTypeRegistration` implementation,
 /// which will be used by the reflection serializers to determine whether or not the field is serializable.
+///
+/// ## `#[reflect(skip_hash)]`
+///
+/// This attribute excludes the field from the hash computation in `Reflect::reflect_hash`.
+///
+/// ## `#[reflect(skip_partial_eq)]`
+///
+/// This attribute excludes the field from comparison in `Reflect::reflect_partial_eq`.
 ///
 /// [`reflect_trait`]: macro@reflect_trait
 #[proc_macro_derive(Reflect, attributes(reflect, reflect_value, type_path, type_name))]

--- a/crates/bevy_reflect/examples/reflect_docs.rs
+++ b/crates/bevy_reflect/examples/reflect_docs.rs
@@ -43,7 +43,7 @@ fn main() {
     if let TypeInfo::Struct(struct_info) = player_info {
         for field in struct_info.iter() {
             let field_name = field.name();
-            let field_docs = field.docs().unwrap_or("<NO_DOCUMENTATION>");
+            let field_docs = field.meta().docs.unwrap_or("<NO_DOCUMENTATION>");
             println!("-----[ Player::{field_name} ]-----\n{field_docs}");
         }
     }

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -82,8 +82,7 @@ pub struct ArrayInfo {
     item_type_name: &'static str,
     item_type_id: TypeId,
     capacity: usize,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: ArrayMeta,
 }
 
 impl ArrayInfo {
@@ -100,15 +99,13 @@ impl ArrayInfo {
             item_type_name: std::any::type_name::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
             capacity,
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: ArrayMeta::new(),
         }
     }
 
-    /// Sets the docstring for this array.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this array.
+    pub fn with_meta(self, meta: ArrayMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The compile-time capacity of the array.
@@ -126,6 +123,11 @@ impl ArrayInfo {
     /// The [`TypeId`] of the array.
     pub fn type_id(&self) -> TypeId {
         self.type_id
+    }
+
+    /// The metadata of the array.
+    pub fn meta(&self) -> &ArrayMeta {
+        &self.meta
     }
 
     /// Check if the given type matches the array type.
@@ -149,11 +151,30 @@ impl ArrayInfo {
     pub fn item_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.item_type_id
     }
+}
 
+/// Metadata for [arrays], accessed via [`ArrayInfo::meta`].
+///
+/// [arrays]: Array
+#[derive(Clone, Debug)]
+pub struct ArrayMeta {
     /// The docstring of this array, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl ArrayMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for ArrayMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -454,17 +454,19 @@ pub fn array_apply<A: Array>(array: &mut A, reflect: &dyn Reflect) {
 ///
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
-pub fn array_partial_eq<A: Array>(array: &A, reflect: &dyn Reflect) -> Option<bool> {
-    match reflect.reflect_ref() {
-        ReflectRef::Array(reflect_array) if reflect_array.len() == array.len() => {
-            for (a, b) in array.iter().zip(reflect_array.iter()) {
-                let eq_result = a.reflect_partial_eq(b);
-                if let failed @ (Some(false) | None) = eq_result {
-                    return failed;
-                }
-            }
+pub fn array_partial_eq<A: Array>(a: &A, b: &dyn Reflect) -> Option<bool> {
+    let ReflectRef::Array(b) = b.reflect_ref()  else {
+        return Some(false);
+    };
+
+    if a.len() != b.len() {
+        return Some(false);
+    }
+
+    for (value_a, value_b) in a.iter().zip(b.iter()) {
+        if !value_a.reflect_partial_eq(value_b)? {
+            return Some(false);
         }
-        _ => return Some(false),
     }
 
     Some(true)

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -139,8 +139,7 @@ pub struct EnumInfo {
     variants: Box<[VariantInfo]>,
     variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: EnumMeta,
 }
 
 impl EnumInfo {
@@ -167,15 +166,13 @@ impl EnumInfo {
             variants: variants.to_vec().into_boxed_slice(),
             variant_names,
             variant_indices,
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: EnumMeta::new(),
         }
     }
 
-    /// Sets the docstring for this enum.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this enum.
+    pub fn with_meta(self, meta: EnumMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// A slice containing the names of all variants in order.
@@ -243,15 +240,36 @@ impl EnumInfo {
         self.type_id
     }
 
+    /// The metadata of the enum.
+    pub fn meta(&self) -> &EnumMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the enum type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
+#[derive(Clone, Debug)]
+pub struct EnumMeta {
     /// The docstring of this enum, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl EnumMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for EnumMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/enums/helpers.rs
+++ b/crates/bevy_reflect/src/enums/helpers.rs
@@ -1,3 +1,6 @@
+use crate::equality_utility::{
+    compare_structs, compare_tuple_structs, extract_info, get_type_info_pair,
+};
 use crate::utility::reflect_hasher;
 use crate::{Enum, Reflect, ReflectRef, TypeInfo, VariantInfo, VariantType};
 use std::any::TypeId;
@@ -67,62 +70,52 @@ pub fn enum_hash<TEnum: Enum>(value: &TEnum) -> Option<u64> {
 
 /// Compares an [`Enum`] with a [`Reflect`] value.
 ///
-/// Returns true if and only if all of the following are true:
+/// Returns `Some(true)` if and only if all of the following are true:
 /// - `b` is an enum;
 /// - `b` is the same variant as `a`;
 /// - For each field in `a`, `b` contains a field with the same name and
 ///   [`Reflect::reflect_partial_eq`] returns `Some(true)` for the two field
-///   values.
+///   values[^1]
+///
+/// Returns `None` if the comparison cannot be performed.
+///
+/// [^1]: If a field is marked with `#[reflect(skip_partial_eq)]`, then it will be skipped
+///       unless the corresponding field in `b` is not marked with `#[reflect(skip_partial_eq)]`,
+///       in which case the comparison will return `Some(false)`.
 #[inline]
 pub fn enum_partial_eq<TEnum: Enum>(a: &TEnum, b: &dyn Reflect) -> Option<bool> {
-    // Both enums?
-    let ReflectRef::Enum(b) = b.reflect_ref() else {
+    let ReflectRef::Enum(b) = b.reflect_ref()  else {
         return Some(false);
     };
 
-    // Same variant name?
     if a.variant_name() != b.variant_name() {
         return Some(false);
     }
 
-    // Same variant type?
     if !a.is_variant(b.variant_type()) {
         return Some(false);
     }
 
+    let variant_name = a.variant_name();
+
+    let (info_a, info_b) = get_type_info_pair(a.as_reflect(), b.as_reflect());
+    let info_a = extract_info!(info_a, TypeInfo::Enum(info) => info.variant(variant_name));
+    let info_b = extract_info!(info_b, TypeInfo::Enum(info) => info.variant(variant_name));
+
     match a.variant_type() {
         VariantType::Struct => {
-            // Same struct fields?
-            for field in a.iter_fields() {
-                let field_name = field.name().unwrap();
-                if let Some(field_value) = b.field(field_name) {
-                    if let Some(false) | None = field_value.reflect_partial_eq(field.value()) {
-                        // Fields failed comparison
-                        return Some(false);
-                    }
-                } else {
-                    // Field does not exist
-                    return Some(false);
-                }
-            }
-            Some(true)
+            let info_a = extract_info!(info_a, VariantInfo::Struct(info) => Some(info));
+            let info_b = extract_info!(info_b, VariantInfo::Struct(info) => Some(info));
+
+            compare_structs!(a, b, info_a, info_b, accessor=.value)
         }
         VariantType::Tuple => {
-            // Same tuple fields?
-            for (i, field) in a.iter_fields().enumerate() {
-                if let Some(field_value) = b.field_at(i) {
-                    if let Some(false) | None = field_value.reflect_partial_eq(field.value()) {
-                        // Fields failed comparison
-                        return Some(false);
-                    }
-                } else {
-                    // Field does not exist
-                    return Some(false);
-                }
-            }
-            Some(true)
+            let info_a = extract_info!(info_a, VariantInfo::Tuple(info) => Some(info));
+            let info_b = extract_info!(info_b, VariantInfo::Tuple(info) => Some(info));
+
+            compare_tuple_structs!(a, b, info_a, info_b, accessor=.field_at)
         }
-        _ => Some(true),
+        VariantType::Unit => Some(true),
     }
 }
 

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -73,13 +73,12 @@ impl VariantInfo {
         }
     }
 
-    /// The docstring of the underlying variant, if any.
-    #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&str> {
+    /// The metadata of the underlying variant.
+    pub fn meta(&self) -> &VariantMeta {
         match self {
-            Self::Struct(info) => info.docs(),
-            Self::Tuple(info) => info.docs(),
-            Self::Unit(info) => info.docs(),
+            Self::Struct(info) => info.meta(),
+            Self::Tuple(info) => info.meta(),
+            Self::Unit(info) => info.meta(),
         }
     }
 }
@@ -91,8 +90,7 @@ pub struct StructVariantInfo {
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: VariantMeta,
 }
 
 impl StructVariantInfo {
@@ -105,15 +103,13 @@ impl StructVariantInfo {
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: VariantMeta::new(),
         }
     }
 
-    /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this variant.
+    pub fn with_meta(self, meta: VariantMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The name of this variant.
@@ -161,10 +157,9 @@ impl StructVariantInfo {
             .collect()
     }
 
-    /// The docstring of this variant, if any.
-    #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    /// The metadata of the variant.
+    pub fn meta(&self) -> &VariantMeta {
+        &self.meta
     }
 }
 
@@ -173,8 +168,7 @@ impl StructVariantInfo {
 pub struct TupleVariantInfo {
     name: &'static str,
     fields: Box<[UnnamedField]>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: VariantMeta,
 }
 
 impl TupleVariantInfo {
@@ -183,15 +177,13 @@ impl TupleVariantInfo {
         Self {
             name,
             fields: fields.to_vec().into_boxed_slice(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: VariantMeta::new(),
         }
     }
 
-    /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this variant.
+    pub fn with_meta(self, meta: VariantMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The name of this variant.
@@ -214,10 +206,9 @@ impl TupleVariantInfo {
         self.fields.len()
     }
 
-    /// The docstring of this variant, if any.
-    #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    /// The metadata of the variant.
+    pub fn meta(&self) -> &VariantMeta {
+        &self.meta
     }
 }
 
@@ -225,8 +216,7 @@ impl TupleVariantInfo {
 #[derive(Clone, Debug)]
 pub struct UnitVariantInfo {
     name: &'static str,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: VariantMeta,
 }
 
 impl UnitVariantInfo {
@@ -234,15 +224,13 @@ impl UnitVariantInfo {
     pub fn new(name: &'static str) -> Self {
         Self {
             name,
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: VariantMeta::new(),
         }
     }
 
-    /// Sets the docstring for this variant.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this variant.
+    pub fn with_meta(self, meta: VariantMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The name of this variant.
@@ -250,9 +238,30 @@ impl UnitVariantInfo {
         self.name
     }
 
+    /// The metadata of the variant.
+    pub fn meta(&self) -> &VariantMeta {
+        &self.meta
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VariantMeta {
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl VariantMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for VariantMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/bevy_reflect/src/equality_utility.rs
+++ b/crates/bevy_reflect/src/equality_utility.rs
@@ -1,0 +1,179 @@
+//! Utilities for performing partial equality checks on [`Reflect`] types.
+
+use crate::{Reflect, TypeInfo};
+
+/// Helper macro for extracting type information for use in [`Reflect::reflect_partial_eq`] implementations.
+///
+/// `$info` is an [`Option<TypeInfo>`] that must match a pattern, `$pat`, and
+/// return expression, `$expr`, with type `Option<T>`.
+///
+/// If `$info` does not match the givn pattern or `None`, the macro performs an early return
+/// with the value `Some(false)`.
+///
+/// [`Option<TypeInfo>`]: TypeInfo
+macro_rules! extract_info {
+    ($info:ident, $pat:pat => $expr:expr) => {{
+        match $info {
+            None => None,
+            Some($pat) => $expr,
+            _ => return Some(false),
+        }
+    }};
+}
+
+/// Helper macro for comparing two struct-like types with [`Reflect::reflect_partial_eq`].
+///
+/// By using a macro, we are able to share logic between standard structs and struct variants.
+macro_rules! compare_structs {
+    ($a:ident, $b:ident, $info_a:ident, $info_b:ident $(, accessor=.$field_accessor:ident)? $(,)?) => {{
+        // By default, we only need to perform a separate check on `$b` if it has
+        // a different number of fields than `$a`.
+        let mut needs_field_check = $a.field_len() != $b.field_len();
+
+        if $info_a.is_none() && $info_b.is_none() {
+            // Both are pure dynamic types, so no fields are skippable
+            if $a.field_len() != $b.field_len() {
+                return Some(false);
+            }
+        }
+
+        for (index, value_a) in $a.iter_fields().enumerate() {
+            let value_a = value_a $(.$field_accessor())?;
+            let field_name = $a.name_at(index)?;
+
+            let field_a = $info_a.and_then(|info| info.field(field_name));
+            let field_b = $info_b.and_then(|info| info.field(field_name));
+            match (field_a, field_b) {
+                (Some(field_a), Some(field_b)) => {
+                    if field_a.meta().skip_partial_eq && field_b.meta().skip_partial_eq {
+                        // Both fields have opted out of partial equality
+                        continue;
+                    }
+
+                    if field_a.meta().skip_partial_eq != field_b.meta().skip_partial_eq {
+                        // Only one of the fields is required for partial equality
+                        return Some(false);
+                    }
+                }
+                (Some(field_info), None) => {
+                    if field_info.meta().skip_partial_eq {
+                        // Field doesn't exist on `$b`, but is skipped by `$a`.
+                        // If the number of fields are the same, we have to check
+                        // if the corresponding field on `$b` is also skipped.
+                        needs_field_check |= $a.field_len() == $b.field_len();
+                        continue;
+                    }
+                }
+                (None, Some(field_info)) => {
+                    if field_info.meta().skip_partial_eq {
+                        // Field exists on `$a` and `$b`, but is skipped by `$b`.
+                        continue;
+                    }
+                }
+                (None, None) => {}
+            }
+
+            let Some(value_b) = $b.field(field_name) else { return Some(false); };
+            let is_equal = value_a.reflect_partial_eq(value_b)?;
+
+            if !is_equal {
+                return Some(false);
+            }
+        }
+
+        // If 1 or more fields are missing from `b`, we need to check that they
+        // are all marked as `skip_partial_eq` so as to preserve symmetry.
+        if needs_field_check {
+            for (index, _) in $b.iter_fields().enumerate() {
+                let field_name = $b.name_at(index)?;
+                if let Some(field_b) = $info_b.and_then(|info| info.field(field_name)) {
+                    if field_b.meta().skip_partial_eq {
+                        continue;
+                    }
+                }
+
+                if $a.field(field_name).is_none() {
+                    return Some(false);
+                }
+            }
+        }
+
+        Some(true)
+    }};
+}
+
+/// Helper macro for comparing two tuple struct-like types with [`Reflect::reflect_partial_eq`].
+///
+/// By using a macro, we are able to share logic between standard tuple structs and tuple variants.
+macro_rules! compare_tuple_structs {
+    ($a:ident, $b:ident, $info_a:ident, $info_b:ident, accessor=.$field_accessor:ident $(,)?) => {{
+        if $info_a.is_none() && $info_b.is_none() {
+            // Both are pure dynamic types, so no fields are skippable
+            if $a.field_len() != $b.field_len() {
+                return Some(false);
+            }
+        }
+
+        let a_len = $a.field_len();
+        let b_len = $b.field_len();
+        let max_len = a_len.max(b_len);
+
+        for index in 0..max_len {
+            let field_a = $info_a.and_then(|info| info.field_at(index));
+            let field_b = $info_b.and_then(|info| info.field_at(index));
+            match (field_a, field_b) {
+                (Some(field_a), Some(field_b)) => {
+                    if field_a.meta().skip_partial_eq && field_b.meta().skip_partial_eq {
+                        // Both fields have opted out of partial equality
+                        continue;
+                    }
+
+                    if field_a.meta().skip_partial_eq != field_b.meta().skip_partial_eq {
+                        // Only one of the fields is required for partial equality
+                        return Some(false);
+                    }
+                }
+                (Some(field_info), None) | (None, Some(field_info)) => {
+                    if field_info.meta().skip_partial_eq {
+                        continue;
+                    }
+                }
+                (None, None) => {}
+            }
+
+            let Some(value_a) = $a.$field_accessor(index) else { return Some(false); };
+            let Some(value_b) = $b.$field_accessor(index) else { return Some(false); };
+            let is_equal = value_a.reflect_partial_eq(value_b)?;
+
+            if !is_equal {
+                return Some(false);
+            }
+        }
+
+        Some(true)
+    }};
+}
+
+pub(crate) use compare_structs;
+pub(crate) use compare_tuple_structs;
+pub(crate) use extract_info;
+
+/// Helper function for returning a tuple of [`Option<TypeInfo>'s`] for two [`Reflect`] values.
+///
+/// This function will try to be smart about when it calls [`Reflect::get_represented_type_info`]
+/// so that it avoids calling the method twice for concrete values of the same type.
+///
+/// [`Option<TypeInfo>'s`]: TypeInfo
+pub(crate) fn get_type_info_pair(
+    a: &dyn Reflect,
+    b: &dyn Reflect,
+) -> (Option<&'static TypeInfo>, Option<&'static TypeInfo>) {
+    let same_concrete_type = a.type_id() == b.type_id() && !a.is_dynamic() && !b.is_dynamic();
+    if same_concrete_type || a.type_name() == b.type_name() {
+        // Fast path for the common case of two concrete/proxy values representing the same type
+        let info = a.get_represented_type_info();
+        return (info, info);
+    }
+
+    (a.get_represented_type_info(), b.get_represented_type_info())
+}

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -118,6 +118,12 @@ pub struct FieldMeta {
     ///
     /// [deriving `Reflect`]: bevy_reflect_derive::Reflect
     pub skip_hash: bool,
+    /// This field should not be used in its container's [`Reflect::reflect_partial_eq`] implementation.
+    ///
+    /// This may be configured when [deriving `Reflect`] by adding `#[reflect(skip_partial_eq)]` to the field.
+    ///
+    /// [deriving `Reflect`]: bevy_reflect_derive::Reflect
+    pub skip_partial_eq: bool,
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
     pub docs: Option<&'static str>,
@@ -127,6 +133,7 @@ impl FieldMeta {
     pub const fn new() -> Self {
         Self {
             skip_hash: false,
+            skip_partial_eq: false,
             #[cfg(feature = "documentation")]
             docs: None,
         }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -112,6 +112,12 @@ impl UnnamedField {
 /// [unnamed]: UnnamedField
 #[derive(Clone, Debug)]
 pub struct FieldMeta {
+    /// This field should not be used in its container's [`Reflect::reflect_hash`] implementation.
+    ///
+    /// This may be configured when [deriving `Reflect`] by adding `#[reflect(skip_hash)]` to the field.
+    ///
+    /// [deriving `Reflect`]: bevy_reflect_derive::Reflect
+    pub skip_hash: bool,
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
     pub docs: Option<&'static str>,
@@ -120,6 +126,7 @@ pub struct FieldMeta {
 impl FieldMeta {
     pub const fn new() -> Self {
         Self {
+            skip_hash: false,
             #[cfg(feature = "documentation")]
             docs: None,
         }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -7,8 +7,7 @@ pub struct NamedField {
     name: &'static str,
     type_name: &'static str,
     type_id: TypeId,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: FieldMeta,
 }
 
 impl NamedField {
@@ -18,15 +17,13 @@ impl NamedField {
             name,
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: FieldMeta::new(),
         }
     }
 
-    /// Sets the docstring for this field.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this field.
+    pub fn with_meta(self, meta: FieldMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The name of the field.
@@ -46,15 +43,14 @@ impl NamedField {
         self.type_id
     }
 
+    /// The metadata of the field.
+    pub fn meta(&self) -> &FieldMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the field type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
-    }
-
-    /// The docstring of this field, if any.
-    #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
     }
 }
 
@@ -64,8 +60,7 @@ pub struct UnnamedField {
     index: usize,
     type_name: &'static str,
     type_id: TypeId,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: FieldMeta,
 }
 
 impl UnnamedField {
@@ -74,15 +69,13 @@ impl UnnamedField {
             index,
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: FieldMeta::new(),
         }
     }
 
-    /// Sets the docstring for this field.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this field.
+    pub fn with_meta(self, meta: FieldMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// Returns the index of the field.
@@ -102,14 +95,39 @@ impl UnnamedField {
         self.type_id
     }
 
+    /// The metadata of the field.
+    pub fn meta(&self) -> &FieldMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the field type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
+/// Metadata for both [named] and [unnamed] fields.
+///
+/// [named]: NamedField
+/// [unnamed]: UnnamedField
+#[derive(Clone, Debug)]
+pub struct FieldMeta {
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl FieldMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for FieldMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -5,7 +5,7 @@ use bevy_reflect_derive::{impl_reflect_struct, impl_reflect_value};
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct IVec2 {
         x: i32,
@@ -13,7 +13,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct IVec3 {
         x: i32,
@@ -22,7 +22,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct IVec4 {
         x: i32,
@@ -33,7 +33,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct UVec2 {
         x: u32,
@@ -41,7 +41,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct UVec3 {
         x: u32,
@@ -50,7 +50,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, Hash, PartialEq, Default)]
+    #[reflect(Debug, PartialEq, Default)]
     #[type_path = "glam"]
     struct UVec4 {
         x: u32,

--- a/crates/bevy_reflect/src/impls/glam.rs
+++ b/crates/bevy_reflect/src/impls/glam.rs
@@ -5,7 +5,7 @@ use bevy_reflect_derive::{impl_reflect_struct, impl_reflect_value};
 use glam::*;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct IVec2 {
         x: i32,
@@ -13,7 +13,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct IVec3 {
         x: i32,
@@ -22,7 +22,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct IVec4 {
         x: i32,
@@ -33,7 +33,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct UVec2 {
         x: u32,
@@ -41,7 +41,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct UVec3 {
         x: u32,
@@ -50,7 +50,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct UVec4 {
         x: u32,
@@ -60,7 +60,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Vec2 {
         x: f32,
@@ -68,7 +68,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Vec3 {
         x: f32,
@@ -77,7 +77,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Vec3A {
         x: f32,
@@ -86,7 +86,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Vec4 {
         x: f32,
@@ -97,7 +97,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct BVec2 {
         x: bool,
@@ -105,7 +105,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct BVec3 {
         x: bool,
@@ -114,7 +114,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct BVec4 {
         x: bool,
@@ -125,7 +125,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DVec2 {
         x: f64,
@@ -133,7 +133,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DVec3 {
         x: f64,
@@ -142,7 +142,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DVec4 {
         x: f64,
@@ -153,7 +153,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Mat2 {
         x_axis: Vec2,
@@ -161,7 +161,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Mat3 {
         x_axis: Vec3,
@@ -170,7 +170,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Mat3A {
         x_axis: Vec3A,
@@ -179,7 +179,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Mat4 {
         x_axis: Vec4,
@@ -190,7 +190,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DMat2 {
         x_axis: DVec2,
@@ -198,7 +198,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DMat3 {
         x_axis: DVec3,
@@ -207,7 +207,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DMat4 {
         x_axis: DVec4,
@@ -218,7 +218,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Affine2 {
         matrix2: Mat2,
@@ -226,7 +226,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct Affine3A {
         matrix3: Mat3A,
@@ -235,7 +235,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DAffine2 {
         matrix2: DMat2,
@@ -243,7 +243,7 @@ impl_reflect_struct!(
     }
 );
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Default)]
+    #[reflect(Debug, Default)]
     #[type_path = "glam"]
     struct DAffine3 {
         matrix3: DMat3,

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -5,7 +5,7 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, Serialize, Deserialize, Default)]
     #[type_path = "bevy_math"]
     struct Rect {
         min: Vec2,

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,6 +1,6 @@
 use bevy_reflect_derive::impl_type_path;
 use smallvec::SmallVec;
-use std::any::Any;
+use std::any::{Any, TypeId};
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
@@ -8,6 +8,7 @@ use crate::{
     Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
     TypeRegistration, Typed,
 };
+use std::hash::{Hash, Hasher};
 
 impl<T: smallvec::Array + TypePath + Send + Sync> List for SmallVec<T>
 where
@@ -135,6 +136,18 @@ where
 
     fn clone_value(&self) -> Box<dyn Reflect> {
         Box::new(self.clone_dynamic())
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        let mut hasher = crate::utility::reflect_hasher();
+        Hash::hash(&TypeId::of::<Self>(), &mut hasher);
+        Hash::hash(&self.len(), &mut hasher);
+
+        for element in self {
+            Hash::hash(&element.reflect_hash()?, &mut hasher);
+        }
+
+        Some(hasher.finish())
     }
 
     fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,11 +1,11 @@
 use crate::std_traits::ReflectDefault;
 use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwned};
 use crate::{
-    impl_type_path, map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum,
-    DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
-    ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    ReflectSerialize, TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed,
-    UnitVariantInfo, UnnamedField, ValueInfo, VariantFieldIter, VariantInfo, VariantType,
+    impl_type_path, map_apply, Array, ArrayInfo, ArrayIter, DynamicEnum, DynamicMap, Enum,
+    EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter, Map, MapInfo,
+    MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, ReflectSerialize,
+    TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed, UnitVariantInfo, UnnamedField,
+    ValueInfo, VariantFieldIter, VariantInfo, VariantType,
 };
 
 use crate::utility::{
@@ -345,8 +345,32 @@ macro_rules! impl_reflect_for_veclike {
                 Some(hasher.finish())
             }
 
-            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-                crate::list_partial_eq(self, value)
+            fn reflect_partial_eq(&self, other: &dyn Reflect) -> Option<bool> {
+                if let Some(other) = other.downcast_ref::<Self>() {
+                    if other.len() != self.len() {
+                        return Some(false);
+                    }
+
+                    for (a, b) in <$sub>::iter(self).zip(<$sub>::iter(other)) {
+                        if !a.reflect_partial_eq(b)? {
+                            return Some(false);
+                        }
+                    }
+                } else {
+                    let ReflectRef::List(other) = Reflect::reflect_ref(other) else { return Some(false); };
+
+                    if other.len() != self.len() {
+                        return Some(false);
+                    }
+
+                    for (a, b) in self.iter().zip(other.iter()) {
+                        if !a.reflect_partial_eq(b)? {
+                            return Some(false);
+                        }
+                    }
+                }
+
+                Some(true)
             }
         }
 
@@ -560,8 +584,40 @@ macro_rules! impl_reflect_for_hashmap {
                 Box::new(self.clone_dynamic())
             }
 
-            fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-                map_partial_eq(self, value)
+            fn reflect_partial_eq(&self, other: &dyn Reflect) -> Option<bool> {
+              if let Some(other) = other.downcast_ref::<Self>() {
+                  if other.len() != self.len() {
+                        return Some(false);
+                    }
+
+                    for (key, a) in Self::iter(self) {
+                        let Some(b) = other.get(key) else {
+                            return Some(false);
+                        };
+
+                        if !a.reflect_partial_eq(b)? {
+                            return Some(false);
+                        }
+                    }
+                } else {
+                    let ReflectRef::Map(other) = Reflect::reflect_ref(other) else { return Some(false); };
+
+                    if other.len() != self.len() {
+                        return Some(false);
+                    }
+
+                    for (key, a) in self.iter() {
+                        let Some(b) = other.get(key) else {
+                            return Some(false);
+                        };
+
+                        if !a.reflect_partial_eq(b)? {
+                            return Some(false);
+                        }
+                    }
+                }
+
+                Some(true)
             }
         }
 
@@ -747,8 +803,30 @@ impl<T: Reflect + TypePath, const N: usize> Reflect for [T; N] {
     }
 
     #[inline]
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        crate::array_partial_eq(self, value)
+    fn reflect_partial_eq(&self, other: &dyn Reflect) -> Option<bool> {
+        if let Some(other) = other.downcast_ref::<Self>() {
+            for (a, b) in <[T]>::iter(self).zip(<[T]>::iter(other)) {
+                if !a.reflect_partial_eq(b)? {
+                    return Some(false);
+                }
+            }
+        } else {
+            let ReflectRef::Array(other) = Reflect::reflect_ref(other) else {
+                return Some(false);
+            };
+
+            if other.len() != self.len() {
+                return Some(false);
+            }
+
+            for (a, b) in self.iter().zip(other.iter()) {
+                if !a.reflect_partial_eq(b)? {
+                    return Some(false);
+                }
+            }
+        }
+
+        Some(true)
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -444,6 +444,7 @@
 #![allow(clippy::type_complexity)]
 
 mod array;
+mod equality_utility;
 mod fields;
 mod from_reflect;
 mod list;
@@ -987,6 +988,418 @@ mod tests {
             };
             let c = Baz::Struct { a: 1.23 };
             validate_hash!("Struct Variant": a, b, c);
+        }
+    }
+
+    mod reflect_partial_eq {
+        use super::*;
+
+        #[derive(Reflect, FromReflect, Clone)]
+        #[reflect_value]
+        struct NotComparable;
+
+        /// Helper macro for generating tests for [`Reflect::reflect_partial_eq`].
+        ///
+        /// # Arguments
+        /// * `$title` - (Required) The string literal title of the test case.
+        /// * `$a` - (Required) A known comparable value. Should implement [`Clone`].
+        /// * `$b` - (Optional) A known comparable value but not equivalent to `$a`.
+        /// * `$c` - (Optional) A known incomparable value.
+        ///
+        /// # Description
+        ///
+        /// Tests the following:
+        /// 1. `$a` should be partially equal to its clone (concrete, dynamic other, and dynamic self)
+        /// 2. `$a` should be partially equal to an equivalent non-proxy dynamic value (dynamic other and dynamic self)
+        /// 3. `$a` should not be partially equal to `$b` (concrete, dynamic other, and dynamic self)
+        /// 4. `$c` should not be comparable (concrete, dynamic other, and dynamic self)
+        /// 5. Two non-proxy dynamics should be partially equal if they are equivalent
+        ///
+        macro_rules! validate_partial_eq {
+            ($title: literal: $a: ident, $b: ident, $c: ident $(,)?) => {{
+                validate_partial_eq!($title: $a, $b);
+
+                // 4.
+                assert!(
+                    $c.reflect_partial_eq(&$c).is_none(),
+                    "{}: expected `c` to not be comparable",
+                    $title
+                );
+                let c2 = $c.clone_value();
+                assert!(
+                    $c.reflect_partial_eq(&*c2).is_none(),
+                    "{}: expected proxy of `c` to not be comparable (dynamic other)",
+                    $title
+                );
+                assert!(
+                    c2.reflect_partial_eq(&$c).is_none(),
+                    "{}: expected proxy of `c` to not be comparable (dynamic self)",
+                    $title
+                );
+            }};
+            ($title: literal: $a: ident, $b: ident $(,)?) => {{
+                validate_partial_eq!($title: $a);
+
+                // 3.
+                assert_eq!(
+                    Some(false),
+                    $a.reflect_partial_eq(&$b),
+                    "{}: expected `a` to not be partially equal to `b`",
+                    $title
+                );
+                assert_eq!(
+                    Some(false),
+                    $a.reflect_partial_eq(&*$b.clone_value()),
+                    "{}: expected `a` to not be partially equal to a proxy of `b`",
+                    $title
+                );
+                assert_eq!(
+                    Some(false),
+                    $b.clone_value().reflect_partial_eq(&$a),
+                    "{}: expected proxy of `b` to not be partially equal to `a`",
+                    $title
+                );
+            }};
+            ($title: literal: $a: ident $(,)?) => {{
+                // 1.
+                let a2 = $a.clone();
+                assert_eq!(
+                    Some(true),
+                    $a.reflect_partial_eq(&a2),
+                    "{}: expected `a` to partially equal its clone",
+                    $title
+                );
+                assert_eq!(
+                    Some(true),
+                    $a.reflect_partial_eq(&*a2.clone_value()),
+                    "{}: expected `a` to partially equal a proxy of its clone",
+                    $title
+                );
+                assert_eq!(
+                    Some(true),
+                    a2.clone_value().reflect_partial_eq(&$a),
+                    "{}: expected a proxy of `a` to partially equal `a`",
+                    $title
+                );
+
+                // 2.
+                let mut a3 = $a.clone_dynamic();
+                a3.set_represented_type(None);
+                assert_eq!(
+                    Some(true),
+                    $a.reflect_partial_eq(&a3),
+                    "{}: expected `a` to partially equal a dynamic with the same value but not a proxy",
+                    $title
+                );
+                assert_eq!(
+                    Some(true),
+                    a3.reflect_partial_eq(&$a),
+                    "{}: expected dynamic with the same value as `a` but not a proxy to partially equal `a`",
+                    $title
+                );
+
+                // 5.
+                let a4 = $a.clone_dynamic();
+                assert_eq!(
+                    Some(true),
+                    a4.reflect_partial_eq(&*a4.clone_value()),
+                    "{}: expected two non-proxy dynamic values of `a` tobe partially equal",
+                    $title
+                );
+            }};
+        }
+
+        #[test]
+        fn should_partial_eq_value() {
+            #[derive(Reflect, PartialEq, Clone)]
+            #[reflect_value(PartialEq)]
+            struct Foo(u32);
+
+            #[derive(Reflect, Clone)]
+            #[reflect_value]
+            struct Baz(u32);
+
+            // === Primitive === //
+            let a = 123u32;
+            let b = 123u32;
+            assert_eq!(Some(true), a.reflect_partial_eq(&b));
+
+            // === Custom === //
+            let a = Foo(123);
+            let b = Foo(123);
+            assert_eq!(Some(true), a.reflect_partial_eq(&b));
+
+            let a = Foo(123);
+            let b = Foo(456);
+            assert_eq!(Some(false), a.reflect_partial_eq(&b));
+
+            // === Custom (not comparable) === //
+            let a = Baz(123);
+            let b = Baz(123);
+            assert!(a.reflect_partial_eq(&b).is_none());
+        }
+
+        #[test]
+        fn should_partial_eq_tuple() {
+            let a = (123, 345, (678,));
+            let b = (123, 345, (679,));
+            let c = (NotComparable,);
+            validate_partial_eq!("Tuple": a, b, c);
+
+            let a = (123, 345, (678,));
+            let b = (123, 345, (678,), 0);
+            validate_partial_eq!("Tuple (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_array() {
+            let a = [123, 345, 678];
+            let b = [123, 345, 679];
+            let c = [NotComparable];
+            validate_partial_eq!("Array": a, b, c);
+
+            let a = [123, 345, 678];
+            let b = [123, 345, 678, 0];
+            validate_partial_eq!("Array (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_list() {
+            let a = vec![123, 345, 678];
+            let b = vec![123, 345, 679];
+            let c = vec![NotComparable];
+            validate_partial_eq!("List": a, b, c);
+
+            let a = vec![123, 345, 678];
+            let b = vec![123, 345, 678, 0];
+            validate_partial_eq!("List (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_map() {
+            let a = HashMap::from([(123, 1.23), (345, 3.45), (678, 6.78)]);
+            let b = HashMap::from([(123, 1.23), (345, 3.45), (678, 6.79)]);
+            let c = HashMap::from([(123, NotComparable)]);
+            validate_partial_eq!("Map": a, b, c);
+
+            let a = HashMap::from([(123, 1.23), (345, 3.45), (678, 6.78)]);
+            let b = HashMap::from([(123, 1.23), (345, 3.45), (678, 6.78), (0, 0.0)]);
+            validate_partial_eq!("Map (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_unit_struct() {
+            #[derive(Reflect)]
+            struct Foo;
+
+            #[derive(Reflect)]
+            struct Bar;
+
+            let a = Foo;
+            let b = Foo;
+            assert_eq!(
+                Some(true),
+                a.reflect_partial_eq(&b),
+                "expected unit struct to be partially equal to itself"
+            );
+
+            let a = Foo;
+            let b = Bar;
+            assert_eq!(
+                Some(true),
+                a.reflect_partial_eq(&b),
+                "expected unit struct to be partially equal to another unit struct"
+            );
+        }
+
+        #[test]
+        fn should_partial_eq_tuple_struct() {
+            #[derive(Reflect, Clone)]
+            struct Foo(u32, #[reflect(skip_partial_eq)] NotComparable, Bar);
+
+            #[derive(Reflect, Clone)]
+            struct Bar(u32);
+
+            #[derive(Reflect)]
+            struct Baz(NotComparable);
+
+            let a = Foo(123, NotComparable, Bar(678));
+            let b = Foo(123, NotComparable, Bar(679));
+            let c = Baz(NotComparable);
+
+            validate_partial_eq!("Tuple Struct": a, b, c);
+
+            let a = Foo(123, NotComparable, Bar(678));
+            let mut b = a.clone_dynamic();
+            b.insert(123);
+            validate_partial_eq!("Tuple Struct (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_struct() {
+            #[derive(Reflect, Clone)]
+            struct Foo {
+                x: u32,
+                #[reflect(skip_partial_eq)]
+                y: NotComparable,
+                z: Bar,
+            }
+
+            #[derive(Reflect, Clone)]
+            struct Bar {
+                value: u32,
+            }
+
+            #[derive(Reflect)]
+            struct Baz {
+                value: NotComparable,
+            }
+
+            let a = Foo {
+                x: 123,
+                y: NotComparable,
+                z: Bar { value: 678 },
+            };
+
+            let b = Foo {
+                x: 123,
+                y: NotComparable,
+                z: Bar { value: 679 },
+            };
+
+            let c = Baz {
+                value: NotComparable,
+            };
+
+            validate_partial_eq!("Struct": a, b, c);
+
+            let a = Foo {
+                x: 123,
+                y: NotComparable,
+                z: Bar { value: 678 },
+            };
+            let mut b = a.clone_dynamic();
+            b.insert("w", 0);
+            validate_partial_eq!("Struct (different lengths)": a, b);
+        }
+
+        #[test]
+        fn should_partial_eq_struct_with_different_skipped_fields() {
+            #[derive(Reflect, Clone)]
+            struct Foo {
+                #[reflect(skip_partial_eq)]
+                a: u32,
+                b: u32,
+            }
+
+            #[derive(Reflect, Clone)]
+            struct Bar {
+                a: u32,
+                b: u32,
+            }
+
+            #[derive(Reflect, Clone)]
+            struct Baz {
+                #[allow(dead_code)]
+                #[reflect(ignore)]
+                a: u32,
+                b: u32,
+            }
+
+            let foo = Foo { a: 123, b: 456 };
+            let bar = Bar { a: 321, b: 456 };
+            assert_eq!(Some(false), foo.reflect_partial_eq(&bar));
+            assert_eq!(Some(false), bar.reflect_partial_eq(&foo));
+
+            let foo = Foo { a: 123, b: 456 };
+            let baz = Baz { a: 321, b: 456 };
+            assert_eq!(Some(true), foo.reflect_partial_eq(&baz));
+            assert_eq!(Some(true), baz.reflect_partial_eq(&foo));
+        }
+
+        #[test]
+        fn should_partial_eq_tuple_struct_with_different_skipped_fields() {
+            #[derive(Reflect, Clone)]
+            struct Foo(u32, #[reflect(skip_partial_eq)] u32);
+
+            #[derive(Reflect, Clone)]
+            struct Bar(u32, u32);
+
+            #[derive(Reflect, Clone)]
+            struct Baz(
+                u32,
+                #[allow(dead_code)]
+                #[reflect(ignore)]
+                u32,
+            );
+
+            let foo = Foo(123, 456);
+            let bar = Bar(123, 654);
+            assert_eq!(Some(false), foo.reflect_partial_eq(&bar));
+            assert_eq!(Some(false), bar.reflect_partial_eq(&foo));
+
+            let foo = Foo(123, 456);
+            let baz = Baz(123, 654);
+            assert_eq!(Some(true), foo.reflect_partial_eq(&baz));
+            assert_eq!(Some(true), baz.reflect_partial_eq(&foo));
+        }
+
+        #[test]
+        fn should_partial_eq_enum() {
+            #[derive(Reflect, Clone)]
+            enum Foo {
+                UnitA,
+                UnitB,
+                Tuple(u32, #[reflect(skip_partial_eq)] NotComparable, Bar),
+                Struct {
+                    a: u32,
+                    #[reflect(skip_partial_eq)]
+                    b: NotComparable,
+                    c: Bar,
+                },
+            }
+
+            #[derive(Reflect, FromReflect, Clone)]
+            enum Bar {
+                UnitA,
+                Tuple(u32),
+                Struct { a: u32 },
+            }
+
+            #[derive(Reflect, Clone)]
+            enum Baz {
+                Unit,
+                Tuple(NotComparable),
+                Struct { a: NotComparable },
+            }
+
+            // === Unit Variant === //
+            let a = Foo::UnitA;
+            let b = Foo::UnitB;
+            validate_partial_eq!("Unit Variant": a, b);
+
+            let c = Baz::Unit;
+            validate_partial_eq!("Unit Variant (incomparable sibling variants)": c);
+
+            // === Tuple Variant === //
+            let a = Foo::Tuple(123, NotComparable, Bar::Tuple(678));
+            let b = Foo::Tuple(123, NotComparable, Bar::Tuple(679));
+            let c = Baz::Tuple(NotComparable);
+            validate_partial_eq!("Tuple Variant": a, b, c);
+
+            // === Struct Variant === //
+            let a = Foo::Struct {
+                a: 123,
+                b: NotComparable,
+                c: Bar::Struct { a: 678 },
+            };
+            let b = Foo::Struct {
+                a: 123,
+                b: NotComparable,
+                c: Bar::Struct { a: 679 },
+            };
+            let c = Baz::Struct { a: NotComparable };
+            validate_partial_eq!("Struct Variant": a, b, c);
         }
     }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -994,7 +994,7 @@ mod tests {
     mod reflect_partial_eq {
         use super::*;
 
-        #[derive(Reflect, FromReflect, Clone)]
+        #[derive(Reflect, Clone)]
         #[reflect_value]
         struct NotComparable;
 
@@ -1359,7 +1359,7 @@ mod tests {
                 },
             }
 
-            #[derive(Reflect, FromReflect, Clone)]
+            #[derive(Reflect, Clone)]
             enum Bar {
                 UnitA,
                 Tuple(u32),
@@ -1552,7 +1552,6 @@ mod tests {
     #[test]
     fn reflect_complex_patch() {
         #[derive(Reflect, Eq, PartialEq, Debug)]
-        #[reflect(PartialEq)]
         struct Foo {
             a: u32,
             #[reflect(ignore)]
@@ -1566,7 +1565,6 @@ mod tests {
         }
 
         #[derive(Reflect, Eq, PartialEq, Clone, Debug)]
-        #[reflect(PartialEq)]
         struct Bar {
             x: u32,
         }
@@ -1804,7 +1802,6 @@ mod tests {
     #[test]
     fn reflect_take() {
         #[derive(Reflect, Debug, PartialEq)]
-        #[reflect(PartialEq)]
         struct Bar {
             x: u32,
         }
@@ -2515,7 +2512,6 @@ bevy_reflect::tests::should_reflect_debug::Test {
     fn multiple_reflect_lists() {
         #[derive(PartialEq, Reflect)]
         #[reflect(Debug)]
-        #[reflect(PartialEq)]
         struct Foo(i32);
 
         impl Debug for Foo {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -704,6 +704,7 @@ mod tests {
         /// 3. `$a` should not return the same hash as an equivalent non-proxy dynamic value
         /// 4. `$a` should not return the same hash as `$b` (concrete and dynamic)
         /// 5. `$c` should not return a hash (concrete and dynamic)
+        /// 6. Two non-proxy dynamics should return the same hash if they are equivalent
         ///
         macro_rules! validate_hash {
             ($title: literal: $a: ident, $b: ident, $c: ident $(,)?) => {{
@@ -781,6 +782,15 @@ mod tests {
                     $a.reflect_hash(),
                     a3.reflect_hash(),
                     "{}: expected `a` to return a different hash than a dynamic with the same value but not a proxy",
+                    $title
+                );
+
+                // 6.
+                let a4 = $a.clone_dynamic();
+                assert_eq!(
+                    a4.reflect_hash(),
+                    a4.clone_value().reflect_hash(),
+                    "{}: expected two non-proxy dynamic values of `a` to return the same hash",
                     $title
                 );
             }};

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -617,8 +617,7 @@ mod tests {
 
     #[test]
     fn reflect_map() {
-        #[derive(Reflect, Hash)]
-        #[reflect(Hash)]
+        #[derive(Reflect)]
         struct Foo {
             a: u32,
             b: String,
@@ -677,13 +676,35 @@ mod tests {
     fn reflect_map_no_hash() {
         #[derive(Reflect)]
         struct Foo {
-            a: u32,
+            a: f32,
         }
 
-        let foo = Foo { a: 1 };
+        let foo = Foo { a: 1.23 };
 
         let mut map = DynamicMap::default();
         map.insert(foo, 10u32);
+    }
+
+    mod reflect_hash {
+        use super::*;
+
+        #[test]
+        fn should_hash_unit_struct() {
+            #[derive(Reflect)]
+            struct Foo;
+
+            #[derive(Reflect)]
+            struct Bar;
+
+            let foo = Foo;
+            assert!(foo.reflect_hash().is_some());
+
+            let foo2 = Foo;
+            assert_eq!(foo.reflect_hash(), foo2.reflect_hash());
+
+            let bar = Bar;
+            assert_ne!(foo.reflect_hash(), bar.reflect_hash());
+        }
     }
 
     #[test]
@@ -1796,8 +1817,8 @@ bevy_reflect::tests::should_reflect_debug::Test {
 
     #[test]
     fn multiple_reflect_lists() {
-        #[derive(Hash, PartialEq, Reflect)]
-        #[reflect(Debug, Hash)]
+        #[derive(PartialEq, Reflect)]
+        #[reflect(Debug)]
         #[reflect(PartialEq)]
         struct Foo(i32);
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1612,9 +1612,9 @@ mod tests {
             let info = <SomeStruct as Typed>::type_info();
             if let TypeInfo::Struct(info) = info {
                 let mut fields = info.iter();
-                assert_eq!(Some(" The name"), fields.next().unwrap().docs());
-                assert_eq!(Some(" The index"), fields.next().unwrap().docs());
-                assert_eq!(None, fields.next().unwrap().docs());
+                assert_eq!(Some(" The name"), fields.next().unwrap().meta().docs);
+                assert_eq!(Some(" The index"), fields.next().unwrap().meta().docs);
+                assert_eq!(None, fields.next().unwrap().meta().docs);
             } else {
                 panic!("expected struct info");
             }
@@ -1641,22 +1641,22 @@ mod tests {
             let info = <SomeEnum as Typed>::type_info();
             if let TypeInfo::Enum(info) = info {
                 let mut variants = info.iter();
-                assert_eq!(None, variants.next().unwrap().docs());
+                assert_eq!(None, variants.next().unwrap().meta().docs);
 
                 let variant = variants.next().unwrap();
-                assert_eq!(Some(" Option A"), variant.docs());
+                assert_eq!(Some(" Option A"), variant.meta().docs);
                 if let VariantInfo::Tuple(variant) = variant {
                     let field = variant.field_at(0).unwrap();
-                    assert_eq!(Some(" Index"), field.docs());
+                    assert_eq!(Some(" Index"), field.meta().docs);
                 } else {
                     panic!("expected tuple variant")
                 }
 
                 let variant = variants.next().unwrap();
-                assert_eq!(Some(" Option B"), variant.docs());
+                assert_eq!(Some(" Option B"), variant.meta().docs);
                 if let VariantInfo::Struct(variant) = variant {
                     let field = variant.field_at(0).unwrap();
-                    assert_eq!(Some(" Name"), field.docs());
+                    assert_eq!(Some(" Name"), field.meta().docs);
                 } else {
                     panic!("expected struct variant")
                 }

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -495,18 +495,17 @@ pub fn list_apply<L: List>(a: &mut L, b: &dyn Reflect) {
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
 pub fn list_partial_eq<L: List>(a: &L, b: &dyn Reflect) -> Option<bool> {
-    let ReflectRef::List(list) = b.reflect_ref() else {
+    let ReflectRef::List(b) = b.reflect_ref()  else {
         return Some(false);
     };
 
-    if a.len() != list.len() {
+    if a.len() != b.len() {
         return Some(false);
     }
 
-    for (a_value, b_value) in a.iter().zip(list.iter()) {
-        let eq_result = a_value.reflect_partial_eq(b_value);
-        if let failed @ (Some(false) | None) = eq_result {
-            return failed;
+    for (a_value, b_value) in a.iter().zip(b.iter()) {
+        if !a_value.reflect_partial_eq(b_value)? {
+            return Some(false);
         }
     }
 

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -112,8 +112,7 @@ pub struct ListInfo {
     type_id: TypeId,
     item_type_name: &'static str,
     item_type_id: TypeId,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: ListMeta,
 }
 
 impl ListInfo {
@@ -124,15 +123,13 @@ impl ListInfo {
             type_id: TypeId::of::<TList>(),
             item_type_name: std::any::type_name::<TItem>(),
             item_type_id: TypeId::of::<TItem>(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: ListMeta::new(),
         }
     }
 
-    /// Sets the docstring for this list.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this list.
+    pub fn with_meta(self, meta: ListMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The [type name] of the list.
@@ -145,6 +142,11 @@ impl ListInfo {
     /// The [`TypeId`] of the list.
     pub fn type_id(&self) -> TypeId {
         self.type_id
+    }
+
+    /// The metadata of the list.
+    pub fn meta(&self) -> &ListMeta {
+        &self.meta
     }
 
     /// Check if the given type matches the list type.
@@ -168,11 +170,30 @@ impl ListInfo {
     pub fn item_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.item_type_id
     }
+}
 
+/// Metadata for [lists], accessed via [`ListInfo::meta`].
+///
+/// [lists]: List
+#[derive(Clone, Debug)]
+pub struct ListMeta {
     /// The docstring of this list, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl ListMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for ListMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -494,21 +494,20 @@ pub fn map_hash<M: Map>(value: &M) -> Option<u64> {
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
 pub fn map_partial_eq<M: Map>(a: &M, b: &dyn Reflect) -> Option<bool> {
-    let ReflectRef::Map(map) = b.reflect_ref() else {
+    let ReflectRef::Map(b) = b.reflect_ref()  else {
         return Some(false);
     };
 
-    if a.len() != map.len() {
+    if a.len() != b.len() {
         return Some(false);
     }
 
-    for (key, value) in a.iter() {
-        if let Some(map_value) = map.get(key) {
-            let eq_result = value.reflect_partial_eq(map_value);
-            if let failed @ (Some(false) | None) = eq_result {
-                return failed;
-            }
-        } else {
+    for (key, value_a) in a.iter() {
+        let Some(value_b) = b.get(key) else {
+            return Some(false);
+        };
+
+        if !value_a.reflect_partial_eq(value_b)? {
             return Some(false);
         }
     }

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -99,8 +99,7 @@ pub struct MapInfo {
     key_type_id: TypeId,
     value_type_name: &'static str,
     value_type_id: TypeId,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: MapMeta,
 }
 
 impl MapInfo {
@@ -113,15 +112,13 @@ impl MapInfo {
             key_type_id: TypeId::of::<TKey>(),
             value_type_name: std::any::type_name::<TValue>(),
             value_type_id: TypeId::of::<TValue>(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: MapMeta::new(),
         }
     }
 
-    /// Sets the docstring for this map.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this map.
+    pub fn with_meta(self, meta: MapMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The [type name] of the map.
@@ -134,6 +131,11 @@ impl MapInfo {
     /// The [`TypeId`] of the map.
     pub fn type_id(&self) -> TypeId {
         self.type_id
+    }
+
+    /// The metadata of the struct.
+    pub fn meta(&self) -> &MapMeta {
+        &self.meta
     }
 
     /// Check if the given type matches the map type.
@@ -174,11 +176,30 @@ impl MapInfo {
     pub fn value_is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.value_type_id
     }
+}
 
+/// Metadata for [maps], accessed via [`MapInfo::meta`].
+///
+/// [maps]: Map
+#[derive(Clone, Debug)]
+pub struct MapMeta {
     /// The docstring of this map, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl MapMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for MapMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -183,17 +183,52 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// use those subtraits' respective `clone_dynamic` methods.
     fn clone_value(&self) -> Box<dyn Reflect>;
 
-    /// Returns a hash of the value (which includes the type).
+    /// Returns a hash of the value.
     ///
-    /// If the underlying type does not support hashing, returns `None`.
+    /// If the underlying type or any of its members do not support hashing, returns `None`.
+    ///
+    /// # For Implementors
+    ///
+    /// For value types (i.e. [`ReflectRef::Value`]), the hash should be the same
+    /// as its [`Hash`] implementation.
+    /// If it does not implement `Hash`, then it should return `None`.
+    ///
+    /// For all other types, the hash should be consistent with its respective dynamic type,
+    /// such that a concrete type and its dynamic type return the same hash value given
+    /// the same contents.
+    ///
+    /// For example, a [`Struct`] should return the same hash as [`DynamicStruct`].
+    /// This can easily be achieved by using the pre-built hash function, [`struct_hash`].
+    ///
+    /// [`Hash`]: std::hash::Hash
+    /// [`DynamicStruct`]: crate::DynamicStruct
+    /// [`struct_hash`]: crate::struct_hash
     fn reflect_hash(&self) -> Option<u64> {
         None
     }
 
-    /// Returns a "partial equality" comparison result.
+    /// Compares this value to another reflected value, similar to [`PartialEq`].
     ///
-    /// If the underlying type does not support equality testing, returns `None`.
-    fn reflect_partial_eq(&self, _value: &dyn Reflect) -> Option<bool> {
+    /// If the underlying type or any of its members do not support comparisons, returns `None`.
+    ///
+    /// # For Implementors
+    ///
+    /// For value types (i.e. [`ReflectRef::Value`]), the result should be the same
+    /// as its `PartialEq` implementation.
+    /// If it does not implement `PartialEq`, then it should return `None`.
+    ///
+    /// For all other types, the result should be consistent with its respective dynamic type,
+    /// such that a concrete type and its dynamic type return the same result given
+    /// the same contents.
+    ///
+    /// For example, a [`Struct`] should return the same result as [`DynamicStruct`].
+    /// This can easily be achieved by using the pre-built comparison function, [`struct_partial_eq`].
+    ///
+    /// [`PartialEq`]: std::cmp::PartialEq
+    /// [`DynamicStruct`]: crate::DynamicStruct
+    /// [`struct_partial_eq`]: crate::struct_partial_eq
+    #[allow(unused_variables)]
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
         None
     }
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -19,7 +19,6 @@ mod tests {
     #[test]
     fn test_serialization_struct() {
         #[derive(Debug, Reflect, PartialEq)]
-        #[reflect(PartialEq)]
         struct TestStruct {
             a: i32,
             #[reflect(ignore)]
@@ -61,7 +60,6 @@ mod tests {
     #[test]
     fn test_serialization_tuple_struct() {
         #[derive(Debug, Reflect, PartialEq)]
-        #[reflect(PartialEq)]
         struct TestStruct(
             i32,
             #[reflect(ignore)] i32,

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -81,8 +81,7 @@ pub struct StructInfo {
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: StructMeta,
 }
 
 impl StructInfo {
@@ -109,15 +108,13 @@ impl StructInfo {
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: StructMeta::new(),
         }
     }
 
-    /// Sets the docstring for this struct.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this struct.
+    pub fn with_meta(self, meta: StructMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// A slice containing the names of all fields in order.
@@ -173,15 +170,39 @@ impl StructInfo {
         self.type_id
     }
 
+    /// The metadata of the struct.
+    pub fn meta(&self) -> &StructMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the struct type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
+/// Metadata for [structs], accessed via [`StructInfo::meta`].
+///
+/// [structs]: Struct
+#[derive(Clone, Debug)]
+pub struct StructMeta {
     /// The docstring of this struct, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl StructMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for StructMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -141,8 +141,7 @@ pub struct TupleInfo {
     type_name: &'static str,
     type_id: TypeId,
     fields: Box<[UnnamedField]>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: TupleMeta,
 }
 
 impl TupleInfo {
@@ -157,15 +156,13 @@ impl TupleInfo {
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: TupleMeta::new(),
         }
     }
 
-    /// Sets the docstring for this tuple.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this tuple.
+    pub fn with_meta(self, meta: TupleMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// Get the field at the given index.
@@ -195,15 +192,39 @@ impl TupleInfo {
         self.type_id
     }
 
+    /// The metadata of the struct.
+    pub fn meta(&self) -> &TupleMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the tuple type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
+/// Metadata for [tuples], accessed via [`TupleInfo::meta`].
+///
+/// [tuples]: Tuple
+#[derive(Clone, Debug)]
+pub struct TupleMeta {
     /// The docstring of this tuple, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl TupleMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for TupleMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -59,8 +59,7 @@ pub struct TupleStructInfo {
     type_name: &'static str,
     type_id: TypeId,
     fields: Box<[UnnamedField]>,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: TupleStructMeta,
 }
 
 impl TupleStructInfo {
@@ -77,15 +76,13 @@ impl TupleStructInfo {
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: TupleStructMeta::new(),
         }
     }
 
-    /// Sets the docstring for this struct.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, docs: Option<&'static str>) -> Self {
-        Self { docs, ..self }
+    /// Add metadata for this struct.
+    pub fn with_meta(self, meta: TupleStructMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// Get the field at the given index.
@@ -124,15 +121,39 @@ impl TupleStructInfo {
         self.type_id
     }
 
+    /// The metadata of the struct.
+    pub fn meta(&self) -> &TupleStructMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the tuple struct type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
-    /// The docstring of this struct, if any.
+/// Metadata for [tuple structs], accessed via [`TupleStructInfo::meta`].
+///
+/// [tuple structs]: TupleStruct
+#[derive(Clone, Debug)]
+pub struct TupleStructMeta {
+    /// The docstring of this tuple struct, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl TupleStructMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for TupleStructMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/crates/bevy_reflect/src/type_info.rs
+++ b/crates/bevy_reflect/src/type_info.rs
@@ -153,14 +153,14 @@ impl TypeInfo {
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&str> {
         match self {
-            Self::Struct(info) => info.docs(),
-            Self::TupleStruct(info) => info.docs(),
-            Self::Tuple(info) => info.docs(),
-            Self::List(info) => info.docs(),
-            Self::Array(info) => info.docs(),
-            Self::Map(info) => info.docs(),
-            Self::Enum(info) => info.docs(),
-            Self::Value(info) => info.docs(),
+            Self::Struct(info) => info.meta().docs,
+            Self::TupleStruct(info) => info.meta().docs,
+            Self::Tuple(info) => info.meta().docs,
+            Self::List(info) => info.meta().docs,
+            Self::Array(info) => info.meta().docs,
+            Self::Map(info) => info.meta().docs,
+            Self::Enum(info) => info.meta().docs,
+            Self::Value(info) => info.meta().docs,
         }
     }
 }
@@ -177,8 +177,7 @@ impl TypeInfo {
 pub struct ValueInfo {
     type_name: &'static str,
     type_id: TypeId,
-    #[cfg(feature = "documentation")]
-    docs: Option<&'static str>,
+    meta: ValueMeta,
 }
 
 impl ValueInfo {
@@ -186,15 +185,13 @@ impl ValueInfo {
         Self {
             type_name: std::any::type_name::<T>(),
             type_id: TypeId::of::<T>(),
-            #[cfg(feature = "documentation")]
-            docs: None,
+            meta: ValueMeta::new(),
         }
     }
 
-    /// Sets the docstring for this value.
-    #[cfg(feature = "documentation")]
-    pub fn with_docs(self, doc: Option<&'static str>) -> Self {
-        Self { docs: doc, ..self }
+    /// Add metadata for this value.
+    pub fn with_meta(self, meta: ValueMeta) -> Self {
+        Self { meta, ..self }
     }
 
     /// The [type name] of the value.
@@ -209,14 +206,38 @@ impl ValueInfo {
         self.type_id
     }
 
+    /// The metadata of the value.
+    pub fn meta(&self) -> &ValueMeta {
+        &self.meta
+    }
+
     /// Check if the given type matches the value type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
     }
+}
 
-    /// The docstring of this dynamic value, if any.
+/// Metadata for [value types], accessed via [`ValueInfo::meta`].
+///
+/// [value types]: ValueInfo
+#[derive(Clone, Debug)]
+pub struct ValueMeta {
+    /// The docstring of this value, if any.
     #[cfg(feature = "documentation")]
-    pub fn docs(&self) -> Option<&'static str> {
-        self.docs
+    pub docs: Option<&'static str>,
+}
+
+impl ValueMeta {
+    pub const fn new() -> Self {
+        Self {
+            #[cfg(feature = "documentation")]
+            docs: None,
+        }
+    }
+}
+
+impl Default for ValueMeta {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.fail.rs
@@ -1,0 +1,17 @@
+use bevy_reflect::prelude::*;
+
+// Reason: `#[reflect(Hash)]` only supported for value types
+#[derive(Reflect, Hash)]
+#[reflect(Hash)]
+struct Foo {
+    a: u32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    // Reason: `#[reflect(skip_hash)]` does not take any arguments
+    #[reflect(skip_hash = true)]
+    a: u32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.fail.stderr
@@ -1,0 +1,11 @@
+error: concrete `Hash` impl can only be used for items marked `#[reflect_value]`
+ --> tests/reflect_derive/hash.fail.rs:5:11
+  |
+5 | #[reflect(Hash)]
+  |           ^^^^
+
+error: unknown attribute parameter: skip_hash
+  --> tests/reflect_derive/hash.fail.rs:13:15
+   |
+13 |     #[reflect(skip_hash = true)]
+   |               ^^^^^^^^^

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.pass.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/hash.pass.rs
@@ -1,0 +1,15 @@
+use bevy_reflect::prelude::*;
+
+#[derive(Reflect, Hash, Clone)]
+#[reflect_value(Hash)]
+struct Foo {
+    a: u32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    #[reflect(skip_hash)]
+    a: u32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.fail.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.fail.rs
@@ -1,0 +1,17 @@
+use bevy_reflect::prelude::*;
+
+// Reason: `#[reflect(PartialEq)]` only supported for value types
+#[derive(Reflect, PartialEq)]
+#[reflect(PartialEq)]
+struct Foo {
+    a: u32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    // Reason: `#[reflect(skip_partial_eq)]` does not take any arguments
+    #[reflect(skip_partial_eq = true)]
+    a: u32,
+}
+
+fn main() {}

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.fail.stderr
@@ -1,0 +1,11 @@
+error: concrete `PartialEq` impl can only be used for items marked `#[reflect_value]`
+ --> tests/reflect_derive/partial_eq.fail.rs:5:11
+  |
+5 | #[reflect(PartialEq)]
+  |           ^^^^^^^^^
+
+error: unknown attribute parameter: skip_partial_eq
+  --> tests/reflect_derive/partial_eq.fail.rs:13:15
+   |
+13 |     #[reflect(skip_partial_eq = true)]
+   |               ^^^^^^^^^^^^^^^

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.pass.rs
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/partial_eq.pass.rs
@@ -1,0 +1,15 @@
+use bevy_reflect::prelude::*;
+
+#[derive(Reflect, PartialEq, Clone)]
+#[reflect_value(PartialEq)]
+struct Foo {
+    a: u32,
+}
+
+#[derive(Reflect)]
+struct Bar {
+    #[reflect(skip_partial_eq)]
+    a: u32,
+}
+
+fn main() {}

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -9,7 +9,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign};
 use thiserror::Error;
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum Color {
     /// sRGBA color
     Rgba {

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -21,7 +21,7 @@ pub type Layer = u8;
 ///
 /// Entities without this component belong to layer `0`.
 #[derive(Component, Copy, Clone, Reflect, PartialEq, Eq, PartialOrd, Ord)]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default)]
 pub struct RenderLayers(LayerMask);
 
 impl std::fmt::Debug for RenderLayers {

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -470,7 +470,7 @@ mod tests {
     }
 
     #[derive(Clone, Component, Reflect, PartialEq)]
-    #[reflect(Component, MapEntities, PartialEq)]
+    #[reflect(Component, MapEntities)]
     struct MyEntityRef(Entity);
 
     impl MapEntities for MyEntityRef {

--- a/crates/bevy_transform/src/components/global_transform.rs
+++ b/crates/bevy_transform/src/components/global_transform.rs
@@ -35,7 +35,7 @@ use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default)]
 pub struct GlobalTransform(Affine3A);
 
 macro_rules! impl_local_axis {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -37,7 +37,7 @@ use std::ops::Mul;
 /// [`Transform`]: super::Transform
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default)]
 pub struct Transform {
     /// Position of the entity. In 2d, the last value of the `Vec3` is used for z-ordering.
     ///

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -33,7 +33,7 @@ use smallvec::SmallVec;
 /// Note that you can also control the visibility of a node using the [`Display`](crate::ui_node::Display) property,
 /// which fully collapses it during layout calculations.
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(Component, Serialize, Deserialize)]
 pub enum Interaction {
     /// The node has been clicked
     Clicked,
@@ -71,7 +71,7 @@ impl Default for Interaction {
     Serialize,
     Deserialize,
 )]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(Component, Serialize, Deserialize)]
 pub struct RelativeCursorPosition {
     /// Cursor position relative to size and position of the Node.
     pub normalized: Option<Vec2>,
@@ -88,7 +88,7 @@ impl RelativeCursorPosition {
 
 /// Describes whether the node should block interactions with lower nodes
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(Component, Serialize, Deserialize, PartialEq)]
+#[reflect(Component, Serialize, Deserialize)]
 pub enum FocusPolicy {
     /// Blocks interaction
     Block,

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -46,7 +46,6 @@ use bevy_reflect::Reflect;
 /// };
 /// ```
 #[derive(Copy, Clone, PartialEq, Debug, Reflect)]
-#[reflect(PartialEq)]
 pub struct UiRect {
     /// The value corresponding to the left side of the UI rect.
     pub left: Val,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -78,7 +78,7 @@ impl Default for Node {
 /// This enum allows specifying values for various [`Style`] properties in different units,
 /// such as logical pixels, percentages, or automatically determined values.
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum Val {
     /// Automatically determine the value based on the context and other [`Style`] properties.
     Auto,
@@ -294,7 +294,7 @@ impl Val {
 /// - [CSS Grid Garden](https://cssgridgarden.com/). An interactive tutorial/game that teaches the essential parts of CSS Grid in a fun engaging way.
 
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
-#[reflect(Component, Default, PartialEq)]
+#[reflect(Component, Default)]
 pub struct Style {
     /// Which layout algorithm to use when laying out this node's contents:
     ///   - [`Display::Flex`]: Use the Flexbox layout algorithm
@@ -628,7 +628,7 @@ impl Default for Style {
 
 /// How items are aligned according to the cross axis
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum AlignItems {
     /// The items are packed in their default position as if no alignment was applied
     Default,
@@ -662,7 +662,7 @@ impl Default for AlignItems {
 
 /// How items are aligned according to the cross axis
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum JustifyItems {
     /// The items are packed in their default position as if no alignment was applied
     Default,
@@ -691,7 +691,7 @@ impl Default for JustifyItems {
 /// How this item is aligned according to the cross axis.
 /// Overrides [`AlignItems`].
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum AlignSelf {
     /// Use the parent node's [`AlignItems`] value to determine how this item should be aligned.
     Auto,
@@ -726,7 +726,7 @@ impl Default for AlignSelf {
 /// How this item is aligned according to the cross axis.
 /// Overrides [`AlignItems`].
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum JustifySelf {
     /// Use the parent node's [`AlignItems`] value to determine how this item should be aligned.
     Auto,
@@ -756,7 +756,7 @@ impl Default for JustifySelf {
 ///
 /// It only applies if [`FlexWrap::Wrap`] is present and if there are multiple lines of items.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum AlignContent {
     /// The items are packed in their default position as if no alignment was applied
     Default,
@@ -795,7 +795,7 @@ impl Default for AlignContent {
 
 /// Defines how items are aligned according to the main axis
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum JustifyContent {
     /// The items are packed in their default position as if no alignment was applied
     Default,
@@ -831,7 +831,7 @@ impl Default for JustifyContent {
 ///
 /// For example English is written LTR (left-to-right) while Arabic is written RTL (right-to-left).
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum Direction {
     /// Inherit from parent node.
     Inherit,
@@ -855,7 +855,7 @@ impl Default for Direction {
 ///
 /// Part of the [`Style`] component.
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum Display {
     /// Use Flexbox layout model to determine the position of this [`Node`].
     Flex,
@@ -880,7 +880,7 @@ impl Default for Display {
 
 /// Defines how flexbox items are ordered within a flexbox
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum FlexDirection {
     /// Same way as text direction along the main axis.
     Row,
@@ -904,7 +904,7 @@ impl Default for FlexDirection {
 
 /// Whether to show or hide overflowing items
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub struct Overflow {
     /// Whether to show or clip overflowing items on the x axis        
     pub x: OverflowAxis,
@@ -964,7 +964,7 @@ impl Default for Overflow {
 
 /// Whether to show or hide overflowing items
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Reflect, Serialize, Deserialize)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum OverflowAxis {
     /// Show overflowing items.
     Visible,
@@ -989,7 +989,7 @@ impl Default for OverflowAxis {
 
 /// The strategy used to position this node
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum PositionType {
     /// Relative to all other nodes with the [`PositionType::Relative`] value.
     Relative,
@@ -1011,7 +1011,7 @@ impl Default for PositionType {
 
 /// Defines if flexbox items appear on a single line or on multiple lines
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum FlexWrap {
     /// Single line, will overflow if needed.
     NoWrap,
@@ -1039,7 +1039,7 @@ impl Default for FlexWrap {
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-flow>
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub enum GridAutoFlow {
     /// Items are placed by filling each row in turn, adding new rows as necessary
     Row,
@@ -1102,7 +1102,7 @@ pub enum MaxTrackSizingFunction {
 /// A [`GridTrack`] is a Row or Column of a CSS Grid. This struct specifies what size the track should be.
 /// See below for the different "track sizing functions" you can specify.
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub struct GridTrack {
     pub(crate) min_sizing_function: MinTrackSizingFunction,
     pub(crate) max_sizing_function: MaxTrackSizingFunction,
@@ -1220,7 +1220,7 @@ impl Default for GridTrack {
 }
 
 #[derive(Copy, Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 /// How many times to repeat a repeated grid track
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/repeat>
@@ -1270,7 +1270,7 @@ impl From<usize> for GridTrackRepetition {
 /// then all track (in and outside of the repetition) must be fixed size (px or percent). Integer repetitions are just shorthand for writing out
 /// N tracks longhand and are not subject to the same limitations.
 #[derive(Clone, PartialEq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub struct RepeatedGridTrack {
     pub(crate) repetition: GridTrackRepetition,
     pub(crate) tracks: SmallVec<[GridTrack; 1]>,
@@ -1420,7 +1420,7 @@ impl From<RepeatedGridTrack> for Vec<RepeatedGridTrack> {
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Reflect)]
-#[reflect(PartialEq, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 /// Represents the position of a grid item in a single axis.
 ///
 /// There are 3 fields which may be set:

--- a/crates/bevy_window/src/cursor.rs
+++ b/crates/bevy_window/src/cursor.rs
@@ -14,7 +14,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(Debug, Default)]
 pub enum CursorIcon {
     /// The platform-dependent default cursor.
     #[default]

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -12,7 +12,7 @@ use crate::WindowTheme;
 
 /// A window event that is sent whenever a window's logical size has changed.
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -30,7 +30,7 @@ pub struct WindowResized {
 /// An event that indicates all of the application's windows should be redrawn,
 /// even if their control flow is set to `Wait` and there have been no window events.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -42,7 +42,7 @@ pub struct RequestRedraw;
 ///
 /// To create a new window, spawn an entity with a [`crate::Window`] on it.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -64,7 +64,7 @@ pub struct WindowCreated {
 /// [`WindowPlugin`]: crate::WindowPlugin
 /// [`Window`]: crate::Window
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -78,7 +78,7 @@ pub struct WindowCloseRequested {
 /// An event that is sent whenever a window is closed. This will be sent when
 /// the window entity loses its [`Window`](crate::window::Window) component or is despawned.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -101,7 +101,7 @@ pub struct WindowClosed {
 /// [`WindowEvent::CursorMoved`]: https://docs.rs/winit/latest/winit/event/enum.WindowEvent.html#variant.CursorMoved
 /// [`MouseMotion`]: bevy_input::mouse::MouseMotion
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -116,7 +116,7 @@ pub struct CursorMoved {
 
 /// An event that is sent whenever the user's cursor enters a window.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -129,7 +129,7 @@ pub struct CursorEntered {
 
 /// An event that is sent whenever the user's cursor leaves a window.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -142,7 +142,7 @@ pub struct CursorLeft {
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -161,7 +161,7 @@ pub struct ReceivedCharacter {
 ///
 /// It is only sent if IME was enabled on the window with [`Window::ime_enabled`](crate::window::Window::ime_enabled).
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -203,7 +203,7 @@ pub enum Ime {
 
 /// An event that indicates a window has received or lost focus.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -218,7 +218,7 @@ pub struct WindowFocused {
 
 /// An event that indicates a window's scale factor has changed.
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -233,7 +233,7 @@ pub struct WindowScaleFactorChanged {
 
 /// An event that indicates a window's OS-reported scale factor has changed.
 #[derive(Event, Debug, Clone, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -248,7 +248,7 @@ pub struct WindowBackendScaleFactorChanged {
 
 /// Events related to files being dragged and dropped on a window.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -280,7 +280,7 @@ pub enum FileDragAndDrop {
 
 /// An event that is sent when a window is repositioned in physical pixels.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -298,7 +298,7 @@ pub struct WindowMoved {
 /// This event is only sent when the window is relying on the system theme to control its appearance.
 /// i.e. It is only sent when [`Window::window_theme`](crate::window::Window::window_theme) is `None` and the system theme changes.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -813,7 +813,7 @@ pub enum MonitorSelection {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Hash)]
+#[reflect(Debug, PartialEq)]
 #[doc(alias = "vsync")]
 pub enum PresentMode {
     /// Chooses FifoRelaxed -> Fifo based on availability.
@@ -853,7 +853,7 @@ pub enum PresentMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Hash)]
+#[reflect(Debug, PartialEq)]
 pub enum CompositeAlphaMode {
     /// Chooses either [`Opaque`](CompositeAlphaMode::Opaque) or [`Inherit`](CompositeAlphaMode::Inherit)
     /// automatically, depending on the `alpha_mode` that the current surface can support.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -342,7 +342,7 @@ impl Window {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(Debug, Default)]
 pub struct WindowResizeConstraints {
     /// The minimum width the window can have.
     pub min_width: f32,
@@ -461,7 +461,7 @@ impl Default for Cursor {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum WindowPosition {
     /// Position will be set by the window manager.
     /// Bevy will delegate this decision to the window manager and no guarantees can be made about where the window will be placed.
@@ -550,7 +550,7 @@ impl WindowPosition {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(Debug, Default)]
 pub struct WindowResolution {
     /// Width of the window in physical pixels.
     physical_width: u32,
@@ -725,7 +725,7 @@ impl From<bevy_math::DVec2> for WindowResolution {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(Debug, Default)]
 pub enum CursorGrabMode {
     /// The cursor can freely leave the window.
     #[default]
@@ -743,7 +743,7 @@ pub enum CursorGrabMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq, Default)]
+#[reflect(Debug, Default)]
 pub struct InternalWindowState {
     /// If this is true then next frame we will ask to minimize the window.
     minimize_request: Option<bool>,
@@ -774,7 +774,7 @@ impl InternalWindowState {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum MonitorSelection {
     /// Uses the current monitor of the window.
     ///
@@ -813,7 +813,7 @@ pub enum MonitorSelection {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 #[doc(alias = "vsync")]
 pub enum PresentMode {
     /// Chooses FifoRelaxed -> Fifo based on availability.
@@ -853,7 +853,7 @@ pub enum PresentMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum CompositeAlphaMode {
     /// Chooses either [`Opaque`](CompositeAlphaMode::Opaque) or [`Inherit`](CompositeAlphaMode::Inherit)
     /// automatically, depending on the `alpha_mode` that the current surface can support.
@@ -888,7 +888,7 @@ pub enum CompositeAlphaMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum WindowMode {
     /// The window should take a portion of the screen, using the window resolution size.
     #[default]
@@ -935,7 +935,7 @@ pub enum WindowMode {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum WindowLevel {
     /// The window will always be below [`WindowLevel::Normal`] and [`WindowLevel::AlwaysOnTop`] windows.
     ///
@@ -955,7 +955,7 @@ pub enum WindowLevel {
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug)]
 pub enum WindowTheme {
     /// Use the light variant.
     Light,

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -40,12 +40,12 @@ pub enum D {
     C { value: f32 },
 }
 
-/// Reflect has "built in" support for some common traits like `PartialEq`, `Hash`, and `Serialize`.
-/// These are exposed via methods like `Reflect::reflect_hash()`, `Reflect::reflect_partial_eq()`, and
-/// `Reflect::serializable()`. You can force these implementations to use the actual trait
+/// Reflect has "built in" support for some common traits like `PartialEq` and `Debug`.
+/// These are exposed via methods like `Reflect::reflect_partial_eq()` and `Reflect::debug()`.
+/// You can force these implementations to use the actual trait
 /// implementations (instead of their defaults) like this:
-#[derive(Reflect, Hash, Serialize, PartialEq, Eq)]
-#[reflect(Hash, Serialize, PartialEq)]
+#[derive(Reflect, Debug, PartialEq, Eq)]
+#[reflect(PartialEq, Debug)]
 pub struct E {
     x: usize,
 }

--- a/examples/reflection/reflection_types.rs
+++ b/examples/reflection/reflection_types.rs
@@ -40,16 +40,6 @@ pub enum D {
     C { value: f32 },
 }
 
-/// Reflect has "built in" support for some common traits like `PartialEq` and `Debug`.
-/// These are exposed via methods like `Reflect::reflect_partial_eq()` and `Reflect::debug()`.
-/// You can force these implementations to use the actual trait
-/// implementations (instead of their defaults) like this:
-#[derive(Reflect, Debug, PartialEq, Eq)]
-#[reflect(PartialEq, Debug)]
-pub struct E {
-    x: usize,
-}
-
 /// By default, deriving with Reflect assumes the type is either a "struct" or an "enum".
 /// You can tell reflect to treat your type instead as a "value type" by using the `reflect_value`
 /// attribute in place of `reflect`. It is generally a good idea to implement (and reflect)


### PR DESCRIPTION
# Objective

Fixes #6601

The issue already describes the problem in detail but here's a quick description of what we want.

**A reflected (`dyn Reflect`) type should share the same `reflect_hash` and `reflect_partial_eq` behavior as a proxy of that type.**

Additionally, `reflect_partial_eq` should be symmetric. In other words, `a.reflect_partial_eq(b)` produces the same result as `b.reflect_partial_eq(a)`.

This means that the following should test should succeed:

```rust
let value: Box<dyn TupleStruct> = Box::new(Foo(123));
let dynamic: DynamicTupleStruct = value.clone_dynamic();

// `reflect_hash` values are the same
assert_eq!(value.reflect_hash(), dynamic.reflect_hash());

// `reflect_partial_eq` works and is symmetric
assert_eq!(Some(true), value.reflect_partial_eq(&dynamic));
assert_eq!(Some(true), dynamic.reflect_partial_eq(&value));
```

## Solution

Both `reflect_hash` and `reflect_partial_eq` now make use of stored type information in order to perform their computations. Furthermore, they are now consistent and symmetric.

This replaces the old system of registering `Hash` and `PartialEq` like `#[reflect(Hash, PartialEq)]`. Although, this still exists for value types via `#[reflect_value(Hash, PartialEq)]`, since value types base their implementation on the actual traits.

Any field that cannot be hashed or compared, may opt-out of the computation using `#[reflect(skip_hash)]` and `#[reflect(skip_partial_eq)]`, respectively.

```rust
#[derive(Reflect)]
struct Foo {
  a: i32,
  // `f32` doesn't implement `Hash` so its `reflect_hash` will
  // always return `None`, causing our container to return `None`
  // unless we opt it out of the hashing computation.
  #[reflect(skip_hash)]
  b: f32,
}

#[derive(Reflect)]
struct Bar {
  id: u32,
  // We can exclude certain fields from comparison as well.
  #[reflect(skip_partial_eq)]
  _temp: u32,
}
```

If any field returns `None` during one of these operations, the entire container will return `None`.

#### `reflect_partial_eq` Behavior

The behavior of `reflect_partial_eq` is a bit more intuitive now that it is consistent between concrete and proxy types. We essentially only consider types equal if they all share the same non-skipped fields and those fields are equivalent between them.

<details>
<summary><h5>Example Behavior</h5></summary>

Here's an example comparing a type, `Foo`, to a dynamic type. 

> Note that we use a dynamic type here to just make demonstrating the existence and nonexistence of fields simpler. The same would be true when comparing against another concrete type.

```rust
#[derive(Reflect)]
struct Foo {
  a: u32,
  #[reflect(skip_partial_eq)]
  b: u32,
  c: u32,
}

let foo = Foo {
  a: 1,
  b: 2,
  c: 3,
};

let mut dynamic = DynamicStruct::default();

// 1.
assert_eq!(Some(false), foo.reflect_partial_eq(&dynamic));

// 2.
dynamic.insert("a", 1u32);
assert_eq!(Some(false), foo.reflect_partial_eq(&dynamic));

// 3.
dynamic.insert("c", 3u32);
assert_eq!(Some(true), foo.reflect_partial_eq(&dynamic));

// 4.
dynamic.insert("c", 3u32);
assert_eq!(Some(true), foo.reflect_partial_eq(&dynamic));

// 5.
dynamic.insert("b", 555u32);
assert_eq!(Some(true), foo.reflect_partial_eq(&dynamic));

// 6.
dynamic.insert("d", 4u32);
assert_eq!(Some(false), foo.reflect_partial_eq(&dynamic));

#[derive(Reflect)]
struct Bar {
  #[reflect(skip_partial_eq)]
  d: u32,
}

// 7.
dynamic.set_represented_type(Some(Bar::type_info()));
assert_eq!(Some(true), foo.reflect_partial_eq(&dynamic));

#[derive(Reflect)]
struct Baz {
  b: u32,
}

// 8.
dynamic.set_represented_type(Some(Baz::type_info()));
assert_eq!(Some(false), foo.reflect_partial_eq(&dynamic));
```

Explanation for the code above:

1. `false`: `Foo` requires fields `a` and `c`, but `dynamic` is missing both of them.
2. `false`: `Foo` requires fields `a` and `c`, but `dynamic` is missing `c`.
3. `false`: `Foo` and `dynamic` share the same required fields, but have different values for `c`.
4. `true`: `Foo` and `dynamic` share the same required fields and are all equivalent.
5. `true`: Despite the `b` fields not being equivalent, `Foo` skips it so it is not considered for comparison.
6. `false`: `Foo` does not contain a `d` field but `dynamic` does.
7. `true`: `dynamic` has become a proxy of `Bar` which skips `d`, making only fields `a` and `c` relevant for comparison.
8. `false`: `dynamic` has become a proxy of `Baz` which requires `b` even though `Foo` skips `b`

</details>

#### `***Meta` Types

This PR also adds the concept of "metadata" on info types. This is meant to capture various attribute ("meta") data on containers and their fields. For example, the `docs` attribute has been moved to these types rather than on the info type directly.

These meta types are also where we keep track of `skip_hash` and `skip_partial_eq` so they can be utilized within dynamic contexts.

<details>
<summary><h5>Rationale</h5></summary>

There were a few ways to accomplish this: add getters and setters to the meta fields, create separate builders for each meta type, or just make all members `pub`. I went with that last one as it was the simplest and the others felt like possible overkill with the data we have now. Also, there's no concern over accidental mutations since types always share their type information as a static immutable reference.

I also decided to make the constructor for this type `const`. This might be controversial, but my thought was that this helps force us to:
1. **Strive to be const-ready.** The main reason the info types aren't const is because `TypeId` and `type_name` are not const-stable. Stabilization is probably a ways out for them, but it's probably best we don't establish any patterns that would prevent us from easily making the switch to being const.
2. **Store only necessary data.** Since we're storing additional metadata, we might be tempted to store everything: type data registrations, custom attributes, etc. And while I think that's worth considering, there's also a concern that it creates a split between stuff stored on the type and stuff stored in the registry. Users shouldn't be able to configure the names of fields or certain other metadata at runtime. However, they should be able to register type data structs on types they don't own (whether they created the type data or not). With such a split, we would be asking users and library authors to check both the type and the registry for type data, which is prone to error.
3. **Simplify the API.** At the end of the day, this is a public interface. We should avoid complex, crate/case-specific fields and methods that make this interface more difficult to understand and use. This is another reason I went with just making the fields `pub`— it indicates that these fields are standalone and no additional care is needed in using them.

With all that being said, I'm definitely open to changing how meta types are constructed and what they're allowed to contain. This was all a very opinionated implementation on my part and I understand it might enforce restrictions prematurely when we could just wait until it's absolutely needed. So feel free to leave a comment telling me I'm wrong so that we can find a pattern the community can agree on.

</details>

### Notes

<details>
<summary><h4>Concrete vs Reflected</h4></summary>

This change now means that the corresponding concrete impls may give different results than the reflected ones:
* `Reflect::reflect_hash` = / ≠ `Hash::hash`
* `Reflect::reflect_partial_eq`  = / ≠ `PartialEq::eq`

This could be an issue when comparing results between the concrete realm and the reflected one. However, this is likely not a major issue for the following reasons:

##### `Hash` vs `reflect_hash`

The general usage for hashing is to interact with maps and sets. Most users are not manually creating a hasher and calculating the `u64` of a value. Because of this, they are unlikely to run into the scenario where they would be comparing the results of `Hash` and `reflect_hash`.

##### `PartialEq` vs `reflect_partial_eq`

This could be a potential issue for users who rely on `PartialEq` to establish and maintain contracts guaranteeing that two values are equal. If they then try to use `reflect_partial_eq`, the result may go against that supposed guarantee.

In most cases, though, the results should be the same. This is because in most cases `PartialEq` is derived, which means it essentially performs the same operations that `reflect_partial_eq` does: ensure that all fields are equal recursively.

However, if the user has a custom `PartialEq` implementation  or marks their fields as `#[reflect(skip_partial_eq)]`, then the divergence is more likely.

##### User Responsibility

In either case, the best course of action would be for the user to decide which solution they want to use and be consistent in using it— or at least not rely on the results being identical across concrete and reflected implementations.

</details>

<details>
<summary><h4>Transitivity</h4></summary>

One aspect of `PartialEq` that `reflect_partial_eq` does not fully guarantee is transitivity. That is, if `A == B` and `B == C`, then `A == C`.

While concrete types and their proxies should respect transitivity, dynamic types (ones without a represented `TypeInfo`) do not.

##### Example

```rust
#[derive(Reflect)]
struct Foo {
  #[reflect(skip_partial_eq)]
  a: u32,
  b: u32,
}

#[derive(Reflect)]
struct Bar {
  #[reflect(skip_partial_eq)]
  c: u32,
  b: u32,
}

let foo = Foo { a: 1, b: 2 };
let bar = Bar { c: 1, b: 2 };

// `foo == bar` -> ✅
assert_eq!(Some(true), foo.reflect_partial_eq(&bar));

let mut baz = DynamicStruct::default();
baz.insert("c", 1u32);
baz.insert("b", 2u32);

// `bar == baz`  -> ✅
assert_eq!(Some(true), bar.reflect_partial_eq(&baz));

// `foo == baz` -> ❌ (not transitive)
// Not equal because `foo` doesn't contain `c`
assert_eq!(Some(false), foo.reflect_partial_eq(&baz));

// Make `baz` a proxy of `Bar`
baz.set_represented_type(Some(Bar::type_info()));

// `foo == baz` -> ✅ (transitive)
assert_eq!(Some(true), foo.reflect_partial_eq(&baz));
```

As you can see, comparison between concrete values and proxy values are transitive. It's when comparing against a dynamic type that transitivity starts to no longer be guaranteed.

</details>

<details>
<summary><h4>Hashing and Equality</h4></summary>

The [docs](https://doc.rust-lang.org/std/hash/trait.Hash.html#hash-and-eq) for `Hash` state the following:

> When implementing both Hash and Eq, it is important that the following property holds:
> ```
> k1 == k2 -> hash(k1) == hash(k2)
> ```
> In other words, if two keys are equal, their hashes must also be equal. HashMap and HashSet both rely on this behavior.

While the idea is that these `Reflect` methods uphold this property, there is a chance for this to be broken when skipping fields (see example below). This could be problematic for cases where users expect two "equal" values to result in the same hash.

Currently, we just warn against it in the documentation. But there may be other solutions.

Additionally, it's not certain whether or not this truly applies to us since `reflect_partial_eq` is meant to be used like `PartialEq`, and `PartialEq` cannot make these same guarantees as `Eq`. If anything, we would probably need something like `reflect_eq` to match `Eq` behavior.

##### Example

```rust
#[derive(Reflect)]
struct Foo {
    a: u32,
    #[reflect(skip_partial_eq)]
    b: u32,
}

let foo1 = Foo { a: 123, b: 456 };
let foo2 = Foo { a: 123, b: 0 };

// OK!
assert_eq!(Some(true), foo1.reflect_partial_eq(&foo2));
// PANIC!
assert_eq!(foo1.reflect_hash(), foo2.reflect_hash());
```

In the above case `foo1 == foo2` but `hash(foo1) != hash(foo2)`.  Again, this property might not be applicable due to the differences between `PartialEq` and `Eq`, but it should nevertheless be noted.

</details>

### Open Questions

1. Should we make these operations opt-in only? Should we allow entire containers to opt out?
2. Should we return `None` during `reflect_partial_eq` if a field has differing skip configuration (i.e. type `A` skips field `x` while type `B` requires it)? Should we make `reflect_partial_eq` return a `Result` to allow users to branch on this versus other causes for failures?
3. Should we have a convenience attribute that does the same as `#[reflect(skip_hash)]` and `#[reflect(skip_partial_eq)]` combined? Such as a `#[reflect(skip_equivalence)]` attribute.

### Future Work

There are some things we could  possibly consider adding in a future PR:

- Add a `reflect_eq` method to mimic `Eq`
- Improve proxy types to be more robust so we can possibly branch and reduce the number of lookups and redundant checks

---

## Changelog

### Changed

- `Reflect::reflect_hash` and `Reflect::reflect_partial_eq` are now consistent between concrete types and proxies of those types (proxies are simply dynamic types like `DynamicStruct` that contain the `TypeInfo` for a concrete type )
- `Reflect::reflect_hash` and `Reflect::reflect_partial_eq` no longer rely on `Hash` and `PartialEq` implementations
  - This also means they no longer need to be registered via `#[reflect(Hash)]` and `#[reflect(PartialEq)]` for most types, and doing so will result in a compile error 
  - All items that derive `Reflect` now opt into this behavior by default
- Accessing a type's docs has moved from its info type (e.g. `StructInfo`) to its meta type (e.g. `StructMeta`)

### Added

- Added `#[reflect(skip_hash)]` and `#[reflect(skip_partial_eq)]` attributes for controlling the implementations of `Reflect::reflect_hash` and `Reflect::reflect_partial_eq`, respectively
- Added "meta types" which are accessible through a type's info type (e.g. `StructInfo`):
  - `ValueMeta`
  - `TupleMeta`
  - `ArrayMeta`
  - `ListMeta`
  - `MapMeta`
  - `TupleStructMeta`
  - `StructMeta`
  - `EnumMeta`
  - `VariantMeta`
  - `FieldMeta`


## Migration Guide

#### `Hash` and `PartialEq` registrations

Registering `Hash` and/or `PartialEq` now results in a compile error. Such registrations will need to be removed.

```rust
// BEFORE
#[derive(Reflect, Hash, PartialEq, Default)]
#[reflect(Hash, PartialEq, Default)]
struct MyType(u32);

// AFTER
#[derive(Reflect, Hash, PartialEq, Default)]
#[reflect(Default)]
struct MyType(u32);
```

This does not apply to value types created with `#[reflect_value]`:

```rust
#[derive(Reflect, Hash, PartialEq, Default)]
#[reflect_value(Hash, PartialEq, Default)]
struct MyType(u32);
```

#### New `Reflect::reflect_hash` behavior

`Reflect::reflect_hash` no longer relies on a concrete `Hash` implementation. All types that derive `Reflect` come with a built-in implementation of `Reflect::reflect_hash` that is purely based on reflection.

If a particular field is not hashable, you will need to mark it with `#[reflect(skip_hash)]`:

```rust
// BEFORE
#[derive(Reflect)]
#[reflect(Hash)]
struct MyType {
  id: String,
  _temp: f32,
}

impl Hash for MyType {
  fn hash<H: Hasher>(&self, state: &mut H) {
    self.id.hash(state);
  }
}

// AFTER
#[derive(Reflect)]
struct MyType {
  id: String,
  #[reflect(skip_hash)]
  _temp: f32,
}
```

#### New `Reflect::reflect_partial_eq` behavior

`Reflect::reflect_partial_eq` no longer relies on a concrete `PartialEq` implementation. All types that derive `Reflect` come with a built-in implementation of `Reflect::reflect_partial_eq` that is purely based on reflection.

If a particular field is not comparable or should not be considered for comparison, you will need to mark it with `#[reflect(skip_partial_eq)]`:

```rust
// BEFORE
#[derive(Reflect)]
#[reflect(PartialEq)]
struct MyType {
  id: String,
  _temp: f32,
}

impl PartialEq for MyType {
  fn eq(&self, other: &Self) -> bool {
    self.id == other.id
  }
}

// AFTER
#[derive(Reflect)]
struct MyType {
  id: String,
  #[reflect(skip_partial_eq)]
  _temp: f32,
}
```

This also means that some types that might have been considered equal or unequal before may no longer provide the same result. This is especially true for comparison against dynamic types since they now aim to be consistent with their concrete counterparts.

#### `docs` access

Those using the `documentation` feature to access doc strings will now need to get it from a type's meta type rather than the info type directly:

```rust
// BEFORE

/// Some documentation...
#[derive(Reflect)]
struct MyType;

let docs = MyType::type_info().docs();
assert_eq!(Some("Some documentation..."), docs);

// AFTER

/// Some documentation...
#[derive(Reflect)]
struct MyType;

let docs = MyType::type_info().meta().docs;
assert_eq!(Some("Some documentation..."), docs);
```

