### PR TITLE
Fix screenshots on Wayland + Nvidia

### DIFF
--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -199,7 +199,7 @@ impl Image {
             .map(DynamicImage::ImageRgba8),
             // This format is commonly used as the format for the swapchain texture
             // This conversion is added here to support screenshots
-            TextureFormat::Bgra8UnormSrgb => ImageBuffer::from_raw(
+            TextureFormat::Bgra8UnormSrgb | TextureFormat::Bgra8Unorm => ImageBuffer::from_raw(
                 self.texture_descriptor.size.width,
                 self.texture_descriptor.size.height,
                 {

--- a/crates/bevy_render/src/view/window.rs
+++ b/crates/bevy_render/src/view/window.rs
@@ -377,7 +377,7 @@ pub fn prepare_windows(
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: wgpu::TextureDimension::D2,
-                format: surface_configuration.format,
+                format: surface_configuration.format.add_srgb_suffix(),
                 usage: TextureUsages::RENDER_ATTACHMENT
                     | TextureUsages::COPY_SRC
                     | TextureUsages::TEXTURE_BINDING,

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -234,16 +234,11 @@ impl SpecializedRenderPipeline for ScreenshotToScreenPipeline {
                 shader: SCREENSHOT_SHADER_HANDLE.typed(),
             },
             primitive: wgpu::PrimitiveState {
-                topology: wgpu::PrimitiveTopology::TriangleList,
-                strip_index_format: None,
-                front_face: wgpu::FrontFace::Ccw,
                 cull_mode: Some(wgpu::Face::Back),
-                polygon_mode: wgpu::PolygonMode::Fill,
-                conservative: false,
-                unclipped_depth: false,
+                ..Default::default()
             },
             depth_stencil: None,
-            multisample: wgpu::MultisampleState::default(),
+            multisample: Default::default(),
             fragment: Some(FragmentState {
                 shader: SCREENSHOT_SHADER_HANDLE.typed(),
                 entry_point: Cow::Borrowed("fs_main"),


### PR DESCRIPTION
# Objective

Fix #8604

## Solution

Use `.add_srgb_suffix()` when creating the screenshot texture.
Allow converting `Bgra8Unorm` images.

Only a two line change for the fix, the `screenshot.rs` changes are just a bit of cleanup.

