### PR TITLE
Add `CubicCurve::segment_count` + `iter_samples` adjustment

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -489,10 +489,10 @@ impl<P: Point> CubicCurve<P> {
 
     /// An iterator that returns values of `t` uniformly spaced over `0..=subdivisions`.
     #[inline]
-    fn iter_uniformly(&self, subdivisions: usize) -> impl ExactSizeIterator<Item = f32> {
+    fn iter_uniformly(&self, subdivisions: usize) -> impl Iterator<Item = f32> {
         let segments = self.segments.len() as f32;
         let step = segments / subdivisions as f32;
-        (0..subdivisions.saturating_add(1)).map(move |i| i as f32 * step)
+        (0..=subdivisions).map(move |i| i as f32 * step)
     }
 
     /// The list of segments contained in this `CubicCurve`.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -472,22 +472,40 @@ impl<P: Point> CubicCurve<P> {
     /// A flexible iterator used to sample curves with arbitrary functions.
     ///
     /// This splits the curve into `subdivisions` of evenly spaced `t` values across the
-    /// length of the curve from start (t = 0) to end (t = 1), returning an iterator that evaluates
-    /// the curve with the supplied `sample_function` at each `t`.
+    /// length of the curve from start (t = 0) to end (t = n), where `n = self.segment_count()`,
+    /// returning an iterator evaluating the curve with the supplied `sample_function` at each `t`.
     ///
-    /// Given `subdivisions = 2`, this will split the curve into two lines, or three points, and
-    /// return an iterator over those three points, one at the start, middle, and end.
+    /// For `subdivisions = 2`, this will split the curve into two lines, or three points, and
+    /// return an iterator with 3 items, the three points, one at the start, middle, and end.
     #[inline]
-    pub fn iter_samples(
-        &self,
+    pub fn iter_samples<'a, 'b: 'a>(
+        &'b self,
         subdivisions: usize,
-        sample_function: fn(&Self, f32) -> P,
-    ) -> impl Iterator<Item = P> + '_ {
-        (0..=subdivisions).map(move |i| {
-            let segments = self.segments.len() as f32;
-            let t = i as f32 / subdivisions as f32 * segments;
-            sample_function(self, t)
-        })
+        mut sample_function: impl FnMut(&Self, f32) -> P + 'a,
+    ) -> impl Iterator<Item = P> + 'a {
+        self.iter_samples_t(subdivisions)
+            .map(move |t| sample_function(self, t))
+    }
+
+    /// Iterates over `subdivisions + 1` `t`s evenly spaced from the start of
+    /// the first curve segment to the end of the last segment.
+    #[inline]
+    fn iter_samples_t(&self, subdivisions: usize) -> impl ExactSizeIterator<Item = f32> {
+        let segments = self.segment_count() as f32;
+        let step = segments / subdivisions as f32;
+        (0..subdivisions.saturating_add(1)).map(move |i| i as f32 * step)
+    }
+
+    /// How many segments does this `CubicCurve` contain.
+    ///
+    /// This spline's global `t` value is equal to how many segments it has.
+    ///
+    /// All method accepting `t` on `CubicSpline` depends on the global `t`.
+    /// When sampling over the entire curve, you should either use one of the
+    /// `iter_*` methods or account for the segment count using this method.
+    #[inline]
+    pub fn segment_count(&self) -> usize {
+        self.segments.len()
     }
 
     /// Iterate over the curve split into `subdivisions`, sampling the position at each step.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -483,29 +483,28 @@ impl<P: Point> CubicCurve<P> {
         subdivisions: usize,
         mut sample_function: impl FnMut(&Self, f32) -> P + 'a,
     ) -> impl Iterator<Item = P> + 'a {
-        self.iter_samples_t(subdivisions)
+        self.iter_uniformly(subdivisions)
             .map(move |t| sample_function(self, t))
     }
 
-    /// Iterates over `subdivisions + 1` `t`s evenly spaced from the start of
-    /// the first curve segment to the end of the last segment.
+    /// An iterator that returns values of `t` uniformly spaced over `0..=subdivisions`.
     #[inline]
-    fn iter_samples_t(&self, subdivisions: usize) -> impl ExactSizeIterator<Item = f32> {
-        let segments = self.segment_count() as f32;
+    fn iter_uniformly(&self, subdivisions: usize) -> impl ExactSizeIterator<Item = f32> {
+        let segments = self.segments.len() as f32;
         let step = segments / subdivisions as f32;
         (0..subdivisions.saturating_add(1)).map(move |i| i as f32 * step)
     }
 
-    /// How many segments does this `CubicCurve` contain.
+    /// The list of segments contained in this `CubicCurve`.
     ///
     /// This spline's global `t` value is equal to how many segments it has.
     ///
-    /// All method accepting `t` on `CubicSpline` depends on the global `t`.
+    /// All method accepting `t` on `CubicCurve` depends on the global `t`.
     /// When sampling over the entire curve, you should either use one of the
-    /// `iter_*` methods or account for the segment count using this method.
+    /// `iter_*` methods or account for the segment count using `curve.segments().len()`.
     #[inline]
-    pub fn segment_count(&self) -> usize {
-        self.segments.len()
+    pub fn segments(&self) -> &[CubicSegment<P>] {
+        &self.segments
     }
 
     /// Iterate over the curve split into `subdivisions`, sampling the position at each step.


### PR DESCRIPTION
## Objective

- Provide a way to use `CubicCurve` non-iter methods
- Accept a `FnMut` over a `fn` pointer on `iter_samples`
- Improve `build_*_cubic_100_points` benchmark by -45% (this means they are twice as fast)

### Solution

Previously, the only way to iterate over an evenly spaced set of points on a `CubicCurve` was to use one of the `iter_*` methods.

The return value of those methods were bound by `&self` lifetime, making them unusable in certain contexts.

Furthermore, other `CubicCurve` methods (`position`, `velocity`, `acceleration`) required normalizing `t` over the `CubicCurve`'s internal segment count.

There were no way to access this segment count, making those methods pretty much unusable.

The newly added `segment_count` allows accessing the segment count.

`iter_samples` used to accept a `fn`, a function pointer. This is surprising and contrary to the rust stdlib APIs, which accept `Fn` traits for `Iterator` combinators.

`iter_samples` now accepts a `FnMut`.

I don't trust a bit the bevy benchmark suit, but according to it, this doubles (-45%) the performance on the `build_pos_cubic_100_points` and `build_accel_cubic_100_points` benchmarks.

---

## Changelog

- Added the `CubicCurve::segments` method to access the underlying segments of a cubic curve
- Allow closures as `CubicCurve::iter_samples` `sample_function` argument.