### PR TITLE
Fix example-showcase tool producing invalid front-matter paths when run on windows

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -1,8 +1,9 @@
 use std::{
     collections::HashMap,
+    ffi::OsStr,
     fs::{self, File},
     io::Write,
-    path::{Path, PathBuf},
+    path::Path,
     process::exit,
     thread,
     time::{Duration, Instant},
@@ -240,8 +241,10 @@ header_message = \"Examples (WebGPU)\"
                             code_path
                                 .components()
                                 .skip(1)
-                                .collect::<PathBuf>()
-                                .display(),
+                                .map(|v| v.as_os_str())
+                                .collect::<Vec<_>>()
+                                .join(OsStr::new("/"))
+                                .to_string_lossy(),
                             &to_show.path,
                         )
                         .as_bytes(),


### PR DESCRIPTION
# Objective

Fix the example-showcase tool producing invalid paths in the generated front-matter when run on Windows. Before this PR the generated index.md could include paths like these (mixing both unix and windows style):

```toml
code_path = "content/examples-webgpu/2D Rendering\2d-gizmos\2d_gizmos.rs"
```

This is an effect of PathBuf::display() only generating strings in the style of the host OS. 

## Solution

Switch out PathBuf::display() for a generic "collect parts as strings and join with slash(/)" instead. Forcing output to be unix style on all platforms.
