### PR TITLE
Make `UVSphere` 3d shape use Y-up convention

### DIFF
--- a/crates/bevy_render/src/mesh/shape/uvsphere.rs
+++ b/crates/bevy_render/src/mesh/shape/uvsphere.rs
@@ -52,7 +52,7 @@ impl From<UVSphere> for Mesh {
 
                 vertices.push([x, y, z]);
                 normals.push([x * length_inv, y * length_inv, z * length_inv]);
-                uvs.push([(j as f32) / sectors, (i as f32) / stacks]);
+                uvs.push([(j as f32) / sectors, 1.0 - (i as f32) / stacks]);
             }
         }
 

--- a/crates/bevy_render/src/mesh/shape/uvsphere.rs
+++ b/crates/bevy_render/src/mesh/shape/uvsphere.rs
@@ -42,13 +42,13 @@ impl From<UVSphere> for Mesh {
 
         for i in 0..sphere.stacks + 1 {
             let stack_angle = PI / 2. - (i as f32) * stack_step;
-            let xy = sphere.radius * stack_angle.cos();
-            let z = sphere.radius * stack_angle.sin();
+            let xz = sphere.radius * stack_angle.cos();
+            let y = sphere.radius * stack_angle.sin();
 
             for j in 0..sphere.sectors + 1 {
                 let sector_angle = (j as f32) * sector_step;
-                let x = xy * sector_angle.cos();
-                let y = xy * sector_angle.sin();
+                let x = xz * sector_angle.cos();
+                let z = xz * sector_angle.sin();
 
                 vertices.push([x, y, z]);
                 normals.push([x * length_inv, y * length_inv, z * length_inv]);
@@ -66,13 +66,13 @@ impl From<UVSphere> for Mesh {
             let mut k2 = k1 + sphere.sectors + 1;
             for _j in 0..sphere.sectors {
                 if i != 0 {
-                    indices.push(k1 as u32);
                     indices.push(k2 as u32);
+                    indices.push(k1 as u32);
                     indices.push((k1 + 1) as u32);
                 }
                 if i != sphere.stacks - 1 {
-                    indices.push((k1 + 1) as u32);
                     indices.push(k2 as u32);
+                    indices.push((k1 + 1) as u32);
                     indices.push((k2 + 1) as u32);
                 }
                 k1 += 1;


### PR DESCRIPTION
# Objective

### Before
<img width="1392" alt="Screenshot 2023-05-29 at 21 33 45" src="https://github.com/bevyengine/bevy/assets/418473/ff409931-3d99-4404-af0a-87f264388723">

### After

<img width="1392" alt="Screenshot 2023-05-29 at 21 33 05" src="https://github.com/bevyengine/bevy/assets/418473/cd781ea0-16af-4898-9748-f8b20f9d1c1b">

- As noted by 0xC0DEDBAD on this [Discord message](https://discord.com/channels/691052431525675048/743663924229963868/1112508519514652675) our current UV Sphere is Z-up (with the poles on +Z, -Z). This PR makes it Y-up, to be more consistent with other 3d shapes.

## Solution

- Swapped `y` and `z` in the math and also swapped first and second triangle indexes to preserve right-handedness;
- Flipped UV's V component.

---

## Changelog

### Changed

- Made `UVSphere` Y-up (instead of Z-up) for consistency with other 3d shapes and Bevy's convention;
 
## Migration Guide

- `UVSphere` poles are now on +Y, -Y. If you're currently relying on `UVSphere` poles being +Z, -Z, (e.g. for texturing/uv mapping purposes) you must rotate your `UVSphere` by `PI / 2.0` (90º) on the X axis;
