### PR TITLE
Make the `Condition` trait generic

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -17,7 +17,7 @@ pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
 /// # Examples
 /// A condition that returns true every other time it's called.
 /// ```
-/// # use bevy_ecs::prelude;
+/// # use bevy_ecs::prelude::*;
 /// fn every_other_time() -> impl Condition<()> {
 ///     IntoSystem::into_system(|mut flag: Local<bool>| {
 ///         *flag = !*flag;

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -11,7 +11,7 @@ pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
 
 /// A system that determines if one or more scheduled systems should run.
 ///
-/// Implemented for functions and closures that convert into [`System<In=(), Out=bool>`](crate::system::System)
+/// Implemented for functions and closures that convert into [`System<Out=bool>`](crate::system::System)
 /// with [read-only](crate::system::ReadOnlySystemParam) parameters.
 pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// Returns a new run condition that only returns `true`

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -19,14 +19,14 @@ pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
 /// ```
 /// # use bevy_ecs::prelude;
 /// fn every_other_time() -> impl Condition<()> {
-///     IntoSystem::into_system(|flag: Local<bool>| {
+///     IntoSystem::into_system(|mut flag: Local<bool>| {
 ///         *flag = !*flag;
 ///         *flag
 ///     })
 /// }
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
-/// # fn my_system(did_run: ResMut<DidRun>) { did_run.0 = true; }
+/// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
 /// # let mut schedule = Schedule::new();
 /// schedule.add_systems(my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
@@ -49,7 +49,7 @@ pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
 /// # fn always_true() -> bool { true }
 /// # let mut schedule = Schedule::new();
 /// # #[derive(Resource)] struct DidRun(bool);
-/// # fn my_system(did_run: ResMut<DidRun>) { did_run.0 = true; }
+/// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
 /// schedule.add_systems(my_system.run_if(always_true.pipe(identity())));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -7,7 +7,7 @@ use crate::query::Access;
 use crate::system::{CombinatorSystem, Combine, IntoSystem, ReadOnlySystem, System};
 use crate::world::World;
 
-pub type BoxedCondition = Box<dyn ReadOnlySystem<In = (), Out = bool>>;
+pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 
 /// A system that determines if one or more scheduled systems should run.
 ///


### PR DESCRIPTION
# Objective

The `Condition` trait is only implemented for systems and system functions that take no input. This can make it awkward to write conditions that are intended to be used with system piping.

## Solution

Add an `In` generic to the trait. It defaults to `()`.

---

## Changelog

- Made the `Condition` trait generic over system inputs.