### PR TITLE
Add winit's wayland-csd-adwaita feature to Bevy's wayland feature

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [features]
 trace = []
-wayland = ["winit/wayland"]
+wayland = ["winit/wayland", "winit/wayland-csd-adwaita"]
 x11 = ["winit/x11"]
 accesskit_unix = ["accesskit_winit/accesskit_unix"]
 


### PR DESCRIPTION
# Objective

- Fix Wayland window client side decorations issue on Gnome Wayland, fixes #3301. 

## Solution

- One simple one line solution: Add winit's `wayland-csd-adwaita` feature to Bevy's `wayland` feature.

