### PR TITLE
bevy_reflect: Allow construction of MapIter outside of the bevy_reflect crate.

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -379,10 +379,7 @@ macro_rules! impl_reflect_for_hashmap {
             }
 
             fn iter(&self) -> MapIter {
-                MapIter {
-                    map: self,
-                    index: 0,
-                }
+                MapIter::new(self)
             }
 
             fn drain(self: Box<Self>) -> Vec<(Box<dyn Reflect>, Box<dyn Reflect>)> {

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -381,6 +381,14 @@ pub struct MapIter<'a> {
     pub(crate) index: usize,
 }
 
+impl<'a> MapIter<'a> {
+    /// Creates a new [`MapIter`].
+    #[inline]
+    pub const fn new(map: &'a dyn Map) -> MapIter {
+        MapIter { map, index: 0 }
+    }
+}
+
 impl<'a> Iterator for MapIter<'a> {
     type Item = (&'a dyn Reflect, &'a dyn Reflect);
 

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -245,10 +245,7 @@ impl Map for DynamicMap {
     }
 
     fn iter(&self) -> MapIter {
-        MapIter {
-            map: self,
-            index: 0,
-        }
+        MapIter::new(self)
     }
 
     fn get_at(&self, index: usize) -> Option<(&dyn Reflect, &dyn Reflect)> {
@@ -377,8 +374,8 @@ impl Debug for DynamicMap {
 
 /// An iterator over the key-value pairs of a [`Map`].
 pub struct MapIter<'a> {
-    pub(crate) map: &'a dyn Map,
-    pub(crate) index: usize,
+    map: &'a dyn Map,
+    index: usize,
 }
 
 impl<'a> MapIter<'a> {


### PR DESCRIPTION
# Objective

Right now it's impossible to construct a MapIter outside of the bevy_reflect crate, making it impossible to implement the Map trait for custom map types.

## Solution

Addition of a pub constructor to MapIter.
