### PR TITLE
Simplify the implementation of `UnsafeWorldCell`

### DIFF
--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -80,6 +80,7 @@ impl<'w> UnsafeWorldCell<'w> {
     pub(crate) fn new_readonly(world: &'w World) -> Self {
         // SAFETY: `SyncUnsafeCell<World>` has the same representation as `World`,
         // so we can safely cast the latter to the former.
+        // The caller is forbidden from mutating the world with the returned value.
         Self(unsafe { &*(world as *const _ as *const _) })
     }
 


### PR DESCRIPTION
# Objective

The type `UnsafeWorldCell` is essentially a manual implementation of `SyncUnsafeCell`, which is unnecessary.

## Solution

Make `UnsafeWorldCell` a wrapper around `SyncUnsafeCell`.