### PR TITLE
Resolve clippy issues for rust 1.70.0

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -99,6 +99,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
     let read_only_struct_name = if fetch_struct_attributes.is_mutable {
         Ident::new(&format!("{struct_name}ReadOnly"), Span::call_site())
     } else {
+        #[allow(clippy::redundant_clone)]
         struct_name.clone()
     };
 
@@ -106,6 +107,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
     let read_only_item_struct_name = if fetch_struct_attributes.is_mutable {
         Ident::new(&format!("{struct_name}ReadOnlyItem"), Span::call_site())
     } else {
+        #[allow(clippy::redundant_clone)]
         item_struct_name.clone()
     };
 
@@ -115,6 +117,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
         let new_ident = Ident::new(&format!("{struct_name}ReadOnlyFetch"), Span::call_site());
         ensure_no_collision(new_ident, tokens.clone())
     } else {
+        #[allow(clippy::redundant_clone)]
         fetch_struct_name.clone()
     };
 

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -88,14 +88,14 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
     let user_generics = ast.generics.clone();
     let (user_impl_generics, user_ty_generics, user_where_clauses) = user_generics.split_for_impl();
     let user_generics_with_world = {
-        let mut generics = ast.generics.clone();
+        let mut generics = ast.generics;
         generics.params.insert(0, parse_quote!('__w));
         generics
     };
     let (user_impl_generics_with_world, user_ty_generics_with_world, user_where_clauses_with_world) =
         user_generics_with_world.split_for_impl();
 
-    let struct_name = ast.ident.clone();
+    let struct_name = ast.ident;
     let read_only_struct_name = if fetch_struct_attributes.is_mutable {
         Ident::new(&format!("{struct_name}ReadOnly"), Span::call_site())
     } else {

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_to_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_to_readonly.stderr
@@ -42,4 +42,4 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
    |                           ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 56 |
 57 |         println!("{ref_foo:?}");
-   |                    ------- immutable borrow later used here
+   |                   ----------- immutable borrow later used here

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,9 +6,6 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -18,9 +15,6 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -15,6 +18,9 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -162,6 +162,7 @@ impl ShaderDefVal {
 }
 
 impl ShaderCache {
+    #[allow(clippy::result_large_err)]
     fn get(
         &mut self,
         render_device: &RenderDevice,


### PR DESCRIPTION
- Supress false positive `redundant_clone` lints.
- Supress inactionable `result_large_err` lint.
  Most of the size(50 out of 68 bytes) is coming from `naga::WithSpan<naga::valid::ValidationError>`