### PR TITLE
remove some use of once_cell that can be replace with new std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 
 [workspace]
 exclude = [

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -13,7 +13,6 @@ futures-lite = "1.4.0"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 async-task = "4.2.0"
-once_cell = "1.7"
 concurrent-queue = "2.0.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/crates/bevy_tasks/src/usages.rs
+++ b/crates/bevy_tasks/src/usages.rs
@@ -11,12 +11,11 @@
 //! for consumption. (likely via channels)
 
 use super::TaskPool;
-use once_cell::sync::OnceCell;
-use std::ops::Deref;
+use std::{ops::Deref, sync::OnceLock};
 
-static COMPUTE_TASK_POOL: OnceCell<ComputeTaskPool> = OnceCell::new();
-static ASYNC_COMPUTE_TASK_POOL: OnceCell<AsyncComputeTaskPool> = OnceCell::new();
-static IO_TASK_POOL: OnceCell<IoTaskPool> = OnceCell::new();
+static COMPUTE_TASK_POOL: OnceLock<ComputeTaskPool> = OnceLock::new();
+static ASYNC_COMPUTE_TASK_POOL: OnceLock<AsyncComputeTaskPool> = OnceLock::new();
+static IO_TASK_POOL: OnceLock<IoTaskPool> = OnceLock::new();
 
 /// A newtype for a task pool for CPU-intensive work that must be completed to deliver the next
 /// frame

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -35,7 +35,6 @@ raw-window-handle = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
 winit = { version = "0.28", default-features = false, features = ["android-native-activity"] }
-once_cell = "1.11"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -58,7 +58,7 @@ use crate::accessibility::{AccessKitAdapters, AccessibilityPlugin, WinitActionHa
 use crate::web_resize::{CanvasParentResizeEventChannel, CanvasParentResizePlugin};
 
 #[cfg(target_os = "android")]
-pub static ANDROID_APP: once_cell::sync::OnceCell<AndroidApp> = once_cell::sync::OnceCell::new();
+pub static ANDROID_APP: std::sync::OnceLock<AndroidApp> = std::sync::OnceLock::new();
 
 /// A [`Plugin`] that utilizes [`winit`] for window creation and event loop management.
 #[derive(Default)]


### PR DESCRIPTION
# Objective

- Some methods are stabilised with Rust 1.70 https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html#oncecell-and-oncelock

## Solution

- Remove `once_cell` when possible and use std instead
