### PR TITLE
correctly setup everything in the default run_once runner

### DIFF
--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -20,6 +20,7 @@ bevy_derive = { path = "../bevy_derive", version = "0.11.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.11.0-dev", default-features = false }
 bevy_reflect = { path = "../bevy_reflect", version = "0.11.0-dev", optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.11.0-dev" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.11.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -956,6 +956,13 @@ impl App {
 }
 
 fn run_once(mut app: App) {
+    while !app.ready() {
+        #[cfg(not(target_arch = "wasm32"))]
+        bevy_tasks::tick_global_task_pools_on_main_thread();
+    }
+    app.finish();
+    app.cleanup();
+
     app.update();
 }
 


### PR DESCRIPTION
# Objective

- Fix #8658 
- `without_winit` example panics `thread 'Compute Task Pool (2)' panicked at 'called `Option::unwrap()` on a `None` value', crates/bevy_render/src/pipelined_rendering.rs:134:84`

## Solution

- In the default runner method `run_once`, correctly finish the initialisation of the plugins. `run_once` can't be called twice so it's ok to do it there
