### PR TITLE
Rename `Plane` struct to `HalfSpace`

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -8,7 +8,7 @@ use bevy_render::{
     color::Color,
     extract_resource::ExtractResource,
     prelude::Projection,
-    primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, Plane, Sphere},
+    primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, HalfSpace, Sphere},
     render_resource::BufferBindingType,
     renderer::RenderDevice,
     view::{ComputedVisibility, RenderLayers, VisibleEntities},
@@ -1457,7 +1457,7 @@ pub(crate) fn assign_lights_to_clusters(
                 let view_x = clip_to_view(inverse_projection, Vec4::new(x_pos, 0.0, 1.0, 1.0)).x;
                 let normal = Vec3::X;
                 let d = view_x * normal.x;
-                x_planes.push(Plane::new(normal.extend(d)));
+                x_planes.push(HalfSpace::new(normal.extend(d)));
             }
 
             let y_slices = clusters.dimensions.y as f32;
@@ -1467,7 +1467,7 @@ pub(crate) fn assign_lights_to_clusters(
                 let view_y = clip_to_view(inverse_projection, Vec4::new(0.0, y_pos, 1.0, 1.0)).y;
                 let normal = Vec3::Y;
                 let d = view_y * normal.y;
-                y_planes.push(Plane::new(normal.extend(d)));
+                y_planes.push(HalfSpace::new(normal.extend(d)));
             }
         } else {
             let x_slices = clusters.dimensions.x as f32;
@@ -1478,7 +1478,7 @@ pub(crate) fn assign_lights_to_clusters(
                 let nt = clip_to_view(inverse_projection, Vec4::new(x_pos, 1.0, 1.0, 1.0)).xyz();
                 let normal = nb.cross(nt);
                 let d = nb.dot(normal);
-                x_planes.push(Plane::new(normal.extend(d)));
+                x_planes.push(HalfSpace::new(normal.extend(d)));
             }
 
             let y_slices = clusters.dimensions.y as f32;
@@ -1489,7 +1489,7 @@ pub(crate) fn assign_lights_to_clusters(
                 let nr = clip_to_view(inverse_projection, Vec4::new(1.0, y_pos, 1.0, 1.0)).xyz();
                 let normal = nr.cross(nl);
                 let d = nr.dot(normal);
-                y_planes.push(Plane::new(normal.extend(d)));
+                y_planes.push(HalfSpace::new(normal.extend(d)));
             }
         }
 
@@ -1498,7 +1498,7 @@ pub(crate) fn assign_lights_to_clusters(
             let view_z = z_slice_to_view_z(first_slice_depth, far_z, z_slices, z, is_orthographic);
             let normal = -Vec3::Z;
             let d = view_z * normal.z;
-            z_planes.push(Plane::new(normal.extend(d)));
+            z_planes.push(HalfSpace::new(normal.extend(d)));
         }
 
         let mut update_from_light_intersections = |visible_lights: &mut Vec<Entity>| {
@@ -1737,7 +1737,7 @@ pub(crate) fn assign_lights_to_clusters(
 }
 
 // NOTE: This exploits the fact that a x-plane normal has only x and z components
-fn get_distance_x(plane: Plane, point: Vec3A, is_orthographic: bool) -> f32 {
+fn get_distance_x(plane: HalfSpace, point: Vec3A, is_orthographic: bool) -> f32 {
     if is_orthographic {
         point.x - plane.d()
     } else {
@@ -1750,7 +1750,7 @@ fn get_distance_x(plane: Plane, point: Vec3A, is_orthographic: bool) -> f32 {
 }
 
 // NOTE: This exploits the fact that a z-plane normal has only a z component
-fn project_to_plane_z(z_light: Sphere, z_plane: Plane) -> Option<Sphere> {
+fn project_to_plane_z(z_light: Sphere, z_plane: HalfSpace) -> Option<Sphere> {
     // p = sphere center
     // n = plane normal
     // d = n.p if p is in the plane
@@ -1772,7 +1772,11 @@ fn project_to_plane_z(z_light: Sphere, z_plane: Plane) -> Option<Sphere> {
 }
 
 // NOTE: This exploits the fact that a y-plane normal has only y and z components
-fn project_to_plane_y(y_light: Sphere, y_plane: Plane, is_orthographic: bool) -> Option<Sphere> {
+fn project_to_plane_y(
+    y_light: Sphere,
+    y_plane: HalfSpace,
+    is_orthographic: bool,
+) -> Option<Sphere> {
     let distance_to_plane = if is_orthographic {
         y_plane.d() - y_light.center.y
     } else {

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -161,6 +161,8 @@ impl Frustum {
     // NOTE: This approach of extracting the frustum half-space from the view
     // projection matrix is from Foundations of Game Engine Development 2
     // Rendering by Lengyel.
+    /// Returns a frustum derived from `view_projection`,
+    /// without a far plane.
     fn from_view_projection_no_far(view_projection: &Mat4) -> Self {
         let row3 = view_projection.row(3);
         let mut half_spaces = [HalfSpace::default(); 6];

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -81,9 +81,10 @@ impl Sphere {
     }
 }
 
-/// A half-space defined by a unit normal and distance from the origin along the normal
-/// Any point `p` is considered to be within the half-space,
-/// or on the positive side (inside) of the plane, if the equation `n.p + d > 0` is satisfied.
+/// A HalfSpace, characterized by the bisecting plane's unit normal and distance from the origin along the normal.
+/// This bisecting plane partitions the 3D space into two regions.
+/// Any point `p` is considered to be within the HalfSpace when the distance is positive,
+/// meaning: if the equation `n.p + d > 0` is satisfied.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HalfSpace {
     normal_d: Vec4,
@@ -91,10 +92,9 @@ pub struct HalfSpace {
 
 impl HalfSpace {
     /// Constructs a `HalfSpace` from a 4D vector whose first 3 components
-    /// are the normal and whose last component is the distance along the normal
-    /// from the origin.
-    /// This constructor ensures that the normal is normalized and the distance is
-    /// scaled accordingly so it represents the signed distance from the origin.
+    /// represent the bisecting plane's unit normal, and the last component signifies
+    /// the distance from the origin to the plane along the normal.
+    /// The constructor ensures the normal vector is normalized and the distance is appropriately scaled.
     #[inline]
     pub fn new(normal_d: Vec4) -> Self {
         Self {
@@ -102,21 +102,21 @@ impl HalfSpace {
         }
     }
 
-    /// `HalfSpace` unit normal
+    /// Returns the unit normal vector of the bisecting plane that characterizes the `HalfSpace`.
     #[inline]
     pub fn normal(&self) -> Vec3A {
         Vec3A::from(self.normal_d)
     }
 
-    /// Signed distance from the origin along the unit normal such that n.p + d = 0 for point p in
-    /// the `HalfSpace`
+    /// Returns the distance from the origin to the bisecting plane along the plane's unit normal vector.
+    /// This distance helps determine the position of a point `p` on the bisecting plane, as per the equation `n.p + d = 0`.
     #[inline]
     pub fn d(&self) -> f32 {
         self.normal_d.w
     }
 
-    /// `HalfSpace` unit normal and signed distance from the origin such that n.p + d = 0 for point p
-    /// in the `HalfSpace`
+    /// Returns the bisecting plane's unit normal vector and the distance from the origin to the plane.
+    /// The returned 4D vector embodies the key properties of the bisecting plane that characterizes the `HalfSpace`.
     #[inline]
     pub fn normal_d(&self) -> Vec4 {
         self.normal_d

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -81,8 +81,9 @@ impl Sphere {
     }
 }
 
-/// A HalfSpace, characterized by the bisecting plane's unit normal and distance from the origin along the normal.
-/// This bisecting plane partitions the 3D space into two regions.
+/// A bisecting plane that partitions 3D space into two regions.
+///
+/// Mathematically, each instance of this type is characterized by the bisecting plane's unit normal and distance from the origin along the normal.
 /// Any point `p` is considered to be within the HalfSpace when the distance is positive,
 /// meaning: if the equation `n.p + d > 0` is satisfied.
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -123,7 +123,7 @@ impl HalfSpace {
     }
 }
 
-/// A frustum defined by the 6 defining half spaces.
+/// A frustum made up of the 6 defining half spaces.
 /// Half spaces are ordered left, right, top, bottom, near, far.
 /// The normal vectors of the half spaces point towards the interior of the frustum.
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -158,7 +158,7 @@ impl Frustum {
         frustum
     }
 
-    // NOTE: This approach of extracting the frustum HalfSpaces from the view
+    // NOTE: This approach of extracting the frustum half-space from the view
     // projection matrix is from Foundations of Game Engine Development 2
     // Rendering by Lengyel.
     fn from_view_projection_no_far(view_projection: &Mat4) -> Self {

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -83,7 +83,7 @@ impl Sphere {
 
 /// A bisecting plane that partitions 3D space into two regions.
 ///
-/// Mathematically, each instance of this type is characterized by the bisecting plane's unit normal and distance from the origin along the normal.
+/// Each instance of this type is characterized by the bisecting plane's unit normal and distance from the origin along the normal.
 /// Any point `p` is considered to be within the `HalfSpace` when the distance is positive,
 /// meaning: if the equation `n.p + d > 0` is satisfied.
 #[derive(Clone, Copy, Debug, Default)]

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -123,9 +123,9 @@ impl HalfSpace {
     }
 }
 
-/// A frustum defined by the 6 containing planes
-/// Planes are ordered left, right, top, bottom, near, far
-/// Normals point into the contained volume
+/// A frustum defined by the 6 defining half spaces.
+/// Half spaces are ordered left, right, top, bottom, near, far.
+/// The normal vectors of the half spaces point towards the interior of the frustum.
 #[derive(Component, Clone, Copy, Debug, Default, Reflect)]
 #[reflect(Component)]
 pub struct Frustum {
@@ -142,8 +142,8 @@ impl Frustum {
         frustum
     }
 
-    /// Returns a frustum derived from `view_projection`, but with a custom
-    /// far plane.
+    /// Returns a frustum derived from `view_projection`,
+    /// but with a custom far plane.
     #[inline]
     pub fn from_view_projection_custom_far(
         view_projection: &Mat4,
@@ -157,7 +157,7 @@ impl Frustum {
         frustum
     }
 
-    // NOTE: This approach of extracting the frustum planes from the view
+    // NOTE: This approach of extracting the frustum HalfSpaces from the view
     // projection matrix is from Foundations of Game Engine Development 2
     // Rendering by Lengyel.
     fn from_view_projection_no_far(view_projection: &Mat4) -> Self {
@@ -174,6 +174,7 @@ impl Frustum {
         Self { planes }
     }
 
+    /// Checks if a sphere intersects the frustum.
     #[inline]
     pub fn intersects_sphere(&self, sphere: &Sphere, intersect_far: bool) -> bool {
         let sphere_center = sphere.center.extend(1.0);
@@ -186,6 +187,7 @@ impl Frustum {
         true
     }
 
+    /// Checks if an Oriented Bounding Box (obb) intersects the frustum.
     #[inline]
     pub fn intersects_obb(
         &self,

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -84,7 +84,7 @@ impl Sphere {
 /// A bisecting plane that partitions 3D space into two regions.
 ///
 /// Mathematically, each instance of this type is characterized by the bisecting plane's unit normal and distance from the origin along the normal.
-/// Any point `p` is considered to be within the HalfSpace when the distance is positive,
+/// Any point `p` is considered to be within the `HalfSpace` when the distance is positive,
 /// meaning: if the equation `n.p + d > 0` is satisfied.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HalfSpace {

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -83,7 +83,7 @@ impl Sphere {
 
 /// A half-space defined by a unit normal and distance from the origin along the normal
 /// Any point `p` is considered to be within the half-space,
-/// or on the positive side (inside) of the plane, if the equation n.p + d > 0 is satisfied.
+/// or on the positive side (inside) of the plane, if the equation `n.p + d > 0` is satisfied.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HalfSpace {
     normal_d: Vec4,

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -117,7 +117,6 @@ impl HalfSpace {
     }
 
     /// Returns the bisecting plane's unit normal vector and the distance from the origin to the plane.
-    /// The returned 4D vector embodies the key properties of the bisecting plane that characterizes the `HalfSpace`.
     #[inline]
     pub fn normal_d(&self) -> Vec4 {
         self.normal_d

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -82,9 +82,8 @@ impl Sphere {
 }
 
 /// A half-space defined by a unit normal and distance from the origin along the normal
-/// Any point `p` is in the half-space if `n.p + d = 0`
-/// When defining half-spaces such as for frusta, if `n.p + d > 0` then `p` is on
-/// the positive side (inside) of the plane.
+/// Any point `p` is considered to be within the half-space,
+/// or on the positive side (inside) of the plane, if the equation n.p + d > 0 is satisfied.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct HalfSpace {
     normal_d: Vec4,


### PR DESCRIPTION
# Objective

- Rename the `render::primitives::Plane` struct as to not confuse it with `bevy_render::mesh::shape::Plane`
- Fixes https://github.com/bevyengine/bevy/issues/8730

## Solution

- Refactor the `render::primitives::Plane` struct to `render::primitives::HalfSpace`
- Modify documentation to reflect this change

## Changelog

- Renamed `render::primitives::Plane` to `render::primitives::HalfSpace` to more accurately represent it's use
- Renamed `planes` member in `render::primitives::Frustum` to `half_spaces` to reflect changes

## Migration Guide

- Change instances of `render::primitives::Plane` to `render::primitives::HalfSpace`
- Change instances of the `planes` member in `render::primitives::Frustum` to `half_spaces`