### PR TITLE
Mention that default spawned primary window is spawned with `PrimaryWindow` marker component

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -39,7 +39,7 @@ impl Default for WindowPlugin {
 /// A [`Plugin`] that defines an interface for windowing support in Bevy.
 pub struct WindowPlugin {
     /// Settings for the primary window. This will be spawned by
-    /// default, bundled with the marker component [`PrimaryWindow`](PrimaryWindow).
+    /// default, with the marker component [`PrimaryWindow`](PrimaryWindow).
     /// If you want to run without a primary window you should set this to `None`.
     ///
     /// Note that if there are no windows, by default the App will exit,

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -39,8 +39,8 @@ impl Default for WindowPlugin {
 /// A [`Plugin`] that defines an interface for windowing support in Bevy.
 pub struct WindowPlugin {
     /// Settings for the primary window. This will be spawned by
-    /// default, if you want to run without a primary window you should
-    /// set this to `None`.
+    /// default, bundled with the marker component [`PrimaryWindow`](PrimaryWindow).
+    /// If you want to run without a primary window you should set this to `None`.
     ///
     /// Note that if there are no windows, by default the App will exit,
     /// due to [`exit_on_all_closed`].


### PR DESCRIPTION
# Objective

Fixes #8751 

## Solution

The doc string for the `primary_window` field on `Window` now mentions that the default spawned primary window is spawned with the `PrimaryWindow` marker component.
