### PR TITLE
Change Camera3dBundle::tonemapping to Default

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -104,7 +104,7 @@ impl Default for Camera3dBundle {
             transform: Default::default(),
             global_transform: Default::default(),
             camera_3d: Default::default(),
-            tonemapping: Tonemapping::ReinhardLuminance,
+            tonemapping: Default::default(),
             dither: DebandDither::Enabled,
             color_grading: ColorGrading::default(),
         }


### PR DESCRIPTION
# Objective

- Continue with #8685 to make `TonyMcMapface` the default tonemapping

## Solution

- Change the default value `Camera3dBundle::tonemapping` from `Tonemapping::ReinhardLuminance` to `Default::default()` (`Tonemapping::TonyMcMapface`)

