### PR TITLE
Fix `many_sprites` and `many_animated_sprites` crash

### DIFF
--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -19,9 +19,6 @@ const CAMERA_SPEED: f32 = 1000.0;
 
 fn main() {
     App::new()
-        // Since this is also used as a benchmark, we want it to display performance data.
-        .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
@@ -29,6 +26,9 @@ fn main() {
             }),
             ..default()
         }))
+        // Since this is also used as a benchmark, we want it to display performance data.
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_systems(Startup, setup)
         .add_systems(
             Update,

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -27,9 +27,6 @@ fn main() {
         .insert_resource(ColorTint(
             std::env::args().nth(1).unwrap_or_default() == "--colored",
         ))
-        // Since this is also used as a benchmark, we want it to display performance data.
-        .add_plugin(LogDiagnosticsPlugin::default())
-        .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 present_mode: PresentMode::AutoNoVsync,
@@ -37,6 +34,9 @@ fn main() {
             }),
             ..default()
         }))
+        // Since this is also used as a benchmark, we want it to display performance data.
+        .add_plugin(LogDiagnosticsPlugin::default())
+        .add_plugin(FrameTimeDiagnosticsPlugin)
         .add_systems(Startup, setup)
         .add_systems(
             Update,


### PR DESCRIPTION
# Objective

- Fixes #8782

## Solution

- Change the plugin initialization order so that the diagnostics plugins get added after `DiagnosticsPlugin`
