### PR TITLE
Add documentation to note that some diagnostic plugins must be added after `DiagnosticsPlugin`

### DIFF
--- a/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
+++ b/crates/bevy_asset/src/diagnostic/asset_count_diagnostics_plugin.rs
@@ -6,6 +6,10 @@ use bevy_diagnostic::{
 use bevy_ecs::prelude::*;
 
 /// Adds an asset count diagnostic to an [`App`] for assets of type `T`.
+///
+/// # Warning
+///
+/// Must be added after [`DiagnosticsPlugin`](bevy_diagnostic::DiagnosticsPlugin) or a panic will occur due to missing resources.
 pub struct AssetCountDiagnosticsPlugin<T: Asset> {
     marker: std::marker::PhantomData<T>,
 }

--- a/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/entity_count_diagnostics_plugin.rs
@@ -3,7 +3,11 @@ use bevy_ecs::entity::Entities;
 
 use crate::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic};
 
-/// Adds "entity count" diagnostic to an App
+/// Adds "entity count" diagnostic to an [`App`]
+///
+/// # Warning
+///
+/// Must be added after [`DiagnosticsPlugin`](crate::DiagnosticsPlugin) or a panic will occur due to missing resources.
 #[derive(Default)]
 pub struct EntityCountDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -1,4 +1,4 @@
-use crate::{Diagnostic, DiagnosticId, Diagnostics, DiagnosticsPlugin, RegisterDiagnostic};
+use crate::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic};
 use bevy_app::prelude::*;
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
@@ -8,7 +8,7 @@ use bevy_time::Time;
 ///
 /// # Warning
 ///
-/// Must be added after [`DiagnosticsPlugin`] or a panic will occur due to missing resources.
+/// Must be added after [`DiagnosticsPlugin`](crate::DiagnosticsPlugin) or a panic will occur due to missing resources.
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -5,7 +5,10 @@ use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
 /// Adds "frame time" diagnostic to an [`App`], specifically "frame time", "fps" and "frame count"
-/// Must be added after [`DiagnosticsPlugin`]
+///
+/// # Warning
+///
+/// Must be added after [`DiagnosticsPlugin`] or a panic will occur due to missing resources.
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -1,4 +1,4 @@
-use crate::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic};
+use crate::{Diagnostic, DiagnosticId, Diagnostics, DiagnosticsPlugin, RegisterDiagnostic};
 use bevy_app::prelude::*;
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;

--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -4,7 +4,8 @@ use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
 use bevy_time::Time;
 
-/// Adds "frame time" diagnostic to an App, specifically "frame time", "fps" and "frame count"
+/// Adds "frame time" diagnostic to an [`App`], specifically "frame time", "fps" and "frame count"
+/// Must be added after [`DiagnosticsPlugin`]
 #[derive(Default)]
 pub struct FrameTimeDiagnosticsPlugin;
 

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -10,6 +10,10 @@ use bevy_app::prelude::*;
 /// * macos
 ///
 /// NOT supported when using the `bevy/dynamic` feature even when using previously mentioned targets
+///
+/// # Warning
+///
+/// Must be added after [`DiagnosticsPlugin`](crate::DiagnosticsPlugin) or a panic will occur due to missing resources.
 #[derive(Default)]
 pub struct SystemInformationDiagnosticsPlugin;
 impl Plugin for SystemInformationDiagnosticsPlugin {


### PR DESCRIPTION
# Objective

- Some diagnostic plugins do not currently have docs to explain that it must be added after `DiagnosticsPlugin`

## Solution

- Add documentation for it
