### PR TITLE
Touchpad magnify and rotate events

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -35,7 +35,7 @@ use mouse::{
     MouseWheel,
 };
 use touch::{touch_screen_input_system, ForceTouch, TouchInput, TouchPhase, Touches};
-use touchpad::{Magnify, Rotate};
+use touchpad::{TouchpadMagnify, TouchpadRotate};
 
 use gamepad::{
     gamepad_axis_event_system, gamepad_button_event_system, gamepad_connection_system,
@@ -69,8 +69,8 @@ impl Plugin for InputPlugin {
             .add_event::<MouseWheel>()
             .init_resource::<Input<MouseButton>>()
             .add_systems(PreUpdate, mouse_button_input_system.in_set(InputSystem))
-            .add_event::<Magnify>()
-            .add_event::<Rotate>()
+            .add_event::<TouchpadMagnify>()
+            .add_event::<TouchpadRotate>()
             // gamepad
             .add_event::<GamepadConnectionEvent>()
             .add_event::<GamepadButtonChangedEvent>()
@@ -117,7 +117,8 @@ impl Plugin for InputPlugin {
             .register_type::<MouseWheel>();
 
         // Register touchpad types
-        app.register_type::<Magnify>().register_type::<Rotate>();
+        app.register_type::<TouchpadMagnify>()
+            .register_type::<TouchpadRotate>();
 
         // Register touch types
         app.register_type::<TouchInput>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -8,6 +8,7 @@ mod input;
 pub mod keyboard;
 pub mod mouse;
 pub mod touch;
+pub mod touchpad;
 
 pub use axis::*;
 pub use input::*;
@@ -30,10 +31,11 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::{FromReflect, Reflect};
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput, ScanCode};
 use mouse::{
-    mouse_button_input_system, Magnify, MouseButton, MouseButtonInput, MouseMotion,
-    MouseScrollUnit, MouseWheel, Rotate,
+    mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseScrollUnit,
+    MouseWheel,
 };
 use touch::{touch_screen_input_system, ForceTouch, TouchInput, TouchPhase, Touches};
+use touchpad::{Magnify, Rotate};
 
 use gamepad::{
     gamepad_axis_event_system, gamepad_button_event_system, gamepad_connection_system,

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -31,7 +31,7 @@ use bevy_reflect::{FromReflect, Reflect};
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput, ScanCode};
 use mouse::{
     mouse_button_input_system, Magnify, MouseButton, MouseButtonInput, MouseMotion,
-    MouseScrollUnit, MouseWheel,
+    MouseScrollUnit, MouseWheel, Rotate,
 };
 use touch::{touch_screen_input_system, ForceTouch, TouchInput, TouchPhase, Touches};
 
@@ -69,6 +69,7 @@ impl Plugin for InputPlugin {
             .add_systems(PreUpdate, mouse_button_input_system.in_set(InputSystem))
             // touchpad
             .add_event::<Magnify>()
+            .add_event::<Rotate>()
             // gamepad
             .add_event::<GamepadConnectionEvent>()
             .add_event::<GamepadButtonChangedEvent>()
@@ -115,7 +116,7 @@ impl Plugin for InputPlugin {
             .register_type::<MouseWheel>();
 
         // Register touchpad types
-        app.register_type::<Magnify>();
+        app.register_type::<Magnify>().register_type::<Rotate>();
 
         // Register touch types
         app.register_type::<TouchInput>()

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -67,7 +67,6 @@ impl Plugin for InputPlugin {
             .add_event::<MouseWheel>()
             .init_resource::<Input<MouseButton>>()
             .add_systems(PreUpdate, mouse_button_input_system.in_set(InputSystem))
-            // touchpad
             .add_event::<Magnify>()
             .add_event::<Rotate>()
             // gamepad

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -30,8 +30,8 @@ use bevy_ecs::prelude::*;
 use bevy_reflect::{FromReflect, Reflect};
 use keyboard::{keyboard_input_system, KeyCode, KeyboardInput, ScanCode};
 use mouse::{
-    mouse_button_input_system, MouseButton, MouseButtonInput, MouseMotion, MouseScrollUnit,
-    MouseWheel,
+    mouse_button_input_system, Magnify, MouseButton, MouseButtonInput, MouseMotion,
+    MouseScrollUnit, MouseWheel,
 };
 use touch::{touch_screen_input_system, ForceTouch, TouchInput, TouchPhase, Touches};
 
@@ -67,6 +67,8 @@ impl Plugin for InputPlugin {
             .add_event::<MouseWheel>()
             .init_resource::<Input<MouseButton>>()
             .add_systems(PreUpdate, mouse_button_input_system.in_set(InputSystem))
+            // touchpad
+            .add_event::<Magnify>()
             // gamepad
             .add_event::<GamepadConnectionEvent>()
             .add_event::<GamepadButtonChangedEvent>()
@@ -111,6 +113,9 @@ impl Plugin for InputPlugin {
             .register_type::<MouseMotion>()
             .register_type::<MouseScrollUnit>()
             .register_type::<MouseWheel>();
+
+        // Register touchpad types
+        app.register_type::<Magnify>();
 
         // Register touch types
         app.register_type::<TouchInput>()

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -139,6 +139,19 @@ pub struct MouseWheel {
 )]
 pub struct Magnify(pub f32);
 
+/// Touchpad rotation event with two-finger rotation gesture.
+///
+/// Positive delta values indicate rotation counterclockwise and
+/// negative delta values indicate rotation clockwise.
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Rotate(pub f32);
+
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.
 ///
 /// ## Differences

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -130,6 +130,10 @@ pub struct MouseWheel {
 ///
 /// Positive delta values indicate magnification (zooming in) and
 /// negative delta values indicate shrinking (zooming out).
+///
+/// ## Platform-specific
+///
+/// - Only available on **macOS**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
@@ -143,6 +147,10 @@ pub struct Magnify(pub f32);
 ///
 /// Positive delta values indicate rotation counterclockwise and
 /// negative delta values indicate rotation clockwise.
+///
+/// ## Platform-specific
+///
+/// - Only available on **macOS**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -133,7 +133,7 @@ pub struct MouseWheel {
 ///
 /// ## Platform-specific
 ///
-/// - Only available on **macOS**.
+/// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
@@ -150,7 +150,7 @@ pub struct Magnify(pub f32);
 ///
 /// ## Platform-specific
 ///
-/// - Only available on **macOS**.
+/// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -126,6 +126,19 @@ pub struct MouseWheel {
     pub y: f32,
 }
 
+/// Touchpad magnification event with two-finger pinch gesture.
+///
+/// Positive delta values indicate magnification (zooming in) and
+/// negative delta values indicate shrinking (zooming out).
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Magnify(pub f32);
+
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.
 ///
 /// ## Differences

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -126,40 +126,6 @@ pub struct MouseWheel {
     pub y: f32,
 }
 
-/// Touchpad magnification event with two-finger pinch gesture.
-///
-/// Positive delta values indicate magnification (zooming in) and
-/// negative delta values indicate shrinking (zooming out).
-///
-/// ## Platform-specific
-///
-/// - Only available on **`macOS`**.
-#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
-    reflect(Serialize, Deserialize)
-)]
-pub struct Magnify(pub f32);
-
-/// Touchpad rotation event with two-finger rotation gesture.
-///
-/// Positive delta values indicate rotation counterclockwise and
-/// negative delta values indicate rotation clockwise.
-///
-/// ## Platform-specific
-///
-/// - Only available on **`macOS`**.
-#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
-#[cfg_attr(
-    feature = "serialize",
-    derive(serde::Serialize, serde::Deserialize),
-    reflect(Serialize, Deserialize)
-)]
-pub struct Rotate(pub f32);
-
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.
 ///
 /// ## Differences

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -19,7 +19,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct Magnify(pub f32);
+pub struct TouchpadMagnify(pub f32);
 
 /// Touchpad rotation event with two-finger rotation gesture.
 ///
@@ -36,4 +36,4 @@ pub struct Magnify(pub f32);
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct Rotate(pub f32);
+pub struct TouchpadRotate(pub f32);

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -1,0 +1,39 @@
+use bevy_ecs::event::Event;
+use bevy_reflect::{FromReflect, Reflect};
+
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
+/// Touchpad magnification event with two-finger pinch gesture.
+///
+/// Positive delta values indicate magnification (zooming in) and
+/// negative delta values indicate shrinking (zooming out).
+///
+/// ## Platform-specific
+///
+/// - Only available on **`macOS`**.
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Magnify(pub f32);
+
+/// Touchpad rotation event with two-finger rotation gesture.
+///
+/// Positive delta values indicate rotation counterclockwise and
+/// negative delta values indicate rotation clockwise.
+///
+/// ## Platform-specific
+///
+/// - Only available on **`macOS`**.
+#[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct Rotate(pub f32);

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::event::Event;
-use bevy_reflect::{FromReflect, Reflect};
+use bevy_reflect::{FromReflect, Reflect, ReflectFromReflect};
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -13,7 +13,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq, FromReflect)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
@@ -30,7 +30,7 @@ pub struct TouchpadMagnify(pub f32);
 ///
 /// - Only available on **`macOS`**.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
-#[reflect(Debug, PartialEq)]
+#[reflect(Debug, PartialEq, FromReflect)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -31,7 +31,7 @@ use bevy_input::{
     keyboard::KeyboardInput,
     mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
-    touchpad::{Magnify, Rotate},
+    touchpad::{TouchpadMagnify, TouchpadRotate},
 };
 use bevy_math::{ivec2, DVec2, Vec2};
 use bevy_utils::{
@@ -237,8 +237,8 @@ struct InputEvents<'w> {
     keyboard_input: EventWriter<'w, KeyboardInput>,
     character_input: EventWriter<'w, ReceivedCharacter>,
     mouse_button_input: EventWriter<'w, MouseButtonInput>,
-    magnify_input: EventWriter<'w, Magnify>,
-    rotate_input: EventWriter<'w, Rotate>,
+    touchpad_magnify_input: EventWriter<'w, TouchpadMagnify>,
+    touchpad_rotate_input: EventWriter<'w, TouchpadRotate>,
     mouse_wheel_input: EventWriter<'w, MouseWheel>,
     touch_input: EventWriter<'w, TouchInput>,
     ime_input: EventWriter<'w, Ime>,
@@ -485,10 +485,14 @@ pub fn winit_runner(mut app: App) {
                         });
                     }
                     WindowEvent::TouchpadMagnify { delta, .. } => {
-                        input_events.magnify_input.send(Magnify(delta as f32));
+                        input_events
+                            .touchpad_magnify_input
+                            .send(TouchpadMagnify(delta as f32));
                     }
                     WindowEvent::TouchpadRotate { delta, .. } => {
-                        input_events.rotate_input.send(Rotate(delta));
+                        input_events
+                            .touchpad_rotate_input
+                            .send(TouchpadRotate(delta));
                     }
                     WindowEvent::MouseWheel { delta, .. } => match delta {
                         event::MouseScrollDelta::LineDelta(x, y) => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -29,7 +29,7 @@ use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::*;
 use bevy_input::{
     keyboard::KeyboardInput,
-    mouse::{Magnify, MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
+    mouse::{Magnify, MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel, Rotate},
     touch::TouchInput,
 };
 use bevy_math::{ivec2, DVec2, Vec2};
@@ -237,6 +237,7 @@ struct InputEvents<'w> {
     character_input: EventWriter<'w, ReceivedCharacter>,
     mouse_button_input: EventWriter<'w, MouseButtonInput>,
     magnify_input: EventWriter<'w, Magnify>,
+    rotate_input: EventWriter<'w, Rotate>,
     mouse_wheel_input: EventWriter<'w, MouseWheel>,
     touch_input: EventWriter<'w, TouchInput>,
     ime_input: EventWriter<'w, Ime>,
@@ -484,6 +485,9 @@ pub fn winit_runner(mut app: App) {
                     }
                     WindowEvent::TouchpadMagnify { delta, .. } => {
                         input_events.magnify_input.send(Magnify(delta as f32));
+                    }
+                    WindowEvent::TouchpadRotate { delta, .. } => {
+                        input_events.rotate_input.send(Rotate(delta as f32));
                     }
                     WindowEvent::MouseWheel { delta, .. } => match delta {
                         event::MouseScrollDelta::LineDelta(x, y) => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -29,7 +29,7 @@ use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::*;
 use bevy_input::{
     keyboard::KeyboardInput,
-    mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
+    mouse::{Magnify, MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
 };
 use bevy_math::{ivec2, DVec2, Vec2};
@@ -236,6 +236,7 @@ struct InputEvents<'w> {
     keyboard_input: EventWriter<'w, KeyboardInput>,
     character_input: EventWriter<'w, ReceivedCharacter>,
     mouse_button_input: EventWriter<'w, MouseButtonInput>,
+    magnify_input: EventWriter<'w, Magnify>,
     mouse_wheel_input: EventWriter<'w, MouseWheel>,
     touch_input: EventWriter<'w, TouchInput>,
     ime_input: EventWriter<'w, Ime>,
@@ -480,6 +481,9 @@ pub fn winit_runner(mut app: App) {
                             button: converters::convert_mouse_button(button),
                             state: converters::convert_element_state(state),
                         });
+                    }
+                    WindowEvent::TouchpadMagnify { delta, .. } => {
+                        input_events.magnify_input.send(Magnify(delta as f32));
                     }
                     WindowEvent::MouseWheel { delta, .. } => match delta {
                         event::MouseScrollDelta::LineDelta(x, y) => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -29,8 +29,9 @@ use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::*;
 use bevy_input::{
     keyboard::KeyboardInput,
-    mouse::{Magnify, MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel, Rotate},
+    mouse::{MouseButtonInput, MouseMotion, MouseScrollUnit, MouseWheel},
     touch::TouchInput,
+    touchpad::{Magnify, Rotate},
 };
 use bevy_math::{ivec2, DVec2, Vec2};
 use bevy_utils::{

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -487,7 +487,7 @@ pub fn winit_runner(mut app: App) {
                         input_events.magnify_input.send(Magnify(delta as f32));
                     }
                     WindowEvent::TouchpadRotate { delta, .. } => {
-                        input_events.rotate_input.send(Rotate(delta as f32));
+                        input_events.rotate_input.send(Rotate(delta));
                     }
                     WindowEvent::MouseWheel { delta, .. } => match delta {
                         event::MouseScrollDelta::LineDelta(x, y) => {

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -1,7 +1,7 @@
 //! Prints all mouse events to the console.
 
 use bevy::{
-    input::mouse::{MouseButtonInput, MouseMotion, MouseWheel},
+    input::mouse::{Magnify, MouseButtonInput, MouseMotion, MouseWheel},
     prelude::*,
 };
 
@@ -18,6 +18,7 @@ fn print_mouse_events_system(
     mut mouse_motion_events: EventReader<MouseMotion>,
     mut cursor_moved_events: EventReader<CursorMoved>,
     mut mouse_wheel_events: EventReader<MouseWheel>,
+    mut magnify_events: EventReader<Magnify>,
 ) {
     for event in mouse_button_input_events.iter() {
         info!("{:?}", event);
@@ -32,6 +33,10 @@ fn print_mouse_events_system(
     }
 
     for event in mouse_wheel_events.iter() {
+        info!("{:?}", event);
+    }
+
+    for event in magnify_events.iter() {
         info!("{:?}", event);
     }
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -1,7 +1,7 @@
 //! Prints all mouse events to the console.
 
 use bevy::{
-    input::mouse::{Magnify, MouseButtonInput, MouseMotion, MouseWheel},
+    input::mouse::{Magnify, MouseButtonInput, MouseMotion, MouseWheel, Rotate},
     prelude::*,
 };
 
@@ -19,6 +19,7 @@ fn print_mouse_events_system(
     mut cursor_moved_events: EventReader<CursorMoved>,
     mut mouse_wheel_events: EventReader<MouseWheel>,
     mut magnify_events: EventReader<Magnify>,
+    mut rotate_events: EventReader<Rotate>,
 ) {
     for event in mouse_button_input_events.iter() {
         info!("{:?}", event);
@@ -37,6 +38,10 @@ fn print_mouse_events_system(
     }
 
     for event in magnify_events.iter() {
+        info!("{:?}", event);
+    }
+
+    for event in rotate_events.iter() {
         info!("{:?}", event);
     }
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -37,10 +37,12 @@ fn print_mouse_events_system(
         info!("{:?}", event);
     }
 
+    // This event will only fire on macOS
     for event in magnify_events.iter() {
         info!("{:?}", event);
     }
 
+    // This event will only fire on macOS
     for event in rotate_events.iter() {
         info!("{:?}", event);
     }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -3,7 +3,7 @@
 use bevy::{
     input::{
         mouse::{MouseButtonInput, MouseMotion, MouseWheel},
-        touchpad::{Magnify, Rotate},
+        touchpad::{TouchpadMagnify, TouchpadRotate},
     },
     prelude::*,
 };
@@ -21,8 +21,8 @@ fn print_mouse_events_system(
     mut mouse_motion_events: EventReader<MouseMotion>,
     mut cursor_moved_events: EventReader<CursorMoved>,
     mut mouse_wheel_events: EventReader<MouseWheel>,
-    mut magnify_events: EventReader<Magnify>,
-    mut rotate_events: EventReader<Rotate>,
+    mut touchpad_magnify_events: EventReader<TouchpadMagnify>,
+    mut touchpad_rotate_events: EventReader<TouchpadRotate>,
 ) {
     for event in mouse_button_input_events.iter() {
         info!("{:?}", event);
@@ -41,12 +41,12 @@ fn print_mouse_events_system(
     }
 
     // This event will only fire on macOS
-    for event in magnify_events.iter() {
+    for event in touchpad_magnify_events.iter() {
         info!("{:?}", event);
     }
 
     // This event will only fire on macOS
-    for event in rotate_events.iter() {
+    for event in touchpad_rotate_events.iter() {
         info!("{:?}", event);
     }
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -1,7 +1,10 @@
 //! Prints all mouse events to the console.
 
 use bevy::{
-    input::mouse::{Magnify, MouseButtonInput, MouseMotion, MouseWheel, Rotate},
+    input::{
+        mouse::{MouseButtonInput, MouseMotion, MouseWheel},
+        touchpad::{Magnify, Rotate},
+    },
     prelude::*,
 };
 


### PR DESCRIPTION
# Objective

The goal of this PR is to receive touchpad magnification and rotation events.

## Solution

Implement pendants for winit's `TouchpadMagnify` and `TouchpadRotate` events.

Adjust the `mouse_input_events.rs` example to debug magnify and rotate events.

Since winit only reports these events on macOS, the Bevy events for touchpad magnification and rotation are currently only fired on macOS.
