### PR TITLE
Perform `relative_cursor_position` calculation vectorwise in `ui_focus_system`

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -227,12 +227,7 @@ pub fn ui_focus_system(
 
                 // The mouse position relative to the node
                 // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
-                let relative_cursor_position = cursor_position.map(|cursor_position| {
-                    Vec2::new(
-                        (cursor_position.x - min.x) / node.node.size().x,
-                        (cursor_position.y - min.y) / node.node.size().y,
-                    )
-                });
+                let relative_cursor_position = cursor_position.map(|cursor_position| (cursor_position - min) / node.node.size());
 
                 // If the current cursor position is within the bounds of the node, consider it for
                 // clicking

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -227,7 +227,8 @@ pub fn ui_focus_system(
 
                 // The mouse position relative to the node
                 // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
-                let relative_cursor_position = cursor_position.map(|cursor_position| (cursor_position - min) / node.node.size());
+                let relative_cursor_position = cursor_position
+                    .map(|cursor_position| (cursor_position - min) / node.node.size());
 
                 // If the current cursor position is within the bounds of the node, consider it for
                 // clicking


### PR DESCRIPTION
# Objective

This calculation is performed componentwise but all the values are vectors so it should be using vector operations.
Works correctly with the `relative_cursor_position` example.
