### PR TITLE
Disable camera on window close

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -24,8 +24,7 @@ use bevy_reflect::FromReflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{HashMap, HashSet};
 use bevy_window::{
-    NormalizedWindowRef, PrimaryWindow, Window, WindowClosed, WindowCreated, WindowRef,
-    WindowResized,
+    NormalizedWindowRef, PrimaryWindow, Window, WindowCreated, WindowRef, WindowResized,
 };
 
 use std::{borrow::Cow, ops::Range};
@@ -493,9 +492,6 @@ impl NormalizedRenderTarget {
 
 /// System in charge of updating a [`Camera`] when its window or projection changes.
 ///
-/// The system will detect when a [`Window`] is closed and it disables any [`Camera`] that used that
-/// [`Window`] has a [`RenderTarget`].
-///
 /// The system detects window creation and resize events to update the camera projection if
 /// needed. It also queries any [`CameraProjection`] component associated with the same entity
 /// as the [`Camera`] one, to automatically update the camera projection matrix.
@@ -513,11 +509,9 @@ impl NormalizedRenderTarget {
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
 /// [`PerspectiveProjection`]: crate::camera::PerspectiveProjection
 /// [`Projection`]: crate::camera::Projection
-#[allow(clippy::too_many_arguments)]
 pub fn camera_system<T: CameraProjection + Component>(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
-    mut window_close_events: EventReader<WindowClosed>,
     mut image_asset_events: EventReader<AssetEvent<Image>>,
     primary_window: Query<Entity, With<PrimaryWindow>>,
     windows: Query<(Entity, &Window)>,
@@ -525,18 +519,6 @@ pub fn camera_system<T: CameraProjection + Component>(
     mut cameras: Query<(&mut Camera, &mut T)>,
 ) {
     let primary_window = primary_window.iter().next();
-
-    // Disable the camera associated to a window that's just been closed
-    for ev in window_close_events.iter() {
-        for (mut camera, _) in &mut cameras {
-            let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target.normalize(primary_window)
-            else { continue; };
-
-            if window_ref.entity() == ev.window {
-                camera.is_active = false;
-            }
-        }
-    }
 
     let mut changed_window_ids = HashSet::new();
     changed_window_ids.extend(window_created_events.iter().map(|event| event.window));

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -31,12 +31,24 @@ impl Node for CameraDriverNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let sorted_cameras = world.resource::<SortedCameras>();
+        let windows = world.resource::<ExtractedWindows>();
         let mut camera_windows = HashSet::new();
         for sorted_camera in &sorted_cameras.0 {
-            if let Ok(camera) = self.cameras.get_manual(world, sorted_camera.entity) {
-                if let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target {
-                    camera_windows.insert(window_ref.entity());
+            let Ok(camera) = self.cameras.get_manual(world, sorted_camera.entity) else {
+                continue;
+            };
+
+            let mut run_graph = true;
+            if let Some(NormalizedRenderTarget::Window(window_ref)) = camera.target {
+                let window_entity = window_ref.entity();
+                if windows.windows.get(&window_entity).is_some() {
+                    camera_windows.insert(window_entity);
+                } else {
+                    // The window doesn't exist anymore so we don't need to run the graph
+                    run_graph = false;
                 }
+            }
+            if run_graph {
                 graph.run_sub_graph(
                     camera.render_graph.clone(),
                     vec![],


### PR DESCRIPTION
# Objective

- When a window is closed, the associated camera keeps rendering even if the RenderTarget isn't valid anymore.
	- This is essentially just wasting a lot of performance.

## Solution

- Detect the window close event and disable any camera that used the window has a RenderTarget.

## Notes

It's possible a similar thing could be done for camera that use an image handle, but I would fix that in a separate PR.