### PR TITLE
Add last_changed_tick and added_tick to ComponentTicks

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -686,16 +686,22 @@ pub struct ComponentTicks {
 }
 
 impl ComponentTicks {
-    #[inline]
     /// Returns `true` if the component was added after the system last ran.
+    #[inline]
     pub fn is_added(&self, last_run: Tick, this_run: Tick) -> bool {
         self.added.is_newer_than(last_run, this_run)
     }
 
-    #[inline]
     /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
+    #[inline]
     pub fn is_changed(&self, last_run: Tick, this_run: Tick) -> bool {
         self.changed.is_newer_than(last_run, this_run)
+    }
+
+    /// Returns the change tick recording the time this data was most recently changed.
+    #[inline]
+    pub fn last_changed(&self) -> u32 {
+        self.changed.get()
     }
 
     pub(crate) fn new(change_tick: Tick) -> Self {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -698,10 +698,16 @@ impl ComponentTicks {
         self.changed.is_newer_than(last_run, this_run)
     }
 
-    /// Returns the change tick recording the time this data was most recently changed.
+    /// Returns the tick recording the time this component was most recently changed.
     #[inline]
-    pub fn last_changed(&self) -> u32 {
-        self.changed.get()
+    pub fn last_changed_tick(&self) -> Tick {
+        self.changed
+    }
+
+    /// Returns the tick recording the time this component was added.
+    #[inline]
+    pub fn added_tick(&self) -> Tick {
+        self.added
     }
 
     pub(crate) fn new(change_tick: Tick) -> Self {


### PR DESCRIPTION
# Objective

EntityRef::get_change_ticks mentions that ComponentTicks is useful to create change detection for your own runtime.

However, ComponentTicks doesn't even expose enough data to create something that implements DetectChanges. Specifically, we need to be able to extract the last change tick.

## Solution

We add a method to get the last change tick. We also add a method to get the added tick.

## Changelog

- Add `last_changed_tick` and `added_tick` to `ComponentTicks`