### PR TITLE
Remove `Component` derive for AlphaMode

### DIFF
--- a/crates/bevy_pbr/src/alpha.rs
+++ b/crates/bevy_pbr/src/alpha.rs
@@ -1,11 +1,10 @@
-use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{FromReflect, Reflect};
 
 // TODO: add discussion about performance.
 /// Sets how a material's base color alpha channel is used for transparency.
-#[derive(Component, Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
-#[reflect(Component, Default, Debug)]
+#[derive(Debug, Default, Reflect, Copy, Clone, PartialEq, FromReflect)]
+#[reflect(Default, Debug)]
 pub enum AlphaMode {
     /// Base color alpha values are overridden to be fully opaque (1.0).
     #[default]


### PR DESCRIPTION
`AlphaMode` is not used as a component anywhere in the engine. It shouldn't implement `Component`. It might mislead users into thinking it has any effect as a component.

---

## Changelog

- Remove `Component` implementation for `AlphaMode`. It wasn't used by anything.

## Migration Guide

`AlphaMode` is not a component anymore.

It wasn't used anywhere in the engine. If you were using it as a component for your own purposes, you should use a newtype instead, as follow:

```rust
#[derive(Component, Deref)]
struct MyAlphaMode(AlphaMode);
```

Then replace uses of `AlphaMode` with `MyAlphaMode`

```diff
- Query<&AlphaMode, …>,
+ Query<&MyAlphaMode, …>,
```