### PR TITLE
Implement basic AutoExposure plugin

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -17,6 +17,7 @@ pub mod graph {
         pub const BLOOM: &str = "bloom";
         pub const TONEMAPPING: &str = "tonemapping";
         pub const FXAA: &str = "fxaa";
+        pub const AUTOEXPOSURE: &str = "autoexposure";
         pub const UPSCALING: &str = "upscaling";
         pub const CONTRAST_ADAPTIVE_SHARPENING: &str = "contrast_adaptive_sharpening";
         pub const END_MAIN_PASS_POST_PROCESSING: &str = "end_main_pass_post_processing";

--- a/crates/bevy_core_pipeline/src/exposure/autoexposure.wgsl
+++ b/crates/bevy_core_pipeline/src/exposure/autoexposure.wgsl
@@ -1,0 +1,70 @@
+#import bevy_render::view
+
+@group(0) @binding(0)
+var<storage, read_write> view: View;
+
+@group(0) @binding(1)
+var hdr_texture: texture_2d<f32>;
+
+@group(0) @binding(2)
+var<storage, read_write> global_luminance_histogram: array<atomic<u32>, 64>;
+
+var<workgroup> luminance_histogram: array<atomic<u32>, 64>;
+
+@compute @workgroup_size(16, 16, 1)
+fn build_histogram(@builtin(global_invocation_id) global_id: vec3<u32>, @builtin(local_invocation_id) local_id: vec3<u32>) {
+    let texture_size = textureDimensions(hdr_texture, 0);
+    if (global_id.x < u32(view.viewport.z) && global_id.y < u32(view.viewport.w)) {
+        let color = textureLoad(hdr_texture, global_id.xy + vec2<u32>(view.viewport.xy), 0);
+        let luminance = color.r * 0.2126 + color.g * 0.7152 + color.b * 0.0722;
+        if (luminance > 0.0) {
+            let ev = log2(luminance) + 3.0;
+            let bin = u32(clamp(round(ev * 2.0 + 16.0), 1.0, 63.0));
+            atomicAdd(&luminance_histogram[bin], 1u);
+        } else {
+            atomicAdd(&luminance_histogram[0], 1u);
+        }
+    }
+
+    workgroupBarrier();
+
+    let index = local_id.x + local_id.y * 16u;
+    if (index < 64u) {
+        atomicAdd(&global_luminance_histogram[index], luminance_histogram[index]);
+    }
+}
+
+@compute @workgroup_size(1)
+fn compute_exposure() {
+    var sum = 0u;
+    for (var i = 0; i < 64; i++) {
+        sum += global_luminance_histogram[i];
+        luminance_histogram[i] = sum;
+    }
+
+    let first_index = sum * 40u / 100u;
+    let last_index = sum * 95u / 100u;
+
+    var count = 0u;
+    var sum_ev = 0.0;
+    for (var i = 1; i < 64; i++) {
+        if (luminance_histogram[i] < first_index) {
+            continue;
+        }
+
+        let bin_count = min(luminance_histogram[i], last_index)
+            - min(luminance_histogram[i - 1], last_index);
+        sum_ev += f32(bin_count) * (f32(i) - 16.0) * 0.5;
+        count += bin_count;
+   }
+
+    var target_exposure = 0.0;
+    if (count > 0u) {
+        // TODO: Apply exposure compensation curve so that night scenes seem darker than day scenes.
+        let avg_ev = sum_ev / f32(count);
+        target_exposure = log2(1.2) - avg_ev;
+    }
+
+    // TODO: Use a moving average to smooth out the exposure changes.
+    view.color_grading.exposure = target_exposure;
+}

--- a/crates/bevy_core_pipeline/src/exposure/mod.rs
+++ b/crates/bevy_core_pipeline/src/exposure/mod.rs
@@ -1,0 +1,158 @@
+use bevy_app::prelude::*;
+use bevy_asset::{load_internal_asset, HandleUntyped};
+use bevy_ecs::prelude::*;
+use bevy_reflect::TypeUuid;
+use bevy_render::render_graph::RenderGraphApp;
+use bevy_render::renderer::{RenderDevice, RenderQueue};
+use bevy_render::view::{ViewTarget, ViewUniform};
+use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
+
+mod node;
+
+pub use node::AutoExposureNode;
+
+use crate::core_3d::graph::node::{AUTOEXPOSURE, END_MAIN_PASS, TONEMAPPING};
+use crate::core_3d::CORE_3D;
+
+const AUTO_EXPOSURE_SHADER_HANDLE: HandleUntyped =
+    HandleUntyped::weak_from_u64(Shader::TYPE_UUID, 15323641124464253870);
+
+pub struct AutoExposurePlugin;
+impl Plugin for AutoExposurePlugin {
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            AUTO_EXPOSURE_SHADER_HANDLE,
+            "autoexposure.wgsl",
+            Shader::from_wgsl
+        );
+
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .init_resource::<SpecializedComputePipelines<AutoExposurePipeline>>()
+                .init_resource::<AutoExposureStorage>()
+                .add_render_graph_node::<AutoExposureNode>(CORE_3D, AUTOEXPOSURE)
+                .add_render_graph_edges(CORE_3D, &[END_MAIN_PASS, AUTOEXPOSURE, TONEMAPPING])
+                .add_systems(
+                    Render,
+                    (
+                        queue_view_auto_exposure_pipelines.in_set(RenderSet::Queue),
+                        prepare_storage_buffer.in_set(RenderSet::Prepare),
+                    ),
+                );
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.init_resource::<AutoExposurePipeline>();
+        }
+    }
+}
+
+#[derive(Resource)]
+pub struct AutoExposurePipeline {
+    bind_group: BindGroupLayout,
+}
+
+impl SpecializedComputePipeline for AutoExposurePipeline {
+    type Key = usize;
+
+    fn specialize(&self, key: Self::Key) -> ComputePipelineDescriptor {
+        ComputePipelineDescriptor {
+            label: Some("autoexposure pipeline".into()),
+            layout: vec![self.bind_group.clone()],
+            push_constant_ranges: Vec::new(),
+            shader: AUTO_EXPOSURE_SHADER_HANDLE.typed(),
+            shader_defs: Vec::new(),
+            entry_point: match key {
+                0 => "build_histogram",
+                1 => "compute_exposure",
+                _ => unreachable!(),
+            }
+            .into(),
+        }
+    }
+}
+
+impl FromWorld for AutoExposurePipeline {
+    fn from_world(render_world: &mut World) -> Self {
+        let entries = vec![
+            BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: true,
+                    min_binding_size: Some(ViewUniform::min_size()),
+                },
+                count: None,
+            },
+            BindGroupLayoutEntry {
+                binding: 1,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Texture {
+                    sample_type: TextureSampleType::Float { filterable: false },
+                    view_dimension: TextureViewDimension::D2,
+                    multisampled: false,
+                },
+                count: None,
+            },
+            BindGroupLayoutEntry {
+                binding: 2,
+                visibility: ShaderStages::COMPUTE,
+                ty: BindingType::Buffer {
+                    ty: BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                },
+                count: None,
+            },
+        ];
+
+        AutoExposurePipeline {
+            bind_group: render_world
+                .resource::<RenderDevice>()
+                .create_bind_group_layout(&BindGroupLayoutDescriptor {
+                    label: Some("autoexposure_bind_group_layout"),
+                    entries: &entries,
+                }),
+        }
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct AutoExposureStorage(Option<Buffer>);
+
+pub fn prepare_storage_buffer(
+    render_device: Res<RenderDevice>,
+    _render_queue: Res<RenderQueue>,
+    mut storage: ResMut<AutoExposureStorage>,
+) {
+    if storage.0.is_none() {
+        storage.0 = Some(render_device.create_buffer(&BufferDescriptor {
+            label: Some("autoexposure_storage_buffer"),
+            size: 64 * 4,
+            usage: BufferUsages::STORAGE | BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        }));
+    }
+}
+
+#[derive(Component)]
+pub struct ViewAutoExposurePipeline([CachedComputePipelineId; 2]);
+
+pub fn queue_view_auto_exposure_pipelines(
+    mut commands: Commands,
+    pipeline_cache: Res<PipelineCache>,
+    mut pipelines: ResMut<SpecializedComputePipelines<AutoExposurePipeline>>,
+    upscaling_pipeline: Res<AutoExposurePipeline>,
+    view_targets: Query<Entity, With<ViewTarget>>,
+) {
+    for entity in view_targets.iter() {
+        commands.entity(entity).insert(ViewAutoExposurePipeline([
+            pipelines.specialize(&pipeline_cache, &upscaling_pipeline, 0),
+            pipelines.specialize(&pipeline_cache, &upscaling_pipeline, 1),
+        ]));
+    }
+}

--- a/crates/bevy_core_pipeline/src/exposure/node.rs
+++ b/crates/bevy_core_pipeline/src/exposure/node.rs
@@ -1,0 +1,132 @@
+use std::sync::Mutex;
+
+use crate::exposure::{AutoExposurePipeline, AutoExposureStorage, ViewAutoExposurePipeline};
+use bevy_ecs::prelude::*;
+use bevy_ecs::query::QueryState;
+use bevy_render::{
+    render_graph::{Node, NodeRunError, RenderGraphContext},
+    render_resource::{
+        BindGroup, BindGroupDescriptor, BindGroupEntry, BindingResource, BufferBinding,
+        ComputePassDescriptor, PipelineCache, ShaderType, TextureViewId,
+    },
+    renderer::RenderContext,
+    view::{ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
+};
+
+pub struct AutoExposureNode {
+    query: QueryState<
+        (
+            &'static ViewUniformOffset,
+            &'static ViewTarget,
+            &'static ViewAutoExposurePipeline,
+            &'static ExtractedView,
+        ),
+        With<ExtractedView>,
+    >,
+    cached_texture_bind_group: Mutex<Option<(TextureViewId, BindGroup)>>,
+}
+
+impl FromWorld for AutoExposureNode {
+    fn from_world(world: &mut World) -> Self {
+        Self {
+            query: QueryState::new(world),
+            cached_texture_bind_group: Mutex::new(None),
+        }
+    }
+}
+
+impl Node for AutoExposureNode {
+    fn update(&mut self, world: &mut World) {
+        self.query.update_archetypes(world);
+    }
+
+    fn run(
+        &self,
+        graph: &mut RenderGraphContext,
+        render_context: &mut RenderContext,
+        world: &World,
+    ) -> Result<(), NodeRunError> {
+        let view_entity = graph.view_entity();
+        let pipeline_cache = world.resource::<PipelineCache>();
+        let auto_exposure_pipeline = world.resource::<AutoExposurePipeline>();
+        let storage_buffer = world.resource::<AutoExposureStorage>();
+
+        if storage_buffer.0.is_none() {
+            return Ok(());
+        }
+
+        let view_uniforms_resource = world.resource::<ViewUniforms>();
+        let view_uniforms = &view_uniforms_resource.uniforms;
+        let view_uniforms_buffer = view_uniforms.buffer().unwrap();
+
+        let (view_uniform_offset, target, pipeline, view) =
+            match self.query.get_manual(world, view_entity) {
+                Ok(result) => result,
+                Err(_) => return Ok(()),
+            };
+
+        let pipeline0 = pipeline_cache.get_compute_pipeline(pipeline.0[0]).unwrap();
+        let pipeline1 = pipeline_cache.get_compute_pipeline(pipeline.0[1]).unwrap();
+
+        let main_texture = target.main_texture_view();
+        let mut cached_bind_group = self.cached_texture_bind_group.lock().unwrap();
+        let bind_group = match &mut *cached_bind_group {
+            Some((id, bind_group)) if main_texture.id() == *id => bind_group,
+            cached_bind_group => {
+                let bind_group =
+                    render_context
+                        .render_device()
+                        .create_bind_group(&BindGroupDescriptor {
+                            label: None,
+                            layout: &auto_exposure_pipeline.bind_group,
+                            entries: &[
+                                BindGroupEntry {
+                                    binding: 0,
+                                    resource: BindingResource::Buffer(BufferBinding {
+                                        buffer: view_uniforms_buffer,
+                                        size: Some(ViewUniform::min_size()),
+                                        offset: 0,
+                                    }),
+                                },
+                                BindGroupEntry {
+                                    binding: 1,
+                                    resource: BindingResource::TextureView(main_texture),
+                                },
+                                BindGroupEntry {
+                                    binding: 2,
+                                    resource: BindingResource::Buffer(BufferBinding {
+                                        buffer: storage_buffer.0.as_ref().unwrap(),
+                                        size: None,
+                                        offset: 0,
+                                    }),
+                                },
+                            ],
+                        });
+
+                let (_, bind_group) = cached_bind_group.insert((main_texture.id(), bind_group));
+                bind_group
+            }
+        };
+
+        let pass_descriptor = ComputePassDescriptor {
+            label: Some("autoexposure_pass"),
+        };
+
+        let encoder = render_context.command_encoder();
+        encoder.clear_buffer(storage_buffer.0.as_ref().unwrap(), 0, None);
+
+        let mut compute_pass = encoder.begin_compute_pass(&pass_descriptor);
+        compute_pass.set_pipeline(pipeline0);
+        compute_pass.set_bind_group(0, bind_group, &[view_uniform_offset.offset]);
+        compute_pass.dispatch_workgroups(
+            (view.viewport.z + 15) / 16,
+            (view.viewport.w + 15) / 16,
+            1,
+        );
+        compute_pass.set_pipeline(pipeline1);
+        compute_pass.set_bind_group(0, bind_group, &[view_uniform_offset.offset]);
+        compute_pass.dispatch_workgroups(1, 1, 1);
+
+        Ok(())
+    }
+}

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -6,6 +6,7 @@ pub mod clear_color;
 pub mod contrast_adaptive_sharpening;
 pub mod core_2d;
 pub mod core_3d;
+pub mod exposure;
 pub mod fullscreen_vertex_shader;
 pub mod fxaa;
 pub mod msaa_writeback;


### PR DESCRIPTION
# Objective

- Add a way to set the scene exposure based on the brightness of objects in the scene
- May be helpful to reduce breakage caused by #8407

## Solution

- Run compute shader over the render target to build a histogram of scene luminances
- Remove outliers (currently hard-coded to remove the lowest 40% and upper 5%)
- Compute the log average luminance and set the exposure accordingly

## TODOs:
* [ ] Enable/disable per-camera
* [ ] Exposure compensation curve so darker scenes actually look darker (right now autoexposure makes all scenes the same brightness so day and night look the same).
* [ ] Gradual adjustment via a moving average

---

## Changelog

Added: AutoExposure plugin that automatically adjusts the view exposure based on scene luminance