### PR TITLE
Allow unsized types as mapped value in `Ref::map`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -551,7 +551,7 @@ impl<'a, T: ?Sized> Ref<'a, T> {
     ///
     /// This doesn't do anything else than call `f` on the wrapped value.
     /// This is equivalent to [`Mut::map_unchanged`].
-    pub fn map<U>(self, f: impl FnOnce(&T) -> &U) -> Ref<'a, U> {
+    pub fn map<U: ?Sized>(self, f: impl FnOnce(&T) -> &U) -> Ref<'a, U> {
         Ref {
             value: f(self.value),
             ticks: self.ticks,


### PR DESCRIPTION
# Objective

- I can't map unsized type using `Ref::map` (for example `dyn Reflect`)

## Solution

- Allow unsized types (this is possible because `Ref` stores a reference to `T`)
