### PR TITLE
Initialize `DiagnosticStore` on `register_diagnostic` if it does not exist

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -2,7 +2,6 @@ use bevy_app::App;
 use bevy_ecs::system::{Deferred, Res, Resource, SystemBuffer, SystemParam};
 use bevy_log::warn;
 use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
-use std::collections::vec_deque::VecDeque;
 use std::{borrow::Cow, collections::VecDeque};
 
 use crate::MAX_DIAGNOSTIC_NAME_WIDTH;

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -289,7 +289,7 @@ pub trait RegisterDiagnostic {
 impl RegisterDiagnostic for App {
     /// Register a new [`Diagnostic`] with an [`App`].
     ///
-    /// Will initialize a [`DiagnosticStore`] if it doesn't exist.
+    /// Will initialize a [`DiagnosticsStore`] if it doesn't exist.
     ///
     /// ```rust
     /// use bevy_app::App;

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -2,6 +2,7 @@ use bevy_app::App;
 use bevy_ecs::system::{Deferred, Res, Resource, SystemBuffer, SystemParam};
 use bevy_log::warn;
 use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
+use std::collections::vec_deque::VecDeque;
 use std::{borrow::Cow, collections::VecDeque};
 
 use crate::MAX_DIAGNOSTIC_NAME_WIDTH;
@@ -289,6 +290,8 @@ pub trait RegisterDiagnostic {
 impl RegisterDiagnostic for App {
     /// Register a new [`Diagnostic`] with an [`App`].
     ///
+    /// Will initialize a [`DiagnosticStore`] if it doesn't exist.
+    ///
     /// ```rust
     /// use bevy_app::App;
     /// use bevy_diagnostic::{Diagnostic, DiagnosticsPlugin, DiagnosticId, RegisterDiagnostic};
@@ -296,12 +299,12 @@ impl RegisterDiagnostic for App {
     /// const UNIQUE_DIAG_ID: DiagnosticId = DiagnosticId::from_u128(42);
     ///
     /// App::new()
-    ///     .add_plugin(DiagnosticsPlugin)
-    ///     // Must only be called after the `DiagnosticsPlugin` has been added.
     ///     .register_diagnostic(Diagnostic::new(UNIQUE_DIAG_ID, "example", 10))
+    ///     .add_plugin(DiagnosticsPlugin)
     ///     .run();
     /// ```
     fn register_diagnostic(&mut self, diagnostic: Diagnostic) -> &mut Self {
+        self.init_resource::<DiagnosticsStore>();
         let mut diagnostics = self.world.resource_mut::<DiagnosticsStore>();
         diagnostics.add(diagnostic);
 


### PR DESCRIPTION
# Objective

- Fixes #8782

## Solution

- Call `init_resource` on `register_diagnostic` so that a `DiagnosticStore` gets initialized if it does not exist.
