### PR TITLE
Implement `Clone` for `CombinatorSystem`

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -242,6 +242,17 @@ where
 {
 }
 
+impl<Func, A, B> Clone for CombinatorSystem<Func, A, B>
+where
+    A: Clone,
+    B: Clone,
+{
+    /// Clone the combined system. The cloned instance must be `.initialize()`d before it can run.
+    fn clone(&self) -> Self {
+        CombinatorSystem::new(self.a.clone(), self.b.clone(), self.name.clone())
+    }
+}
+
 /// A [`System`] created by piping the output of the first system into the input of the second.
 ///
 /// This can be repeated indefinitely, but system pipes cannot branch: the output is consumed by the receiving system.

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -493,7 +493,10 @@ mod tests {
         prelude::AnyOf,
         query::{Added, Changed, Or, With, Without},
         removal_detection::RemovedComponents,
-        schedule::{apply_deferred, IntoSystemConfigs, Schedule},
+        schedule::{
+            apply_deferred, common_conditions::resource_exists, Condition, IntoSystemConfigs,
+            Schedule,
+        },
         system::{
             adapter::new, Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
             QueryComponentError, Res, ResMut, Resource, System, SystemState,
@@ -1834,5 +1837,34 @@ mod tests {
         assert!(!info1.second_flag);
         assert!(info2.first_flag);
         assert!(!info2.second_flag);
+    }
+
+    #[test]
+    fn test_combinator_clone() {
+        let mut world = World::new();
+        #[derive(Resource)]
+        struct A;
+        #[derive(Resource)]
+        struct B;
+        #[derive(Resource, PartialEq, Eq, Debug)]
+        struct C(i32);
+
+        world.insert_resource(A);
+        world.insert_resource(C(0));
+        let mut sched = Schedule::new();
+        sched.add_systems(
+            (
+                (|mut res: ResMut<C>| {
+                    res.0 += 1;
+                }),
+                (|mut res: ResMut<C>| {
+                    res.0 += 2;
+                }),
+            )
+                .distributive_run_if(resource_exists::<A>().or_else(resource_exists::<B>())),
+        );
+        sched.initialize(&mut world).unwrap();
+        sched.run(&mut world);
+        assert_eq!(world.get_resource(), Some(&C(3)));
     }
 }


### PR DESCRIPTION
# Objective

Make a combined system cloneable if both systems are cloneable on their own. This is necessary for using chained conditions (e.g `cond1.and_then(cond2)`) with `distributive_run_if()`.

## Solution

Implement `Clone` for `CombinatorSystem<Func, A, B>` where `A, B: Clone`.
