### PR TITLE
Implement `SystemSet` for `BoxedSystemSet`

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -504,13 +504,7 @@ pub trait IntoSystemSetConfig: Sized {
 
 impl<S: SystemSet> IntoSystemSetConfig for S {
     fn into_config(self) -> SystemSetConfig {
-        SystemSetConfig::new(Box::new(self))
-    }
-}
-
-impl IntoSystemSetConfig for BoxedSystemSet {
-    fn into_config(self) -> SystemSetConfig {
-        SystemSetConfig::new(self)
+        SystemSetConfig::new(self.into_boxed())
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -30,6 +30,15 @@ pub trait SystemSet: DynHash + Debug + Send + Sync + 'static {
     fn is_anonymous(&self) -> bool {
         false
     }
+
+    /// Convert this system set to a [`BoxedSystemSet`]
+    fn into_boxed(self) -> BoxedSystemSet
+    where
+        Self: Sized,
+    {
+        Box::new(self)
+    }
+
     /// Creates a boxed clone of the label corresponding to this system set.
     fn dyn_clone(&self) -> Box<dyn SystemSet>;
 }
@@ -51,6 +60,24 @@ impl Hash for dyn SystemSet {
 impl Clone for Box<dyn SystemSet> {
     fn clone(&self) -> Self {
         self.dyn_clone()
+    }
+}
+
+impl SystemSet for BoxedSystemSet {
+    fn dyn_clone(&self) -> Box<dyn SystemSet> {
+        self.as_ref().dyn_clone()
+    }
+
+    fn system_type(&self) -> Option<TypeId> {
+        self.as_ref().system_type()
+    }
+
+    fn is_anonymous(&self) -> bool {
+        self.as_ref().is_anonymous()
+    }
+
+    fn into_boxed(self) -> BoxedSystemSet {
+        self
     }
 }
 


### PR DESCRIPTION
# Objective

- Fix #8813

## Solution

Explicitly implement `SystemSet` (implying `IntoSystemSet`) for `BoxedSystemSet`

---

## Rationale 

I'm not sure why `BoxedSystemSet` wasn't `SystemSet` before, presumably because of the implicit deref, but for `IntoSystemSet` to work I think it should implement it explicitly. 

`IntoSystemSetConfig` was specialized on `BoxedSystemSet` to avoid double-boxing it so I just added a (non-dispatchable) `.into_boxed()` method.