### PR TITLE
Deprecate type aliases for `WorldQuery::Fetch`

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -450,14 +450,17 @@ pub unsafe trait WorldQuery {
 /// This must only be implemented for read-only [`WorldQuery`]'s.
 pub unsafe trait ReadOnlyWorldQuery: WorldQuery<ReadOnly = Self> {}
 
-/// The `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
-pub type QueryFetch<'w, Q> = <Q as WorldQuery>::Fetch<'w>;
 /// The item type returned when a [`WorldQuery`] is iterated over
 pub type QueryItem<'w, Q> = <Q as WorldQuery>::Item<'w>;
-/// The read-only `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
-pub type ROQueryFetch<'w, Q> = QueryFetch<'w, <Q as WorldQuery>::ReadOnly>;
 /// The read-only variant of the item type returned when a [`WorldQuery`] is iterated over immutably
 pub type ROQueryItem<'w, Q> = QueryItem<'w, <Q as WorldQuery>::ReadOnly>;
+
+/// The `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
+#[deprecated = "use <Q as WorldQuery>::Fetch<'w> instead"]
+pub type QueryFetch<'w, Q> = <Q as WorldQuery>::Fetch<'w>;
+/// The read-only `Fetch` of a [`WorldQuery`], which is used to store state for each archetype/table.
+#[deprecated = "use <<Q as WorldQuery>::ReadOnly as WorldQuery>::Fetch<'w> instead"]
+pub type ROQueryFetch<'w, Q> = <<Q as WorldQuery>::ReadOnly as WorldQuery>::Fetch<'w>;
 
 /// SAFETY: no component or archetype access
 unsafe impl WorldQuery for Entity {


### PR DESCRIPTION
# Objective

`WorldQuery::Fetch` is a type used to optimize the implementation of queries. These types are hidden and not intended to be outside of the engine, so there is no need to provide type aliases to make it easier to refer to them. If a user absolutely needs to refer to one of these types, they can always just refer to the associated type directly.

## Solution

Deprecate these type aliases.

---

## Changelog

- Deprecated the type aliases `QueryFetch` and `ROQueryFetch`.

## Migration Guide

The type aliases `bevy_ecs::query::QueryFetch` and `ROQueryFetch` have been deprecated. If you need to refer to a `WorldQuery` struct's fetch type, refer to the associated type defined on `WorldQuery` directly:

```rust
// Before:
type MyFetch<'w> = QueryFetch<'w, MyQuery>;
type MyFetchReadOnly<'w> = ROQueryFetch<'w, MyQuery>;

// After:
type MyFetch<'w> = <MyQuery as WorldQuery>::Fetch;
type MyFetchReadOnly<'w> = <<MyQuery as WorldQuery>::ReadOnly as WorldQuery>::Fetch;
```