### PR TITLE
Simplify the `ComponentIdFor` type

### DIFF
--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -136,7 +136,7 @@ impl RemovedComponentEvents {
 /// ```
 #[derive(SystemParam)]
 pub struct RemovedComponents<'w, 's, T: Component> {
-    component_id: Local<'s, ComponentIdFor<T>>,
+    component_id: ComponentIdFor<'s, T>,
     reader: Local<'s, RemovedComponentReader<T>>,
     event_sets: &'w RemovedComponentEvents,
 }
@@ -180,7 +180,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
 
     /// Fetch underlying [`Events`].
     pub fn events(&self) -> Option<&Events<RemovedComponentEntity>> {
-        self.event_sets.get(**self.component_id)
+        self.event_sets.get(self.component_id.get())
     }
 
     /// Destructures to get a mutable reference to the `ManualEventReader`
@@ -195,7 +195,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
         &Events<RemovedComponentEntity>,
     )> {
         self.event_sets
-            .get(**self.component_id)
+            .get(self.component_id.get())
             .map(|events| (&mut *self.reader, events))
     }
 


### PR DESCRIPTION
# Objective

`ComponentIdFor` is a type that gives you access to a component's `ComponentId` in a system. It is currently awkward to use, since it must be wrapped in a `Local<>` to be used.

## Solution

Make `ComponentIdFor` a proper SystemParam.

---

## Changelog

- Refactored the type `ComponentIdFor` in order to simplify how it is used.

## Migration Guide

The type `ComponentIdFor<T>` now implements `SystemParam` instead of `FromWorld` -- this means it should be used as the parameter for a system directly instead of being used in a `Local`.

```rust
// Before:
fn my_system(
    component_id: Local<ComponentIdFor<MyComponent>>,
) {
    let component_id = **component_id;
}

// After:
fn my_system(
    component_id: ComponentIdFor<MyComponent>,
) {
    let component_id = component_id.get();
}
```