### PR TITLE
Make `QueryParIter::for_each_unchecked` private

### DIFF
--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -147,10 +147,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> QueryParIter<'w, 's, Q, F> {
     ///
     /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
     #[inline]
-    pub unsafe fn for_each_unchecked<FN: Fn(QueryItem<'w, Q>) + Send + Sync + Clone>(
-        &self,
-        func: FN,
-    ) {
+    unsafe fn for_each_unchecked<FN: Fn(QueryItem<'w, Q>) + Send + Sync + Clone>(&self, func: FN) {
         let thread_count = ComputeTaskPool::get().thread_num();
         if thread_count <= 1 {
             self.state


### PR DESCRIPTION
# Objective

- The function `QueryParIter::for_each_unchecked` is a footgun: the only ways to use it soundly can be done in safe code using `for_each` or `for_each_mut`. See [this discussion on discord](https://discord.com/channels/691052431525675048/749335865876021248/1118642977275924583).

## Solution

- Make `for_each_unchecked` private.

---

## Changelog

- Removed `QueryParIter::for_each_unchecked`. All use-cases of this method were either unsound or doable in safe code using `for_each` or `for_each_mut`.

## Migration Guide

The method `QueryParIter::for_each_unchecked` has been removed -- use `for_each` or `for_each_mut` instead. If your use case can not be achieved using either of these, then your code was likely unsound.

If you have a use-case for `for_each_unchecked` that you believe is sound, please [open an issue](https://github.com/bevyengine/bevy/issues/new/choose).