### PR TITLE
Generic param for RenderAsset::extract_asset, AsBindGroup::as_bind_group

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -346,11 +346,13 @@ struct GpuLineGizmo {
 impl RenderAsset for LineGizmo {
     type ExtractedAsset = LineGizmo;
 
+    type ExtractParam = ();
+
     type PreparedAsset = GpuLineGizmo;
 
     type Param = SRes<RenderDevice>;
 
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -40,6 +40,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
     let manifest = BevyManifest::default();
     let render_path = manifest.get_path("bevy_render");
     let asset_path = manifest.get_path("bevy_asset");
+    let ecs_path = manifest.get_path("bevy_ecs");
 
     let mut binding_states: Vec<BindingState> = Vec::new();
     let mut binding_impls = Vec::new();
@@ -422,12 +423,17 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
 
         impl #impl_generics #render_path::render_resource::AsBindGroup for #struct_name #ty_generics #where_clause {
             type Data = #prepared_data;
+
+            type Param = (
+                #ecs_path::system::lifetimeless::SRes<#render_path::render_asset::RenderAssets<#render_path::texture::Image>>,
+                #ecs_path::system::lifetimeless::SRes<#render_path::texture::FallbackImage>,
+            );
+
             fn as_bind_group(
                 &self,
                 layout: &#render_path::render_resource::BindGroupLayout,
                 render_device: &#render_path::renderer::RenderDevice,
-                images: &#render_path::render_asset::RenderAssets<#render_path::texture::Image>,
-                fallback_image: &#render_path::texture::FallbackImage,
+                (images, fallback_image): &#ecs_path::system::SystemParamItem<Self::Param>,
             ) -> Result<#render_path::render_resource::PreparedBindGroup<Self::Data>, #render_path::render_resource::AsBindGroupError> {
                 let bindings = vec![#(#binding_impls,)*];
 

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -840,11 +840,12 @@ pub enum GpuBufferInfo {
 
 impl RenderAsset for Mesh {
     type ExtractedAsset = Mesh;
+    type ExtractParam = ();
     type PreparedAsset = GpuMesh;
     type Param = SRes<RenderDevice>;
 
     /// Clones the mesh.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -4,8 +4,8 @@ use crate::{
     render_asset::RenderAssets,
     render_resource::{resource_macros::*, BindGroupLayout, Buffer, Sampler, TextureView},
     renderer::RenderDevice,
-    texture::FallbackImage,
 };
+use bevy_ecs::system::{SystemParam, SystemParamItem};
 pub use bevy_render_macros::AsBindGroup;
 use encase::ShaderType;
 use std::ops::Deref;
@@ -267,13 +267,16 @@ pub trait AsBindGroup {
     /// Data that will be stored alongside the "prepared" bind group.
     type Data: Send + Sync;
 
+    /// Specifies all ECS data required by [`AsBindGroup::as_bind_group`].
+    /// For convenience use the [`lifetimeless`](bevy_ecs::system::lifetimeless) [`SystemParam`].
+    type Param: SystemParam;
+
     /// Creates a bind group for `self` matching the layout defined in [`AsBindGroup::bind_group_layout`].
     fn as_bind_group(
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        images: &RenderAssets<Image>,
-        fallback_image: &FallbackImage,
+        param: &SystemParamItem<Self::Param>,
     ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError>;
 
     /// Creates the bind group layout matching all bind groups returned by [`AsBindGroup::as_bind_group`]

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -57,7 +57,7 @@ impl Deref for BindGroup {
 ///
 /// This is an opinionated trait that is intended to make it easy to generically
 /// convert a type into a [`BindGroup`]. It provides access to specific render resources,
-/// such as [`RenderAssets<Image>`] and [`FallbackImage`]. If a type has a [`Handle<Image>`](bevy_asset::Handle),
+/// such as [`RenderAssets<Image>`] and [`FallbackImage`](crate::texture::FallbackImage). If a type has a [`Handle<Image>`](bevy_asset::Handle),
 /// these can be used to retrieve the corresponding [`Texture`](crate::render_resource::Texture) resource.
 ///
 /// [`AsBindGroup::as_bind_group`] is intended to be called once, then the result cached somewhere. It is generally
@@ -115,7 +115,7 @@ impl Deref for BindGroup {
 ///     * This field's [`Handle<Image>`](bevy_asset::Handle) will be used to look up the matching [`Texture`](crate::render_resource::Texture)
 ///     GPU resource, which will be bound as a texture in shaders. The field will be assumed to implement [`Into<Option<Handle<Image>>>`]. In practice,
 ///     most fields should be a [`Handle<Image>`](bevy_asset::Handle) or [`Option<Handle<Image>>`]. If the value of an [`Option<Handle<Image>>`] is
-///     [`None`], the [`FallbackImage`] resource will be used instead. This attribute can be used in conjunction with a `sampler` binding attribute
+///     [`None`], the [`FallbackImage`](crate::texture::FallbackImage) resource will be used instead. This attribute can be used in conjunction with a `sampler` binding attribute
 ///    (with a different binding index) if a binding of the sampler for the [`Image`] is also required.
 ///
 /// | Arguments             | Values                                                                  | Default              |
@@ -130,7 +130,7 @@ impl Deref for BindGroup {
 ///     * This field's [`Handle<Image>`](bevy_asset::Handle) will be used to look up the matching [`Sampler`](crate::render_resource::Sampler) GPU
 ///     resource, which will be bound as a sampler in shaders. The field will be assumed to implement [`Into<Option<Handle<Image>>>`]. In practice,
 ///     most fields should be a [`Handle<Image>`](bevy_asset::Handle) or [`Option<Handle<Image>>`]. If the value of an [`Option<Handle<Image>>`] is
-///     [`None`], the [`FallbackImage`] resource will be used instead. This attribute can be used in conjunction with a `texture` binding attribute
+///     [`None`], the [`FallbackImage`](crate::texture::FallbackImage) resource will be used instead. This attribute can be used in conjunction with a `texture` binding attribute
 ///     (with a different binding index) if a binding of the texture for the [`Image`] is also required.
 ///
 /// | Arguments              | Values                                                                  | Default                |
@@ -172,7 +172,7 @@ impl Deref for BindGroup {
 ///     color_texture: Option<Handle<Image>>,
 /// }
 /// ```
-/// This is useful if you want a texture to be optional. When the value is [`None`], the [`FallbackImage`] will be used for the binding instead, which defaults
+/// This is useful if you want a texture to be optional. When the value is [`None`], the [`FallbackImage`](crate::texture::FallbackImage) will be used for the binding instead, which defaults
 /// to "pure white".
 ///
 /// Field uniforms with the same index will be combined into a single binding:

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -504,6 +504,7 @@ pub struct GpuImage {
 
 impl RenderAsset for Image {
     type ExtractedAsset = Image;
+    type ExtractParam = ();
     type PreparedAsset = GpuImage;
     type Param = (
         SRes<RenderDevice>,
@@ -512,7 +513,7 @@ impl RenderAsset for Image {
     );
 
     /// Clones the Image.
-    fn extract_asset(&self) -> Self::ExtractedAsset {
+    fn extract_asset(&self, _: &SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
         self.clone()
     }
 

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -2,6 +2,7 @@
 //! `binding_array<texture<f32>>` shader binding slot and sample non-uniformly.
 
 use bevy::{
+    ecs::system::{lifetimeless::SRes, SystemParamItem},
     prelude::*,
     reflect::{TypePath, TypeUuid},
     render::{
@@ -94,12 +95,13 @@ struct BindlessMaterial {
 impl AsBindGroup for BindlessMaterial {
     type Data = ();
 
+    type Param = (SRes<RenderAssets<Image>>, SRes<FallbackImage>);
+
     fn as_bind_group(
         &self,
         layout: &BindGroupLayout,
         render_device: &RenderDevice,
-        image_assets: &RenderAssets<Image>,
-        fallback_image: &FallbackImage,
+        (image_assets, fallback_image): &SystemParamItem<Self::Param>,
     ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError> {
         // retrieve the render resources from handles
         let mut images = vec![];


### PR DESCRIPTION
# Objective

When customizing `Material`, we may access custom `RenderAsset` or other ecs data, generic param helps to achieve this.

---

## Changelog

- Add `ExtractParam` associated type to `RenderAsset`, which specify all ecs data required by `RenderAsset::extract_asset`.
- Add `Param` associated type to `AsBindGroup`, which specify all ecs data required by `AsBindGroup::as_bind_group`.

## Migration Guide

Before: 
```rust
impl RenderAsset for MyRenderAsset {
    // ..
    fn extract_asset(&self) -> Self::ExtractedAsset {
        // ..
    }
}

impl AsBindGroup for MyMaterial {
    // ..

    fn as_bind_group(
        &self,
        layout: &BindGroupLayout,
        render_device: &RenderDevice,
        image_assets: &RenderAssets<Image>,
        fallback_image: &FallbackImage,
    ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError> {
    // ..
}
```
After: 
```rust
impl RenderAsset for MyRenderAsset {
   // ..
   type ExtractParam = (
       EcsDataRequiredByExtractAsset0,
       EcsDataRequiredByExtractAsset1,
   );
    fn extract_asset(&self, (ecs_data0, ecs_data1): &SystemParamItem<Self::ExtractParam>) -> Self::ExtractedAsset {
        // ...
    }
}

impl AsBindGroup for BindlessMaterial {
    // ..
    type Param = (
       EcsDataRequiredByExtractAsset0,
       EcsDataRequiredByExtractAsset1,
    );

    fn as_bind_group(
        &self,
        layout: &BindGroupLayout,
        render_device: &RenderDevice,
        (ecs_data0, ecs_data1): &SystemParamItem<Self::Param>,
    ) -> Result<PreparedBindGroup<Self::Data>, AsBindGroupError> {
    // ..
}
```

