### PR TITLE
generate indices for Mikktspace

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -99,7 +99,7 @@ async fn load_gltf<'a, 'b>(
     let mut named_materials = HashMap::default();
     let mut linear_textures = HashSet::default();
     for material in gltf.materials() {
-        let handle = load_material(&material, load_context);
+        let handle = load_material(&material, load_context, false);
         if let Some(name) = material.name() {
             named_materials.insert(name.to_string(), handle.clone());
         }
@@ -592,8 +592,12 @@ async fn load_texture<'a>(
 }
 
 /// Loads a glTF material as a bevy [`StandardMaterial`] and returns it.
-fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<StandardMaterial> {
-    let material_label = material_label(material);
+fn load_material(
+    material: &Material,
+    load_context: &mut LoadContext,
+    is_scale_inverted: bool,
+) -> Handle<StandardMaterial> {
+    let material_label = material_label(material, is_scale_inverted);
 
     let pbr = material.pbr_metallic_roughness();
 
@@ -650,6 +654,8 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
             double_sided: material.double_sided(),
             cull_mode: if material.double_sided() {
                 None
+            } else if is_scale_inverted {
+                Some(Face::Front)
             } else {
                 Some(Face::Back)
             },
@@ -675,6 +681,7 @@ fn load_node(
     let transform = gltf_node.transform();
     let mut gltf_error = None;
     let transform = Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix()));
+    let is_scale_inverted = transform.scale.is_negative_bitmask().count_ones() & 1 == 1;
     let mut node = world_builder.spawn(SpatialBundle::from(transform));
 
     node.insert(node_name(gltf_node));
@@ -736,13 +743,13 @@ fn load_node(
             // append primitives
             for primitive in mesh.primitives() {
                 let material = primitive.material();
-                let material_label = material_label(&material);
+                let material_label = material_label(&material, is_scale_inverted);
 
                 // This will make sure we load the default material now since it would not have been
                 // added when iterating over all the gltf materials (since the default material is
                 // not explicitly listed in the gltf).
                 if !load_context.has_labeled_asset(&material_label) {
-                    load_material(&material, load_context);
+                    load_material(&material, load_context, is_scale_inverted);
                 }
 
                 let primitive_label = primitive_label(&mesh, &primitive);
@@ -886,9 +893,12 @@ fn primitive_label(mesh: &gltf::Mesh, primitive: &Primitive) -> String {
 }
 
 /// Returns the label for the `material`.
-fn material_label(material: &gltf::Material) -> String {
+fn material_label(material: &gltf::Material, is_scale_inverted: bool) -> String {
     if let Some(index) = material.index() {
-        format!("Material{index}")
+        format!(
+            "Material{index}{}",
+            if is_scale_inverted { " (inverted)" } else { "" }
+        )
     } else {
         "MaterialDefault".to_string()
     }

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -441,7 +441,6 @@ async fn load_gltf<'a, 'b>(
                         &mut node_index_to_entity_map,
                         &mut entity_to_skin_index_map,
                         &mut active_camera_found,
-                        &Transform::default(),
                     );
                     if result.is_err() {
                         err = Some(result);
@@ -678,13 +677,11 @@ fn load_node(
     node_index_to_entity_map: &mut HashMap<usize, Entity>,
     entity_to_skin_index_map: &mut HashMap<Entity, usize>,
     active_camera_found: &mut bool,
-    parent_transform: &Transform,
 ) -> Result<(), GltfError> {
     let transform = gltf_node.transform();
     let mut gltf_error = None;
     let transform = Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix()));
-    let world_transform = *parent_transform * transform;
-    let is_scale_inverted = world_transform.scale.is_negative_bitmask().count_ones() & 1 == 1;
+    let is_scale_inverted = transform.scale.is_negative_bitmask().count_ones() & 1 == 1;
     let mut node = world_builder.spawn(SpatialBundle::from(transform));
 
     node.insert(node_name(gltf_node));
@@ -872,7 +869,6 @@ fn load_node(
                 node_index_to_entity_map,
                 entity_to_skin_index_map,
                 active_camera_found,
-                &world_transform,
             ) {
                 gltf_error = Some(err);
                 return;

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -441,6 +441,7 @@ async fn load_gltf<'a, 'b>(
                         &mut node_index_to_entity_map,
                         &mut entity_to_skin_index_map,
                         &mut active_camera_found,
+                        &Transform::default(),
                     );
                     if result.is_err() {
                         err = Some(result);
@@ -677,11 +678,13 @@ fn load_node(
     node_index_to_entity_map: &mut HashMap<usize, Entity>,
     entity_to_skin_index_map: &mut HashMap<Entity, usize>,
     active_camera_found: &mut bool,
+    parent_transform: &Transform,
 ) -> Result<(), GltfError> {
     let transform = gltf_node.transform();
     let mut gltf_error = None;
     let transform = Transform::from_matrix(Mat4::from_cols_array_2d(&transform.matrix()));
-    let is_scale_inverted = transform.scale.is_negative_bitmask().count_ones() & 1 == 1;
+    let world_transform = *parent_transform * transform;
+    let is_scale_inverted = world_transform.scale.is_negative_bitmask().count_ones() & 1 == 1;
     let mut node = world_builder.spawn(SpatialBundle::from(transform));
 
     node.insert(node_name(gltf_node));
@@ -869,6 +872,7 @@ fn load_node(
                 node_index_to_entity_map,
                 entity_to_skin_index_map,
                 active_camera_found,
+                &world_transform,
             ) {
                 gltf_error = Some(err);
                 return;

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -908,7 +908,10 @@ impl MikktspaceGeometryHelper<'_> {
 
 impl bevy_mikktspace::Geometry for MikktspaceGeometryHelper<'_> {
     fn num_faces(&self) -> usize {
-        self.indices.map(Indices::len).unwrap_or_else(|| self.positions.len()) / 3
+        self.indices
+            .map(Indices::len)
+            .unwrap_or_else(|| self.positions.len())
+            / 3
     }
 
     fn num_vertices_of_face(&self, _: usize) -> usize {
@@ -987,7 +990,6 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
             ))
         }
     };
-
 
     let len = positions.len();
     let tangents = vec![[0., 0., 0., 0.]; len];

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -887,7 +887,7 @@ impl RenderAsset for Mesh {
 }
 
 struct MikktspaceGeometryHelper<'a> {
-    indices: &'a Indices,
+    indices: Option<&'a Indices>,
     positions: &'a Vec<[f32; 3]>,
     normals: &'a Vec<[f32; 3]>,
     uvs: &'a Vec<[f32; 2]>,
@@ -899,15 +899,16 @@ impl MikktspaceGeometryHelper<'_> {
         let index_index = face * 3 + vert;
 
         match self.indices {
-            Indices::U16(indices) => indices[index_index] as usize,
-            Indices::U32(indices) => indices[index_index] as usize,
+            Some(Indices::U16(indices)) => indices[index_index] as usize,
+            Some(Indices::U32(indices)) => indices[index_index] as usize,
+            None => index_index,
         }
     }
 }
 
 impl bevy_mikktspace::Geometry for MikktspaceGeometryHelper<'_> {
     fn num_faces(&self) -> usize {
-        self.indices.len() / 3
+        self.indices.map(Indices::len).unwrap_or_else(|| self.positions.len()) / 3
     }
 
     fn num_vertices_of_face(&self, _: usize) -> usize {
@@ -987,21 +988,11 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
         }
     };
 
-    let indices = if mesh.indices().is_none() {
-        if positions.len() < u16::MAX as usize {
-            Indices::U16((0..positions.len()).map(|i| i as u16).collect())
-        } else {
-            Indices::U32((0..positions.len()).map(|i| i as u32).collect())
-        }
-    } else {
-        Indices::U16(Default::default())
-    };
-    let indices = mesh.indices().unwrap_or(&indices);
 
     let len = positions.len();
     let tangents = vec![[0., 0., 0., 0.]; len];
     let mut mikktspace_mesh = MikktspaceGeometryHelper {
-        indices,
+        indices: mesh.indices(),
         positions,
         normals,
         uvs,

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -996,9 +996,7 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
     } else {
         Indices::U16(Default::default())
     };
-    let indices = mesh
-        .indices()
-        .unwrap_or(&indices);
+    let indices = mesh.indices().unwrap_or(&indices);
 
     let len = positions.len();
     let tangents = vec![[0., 0., 0., 0.]; len];

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -986,9 +986,19 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
             ))
         }
     };
+
+    let indices = if mesh.indices().is_none() {
+        if positions.len() < u16::MAX as usize {
+            Indices::U16((0..positions.len()).map(|i| i as u16).collect())
+        } else {
+            Indices::U32((0..positions.len()).map(|i| i as u32).collect())
+        }
+    } else {
+        Indices::U16(Default::default())
+    };
     let indices = mesh
         .indices()
-        .ok_or(GenerateTangentsError::MissingIndices)?;
+        .unwrap_or(&indices);
 
     let len = positions.len();
     let tangents = vec![[0., 0., 0., 0.]; len];


### PR DESCRIPTION
# Objective

mikktspace tangent generation requires mesh indices, and currently fails when they are not present. we can just generate them instead.

## Solution

generate the indices.