### PR TITLE
Add get_unclamped to Axis

### DIFF
--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -34,20 +34,34 @@ where
 
     /// Sets the position data of the `input_device` to `position_data`.
     ///
-    /// The `position_data` is clamped to be between [`Axis::MIN`] and [`Axis::MAX`], inclusive.
-    ///
     /// If the `input_device`:
     /// - was present before, the position data is updated, and the old value is returned.
     /// - wasn't present before, [None] is returned.
     pub fn set(&mut self, input_device: T, position_data: f32) -> Option<f32> {
-        let new_position_data = position_data.clamp(Self::MIN, Self::MAX);
-        self.axis_data.insert(input_device, new_position_data)
+        self.axis_data.insert(input_device, position_data)
     }
 
-    /// Returns a position data corresponding to the `input_device`.
+    /// Returns the position data of the provided `input_device`.
+    ///
+    /// This will be clamped between [`Axis::MIN`] and [`Axis::MAX`].
     pub fn get(&self, input_device: T) -> Option<f32> {
+        self.axis_data
+            .get(&input_device)
+            .copied()
+            .map(|value| value.clamp(Self::MIN, Self::MAX))
+    }
+
+    /// Returns the unclamped position data of the provided `input_device`.
+    ///
+    /// This value may be outside of the [`Axis::MIN`] and [`Axis::MAX`] range.
+    ///
+    /// Use for things like camera zoom, where you want devices like mouse wheels to be able to
+    /// exceed the normal range. If being able to move faster on one input device
+    /// than another would give an unfair advantage, you should likely use [`Axis::get`] instead.
+    pub fn get_unclamped(&self, input_device: T) -> Option<f32> {
         self.axis_data.get(&input_device).copied()
     }
+
     /// Removes the position data of the `input_device`, returning the position data if the input device was previously set.
     pub fn remove(&mut self, input_device: T) -> Option<f32> {
         self.axis_data.remove(&input_device)

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -4,7 +4,9 @@ use std::hash::Hash;
 
 /// Stores the position data of the input devices of type `T`.
 ///
-/// The values are stored as `f32`s, which range from [`Axis::MIN`] to [`Axis::MAX`], inclusive.
+/// The values are stored as `f32`s, using [`Axis::set`].
+/// Use [`Axis::get`] to retrieve the value clamped between [`Axis::MIN`] and [`Axis::MAX`]
+/// inclusive, or unclamped using [`Axis::get_unclamped`].
 #[derive(Debug, Resource)]
 pub struct Axis<T> {
     /// The position data of the input devices.
@@ -43,7 +45,7 @@ where
 
     /// Returns the position data of the provided `input_device`.
     ///
-    /// This will be clamped between [`Axis::MIN`] and [`Axis::MAX`].
+    /// This will be clamped between [`Axis::MIN`] and [`Axis::MAX`] inclusive.
     pub fn get(&self, input_device: T) -> Option<f32> {
         self.axis_data
             .get(&input_device)


### PR DESCRIPTION
# Objective

Add a get_unclamped method to [Axis](https://docs.rs/bevy/0.10.1/bevy/input/struct.Axis.html) to allow it to be used in cases where being able to get a precise relative movement is important. For example, camera zoom with the mouse wheel.

This would make it possible for libraries like leafwing input manager to leverage `Axis` for mouse motion and mouse wheel axis mapping. I tried to use it my PR here https://github.com/Leafwing-Studios/leafwing-input-manager/pull/346 but will likely have to revert that and read the mouse wheel events for now which is what prompted this PR. 

## Solution

Instead of clamping the axis value when it is set, it now stores the raw value and clamps it in the `get` method. This allows a simple get_unclamped method that just returns the raw value.


## Changelog

- Added a get_unclamped method to Axis that can return values outside of -1.0 to 1.0
