### PR TITLE
Fix Plane UVs / texture flip

### DIFF
--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -233,13 +233,13 @@ impl From<Plane> for Mesh {
         let mut uvs: Vec<[f32; 2]> = Vec::with_capacity(num_vertices);
         let mut indices: Vec<u32> = Vec::with_capacity(num_indices);
 
-        for y in 0..z_vertex_count {
+        for z in 0..z_vertex_count {
             for x in 0..x_vertex_count {
                 let tx = x as f32 / (x_vertex_count - 1) as f32;
-                let ty = y as f32 / (z_vertex_count - 1) as f32;
-                positions.push([(-0.5 + tx) * plane.size, 0.0, (-0.5 + ty) * plane.size]);
+                let tz = z as f32 / (z_vertex_count - 1) as f32;
+                positions.push([(-0.5 + tx) * plane.size, 0.0, (-0.5 + tz) * plane.size]);
                 normals.push(up);
-                uvs.push([tx, 1.0 - ty]);
+                uvs.push([tx, tz]);
             }
         }
 


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/1018 (Textures on the `Plane` shape appear flipped).

This bug have been around for a very long time apparently, I tested it was still there (see test code bellow) and sure enough, this image:

![test](https://github.com/bevyengine/bevy/assets/134181069/4cda7cf8-57d9-4677-91f5-02240d1e79b1)

... is flipped vertically when used as a texture on a plane (in main, 0.10.1 and 0.9):
![image](https://github.com/bevyengine/bevy/assets/134181069/0db4f52a-51af-4041-9c45-7bfe1f08b0cc)

I'm pretty confused because this bug is so easy to fix, it has been around for so long, it is easy to encounter, and PRs touching this code still didn't fix it: https://github.com/bevyengine/bevy/pull/7546 To the point where I'm wondering if it's actually intended. If it is, please explain why and this PR can be changed to "mention that in the doc".

## Solution

Fix the UV mapping on the Plane shape

Here is how it looks after the PR
![image](https://github.com/bevyengine/bevy/assets/134181069/e07ce641-3de8-4da3-a4f3-95a6054c86d7)

## Test code

```rust
use bevy::{
    prelude::*,
};

fn main () {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_startup_system(setup)
        .run();
}

fn setup(
    mut commands: Commands,
    assets: ResMut<AssetServer>,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    commands.spawn(Camera3dBundle {
        transform: Transform::from_xyz(0., 3., 0.).looking_at(Vec3::ZERO, Vec3::NEG_Z),
        ..default()
    });

    let mesh = meshes.add(Mesh::from(shape::Plane::default()));
    let texture_image = assets.load("test.png");
    let material = materials.add(StandardMaterial { 
        base_color_texture: Some(texture_image),
        ..default()
    });
    commands.spawn(PbrBundle {
        mesh,
        material,
        ..default()
    });
}
```

## Changelog

Fix textures on `Plane` shapes being flipped vertically.

## Migration Guide

Flip the textures you use on `Plane` shapes.