### PR TITLE
doc: update a reference from add_system to add_systems

### DIFF
--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -13,7 +13,7 @@ use std::borrow::Cow;
 /// Systems are functions with all arguments implementing
 /// [`SystemParam`](crate::system::SystemParam).
 ///
-/// Systems are added to an application using `App::add_system(my_system)`
+/// Systems are added to an application using `App::add_systems(Update, my_system)`
 /// or similar methods, and will generally run once per pass of the main loop.
 ///
 /// Systems are executed in parallel, in opportunistic order; data access is managed automatically.


### PR DESCRIPTION
Small fix for a forgotten documentation comment.