### PR TITLE
log to stderr instead of stdout

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -159,7 +159,7 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let tracy_layer = tracing_tracy::TracyLayer::new();
 
-            let fmt_layer = tracing_subscriber::fmt::Layer::default();
+            let fmt_layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
 
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.


### PR DESCRIPTION
# Objective

- `bevy_log` writes logs to `stdout` (with ANSI formatting), which gets in the way with program output and complicates parsing.
- Closes #8869

## Solution

- Change `bevy_log` to write to `stderr` instead of `stdout`

---

## Changelog

Changed: 
  - Logs write to `stderr` rather than `stdout` on desktop targets
  
## Migration Guide

- Capture logs from `stderr` instead of from `stdout`
  - Use `2> output.log` on the command line to save `stderr` to a file