### PR TITLE
Refactor `path` module of `bevy_reflect`

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -233,7 +233,7 @@
 //!
 //! The [`GetPath`] trait allows accessing arbitrary nested fields of a [`Reflect`] type.
 //!
-//! Using [`GetPath`], it is possible to use a path strings to access a specific field
+//! Using `GetPath`, it is possible to use a path string to access a specific field
 //! of a reflected type.
 //!
 //! ```
@@ -251,8 +251,6 @@
 //!   &123,
 //! );
 //! ```
-//!
-//! Check the [`GetPath`] documentation for more details.
 //!
 //! # Type Registration
 //!

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -229,6 +229,31 @@
 //!
 //! All primitives and simple types implement `FromReflect` by relying on their [`Default`] implementation.
 //!
+//! # Path navigation
+//!
+//! The [`GetPath`] trait allows accessing arbitrary nested fields of a [`Reflect`] type.
+//!
+//! Using [`GetPath`], it is possible to use a path strings to access a specific field
+//! of a reflected type.
+//!
+//! ```
+//! # use bevy_reflect::{Reflect, GetPath};
+//! #[derive(Reflect)]
+//! struct MyStruct {
+//!   value: Vec<Option<u32>>
+//! }
+//!
+//! let my_struct = MyStruct {
+//!   value: vec![None, None, Some(123)],
+//! };
+//! assert_eq!(
+//!   my_struct.path::<u32>(".value[2].0").unwrap(),
+//!   &123,
+//! );
+//! ```
+//!
+//! Check the [`GetPath`] documentation for more details.
+//!
 //! # Type Registration
 //!
 //! This crate also comes with a [`TypeRegistry`] that can be used to store and retrieve additional type metadata at runtime,

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -451,7 +451,7 @@ impl fmt::Display for ParsedPath {
 /// A path is composed of multiple accesses in sequence.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 enum Access {
-    Field(String),
+    Field(Box<str>),
     FieldIndex(usize),
     TupleIndex(usize),
     ListIndex(usize),
@@ -485,7 +485,7 @@ enum AccessRef<'a> {
 impl<'a> AccessRef<'a> {
     fn to_owned(&self) -> Access {
         match self {
-            Self::Field(value) => Access::Field(value.to_string()),
+            Self::Field(value) => Access::Field(value.to_string().into_boxed_str()),
             Self::FieldIndex(value) => Access::FieldIndex(*value),
             Self::TupleIndex(value) => Access::TupleIndex(*value),
             Self::ListIndex(value) => Access::ListIndex(*value),
@@ -875,7 +875,7 @@ mod tests {
     }
 
     fn access_field(field: &'static str) -> Access {
-        Access::Field(field.to_string())
+        Access::Field(field.to_string().into_boxed_str())
     }
 
     #[test]

--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -412,32 +412,33 @@ impl ParsedPath {
     }
 }
 
+impl fmt::Display for Access {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Access::Field(field) => {
+                Token::DOT.fmt(f)?;
+                f.write_str(field.as_ref())
+            }
+            Access::FieldIndex(index) => {
+                Token::CROSSHATCH.fmt(f)?;
+                index.fmt(f)
+            }
+            Access::TupleIndex(index) => {
+                Token::DOT.fmt(f)?;
+                index.fmt(f)
+            }
+            Access::ListIndex(index) => {
+                Token::OPEN_BRACKET.fmt(f)?;
+                index.fmt(f)?;
+                Token::CLOSE_BRACKET.fmt(f)
+            }
+        }
+    }
+}
 impl fmt::Display for ParsedPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (idx, (access, _)) in self.0.iter().enumerate() {
-            match access {
-                Access::Field(field) => {
-                    if idx != 0 {
-                        Token::DOT.fmt(f)?;
-                    }
-                    f.write_str(field.as_str())?;
-                }
-                Access::FieldIndex(index) => {
-                    Token::CROSSHATCH.fmt(f)?;
-                    index.fmt(f)?;
-                }
-                Access::TupleIndex(index) => {
-                    if idx != 0 {
-                        Token::DOT.fmt(f)?;
-                    }
-                    index.fmt(f)?;
-                }
-                Access::ListIndex(index) => {
-                    Token::OPEN_BRACKET.fmt(f)?;
-                    index.fmt(f)?;
-                    Token::CLOSE_BRACKET.fmt(f)?;
-                }
-            }
+        for (access, _) in self.0.iter() {
+            write!(f, "{access}")?;
         }
         Ok(())
     }

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -40,7 +40,7 @@ impl Error<'static> {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum Type {
+pub(super) enum Type {
     Struct,
     TupleStruct,
     Tuple,

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -1,0 +1,240 @@
+use std::fmt;
+
+use super::ReflectPathError;
+use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
+use thiserror::Error;
+
+type InnerResult<T> = Result<Option<T>, AccessError<'static>>;
+
+#[derive(Debug, PartialEq, Eq, Error)]
+pub enum AccessError<'a> {
+    #[error(
+        "the current {ty} doesn't have the {} {}",
+        access.kind(),
+        access.display_value(),
+    )]
+    Access { ty: Type, access: AccessRef<'a> },
+
+    #[error("invalid type shape: expected {expected} but found a reflect {actual}")]
+    Type { expected: Type, actual: Type },
+
+    #[error("invalid enum access: expected {expected} variant but found {actual} variant")]
+    Enum { expected: Type, actual: Type },
+}
+
+impl<'a> AccessError<'a> {
+    fn with_offset(self, offset: usize) -> ReflectPathError<'a> {
+        let error = self;
+        ReflectPathError::InvalidAccess { offset, error }
+    }
+}
+impl AccessError<'static> {
+    fn bad_enum(expected: Type, actual: impl Into<Type>) -> Self {
+        let actual = actual.into();
+        AccessError::Enum { expected, actual }
+    }
+    fn bad_type(expected: Type, actual: impl Into<Type>) -> Self {
+        let actual = actual.into();
+        AccessError::Type { expected, actual }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum Type {
+    Struct,
+    TupleStruct,
+    Tuple,
+    List,
+    Array,
+    Map,
+    Enum,
+    Value,
+    Unit,
+}
+
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            Type::Struct => "struct",
+            Type::TupleStruct => "tuple struct",
+            Type::Tuple => "tuple",
+            Type::List => "list",
+            Type::Array => "array",
+            Type::Map => "map",
+            Type::Enum => "enum",
+            Type::Value => "value",
+            Type::Unit => "unit",
+        };
+        write!(f, "{name}")
+    }
+}
+impl<'a> From<ReflectRef<'a>> for Type {
+    fn from(value: ReflectRef<'a>) -> Self {
+        match value {
+            ReflectRef::Struct(_) => Type::Struct,
+            ReflectRef::TupleStruct(_) => Type::TupleStruct,
+            ReflectRef::Tuple(_) => Type::Tuple,
+            ReflectRef::List(_) => Type::List,
+            ReflectRef::Array(_) => Type::Array,
+            ReflectRef::Map(_) => Type::Map,
+            ReflectRef::Enum(_) => Type::Enum,
+            ReflectRef::Value(_) => Type::Value,
+        }
+    }
+}
+impl From<VariantType> for Type {
+    fn from(value: VariantType) -> Self {
+        match value {
+            VariantType::Struct => Type::Struct,
+            VariantType::Tuple => Type::Tuple,
+            VariantType::Unit => Type::Unit,
+        }
+    }
+}
+
+/// A singular owned element access within a path.
+///
+/// Can be applied to a `dyn Reflect` to get a reference to the targeted element.
+///
+/// A path is composed of multiple accesses in sequence.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub(super) enum Access {
+    Field(Box<str>),
+    FieldIndex(usize),
+    TupleIndex(usize),
+    ListIndex(usize),
+}
+
+impl fmt::Display for Access {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Access::Field(field) => write!(f, ".{field}"),
+            Access::FieldIndex(index) => write!(f, "#{index}"),
+            Access::TupleIndex(index) => write!(f, ".{index}"),
+            Access::ListIndex(index) => write!(f, "[{index}]"),
+        }
+    }
+}
+
+/// A singular borrowed element access within a path.
+///
+/// Can be applied to a `dyn Reflect` to get a reference to the targeted element.
+///
+/// Does not own the backing store it's sourced from.
+/// For an owned version, you can convert one to an [`Access`] with [`AccessRef::to_owned`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessRef<'a> {
+    Field(&'a str),
+    FieldIndex(usize),
+    TupleIndex(usize),
+    ListIndex(usize),
+}
+
+impl Access {
+    pub(super) fn as_ref(&self) -> AccessRef<'_> {
+        match self {
+            Self::Field(value) => AccessRef::Field(value),
+            Self::FieldIndex(value) => AccessRef::FieldIndex(*value),
+            Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
+            Self::ListIndex(value) => AccessRef::ListIndex(*value),
+        }
+    }
+}
+
+impl<'a> AccessRef<'a> {
+    pub(super) fn to_owned(self) -> Access {
+        match self {
+            Self::Field(value) => Access::Field(value.to_string().into_boxed_str()),
+            Self::FieldIndex(value) => Access::FieldIndex(value),
+            Self::TupleIndex(value) => Access::TupleIndex(value),
+            Self::ListIndex(value) => Access::ListIndex(value),
+        }
+    }
+
+    fn display_value(&self) -> &dyn fmt::Display {
+        match self {
+            Self::Field(value) => value,
+            Self::FieldIndex(value) | Self::TupleIndex(value) | Self::ListIndex(value) => value,
+        }
+    }
+    fn kind(&self) -> &'static str {
+        match self {
+            Self::Field(_) => "field",
+            Self::FieldIndex(_) => "field index",
+            Self::TupleIndex(_) | Self::ListIndex(_) => "index",
+        }
+    }
+
+    pub(super) fn element(
+        self,
+        base: &dyn Reflect,
+        offset: usize,
+    ) -> Result<&dyn Reflect, ReflectPathError<'a>> {
+        let ty = base.reflect_ref().into();
+        self.element_inner(base)
+            .and_then(|maybe| maybe.ok_or(AccessError::Access { ty, access: self }))
+            .map_err(|err| err.with_offset(offset))
+    }
+    fn element_inner(self, base: &dyn Reflect) -> InnerResult<&dyn Reflect> {
+        use ReflectRef::*;
+        match (self, base.reflect_ref()) {
+            (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field)),
+            (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
+                VariantType::Struct => Ok(enum_ref.field(field)),
+                actual => Err(AccessError::bad_enum(Type::Struct, actual)),
+            },
+            (Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
+            (Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
+                VariantType::Struct => Ok(enum_ref.field_at(index)),
+                actual => Err(AccessError::bad_enum(Type::Struct, actual)),
+            },
+            (Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
+            (Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
+            (Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
+                VariantType::Tuple => Ok(enum_ref.field_at(index)),
+                actual => Err(AccessError::bad_enum(Type::Tuple, actual)),
+            },
+            (Self::ListIndex(index), List(list)) => Ok(list.get(index)),
+            (Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
+            (Self::ListIndex(_), actual) => Err(AccessError::bad_type(Type::List, actual)),
+            (_, actual) => Err(AccessError::bad_type(Type::Struct, actual)),
+        }
+    }
+
+    pub(super) fn element_mut(
+        self,
+        base: &mut dyn Reflect,
+        offset: usize,
+    ) -> Result<&mut dyn Reflect, ReflectPathError<'a>> {
+        let ty = base.reflect_ref().into();
+        self.element_inner_mut(base)
+            .and_then(|maybe| maybe.ok_or(AccessError::Access { ty, access: self }))
+            .map_err(|err| err.with_offset(offset))
+    }
+    fn element_inner_mut(self, base: &mut dyn Reflect) -> InnerResult<&mut dyn Reflect> {
+        use ReflectMut::*;
+        let base_kind: Type = base.reflect_ref().into();
+        match (self, base.reflect_mut()) {
+            (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field)),
+            (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
+                VariantType::Struct => Ok(enum_mut.field_mut(field)),
+                actual => Err(AccessError::bad_enum(Type::Struct, actual)),
+            },
+            (Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
+            (Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
+                VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
+                actual => Err(AccessError::bad_enum(Type::Struct, actual)),
+            },
+            (Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
+            (Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
+            (Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
+                VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
+                actual => Err(AccessError::bad_enum(Type::Tuple, actual)),
+            },
+            (Self::ListIndex(index), List(list)) => Ok(list.get_mut(index)),
+            (Self::ListIndex(index), Array(list)) => Ok(list.get_mut(index)),
+            (Self::ListIndex(_), _) => Err(AccessError::bad_type(Type::List, base_kind)),
+            (_, _) => Err(AccessError::bad_type(Type::Struct, base_kind)),
+        }
+    }
+}

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-use super::ReflectPathError;
+use super::{AccessError, ReflectPathError};
 use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
 use thiserror::Error;
 
@@ -13,34 +13,43 @@ pub(super) enum Error<'a> {
         access.kind(),
         access.display_value(),
     )]
-    Access { ty: Type, access: AccessRef<'a> },
+    Access {
+        ty: TypeShape,
+        access: AccessRef<'a>,
+    },
 
     #[error("invalid type shape: expected {expected} but found a reflect {actual}")]
-    Type { expected: Type, actual: Type },
+    Type {
+        expected: TypeShape,
+        actual: TypeShape,
+    },
 
     #[error("invalid enum access: expected {expected} variant but found {actual} variant")]
-    Enum { expected: Type, actual: Type },
+    Enum {
+        expected: TypeShape,
+        actual: TypeShape,
+    },
 }
 
 impl<'a> Error<'a> {
     fn with_offset(self, offset: usize) -> ReflectPathError<'a> {
-        let error = super::AccessError(self);
+        let error = AccessError(self);
         ReflectPathError::InvalidAccess { offset, error }
     }
 }
 impl Error<'static> {
-    fn bad_enum(expected: Type, actual: impl Into<Type>) -> Self {
+    fn bad_enum_variant(expected: TypeShape, actual: impl Into<TypeShape>) -> Self {
         let actual = actual.into();
         Error::Enum { expected, actual }
     }
-    fn bad_type(expected: Type, actual: impl Into<Type>) -> Self {
+    fn bad_type(expected: TypeShape, actual: impl Into<TypeShape>) -> Self {
         let actual = actual.into();
         Error::Type { expected, actual }
     }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(super) enum Type {
+pub(super) enum TypeShape {
     Struct,
     TupleStruct,
     Tuple,
@@ -52,42 +61,42 @@ pub(super) enum Type {
     Unit,
 }
 
-impl fmt::Display for Type {
+impl fmt::Display for TypeShape {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
-            Type::Struct => "struct",
-            Type::TupleStruct => "tuple struct",
-            Type::Tuple => "tuple",
-            Type::List => "list",
-            Type::Array => "array",
-            Type::Map => "map",
-            Type::Enum => "enum",
-            Type::Value => "value",
-            Type::Unit => "unit",
+            TypeShape::Struct => "struct",
+            TypeShape::TupleStruct => "tuple struct",
+            TypeShape::Tuple => "tuple",
+            TypeShape::List => "list",
+            TypeShape::Array => "array",
+            TypeShape::Map => "map",
+            TypeShape::Enum => "enum",
+            TypeShape::Value => "value",
+            TypeShape::Unit => "unit",
         };
         write!(f, "{name}")
     }
 }
-impl<'a> From<ReflectRef<'a>> for Type {
+impl<'a> From<ReflectRef<'a>> for TypeShape {
     fn from(value: ReflectRef<'a>) -> Self {
         match value {
-            ReflectRef::Struct(_) => Type::Struct,
-            ReflectRef::TupleStruct(_) => Type::TupleStruct,
-            ReflectRef::Tuple(_) => Type::Tuple,
-            ReflectRef::List(_) => Type::List,
-            ReflectRef::Array(_) => Type::Array,
-            ReflectRef::Map(_) => Type::Map,
-            ReflectRef::Enum(_) => Type::Enum,
-            ReflectRef::Value(_) => Type::Value,
+            ReflectRef::Struct(_) => TypeShape::Struct,
+            ReflectRef::TupleStruct(_) => TypeShape::TupleStruct,
+            ReflectRef::Tuple(_) => TypeShape::Tuple,
+            ReflectRef::List(_) => TypeShape::List,
+            ReflectRef::Array(_) => TypeShape::Array,
+            ReflectRef::Map(_) => TypeShape::Map,
+            ReflectRef::Enum(_) => TypeShape::Enum,
+            ReflectRef::Value(_) => TypeShape::Value,
         }
     }
 }
-impl From<VariantType> for Type {
+impl From<VariantType> for TypeShape {
     fn from(value: VariantType) -> Self {
         match value {
-            VariantType::Struct => Type::Struct,
-            VariantType::Tuple => Type::Tuple,
-            VariantType::Unit => Type::Unit,
+            VariantType::Struct => TypeShape::Struct,
+            VariantType::Tuple => TypeShape::Tuple,
+            VariantType::Unit => TypeShape::Unit,
         }
     }
 }
@@ -116,6 +125,17 @@ impl fmt::Display for Access {
     }
 }
 
+impl Access {
+    pub(super) fn as_ref(&self) -> AccessRef<'_> {
+        match self {
+            Self::Field(value) => AccessRef::Field(value),
+            Self::FieldIndex(value) => AccessRef::FieldIndex(*value),
+            Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
+            Self::ListIndex(value) => AccessRef::ListIndex(*value),
+        }
+    }
+}
+
 /// A singular borrowed element access within a path.
 ///
 /// Can be applied to a `dyn Reflect` to get a reference to the targeted element.
@@ -128,17 +148,6 @@ pub(super) enum AccessRef<'a> {
     FieldIndex(usize),
     TupleIndex(usize),
     ListIndex(usize),
-}
-
-impl Access {
-    pub(super) fn as_ref(&self) -> AccessRef<'_> {
-        match self {
-            Self::Field(value) => AccessRef::Field(value),
-            Self::FieldIndex(value) => AccessRef::FieldIndex(*value),
-            Self::TupleIndex(value) => AccessRef::TupleIndex(*value),
-            Self::ListIndex(value) => AccessRef::ListIndex(*value),
-        }
-    }
 }
 
 impl<'a> AccessRef<'a> {
@@ -175,29 +184,30 @@ impl<'a> AccessRef<'a> {
             .and_then(|maybe| maybe.ok_or(Error::Access { ty, access: self }))
             .map_err(|err| err.with_offset(offset))
     }
+
     fn element_inner(self, base: &dyn Reflect) -> InnerResult<&dyn Reflect> {
         use ReflectRef::*;
         match (self, base.reflect_ref()) {
             (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field)),
             (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field(field)),
-                actual => Err(Error::bad_enum(Type::Struct, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
             },
             (Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
             (Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field_at(index)),
-                actual => Err(Error::bad_enum(Type::Struct, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
             },
             (Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
             (Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
             (Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Tuple => Ok(enum_ref.field_at(index)),
-                actual => Err(Error::bad_enum(Type::Tuple, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Tuple, actual)),
             },
             (Self::ListIndex(index), List(list)) => Ok(list.get(index)),
             (Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
-            (Self::ListIndex(_), actual) => Err(Error::bad_type(Type::List, actual)),
-            (_, actual) => Err(Error::bad_type(Type::Struct, actual)),
+            (Self::ListIndex(_), actual) => Err(Error::bad_type(TypeShape::List, actual)),
+            (_, actual) => Err(Error::bad_type(TypeShape::Struct, actual)),
         }
     }
 
@@ -211,30 +221,31 @@ impl<'a> AccessRef<'a> {
             .and_then(|maybe| maybe.ok_or(Error::Access { ty, access: self }))
             .map_err(|err| err.with_offset(offset))
     }
+
     fn element_inner_mut(self, base: &mut dyn Reflect) -> InnerResult<&mut dyn Reflect> {
         use ReflectMut::*;
-        let base_kind: Type = base.reflect_ref().into();
+        let base_kind: TypeShape = base.reflect_ref().into();
         match (self, base.reflect_mut()) {
             (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field)),
             (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_mut(field)),
-                actual => Err(Error::bad_enum(Type::Struct, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
             },
             (Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
             (Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(Error::bad_enum(Type::Struct, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
             },
             (Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
             (Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
             (Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(Error::bad_enum(Type::Tuple, actual)),
+                actual => Err(Error::bad_enum_variant(TypeShape::Tuple, actual)),
             },
             (Self::ListIndex(index), List(list)) => Ok(list.get_mut(index)),
             (Self::ListIndex(index), Array(list)) => Ok(list.get_mut(index)),
-            (Self::ListIndex(_), _) => Err(Error::bad_type(Type::List, base_kind)),
-            (_, _) => Err(Error::bad_type(Type::Struct, base_kind)),
+            (Self::ListIndex(_), _) => Err(Error::bad_type(TypeShape::List, base_kind)),
+            (_, _) => Err(Error::bad_type(TypeShape::Struct, base_kind)),
         }
     }
 }

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -4,11 +4,15 @@ use std::fmt;
 use std::num::ParseIntError;
 
 use crate::Reflect;
-pub use access::AccessError;
 use access::{Access, AccessRef};
 use thiserror::Error;
 
 type ParseResult<T> = Result<T, ReflectPathParseError>;
+
+/// An error specific to accessing a field/index on a `Reflect`.
+#[derive(Debug, PartialEq, Eq, Error)]
+#[error(transparent)]
+pub struct AccessError<'a>(access::Error<'a>);
 
 /// A parse error for a path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -771,10 +775,10 @@ mod tests {
             a.reflect_path("x.notreal").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 2,
-                error: AccessError::Access {
+                error: AccessError(access::Error::Access {
                     ty: Type::Struct,
                     access: AccessRef::Field("notreal"),
-                },
+                }),
             }
         );
 
@@ -782,10 +786,10 @@ mod tests {
             a.reflect_path("unit_variant.0").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 13,
-                error: AccessError::Enum {
+                error: AccessError(access::Error::Enum {
                     actual: Type::Unit,
                     expected: Type::Tuple
-                },
+                }),
             }
         );
 
@@ -798,10 +802,10 @@ mod tests {
             a.reflect_path("x[0]").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 2,
-                error: AccessError::Type {
+                error: AccessError(access::Error::Type {
                     actual: Type::Struct,
                     expected: Type::List
-                },
+                }),
             }
         );
 
@@ -809,10 +813,10 @@ mod tests {
             a.reflect_path("y.x").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 2,
-                error: AccessError::Type {
+                error: AccessError(access::Error::Type {
                     actual: Type::List,
                     expected: Type::Struct
-                },
+                }),
             }
         );
 

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -29,6 +29,7 @@ pub enum ReflectPathParseError {
     #[error("failed to parse a usize")]
     IndexParseError(#[from] ParseIntError),
 }
+
 /// An error returned from a failed path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ReflectPathError<'a> {

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -14,7 +14,7 @@ type ParseResult<T> = Result<T, ReflectPathParseError>;
 #[error(transparent)]
 pub struct AccessError<'a>(access::Error<'a>);
 
-/// A parse error for a path string query.
+/// A parse error for a path string.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ReflectPathParseError {
     #[error("expected an identifier at offset {offset}")]
@@ -558,7 +558,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::*;
-    use access::Type;
+    use access::TypeShape;
 
     #[derive(Reflect)]
     struct A {
@@ -777,7 +777,7 @@ mod tests {
             ReflectPathError::InvalidAccess {
                 offset: 2,
                 error: AccessError(access::Error::Access {
-                    ty: Type::Struct,
+                    ty: TypeShape::Struct,
                     access: AccessRef::Field("notreal"),
                 }),
             }
@@ -788,8 +788,8 @@ mod tests {
             ReflectPathError::InvalidAccess {
                 offset: 13,
                 error: AccessError(access::Error::Enum {
-                    actual: Type::Unit,
-                    expected: Type::Tuple
+                    actual: TypeShape::Unit,
+                    expected: TypeShape::Tuple
                 }),
             }
         );
@@ -804,8 +804,8 @@ mod tests {
             ReflectPathError::InvalidAccess {
                 offset: 2,
                 error: AccessError(access::Error::Type {
-                    actual: Type::Struct,
-                    expected: Type::List
+                    actual: TypeShape::Struct,
+                    expected: TypeShape::List
                 }),
             }
         );
@@ -815,8 +815,8 @@ mod tests {
             ReflectPathError::InvalidAccess {
                 offset: 2,
                 error: AccessError(access::Error::Type {
-                    actual: Type::List,
-                    expected: Type::Struct
+                    actual: TypeShape::List,
+                    expected: TypeShape::Struct
                 }),
             }
         );


### PR DESCRIPTION
# Objective

- The `path` module was getting fairly large.
- The code in `AccessRef::read_element` and mut equivalent was very complex and difficult to understand.
- The `ReflectPathError` had a lot of variants, and was difficult to read.

## Solution

- Split the file in two, `access` now has its own module
- Rewrite the `read_element` methods, they were ~200 lines long, they are now ~70 lines long — I didn't change any of the logic. It's really just the same code, but error handling is separated.
- Split the `ReflectPathError` error
- Merge `AccessRef` and `Access`
- A few other changes that aim to reduce code complexity

### Fully detailed change list

- `Display` impl of `ParsedPath` now includes prefix dots — this allows simplifying its implementation, and IMO `.path.to.field` is a better way to express a "path" than `path.to.field` which could suggest we are reading the `to` field of a variable named `path`
- Add a test to check that dot prefixes and other are correctly parsed — Until now, no test contained a prefixing dot
- Merge `Access` and `AccessRef`, using a `Cow<'a, str>`. Generated code seems to agree with this decision (`ParsedPath::parse` sheds 5% of instructions)
   - Remove `Access::as_ref` since there is no such thing as an `AccessRef` anymore.
   - Rename `AccessRef::to_owned` into `AccessRef::into_owned()` since it takes ownership of `self` now.
   - Add a `parse_static` that doesn't allocate new strings for named fields!
- Add a section about path reflection in the `bevy_reflect` crate root doc — I saw a few people that weren't aware of path reflection, so I thought it was pertinent to add it to the root doc
- a lot of nits
  - rename `index` to `offset` when it refers to offset in the path string — There is no more confusion with the other kind of indices in this context, also it's a common naming convention for parsing.
  - Make a dedicated enum for parsing errors
  - rename the `read_element` methods to `element` — shorter, but also `read_element_mut` was a fairly poor name
  - The error values now not only contain the expected type but also the actual type.
- Remove lifetimes that could be inferred from the `GetPath` trait methods.

---

## Change log

- Added the `ParsedPath::parse_static` method, avoids allocating when parsing `&'static str`.

## Migration Guide

If you were matching on the `Err(ReflectPathError)` value returned by `GetPath` and `ParsedPath` methods, now only the parse-related errors and the offset are publicly accessible. You can always use the `fmt::Display` to get a clear error message, but if you need programmatic access to the error types, please open an issue.
