### PR TITLE
fix normal prepass

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -682,7 +682,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
         let mut shader_defs = Vec::new();
         let mut vertex_attributes = Vec::new();
 
-        if key.contains(MeshPipelineKey::NORMAL_PREPASS) {
+        if key.contains(MeshPipelineKey::NORMAL_PREPASS) && key.msaa_samples() == 1 {
             shader_defs.push("LOAD_PREPASS_NORMALS".into());
         }
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -682,10 +682,6 @@ impl SpecializedMeshPipeline for MeshPipeline {
         let mut shader_defs = Vec::new();
         let mut vertex_attributes = Vec::new();
 
-        if key.contains(MeshPipelineKey::NORMAL_PREPASS) && key.msaa_samples() == 1 {
-            shader_defs.push("LOAD_PREPASS_NORMALS".into());
-        }
-
         if layout.contains(Mesh::ATTRIBUTE_POSITION) {
             shader_defs.push("VERTEX_POSITIONS".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_POSITION.at_shader_location(0));
@@ -747,6 +743,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
 
         let (label, blend, depth_write_enabled);
         let pass = key.intersection(MeshPipelineKey::BLEND_RESERVED_BITS);
+        let mut is_opaque = false;
         if pass == MeshPipelineKey::BLEND_ALPHA {
             label = "alpha_blend_mesh_pipeline".into();
             blend = Some(BlendState::ALPHA_BLENDING);
@@ -783,6 +780,11 @@ impl SpecializedMeshPipeline for MeshPipeline {
             // the current fragment value in the output and the depth is written to the
             // depth buffer
             depth_write_enabled = true;
+            is_opaque = true;
+        }
+
+        if key.contains(MeshPipelineKey::NORMAL_PREPASS) && key.msaa_samples() == 1 && is_opaque {
+            shader_defs.push("LOAD_PREPASS_NORMALS".into());
         }
 
         if key.contains(MeshPipelineKey::TONEMAP_IN_SHADER) {

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -118,11 +118,8 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         pbr_input.is_orthographic = is_orthographic;
 
 #ifdef LOAD_PREPASS_NORMALS
-    let alpha_mode = material.flags & STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
-    if alpha_mode == STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE || alpha_mode == STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {
         pbr_input.N = prepass_normal(in.frag_coord, 0u);
-    } else {
-#endif
+#else
         pbr_input.N = apply_normal_mapping(
             material.flags,
             pbr_input.world_normal,
@@ -135,8 +132,6 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
             uv,
 #endif
         );
-#ifdef LOAD_PREPASS_NORMALS
-    }
 #endif
 
         pbr_input.V = V;
@@ -145,7 +140,6 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
         pbr_input.flags = mesh.flags;
 
         output_color = pbr(pbr_input);
-        // return vec4(pbr_input.N, 1.0);
     } else {
         output_color = alpha_discard(material, output_color);
     }

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -122,6 +122,7 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
     if alpha_mode == STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE || alpha_mode == STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {
         pbr_input.N = prepass_normal(in.frag_coord, 0u);
     } else {
+#endif
         pbr_input.N = apply_normal_mapping(
             material.flags,
             pbr_input.world_normal,
@@ -134,22 +135,9 @@ fn fragment(in: FragmentInput) -> @location(0) vec4<f32> {
             uv,
 #endif
         );
+#ifdef LOAD_PREPASS_NORMALS
     }
-#else LOAD_PREPASS_NORMALS
-        pbr_input.N = apply_normal_mapping(
-            material.flags,
-            pbr_input.world_normal,
-#ifdef VERTEX_TANGENTS
-#ifdef STANDARDMATERIAL_NORMAL_MAP
-            in.world_tangent,
 #endif
-#endif
-#ifdef VERTEX_UVS
-            uv,
-#endif
-        );
-#endif // LOAD_PREPASS_NORMALS
-
 
         pbr_input.V = V;
         pbr_input.occlusion = occlusion;


### PR DESCRIPTION
# Objective

- Fix broken normals when the NormalPrepass is enabled

## Solution

- Don't use the normal prepass for the world_normal
- Only loadthe normal prepass 
    - when msaa is disabled
	- for opaque or alpha mask meshes and only for use it for N not world_normal
	