### PR TITLE
Do not require mut on ParsedPath::element_mut

### DIFF
--- a/crates/bevy_reflect/src/path.rs
+++ b/crates/bevy_reflect/src/path.rs
@@ -371,7 +371,7 @@ impl ParsedPath {
     ///
     /// See [`element_mut`](Self::element_mut) for a typed version of this method.
     pub fn reflect_element_mut<'r, 'p>(
-        &'p mut self,
+        &'p self,
         root: &'r mut dyn Reflect,
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'p>> {
         let mut current = root;
@@ -402,7 +402,7 @@ impl ParsedPath {
     ///
     /// See [`reflect_element_mut`](Self::reflect_element_mut) for an untyped version of this method.
     pub fn element_mut<'r, 'p, T: Reflect>(
-        &'p mut self,
+        &'p self,
         root: &'r mut dyn Reflect,
     ) -> Result<&'r mut T, ReflectPathError<'p>> {
         self.reflect_element_mut(root).and_then(|p| {


### PR DESCRIPTION
# Objective

`ParsedPath` does not need to be mut to access a field of a `Reflect`. Be that access mutable or not. Yet `element_mut` requires a mutable borrow on `self`.

## Solution

- Make `element_mut` take a `&self` over a `&mut self`.

#8887 fixes this, but this is a major limitation in the API and I'd rather see it merged before 0.11.

---

## Changelog

- `ParsedPath::element_mut` and `ParsedPath::reflect_element_mut` now accept a non-mutable `ParsedPath` (only the accessed `Reflect` needs to be mutable)