### PR TITLE
Add missing inline documentation for android code

### DIFF
--- a/crates/bevy_asset/src/io/android_asset_io.rs
+++ b/crates/bevy_asset/src/io/android_asset_io.rs
@@ -22,6 +22,7 @@ pub struct AndroidAssetIo {
 }
 
 impl AndroidAssetIo {
+    /// Creates a new [`AndroidAssetIo`] at the given root path
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         AndroidAssetIo {
             root_path: path.as_ref().to_owned(),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -59,6 +59,7 @@ use crate::converters::convert_winit_theme;
 #[cfg(target_arch = "wasm32")]
 use crate::web_resize::{CanvasParentResizeEventChannel, CanvasParentResizePlugin};
 
+/// [`AndroidApp`] provides an interface to query the application state as well as monitor events (for example lifecycle and input events)
 #[cfg(target_os = "android")]
 pub static ANDROID_APP: std::sync::OnceLock<AndroidApp> = std::sync::OnceLock::new();
 


### PR DESCRIPTION
# Objective

- Document android code that is currently causing clippy warnings due to not being documented

## Solution

- Document the two previously undocumented items