### PR TITLE
Move AppTypeRegistry to bevy_ecs

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -25,11 +25,6 @@ bevy_utils::define_label!(
     AppLabelId,
 );
 
-/// The [`Resource`] that stores the [`App`]'s [`TypeRegistry`](bevy_reflect::TypeRegistry).
-#[cfg(feature = "bevy_reflect")]
-#[derive(Resource, Clone, bevy_derive::Deref, bevy_derive::DerefMut, Default)]
-pub struct AppTypeRegistry(pub bevy_reflect::TypeRegistryArc);
-
 pub(crate) enum AppError {
     DuplicatePlugin { plugin_name: String },
 }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -21,9 +21,6 @@ pub use schedule_runner::*;
 
 #[allow(missing_docs)]
 pub mod prelude {
-    #[cfg(feature = "bevy_reflect")]
-    #[doc(hidden)]
-    pub use crate::AppTypeRegistry;
     #[doc(hidden)]
     pub use crate::{
         app::App,

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -2,8 +2,9 @@ use crate::{
     update_asset_storage_system, Asset, AssetEvents, AssetLoader, AssetServer, Handle, HandleId,
     LoadAssets, RefChange, ReflectAsset, ReflectHandle,
 };
-use bevy_app::{App, AppTypeRegistry};
+use bevy_app::App;
 use bevy_ecs::prelude::*;
+use bevy_ecs::reflect::AppTypeRegistry;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect};
 use bevy_utils::HashMap;
 use crossbeam_channel::Sender;

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -253,7 +253,8 @@ impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
 mod tests {
     use std::any::TypeId;
 
-    use bevy_app::{App, AppTypeRegistry};
+    use bevy_app::App;
+    use bevy_ecs::reflect::AppTypeRegistry;
     use bevy_reflect::{FromReflect, Reflect, ReflectMut, TypeUuid};
 
     use crate::{AddAsset, AssetPlugin, HandleUntyped, ReflectAsset};

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,7 +29,7 @@ pub use bevy_ptr as ptr;
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
-    pub use crate::reflect::{ReflectComponent, ReflectResource};
+    pub use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectResource};
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -1,8 +1,12 @@
 //! Types that enable reflection support.
 
-use crate::entity::Entity;
+use std::ops::{Deref, DerefMut};
+
+use crate as bevy_ecs;
+use crate::{entity::Entity, system::Resource};
 use bevy_reflect::{
     impl_from_reflect_value, impl_reflect_value, ReflectDeserialize, ReflectSerialize,
+    TypeRegistryArc,
 };
 
 mod component;
@@ -12,6 +16,27 @@ mod resource;
 pub use component::{ReflectComponent, ReflectComponentFns};
 pub use map_entities::ReflectMapEntities;
 pub use resource::{ReflectResource, ReflectResourceFns};
+
+/// A [`Resource`] storing [`TypeRegistry`](bevy_reflect::TypeRegistry) for
+/// type registrations relevant to a whole app.
+#[derive(Resource, Clone, Default)]
+pub struct AppTypeRegistry(pub TypeRegistryArc);
+
+impl Deref for AppTypeRegistry {
+    type Target = TypeRegistryArc;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AppTypeRegistry {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
 
 impl_reflect_value!((in bevy_ecs) Entity(Hash, PartialEq, Serialize, Deserialize));
 impl_from_reflect_value!(Entity);

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -2,10 +2,9 @@ use std::any::TypeId;
 
 use crate::{DynamicSceneBuilder, Scene, SceneSpawnError};
 use anyhow::Result;
-use bevy_app::AppTypeRegistry;
 use bevy_ecs::{
     entity::{Entity, EntityMap},
-    reflect::{ReflectComponent, ReflectMapEntities},
+    reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities},
     world::World,
 };
 use bevy_reflect::{Reflect, TypePath, TypeRegistryArc, TypeUuid};
@@ -185,8 +184,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bevy_app::AppTypeRegistry;
-    use bevy_ecs::{entity::EntityMap, system::Command, world::World};
+    use bevy_ecs::{entity::EntityMap, reflect::AppTypeRegistry, system::Command, world::World};
     use bevy_hierarchy::{AddChild, Parent};
 
     use crate::dynamic_scene_builder::DynamicSceneBuilder;

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,9 +1,8 @@
 use crate::{DynamicEntity, DynamicScene};
-use bevy_app::AppTypeRegistry;
 use bevy_ecs::component::ComponentId;
 use bevy_ecs::{
     prelude::Entity,
-    reflect::{ReflectComponent, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},
     world::World,
 };
 use bevy_reflect::Reflect;
@@ -204,10 +203,10 @@ impl<'w> DynamicSceneBuilder<'w> {
 
 #[cfg(test)]
 mod tests {
-    use bevy_app::AppTypeRegistry;
     use bevy_ecs::{
         component::Component, prelude::Entity, prelude::Resource, query::With,
-        reflect::ReflectComponent, reflect::ReflectResource, world::World,
+        reflect::AppTypeRegistry, reflect::ReflectComponent, reflect::ReflectResource,
+        world::World,
     };
 
     use bevy_reflect::Reflect;

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -1,7 +1,6 @@
-use bevy_app::AppTypeRegistry;
 use bevy_ecs::{
     entity::EntityMap,
-    reflect::{ReflectComponent, ReflectMapEntities, ReflectResource},
+    reflect::{AppTypeRegistry, ReflectComponent, ReflectMapEntities, ReflectResource},
     world::World,
 };
 use bevy_reflect::{TypePath, TypeUuid};

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -1,8 +1,8 @@
 #[cfg(feature = "serialize")]
 use crate::serde::SceneDeserializer;
 use anyhow::{anyhow, Result};
-use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetLoader, LoadContext, LoadedAsset};
+use bevy_ecs::reflect::AppTypeRegistry;
 use bevy_ecs::world::{FromWorld, World};
 use bevy_reflect::TypeRegistryArc;
 use bevy_utils::BoxedFuture;

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,9 +1,9 @@
 use crate::{DynamicScene, Scene};
-use bevy_app::AppTypeRegistry;
 use bevy_asset::{AssetEvent, Assets, Handle};
 use bevy_ecs::{
     entity::{Entity, EntityMap},
     event::{Events, ManualEventReader},
+    reflect::AppTypeRegistry,
     system::{Command, Resource},
     world::{Mut, World},
 };

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -424,11 +424,10 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
 mod tests {
     use crate::serde::{SceneDeserializer, SceneSerializer};
     use crate::{DynamicScene, DynamicSceneBuilder};
-    use bevy_app::AppTypeRegistry;
     use bevy_ecs::entity::{Entity, EntityMap, EntityMapper, MapEntities};
     use bevy_ecs::prelude::{Component, ReflectComponent, ReflectResource, Resource, World};
     use bevy_ecs::query::{With, Without};
-    use bevy_ecs::reflect::ReflectMapEntities;
+    use bevy_ecs::reflect::{AppTypeRegistry, ReflectMapEntities};
     use bevy_ecs::world::FromWorld;
     use bevy_reflect::{FromReflect, Reflect, ReflectSerialize};
     use bincode::Options;


### PR DESCRIPTION
# Objective

- Use `AppTypeRegistry` on API defined in `bevy_ecs` (https://github.com/bevyengine/bevy/pull/8895#discussion_r1234748418)

A lot of the API on `Reflect` depends on a registry. When it comes to the ECS. We should use `AppTypeRegistry` in the general case.

This is however impossible in `bevy_ecs`, since `AppTypeRegistry` is defined in `bevy_app`.

## Solution

- Move `AppTypeRegistry` resource definition from `bevy_app` to `bevy_ecs`
- Still add the resource in the `App` plugin, since bevy_ecs itself doesn't know of plugins

Note that `bevy_ecs` is a dependency of `bevy_app`, so nothing revolutionary happens.

## Alternative

- Define the API as a trait in `bevy_app` over `bevy_ecs`. (though this prevents us from using bevy_ecs internals)
- Do not rely on `AppTypeRegistry` for the API in question, requring users to extract themselves the resource and pass it to the API methods.

### Why not derive `DerefMut`

`TypeRegistryArc` is a `Arc<RwLock<TypeRegistry>>`, which means even mutable 

---

## Changelog

- Moved `AppTypeRegistry` resource definition from `bevy_app` to `bevy_ecs`

## Migration Guide

- If you were **not** using a `prelude::*` to import `AppTypeRegistry`, you should update your imports:

```diff
- use bevy::app::AppTypeRegistry;
+ use bevy::ecs::reflect::AppTypeRegistry
```