### PR TITLE
Fix windows not being centered properly when system interface is scaled

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -346,7 +346,7 @@ pub fn winit_window_position(
                 let screen_size = monitor.size();
                 
                 // We use the monitors scale factor here since WindowResolution.scale_factor
-                // is not yet populated at window creation time.
+                // is not yet populated when windows are created at plugin setup
                 let scale_factor = monitor.scale_factor();
 
                 // Logical to physical window size

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -344,8 +344,10 @@ pub fn winit_window_position(
 
             if let Some(monitor) = maybe_monitor {
                 let screen_size = monitor.size();
-
-                let scale_factor = resolution.base_scale_factor();
+                
+                // We use the monitors scale factor here since WindowResolution.scale_factor
+                // is not yet populated at window creation time.
+                let scale_factor = monitor.scale_factor();
 
                 // Logical to physical window size
                 let (width, height): (u32, u32) =

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -344,7 +344,7 @@ pub fn winit_window_position(
 
             if let Some(monitor) = maybe_monitor {
                 let screen_size = monitor.size();
-                
+
                 // We use the monitors scale factor here since WindowResolution.scale_factor
                 // is not yet populated when windows are created at plugin setup
                 let scale_factor = monitor.scale_factor();


### PR DESCRIPTION
# Objective

Fixes #8765 

## Solution

When windows are created during plugin setup, the scale_factor of a WindowResolution struct will always be 1.0 (default). The correct scale factor is set later in flow. To get correct center calculations use the monitors scale factor directly instead. 

## Results
System: Windows 10 Pro (125% scaling)
### main 
![scale_125_without_fix](https://github.com/bevyengine/bevy/assets/644930/df808013-adc9-4300-8930-08ac87cc62b8)

### This PR
![scale_125_with_fix](https://github.com/bevyengine/bevy/assets/644930/c3d73606-d9e3-4f65-b4cc-2a1c20dbb64d)
