### PR TITLE
Remove "bevy_text" feature attributes on imports used by non-text systems

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -4,7 +4,6 @@ mod render_pass;
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
 use bevy_render::{ExtractSchedule, Render};
-#[cfg(feature = "bevy_text")]
 use bevy_window::{PrimaryWindow, Window};
 pub use pipeline::*;
 pub use render_pass::*;
@@ -33,7 +32,6 @@ use bevy_render::{
     Extract, RenderApp, RenderSet,
 };
 use bevy_sprite::SpriteAssetEvents;
-#[cfg(feature = "bevy_text")]
 use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{PositionedGlyph, Text, TextLayoutInfo};


### PR DESCRIPTION
# Objective

The "bevy_text" feature attributes for the `PrimaryWindow`, `Window` and `TextureAtlas` imports in `bevy_ui::render` are used by non-text systems (`extract_uinode_borders` and `extract_atlas_uinodes`) and need to be removed.