### PR TITLE
Support `&mut QueryState` parameters in regular systems

### DIFF
--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1786,7 +1786,7 @@ mod tests {
         assert_is_system(my_system);
     }
 
-    // Compile test for [insert link here]
+    // Compile test for https://github.com/bevyengine/bevy/pull/8914.
     #[test]
     fn system_param_states() {
         #[derive(Component)]


### PR DESCRIPTION
# Objective

Exclusive systems allow parameters of type `&mut QueryState<>`, which is a shorthand for writing `Local<QueryState<>>`. For consistency, this should also be supported in non-exclusive systems (this is useful for systems with an `&World` parameter).

## Solution

Add the respective impl, as well as an impl for `&mut SystemState<>`.

Since these parameters can only be used with `&World`, these are only useful for read-only queries or system states. I considered adding the bound `ReadOnlyWorldQuery` to these impls in order to prevent users from defining useless SystemParams -- however, this would result in a much worse failure mode as users would encounter a cryptic compile error instead of just having a useless value.

---

## Changelog

- Added support for `&mut QueryState<...>` and `&mut SystemState<...>` parameters in regular systems. This is a shorthand for writing `Local<QueryState<...>>` or `Local<SystemState<...>>`.
