### PR TITLE
Add missing dependencies to `bevy_text` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ bevy_scene = ["bevy_internal/bevy_scene", "bevy_asset"]
 bevy_sprite = ["bevy_internal/bevy_sprite", "bevy_render", "bevy_core_pipeline"]
 
 # Provides text functionality
-bevy_text = ["bevy_internal/bevy_text"]
+bevy_text = ["bevy_internal/bevy_text", "bevy_asset", "bevy_sprite"]
 
 # A custom ECS-driven UI framework
 bevy_ui = ["bevy_internal/bevy_ui", "bevy_core_pipeline", "bevy_text", "bevy_sprite"]


### PR DESCRIPTION
# Objective

- Fixes #8918.
- The app should not crash if only the `bevy_text` feature is enabled.

## Solution

The `bevy_text` feature now depends on `bevy_asset` and `bevy_sprite`, because it uses resources from these crates.

