### PR TITLE
Change `despawn_descendants` to return `&mut Self`

### DIFF
--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -269,7 +269,7 @@ mod tests {
 
         queue.apply(&mut world);
 
-        // The parent's Children component should still have a two children.
+        // The parent's Children component should still have two children.
         let children = world.entity(parent).get::<Children>();
         assert!(children.is_some());
         assert!(children.unwrap().len() == 2_usize);

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -248,4 +248,32 @@ mod tests {
         // The child should be despawned.
         assert!(world.get_entity(child).is_none());
     }
+
+    #[test]
+    fn spawn_children_after_despawn_descendants() {
+        let mut world = World::default();
+        let mut queue = CommandQueue::default();
+        let mut commands = Commands::new(&mut queue, &world);
+
+        let parent = commands.spawn_empty().id();
+        let child = commands.spawn_empty().id();
+
+        commands
+            .entity(parent)
+            .add_child(child)
+            .despawn_descendants()
+            .with_children(|parent| {
+                parent.spawn_empty();
+                parent.spawn_empty();
+            });
+
+        queue.apply(&mut world);
+
+        // The parent's Children component should still have a two children.
+        let children = world.entity(parent).get::<Children>();
+        assert!(children.is_some());
+        assert!(children.unwrap().len() == 2 as usize);
+        // The original child should be despawned.
+        assert!(world.get_entity(child).is_none());
+    }
 }

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -86,7 +86,7 @@ pub trait DespawnRecursiveExt {
     fn despawn_recursive(self);
 
     /// Despawns all descendants of the given entity.
-    fn despawn_descendants(&mut self);
+    fn despawn_descendants(&mut self) -> &mut Self;
 }
 
 impl<'w, 's, 'a> DespawnRecursiveExt for EntityCommands<'w, 's, 'a> {
@@ -96,9 +96,10 @@ impl<'w, 's, 'a> DespawnRecursiveExt for EntityCommands<'w, 's, 'a> {
         self.commands().add(DespawnRecursive { entity });
     }
 
-    fn despawn_descendants(&mut self) {
+    fn despawn_descendants(&mut self) -> &mut Self {
         let entity = self.id();
         self.commands().add(DespawnChildrenRecursive { entity });
+        self
     }
 }
 
@@ -117,7 +118,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         despawn_with_children_recursive(self.into_world_mut(), entity);
     }
 
-    fn despawn_descendants(&mut self) {
+    fn despawn_descendants(&mut self) -> &mut Self {
         let entity = self.id();
 
         #[cfg(feature = "trace")]
@@ -130,6 +131,7 @@ impl<'w> DespawnRecursiveExt for EntityMut<'w> {
         self.world_scope(|world| {
             despawn_children_recursive(world, entity);
         });
+        self
     }
 }
 

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -272,7 +272,7 @@ mod tests {
         // The parent's Children component should still have a two children.
         let children = world.entity(parent).get::<Children>();
         assert!(children.is_some());
-        assert!(children.unwrap().len() == 2 as usize);
+        assert!(children.unwrap().len() == 2_usize);
         // The original child should be despawned.
         assert!(world.get_entity(child).is_none());
     }


### PR DESCRIPTION
# Objective

- Change despawn descendants to return self (#8883).

## Solution

- Change function signature `despawn_descendants` under trait `DespawnRecursiveExt`.
- Add single extra test `spawn_children_after_despawn_descendants` (May be unnecessary)