### PR TITLE
Reduce android example APK size

### DIFF
--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -18,6 +18,8 @@ package = "org.bevyengine.example"
 apk_name = "bevyexample"
 assets = "../../assets"
 resources = "../../assets/android-res"
+# This strips debug symbols from the shared libraries, drastically reducing APK size. If you need them, remove the option.
+strip = "strip"
 build_targets = ["aarch64-linux-android", "armv7-linux-androideabi"]
 
 [package.metadata.android.sdk]


### PR DESCRIPTION
# Objective

The current mobile example produces an APK of 1.5 Gb.
- Running the example on a real device takes significant time (around one minute just to copy the file over USB to my phone).
- Default virtual devices in Android studio run out of space after the first install. This can of course be solved/configured, but it causes unnecessary friction.
- One impression could be, that Bevy produces bloated APKs. 1.5Gb is even double the size of debug builds for desktop examples.

## Solution

- Strip the debug symbols of the shared libraries before they are copied to the APK

APK size after this change: 200Mb
Copy time on my machine: ~8s

## Considered alternative

APKs built in release mode are only 50Mb in size, but require setting up signing for the profile and compile longer.


