### PR TITLE
Fix WebGPU error in "ui_pipeline" by adding a flat interpolate attribute

### DIFF
--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -8,7 +8,7 @@ var<uniform> view: View;
 struct VertexOutput {
     @location(0) uv: vec2<f32>,
     @location(1) color: vec4<f32>,
-    @location(3) mode: u32,
+    @location(3) @interpolate(flat) mode: u32,
     @builtin(position) position: vec4<f32>,
 };
 
@@ -39,7 +39,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     if in.mode == TEXTURED_QUAD {
         color = in.color * color;
     } else {
-        color = in.color;   
+        color = in.color;
     }
     return color;
 }


### PR DESCRIPTION
# Objective

- Fix this error to be able to run UI examples in WebGPU
```
1 error(s) generated while compiling the shader:
:31:18 error: integral user-defined vertex outputs must have a flat interpolation attribute
    @location(3) mode: u32,
                 ^^^^

:36:1 note: while analyzing entry point 'vertex'
fn vertex(
^^
```

It was introduce in #8793

## Solution

- Add `@interpolate(flat)` to the `mode` field