### PR TITLE
Fix any_component_removed

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -948,7 +948,7 @@ pub mod common_conditions {
         // Simply checking `is_empty` would not be enough.
         // PERF: note that `count` is efficient (not actually looping/iterating),
         // due to Bevy having a specialized implementation for events.
-        move |mut removals: RemovedComponents<T>| !removals.iter().count() != 0
+        move |mut removals: RemovedComponents<T>| removals.iter().count() != 0
     }
 
     /// Generates a [`Condition`](super::Condition) that inverses the result of passed one.


### PR DESCRIPTION
# Objective

`any_component_removed` condition is inversed.

## Solution

Remove extra `!`.

---

## Changelog

### Fixed

Fix `any_component_removed` condition.