### PR TITLE
Refs #8900 -- Changing scale factor to f32

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -63,7 +63,7 @@ pub struct RenderTargetInfo {
     /// The physical size of this render target (ignores scale factor).
     pub physical_size: UVec2,
     /// The scale factor of this render target.
-    pub scale_factor: f64,
+    pub scale_factor: f32,
 }
 
 /// Holds internally computed [`Camera`] values.
@@ -135,7 +135,7 @@ impl Camera {
     #[inline]
     pub fn to_logical(&self, physical_size: UVec2) -> Option<Vec2> {
         let scale = self.computed.target_info.as_ref()?.scale_factor;
-        Some((physical_size.as_dvec2() / scale).as_vec2())
+        Some((physical_size.as_dvec2() / scale as f64).as_vec2())
     }
 
     /// The rendered physical bounds (minimum, maximum) of the camera. If the `viewport` field is
@@ -475,7 +475,7 @@ impl NormalizedRenderTarget {
                         window.resolution.physical_width(),
                         window.resolution.physical_height(),
                     ),
-                    scale_factor: window.resolution.scale_factor() as f64,
+                    scale_factor: window.resolution.scale_factor(),
                 }),
             NormalizedRenderTarget::Image(image_handle) => {
                 let image = images.get(image_handle)?;

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -475,7 +475,7 @@ impl NormalizedRenderTarget {
                         window.resolution.physical_width(),
                         window.resolution.physical_height(),
                     ),
-                    scale_factor: window.resolution.scale_factor(),
+                    scale_factor: window.resolution.scale_factor() as f64,
                 }),
             NormalizedRenderTarget::Image(image_handle) => {
                 let image = images.get(image_handle)?;

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -135,7 +135,7 @@ impl Camera {
     #[inline]
     pub fn to_logical(&self, physical_size: UVec2) -> Option<Vec2> {
         let scale = self.computed.target_info.as_ref()?.scale_factor;
-        Some((physical_size.as_dvec2() / scale as f64).as_vec2())
+        Some(physical_size.as_vec2() / scale)
     }
 
     /// The rendered physical bounds (minimum, maximum) of the camera. If the `viewport` field is

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -43,7 +43,7 @@ impl TextPipeline {
         &mut self,
         fonts: &Assets<Font>,
         sections: &[TextSection],
-        scale_factor: f64,
+        scale_factor: f32,
         text_alignment: TextAlignment,
         linebreak_behavior: BreakLineOn,
         bounds: Vec2,
@@ -122,7 +122,7 @@ impl TextPipeline {
         &mut self,
         fonts: &Assets<Font>,
         sections: &[TextSection],
-        scale_factor: f64,
+        scale_factor: f32,
         text_alignment: TextAlignment,
         linebreak_behaviour: BreakLineOn,
     ) -> Result<TextMeasureInfo, TextError> {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -94,7 +94,7 @@ pub fn extract_text2d_sprite(
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = windows
         .get_single()
-        .map(|window| window.resolution.scale_factor() as f32)
+        .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.0);
     let scaling = GlobalTransform::from_scale(Vec3::splat(scale_factor.recip()));
 
@@ -210,6 +210,6 @@ pub fn update_text2d_layout(
     }
 }
 
-pub fn scale_value(value: f32, factor: f64) -> f32 {
-    (value as f64 * factor) as f32
+pub fn scale_value(value: f32, factor: f32) -> f32 {
+    value * factor
 }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -17,9 +17,9 @@ impl Val {
         match self {
             Val::Auto => taffy::style::LengthPercentageAuto::Auto,
             Val::Percent(value) => taffy::style::LengthPercentageAuto::Percent(value / 100.),
-            Val::Px(value) => taffy::style::LengthPercentageAuto::Points(
-                (context.scale_factor * value as f64) as f32,
-            ),
+            Val::Px(value) => {
+                taffy::style::LengthPercentageAuto::Points(context.scale_factor * value)
+            }
             Val::VMin(value) => {
                 taffy::style::LengthPercentageAuto::Points(context.min_size * value / 100.)
             }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -21,7 +21,7 @@ use std::fmt;
 use taffy::{prelude::Size, style_helpers::TaffyMaxContent, Taffy};
 
 pub struct LayoutContext {
-    pub scale_factor: f64,
+    pub scale_factor: f32,
     pub physical_size: Vec2,
     pub min_size: f32,
     pub max_size: f32,
@@ -29,7 +29,7 @@ pub struct LayoutContext {
 
 impl LayoutContext {
     /// create new a [`LayoutContext`] from the window's physical size and scale factor
-    fn new(scale_factor: f64, physical_size: Vec2) -> Self {
+    fn new(scale_factor: f32, physical_size: Vec2) -> Self {
         Self {
             scale_factor,
             physical_size,
@@ -303,7 +303,7 @@ pub fn ui_layout_system(
 
     let physical_to_logical_factor = 1. / logical_to_physical_factor;
 
-    let to_logical = |v| (physical_to_logical_factor * v as f64) as f32;
+    let to_logical = |v| physical_to_logical_factor * v;
 
     // PERF: try doing this incrementally
     for (entity, mut node, mut transform, parent) in &mut node_transform_query {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -70,7 +70,7 @@ pub enum UiSystem {
 #[derive(Debug, Resource)]
 pub struct UiScale {
     /// The scale to be applied.
-    pub scale: f64,
+    pub scale: f32,
 }
 
 impl Default for UiScale {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -495,7 +495,7 @@ pub fn extract_text_uinodes(
     // TODO: Support window-independent UI scale: https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = windows
         .get_single()
-        .map(|window| window.resolution.scale_factor() as f32)
+        .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.0);
 
     let inverse_scale_factor = scale_factor.recip();

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -31,10 +31,10 @@ impl Node {
 
     /// Returns the size of the node in physical pixels based on the given scale factor.
     #[inline]
-    pub fn physical_size(&self, scale_factor: f64) -> Vec2 {
+    pub fn physical_size(&self, scale_factor: f32) -> Vec2 {
         Vec2::new(
-            (self.calculated_size.x as f64 * scale_factor) as f32,
-            (self.calculated_size.y as f64 * scale_factor) as f32,
+            self.calculated_size.x * scale_factor,
+            self.calculated_size.y * scale_factor,
         )
     }
 
@@ -46,17 +46,11 @@ impl Node {
 
     /// Returns the physical pixel coordinates of the UI node, based on its [`GlobalTransform`] and the scale factor.
     #[inline]
-    pub fn physical_rect(&self, transform: &GlobalTransform, scale_factor: f64) -> Rect {
+    pub fn physical_rect(&self, transform: &GlobalTransform, scale_factor: f32) -> Rect {
         let rect = self.logical_rect(transform);
         Rect {
-            min: Vec2::new(
-                (rect.min.x as f64 * scale_factor) as f32,
-                (rect.min.y as f64 * scale_factor) as f32,
-            ),
-            max: Vec2::new(
-                (rect.max.x as f64 * scale_factor) as f32,
-                (rect.max.y as f64 * scale_factor) as f32,
-            ),
+            min: Vec2::new(rect.min.x * scale_factor, rect.min.y * scale_factor),
+            max: Vec2::new(rect.max.x * scale_factor, rect.max.y * scale_factor),
         }
     }
 }

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -75,7 +75,7 @@ impl Measure for ImageMeasure {
 
 /// Updates content size of the node based on the image provided
 pub fn update_image_content_size_system(
-    mut previous_combined_scale_factor: Local<f64>,
+    mut previous_combined_scale_factor: Local<f32>,
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     textures: Res<Assets<Image>>,
@@ -105,7 +105,7 @@ pub fn update_image_content_size_system(
                 image_size.size = size;
                 content_size.set(ImageMeasure {
                     // multiply the image size by the scale factor to get the physical size
-                    size: size * combined_scale_factor as f32,
+                    size: size * combined_scale_factor,
                 });
             }
         }
@@ -116,7 +116,7 @@ pub fn update_image_content_size_system(
 
 /// Updates content size of the node based on the texture atlas sprite
 pub fn update_atlas_content_size_system(
-    mut previous_combined_scale_factor: Local<f64>,
+    mut previous_combined_scale_factor: Local<f32>,
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     atlases: Res<Assets<TextureAtlas>>,
@@ -153,7 +153,7 @@ pub fn update_atlas_content_size_system(
                 image_size.size = size;
                 content_size.set(ImageMeasure {
                     // multiply the image size by the scale factor to get the physical size
-                    size: size * combined_scale_factor as f32,
+                    size: size * combined_scale_factor,
                 });
             }
         }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -78,7 +78,7 @@ impl Measure for TextMeasure {
 fn create_text_measure(
     fonts: &Assets<Font>,
     text_pipeline: &mut TextPipeline,
-    scale_factor: f64,
+    scale_factor: f32,
     text: Ref<Text>,
     mut content_size: Mut<ContentSize>,
     mut text_flags: Mut<TextFlags>,
@@ -116,7 +116,7 @@ fn create_text_measure(
 /// Creates a `Measure` for text nodes that allows the UI to determine the appropriate amount of space
 /// to provide for the text given the fonts, the text itself and the constraints of the layout.
 pub fn measure_text_system(
-    mut last_scale_factor: Local<f64>,
+    mut last_scale_factor: Local<f32>,
     fonts: Res<Assets<Font>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
@@ -172,7 +172,7 @@ fn queue_text(
     texture_atlases: &mut Assets<TextureAtlas>,
     textures: &mut Assets<Image>,
     text_settings: &TextSettings,
-    scale_factor: f64,
+    scale_factor: f32,
     text: &Text,
     node: Ref<Node>,
     mut text_flags: Mut<TextFlags>,
@@ -226,7 +226,7 @@ fn queue_text(
 #[allow(clippy::too_many_arguments)]
 pub fn text_system(
     mut textures: ResMut<Assets<Image>>,
-    mut last_scale_factor: Local<f64>,
+    mut last_scale_factor: Local<f32>,
     fonts: Res<Assets<Font>>,
     windows: Query<&Window, With<PrimaryWindow>>,
     text_settings: Res<TextSettings>,

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -284,7 +284,7 @@ impl Window {
     ///
     /// Ratio of physical size to logical size, see [`WindowResolution`].
     #[inline]
-    pub fn scale_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f32 {
         self.resolution.scale_factor()
     }
 
@@ -297,7 +297,7 @@ impl Window {
     pub fn cursor_position(&self) -> Option<Vec2> {
         self.internal
             .physical_cursor_position
-            .map(|position| (position / self.scale_factor()).as_vec2())
+            .map(|position| (position / self.scale_factor() as f64).as_vec2())
     }
 
     /// The cursor position in this window in physical pixels.
@@ -317,7 +317,7 @@ impl Window {
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     pub fn set_cursor_position(&mut self, position: Option<Vec2>) {
         self.internal.physical_cursor_position =
-            position.map(|p| p.as_dvec2() * self.scale_factor());
+            position.map(|p| p.as_dvec2() * self.scale_factor() as f64);
     }
 
     /// Set the cursor position in this window in physical pixels.
@@ -559,11 +559,11 @@ pub struct WindowResolution {
     /// Code-provided ratio of physical size to logical size.
     ///
     /// Should be used instead `scale_factor` when set.
-    scale_factor_override: Option<f64>,
+    scale_factor_override: Option<f32>,
     /// OS-provided ratio of physical size to logical size.
     ///
     /// Set automatically depending on the pixel density of the screen.
-    scale_factor: f64,
+    scale_factor: f32,
 }
 
 impl Default for WindowResolution {
@@ -588,7 +588,7 @@ impl WindowResolution {
     }
 
     /// Builder method for adding a scale factor override to the resolution.
-    pub fn with_scale_factor_override(mut self, scale_factor_override: f64) -> Self {
+    pub fn with_scale_factor_override(mut self, scale_factor_override: f32) -> Self {
         self.scale_factor_override = Some(scale_factor_override);
         self
     }
@@ -596,13 +596,13 @@ impl WindowResolution {
     /// The window's client area width in logical pixels.
     #[inline]
     pub fn width(&self) -> f32 {
-        (self.physical_width() as f64 / self.scale_factor()) as f32
+        self.physical_width() as f32 / self.scale_factor()
     }
 
     /// The window's client area height in logical pixels.
     #[inline]
     pub fn height(&self) -> f32 {
-        (self.physical_height() as f64 / self.scale_factor()) as f32
+        self.physical_height() as f32 / self.scale_factor()
     }
 
     /// The window's client area width in physical pixels.
@@ -620,7 +620,7 @@ impl WindowResolution {
     /// The ratio of physical pixels to logical pixels.
     ///
     /// `physical_pixels = logical_pixels * scale_factor`
-    pub fn scale_factor(&self) -> f64 {
+    pub fn scale_factor(&self) -> f32 {
         self.scale_factor_override
             .unwrap_or_else(|| self.base_scale_factor())
     }
@@ -629,7 +629,7 @@ impl WindowResolution {
     ///
     /// This value is unaffected by [`WindowResolution::scale_factor_override`].
     #[inline]
-    pub fn base_scale_factor(&self) -> f64 {
+    pub fn base_scale_factor(&self) -> f32 {
         self.scale_factor
     }
 
@@ -637,7 +637,7 @@ impl WindowResolution {
     ///
     /// This value may be different from the scale factor reported by the window backend.
     #[inline]
-    pub fn scale_factor_override(&self) -> Option<f64> {
+    pub fn scale_factor_override(&self) -> Option<f32> {
         self.scale_factor_override
     }
 
@@ -645,8 +645,8 @@ impl WindowResolution {
     #[inline]
     pub fn set(&mut self, width: f32, height: f32) {
         self.set_physical_resolution(
-            (width as f64 * self.scale_factor()) as u32,
-            (height as f64 * self.scale_factor()) as u32,
+            (width * self.scale_factor()) as u32,
+            (height * self.scale_factor()) as u32,
         );
     }
 
@@ -662,7 +662,7 @@ impl WindowResolution {
 
     /// Set the window's scale factor, this may get overridden by the backend.
     #[inline]
-    pub fn set_scale_factor(&mut self, scale_factor: f64) {
+    pub fn set_scale_factor(&mut self, scale_factor: f32) {
         let (width, height) = (self.width(), self.height());
         self.scale_factor = scale_factor;
         self.set(width, height);
@@ -673,7 +673,7 @@ impl WindowResolution {
     /// This can change the logical and physical sizes if the resulting physical
     /// size is not within the limits.
     #[inline]
-    pub fn set_scale_factor_override(&mut self, scale_factor_override: Option<f64>) {
+    pub fn set_scale_factor_override(&mut self, scale_factor_override: Option<f32>) {
         let (width, height) = (self.width(), self.height());
         self.scale_factor_override = scale_factor_override;
         self.set(width, height);

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -463,7 +463,7 @@ pub fn winit_runner(mut app: App) {
 
                         cursor_events.cursor_moved.send(CursorMoved {
                             window: window_entity,
-                            position: (physical_position / window.resolution.scale_factor())
+                            position: (physical_position / window.resolution.scale_factor() as f64)
                                 .as_vec2(),
                         });
                     }
@@ -515,7 +515,9 @@ pub fn winit_runner(mut app: App) {
                         }
                     },
                     WindowEvent::Touch(touch) => {
-                        let location = touch.location.to_logical(window.resolution.scale_factor());
+                        let location = touch
+                            .location
+                            .to_logical(window.resolution.scale_factor() as f64);
 
                         // Event
                         input_events
@@ -540,7 +542,7 @@ pub fn winit_runner(mut app: App) {
                         );
 
                         let prior_factor = window.resolution.scale_factor();
-                        window.resolution.set_scale_factor(scale_factor);
+                        window.resolution.set_scale_factor(scale_factor as f32);
                         let new_factor = window.resolution.scale_factor();
 
                         if let Some(forced_factor) = window.resolution.scale_factor_override() {
@@ -550,7 +552,7 @@ pub fn winit_runner(mut app: App) {
                             // the new_inner_size should take those into account
                             *new_inner_size =
                                 winit::dpi::LogicalSize::new(window.width(), window.height())
-                                    .to_physical::<u32>(forced_factor);
+                                    .to_physical::<u32>(forced_factor as f64);
                             // TODO: Should this not trigger a WindowsScaleFactorChanged?
                         } else if approx::relative_ne!(new_factor, prior_factor) {
                             // Trigger a change event if they are approximately different
@@ -562,8 +564,8 @@ pub fn winit_runner(mut app: App) {
                             );
                         }
 
-                        let new_logical_width = (new_inner_size.width as f64 / new_factor) as f32;
-                        let new_logical_height = (new_inner_size.height as f64 / new_factor) as f32;
+                        let new_logical_width = new_inner_size.width as f32 / new_factor;
+                        let new_logical_height = new_inner_size.height as f32 / new_factor;
                         if approx::relative_ne!(window.width(), new_logical_width)
                             || approx::relative_ne!(window.height(), new_logical_height)
                         {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -69,7 +69,7 @@ pub(crate) fn create_window<'a>(
 
         window
             .resolution
-            .set_scale_factor(winit_window.scale_factor());
+            .set_scale_factor(winit_window.scale_factor() as f32);
         commands
             .entity(entity)
             .insert(RawHandleWrapper {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -83,7 +83,7 @@ impl WinitWindows {
 
                 let logical_size = LogicalSize::new(window.width(), window.height());
                 if let Some(sf) = window.resolution.scale_factor_override() {
-                    winit_window_builder.with_inner_size(logical_size.to_physical::<f64>(sf))
+                    winit_window_builder.with_inner_size(logical_size.to_physical::<f64>(sf as f64))
                 } else {
                     winit_window_builder.with_inner_size(logical_size)
                 }

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -99,22 +99,22 @@ fn change_scaling(input: Res<Input<KeyCode>>, mut ui_scale: ResMut<TargetScale>)
 
 #[derive(Resource)]
 struct TargetScale {
-    start_scale: f64,
-    target_scale: f64,
+    start_scale: f32,
+    target_scale: f32,
     target_time: Timer,
 }
 
 impl TargetScale {
-    fn set_scale(&mut self, scale: f64) {
+    fn set_scale(&mut self, scale: f32) {
         self.start_scale = self.current_scale();
         self.target_scale = scale;
         self.target_time.reset();
     }
 
-    fn current_scale(&self) -> f64 {
+    fn current_scale(&self) -> f32 {
         let completion = self.target_time.percent();
         let multiplier = ease_in_expo(completion as f64);
-        self.start_scale + (self.target_scale - self.start_scale) * multiplier
+        self.start_scale + (self.target_scale - self.start_scale) * multiplier as f32
     }
 
     fn tick(&mut self, delta: Duration) -> &Self {


### PR DESCRIPTION
Hi! 
This is my first contribution! I am not familiar yet with everything in Bevy so I am opened to criticism to learn :) 

# Objective

Fixes #8900 

## Solution

- Changed `scale_factor` of `Window` and `UI` from f64 to f32

---

## Changelog

Structs changed:
- bevy_ui: layout_context
- bevy_ui: UI_Scale
- bevy_window: WindowResolution
- carmera.rs: RenderTargetInfo

Tests changed:
- examples/ui/ui_scaling.rs

## Migration Guide

If manipulating `scale_factor`, some conversion from f64 to f32 may be necessary. 
