### PR TITLE
Unify `FixedTime` and `Time` (ver. B) (proof-of-concept) 

### DIFF
--- a/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/frame_time_diagnostics_plugin.rs
@@ -2,7 +2,7 @@ use crate::{Diagnostic, DiagnosticId, Diagnostics, RegisterDiagnostic};
 use bevy_app::prelude::*;
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
-use bevy_time::Time;
+use bevy_time::RealTime;
 
 /// Adds "frame time" diagnostic to an App, specifically "frame time", "fps" and "frame count"
 #[derive(Default)]
@@ -30,12 +30,12 @@ impl FrameTimeDiagnosticsPlugin {
 
     pub fn diagnostic_system(
         mut diagnostics: Diagnostics,
-        time: Res<Time>,
+        real_time: Res<RealTime>,
         frame_count: Res<FrameCount>,
     ) {
         diagnostics.add_measurement(Self::FRAME_COUNT, || frame_count.0 as f64);
 
-        let delta_seconds = time.raw_delta_seconds_f64();
+        let delta_seconds = real_time.delta_seconds_f64();
         if delta_seconds == 0.0 {
             return;
         }

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -2,7 +2,7 @@ use super::{Diagnostic, DiagnosticId, DiagnosticsStore};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_log::{debug, info};
-use bevy_time::{Time, Timer, TimerMode};
+use bevy_time::{RealTime, Timer, TimerMode};
 use bevy_utils::Duration;
 
 /// An App Plugin that logs diagnostics to the console
@@ -82,10 +82,10 @@ impl LogDiagnosticsPlugin {
 
     fn log_diagnostics_system(
         mut state: ResMut<LogDiagnosticsState>,
-        time: Res<Time>,
+        real_time: Res<RealTime>,
         diagnostics: Res<DiagnosticsStore>,
     ) {
-        if state.timer.tick(time.raw_delta()).finished() {
+        if state.timer.tick(real_time.delta()).finished() {
             if let Some(ref filter) = state.filter {
                 for diagnostic in filter.iter().flat_map(|id| {
                     diagnostics
@@ -107,10 +107,10 @@ impl LogDiagnosticsPlugin {
 
     fn log_diagnostics_debug_system(
         mut state: ResMut<LogDiagnosticsState>,
-        time: Res<Time>,
+        real_time: Res<RealTime>,
         diagnostics: Res<DiagnosticsStore>,
     ) {
-        if state.timer.tick(time.raw_delta()).finished() {
+        if state.timer.tick(real_time.delta()).finished() {
             if let Some(ref filter) = state.filter {
                 for diagnostic in filter.iter().flat_map(|id| {
                     diagnostics

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
 };
 use bevy_input::gamepad::{GamepadRumbleIntensity, GamepadRumbleRequest};
 use bevy_log::{debug, warn};
-use bevy_time::Time;
+use bevy_time::RealTime;
 use bevy_utils::{Duration, HashMap};
 use gilrs::{
     ff::{self, BaseEffect, BaseEffectType, Repeat, Replay},
@@ -120,12 +120,12 @@ fn handle_rumble_request(
     Ok(())
 }
 pub(crate) fn play_gilrs_rumble(
-    time: Res<Time>,
+    real_time: Res<RealTime>,
     mut gilrs: NonSendMut<Gilrs>,
     mut requests: EventReader<GamepadRumbleRequest>,
     mut running_rumbles: NonSendMut<RunningRumbleEffects>,
 ) {
-    let current_time = time.raw_elapsed();
+    let current_time = real_time.elapsed();
     // Remove outdated rumble effects.
     for rumbles in running_rumbles.rumbles.values_mut() {
         // `ff::Effect` uses RAII, dropping = deactivating

--- a/crates/bevy_time/src/clock.rs
+++ b/crates/bevy_time/src/clock.rs
@@ -29,15 +29,15 @@ pub struct Clock {
 impl Default for Clock {
     fn default() -> Self {
         Self {
+            startup: Instant::now(),
+            first_update: None,
+            last_update: None,
             delta: Duration::ZERO,
             delta_seconds: 0.0,
             delta_seconds_f64: 0.0,
             elapsed: Duration::ZERO,
             elapsed_seconds: 0.0,
             elapsed_seconds_f64: 0.0,
-            startup: Instant::now(),
-            first_update: None,
-            last_update: None,
             wrap_period: Duration::from_secs(3600), // 1 hour
             elapsed_wrapped: Duration::ZERO,
             elapsed_seconds_wrapped: 0.0,
@@ -55,7 +55,8 @@ impl Clock {
         }
     }
 
-    pub fn tick(&mut self, dt: Duration, instant: Instant) {
+    /// Advances the clock by `dt` and records it happening at `instant`.
+    pub fn update(&mut self, dt: Duration, instant: Instant) {
         self.delta = dt;
         self.delta_seconds = self.delta.as_secs_f32();
         self.delta_seconds_f64 = self.delta.as_secs_f64();

--- a/crates/bevy_time/src/clock.rs
+++ b/crates/bevy_time/src/clock.rs
@@ -1,0 +1,182 @@
+use bevy_reflect::{FromReflect, Reflect};
+use bevy_utils::{default, Duration, Instant};
+
+fn duration_div_rem(dividend: Duration, divisor: Duration) -> (u32, Duration) {
+    // `Duration` does not have a built-in modulo operation
+    let quotient = (dividend.as_nanos() / divisor.as_nanos()) as u32;
+    let remainder = dividend - (quotient * divisor);
+    (quotient, remainder)
+}
+
+/// A stopwatch that tracks the time since last update and the time since creation.
+#[derive(Debug, Clone, Copy, Reflect, FromReflect, PartialEq)]
+pub struct Clock {
+    startup: Instant,
+    first_update: Option<Instant>,
+    last_update: Option<Instant>,
+    delta: Duration,
+    delta_seconds: f32,
+    delta_seconds_f64: f64,
+    elapsed: Duration,
+    elapsed_seconds: f32,
+    elapsed_seconds_f64: f64,
+    wrap_period: Duration,
+    elapsed_wrapped: Duration,
+    elapsed_seconds_wrapped: f32,
+    elapsed_seconds_wrapped_f64: f64,
+}
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self {
+            delta: Duration::ZERO,
+            delta_seconds: 0.0,
+            delta_seconds_f64: 0.0,
+            elapsed: Duration::ZERO,
+            elapsed_seconds: 0.0,
+            elapsed_seconds_f64: 0.0,
+            startup: Instant::now(),
+            first_update: None,
+            last_update: None,
+            wrap_period: Duration::from_secs(3600), // 1 hour
+            elapsed_wrapped: Duration::ZERO,
+            elapsed_seconds_wrapped: 0.0,
+            elapsed_seconds_wrapped_f64: 0.0,
+        }
+    }
+}
+
+impl Clock {
+    /// Constructs a new `Clock` instance with a specific startup `Instant`.
+    pub fn new(startup: Instant) -> Self {
+        Self {
+            startup,
+            ..default()
+        }
+    }
+
+    pub fn tick(&mut self, dt: Duration, instant: Instant) {
+        self.delta = dt;
+        self.delta_seconds = self.delta.as_secs_f32();
+        self.delta_seconds_f64 = self.delta.as_secs_f64();
+
+        self.elapsed += dt;
+        self.elapsed_seconds = self.elapsed.as_secs_f32();
+        self.elapsed_seconds_f64 = self.elapsed.as_secs_f64();
+
+        self.elapsed_wrapped = duration_div_rem(self.elapsed, self.wrap_period).1;
+        self.elapsed_seconds_wrapped = self.elapsed_wrapped.as_secs_f32();
+        self.elapsed_seconds_wrapped_f64 = self.elapsed_wrapped.as_secs_f64();
+
+        if self.last_update.is_none() {
+            self.first_update = Some(instant);
+        }
+
+        self.last_update = Some(instant);
+    }
+
+    /// Returns the [`Instant`] the clock was created.
+    #[inline]
+    pub fn startup(&self) -> Instant {
+        self.startup
+    }
+
+    /// Returns the [`Instant`] when [`update`](#method.update) was first called, if it exists.
+    #[inline]
+    pub fn first_update(&self) -> Option<Instant> {
+        self.first_update
+    }
+
+    /// Returns the [`Instant`] when [`update`](#method.update) was last called, if it exists.
+    #[inline]
+    pub fn last_update(&self) -> Option<Instant> {
+        self.last_update
+    }
+
+    /// Returns how much time has advanced since the last [`update`](#method.update), as a [`Duration`].
+    #[inline]
+    pub fn delta(&self) -> Duration {
+        self.delta
+    }
+
+    /// Returns how much time has advanced since the last [`update`](#method.update), as [`f32`] seconds.
+    #[inline]
+    pub fn delta_seconds(&self) -> f32 {
+        self.delta_seconds
+    }
+
+    /// Returns how much time has advanced since the last [`update`](#method.update), as [`f64`] seconds.
+    #[inline]
+    pub fn delta_seconds_f64(&self) -> f64 {
+        self.delta_seconds_f64
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup), as [`Duration`].
+    #[inline]
+    pub fn elapsed(&self) -> Duration {
+        self.elapsed
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup), as [`f32`] seconds.
+    ///
+    /// **Note:** This is a monotonically increasing value. It's precision will degrade over time.
+    /// If you need an `f32` but that precision loss is unacceptable,
+    /// use [`elapsed_seconds_wrapped`](#method.elapsed_seconds_wrapped).
+    #[inline]
+    pub fn elapsed_seconds(&self) -> f32 {
+        self.elapsed_seconds
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup), as [`f64`] seconds.
+    #[inline]
+    pub fn elapsed_seconds_f64(&self) -> f64 {
+        self.elapsed_seconds_f64
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`Duration`].
+    #[inline]
+    pub fn elapsed_wrapped(&self) -> Duration {
+        self.elapsed_wrapped
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`f32`] seconds.
+    ///
+    /// This method is intended for applications (e.g. shaders) that require an [`f32`] value but
+    /// suffer from the gradual precision loss of [`elapsed_seconds`](#method.elapsed_seconds).
+    #[inline]
+    pub fn elapsed_seconds_wrapped(&self) -> f32 {
+        self.elapsed_seconds_wrapped
+    }
+
+    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`f64`] seconds.
+    #[inline]
+    pub fn elapsed_seconds_wrapped_f64(&self) -> f64 {
+        self.elapsed_seconds_wrapped_f64
+    }
+
+    /// Returns the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
+    ///
+    /// **Note:** The default modulus is one hour.
+    #[inline]
+    pub fn wrap_period(&self) -> Duration {
+        self.wrap_period
+    }
+
+    /// Sets the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
+    ///
+    /// **Note:** This will not take effect until the next update.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `wrap_period` is a zero-length duration.
+    #[inline]
+    pub fn set_wrap_period(&mut self, wrap_period: Duration) {
+        assert!(!wrap_period.is_zero(), "division by zero");
+        self.wrap_period = wrap_period;
+    }
+}

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,11 +1,9 @@
-use crate::{fixed_timestep::FixedTime, Time, Timer, TimerMode};
+use crate::{Time, Timer, TimerMode};
 use bevy_ecs::system::Res;
 use bevy_utils::Duration;
 
 /// Run condition that is active on a regular time interval, using [`Time`] to advance
 /// the timer.
-///
-/// If used for a fixed timestep system, use [`on_fixed_timer`] instead.
 ///
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
@@ -29,47 +27,12 @@ use bevy_utils::Duration;
 /// times. This condition should only be used with large time durations (relative to
 /// delta time).
 ///
-/// For more accurate timers, use the [`Timer`] class directly (see
-/// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
-/// use fixed timesteps that allow systems to run multiple times per frame.
+/// To create a more precise timer, use the [`Timer`] class directly (see
+/// [`Timer::times_finished_this_tick`], which can address the issue described above).
 pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
     let mut timer = Timer::new(duration, TimerMode::Repeating);
     move |time: Res<Time>| {
         timer.tick(time.delta());
-        timer.just_finished()
-    }
-}
-
-/// Run condition that is active on a regular time interval, using [`FixedTime`] to
-/// advance the timer.
-///
-/// If used for a non-fixed timestep system, use [`on_timer`] instead.
-///
-/// ```rust,no_run
-/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, FixedUpdate};
-/// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
-/// # use bevy_time::common_conditions::on_fixed_timer;
-/// fn main() {
-///     App::new()
-///         .add_plugins(DefaultPlugins)
-///         .add_systems(FixedUpdate,
-///             tick.run_if(on_fixed_timer(Duration::from_secs(1))),
-///         )
-///         .run();
-/// }
-/// fn tick() {
-///     // ran once a second
-/// }
-/// ```
-///
-/// Note that this run condition may not behave as expected if `duration` is smaller
-/// than the fixed timestep period, since the timer may complete multiple times in
-/// one fixed update.
-pub fn on_fixed_timer(duration: Duration) -> impl FnMut(Res<FixedTime>) -> bool + Clone {
-    let mut timer = Timer::new(duration, TimerMode::Repeating);
-    move |time: Res<FixedTime>| {
-        timer.tick(time.period);
         timer.just_finished()
     }
 }
@@ -85,9 +48,7 @@ mod tests {
     #[test]
     fn distributive_run_if_compiles() {
         Schedule::default().add_systems(
-            (test_system, test_system)
-                .distributive_run_if(on_timer(Duration::new(1, 0)))
-                .distributive_run_if(on_fixed_timer(Duration::new(1, 0))),
+            (test_system, test_system).distributive_run_if(on_timer(Duration::new(1, 0))),
         );
     }
 }

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -12,7 +12,7 @@
 
 use bevy_app::FixedUpdate;
 use bevy_ecs::{system::Resource, world::World};
-use bevy_utils::{default, Duration, Instant};
+use bevy_utils::{default, Duration};
 
 use crate::{Time, TimeContext};
 
@@ -28,7 +28,7 @@ pub struct FixedTimestep {
 impl Default for FixedTimestep {
     fn default() -> Self {
         Self {
-            size: Duration::from_micros(15625),
+            size: Self::DEFAULT_STEP_SIZE,
             steps: 0,
             overstep: Duration::ZERO,
             max_steps_per_update: u32::MAX,
@@ -37,6 +37,9 @@ impl Default for FixedTimestep {
 }
 
 impl FixedTimestep {
+    /// The default step size.
+    pub const DEFAULT_STEP_SIZE: Duration = Duration::from_micros(15625);
+
     /// Constructs a new `FixedTimestep` from a [`Duration`].
     pub fn new(size: Duration) -> Self {
         assert!(!size.is_zero(), "timestep is zero");
@@ -139,11 +142,10 @@ pub fn run_fixed_update_schedule(world: &mut World) {
         }
 
         // run schedule however many times
-        let dt = timestep.size();
         for _ in 0..steps {
             let mut time = world.resource_mut::<Time>();
             assert!(matches!(time.context(), TimeContext::FixedUpdate));
-            time.tick(dt, Instant::now());
+            time.update();
             schedule.run(world);
         }
 

--- a/crates/bevy_time/src/fixed_timestep.rs
+++ b/crates/bevy_time/src/fixed_timestep.rs
@@ -16,7 +16,7 @@ use bevy_utils::{default, Duration, Instant};
 
 use crate::{Time, TimeContext};
 
-/// The step size (and some metadata) for the `FixedUpdate` schedule .
+/// The step size (and some metadata) for the `FixedUpdate` schedule.
 #[derive(Resource, Debug, Clone, Copy)]
 pub struct FixedTimestep {
     size: Duration,

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -139,6 +139,9 @@ fn time_system(
     // update virtual time clock
     time.update_with_instant(frame_start);
 
+    // apply any step size changes
+    time.fixed_timestep_size = fixed_timestep.size();
+
     // accumulate
     fixed_timestep.accumulate(time.delta());
 }

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -139,9 +139,6 @@ fn time_system(
     // update virtual time clock
     time.update_with_instant(frame_start);
 
-    // apply any step size changes
-    time.fixed_timestep_size = fixed_timestep.size();
-
     // accumulate
     fixed_timestep.accumulate(time.delta());
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,68 +1,46 @@
 use bevy_ecs::{reflect::ReflectResource, system::Resource};
 use bevy_reflect::{FromReflect, Reflect};
-use bevy_utils::{Duration, Instant};
+use bevy_utils::tracing::warn;
+use bevy_utils::{default, Duration, Instant};
 
-/// A clock that tracks how much it has advanced (and how much real time has elapsed) since
-/// its previous update and since its creation.
+use crate::clock::Clock;
+
+/// A clock that tracks how much time has advanced since the last update and since startup.
+///
+/// **NOTE:** This clock can be set to advance faster or slower than real-time. It can also be paused.
+/// For a clock that tracks the actual time that elapses, see [`RealTime`].
 #[derive(Resource, Reflect, FromReflect, Debug, Clone)]
 #[reflect(Resource)]
 pub struct Time {
-    startup: Instant,
-    first_update: Option<Instant>,
-    last_update: Option<Instant>,
-    // pausing
+    context: TimeContext,
+    update: Clock,
+    fixed_update: Clock,
+    // settings
     paused: bool,
-    // scaling
+    next_paused: Option<bool>,
     relative_speed: f64, // using `f64` instead of `f32` to minimize drift from rounding errors
-    delta: Duration,
-    delta_seconds: f32,
-    delta_seconds_f64: f64,
-    elapsed: Duration,
-    elapsed_seconds: f32,
-    elapsed_seconds_f64: f64,
-    raw_delta: Duration,
-    raw_delta_seconds: f32,
-    raw_delta_seconds_f64: f64,
-    raw_elapsed: Duration,
-    raw_elapsed_seconds: f32,
-    raw_elapsed_seconds_f64: f64,
-    // wrapping
-    wrap_period: Duration,
-    elapsed_wrapped: Duration,
-    elapsed_seconds_wrapped: f32,
-    elapsed_seconds_wrapped_f64: f64,
-    raw_elapsed_wrapped: Duration,
-    raw_elapsed_seconds_wrapped: f32,
-    raw_elapsed_seconds_wrapped_f64: f64,
+    next_relative_speed: Option<f64>,
+}
+
+/// [`Time`] stores two clocks that are synchronized but advance at different rates.
+/// This value determines which one is shown.
+#[derive(Debug, Default, Clone, Copy, Reflect, FromReflect, PartialEq, Eq)]
+pub enum TimeContext {
+    #[default]
+    Update,
+    FixedUpdate,
 }
 
 impl Default for Time {
     fn default() -> Self {
         Self {
-            startup: Instant::now(),
-            first_update: None,
-            last_update: None,
+            context: TimeContext::Update,
+            update: default(),
+            fixed_update: default(),
             paused: false,
+            next_paused: None,
             relative_speed: 1.0,
-            delta: Duration::ZERO,
-            delta_seconds: 0.0,
-            delta_seconds_f64: 0.0,
-            elapsed: Duration::ZERO,
-            elapsed_seconds: 0.0,
-            elapsed_seconds_f64: 0.0,
-            raw_delta: Duration::ZERO,
-            raw_delta_seconds: 0.0,
-            raw_delta_seconds_f64: 0.0,
-            raw_elapsed: Duration::ZERO,
-            raw_elapsed_seconds: 0.0,
-            raw_elapsed_seconds_f64: 0.0,
-            wrap_period: Duration::from_secs(3600), // 1 hour
-            elapsed_wrapped: Duration::ZERO,
-            elapsed_seconds_wrapped: 0.0,
-            elapsed_seconds_wrapped_f64: 0.0,
-            raw_elapsed_wrapped: Duration::ZERO,
-            raw_elapsed_seconds_wrapped: 0.0,
-            raw_elapsed_seconds_wrapped_f64: 0.0,
+            next_relative_speed: None,
         }
     }
 }
@@ -70,10 +48,44 @@ impl Default for Time {
 impl Time {
     /// Constructs a new `Time` instance with a specific startup `Instant`.
     pub fn new(startup: Instant) -> Self {
+        let clock = Clock::new(startup);
         Self {
-            startup,
-            ..Default::default()
+            update: clock,
+            fixed_update: clock,
+            ..default()
         }
+    }
+
+    pub fn clock(&self, context: TimeContext) -> &Clock {
+        match context {
+            TimeContext::Update => &self.update,
+            TimeContext::FixedUpdate => &self.fixed_update,
+        }
+    }
+
+    pub(crate) fn clock_mut(&mut self, context: TimeContext) -> &mut Clock {
+        match context {
+            TimeContext::Update => &mut self.update,
+            TimeContext::FixedUpdate => &mut self.fixed_update,
+        }
+    }
+
+    pub(crate) fn current_clock(&self) -> &Clock {
+        self.clock(self.context)
+    }
+
+    pub(crate) fn current_clock_mut(&mut self) -> &mut Clock {
+        self.clock_mut(self.context)
+    }
+
+    /// Returns the current [`TimeContext`].
+    pub fn context(&self) -> TimeContext {
+        self.context
+    }
+
+    /// Changes the current [`TimeContext`].
+    pub fn set_context(&mut self, context: TimeContext) {
+        self.context = context;
     }
 
     /// Updates the internal time measurements.
@@ -138,42 +150,47 @@ impl Time {
     /// }
     /// ```
     pub fn update_with_instant(&mut self, instant: Instant) {
-        let raw_delta = instant - self.last_update.unwrap_or(self.startup);
-        let delta = if self.paused {
-            Duration::ZERO
-        } else if self.relative_speed != 1.0 {
-            raw_delta.mul_f64(self.relative_speed)
-        } else {
-            // avoid rounding when at normal speed
-            raw_delta
-        };
+        match self.context {
+            TimeContext::Update => {
+                // apply pending pause and relative speed changes
+                self.apply_pending_changes();
 
-        if self.last_update.is_some() {
-            self.delta = delta;
-            self.delta_seconds = self.delta.as_secs_f32();
-            self.delta_seconds_f64 = self.delta.as_secs_f64();
-            self.raw_delta = raw_delta;
-            self.raw_delta_seconds = self.raw_delta.as_secs_f32();
-            self.raw_delta_seconds_f64 = self.raw_delta.as_secs_f64();
-        } else {
-            self.first_update = Some(instant);
+                // zero for first update
+                let dt = instant - self.current_clock().last_update().unwrap_or(instant);
+                let dt = if self.paused {
+                    Duration::ZERO
+                } else if self.relative_speed != 1.0 {
+                    dt.mul_f64(self.relative_speed)
+                } else {
+                    // avoid rounding when at normal speed
+                    dt
+                };
+
+                self.update.tick(dt, instant);
+            }
+            TimeContext::FixedUpdate => {
+                warn!("In the `FixedUpdate` context, `Time` can only be advanced via `tick`.");
+            }
+        }
+    }
+
+    pub(crate) fn tick(&mut self, dt: Duration, instant: Instant) {
+        self.current_clock_mut().tick(dt, instant);
+    }
+
+    /// Applies pending pause or relative speed changes.
+    ///
+    /// This method is provided for use in tests. Calling this method as part of your app will most
+    /// likely result in inaccurate timekeeping, as the `Time` resource is ordinarily managed by the
+    /// [`TimePlugin`](crate::TimePlugin).
+    pub fn apply_pending_changes(&mut self) {
+        if let Some(value) = self.next_paused.take() {
+            self.paused = value;
         }
 
-        self.elapsed += delta;
-        self.elapsed_seconds = self.elapsed.as_secs_f32();
-        self.elapsed_seconds_f64 = self.elapsed.as_secs_f64();
-        self.raw_elapsed += raw_delta;
-        self.raw_elapsed_seconds = self.raw_elapsed.as_secs_f32();
-        self.raw_elapsed_seconds_f64 = self.raw_elapsed.as_secs_f64();
-
-        self.elapsed_wrapped = duration_div_rem(self.elapsed, self.wrap_period).1;
-        self.elapsed_seconds_wrapped = self.elapsed_wrapped.as_secs_f32();
-        self.elapsed_seconds_wrapped_f64 = self.elapsed_wrapped.as_secs_f64();
-        self.raw_elapsed_wrapped = duration_div_rem(self.raw_elapsed, self.wrap_period).1;
-        self.raw_elapsed_seconds_wrapped = self.raw_elapsed_wrapped.as_secs_f32();
-        self.raw_elapsed_seconds_wrapped_f64 = self.raw_elapsed_wrapped.as_secs_f64();
-
-        self.last_update = Some(instant);
+        if let Some(value) = self.next_relative_speed.take() {
+            self.relative_speed = value;
+        }
     }
 
     /// Returns the [`Instant`] the clock was created.
@@ -181,7 +198,7 @@ impl Time {
     /// This usually represents when the app was started.
     #[inline]
     pub fn startup(&self) -> Instant {
-        self.startup
+        self.current_clock().startup()
     }
 
     /// Returns the [`Instant`] when [`update`](#method.update) was first called, if it exists.
@@ -189,7 +206,7 @@ impl Time {
     /// This usually represents when the first app update started.
     #[inline]
     pub fn first_update(&self) -> Option<Instant> {
-        self.first_update
+        self.current_clock().first_update()
     }
 
     /// Returns the [`Instant`] when [`update`](#method.update) was last called, if it exists.
@@ -197,148 +214,84 @@ impl Time {
     /// This usually represents when the current app update started.
     #[inline]
     pub fn last_update(&self) -> Option<Instant> {
-        self.last_update
+        self.current_clock().last_update()
     }
 
     /// Returns how much time has advanced since the last [`update`](#method.update), as a [`Duration`].
     #[inline]
     pub fn delta(&self) -> Duration {
-        self.delta
+        self.current_clock().delta()
     }
 
     /// Returns how much time has advanced since the last [`update`](#method.update), as [`f32`] seconds.
     #[inline]
     pub fn delta_seconds(&self) -> f32 {
-        self.delta_seconds
+        self.current_clock().delta_seconds()
     }
 
     /// Returns how much time has advanced since the last [`update`](#method.update), as [`f64`] seconds.
     #[inline]
     pub fn delta_seconds_f64(&self) -> f64 {
-        self.delta_seconds_f64
+        self.current_clock().delta_seconds_f64()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup), as [`Duration`].
+    /// Returns how much time has advanced since [`first_update`](#method.first_update), as [`Duration`].
     #[inline]
     pub fn elapsed(&self) -> Duration {
-        self.elapsed
+        self.current_clock().elapsed()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup), as [`f32`] seconds.
+    /// Returns how much time has advanced since [`first_update`](#method.first_update), as [`f32`] seconds.
     ///
     /// **Note:** This is a monotonically increasing value. It's precision will degrade over time.
     /// If you need an `f32` but that precision loss is unacceptable,
     /// use [`elapsed_seconds_wrapped`](#method.elapsed_seconds_wrapped).
     #[inline]
     pub fn elapsed_seconds(&self) -> f32 {
-        self.elapsed_seconds
+        self.current_clock().elapsed_seconds()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup), as [`f64`] seconds.
+    /// Returns how much time has advanced since [`first_update`](#method.first_update), as [`f64`] seconds.
     #[inline]
     pub fn elapsed_seconds_f64(&self) -> f64 {
-        self.elapsed_seconds_f64
+        self.current_clock().elapsed_seconds_f64()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// Returns how much time has advanced since [`first_update`](#method.first_update) modulo
     /// the [`wrap_period`](#method.wrap_period), as [`Duration`].
     #[inline]
     pub fn elapsed_wrapped(&self) -> Duration {
-        self.elapsed_wrapped
+        self.current_clock().elapsed_wrapped()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// Returns how much time has advanced since [`first_update`](#method.first_update) modulo
     /// the [`wrap_period`](#method.wrap_period), as [`f32`] seconds.
     ///
     /// This method is intended for applications (e.g. shaders) that require an [`f32`] value but
     /// suffer from the gradual precision loss of [`elapsed_seconds`](#method.elapsed_seconds).
     #[inline]
     pub fn elapsed_seconds_wrapped(&self) -> f32 {
-        self.elapsed_seconds_wrapped
+        self.current_clock().elapsed_seconds_wrapped()
     }
 
-    /// Returns how much time has advanced since [`startup`](#method.startup) modulo
+    /// Returns how much time has advanced since [`first_update`](#method.first_update) modulo
     /// the [`wrap_period`](#method.wrap_period), as [`f64`] seconds.
     #[inline]
     pub fn elapsed_seconds_wrapped_f64(&self) -> f64 {
-        self.elapsed_seconds_wrapped_f64
-    }
-
-    /// Returns how much real time has elapsed since the last [`update`](#method.update), as a [`Duration`].
-    #[inline]
-    pub fn raw_delta(&self) -> Duration {
-        self.raw_delta
-    }
-
-    /// Returns how much real time has elapsed since the last [`update`](#method.update), as [`f32`] seconds.
-    #[inline]
-    pub fn raw_delta_seconds(&self) -> f32 {
-        self.raw_delta_seconds
-    }
-
-    /// Returns how much real time has elapsed since the last [`update`](#method.update), as [`f64`] seconds.
-    #[inline]
-    pub fn raw_delta_seconds_f64(&self) -> f64 {
-        self.raw_delta_seconds_f64
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup), as [`Duration`].
-    #[inline]
-    pub fn raw_elapsed(&self) -> Duration {
-        self.raw_elapsed
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup), as [`f32`] seconds.
-    ///
-    /// **Note:** This is a monotonically increasing value. It's precision will degrade over time.
-    /// If you need an `f32` but that precision loss is unacceptable,
-    /// use [`raw_elapsed_seconds_wrapped`](#method.raw_elapsed_seconds_wrapped).
-    #[inline]
-    pub fn raw_elapsed_seconds(&self) -> f32 {
-        self.raw_elapsed_seconds
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup), as [`f64`] seconds.
-    #[inline]
-    pub fn raw_elapsed_seconds_f64(&self) -> f64 {
-        self.raw_elapsed_seconds_f64
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup) modulo
-    /// the [`wrap_period`](#method.wrap_period), as [`Duration`].
-    #[inline]
-    pub fn raw_elapsed_wrapped(&self) -> Duration {
-        self.raw_elapsed_wrapped
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup) modulo
-    /// the [`wrap_period`](#method.wrap_period), as [`f32`] seconds.
-    ///
-    /// This method is intended for applications (e.g. shaders) that require an [`f32`] value but
-    /// suffer from the gradual precision loss of [`raw_elapsed_seconds`](#method.raw_elapsed_seconds).
-    #[inline]
-    pub fn raw_elapsed_seconds_wrapped(&self) -> f32 {
-        self.raw_elapsed_seconds_wrapped
-    }
-
-    /// Returns how much real time has elapsed since [`startup`](#method.startup) modulo
-    /// the [`wrap_period`](#method.wrap_period), as [`f64`] seconds.
-    #[inline]
-    pub fn raw_elapsed_seconds_wrapped_f64(&self) -> f64 {
-        self.raw_elapsed_seconds_wrapped_f64
+        self.current_clock().elapsed_seconds_wrapped_f64()
     }
 
     /// Returns the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
-    /// [`raw_elapsed_wrapped`](#method.raw_elapsed_wrapped).
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
     ///
     /// **Note:** The default modulus is one hour.
     #[inline]
     pub fn wrap_period(&self) -> Duration {
-        self.wrap_period
+        self.current_clock().wrap_period()
     }
 
     /// Sets the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
-    /// [`raw_elapsed_wrapped`](#method.raw_elapsed_wrapped).
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
     ///
     /// **Note:** This will not take effect until the next update.
     ///
@@ -347,8 +300,7 @@ impl Time {
     /// Panics if `wrap_period` is a zero-length duration.
     #[inline]
     pub fn set_wrap_period(&mut self, wrap_period: Duration) {
-        assert!(!wrap_period.is_zero(), "division by zero");
-        self.wrap_period = wrap_period;
+        self.current_clock_mut().set_wrap_period(wrap_period);
     }
 
     /// Returns the speed the clock advances relative to your system clock, as [`f32`].
@@ -373,48 +325,50 @@ impl Time {
         }
     }
 
-    /// Sets the speed the clock advances relative to your system clock, given as an [`f32`].
+    /// Sets the speed the clock advances relative to its inputs, given as an [`f32`].
     ///
-    /// For example, setting this to `2.0` will make the clock advance twice as fast as your system clock.
+    /// For example, setting this to `2.0` will make the clock advance twice as fast as its inputs.
     ///
-    /// **Note:** This does not affect the `raw_*` measurements.
+    /// **Note:** This will not take effect until the next update.
     ///
     /// # Panics
     ///
-    /// Panics if `ratio` is negative or not finite.
+    /// Panics if `r` is negative or not finite.
     #[inline]
-    pub fn set_relative_speed(&mut self, ratio: f32) {
-        self.set_relative_speed_f64(ratio as f64);
+    pub fn set_relative_speed(&mut self, r: f32) {
+        self.set_relative_speed_f64(r as f64);
     }
 
-    /// Sets the speed the clock advances relative to your system clock, given as an [`f64`].
+    /// Sets the speed the clock advances relative to its inputs, given as an [`f64`].
     ///
-    /// For example, setting this to `2.0` will make the clock advance twice as fast as your system clock.
+    /// For example, setting this to `2.0` will make the clock advance twice as fast as its inputs.
     ///
-    /// **Note:** This does not affect the `raw_*` measurements.
+    /// **Note:** This will not take effect until the next update.
     ///
     /// # Panics
     ///
-    /// Panics if `ratio` is negative or not finite.
+    /// Panics if `r` is negative or not finite.
     #[inline]
-    pub fn set_relative_speed_f64(&mut self, ratio: f64) {
-        assert!(ratio.is_finite(), "tried to go infinitely fast");
-        assert!(ratio >= 0.0, "tried to go back in time");
-        self.relative_speed = ratio;
+    pub fn set_relative_speed_f64(&mut self, r: f64) {
+        assert!(r.is_finite(), "tried to go infinitely fast");
+        assert!(r >= 0.0, "tried to go back in time");
+        self.next_relative_speed = Some(r);
     }
 
     /// Stops the clock, preventing it from advancing until resumed.
     ///
-    /// **Note:** This does not affect the `raw_*` measurements.
+    /// **Note:** This will not take effect until the next update.
     #[inline]
     pub fn pause(&mut self) {
-        self.paused = true;
+        self.next_paused = Some(true);
     }
 
     /// Resumes the clock if paused.
+    ///
+    /// **Note:** This will not take effect until the next update.
     #[inline]
     pub fn unpause(&mut self) {
-        self.paused = false;
+        self.next_paused = Some(false);
     }
 
     /// Returns `true` if the clock is currently paused.
@@ -424,18 +378,155 @@ impl Time {
     }
 }
 
-fn duration_div_rem(dividend: Duration, divisor: Duration) -> (u32, Duration) {
-    // `Duration` does not have a built-in modulo operation
-    let quotient = (dividend.as_nanos() / divisor.as_nanos()) as u32;
-    let remainder = dividend - (quotient * divisor);
-    (quotient, remainder)
+/// A clock that tracks how much actual time has elasped since the last update and since startup.
+///
+/// This clock cannot be paused and will always advance at the same rate as [`Instant`].
+#[derive(Resource, Debug)]
+pub struct RealTime(Clock);
+
+impl RealTime {
+    /// Constructs a new `Time` instance with a specific startup `Instant`.
+    pub(crate) fn new(startup: Instant) -> Self {
+        Self(Clock::new(startup))
+    }
+
+    /// Updates the internal time measurements.
+    ///
+    /// Calling this method as part of your app will most likely result in inaccurate timekeeping,
+    /// as this resource is ordinarily managed by the [`TimePlugin`](crate::TimePlugin).
+    pub fn update(&mut self) {
+        let now = Instant::now();
+        self.update_with_instant(now);
+    }
+
+    /// Updates time with a specified [`Instant`].
+    ///
+    /// This method is provided for use in tests. Calling this method as part of your app will most
+    /// likely result in inaccurate timekeeping, as this resource is ordinarily managed by the
+    /// [`TimePlugin`](crate::TimePlugin).
+    pub fn update_with_instant(&mut self, instant: Instant) {
+        // zero for first update
+        let dt = instant - self.0.last_update().unwrap_or(instant);
+        self.0.tick(dt, instant);
+    }
+
+    /// Returns the [`Instant`] the clock was created.
+    ///
+    /// This usually represents when the app was started.
+    #[inline]
+    pub fn startup(&self) -> Instant {
+        self.0.startup()
+    }
+
+    /// Returns the [`Instant`] when [`update`](#method.update) was first called, if it exists.
+    ///
+    /// This usually represents when the first app update started.
+    #[inline]
+    pub fn first_update(&self) -> Option<Instant> {
+        self.0.first_update()
+    }
+
+    /// Returns the [`Instant`] when [`update`](#method.update) was last called, if it exists.
+    ///
+    /// This usually represents when the current app update started.
+    #[inline]
+    pub fn last_update(&self) -> Option<Instant> {
+        self.0.last_update()
+    }
+
+    /// Returns how much real time has elapsed since the last [`update`](#method.update), as a [`Duration`].
+    #[inline]
+    pub fn delta(&self) -> Duration {
+        self.0.delta()
+    }
+
+    /// Returns how much real time has elapsed since the last [`update`](#method.update), as [`f32`] seconds.
+    #[inline]
+    pub fn delta_seconds(&self) -> f32 {
+        self.0.delta_seconds()
+    }
+
+    /// Returns how much real time has elapsed since the last [`update`](#method.update), as [`f64`] seconds.
+    #[inline]
+    pub fn delta_seconds_f64(&self) -> f64 {
+        self.0.delta_seconds_f64()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update), as [`Duration`].
+    #[inline]
+    pub fn elapsed(&self) -> Duration {
+        self.0.elapsed()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update), as [`f32`] seconds.
+    ///
+    /// **Note:** This is a monotonically increasing value. It's precision will degrade over time.
+    /// If you need an `f32` but that precision loss is unacceptable,
+    /// use [`elapsed_seconds_wrapped`](#method.elapsed_seconds_wrapped).
+    #[inline]
+    pub fn elapsed_seconds(&self) -> f32 {
+        self.0.elapsed_seconds()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update), as [`f64`] seconds.
+    #[inline]
+    pub fn elapsed_seconds_f64(&self) -> f64 {
+        self.0.elapsed_seconds_f64()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`Duration`].
+    #[inline]
+    pub fn elapsed_wrapped(&self) -> Duration {
+        self.0.elapsed_wrapped()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`f32`] seconds.
+    ///
+    /// This method is intended for applications (e.g. shaders) that require an [`f32`] value but
+    /// suffer from the gradual precision loss of [`elapsed_seconds`](#method.elapsed_seconds).
+    #[inline]
+    pub fn elapsed_seconds_wrapped(&self) -> f32 {
+        self.0.elapsed_seconds_wrapped()
+    }
+
+    /// Returns how much real time has elapsed since [`first_update`](#method.first_update) modulo
+    /// the [`wrap_period`](#method.wrap_period), as [`f64`] seconds.
+    #[inline]
+    pub fn elapsed_seconds_wrapped_f64(&self) -> f64 {
+        self.0.elapsed_seconds_wrapped_f64()
+    }
+
+    /// Returns the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
+    ///
+    /// **Note:** The default modulus is one hour.
+    #[inline]
+    pub fn wrap_period(&self) -> Duration {
+        self.0.wrap_period()
+    }
+
+    /// Sets the modulus used to calculate [`elapsed_wrapped`](#method.elapsed_wrapped) and
+    /// [`elapsed_wrapped`](#method.elapsed_wrapped).
+    ///
+    /// **Note:** This will not take effect until the next update.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `wrap_period` is a zero-length duration.
+    #[inline]
+    pub fn set_wrap_period(&mut self, wrap_period: Duration) {
+        self.0.set_wrap_period(wrap_period);
+    }
 }
 
 #[cfg(test)]
 #[allow(clippy::float_cmp)]
 mod tests {
-    use super::Time;
     use bevy_utils::{Duration, Instant};
+
+    use super::{RealTime, Time};
 
     fn assert_float_eq(a: f32, b: f32) {
         assert!((a - b).abs() <= f32::EPSILON, "{a} != {b}");
@@ -443,286 +534,251 @@ mod tests {
 
     #[test]
     fn update_test() {
-        let start_instant = Instant::now();
-        let mut time = Time::new(start_instant);
+        let startup = Instant::now();
+        let mut time = Time::new(startup);
 
         // Ensure `time` was constructed correctly.
-        assert_eq!(time.startup(), start_instant);
+        assert_eq!(time.startup(), startup);
         assert_eq!(time.first_update(), None);
         assert_eq!(time.last_update(), None);
         assert_eq!(time.relative_speed(), 1.0);
         assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.delta_seconds(), 0.0);
         assert_eq!(time.delta_seconds_f64(), 0.0);
-        assert_eq!(time.raw_delta(), Duration::ZERO);
-        assert_eq!(time.raw_delta_seconds(), 0.0);
-        assert_eq!(time.raw_delta_seconds_f64(), 0.0);
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.elapsed_seconds(), 0.0);
         assert_eq!(time.elapsed_seconds_f64(), 0.0);
-        assert_eq!(time.raw_elapsed(), Duration::ZERO);
-        assert_eq!(time.raw_elapsed_seconds(), 0.0);
-        assert_eq!(time.raw_elapsed_seconds_f64(), 0.0);
 
         // Update `time` and check results.
         // The first update to `time` normally happens before other systems have run,
         // so the first delta doesn't appear until the second update.
-        let first_update_instant = Instant::now();
-        time.update_with_instant(first_update_instant);
+        let first_update = Instant::now();
+        time.update_with_instant(first_update);
 
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(first_update_instant));
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(first_update));
         assert_eq!(time.relative_speed(), 1.0);
         assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.delta_seconds(), 0.0);
         assert_eq!(time.delta_seconds_f64(), 0.0);
-        assert_eq!(time.raw_delta(), Duration::ZERO);
-        assert_eq!(time.raw_delta_seconds(), 0.0);
-        assert_eq!(time.raw_delta_seconds_f64(), 0.0);
-        assert_eq!(time.elapsed(), first_update_instant - start_instant,);
+        assert_eq!(time.elapsed(), first_update - first_update);
         assert_eq!(
             time.elapsed_seconds(),
-            (first_update_instant - start_instant).as_secs_f32(),
+            (first_update - first_update).as_secs_f32(),
         );
         assert_eq!(
             time.elapsed_seconds_f64(),
-            (first_update_instant - start_instant).as_secs_f64(),
-        );
-        assert_eq!(time.raw_elapsed(), first_update_instant - start_instant,);
-        assert_eq!(
-            time.raw_elapsed_seconds(),
-            (first_update_instant - start_instant).as_secs_f32(),
-        );
-        assert_eq!(
-            time.raw_elapsed_seconds_f64(),
-            (first_update_instant - start_instant).as_secs_f64(),
+            (first_update - first_update).as_secs_f64(),
         );
 
         // Update `time` again and check results.
         // At this point its safe to use time.delta().
-        let second_update_instant = Instant::now();
-        time.update_with_instant(second_update_instant);
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(second_update_instant));
+        let second_update = Instant::now();
+        time.update_with_instant(second_update);
+
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(second_update));
         assert_eq!(time.relative_speed(), 1.0);
-        assert_eq!(time.delta(), second_update_instant - first_update_instant);
+        assert_eq!(time.delta(), second_update - first_update);
         assert_eq!(
             time.delta_seconds(),
-            (second_update_instant - first_update_instant).as_secs_f32(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
             time.delta_seconds_f64(),
-            (second_update_instant - first_update_instant).as_secs_f64(),
+            (second_update - first_update).as_secs_f64(),
         );
-        assert_eq!(
-            time.raw_delta(),
-            second_update_instant - first_update_instant,
-        );
-        assert_eq!(
-            time.raw_delta_seconds(),
-            (second_update_instant - first_update_instant).as_secs_f32(),
-        );
-        assert_eq!(
-            time.raw_delta_seconds_f64(),
-            (second_update_instant - first_update_instant).as_secs_f64(),
-        );
-        assert_eq!(time.elapsed(), second_update_instant - start_instant,);
+        assert_eq!(time.elapsed(), second_update - first_update);
         assert_eq!(
             time.elapsed_seconds(),
-            (second_update_instant - start_instant).as_secs_f32(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
             time.elapsed_seconds_f64(),
-            (second_update_instant - start_instant).as_secs_f64(),
-        );
-        assert_eq!(time.raw_elapsed(), second_update_instant - start_instant,);
-        assert_eq!(
-            time.raw_elapsed_seconds(),
-            (second_update_instant - start_instant).as_secs_f32(),
-        );
-        assert_eq!(
-            time.raw_elapsed_seconds_f64(),
-            (second_update_instant - start_instant).as_secs_f64(),
+            (second_update - first_update).as_secs_f64(),
         );
     }
 
     #[test]
     fn wrapping_test() {
-        let start_instant = Instant::now();
+        let startup = Instant::now();
 
-        let mut time = Time {
-            startup: start_instant,
-            wrap_period: Duration::from_secs(3),
-            ..Default::default()
-        };
+        let mut time = Time::new(startup);
+        time.set_wrap_period(Duration::from_secs(3));
 
         assert_eq!(time.elapsed_seconds_wrapped(), 0.0);
 
-        time.update_with_instant(start_instant + Duration::from_secs(1));
+        // time starts counting from first update
+        let first_update = Instant::now();
+        time.update_with_instant(first_update);
+
+        time.update_with_instant(first_update + Duration::from_secs(1));
         assert_float_eq(time.elapsed_seconds_wrapped(), 1.0);
 
-        time.update_with_instant(start_instant + Duration::from_secs(2));
+        time.update_with_instant(first_update + Duration::from_secs(2));
         assert_float_eq(time.elapsed_seconds_wrapped(), 2.0);
 
-        time.update_with_instant(start_instant + Duration::from_secs(3));
+        time.update_with_instant(first_update + Duration::from_secs(3));
         assert_float_eq(time.elapsed_seconds_wrapped(), 0.0);
 
-        time.update_with_instant(start_instant + Duration::from_secs(4));
+        time.update_with_instant(first_update + Duration::from_secs(4));
         assert_float_eq(time.elapsed_seconds_wrapped(), 1.0);
     }
 
     #[test]
     fn relative_speed_test() {
-        let start_instant = Instant::now();
-        let mut time = Time::new(start_instant);
+        let startup = Instant::now();
+        let mut time = Time::new(startup);
+        let mut real_time = RealTime::new(startup);
 
-        let first_update_instant = Instant::now();
-        time.update_with_instant(first_update_instant);
+        let first_update = Instant::now();
+        time.update_with_instant(first_update);
+        real_time.update_with_instant(first_update);
 
         // Update `time` again and check results.
         // At this point its safe to use time.delta().
-        let second_update_instant = Instant::now();
-        time.update_with_instant(second_update_instant);
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(second_update_instant));
+        let second_update = Instant::now();
+        time.update_with_instant(second_update);
+        real_time.update_with_instant(second_update);
+
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(second_update));
         assert_eq!(time.relative_speed(), 1.0);
-        assert_eq!(time.delta(), second_update_instant - first_update_instant);
+        assert_eq!(time.delta(), second_update - first_update);
         assert_eq!(
             time.delta_seconds(),
-            (second_update_instant - first_update_instant).as_secs_f32(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
             time.delta_seconds_f64(),
-            (second_update_instant - first_update_instant).as_secs_f64(),
+            (second_update - first_update).as_secs_f64(),
+        );
+        assert_eq!(real_time.delta(), second_update - first_update);
+        assert_eq!(
+            real_time.delta_seconds(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
-            time.raw_delta(),
-            second_update_instant - first_update_instant,
+            real_time.delta_seconds_f64(),
+            (second_update - first_update).as_secs_f64(),
         );
-        assert_eq!(
-            time.raw_delta_seconds(),
-            (second_update_instant - first_update_instant).as_secs_f32(),
-        );
-        assert_eq!(
-            time.raw_delta_seconds_f64(),
-            (second_update_instant - first_update_instant).as_secs_f64(),
-        );
-        assert_eq!(time.elapsed(), second_update_instant - start_instant,);
+        assert_eq!(time.elapsed(), second_update - first_update);
         assert_eq!(
             time.elapsed_seconds(),
-            (second_update_instant - start_instant).as_secs_f32(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
             time.elapsed_seconds_f64(),
-            (second_update_instant - start_instant).as_secs_f64(),
+            (second_update - first_update).as_secs_f64(),
         );
-        assert_eq!(time.raw_elapsed(), second_update_instant - start_instant,);
+        assert_eq!(real_time.elapsed(), second_update - first_update);
         assert_eq!(
-            time.raw_elapsed_seconds(),
-            (second_update_instant - start_instant).as_secs_f32(),
+            real_time.elapsed_seconds(),
+            (second_update - first_update).as_secs_f32(),
         );
         assert_eq!(
-            time.raw_elapsed_seconds_f64(),
-            (second_update_instant - start_instant).as_secs_f64(),
+            real_time.elapsed_seconds_f64(),
+            (second_update - first_update).as_secs_f64(),
         );
 
         // Make app time advance at 2x the rate of your system clock.
         time.set_relative_speed(2.0);
+        time.apply_pending_changes();
 
         // Update `time` again 1 second later.
         let elapsed = Duration::from_secs(1);
-        let third_update_instant = second_update_instant + elapsed;
-        time.update_with_instant(third_update_instant);
+        let third_update = second_update + elapsed;
+        time.update_with_instant(third_update);
+        real_time.update_with_instant(third_update);
 
         // Since app is advancing 2x your system clock, expect time
         // to have advanced by twice the amount of real time elapsed.
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(third_update_instant));
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(third_update));
         assert_eq!(time.relative_speed(), 2.0);
         assert_eq!(time.delta(), elapsed.mul_f32(2.0));
         assert_eq!(time.delta_seconds(), elapsed.mul_f32(2.0).as_secs_f32());
         assert_eq!(time.delta_seconds_f64(), elapsed.mul_f32(2.0).as_secs_f64());
-        assert_eq!(time.raw_delta(), elapsed);
-        assert_eq!(time.raw_delta_seconds(), elapsed.as_secs_f32());
-        assert_eq!(time.raw_delta_seconds_f64(), elapsed.as_secs_f64());
+        assert_eq!(real_time.delta(), elapsed);
+        assert_eq!(real_time.delta_seconds(), elapsed.as_secs_f32());
+        assert_eq!(real_time.delta_seconds_f64(), elapsed.as_secs_f64());
         assert_eq!(
             time.elapsed(),
-            second_update_instant - start_instant + elapsed.mul_f32(2.0),
+            second_update - first_update + elapsed.mul_f32(2.0),
         );
         assert_eq!(
             time.elapsed_seconds(),
-            (second_update_instant - start_instant + elapsed.mul_f32(2.0)).as_secs_f32(),
+            (second_update - first_update + elapsed.mul_f32(2.0)).as_secs_f32(),
         );
         assert_eq!(
             time.elapsed_seconds_f64(),
-            (second_update_instant - start_instant + elapsed.mul_f32(2.0)).as_secs_f64(),
+            (second_update - first_update + elapsed.mul_f32(2.0)).as_secs_f64(),
+        );
+        assert_eq!(real_time.elapsed(), second_update - first_update + elapsed);
+        assert_eq!(
+            real_time.elapsed_seconds(),
+            (second_update - first_update + elapsed).as_secs_f32(),
         );
         assert_eq!(
-            time.raw_elapsed(),
-            second_update_instant - start_instant + elapsed,
-        );
-        assert_eq!(
-            time.raw_elapsed_seconds(),
-            (second_update_instant - start_instant + elapsed).as_secs_f32(),
-        );
-        assert_eq!(
-            time.raw_elapsed_seconds_f64(),
-            (second_update_instant - start_instant + elapsed).as_secs_f64(),
+            real_time.elapsed_seconds_f64(),
+            (second_update - first_update + elapsed).as_secs_f64(),
         );
     }
 
     #[test]
     fn pause_test() {
-        let start_instant = Instant::now();
-        let mut time = Time::new(start_instant);
+        let startup = Instant::now();
+        let mut time = Time::new(startup);
+        let mut real_time = RealTime::new(startup);
 
-        let first_update_instant = Instant::now();
-        time.update_with_instant(first_update_instant);
+        let first_update = Instant::now();
+        time.update_with_instant(first_update);
+        real_time.update_with_instant(first_update);
 
         assert!(!time.is_paused());
         assert_eq!(time.relative_speed(), 1.0);
 
         time.pause();
+        time.apply_pending_changes();
 
         assert!(time.is_paused());
         assert_eq!(time.relative_speed(), 0.0);
 
-        let second_update_instant = Instant::now();
-        time.update_with_instant(second_update_instant);
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(second_update_instant));
+        let second_update = Instant::now();
+        time.update_with_instant(second_update);
+        real_time.update_with_instant(second_update);
+
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(second_update));
         assert_eq!(time.delta(), Duration::ZERO);
-        assert_eq!(
-            time.raw_delta(),
-            second_update_instant - first_update_instant,
-        );
-        assert_eq!(time.elapsed(), first_update_instant - start_instant);
-        assert_eq!(time.raw_elapsed(), second_update_instant - start_instant);
+        assert_eq!(real_time.delta(), second_update - first_update);
+        assert_eq!(time.elapsed(), first_update - first_update);
+        assert_eq!(real_time.elapsed(), second_update - first_update);
 
         time.unpause();
+        time.apply_pending_changes();
 
         assert!(!time.is_paused());
         assert_eq!(time.relative_speed(), 1.0);
 
-        let third_update_instant = Instant::now();
-        time.update_with_instant(third_update_instant);
-        assert_eq!(time.startup(), start_instant);
-        assert_eq!(time.first_update(), Some(first_update_instant));
-        assert_eq!(time.last_update(), Some(third_update_instant));
-        assert_eq!(time.delta(), third_update_instant - second_update_instant);
-        assert_eq!(
-            time.raw_delta(),
-            third_update_instant - second_update_instant,
-        );
+        let third_update = Instant::now();
+        time.update_with_instant(third_update);
+        real_time.update_with_instant(third_update);
+
+        assert_eq!(time.startup(), startup);
+        assert_eq!(time.first_update(), Some(first_update));
+        assert_eq!(time.last_update(), Some(third_update));
+        assert_eq!(time.delta(), third_update - second_update);
+        assert_eq!(real_time.delta(), third_update - second_update);
         assert_eq!(
             time.elapsed(),
-            (third_update_instant - second_update_instant) + (first_update_instant - start_instant),
+            (third_update - second_update) + (first_update - first_update),
         );
-        assert_eq!(time.raw_elapsed(), third_update_instant - start_instant);
+        assert_eq!(real_time.elapsed(), third_update - first_update);
     }
 }

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -722,7 +722,6 @@ mod tests {
 
         // Make app time advance at 2x the rate of your system clock.
         time.set_relative_speed(2.0);
-        time.apply_pending_changes();
 
         // Update `time` again 1 second later.
         let elapsed = Duration::from_secs(1);
@@ -779,14 +778,17 @@ mod tests {
         assert_eq!(time.relative_speed(), 1.0);
 
         time.pause();
-        time.apply_pending_changes();
 
-        assert!(time.is_paused());
-        assert_eq!(time.relative_speed(), 0.0);
+        // deferred until next update
+        assert!(!time.is_paused());
+        assert_eq!(time.relative_speed(), 1.0);
 
         let second_update = Instant::now();
         time.update_with_instant(second_update);
         real_time.update_with_instant(second_update);
+
+        assert!(time.is_paused());
+        assert_eq!(time.relative_speed(), 0.0);
 
         assert_eq!(time.startup(), startup);
         assert_eq!(time.first_update(), Some(first_update));
@@ -797,14 +799,17 @@ mod tests {
         assert_eq!(real_time.elapsed(), second_update - first_update);
 
         time.unpause();
-        time.apply_pending_changes();
 
-        assert!(!time.is_paused());
-        assert_eq!(time.relative_speed(), 1.0);
+        // deferred until next update
+        assert!(time.is_paused());
+        assert_eq!(time.relative_speed(), 0.0);
 
         let third_update = Instant::now();
         time.update_with_instant(third_update);
         real_time.update_with_instant(third_update);
+
+        assert!(!time.is_paused());
+        assert_eq!(time.relative_speed(), 1.0);
 
         assert_eq!(time.startup(), startup);
         assert_eq!(time.first_update(), Some(first_update));

--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -2,13 +2,12 @@
 
 use bevy::{math::Vec3Swizzles, prelude::*};
 
-const TIME_STEP: f32 = 1.0 / 60.0;
 const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(FixedTime::new_from_secs(TIME_STEP))
+        .insert_resource(FixedTimestep::from_hz(60.0))
         .add_systems(Startup, setup)
         .add_systems(
             FixedUpdate,
@@ -117,6 +116,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 /// Demonstrates applying rotation and movement based on keyboard input.
 fn player_movement_system(
+    time: Res<Time>,
     keyboard_input: Res<Input<KeyCode>>,
     mut query: Query<(&Player, &mut Transform)>,
 ) {
@@ -138,12 +138,12 @@ fn player_movement_system(
     }
 
     // update the ship rotation around the Z axis (perpendicular to the 2D plane of the screen)
-    transform.rotate_z(rotation_factor * ship.rotation_speed * TIME_STEP);
+    transform.rotate_z(rotation_factor * ship.rotation_speed * time.delta_seconds());
 
     // get the ship's forward vector by applying the current rotation to the ships initial facing vector
     let movement_direction = transform.rotation * Vec3::Y;
     // get the distance the ship will move based on direction, the ship's movement speed and delta time
-    let movement_distance = movement_factor * ship.movement_speed * TIME_STEP;
+    let movement_distance = movement_factor * ship.movement_speed * time.delta_seconds();
     // create the change in translation using the new movement direction and distance
     let translation_delta = movement_direction * movement_distance;
     // update the ship translation with our new translation delta
@@ -198,6 +198,7 @@ fn snap_to_player_system(
 /// floating point precision loss, so it pays to clamp your dot product value before calling
 /// `acos`.
 fn rotate_to_player_system(
+    time: Res<Time>,
     mut query: Query<(&RotateToPlayer, &mut Transform), Without<Player>>,
     player_query: Query<&Transform, With<Player>>,
 ) {
@@ -242,7 +243,8 @@ fn rotate_to_player_system(
         let max_angle = forward_dot_player.clamp(-1.0, 1.0).acos(); // clamp acos for safety
 
         // calculate angle of rotation with limit
-        let rotation_angle = rotation_sign * (config.rotation_speed * TIME_STEP).min(max_angle);
+        let rotation_angle =
+            rotation_sign * (config.rotation_speed * time.delta_seconds()).min(max_angle);
 
         // rotate the enemy to face the player
         enemy_transform.rotate_z(rotation_angle);

--- a/examples/ecs/fixed_timestep.rs
+++ b/examples/ecs/fixed_timestep.rs
@@ -1,38 +1,48 @@
 //! Shows how to create systems that run every fixed timestep, rather than every tick.
 
 use bevy::prelude::*;
+use bevy::time::TimeContext;
 
-const FIXED_TIMESTEP: f32 = 0.5;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // this system will run once every update (it should match your screen's refresh rate)
+        // set fixed timestep to run systems ten times a second
+        .insert_resource(FixedTimestep::from_hz(10.0))
+        // this system will run every update (this should match the screen refresh rate)
         .add_systems(Update, frame_update)
-        // add our system to the fixed timestep schedule
+        // this system will run ten times a second
         .add_systems(FixedUpdate, fixed_update)
-        // configure our fixed timestep schedule to run twice a second
-        .insert_resource(FixedTime::new_from_secs(FIXED_TIMESTEP))
         .run();
 }
 
-fn frame_update(mut last_time: Local<f32>, time: Res<Time>) {
+fn frame_update(mut last_time: Local<f32>, time: Res<Time>, real_time: Res<RealTime>) {
     info!(
         "time since last frame_update: {}",
-        time.raw_elapsed_seconds() - *last_time
+        real_time.elapsed_seconds() - *last_time
     );
-    *last_time = time.raw_elapsed_seconds();
+
+    assert!(matches!(time.context(), TimeContext::Update));
+    *last_time = real_time.elapsed_seconds();
 }
 
-fn fixed_update(mut last_time: Local<f32>, time: Res<Time>, fixed_time: Res<FixedTime>) {
+fn fixed_update(
+    mut last_time: Local<f32>,
+    time: Res<Time>,
+    real_time: Res<RealTime>,
+    fixed_timestep: Res<FixedTimestep>,
+) {
+    assert!(matches!(time.context(), TimeContext::FixedUpdate));
+    assert_eq!(time.delta(), fixed_timestep.size());
+
+    info!("fixed timestep: {}\n", time.delta_seconds());
     info!(
         "time since last fixed_update: {}\n",
-        time.raw_elapsed_seconds() - *last_time
+        real_time.elapsed_seconds() - *last_time
     );
 
-    info!("fixed timestep: {}\n", FIXED_TIMESTEP);
     info!(
         "time accrued toward next fixed_update: {}\n",
-        fixed_time.accumulated().as_secs_f32()
+        fixed_timestep.overstep().as_secs_f32()
     );
-    *last_time = time.raw_elapsed_seconds();
+    *last_time = real_time.elapsed_seconds();
 }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -54,7 +54,7 @@ fn main() {
         .insert_resource(ClearColor(BACKGROUND_COLOR))
         .add_event::<CollisionEvent>()
         // Configure how frequently our gameplay systems are run
-        .insert_resource(FixedTime::new_from_secs(1.0 / 60.0))
+        .insert_resource(FixedTimestep::from_hz(60.0))
         .add_systems(Startup, setup)
         // Add our gameplay simulation systems to the fixed timestep schedule
         .add_systems(
@@ -311,7 +311,7 @@ fn setup(
 fn move_paddle(
     keyboard_input: Res<Input<KeyCode>>,
     mut query: Query<&mut Transform, With<Paddle>>,
-    time_step: Res<FixedTime>,
+    time: Res<Time>,
 ) {
     let mut paddle_transform = query.single_mut();
     let mut direction = 0.0;
@@ -326,7 +326,7 @@ fn move_paddle(
 
     // Calculate the new horizontal paddle position based on player input
     let new_paddle_position =
-        paddle_transform.translation.x + direction * PADDLE_SPEED * time_step.period.as_secs_f32();
+        paddle_transform.translation.x + direction * PADDLE_SPEED * time.delta_seconds();
 
     // Update the paddle position,
     // making sure it doesn't cause the paddle to leave the arena
@@ -336,10 +336,10 @@ fn move_paddle(
     paddle_transform.translation.x = new_paddle_position.clamp(left_bound, right_bound);
 }
 
-fn apply_velocity(mut query: Query<(&mut Transform, &Velocity)>, time_step: Res<FixedTime>) {
+fn apply_velocity(mut query: Query<(&mut Transform, &Velocity)>, time: Res<Time>) {
     for (mut transform, velocity) in &mut query {
-        transform.translation.x += velocity.x * time_step.period.as_secs_f32();
-        transform.translation.y += velocity.y * time_step.period.as_secs_f32();
+        transform.translation.x += velocity.x * time.delta_seconds();
+        transform.translation.y += velocity.y * time.delta_seconds();
     }
 }
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -56,7 +56,7 @@ fn main() {
                 counter_system,
             ),
         )
-        .insert_resource(FixedTime::new_from_secs(0.2))
+        .insert_resource(FixedTimestep::from_hz(60.0))
         .run();
 }
 


### PR DESCRIPTION
This is an alternative to #8930 (pretty similar though).

(credit to `@devil-ira` for suggesting this idea to me months ago)

As a quick background, both `Update` and `FixedUpdate` follow "virtual" time (time that can be sped up, slowed down, and paused) but each needs its own clock to measure it because they advance at different rates.

## Objective

I wrote this PR to make the `Time` API usable in `FixedUpdate`, with the goal of making plugin systems more portable. If `Time` is setup so the clock is correct in both `Update` and `FixedUpdate`, then users can write and import systems that access `Res<Time>` and they'll always work no matter which scheduled they're added to.

This would take us off a path that leads to some really annoying compatibility issues that plague third-party code in other engines (e.g. store assets for Unity) because their logic can't be freely moved between their `Update` and `FixedUpdate` equivalents.

Some other issues:

- If running `FixedUpdate` takes longer than the fixed timestep, the app can enter a "death spiral" and ultimately freeze as each frame sees an ever-increasing queue of `FixedUpdate` steps and never catches up.
- If there is a particularly long gap between app updates (e.g. the program was suspended), time will jump[^1] forward a lot all at once, which translates into a huge `FixedUpdate` simulation debt. The app will seem to freeze until it catches up.

## Solution

- Split common functionality into a `Clock` data structure to reduce code duplication.
- Make `Time` report "fixed time" while running `FixedUpdate`.
- Add a setting to directly limit the number of `FixedUpdate` steps per frame. This will spread "paying off a large simulation debt" over multiple frames.
- Add a setting to set a maximum delta time per frame. This will limit the impact of program suspends (by indirectly limiting how many `FixedUpdate` steps can build up between two updates).

I moved the "real time" (same speed as `Instant`) clock into a separate `RealTime` resource. Maybe having all three clocks crammed inside `Time` would have been better, but (1) I didn't like the look of having clock-specific methods (e.g. `time.delta()`, `time.raw_delta()`, `time.fixed_delta()`) and (2) "real time" is pretty meaningless in `FixedUpdate`. More breaking changes though.

I've also kept a `FixedTimestep` struct because keeping the step size and accumulator separate from the clock is much cleaner IMO and leaves room for, say, a networking plugin to sub in its own handling (without requiring more API from us).

## Migration Guide

- Use `FixedTimestep` and `Time` instead of hard-coded constants.
- Replace `FixedTime::period` with `Time::delta`.
- Replace other `FixedTime` methods with `FixedTimestep` equivalents.
- `on_fixed_timer` has been removed. Replace it with `on_timer` as `Time` now works correctly in both schedules.

[^1]: On some platforms.