### PR TITLE
Fix several bugs related to window size

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -338,6 +338,9 @@ impl Window {
 /// Please note that if the window is resizable, then when the window is
 /// maximized it may have a size outside of these limits. The functionality
 /// required to disable maximizing is not yet exposed by winit.
+///
+/// Constraints will be validated using [`WindowResizeConstraints::check_constraints`]
+/// before being used.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect, FromReflect)]
 #[cfg_attr(
     feature = "serialize",
@@ -371,6 +374,15 @@ impl WindowResizeConstraints {
     /// Checks if the constraints are valid.
     ///
     /// Will output warnings if it isn't.
+    ///
+    /// Values under `1.` or `NaN` will be set back to `1.`.
+    ///
+    /// Having an upper ("max") constraint higher than the corresponding lower ("min")
+    /// constraint will show a warning and set the upper constraint value to the lower one.
+    ///
+    /// If a `max_width` is specified (different from [`f32::INFINITY`]), a `max_height`
+    /// should be specified too, and vice versa, because of how `Winit` operates.
+    /// If only one is specified, a warning will be shown and both will be set to [`f32::INFINITY`].
     #[must_use]
     pub fn check_constraints(&self) -> Self {
         let WindowResizeConstraints {
@@ -379,6 +391,7 @@ impl WindowResizeConstraints {
             mut max_width,
             mut max_height,
         } = self;
+
         min_width = min_width.max(1.);
         min_height = min_height.max(1.);
         if max_width < min_width {
@@ -395,6 +408,26 @@ impl WindowResizeConstraints {
             );
             max_height = min_height;
         }
+
+        if (max_width.is_finite() && max_height.is_infinite())
+            || (max_width.is_infinite() && max_height.is_finite())
+        {
+            let (finite, finite_value, infinite) = if max_width.is_finite() {
+                let value = max_width;
+                max_width = f32::INFINITY;
+                ("width", value, "height")
+            } else {
+                let value = max_height;
+                max_height = f32::INFINITY;
+                ("height", value, "width")
+            };
+            warn!(
+                "The maximum {} is specified (value: {}) but the maximum {} is not (infinite). \
+                The {} constraint will be ignored, no maximum constraint will be set.",
+                finite, finite_value, infinite, finite
+            );
+        }
+
         WindowResizeConstraints {
             min_width,
             min_height,

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -181,21 +181,17 @@ pub(crate) fn changed_window(
                 let constraints = window.resize_constraints.check_constraints();
                 let logical_width = if window.resolution.width() > constraints.max_width {
                     constraints.max_width
+                } else if window.resolution.width() < constraints.min_width {
+                    constraints.min_width
                 } else {
-                    if window.resolution.width() < constraints.min_width {
-                        constraints.min_width
-                    } else {
-                        window.resolution.width()
-                    }
+                    window.resolution.width()
                 };
                 let logical_height = if window.resolution.height() > constraints.max_height {
                     constraints.max_height
+                } else if window.resolution.height() < constraints.min_height {
+                    constraints.min_height
                 } else {
-                    if window.resolution.height() < constraints.min_height {
-                        constraints.min_height
-                    } else {
-                        window.resolution.height()
-                    }
+                    window.resolution.height()
                 };
                 window.resolution.set(logical_width, logical_height);
 

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -15,7 +15,7 @@ use bevy_window::{RawHandleWrapper, Window, WindowClosed, WindowCreated};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
 use winit::{
-    dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize, Size},
+    dpi::{LogicalPosition, PhysicalPosition, PhysicalSize},
     event_loop::EventLoopWindowTarget,
 };
 
@@ -24,7 +24,7 @@ use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
     converters::{self, convert_window_level, convert_window_theme, convert_winit_theme},
-    get_best_videomode, get_fitting_videomode, WinitWindows,
+    get_best_videomode, get_fitting_videomode, get_inner_size_constraints, WinitWindows,
 };
 
 /// System responsible for creating new windows whenever a [`Window`] component is added
@@ -170,30 +170,10 @@ pub(crate) fn changed_window(
                 if window.resolution.scale_factor_override()
                     != cache.window.resolution.scale_factor_override()
                 {
-                    let constraints = window.resize_constraints.check_constraints();
-                    let min_inner_size = LogicalSize {
-                        width: constraints.min_width,
-                        height: constraints.min_height,
-                    };
-                    let max_inner_size = LogicalSize {
-                        width: constraints.max_width,
-                        height: constraints.max_height,
-                    };
-
-                    let (min_inner_size, max_inner_size): (Size, Size) =
-                        if let Some(sf) = window.resolution.scale_factor_override() {
-                            (
-                                min_inner_size.to_physical::<f64>(sf).into(),
-                                max_inner_size.to_physical::<f64>(sf).into(),
-                            )
-                        } else {
-                            (min_inner_size.into(), max_inner_size.into())
-                        };
+                    let (min_inner_size, max_inner_size) = get_inner_size_constraints(&window);
 
                     winit_window.set_min_inner_size(Some(min_inner_size));
-                    if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
-                        winit_window.set_max_inner_size(Some(max_inner_size));
-                    }
+                    winit_window.set_max_inner_size(max_inner_size);
                 }
 
                 // Winit doesn't check constraints when using `set_inner_size`.
@@ -287,30 +267,10 @@ pub(crate) fn changed_window(
             }
 
             if window.resize_constraints != cache.window.resize_constraints {
-                let constraints = window.resize_constraints.check_constraints();
-                let min_inner_size = LogicalSize {
-                    width: constraints.min_width,
-                    height: constraints.min_height,
-                };
-                let max_inner_size = LogicalSize {
-                    width: constraints.max_width,
-                    height: constraints.max_height,
-                };
-
-                let (min_inner_size, max_inner_size): (Size, Size) =
-                    if let Some(sf) = window.resolution.scale_factor_override() {
-                        (
-                            min_inner_size.to_physical::<f64>(sf).into(),
-                            max_inner_size.to_physical::<f64>(sf).into(),
-                        )
-                    } else {
-                        (min_inner_size.into(), max_inner_size.into())
-                    };
+                let (min_inner_size, max_inner_size) = get_inner_size_constraints(&window);
 
                 winit_window.set_min_inner_size(Some(min_inner_size));
-                if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
-                    winit_window.set_max_inner_size(Some(max_inner_size));
-                }
+                winit_window.set_max_inner_size(max_inner_size);
             }
 
             if window.position != cache.window.position {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -179,20 +179,8 @@ pub(crate) fn changed_window(
                 // Winit doesn't check constraints when using `set_inner_size`.
                 // Check them manually.
                 let constraints = window.resize_constraints.check_constraints();
-                let logical_width = if window.resolution.width() > constraints.max_width {
-                    constraints.max_width
-                } else if window.resolution.width() < constraints.min_width {
-                    constraints.min_width
-                } else {
-                    window.resolution.width()
-                };
-                let logical_height = if window.resolution.height() > constraints.max_height {
-                    constraints.max_height
-                } else if window.resolution.height() < constraints.min_height {
-                    constraints.min_height
-                } else {
-                    window.resolution.height()
-                };
+                let logical_width = window.resolution.width().clamp(constraints.min_width, constraints.max_width);
+                let logical_height = window.resolution.height().clamp(constraints.min_height, constraints.max_height);
                 window.resolution.set(logical_width, logical_height);
 
                 // Use `set_inner_size` to set the new size.

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -12,7 +12,7 @@ use bevy_utils::{tracing::warn, HashMap};
 use bevy_window::{CursorGrabMode, Window, WindowMode, WindowPosition, WindowResolution};
 
 use winit::{
-    dpi::{LogicalSize, PhysicalPosition},
+    dpi::{LogicalSize, PhysicalPosition, Size},
     monitor::MonitorHandle,
 };
 
@@ -106,6 +106,16 @@ impl WinitWindows {
             width: constraints.max_width,
             height: constraints.max_height,
         };
+
+        let (min_inner_size, max_inner_size): (Size, Size) =
+            if let Some(sf) = window.resolution.scale_factor_override() {
+                (
+                    min_inner_size.to_physical::<f64>(sf).into(),
+                    max_inner_size.to_physical::<f64>(sf).into(),
+                )
+            } else {
+                (min_inner_size.into(), max_inner_size.into())
+            };
 
         let winit_window_builder =
             if constraints.max_width.is_finite() && constraints.max_height.is_finite() {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -97,34 +97,15 @@ impl WinitWindows {
             .with_decorations(window.decorations)
             .with_transparent(window.transparent);
 
-        let constraints = window.resize_constraints.check_constraints();
-        let min_inner_size = LogicalSize {
-            width: constraints.min_width,
-            height: constraints.min_height,
-        };
-        let max_inner_size = LogicalSize {
-            width: constraints.max_width,
-            height: constraints.max_height,
-        };
+        let (min_inner_size, max_inner_size) = get_inner_size_constraints(window);
 
-        let (min_inner_size, max_inner_size): (Size, Size) =
-            if let Some(sf) = window.resolution.scale_factor_override() {
-                (
-                    min_inner_size.to_physical::<f64>(sf).into(),
-                    max_inner_size.to_physical::<f64>(sf).into(),
-                )
-            } else {
-                (min_inner_size.into(), max_inner_size.into())
-            };
-
-        let winit_window_builder =
-            if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
-                winit_window_builder
-                    .with_min_inner_size(min_inner_size)
-                    .with_max_inner_size(max_inner_size)
-            } else {
-                winit_window_builder.with_min_inner_size(min_inner_size)
-            };
+        let winit_window_builder = if let Some(max_inner_size) = max_inner_size {
+            winit_window_builder
+                .with_min_inner_size(min_inner_size)
+                .with_max_inner_size(max_inner_size)
+        } else {
+            winit_window_builder.with_min_inner_size(min_inner_size)
+        };
 
         #[allow(unused_mut)]
         let mut winit_window_builder = winit_window_builder.with_title(window.title.as_str());
@@ -382,6 +363,37 @@ pub fn winit_window_position(
             Some(PhysicalPosition::new(position[0] as f64, position[1] as f64).cast::<i32>())
         }
     }
+}
+
+pub(crate) fn get_inner_size_constraints(window: &Window) -> (Size, Option<Size>) {
+    let constraints = window.resize_constraints.check_constraints();
+    let min_inner_size = LogicalSize {
+        width: constraints.min_width,
+        height: constraints.min_height,
+    };
+    let max_inner_size = LogicalSize {
+        width: constraints.max_width,
+        height: constraints.max_height,
+    };
+
+    let (min_inner_size, max_inner_size): (Size, Size) =
+        if let Some(sf) = window.resolution.scale_factor_override() {
+            (
+                min_inner_size.to_physical::<f64>(sf).into(),
+                max_inner_size.to_physical::<f64>(sf).into(),
+            )
+        } else {
+            (min_inner_size.into(), max_inner_size.into())
+        };
+
+    (
+        min_inner_size,
+        if constraints.max_width.is_finite() && constraints.max_height.is_finite() {
+            Some(max_inner_size)
+        } else {
+            None
+        },
+    )
 }
 
 // WARNING: this only works under the assumption that wasm runtime is single threaded


### PR DESCRIPTION
# Objectives

Fixes 4 bugs:
- number 2 in [#8921](https://github.com/bevyengine/bevy/issues/8921): "WindowResizeConstraints logic ignores scale_factor_override"
- number 5 in [#8921](https://github.com/bevyengine/bevy/issues/8921): "Resizing with code seems to ignore WindowResizeConstraints"
- number 8 in [#8921](https://github.com/bevyengine/bevy/issues/8921): "Resizing with code while in windowed mode and reaching fullscreen will desynchronize the values between Window and winit."
- also I didn't test it but looking at the code I'm pretty sure that if you put a max resize constraint, then you put it back to infinity, the change was ignored, this PR should fix that too.

Adds verification that `WindowSizeConstraints`'s `max_width` and `max_height` are specified (not equal to `f32::INFINITY`) at the same time in `check_constraints`, since if only one of them are it would be ignored anyway. Updates the doc related to that.

## Solution

Made the first 3 fixes in [the first commit](https://github.com/bevyengine/bevy/commit/4d14298b417f5ae40a1fe6a5dd007e95b74ea626).
Refactored the code to encapsulate redundant logic in a function in [second commit](https://github.com/bevyengine/bevy/commit/351edaf68902e04a75ae42bec94472350b0c435e), also found 4th bug and fixed it in second commit.
Changed `check_constraints` in the [fourth commit](https://github.com/bevyengine/bevy/pull/8948/commits/6390f8d89e3f94dc84bda42b99938a95f34f7dcb)

I detailed what I did a bit more in the comments, feel free to ask for clarification.