### PR TITLE
Add option to disable gizmo rendering for specific cameras

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -49,6 +49,7 @@ use bevy_render::{
         VertexFormat, VertexStepMode,
     },
     renderer::RenderDevice,
+    view::RenderLayers,
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
@@ -159,6 +160,10 @@ pub struct GizmoConfig {
     pub depth_bias: f32,
     /// Configuration for the [`AabbGizmo`].
     pub aabb: AabbGizmoConfig,
+    /// Describes which rendering layers gizmos will be rendered to.
+    ///
+    /// Gizmos will only be rendered to cameras with intersecting layers.
+    pub render_layers: RenderLayers,
 }
 
 impl Default for GizmoConfig {
@@ -169,6 +174,7 @@ impl Default for GizmoConfig {
             line_perspective: false,
             depth_bias: 0.,
             aabb: Default::default(),
+            render_layers: Default::default(),
         }
     }
 }

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -1,6 +1,6 @@
 use crate::{
-    line_gizmo_vertex_buffer_layouts, DrawLineGizmo, LineGizmo, LineGizmoUniformBindgroupLayout,
-    SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
+    line_gizmo_vertex_buffer_layouts, DrawLineGizmo, GizmoConfig, LineGizmo,
+    LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::Handle;
@@ -17,7 +17,7 @@ use bevy_render::{
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::*,
     texture::BevyDefault,
-    view::{ExtractedView, Msaa, ViewTarget},
+    view::{ExtractedView, Msaa, RenderLayers, ViewTarget},
     Render, RenderApp, RenderSet,
 };
 use bevy_sprite::{Mesh2dPipeline, Mesh2dPipelineKey, SetMesh2dViewBindGroup};
@@ -131,13 +131,22 @@ fn queue_line_gizmos_2d(
     mut pipelines: ResMut<SpecializedRenderPipelines<LineGizmoPipeline>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
+    config: Res<GizmoConfig>,
     line_gizmos: Query<(Entity, &Handle<LineGizmo>)>,
     line_gizmo_assets: Res<RenderAssets<LineGizmo>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent2d>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &mut RenderPhase<Transparent2d>,
+        Option<&RenderLayers>,
+    )>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo2d>().unwrap();
 
-    for (view, mut transparent_phase) in &mut views {
+    for (view, mut transparent_phase, render_layers) in &mut views {
+        let render_layers = render_layers.copied().unwrap_or_default();
+        if !config.render_layers.intersects(&render_layers) {
+            continue;
+        }
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -21,7 +21,7 @@ use bevy_render::{
     render_phase::{AddRenderCommand, DrawFunctions, RenderPhase, SetItemPipeline},
     render_resource::*,
     texture::BevyDefault,
-    view::{ExtractedView, Msaa, ViewTarget},
+    view::{ExtractedView, Msaa, RenderLayers, ViewTarget},
     Render, RenderApp, RenderSet,
 };
 
@@ -159,11 +159,20 @@ fn queue_line_gizmos_3d(
     config: Res<GizmoConfig>,
     line_gizmos: Query<(Entity, &Handle<LineGizmo>)>,
     line_gizmo_assets: Res<RenderAssets<LineGizmo>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
+    mut views: Query<(
+        &ExtractedView,
+        &mut RenderPhase<Transparent3d>,
+        Option<&RenderLayers>,
+    )>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo3d>().unwrap();
 
-    for (view, mut transparent_phase) in &mut views {
+    for (view, mut transparent_phase, render_layers) in &mut views {
+        let render_layers = render_layers.copied().unwrap_or_default();
+        if !config.render_layers.intersects(&render_layers) {
+            continue;
+        }
+
         let mesh_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
             | MeshPipelineKey::from_hdr(view.hdr);
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -4,7 +4,7 @@ use crate::{
     prelude::Image,
     render_asset::RenderAssets,
     render_resource::TextureView,
-    view::{ColorGrading, ExtractedView, ExtractedWindows, VisibleEntities},
+    view::{ColorGrading, ExtractedView, ExtractedWindows, RenderLayers, VisibleEntities},
     Extract,
 };
 use bevy_asset::{AssetEvent, Assets, Handle};
@@ -615,6 +615,7 @@ pub fn extract_cameras(
             &VisibleEntities,
             Option<&ColorGrading>,
             Option<&TemporalJitter>,
+            Option<&RenderLayers>,
         )>,
     >,
     primary_window: Extract<Query<Entity, With<PrimaryWindow>>>,
@@ -628,6 +629,7 @@ pub fn extract_cameras(
         visible_entities,
         color_grading,
         temporal_jitter,
+        render_layers,
     ) in query.iter()
     {
         let color_grading = *color_grading.unwrap_or(&ColorGrading::default());
@@ -678,6 +680,10 @@ pub fn extract_cameras(
 
             if let Some(temporal_jitter) = temporal_jitter {
                 commands.insert(temporal_jitter.clone());
+            }
+
+            if let Some(render_layers) = render_layers {
+                commands.insert(*render_layers);
             }
         }
     }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -6,15 +6,10 @@ use bevy::{
     core_pipeline::clear_color::ClearColorConfig, pbr::CascadeShadowConfigBuilder, prelude::*,
     render::camera::Viewport, window::WindowResized,
 };
-use bevy_internal::render::view::RenderLayers;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(GizmoConfig {
-            render_layers: RenderLayers::layer(1),
-            ..Default::default()
-        })
         .add_systems(Startup, setup)
         .add_systems(Update, set_camera_viewports)
         .run();
@@ -81,7 +76,6 @@ fn setup(
             },
             ..default()
         },
-        RenderLayers::from_layers(&[0, 1]),
         RightCamera,
     ));
 }
@@ -97,12 +91,7 @@ fn set_camera_viewports(
     mut resize_events: EventReader<WindowResized>,
     mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
     mut right_camera: Query<&mut Camera, With<RightCamera>>,
-    mut gizmos: Gizmos,
 ) {
-    gizmos.cuboid(
-        Transform::IDENTITY.with_scale(Vec3::splat(100.)),
-        Color::GREEN,
-    );
     // We need to dynamically resize the camera's viewports whenever the window size changes
     // so then each camera always takes up half the screen.
     // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -6,10 +6,15 @@ use bevy::{
     core_pipeline::clear_color::ClearColorConfig, pbr::CascadeShadowConfigBuilder, prelude::*,
     render::camera::Viewport, window::WindowResized,
 };
+use bevy_internal::render::view::RenderLayers;
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
+        .insert_resource(GizmoConfig {
+            render_layers: RenderLayers::layer(1),
+            ..Default::default()
+        })
         .add_systems(Startup, setup)
         .add_systems(Update, set_camera_viewports)
         .run();
@@ -76,6 +81,7 @@ fn setup(
             },
             ..default()
         },
+        RenderLayers::from_layers(&[0, 1]),
         RightCamera,
     ));
 }
@@ -91,7 +97,12 @@ fn set_camera_viewports(
     mut resize_events: EventReader<WindowResized>,
     mut left_camera: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
     mut right_camera: Query<&mut Camera, With<RightCamera>>,
+    mut gizmos: Gizmos,
 ) {
+    gizmos.cuboid(
+        Transform::IDENTITY.with_scale(Vec3::splat(100.)),
+        Color::GREEN,
+    );
     // We need to dynamically resize the camera's viewports whenever the window size changes
     // so then each camera always takes up half the screen.
     // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.


### PR DESCRIPTION
Added `GizmoConfig::render_layers`, which will ensure Gizmos are only rendered on cameras that can see those `RenderLayers`.