### PR TITLE
Treat unready Wayland windows as focused

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -753,6 +753,10 @@ pub struct InternalWindowState {
     maximize_request: Option<bool>,
     /// Unscaled cursor position.
     physical_cursor_position: Option<DVec2>,
+    /// Flag that can be freely used by window backends to distinguish between ready and unready windows.
+    /// `bevy_winit` considers Wayland windows to be unready until they are visible on screen and ignores
+    /// `WindowEvent::Focused(false)` events for unready windows.
+    ready: bool,
 }
 
 impl InternalWindowState {
@@ -764,6 +768,16 @@ impl InternalWindowState {
     /// Consumes the current minimize request, if it exists. This should only be called by window backends.
     pub fn take_minimize_request(&mut self) -> Option<bool> {
         self.minimize_request.take()
+    }
+
+    /// Marks the window as ready. This should only be called by window backends.
+    pub fn set_ready(&mut self) {
+        self.ready = true;
+    }
+
+    /// Checks if the window has been marked as ready. This should only be called by window backends.
+    pub fn is_ready(&self) -> bool {
+        self.ready
     }
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -578,13 +578,20 @@ pub fn winit_runner(mut app: App) {
                             .set_physical_resolution(new_inner_size.width, new_inner_size.height);
                     }
                     WindowEvent::Focused(focused) => {
-                        // Component
-                        window.focused = focused;
+                        #[cfg(feature = "wayland")]
+                        if focused && !window.internal.is_ready() {
+                            window.internal.set_ready();
+                        }
 
-                        window_events.window_focused.send(WindowFocused {
-                            window: window_entity,
-                            focused,
-                        });
+                        if window.internal.is_ready() {
+                            // Component
+                            window.focused = focused;
+
+                            window_events.window_focused.send(WindowFocused {
+                                window: window_entity,
+                                focused,
+                            });
+                        }
                     }
                     WindowEvent::DroppedFile(path_buf) => {
                         file_drag_and_drop_events.send(FileDragAndDrop::DroppedFile {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -578,7 +578,10 @@ pub fn winit_runner(mut app: App) {
                             .set_physical_resolution(new_inner_size.width, new_inner_size.height);
                     }
                     WindowEvent::Focused(focused) => {
-                        #[cfg(feature = "wayland")]
+                        // When using Wayland (or sometimes X11 through XWayland) we need to consider the window
+                        // focused after creation and ignore the initial `WindowEvent::Focused(false)` event.
+                        // See https://github.com/bevyengine/bevy/pull/8953 for more details.
+                        #[cfg(any(feature = "wayland", feature = " x11"))]
                         if focused && !window.internal.is_ready() {
                             window.internal.set_ready();
                         }

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -63,7 +63,10 @@ pub(crate) fn create_window<'a>(
             &mut accessibility_requested,
         );
 
-        #[cfg(not(feature = "wayland"))]
+        // When using Wayland (or sometimes X11 through XWayland) we need to consider the window
+        // focused after creation and ignore the initial `WindowEvent::Focused(false)` event.
+        // See https://github.com/bevyengine/bevy/pull/8953 for more details.
+        #[cfg(not(any(feature = "wayland", feature = "x11")))]
         window.internal.set_ready();
 
         if let Some(theme) = winit_window.theme() {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -63,6 +63,9 @@ pub(crate) fn create_window<'a>(
             &mut accessibility_requested,
         );
 
+        #[cfg(not(feature = "wayland"))]
+        window.internal.set_ready();
+
         if let Some(theme) = winit_window.theme() {
             window.window_theme = Some(convert_winit_theme(theme));
         }


### PR DESCRIPTION
# Objective

- Fixes #7974.

## Solution

- Add `ready` field to `InternalWindowState` to distinguish between ready and unready windows.
  - Wayland windows are marked as ready after they become focused for the first time, which only happens after the first frame is submitted.
  - All other windows are marked as ready on creation.
- Ignore `WindowEvent::Focused` events for unready windows, which keeps Wayland windows to be considered as focused.
- For a detailed explanation why this fixes the issue, see https://github.com/bevyengine/bevy/issues/7974#issuecomment-1606042509.

## Changelog

- Added `set_ready` and `is_ready` methods to `InternalWindowState`.
