### PR TITLE
Remove superfluous shader_format_glsl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,9 +235,6 @@ glam_assert = ["bevy_internal/glam_assert"]
 # Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase
 default_font = ["bevy_internal/default_font"]
 
-# Enable support for shaders in GLSL
-shader_format_glsl = ["bevy_internal/shader_format_glsl"]
-
 # Enable support for shaders in SPIR-V
 shader_format_spirv = ["bevy_internal/shader_format_spirv"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -59,7 +59,6 @@ symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
 symphonia-wav = ["bevy_audio/symphonia-wav"]
 
 # Shader formats
-shader_format_glsl = ["bevy_render/shader_format_glsl"]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 
 # Enable watching file system for asset hot reload

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -20,7 +20,6 @@ dds = ["ddsfile"]
 pnm = ["image/pnm"]
 bevy_ci_testing = ["bevy_app/bevy_ci_testing"]
 
-shader_format_glsl = ["naga/glsl-in", "naga/wgsl-out"]
 shader_format_spirv = ["wgpu/spirv", "naga/spv-in", "naga/spv-out"]
 
 # For ktx2 supercompression

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -13,8 +13,6 @@ define_atomic_id!(ShaderId);
 pub enum ShaderReflectError {
     #[error(transparent)]
     WgslParse(#[from] naga::front::wgsl::ParseError),
-    #[cfg(feature = "shader_format_glsl")]
-    #[error("GLSL Parse Error: {0:?}")]
     GlslParse(Vec<naga::front::glsl::Error>),
     #[cfg(feature = "shader_format_spirv")]
     #[error(transparent)]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -59,7 +59,6 @@ The default feature set enables most of the expected features of a game engine, 
 |mp3|MP3 audio format support|
 |pnm|PNM image format support, includes pam, pbm, pgm and ppm|
 |serialize|Enable serialization support through serde|
-|shader_format_glsl|Enable support for shaders in GLSL|
 |shader_format_spirv|Enable support for shaders in SPIR-V|
 |subpixel_glyph_atlas|Enable rendering of font glyphs using subpixel accuracy|
 |symphonia-aac|AAC audio format support (through symphonia)|


### PR DESCRIPTION
# Objective

`naga_oil` now includes glsl support unconditionally, so this feature isn't doing anything.

Fixes #8505 (see recent discussion there and in #8657)

## Solution

Remove the feature

## Changelog

- Removed the `shader_material_glsl` feature. `glsl` support is now included by default.

## Migration Guide

The `shader_material_glsl` feature was removed. `glsl` support is now included by default. If you were previously using this feature, you can remove it from your `Cargo.toml`.
