### PR TITLE
Remove unnecessary required feature metadata for tonemapping example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -570,7 +570,6 @@ wasm = true
 [[example]]
 name = "tonemapping"
 path = "examples/3d/tonemapping.rs"
-required-features = ["ktx2", "zstd"]
 
 [package.metadata.example.tonemapping]
 name = "Tonemapping"


### PR DESCRIPTION
# Objective

These features are now included by default, so this metadata is no longer required.

See https://github.com/bevyengine/bevy/pull/8657#issuecomment-1560065004

## Solution

Remove the metadata