### PR TITLE
`Main`/`Render` schedules be run at different real timing.

### DIFF
--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -85,7 +85,7 @@ pub fn build_schedule(criterion: &mut Criterion) {
                 for _ in 0..graph_size {
                     app.add_systems(Update, empty_system);
                 }
-                app.update();
+                app.world.run_schedule(Update);
             });
         });
 
@@ -111,7 +111,7 @@ pub fn build_schedule(criterion: &mut Criterion) {
                 // This is necessary since dependency resolution does not occur until the game runs.
                 // FIXME: Running the game clutters up the benchmarks, so ideally we'd be
                 // able to benchmark the dependency resolution directly.
-                app.update();
+                app.world.run_schedule(Update);
             });
         });
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -64,7 +64,7 @@ pub struct App {
     /// the application's event loop and advancing the [`Schedule`].
     /// Typically, it is not configured manually, but set by one of Bevy's built-in plugins.
     /// See `bevy::winit::WinitPlugin` and [`ScheduleRunnerPlugin`](crate::schedule_runner::ScheduleRunnerPlugin).
-    pub runner: Box<dyn Fn(App) + Send>, // Send bound is required to make App Send
+    pub runner: Box<dyn FnOnce(App) + Send>, // Send bound is required to make App Send
     /// The schedule that systems are added to by default.
     ///
     /// The schedule that runs the main loop of schedule execution.
@@ -651,7 +651,7 @@ impl App {
     /// App::new()
     ///     .set_runner(my_runner);
     /// ```
-    pub fn set_runner(&mut self, run_fn: impl Fn(App) + 'static + Send) -> &mut Self {
+    pub fn set_runner(&mut self, run_fn: impl FnOnce(App) + 'static + Send) -> &mut Self {
         self.runner = Box::new(run_fn);
         self
     }

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -64,7 +64,7 @@ pub struct App {
     /// the application's event loop and advancing the [`Schedule`].
     /// Typically, it is not configured manually, but set by one of Bevy's built-in plugins.
     /// See `bevy::winit::WinitPlugin` and [`ScheduleRunnerPlugin`](crate::schedule_runner::ScheduleRunnerPlugin).
-    pub runner: Box<dyn FnOnce(App) + Send>, // Send bound is required to make App Send
+    pub runner: Box<dyn FnOnce(App) + Send + Sync>,
     /// The schedule that systems are added to by default.
     ///
     /// The schedule that runs the main loop of schedule execution.
@@ -137,7 +137,7 @@ pub struct SubApp {
 
     /// A function that allows access to both the main [`App`] [`World`] and the [`SubApp`]. This is
     /// useful for moving data between the sub app and the main app.
-    extract: Box<dyn Fn(&mut World, &mut App) + Send>,
+    extract: Box<dyn Fn(&mut World, &mut App) + Send + Sync>,
 }
 
 impl SubApp {
@@ -147,7 +147,7 @@ impl SubApp {
     /// After extract is called, the [`Schedule`] of the sub app is run. The [`World`]
     /// parameter represents the main app world, while the [`App`] parameter is just a mutable
     /// reference to the `SubApp` itself.
-    pub fn new(app: App, extract: impl Fn(&mut World, &mut App) + Send + 'static) -> Self {
+    pub fn new(app: App, extract: impl Fn(&mut World, &mut App) + Send + Sync + 'static) -> Self {
         Self {
             app,
             extract: Box::new(extract),
@@ -651,7 +651,7 @@ impl App {
     /// App::new()
     ///     .set_runner(my_runner);
     /// ```
-    pub fn set_runner(&mut self, run_fn: impl FnOnce(App) + 'static + Send) -> &mut Self {
+    pub fn set_runner(&mut self, run_fn: impl FnOnce(App) + 'static + Send + Sync) -> &mut Self {
         self.runner = Box::new(run_fn);
         self
     }

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -25,7 +25,7 @@ pub mod prelude {
     pub use crate::{
         app::App,
         main_schedule::{
-            First, FixedUpdate, Last, Main, PostStartup, PostUpdate, PreStartup, PreUpdate,
+            First, FixedUpdate, Last, Main, PostStartup, PostUpdate, PreStartup, PreUpdate, Render,
             Startup, StateTransition, Update,
         },
         DynamicPlugin, Plugin, PluginGroup,

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -95,6 +95,10 @@ pub struct PostUpdate;
 #[derive(ScheduleLabel, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Last;
 
+/// The main render schedule.
+#[derive(ScheduleLabel, Debug, Hash, PartialEq, Eq, Clone)]
+pub struct Render;
+
 /// Defines the schedules to be run for the [`Main`] schedule, including
 /// their order.
 #[derive(Resource, Debug)]

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     world::{Mut, World},
 };
 
-/// The schedule that contains the app logic that is evaluated each tick of [`App::update()`].
+/// The schedule that contains the app logic that is evaluated each tick of event loop.
 ///
 /// By default, it will run the following schedules in the given order:
 ///

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -645,7 +645,7 @@ pub fn free_unused_assets_system(asset_server: Res<AssetServer>) {
 mod test {
     use super::*;
     use crate::{loader::LoadedAsset, update_asset_storage_system};
-    use bevy_app::{App, Update};
+    use bevy_app::{App, Main, Update};
     use bevy_ecs::prelude::*;
     use bevy_reflect::{TypePath, TypeUuid};
     use bevy_utils::BoxedFuture;
@@ -896,19 +896,19 @@ mod test {
         // asset is loading
         assert_eq!(LoadState::Loading, get_load_state(&handle, &app.world));
 
-        app.update();
+        app.world.run_schedule(Main);
         // asset should exist and be loaded at this point
         assert_eq!(LoadState::Loaded, get_load_state(&handle, &app.world));
         assert!(get_asset(&handle, &app.world).is_some());
 
         // after dropping the handle, next call to `tick` will prepare the assets for removal.
         drop(handle);
-        app.update();
+        app.world.run_schedule(Main);
         assert_eq!(LoadState::Loaded, get_load_state(&weak_handle, &app.world));
         assert!(get_asset(&weak_handle, &app.world).is_some());
 
         // second call to tick will actually remove the asset.
-        app.update();
+        app.world.run_schedule(Main);
         assert_eq!(
             LoadState::Unloaded,
             get_load_state(&weak_handle, &app.world)
@@ -918,7 +918,7 @@ mod test {
         // finally, reload the asset
         let handle = load_asset(path.clone(), &app.world).typed();
         assert_eq!(LoadState::Loading, get_load_state(&handle, &app.world));
-        app.update();
+        app.world.run_schedule(Main);
         assert_eq!(LoadState::Loaded, get_load_state(&handle, &app.world));
         assert!(get_asset(&handle, &app.world).is_some());
     }

--- a/crates/bevy_asset/src/debug_asset_server.rs
+++ b/crates/bevy_asset/src/debug_asset_server.rs
@@ -2,7 +2,7 @@
 //!
 //! Internal assets (e.g. shaders) are bundled directly into an application and can't be hot
 //! reloaded using the conventional API.
-use bevy_app::{App, Plugin, Update};
+use bevy_app::{App, Main, Plugin, Update};
 use bevy_ecs::{prelude::*, system::SystemState};
 use bevy_tasks::{IoTaskPool, TaskPoolBuilder};
 use bevy_utils::{Duration, HashMap};
@@ -81,7 +81,7 @@ impl Plugin for DebugAssetServerPlugin {
 }
 
 fn run_debug_asset_app(mut debug_asset_app: NonSendMut<DebugAssetApp>) {
-    debug_asset_app.0.update();
+    debug_asset_app.0.world.run_schedule(Main);
 }
 
 pub(crate) fn sync_debug_assets<T: Asset + Clone>(

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -203,7 +203,7 @@ mod tests {
             TypeRegistrationPlugin::default(),
             FrameCountPlugin::default(),
         ));
-        app.update();
+        app.world.run_schedule(Main);
 
         let frame_count = app.world.resource::<FrameCount>();
         assert_eq!(1, frame_count.0);

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -8,7 +8,7 @@ use crate::{
     core_2d::{self, CORE_2D},
     core_3d::{self, CORE_3D},
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_ecs::{prelude::*, query::QueryItem};
 use bevy_math::UVec2;
@@ -24,7 +24,7 @@ use bevy_render::{
     renderer::{RenderContext, RenderDevice},
     texture::{CachedTexture, TextureCache},
     view::ViewTarget,
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 use downsampling_pipeline::{
     prepare_downsampling_pipeline, BloomDownsamplingPipeline, BloomDownsamplingPipelineIds,

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -15,7 +15,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::BevyDefault,
     view::{ExtractedView, ViewTarget},
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 
 mod node;

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -22,7 +22,7 @@ pub const CORE_2D: &str = graph::NAME;
 pub use camera_2d::*;
 pub use main_pass_2d_node::*;
 
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::Camera,
@@ -33,7 +33,7 @@ use bevy_render::{
         DrawFunctionId, DrawFunctions, PhaseItem, RenderPhase,
     },
     render_resource::CachedRenderPipelineId,
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_utils::FloatOrd;
 use std::ops::Range;

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -30,7 +30,7 @@ pub use camera_3d::*;
 pub use main_opaque_pass_3d_node::*;
 pub use main_transparent_pass_3d_node::*;
 
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::{Camera, ExtractedCamera},
@@ -48,7 +48,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::TextureCache,
     view::ViewDepthTexture,
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_utils::{FloatOrd, HashMap};
 

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -19,7 +19,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::BevyDefault,
     view::{ExtractedView, ViewTarget},
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 
 mod node;

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -3,14 +3,14 @@ use crate::{
     core_2d::{self, CORE_2D},
     core_3d::{self, CORE_3D},
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{Node, NodeRunError, RenderGraphApp, RenderGraphContext},
     renderer::RenderContext,
     view::{Msaa, ViewTarget},
-    Render, RenderSet,
+    RenderSet,
 };
 use bevy_render::{render_resource::*, RenderApp};
 

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -1,4 +1,4 @@
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_ecs::{
     prelude::{Component, Entity},
@@ -22,7 +22,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::{BevyDefault, Image},
     view::{ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniforms},
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 
 const SKYBOX_SHADER_HANDLE: HandleUntyped =

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     prelude::Camera3d,
     prepass::{DepthPrepass, MotionVectorPrepass, ViewPrepassTextures},
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_core::FrameCount;
 use bevy_ecs::{
@@ -32,7 +32,7 @@ use bevy_render::{
     renderer::{RenderContext, RenderDevice},
     texture::{BevyDefault, CachedTexture, TextureCache},
     view::{prepare_view_uniforms, ExtractedView, Msaa, ViewTarget},
-    ExtractSchedule, MainWorld, Render, RenderApp, RenderSet,
+    ExtractSchedule, MainWorld, RenderApp, RenderSet,
 };
 
 mod draw_3d_graph {

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -10,7 +10,7 @@ use bevy_render::render_asset::RenderAssets;
 use bevy_render::renderer::RenderDevice;
 use bevy_render::texture::{CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_render::view::{ViewTarget, ViewUniform};
-use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
+use bevy_render::{render_resource::*, RenderApp, RenderSet};
 
 mod node;
 

--- a/crates/bevy_core_pipeline/src/upscaling/mod.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/mod.rs
@@ -3,7 +3,7 @@ use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_render::camera::{CameraOutputMode, ExtractedCamera};
 use bevy_render::view::ViewTarget;
-use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
+use bevy_render::{render_resource::*, RenderApp, RenderSet};
 
 mod node;
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -18,7 +18,7 @@
 
 use std::mem;
 
-use bevy_app::{Last, Plugin, Update};
+use bevy_app::{Last, Plugin, Render, Update};
 use bevy_asset::{load_internal_asset, AddAsset, Assets, Handle, HandleUntyped};
 use bevy_core::cast_slice;
 use bevy_ecs::{
@@ -49,7 +49,7 @@ use bevy_render::{
         VertexFormat, VertexStepMode,
     },
     renderer::RenderDevice,
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -2,7 +2,7 @@ use crate::{
     line_gizmo_vertex_buffer_layouts, DrawLineGizmo, LineGizmo, LineGizmoUniformBindgroupLayout,
     SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::Handle;
 use bevy_core_pipeline::core_2d::Transparent2d;
 
@@ -18,7 +18,7 @@ use bevy_render::{
     render_resource::*,
     texture::BevyDefault,
     view::{ExtractedView, Msaa, ViewTarget},
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 use bevy_sprite::{Mesh2dPipeline, Mesh2dPipelineKey, SetMesh2dViewBindGroup};
 use bevy_utils::FloatOrd;

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -2,7 +2,7 @@ use crate::{
     line_gizmo_vertex_buffer_layouts, DrawLineGizmo, GizmoConfig, LineGizmo,
     LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::Handle;
 use bevy_core_pipeline::core_3d::Transparent3d;
 
@@ -22,7 +22,7 @@ use bevy_render::{
     render_resource::*,
     texture::BevyDefault,
     view::{ExtractedView, Msaa, ViewTarget},
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 
 pub struct LineGizmo3dPlugin;

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -63,7 +63,7 @@ use bevy_render::{
     render_phase::sort_phase_system,
     render_resource::Shader,
     view::{ViewSet, VisibilitySystems},
-    ExtractSchedule, Render, RenderApp, RenderSet,
+    ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::TransformSystem;
 use environment_map::EnvironmentMapPlugin;

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -3,7 +3,7 @@ use crate::{
     MeshUniform, PrepassPipelinePlugin, PrepassPlugin, RenderLightSystems,
     ScreenSpaceAmbientOcclusionSettings, SetMeshBindGroup, SetMeshViewBindGroup, Shadow,
 };
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
 use bevy_core_pipeline::{
     core_3d::{AlphaMask3d, Opaque3d, Transparent3d},
@@ -37,7 +37,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::FallbackImage,
     view::{ExtractedView, Msaa, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::hash::Hash;

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -1,4 +1,4 @@
-use bevy_app::{Plugin, PreUpdate, Update};
+use bevy_app::{Plugin, PreUpdate, Render, Update};
 use bevy_asset::{load_internal_asset, AssetServer, Handle, HandleUntyped};
 use bevy_core_pipeline::{
     prelude::Camera3d,
@@ -39,7 +39,7 @@ use bevy_render::{
     renderer::{RenderDevice, RenderQueue},
     texture::{FallbackImagesDepth, FallbackImagesMsaa},
     view::{ExtractedView, Msaa, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::tracing::error;

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -1,4 +1,4 @@
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_ecs::prelude::*;
 use bevy_math::{Vec3, Vec4};
@@ -8,7 +8,7 @@ use bevy_render::{
     render_resource::{DynamicUniformBuffer, Shader, ShaderType},
     renderer::{RenderDevice, RenderQueue},
     view::ExtractedView,
-    Render, RenderApp, RenderSet,
+    RenderApp, RenderSet,
 };
 
 use crate::{FogFalloff, FogSettings};

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -5,7 +5,7 @@ use crate::{
     ViewLightsUniformOffset, ViewShadowBindings, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT,
     MAX_CASCADES_PER_LIGHT, MAX_DIRECTIONAL_LIGHTS,
 };
-use bevy_app::Plugin;
+use bevy_app::{Plugin, Render};
 use bevy_asset::{load_internal_asset, Assets, Handle, HandleId, HandleUntyped};
 use bevy_core_pipeline::{
     prepass::ViewPrepassTextures,
@@ -38,7 +38,7 @@ use bevy_render::{
         FallbackImagesMsaa, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
     },
     view::{ComputedVisibility, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{tracing::error, HashMap, Hashed};

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -1,4 +1,4 @@
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{load_internal_asset, HandleUntyped};
 use bevy_core_pipeline::{
     core_3d::CORE_3D,
@@ -33,7 +33,7 @@ use bevy_render::{
     renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
     texture::{CachedTexture, TextureCache},
     view::{Msaa, ViewUniform, ViewUniformOffset, ViewUniforms},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_utils::{
     prelude::default,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,13 +1,12 @@
 use crate::MeshPipeline;
 use crate::{DrawMesh, MeshPipelineKey, MeshUniform, SetMeshBindGroup, SetMeshViewBindGroup};
-use bevy_app::Plugin;
+use bevy_app::{Plugin, Render};
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 use bevy_core_pipeline::core_3d::Opaque3d;
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::{FromReflect, Reflect, ReflectFromReflect, TypeUuid};
 use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
-use bevy_render::Render;
 use bevy_render::{
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     mesh::{Mesh, MeshVertexBufferLayout},

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -55,7 +55,7 @@ use crate::{
     settings::WgpuSettings,
     view::{ViewPlugin, WindowRenderPlugin},
 };
-use bevy_app::{App, AppLabel, Plugin, SubApp};
+use bevy_app::{App, AppLabel, Plugin, Render, SubApp};
 use bevy_asset::{AddAsset, AssetServer};
 use bevy_ecs::{prelude::*, schedule::ScheduleLabel, system::SystemState};
 use bevy_utils::tracing::debug;
@@ -108,11 +108,7 @@ pub enum RenderSet {
     CleanupFlush,
 }
 
-/// The main render schedule.
-#[derive(ScheduleLabel, Debug, Hash, PartialEq, Eq, Clone)]
-pub struct Render;
-
-impl Render {
+impl RenderSet {
     /// Sets up the base structure of the rendering [`Schedule`].
     ///
     /// The sets defined in this enum are configured to run in order,
@@ -273,7 +269,7 @@ impl Plugin for RenderPlugin {
 
             render_app
                 .add_schedule(ExtractSchedule, extract_schedule)
-                .add_schedule(Render, Render::base_schedule())
+                .add_schedule(Render, RenderSet::base_schedule())
                 .init_resource::<render_graph::RenderGraph>()
                 .insert_resource(app.world.resource::<AssetServer>().clone())
                 .add_systems(ExtractSchedule, PipelineCache::extract_shaders)

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -1,6 +1,6 @@
 use async_channel::{Receiver, Sender};
 
-use bevy_app::{App, AppLabel, Main, Plugin, SubApp};
+use bevy_app::{App, Plugin, Render, SubApp};
 use bevy_ecs::{
     schedule::MainThreadExecutor,
     system::Resource,

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -48,8 +48,6 @@ pub struct RenderToMainAppReceiver(pub Receiver<SubApp>);
 /// - On the render thread, we first apply the `extract commands`. This is not run during extract, so the
 /// main schedule can start sooner.
 /// - Then the `rendering schedule` is run. See [`RenderSet`](crate::RenderSet) for the standard steps in this process.
-/// - In parallel to the rendering thread the [`RenderExtractApp`] schedule runs. By
-/// default this schedule is empty. But it is useful if you need something to run before I/O processing.
 /// - Next all the `winit events` are processed.
 /// - And finally the `main app schedule` is run.
 /// - Once both the `main app schedule` and the `render schedule` are finished running, `extract` is run again.

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -516,7 +516,7 @@ mod test {
             .entity_mut(root2_child2)
             .push_children(&[root2_child2_grandchild1]);
 
-        app.update();
+        app.world.run_schedule(Main);
 
         let is_visible = |e: Entity| {
             app.world
@@ -613,7 +613,7 @@ mod test {
             .entity_mut(root1_child2)
             .push_children(&[root1_child2_grandchild1]);
 
-        app.update();
+        app.world.run_schedule(Main);
 
         let is_visible = |e: Entity| {
             app.world

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -40,7 +40,7 @@ use bevy_render::{
     render_resource::{Shader, SpecializedRenderPipelines},
     texture::Image,
     view::{NoFrustumCulling, VisibilitySystems},
-    ExtractSchedule, Render, RenderApp, RenderSet,
+    ExtractSchedule, RenderApp, RenderSet,
 };
 
 #[derive(Default)]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -1,4 +1,4 @@
-use bevy_app::{App, Plugin};
+use bevy_app::{App, Plugin, Render};
 use bevy_asset::{AddAsset, AssetEvent, AssetServer, Assets, Handle};
 use bevy_core_pipeline::{
     core_2d::Transparent2d,
@@ -32,7 +32,7 @@ use bevy_render::{
     renderer::RenderDevice,
     texture::FallbackImage,
     view::{ComputedVisibility, ExtractedView, Msaa, Visibility, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 use bevy_utils::{FloatOrd, HashMap, HashSet};

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -1,4 +1,4 @@
-use bevy_app::Plugin;
+use bevy_app::{Plugin, Render};
 use bevy_asset::{load_internal_asset, Handle, HandleUntyped};
 
 use bevy_ecs::{
@@ -22,7 +22,7 @@ use bevy_render::{
     view::{
         ComputedVisibility, ExtractedView, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
     },
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, RenderApp, RenderSet,
 };
 use bevy_transform::components::GlobalTransform;
 

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -424,13 +424,13 @@ mod test {
             })
             .id();
 
-        app.update();
+        app.world.run_schedule(Main);
 
         // check the `Children` structure is spawned
         assert_eq!(&**app.world.get::<Children>(parent).unwrap(), &[child]);
         assert_eq!(&**app.world.get::<Children>(child).unwrap(), &[grandchild]);
         // Note that at this point, the `GlobalTransform`s will not have updated yet, due to `Commands` delay
-        app.update();
+        app.world.run_schedule(Main);
 
         let mut state = app.world.query::<&GlobalTransform>();
         for global in state.iter(&app.world) {
@@ -474,6 +474,6 @@ mod test {
             &mut *temp.get_mut::<Parent>(grandchild).unwrap(),
         );
 
-        app.update();
+        app.world.run_schedule(Main);
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -3,7 +3,7 @@ mod render_pass;
 
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
-use bevy_render::{ExtractSchedule, Render};
+use bevy_render::ExtractSchedule;
 use bevy_window::{PrimaryWindow, Window};
 pub use pipeline::*;
 pub use render_pass::*;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -24,7 +24,7 @@ use system::{changed_window, create_window, despawn_window, CachedWindow};
 pub use winit_config::*;
 pub use winit_windows::*;
 
-use bevy_app::{App, AppExit, Last, Plugin};
+use bevy_app::{App, AppExit, Last, Main, Plugin, Render};
 use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_ecs::prelude::*;
 use bevy_input::{

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -1,4 +1,5 @@
-use bevy_ecs::system::Resource;
+use bevy_app::{Main, Render};
+use bevy_ecs::{schedule::BoxedScheduleLabel, system::Resource};
 use bevy_utils::Duration;
 
 /// A resource for configuring usage of the [`winit`] library.
@@ -31,6 +32,14 @@ pub struct WinitSettings {
     pub focused_mode: UpdateMode,
     /// Configures how the winit event loop updates while the window is *not* focused.
     pub unfocused_mode: UpdateMode,
+    /// The main schedule to run by default.
+    ///
+    /// This is initially set to [`Main`].
+    pub main_schedule_label: BoxedScheduleLabel,
+    /// The render schedule to run by default.
+    ///
+    /// This is initially set to [`Render`].
+    pub render_schedule_label: BoxedScheduleLabel,
 }
 impl WinitSettings {
     /// Configure winit with common settings for a game.
@@ -65,6 +74,8 @@ impl Default for WinitSettings {
             return_from_run: false,
             focused_mode: UpdateMode::Continuous,
             unfocused_mode: UpdateMode::Continuous,
+            main_schedule_label: Box::new(Main),
+            render_schedule_label: Box::new(Render),
         }
     }
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -21,7 +21,7 @@ use bevy::{
         },
         texture::BevyDefault,
         view::{ExtractedView, ViewTarget, VisibleEntities},
-        Extract, Render, RenderApp, RenderSet,
+        Extract, RenderApp, RenderSet,
     },
     sprite::{
         DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, Mesh2dUniform,

--- a/examples/app/custom_loop.rs
+++ b/examples/app/custom_loop.rs
@@ -14,7 +14,7 @@ fn my_runner(mut app: App) {
             let mut input = app.world.resource_mut::<Input>();
             input.0 = line.unwrap();
         }
-        app.update();
+        app.world.run_schedule(Main);
     }
 }
 

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -11,7 +11,7 @@ use bevy::{
         render_graph::{self, RenderGraph},
         render_resource::*,
         renderer::{RenderContext, RenderDevice},
-        Render, RenderApp, RenderSet,
+        RenderApp, RenderSet,
     },
     window::WindowPlugin,
 };

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -19,7 +19,7 @@ use bevy::{
         render_resource::*,
         renderer::RenderDevice,
         view::{ExtractedView, NoFrustumCulling},
-        Render, RenderApp, RenderSet,
+        RenderApp, RenderSet,
     },
 };
 use bytemuck::{Pod, Zeroable};

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -8,7 +8,7 @@ use bevy::{
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
-    render::{camera::ScalingMode, Render, RenderApp, RenderSet},
+    render::{camera::ScalingMode, RenderApp, RenderSet},
     window::{PresentMode, WindowPlugin},
 };
 use rand::{thread_rng, Rng};

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -70,7 +70,7 @@ fn did_hurt_enemy() {
         .id();
 
     // Run systems
-    app.update();
+    app.world.run_schedule(Main);
 
     // Check resulting changes
     assert!(app.world.get::<Enemy>(enemy_id).is_some());
@@ -101,7 +101,7 @@ fn did_despawn_enemy() {
         .id();
 
     // Run systems
-    app.update();
+    app.world.run_schedule(Main);
 
     // Check enemy was despawned
     assert!(app.world.get::<Enemy>(enemy_id).is_none());
@@ -129,7 +129,7 @@ fn spawn_enemy_using_input_resource() {
     app.insert_resource(input);
 
     // Run systems
-    app.update();
+    app.world.run_schedule(Main);
 
     // Check resulting changes, one entity has been spawned with `Enemy` component
     assert_eq!(app.world.query::<&Enemy>().iter(&app.world).len(), 1);
@@ -138,7 +138,7 @@ fn spawn_enemy_using_input_resource() {
     app.world.resource_mut::<Input<KeyCode>>().clear();
 
     // Run systems
-    app.update();
+    app.world.run_schedule(Main);
 
     // Check resulting changes, no new entity has been spawned
     assert_eq!(app.world.query::<&Enemy>().iter(&app.world).len(), 1);
@@ -164,7 +164,7 @@ fn update_score_on_event() {
         .send(EnemyDied(3));
 
     // Run systems
-    app.update();
+    app.world.run_schedule(Main);
 
     // Check resulting changes
     assert_eq!(app.world.resource::<Score>().0, 3);


### PR DESCRIPTION
This pull request is stacked on #8961.

# Objective

Allow the tick rate and frame rate to be configured to different values.

This PR supports the prerequisite that the `Main` schedule and the `Render` schedule be run at different real timings.

Note that tick rate and frame rate control will be implemented in a later PR.

## Solution

Call `SubApp::extract` and `SubApp::run` in the exclusive system. Add that system to the `Render` schedule.

Moved the responsibility for running top-level schedules from `App` struct to the runner function. Within the runner function, call `World::run_schedule` to run schedules separately.

---

## Changelog

### Added

- Added `app::SubApp::main_schedule_label`.
- Added `app::ScheduleRunnerPlugin::main_schedule_label`.
- Added `winit::WinitSettings::main_schedule_label`.
- Added `winit::WinitSettings::render_schedule_label`.
- Added `app::App::update_sub_apps`.

### Changed

- Moved `render::Render` to `app::Render`.
- Moved `render::Render::base_schedule` to `render::RenderSet::base_schedule`. (Back in place?)
- Added `Sync` bounds to `app::App::runner`.
- Added `Sync` bounds to `app::SubApp::extract`.
- If only RenderPlugin is used, the `RenderApp` instance will not be accessible after `cleanup`.

### Removed

- Removed `render::pipelined_rendering::RenderExtractApp`.
- Removed `app::App::update`.
- Removed `app::App::main_schedule_label`.

## Migration Guide

The top-level schedules configuration has been moved from `App` to plugins for setting the runner function. See `ScheduleRunnerPlugin` or `WinitSettings`.

Replace the code that calls `App::update` in the runner function with the following:

```rust
app.world.run_schedule(Main);
app.world.run_schedule(Render);
app.update_sub_apps();
app.world.clear_trackers();
```

(The real timing for running top-level schedules has not yet been changed.)