### PR TITLE
Prevent setting parent as itself

### DIFF
--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -170,9 +170,6 @@ pub struct AddChild {
 
 impl Command for AddChild {
     fn apply(self, world: &mut World) {
-        if self.child == self.parent {
-            panic!("Cannot add entity as a child of itself.");
-        }
         world.entity_mut(self.parent).add_child(self.child);
     }
 }
@@ -187,9 +184,6 @@ pub struct InsertChildren {
 
 impl Command for InsertChildren {
     fn apply(self, world: &mut World) {
-        if self.children.contains(&self.parent) {
-            panic!("Cannot insert entity as a child of itself.");
-        }
         world
             .entity_mut(self.parent)
             .insert_children(self.index, &self.children);
@@ -205,9 +199,6 @@ pub struct PushChildren {
 
 impl Command for PushChildren {
     fn apply(self, world: &mut World) {
-        if self.children.contains(&self.parent) {
-            panic!("Cannot push entity as a child of itself.");
-        }
         world.entity_mut(self.parent).push_children(&self.children);
     }
 }
@@ -244,9 +235,6 @@ pub struct ReplaceChildren {
 
 impl Command for ReplaceChildren {
     fn apply(self, world: &mut World) {
-        if self.children.contains(&self.parent) {
-            panic!("Cannot replace entity as a child of itself.");
-        }
         clear_children(self.parent, world);
         world.entity_mut(self.parent).push_children(&self.children);
     }
@@ -523,6 +511,9 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn add_child(&mut self, child: Entity) -> &mut Self {
         let parent = self.id();
+        if child == parent {
+            panic!("Cannot add entity as a child of itself.");
+        }
         self.world_scope(|world| {
             update_old_parent(world, child, parent);
         });
@@ -537,6 +528,9 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
+        if children.contains(&parent) {
+            panic!("Cannot push entity as a child of itself.");
+        }
         self.world_scope(|world| {
             update_old_parents(world, parent, children);
         });
@@ -553,6 +547,9 @@ impl<'w> BuildWorldChildren for EntityMut<'w> {
 
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
+        if children.contains(&parent) {
+            panic!("Cannot insert entity as a child of itself.");
+        }
         self.world_scope(|world| {
             update_old_parents(world, parent, children);
         });

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -297,12 +297,20 @@ pub trait BuildChildren {
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the children are the same as the parent.
     fn push_children(&mut self, children: &[Entity]) -> &mut Self;
     /// Inserts children at the given index.
     ///
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the children are the same as the parent.
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self;
     /// Removes the given children
     ///
@@ -313,18 +321,30 @@ pub trait BuildChildren {
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the child is the same as the parent.
     fn add_child(&mut self, child: Entity) -> &mut Self;
     /// Removes all children from this entity. The [`Children`] component will be removed if it exists, otherwise this does nothing.
     fn clear_children(&mut self) -> &mut Self;
     /// Removes all current children from this entity, replacing them with the specified list of entities.
     ///
     /// The removed children will have their [`Parent`] component removed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the children are the same as the parent.
     fn replace_children(&mut self, children: &[Entity]) -> &mut Self;
     /// Sets the parent of this entity.
     ///
     /// If this entity already had a parent, the parent's [`Children`] component will have this
     /// child removed from its list. Removing all children from a parent causes its [`Children`]
     /// component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parent is the same as the child.
     fn set_parent(&mut self, parent: Entity) -> &mut Self;
     /// Removes the [`Parent`] of this entity.
     ///

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -504,6 +504,10 @@ pub trait BuildWorldChildren {
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the child is the same as the parent.
     fn add_child(&mut self, child: Entity) -> &mut Self;
 
     /// Pushes children to the back of the builder's children. For any entities that are
@@ -512,12 +516,20 @@ pub trait BuildWorldChildren {
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the children are the same as the parent.
     fn push_children(&mut self, children: &[Entity]) -> &mut Self;
     /// Inserts children at the given index.
     ///
     /// If the children were previously children of another parent, that parent's [`Children`] component
     /// will have those children removed from its list. Removing all children from a parent causes its
     /// [`Children`] component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any of the children are the same as the parent.
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self;
     /// Removes the given children
     ///
@@ -529,6 +541,10 @@ pub trait BuildWorldChildren {
     /// If this entity already had a parent, the parent's [`Children`] component will have this
     /// child removed from its list. Removing all children from a parent causes its [`Children`]
     /// component to be removed from the entity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the parent is the same as the child.
     fn set_parent(&mut self, parent: Entity) -> &mut Self;
 
     /// Removes the [`Parent`] of this entity.

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -170,6 +170,9 @@ pub struct AddChild {
 
 impl Command for AddChild {
     fn apply(self, world: &mut World) {
+        if self.child == self.parent {
+            panic!("Cannot add entity as a child of itself.");
+        }
         world.entity_mut(self.parent).add_child(self.child);
     }
 }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -187,6 +187,9 @@ pub struct InsertChildren {
 
 impl Command for InsertChildren {
     fn apply(self, world: &mut World) {
+        if self.children.contains(&self.parent) {
+            panic!("Cannot insert entity as a child of itself.");
+        }
         world
             .entity_mut(self.parent)
             .insert_children(self.index, &self.children);
@@ -202,6 +205,9 @@ pub struct PushChildren {
 
 impl Command for PushChildren {
     fn apply(self, world: &mut World) {
+        if self.children.contains(&self.parent) {
+            panic!("Cannot push entity as a child of itself.");
+        }
         world.entity_mut(self.parent).push_children(&self.children);
     }
 }
@@ -238,6 +244,9 @@ pub struct ReplaceChildren {
 
 impl Command for ReplaceChildren {
     fn apply(self, world: &mut World) {
+        if self.children.contains(&self.parent) {
+            panic!("Cannot replace entity as a child of itself.");
+        }
         clear_children(self.parent, world);
         world.entity_mut(self.parent).push_children(&self.children);
     }

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -346,12 +346,18 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
 
         spawn_children(&mut builder);
         let children = builder.push_children;
+        if children.children.contains(&parent) {
+            panic!("Entity cannot be a child of itself.");
+        }
         self.commands().add(children);
         self
     }
 
     fn push_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
+        if children.contains(&parent) {
+            panic!("Cannot push entity as a child of itself.");
+        }
         self.commands().add(PushChildren {
             children: SmallVec::from(children),
             parent,
@@ -361,6 +367,9 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
 
     fn insert_children(&mut self, index: usize, children: &[Entity]) -> &mut Self {
         let parent = self.id();
+        if children.contains(&parent) {
+            panic!("Cannot insert entity as a child of itself.");
+        }
         self.commands().add(InsertChildren {
             children: SmallVec::from(children),
             index,
@@ -380,6 +389,9 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
 
     fn add_child(&mut self, child: Entity) -> &mut Self {
         let parent = self.id();
+        if child == parent {
+            panic!("Cannot add entity as a child of itself.");
+        }
         self.commands().add(AddChild { child, parent });
         self
     }
@@ -392,6 +404,9 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
 
     fn replace_children(&mut self, children: &[Entity]) -> &mut Self {
         let parent = self.id();
+        if children.contains(&parent) {
+            panic!("Cannot replace entity as a child of itself.");
+        }
         self.commands().add(ReplaceChildren {
             children: SmallVec::from(children),
             parent,
@@ -401,6 +416,9 @@ impl<'w, 's, 'a> BuildChildren for EntityCommands<'w, 's, 'a> {
 
     fn set_parent(&mut self, parent: Entity) -> &mut Self {
         let child = self.id();
+        if child == parent {
+            panic!("Cannot set parent to itself");
+        }
         self.commands().add(AddChild { child, parent });
         self
     }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/8979.

## Solution

- Panic when parent and child are same entity.
- Add checks into EntityCommands and EntityMut methods