### PR TITLE
Relax `FnMut` to `FnOnce` in `app::edit_schedule`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -940,7 +940,7 @@ impl App {
     pub fn edit_schedule(
         &mut self,
         label: impl ScheduleLabel,
-        mut f: impl FnMut(&mut Schedule),
+        f: impl FnOnce(&mut Schedule),
     ) -> &mut Self {
         let mut schedules = self.world.resource_mut::<Schedules>();
 


### PR DESCRIPTION
# Objective

Currently `App::edit_schedule` takes in `impl FnMut(&mut Schedule)`, but it calls the function only once. It is probably the intention has been to have it take `FnOnce` instead.

## Solution

- Relax the parameter to take `FnOnce` instead of `FnMut`
