### PR TITLE
Fix bevy_ui compilation failure without bevy_text

### DIFF
--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -4,6 +4,7 @@ use bevy_math::Vec2;
 use bevy_reflect::Reflect;
 use std::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
+use taffy::{node::MeasureFunc, prelude::Size as TaffySize};
 
 impl std::fmt::Debug for ContentSize {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -50,33 +51,27 @@ impl Measure for FixedMeasure {
 pub struct ContentSize {
     /// The `Measure` used to compute the intrinsic size
     #[reflect(ignore)]
-    pub(crate) measure_func: Option<taffy::node::MeasureFunc>,
+    pub(crate) measure_func: Option<MeasureFunc>,
 }
 
 impl ContentSize {
     /// Set a `Measure` for this function
     pub fn set(&mut self, measure: impl Measure) {
-        let measure_func =
-            move |size: taffy::prelude::Size<Option<f32>>,
-                  available: taffy::prelude::Size<AvailableSpace>| {
-                let size =
-                    measure.measure(size.width, size.height, available.width, available.height);
-                taffy::prelude::Size {
-                    width: size.x,
-                    height: size.y,
-                }
-            };
-        self.measure_func = Some(taffy::node::MeasureFunc::Boxed(Box::new(measure_func)));
+        let measure_func = move |size: TaffySize<_>, available: TaffySize<_>| {
+            let size = measure.measure(size.width, size.height, available.width, available.height);
+            TaffySize {
+                width: size.x,
+                height: size.y,
+            }
+        };
+        self.measure_func = Some(MeasureFunc::Boxed(Box::new(measure_func)));
     }
 }
 
-#[allow(clippy::derivable_impls)]
 impl Default for ContentSize {
     fn default() -> Self {
         Self {
-            measure_func: Some(taffy::node::MeasureFunc::Raw(|_, _| {
-                taffy::prelude::Size::ZERO
-            })),
+            measure_func: Some(MeasureFunc::Raw(|_, _| TaffySize::ZERO)),
         }
     }
 }

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -172,7 +172,7 @@ pub struct TextBundle {
     /// Text layout information
     pub text_layout_info: TextLayoutInfo,
     /// Text system flags
-    pub text_flags: TextFlags,
+    pub text_flags: crate::widget::TextFlags,
     /// The calculated size based on the given image
     pub calculated_size: ContentSize,
     /// Whether this node should block interaction with lower nodes

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -172,7 +172,7 @@ pub struct TextBundle {
     /// Text layout information
     pub text_layout_info: TextLayoutInfo,
     /// Text system flags
-    pub text_flags: crate::widget::TextFlags,
+    pub text_flags: TextFlags,
     /// The calculated size based on the given image
     pub calculated_size: ContentSize,
     /// Whether this node should block interaction with lower nodes

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -3,7 +3,6 @@ use crate::{
 };
 use bevy_asset::{Assets, Handle};
 
-#[cfg(feature = "bevy_text")]
 use bevy_ecs::query::Without;
 use bevy_ecs::{
     prelude::Component,
@@ -15,8 +14,6 @@ use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::texture::Image;
 use bevy_sprite::TextureAtlas;
-#[cfg(feature = "bevy_text")]
-use bevy_text::Text;
 use bevy_window::{PrimaryWindow, Window};
 
 /// The size of the image's texture
@@ -73,20 +70,20 @@ impl Measure for ImageMeasure {
     }
 }
 
+/// The filter type for `update_image_content_size_system` and `update_atlas_content_size_system`.
+#[cfg(feature = "bevy_text")]
+pub type UpdateImageFilter = (With<Node>, Without<bevy_text::Text>);
+/// The filter type for `update_image_content_size_system` and `update_atlas_content_size_system`.
+#[cfg(not(feature = "bevy_text"))]
+pub type UpdateImageFilter = With<Node>;
+
 /// Updates content size of the node based on the image provided
 pub fn update_image_content_size_system(
     mut previous_combined_scale_factor: Local<f64>,
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     textures: Res<Assets<Image>>,
-    #[cfg(feature = "bevy_text")] mut query: Query<
-        (&mut ContentSize, &UiImage, &mut UiImageSize),
-        (With<Node>, Without<Text>),
-    >,
-    #[cfg(not(feature = "bevy_text"))] mut query: Query<
-        (&mut ContentSize, &UiImage, &mut UiImageSize),
-        With<Node>,
-    >,
+    mut query: Query<(&mut ContentSize, &UiImage, &mut UiImageSize), UpdateImageFilter>,
 ) {
     let combined_scale_factor = windows
         .get_single()
@@ -120,23 +117,14 @@ pub fn update_atlas_content_size_system(
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     atlases: Res<Assets<TextureAtlas>>,
-    #[cfg(feature = "bevy_text")] mut atlas_query: Query<
+    mut atlas_query: Query<
         (
             &mut ContentSize,
             &Handle<TextureAtlas>,
             &UiTextureAtlasImage,
             &mut UiImageSize,
         ),
-        (With<Node>, Without<Text>, Without<UiImage>),
-    >,
-    #[cfg(not(feature = "bevy_text"))] mut atlas_query: Query<
-        (
-            &mut ContentSize,
-            &Handle<TextureAtlas>,
-            &UiTextureAtlasImage,
-            &mut UiImageSize,
-        ),
-        (With<Node>, Without<UiImage>),
+        (UpdateImageFilter, Without<UiImage>),
     >,
 ) {
     let combined_scale_factor = windows

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -70,12 +70,10 @@ impl Measure for ImageMeasure {
     }
 }
 
-/// The filter type for `update_image_content_size_system` and `update_atlas_content_size_system`.
 #[cfg(feature = "bevy_text")]
-pub type UpdateImageFilter = (With<Node>, Without<bevy_text::Text>);
-/// The filter type for `update_image_content_size_system` and `update_atlas_content_size_system`.
+type UpdateImageFilter = (With<Node>, Without<bevy_text::Text>);
 #[cfg(not(feature = "bevy_text"))]
-pub type UpdateImageFilter = With<Node>;
+type UpdateImageFilter = With<Node>;
 
 /// Updates content size of the node based on the image provided
 pub fn update_image_content_size_system(


### PR DESCRIPTION
# Objective

- Fix #8984 

### Solution

- Address compilation errors

I admit: I did sneak it an unrelated mini-refactor. of the `measurment.rs` module. it seemed to me that directly importing `taffy` types helped reduce a lot of boilerplate, so I did it.