### PR TITLE
Fix CAS shader with explicit FullscreenVertexOutput import

### DIFF
--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
@@ -17,7 +17,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import bevy_core_pipeline::fullscreen_vertex_shader
+#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
 
 struct CASUniforms {
     sharpness: f32,


### PR DESCRIPTION
# Objective

Followup bugfix for #5703. Without this we get the following error when CAS  (Contrast Adaptive Sharpening) is enabled:

```
2023-06-29T01:31:23.829331Z ERROR bevy_render::render_resource::pipeline_cache: failed to process shader:
error: unknown type: 'FullscreenVertexOutput'
   ┌─ crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl:63:17
   │
63 │ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
   │                 ^^^^^^^^^^^^^^^^^^^^^^ unknown type
   │
   = unknown type: 'FullscreenVertexOutput'
```

@robtfm I wouldn't expect this to fail. I was under the impression the `#import bevy_core_pipeline::fullscreen_vertex_shader` would pull "everything" from that file into this one?