### PR TITLE
Expose `WindowDestroyed` events

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -91,6 +91,26 @@ pub struct WindowClosed {
     /// by the time this event is received.
     pub window: Entity,
 }
+
+/// An event that is sent whenever a window is destroyed by the underlying window system.
+///
+/// Note that if your application only has a single window, this event may be your last chance to
+/// persist state before the application terminates.
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct WindowDestroyed {
+    /// Window that has been destroyed.
+    ///
+    /// Note that this entity probably no longer exists
+    /// by the time this event is received.
+    pub window: Entity,
+}
+
 /// An event reporting that the mouse cursor has moved inside a window.
 ///
 /// The event is sent only if the cursor is over one of the application's windows.

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -74,6 +74,7 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowCreated>()
             .add_event::<WindowClosed>()
             .add_event::<WindowCloseRequested>()
+            .add_event::<WindowDestroyed>()
             .add_event::<RequestRedraw>()
             .add_event::<CursorMoved>()
             .add_event::<CursorEntered>()

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -41,8 +41,8 @@ use bevy_utils::{
 use bevy_window::{
     exit_on_all_closed, CursorEntered, CursorLeft, CursorMoved, FileDragAndDrop, Ime,
     ReceivedCharacter, RequestRedraw, Window, WindowBackendScaleFactorChanged,
-    WindowCloseRequested, WindowCreated, WindowFocused, WindowMoved, WindowResized,
-    WindowScaleFactorChanged, WindowThemeChanged,
+    WindowCloseRequested, WindowCreated, WindowDestroyed, WindowFocused, WindowMoved,
+    WindowResized, WindowScaleFactorChanged, WindowThemeChanged,
 };
 
 #[cfg(target_os = "android")]
@@ -231,6 +231,7 @@ struct WindowEvents<'w> {
     window_focused: EventWriter<'w, WindowFocused>,
     window_moved: EventWriter<'w, WindowMoved>,
     window_theme_changed: EventWriter<'w, WindowThemeChanged>,
+    window_destroyed: EventWriter<'w, WindowDestroyed>,
 }
 
 #[derive(SystemParam)]
@@ -637,6 +638,11 @@ pub fn winit_runner(mut app: App) {
                             window: window_entity,
                             theme: convert_winit_theme(theme),
                         });
+                    }
+                    WindowEvent::Destroyed => {
+                        window_events.window_destroyed.send(WindowDestroyed {
+                            window: window_entity,
+                        })
                     }
                     _ => {}
                 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -642,7 +642,7 @@ pub fn winit_runner(mut app: App) {
                     WindowEvent::Destroyed => {
                         window_events.window_destroyed.send(WindowDestroyed {
                             window: window_entity,
-                        })
+                        });
                     }
                     _ => {}
                 }


### PR DESCRIPTION
# Objective

I'm creating an iOS game and had to find a way to persist game state when the application is terminated. This required listening to the [`applicationWillTerminate()` method](https://developer.apple.com/documentation/uikit/uiapplicationdelegate/1623111-applicationwillterminate), but I cannot do so myself anymore since `winit` already set up a delegate to listen for it, and there can be only one delegate.

So I had to move up the stack and try to respond to one of the events from `winit` instead. It appears `winit` fires two events that could serve my purpose: `WindowEvent::Destroyed` and `Event::LoopDestroyed`. It seemed to me the former might be slightly more generally useful, and I also found a past discussion that suggested it would be appropriate for Bevy to have a `WindowDestroyed` event: https://github.com/bevyengine/bevy/pull/5589#discussion_r942811021

## Solution

- I've added the `WindowDestroyed` event, which fires when `winit` fires `WindowEvent::Destroyed`.

---

## Changelog

### Added

- Introduced a new `WindowDestroyed` event type. It is used to indicate a window has been destroyed by the windowing system.
