### PR TITLE
Derive Eq, PartialEq for Tick

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -645,7 +645,7 @@ impl Components {
 
 /// A value that tracks when a system ran relative to other systems.
 /// This is used to power change detection.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Tick {
     tick: u32,
 }


### PR DESCRIPTION
# Objective

- Remove need to call `.get()` on two ticks to compare them for equality.

## Solution

- Derive `Eq` and `PartialEq`.

---

## Changelog

> `Tick` now implements `Eq` and `PartialEq`