### PR TITLE
Register bevy_animation::PlayingAnimation

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -606,6 +606,7 @@ impl Plugin for AnimationPlugin {
         app.add_asset::<AnimationClip>()
             .register_asset_reflect::<AnimationClip>()
             .register_type::<AnimationPlayer>()
+            .register_type::<PlayingAnimation>()
             .add_systems(
                 PostUpdate,
                 animation_player.before(TransformSystem::TransformPropagate),


### PR DESCRIPTION
# Objective

`bevy_animation::PlayingAnimation` derives `Reflect` but is not registered.

## Solution

Register `bevy_animation::PlayingAnimation`.