### PR TITLE
Run `update_previous_view_projections` in `PreUpdate` schedule

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -1,4 +1,4 @@
-use bevy_app::{Plugin, PreUpdate, Update};
+use bevy_app::{Plugin, PreUpdate};
 use bevy_asset::{load_internal_asset, AssetServer, Handle, HandleUntyped};
 use bevy_core_pipeline::{
     prelude::Camera3d,
@@ -141,9 +141,15 @@ where
 
         if no_prepass_plugin_loaded {
             app.insert_resource(AnyPrepassPluginLoaded)
-                .add_systems(Update, update_previous_view_projections)
                 // At the start of each frame, last frame's GlobalTransforms become this frame's PreviousGlobalTransforms
-                .add_systems(PreUpdate, update_mesh_previous_global_transforms);
+                // and last frame's view projection matrices become this frame's PreviousViewProjections
+                .add_systems(
+                    PreUpdate,
+                    (
+                        update_mesh_previous_global_transforms,
+                        update_previous_view_projections,
+                    ),
+                );
         }
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {


### PR DESCRIPTION
# Objective

- Fixes #8630.

## Solution

Since a camera's view and projection matrices are modified during `PostUpdate` in `camera_system` and `propagate_transforms`, it is fine to move `update_previous_view_projections` from `Update` to `PreUpdate`. 
Doing so adds consistence with `update_mesh_previous_global_transforms` and allows systems in `Update` to use `PreviousViewProjection` correctly without explicit ordering.

