### PR TITLE
Rename Interaction::Clicked -> Interaction::Pressed (#8989)

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -35,7 +35,9 @@ use smallvec::SmallVec;
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
-    /// The node has been pressed (Note: This does not capture click/press-release action)
+    /// The node has been pressed.
+    /// 
+    /// Note: This does not capture click/press-release action.
     Pressed,
     /// The node has been hovered over
     Hovered,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -35,8 +35,8 @@ use smallvec::SmallVec;
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
-    /// The node has been clicked
-    Clicked,
+    /// The node has been pressed
+    Pressed,
     /// The node has been hovered over
     Hovered,
     /// Nothing has happened
@@ -154,7 +154,7 @@ pub fn ui_focus_system(
     if mouse_released {
         for node in node_query.iter_mut() {
             if let Some(mut interaction) = node.interaction {
-                if *interaction == Interaction::Clicked {
+                if *interaction == Interaction::Pressed {
                     *interaction = Interaction::None;
                 }
             }
@@ -255,15 +255,15 @@ pub fn ui_focus_system(
         .collect::<Vec<Entity>>()
         .into_iter();
 
-    // set Clicked or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
+    // set Pressed or Hovered on top nodes. as soon as a node with a `Block` focus policy is detected,
     // the iteration will stop on it because it "captures" the interaction.
     let mut iter = node_query.iter_many_mut(hovered_nodes.by_ref());
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
             if mouse_clicked {
-                // only consider nodes with Interaction "clickable"
-                if *interaction != Interaction::Clicked {
-                    *interaction = Interaction::Clicked;
+                // only consider nodes with Interaction "pressed"
+                if *interaction != Interaction::Pressed {
+                    *interaction = Interaction::Pressed;
                     // if the mouse was simultaneously released, reset this Interaction in the next
                     // frame
                     if mouse_released {
@@ -279,7 +279,7 @@ pub fn ui_focus_system(
             FocusPolicy::Block => {
                 break;
             }
-            FocusPolicy::Pass => { /* allow the next node to be hovered/clicked */ }
+            FocusPolicy::Pass => { /* allow the next node to be hovered/pressed */ }
         }
     }
     // reset `Interaction` for the remaining lower nodes to `None`. those are the nodes that remain in
@@ -287,8 +287,8 @@ pub fn ui_focus_system(
     let mut iter = node_query.iter_many_mut(hovered_nodes);
     while let Some(node) = iter.fetch_next() {
         if let Some(mut interaction) = node.interaction {
-            // don't reset clicked nodes because they're handled separately
-            if *interaction != Interaction::Clicked {
+            // don't reset pressed nodes because they're handled separately
+            if *interaction != Interaction::Pressed {
                 interaction.set_if_neq(Interaction::None);
             }
         }

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -35,7 +35,7 @@ use smallvec::SmallVec;
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
-    /// The node has been pressed
+    /// The node has been pressed (Note: This does not capture click/press-release action)
     Pressed,
     /// The node has been hovered over
     Hovered,

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -36,7 +36,7 @@ use smallvec::SmallVec;
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub enum Interaction {
     /// The node has been pressed.
-    /// 
+    ///
     /// Note: This does not capture click/press-release action.
     Pressed,
     /// The node has been hovered over

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -99,7 +99,7 @@ fn menu(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 *color = PRESSED_BUTTON.into();
                 next_state.set(AppState::InGame);
             }

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -362,7 +362,7 @@ mod menu {
     ) {
         for (interaction, mut color, selected) in &mut interaction_query {
             *color = match (*interaction, selected) {
-                (Interaction::Clicked, _) | (Interaction::None, Some(_)) => PRESSED_BUTTON.into(),
+                (Interaction::Pressed, _) | (Interaction::None, Some(_)) => PRESSED_BUTTON.into(),
                 (Interaction::Hovered, Some(_)) => HOVERED_PRESSED_BUTTON.into(),
                 (Interaction::Hovered, None) => HOVERED_BUTTON.into(),
                 (Interaction::None, None) => NORMAL_BUTTON.into(),
@@ -379,7 +379,7 @@ mod menu {
         mut setting: ResMut<T>,
     ) {
         for (interaction, button_setting, entity) in &interaction_query {
-            if *interaction == Interaction::Clicked && *setting != *button_setting {
+            if *interaction == Interaction::Pressed && *setting != *button_setting {
                 let (previous_button, mut previous_color) = selected_query.single_mut();
                 *previous_color = NORMAL_BUTTON.into();
                 commands.entity(previous_button).remove::<SelectedOption>();
@@ -789,7 +789,7 @@ mod menu {
         mut game_state: ResMut<NextState<GameState>>,
     ) {
         for (interaction, menu_button_action) in &interaction_query {
-            if *interaction == Interaction::Clicked {
+            if *interaction == Interaction::Pressed {
                 match menu_button_action {
                     MenuButtonAction::Quit => app_exit_events.send(AppExit),
                     MenuButtonAction::Play => {

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -139,7 +139,7 @@ fn button_handler(
 ) {
     for (interaction, mut color) in &mut interaction_query {
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 *color = Color::BLUE.into();
             }
             Interaction::Hovered => {

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -32,7 +32,7 @@ fn button_system(
     for (interaction, mut color, mut border_color, children) in &mut interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 text.sections[0].value = "Press".to_string();
                 *color = PRESSED_BUTTON.into();
                 border_color.0 = Color::RED;

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -442,7 +442,7 @@ fn buttons_handler<T>(
     Target<T>: TargetUpdate + Component,
 {
     for (target, interaction, children) in visibility_button_query.iter_mut() {
-        if matches!(interaction, Interaction::Clicked) {
+        if matches!(interaction, Interaction::Pressed) {
             let mut target_value = left_panel_query.get_mut(target.id).unwrap();
             for &child in children {
                 if let Ok(mut text) = text_query.get_mut(child) {

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -306,7 +306,7 @@ fn update_buttons(
     let mut style = bar_query.single_mut();
     for (button_id, interaction, constraint, value) in button_query.iter_mut() {
         match interaction {
-            Interaction::Clicked => {
+            Interaction::Pressed => {
                 button_activated_event.send(ButtonActivatedEvent(button_id));
                 match constraint {
                     Constraint::FlexBasis => {


### PR DESCRIPTION
# Objective

- Fixes #8989

## Solution

- Renamed Interaction::Clicked -> Interaction::Pressed
- Minor changes to comments to keep clarity of terms

## Migration Guide

- Rename all instances of Interaction::Clicked -> Interaction::Pressed