### PR TITLE
Use a consistent seed for AABB gizmo colors

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -16,7 +16,6 @@
 //!
 //! See the documentation on [`Gizmos`](crate::gizmos::Gizmos) for more examples.
 
-use std::hash::{Hash, Hasher};
 use std::mem;
 
 use bevy_app::{Last, Plugin, Update};
@@ -52,7 +51,6 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::AHasher;
 
 pub mod gizmos;
 
@@ -235,12 +233,13 @@ fn draw_all_aabbs(
 }
 
 fn color_from_entity(entity: Entity) -> Color {
+    use bevy_utils::RandomState;
     const U64_TO_DEGREES: f32 = 360.0 / u64::MAX as f32;
+    const STATE: RandomState =
+        RandomState::with_seeds(5952553601252303067, 16866614500153072625, 0, 0);
 
-    let mut hasher = AHasher::default();
-    entity.hash(&mut hasher);
-
-    let hue = hasher.finish() as f32 * U64_TO_DEGREES;
+    let hash = STATE.hash_one(entity);
+    let hue = hash as f32 * U64_TO_DEGREES;
     Color::hsl(hue, 1., 0.5)
 }
 


### PR DESCRIPTION
# Objective

The bounding box colors are from bevy_gizmo are randomized between app runs. This can get confusing for users.

## Solution

Use a fixed seed with `RandomState::with_seeds` rather than initializing a `AHash`.
The random number was chose so that the first few colors are clearly distinct.

According to the `RandomState::hash_one` documentation, it's also faster.

![bevy_bounding_box_colors_2023-07-03](https://github.com/bevyengine/bevy/assets/26321040/676f0389-d00e-4edd-bd77-1fbf73a3d9fa)

---

## Changelog

* bevy_gizmo: Keep a consistent color for AABBs of identical entities between runs