### PR TITLE
Remove reference to base sets

### DIFF
--- a/crates/bevy_ecs/src/schedule/graph_utils.rs
+++ b/crates/bevy_ecs/src/schedule/graph_utils.rs
@@ -76,7 +76,6 @@ pub(crate) struct GraphInfo {
     pub(crate) sets: Vec<BoxedSystemSet>,
     pub(crate) dependencies: Vec<Dependency>,
     pub(crate) ambiguous_with: Ambiguity,
-    pub(crate) base_set: Option<BoxedSystemSet>,
 }
 
 /// Converts 2D row-major pair of indices into a 1D array index.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -747,10 +747,6 @@ impl ScheduleGraph {
             self.check_set(id, &**set)?;
         }
 
-        if let Some(base_set) = &graph_info.base_set {
-            self.check_set(id, &**base_set)?;
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
# Objective

- Remove all references to base sets following schedule-first rework

## Solution

- Remove last references to base sets in `GraphInfo`