### PR TITLE
`UiRect` builder methods

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -330,8 +330,8 @@ impl UiRect {
     /// # use bevy_ui::{UiRect, Val};
     /// #
     /// let ui_rect = UiRect::all(Val::Vw(25.)).with_left(Val::Px(10.));
-    /// assert_eq!(ui_rect.left, Val::Vw(10.));
-    /// assert_eq!(ui_rect.right, Val::Px(25.));
+    /// assert_eq!(ui_rect.left, Val::Px(10.));
+    /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
     /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
     /// ```

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -334,6 +334,8 @@ impl UiRect {
     /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
     /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    ///
+    /// assert_eq!(UiRect::DEFAULT.with_left(Val::Percent(35.)), UiRect::left(Val::Percent(35.)));
     /// ```
     #[inline]
     pub fn with_left(mut self, left: Val) -> UiRect {
@@ -353,6 +355,8 @@ impl UiRect {
     /// assert_eq!(ui_rect.right, Val::Px(10.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
     /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    ///
+    /// assert_eq!(UiRect::DEFAULT.with_right(Val::Percent(35.)), UiRect::right(Val::Percent(35.)));
     /// ```
     #[inline]
     pub fn with_right(mut self, right: Val) -> UiRect {
@@ -372,6 +376,8 @@ impl UiRect {
     /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Px(10.));
     /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    ///
+    /// assert_eq!(UiRect::DEFAULT.with_top(Val::Percent(35.)), UiRect::top(Val::Percent(35.)));
     /// ```
     #[inline]
     pub fn with_top(mut self, top: Val) -> UiRect {
@@ -391,6 +397,8 @@ impl UiRect {
     /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
+    ///
+    /// assert_eq!(UiRect::DEFAULT.with_bottom(Val::Percent(35.)), UiRect::bottom(Val::Percent(35.)));
     /// ```
     #[inline]
     pub fn with_bottom(mut self, bottom: Val) -> UiRect {

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -329,7 +329,7 @@ impl UiRect {
     /// ```
     /// # use bevy_ui::{UiRect, Val};
     /// #
-    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_left(Val::Px(10.);
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_left(Val::Px(10.));
     /// assert_eq!(ui_rect.left, Val::Vw(10.));
     /// assert_eq!(ui_rect.right, Val::Px(25.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
@@ -348,7 +348,7 @@ impl UiRect {
     /// ```
     /// # use bevy_ui::{UiRect, Val};
     /// #
-    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_right(Val::Px(10.);
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_right(Val::Px(10.));
     /// assert_eq!(ui_rect.left, Val::Vw(25.));
     /// assert_eq!(ui_rect.right, Val::Px(10.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));
@@ -367,7 +367,7 @@ impl UiRect {
     /// ```
     /// # use bevy_ui::{UiRect, Val};
     /// #
-    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_top(Val::Px(10.);
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_top(Val::Px(10.));
     /// assert_eq!(ui_rect.left, Val::Vw(25.));
     /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Px(10.));
@@ -386,7 +386,7 @@ impl UiRect {
     /// ```
     /// # use bevy_ui::{UiRect, Val};
     /// #
-    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_bottom(Val::Px(10.);
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_bottom(Val::Px(10.));
     /// assert_eq!(ui_rect.left, Val::Vw(25.));
     /// assert_eq!(ui_rect.right, Val::Vw(25.));
     /// assert_eq!(ui_rect.top, Val::Vw(25.));

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -321,6 +321,82 @@ impl UiRect {
             ..Default::default()
         }
     }
+
+    /// Returns the [`UiRect`] with its `left` field set to the given value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ui::{UiRect, Val};
+    /// #
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_left(Val::Px(10.);
+    /// assert_eq!(ui_rect.left, Val::Vw(10.));
+    /// assert_eq!(ui_rect.right, Val::Px(25.));
+    /// assert_eq!(ui_rect.top, Val::Vw(25.));
+    /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    /// ```
+    #[inline]
+    pub fn with_left(mut self, left: Val) -> UiRect {
+        self.left = left;
+        self
+    }
+
+    /// Returns the [`UiRect`] with its `right` field set to the given value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ui::{UiRect, Val};
+    /// #
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_right(Val::Px(10.);
+    /// assert_eq!(ui_rect.left, Val::Vw(25.));
+    /// assert_eq!(ui_rect.right, Val::Px(10.));
+    /// assert_eq!(ui_rect.top, Val::Vw(25.));
+    /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    /// ```
+    #[inline]
+    pub fn with_right(mut self, right: Val) -> UiRect {
+        self.right = right;
+        self
+    }
+
+    /// Returns the [`UiRect`] with its `top` field set to the given value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ui::{UiRect, Val};
+    /// #
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_top(Val::Px(10.);
+    /// assert_eq!(ui_rect.left, Val::Vw(25.));
+    /// assert_eq!(ui_rect.right, Val::Vw(25.));
+    /// assert_eq!(ui_rect.top, Val::Px(10.));
+    /// assert_eq!(ui_rect.bottom, Val::Vw(25.0));
+    /// ```
+    #[inline]
+    pub fn with_top(mut self, top: Val) -> UiRect {
+        self.top = top;
+        self
+    }
+
+    /// Returns the [`UiRect`] with its `bottom` field set to the given value.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ui::{UiRect, Val};
+    /// #
+    /// let ui_rect = UiRect::all(Val::Vw(25.)).with_bottom(Val::Px(10.);
+    /// assert_eq!(ui_rect.left, Val::Vw(25.));
+    /// assert_eq!(ui_rect.right, Val::Vw(25.));
+    /// assert_eq!(ui_rect.top, Val::Vw(25.));
+    /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
+    /// ```
+    #[inline]
+    pub fn with_bottom(mut self, bottom: Val) -> UiRect {
+        self.bottom = bottom;
+        self
+    }
 }
 
 impl Default for UiRect {


### PR DESCRIPTION
# Objective

Add `with_left`, `with_right`, `with_top` and `with_bottom` builder methods to `UiRect`.

Found these more convenient sometimes when writing test cases than the current alternatives.  

---

## Changelog

`bevy_ui::geometry::UiRect`
* Added `with_left`, `with_right`, `with_top` and `with_bottom` builder methods to `UiRect`.