### PR TITLE
Remove unused dependency on once_cell in bevy_render

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -65,7 +65,6 @@ serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }
 smallvec = { version = "1.6", features = ["union", "const_generics"] }
-once_cell = "1.4.1" # TODO: replace once_cell with std equivalent if/when this lands: https://github.com/rust-lang/rfcs/pull/2788
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -43,7 +43,6 @@ pub mod prelude {
 
 use bevy_window::{PrimaryWindow, RawHandleWrapper};
 use globals::GlobalsPlugin;
-pub use once_cell;
 use renderer::{RenderAdapter, RenderAdapterInfo, RenderDevice, RenderQueue};
 use wgpu::Instance;
 


### PR DESCRIPTION
# Objective

bevy_render currently has a dependency on a random older version of once_cell which is not used anywhere.

## Solution

Remove the dependency

## Changelog

N/A

## Migration Guide

N/A
