### PR TITLE
More informations for query errors

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -229,7 +229,7 @@ pub struct FilteredAccess<T: SparseSetIndex> {
     access: Access<T>,
     // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
     // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
-    filter_sets: Vec<AccessFilters<T>>,
+    pub(crate) filter_sets: Vec<AccessFilters<T>>,
 }
 
 impl<T: SparseSetIndex> Default for FilteredAccess<T> {
@@ -380,9 +380,9 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 }
 
 #[derive(Clone, Eq, PartialEq)]
-struct AccessFilters<T> {
-    with: FixedBitSet,
-    without: FixedBitSet,
+pub(crate) struct AccessFilters<T> {
+    pub(crate) with: FixedBitSet,
+    pub(crate) without: FixedBitSet,
     _index_type: PhantomData<T>,
 }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1427,7 +1427,7 @@ pub enum QueryEntityMismatchDetail {
 /// Represents which [`Entity`]'s component do not match a [`Query`](crate::system::Query) or [`QueryState`].
 ///
 /// Will be returned automatically with [`QueryEntityMismatchDetail::ComponentMismatch`],
-/// or can be requested manually with [`QueryState::get_mismatch_details_unchecked`].
+/// or can be requested manually with [`QueryState::get_mismatches_detail`].
 ///
 /// This is usually used in an array because of a query like `QueryState<A, Or<(With<B>, With<C)>>`
 /// is separated into two queries `QueryState<A, With<B>>` and `QueryState<A, With<B>>`,

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -511,7 +511,7 @@ mod tests {
         },
         system::{
             adapter::new, Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
-            QueryComponentError, Res, ResMut, Resource, System, SystemState,
+            QueryComponentError, QueryComponentErrorDetails, Res, ResMut, Resource, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -1726,7 +1726,13 @@ mod tests {
         run_system(&mut world, move |q: Query<&mut W<u32>>| {
             let mut rq = q.to_readonly();
             assert_eq!(
-                QueryComponentError::MissingWriteAccess,
+                QueryComponentError::MissingWriteAccess(
+                    QueryComponentErrorDetails {
+                        requested_entity: entity,
+                        requested_component: "W<u32>",
+                        query_type: "Query<'_, '_, &W<u32>>",
+                    }
+                ),
                 rq.get_component_mut::<W<u32>>(entity).unwrap_err(),
             );
         });

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1729,8 +1729,8 @@ mod tests {
             assert_eq!(
                 QueryComponentError::MissingWriteAccess(QueryComponentErrorDetail {
                     requested_entity: entity,
-                    requested_component: "W<u32>",
-                    query_type: "Query<'_, '_, &W<u32>>",
+                    requested_component: "bevy_ecs::system::tests::W<u32>",
+                    query_type: "bevy_ecs::system::query::Query<&bevy_ecs::system::tests::W<u32>>",
                 }),
                 rq.get_component_mut::<W<u32>>(entity).unwrap_err(),
             );

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -511,7 +511,8 @@ mod tests {
         },
         system::{
             adapter::new, Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
-            QueryComponentError, QueryComponentErrorDetails, Res, ResMut, Resource, System, SystemState,
+            QueryComponentError, QueryComponentErrorDetails, Res, ResMut, Resource, System,
+            SystemState,
         },
         world::{FromWorld, World},
     };
@@ -1726,13 +1727,11 @@ mod tests {
         run_system(&mut world, move |q: Query<&mut W<u32>>| {
             let mut rq = q.to_readonly();
             assert_eq!(
-                QueryComponentError::MissingWriteAccess(
-                    QueryComponentErrorDetails {
-                        requested_entity: entity,
-                        requested_component: "W<u32>",
-                        query_type: "Query<'_, '_, &W<u32>>",
-                    }
-                ),
+                QueryComponentError::MissingWriteAccess(QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: "W<u32>",
+                    query_type: "Query<'_, '_, &W<u32>>",
+                }),
                 rq.get_component_mut::<W<u32>>(entity).unwrap_err(),
             );
         });

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -511,7 +511,7 @@ mod tests {
         },
         system::{
             adapter::new, Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
-            QueryComponentError, QueryComponentErrorDetails, Res, ResMut, Resource, System,
+            QueryComponentError, QueryComponentErrorDetail, Res, ResMut, Resource, System,
             SystemState,
         },
         world::{FromWorld, World},
@@ -1727,7 +1727,7 @@ mod tests {
         run_system(&mut world, move |q: Query<&mut W<u32>>| {
             let mut rq = q.to_readonly();
             assert_eq!(
-                QueryComponentError::MissingWriteAccess(QueryComponentErrorDetails {
+                QueryComponentError::MissingWriteAccess(QueryComponentErrorDetail {
                     requested_entity: entity,
                     requested_component: "W<u32>",
                     query_type: "Query<'_, '_, &W<u32>>",

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1062,7 +1062,9 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// Returns a shared reference to the component `T` of the given [`Entity`].
     ///
-    /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
+    /// In case of a nonexisting entity, if the entity doesn't have the requested component,
+    /// or if the query doesn't have read access to this component,
+    /// a [`QueryEntityError`] is returned instead.
     ///
     /// # Example
     ///
@@ -1096,15 +1098,38 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         let world = self.world;
         let entity_ref = world
             .get_entity(entity)
-            .ok_or(QueryComponentError::NoSuchEntity)?;
+            .ok_or(QueryComponentError::NoSuchEntity(
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
+        todo!();
         let component_id = world
             .components()
             .get_id(TypeId::of::<T>())
-            .ok_or(QueryComponentError::MissingComponent)?;
+            .ok_or(QueryComponentError::MissingComponent(
+                "",
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
+        
+        todo!();
         let archetype_component = entity_ref
             .archetype()
             .get_archetype_component_id(component_id)
-            .ok_or(QueryComponentError::MissingComponent)?;
+            .ok_or(QueryComponentError::MissingComponent(
+                "",
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
         if self
             .state
             .archetype_component_access
@@ -1112,15 +1137,31 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         {
             // SAFETY: `self.world` must have access to the component `T` for this entity,
             // since it was registered in `self.state`'s archetype component access set.
-            unsafe { entity_ref.get::<T>() }.ok_or(QueryComponentError::MissingComponent)
+            todo!();
+            unsafe { entity_ref.get::<T>() }.ok_or(QueryComponentError::MissingComponent(
+                "",
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))
         } else {
-            Err(QueryComponentError::MissingReadAccess)
+            Err(QueryComponentError::MissingReadAccess(
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))
         }
     }
 
     /// Returns a mutable reference to the component `T` of the given entity.
     ///
-    /// In case of a nonexisting entity or mismatched component, a [`QueryComponentError`] is returned instead.
+    /// In case of a nonexisting entity, if the entity doesn't have the requested component,
+    /// or if the query doesn't have read access to this component,
+    /// a [`QueryEntityError`] is returned instead.
     ///
     /// # Example
     ///
@@ -1174,30 +1215,72 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         // SAFETY: this check is required to ensure soundness in the case of `to_readonly().get_component_mut()`
         // See the comments on the `force_read_only_component_access` field for more info.
         if self.force_read_only_component_access {
-            return Err(QueryComponentError::MissingWriteAccess);
+            return Err(QueryComponentError::MissingWriteAccess(
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ));
         }
         let world = self.world;
         let entity_ref = world
             .get_entity(entity)
-            .ok_or(QueryComponentError::NoSuchEntity)?;
+            .ok_or(QueryComponentError::NoSuchEntity(
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
+        todo!();
         let component_id = world
             .components()
             .get_id(TypeId::of::<T>())
-            .ok_or(QueryComponentError::MissingComponent)?;
+            .ok_or(QueryComponentError::MissingComponent(
+                "",
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
+        todo!();
         let archetype_component = entity_ref
             .archetype()
             .get_archetype_component_id(component_id)
-            .ok_or(QueryComponentError::MissingComponent)?;
+            .ok_or(QueryComponentError::MissingComponent(
+                "",
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))?;
         if self
             .state
             .archetype_component_access
             .has_write(archetype_component)
         {
+            todo!();
             entity_ref
                 .get_mut_using_ticks::<T>(self.last_run, self.this_run)
-                .ok_or(QueryComponentError::MissingComponent)
+                .ok_or(QueryComponentError::MissingComponent(
+                    "",
+                    QueryComponentErrorDetails {
+                        requested_entity: entity,
+                        requested_component: std::any::type_name::<T>(),
+                        query_type: std::any::type_name::<Self>(),
+                    }
+                ))
         } else {
-            Err(QueryComponentError::MissingWriteAccess)
+            Err(QueryComponentError::MissingWriteAccess(
+                QueryComponentErrorDetails {
+                    requested_entity: entity,
+                    requested_component: std::any::type_name::<T>(),
+                    query_type: std::any::type_name::<Self>(),
+                }
+            ))
         }
     }
 
@@ -1458,7 +1541,7 @@ pub enum QueryComponentError {
     /// }
     /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
     /// ```
-    MissingReadAccess,
+    MissingReadAccess(QueryComponentErrorDetails),
     /// The [`Query`] does not have write access to the requested component.
     ///
     /// This error occurs when the requested component is not included in the original query, or the mutability of the requested component is mismatched with the original query.
@@ -1485,11 +1568,18 @@ pub enum QueryComponentError {
     /// }
     /// # bevy_ecs::system::assert_is_system(get_missing_write_access_error);
     /// ```
-    MissingWriteAccess,
+    MissingWriteAccess(QueryComponentErrorDetails),
     /// The given [`Entity`] does not have the requested component.
-    MissingComponent,
+    MissingComponent(&'static str, QueryComponentErrorDetails),
     /// The requested [`Entity`] does not exist.
-    NoSuchEntity,
+    NoSuchEntity(QueryComponentErrorDetails),
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct QueryComponentErrorDetails {
+    pub requested_entity: Entity,
+    pub requested_component: &'static str,
+    pub query_type: &'static str,
 }
 
 impl std::error::Error for QueryComponentError {}
@@ -1497,23 +1587,46 @@ impl std::error::Error for QueryComponentError {}
 impl std::fmt::Display for QueryComponentError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            QueryComponentError::MissingReadAccess => {
+            QueryComponentError::MissingReadAccess(
+                QueryComponentErrorDetails{requested_component, query_type, ..}
+            ) => {
                 write!(
                     f,
-                    "This query does not have read access to the requested component."
+                    "The query {} does not have read access to the requested component {}.",
+                    requested_component,
+                    query_type
                 )
             }
-            QueryComponentError::MissingWriteAccess => {
+            QueryComponentError::MissingWriteAccess(
+                QueryComponentErrorDetails{requested_component, query_type, ..}
+            ) => {
                 write!(
                     f,
-                    "This query does not have write access to the requested component."
+                    "The query {} does not have write access to the requested component {}.",
+                    requested_component,
+                    query_type
                 )
             }
-            QueryComponentError::MissingComponent => {
-                write!(f, "The given entity does not have the requested component.")
+            QueryComponentError::MissingComponent(
+                component,
+                QueryComponentErrorDetails{requested_entity, requested_component, ..}
+            ) => {
+                todo!();
+                write!(
+                    f,
+                    "The given entity {} does not have the requested component {}.",
+                    requested_entity.index(),
+                    requested_component
+                )
             }
-            QueryComponentError::NoSuchEntity => {
-                write!(f, "The requested entity does not exist.")
+            QueryComponentError::NoSuchEntity(
+                QueryComponentErrorDetails{requested_entity, ..}
+            ) => {
+                write!(
+                    f,
+                    "The requested entity {} does not exist.",
+                    requested_entity.index(),
+                )
             }
         }
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1467,7 +1467,7 @@ pub enum QueryComponentError {
     /// # Example
     ///
     /// ```
-    /// # use bevy_ecs::{prelude::*, system::QueryComponentError};
+    /// # use bevy_ecs::{prelude::*, system::{QueryComponentError, QueryComponentErrorDetail}};
     /// #
     /// # #[derive(Component)]
     /// # struct OtherComponent;
@@ -1503,7 +1503,7 @@ pub enum QueryComponentError {
     /// # Example
     ///
     /// ```
-    /// # use bevy_ecs::{prelude::*, system::QueryComponentError};
+    /// # use bevy_ecs::{prelude::*, system::{QueryComponentError, QueryComponentErrorDetail}};
     /// #
     /// # #[derive(Component, PartialEq, Debug)]
     /// # struct RequestedComponent;
@@ -1601,11 +1601,11 @@ impl std::fmt::Display for QueryComponentError {
 
 impl QueryComponentErrorDetail {
     /// Creates a [`QueryComponentErrorDetail`] given a [`Query`], a [`Component`] and an [`Entity`].
-    pub fn from<Query, C: Component>(entity: Entity) -> QueryComponentErrorDetail {
+    pub fn from<Q, C: Component>(entity: Entity) -> QueryComponentErrorDetail {
         QueryComponentErrorDetail {
             requested_entity: entity,
             requested_component: std::any::type_name::<C>(),
-            query_type: std::any::type_name::<Self>(),
+            query_type: std::any::type_name::<Q>(),
         }
     }
 }


### PR DESCRIPTION
# Objective

1. Fix #8917 : add information about query/entity mismatch for `get`/`get_mut`, ...
2. Fix https://github.com/bevyengine/bevy/issues/8917#issuecomment-1601244691 : add information about query errors in general.
3. Fix #9011 : fix documentation for `get_component`/`get_component_mut`
4. Try to make the documentation for queries better in general.

## Solution

1. Query Entity Component Mismatch:
- Add `QueryEntityMismatchDetail` and `QueryEntityComponentMismatch`.
- Add `get_mismatches_detail` to get the `QueryEntityComponentMismatch` array.
- I didn't handle the logic to get more information in case of a `ChangeDetectionMismatch`, because I have no idea how to get this information.
2. More information in general
- Add `QueryComponentErrorDetail` and `QueryEntityErrorDetail`, I think it's better to put a struct instead of a tuple to know what is what, but I left a singleton tuple in `QuerySingleError` because there's only one information to get here.
- Use `std::any` to fill the type representations of the query/component.

For 3 and 4, just update the documentation.

## Summary of the new structures

(I didn't put all the comments/derive, and didn't put `QuerySingleError` since it didn't change)

For `QueryComponentError`:
```rust
pub enum QueryComponentError {
    /// The [`Query`] does not have read access to the requested component.
    MissingReadAccess(QueryComponentErrorDetail),
    /// The [`Query`] does not have write access to the requested component.
    MissingWriteAccess(QueryComponentErrorDetail),
    /// The given [`Entity`] does not have the requested component.
    MissingComponent(QueryComponentErrorDetail),
    /// The requested [`Entity`] does not exist.
    NoSuchEntity(QueryComponentErrorDetail),
}

/// Additional information in the context of a [`QueryComponentError`].
pub struct QueryComponentErrorDetail {
    /// Specific entity which was requested when encountering the error.
    pub requested_entity: Entity,
    /// Component which was requested when encountering the error.
    pub requested_component: &'static str,
    /// Representation of the query's type.
    pub query_type: &'static str,
}
```

For `QueryEntityError`:
```rust
pub enum QueryEntityError {
    /// The given [`Entity`]'s components do not match the query, see [`QueryEntityMismatchDetail`].
    QueryDoesNotMatch(QueryEntityMismatchDetail, QueryEntityErrorDetail),
    /// The given [`Entity`] does not exist.
    NoSuchEntity(QueryEntityErrorDetail),
    /// The [`Entity`] was requested mutably more than once.
    AliasedMutability(QueryEntityErrorDetail),
}

/// Additional information in the context of a [`QueryEntityError`].
pub struct QueryEntityErrorDetail {
    /// Specific entity which was requested when encountering the error.
    pub requested_entity: Entity,
    /// Representation of the query's type.
    pub query_type: &'static str,
}

/// Diagnosis about why an [`Entity`] and a [`Query`](crate::system::Query) or [`QueryState`] don't match.
pub enum QueryEntityMismatchDetail {
    /// The entity is missing components required by the query,
    /// or it has components that are filtered out by the query.
    ComponentMismatch(Vec<QueryEntityComponentMismatch>),
    /// The entity has the correct components, but some of them are requested
    /// with change detection ([`Added`](crate::query::Added) or [`Changed`](crate::query::Changed))
    /// and the component for that entity is not in that change state.
    ChangeDetectionMismatch,
}

/// Represents which [`Entity`]'s component do not match a [`Query`](crate::system::Query) or [`QueryState`].
///
/// This is usually used in an array because of a query like `QueryState<A, Or<(With<B>, With<C)>>`
/// is separated into two queries `QueryState<A, With<B>>` and `QueryState<A, With<B>>`,
/// in that case a single `QueryEntityMismatchDetail` represents the reasons the entity
/// doesn't match one of those "sub-queries".
pub struct QueryEntityComponentMismatch {
    /// Components that the query requires but the entity doesn't have,
    /// with a representation of their name.
    pub query_with_components_not_in_entity: Vec<(String, ComponentId)>,
    /// Components that the query filters out but the entity have,
    /// with a representation of their name.
    pub query_without_components_in_entity: Vec<(String, ComponentId)>,
    /// [`Archetype`] of the entity, used to retrieve its components.
    pub entity_archetype: ArchetypeId,
    /// Components that the query requires.
    pub query_with_components: FixedBitSet,
    /// Components that the query filters out.
    pub query_without_components: FixedBitSet,
}
```

## Code to test quickly

If you think of other scenarios to test please tell me or test yourself.

```rust
use bevy::prelude::*;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_systems(Startup, setup)
        .add_systems(Update, debug)
        .run();
}

#[derive(Resource)]
struct TestResource {
    entity: Entity
}

fn setup(
    mut commands: Commands,
) {
    let entity = commands.spawn((
        Transform::default(),
        Visibility::default(),
    )).id();
    commands.insert_resource(TestResource{entity});
}

fn debug(
    test_res: Res<TestResource>,
    test_q1: Query<&Transform, Without<Visibility>>,
    test_q2: Query<&Transform, With<GlobalTransform>>,
    test_q3: Query<&Transform, &GlobalTransform>,
    test_q4: Query<&Transform, Or<(Without<Visibility>, With<GlobalTransform>)>>,
    test_q5: Query<&Transform, Added<Visibility>>,
    test_q6: Query<&Transform, Changed<Visibility>>,
) {
    let e = test_res.entity;
    dbg!("_______________________1");
    dbg!(test_q1.get(e));
    dbg!("_______________________2");
    dbg!(test_q2.get(e));
    dbg!("_______________________3");
    dbg!(test_q3.get(e));
    dbg!("_______________________4");
    dbg!(test_q4.get(e));
    dbg!("_______________________5");
    dbg!(test_q5.get(e));
    dbg!("_______________________6");
    dbg!(test_q6.get(e));
}
```

## Drawbacks

This gives more information about why an error happened, and can allow easier generic logic to handle them, but at three costs:
- the `Result` can take more memory if the components requested take less space than the error struct
- the error struct itself takes more memory when an error occurs
- when an error occurs, more computation is needed
All of this even if the end user doesn't really need that information.

I don't think it's a really big deal since the error struct is basically pointers to `Vec` and `String`, errors are not supposed to happen very often, and functions like `contains` can be used to just check if an entity is fetched by a query.

Maybe the error could be computed in debug mode only or be behind a feature or something?

## Notes

- It's the first time I really dive into the ECS code, some stuff aren't clear for me so I may have made mistakes.
- `QueryEntityMismatchDetail` is just an enum, that could be merged with `QueryEntityError` (in `QueryEntityError`, have a variant `QueryDoesNotMatchComponents` and `QueryDoesNotMatchChangeDetection` for example), but I decided against it to avoid a too big breaking change, and to allow for potential additional "mismatch" causes in the future.
- I left `get_mismatches_detail` public but it maybe doesn't need to be, also to not make it unsafe I put specialized arguments instead of taking an `UnsafeWorldCell`. Maybe a more user-friendly `get_mismatches_detail` can be created alongside this one.
- My logic in `get_mismatches_detail` isn't very "rusty" (for loops inside of iterators), you can make it better if you have suggestions to change it.
- As stated above, I didn't handle the logic with change detection, if you have an idea on how to do that, it would be appreciated, I'm not sure where that information is in the `QueryState` (`filter_state`?) and how to retrieve it.

---

## Changelog

- Changed `QueryEntityError`'s variants to add more information on the error.
- Changed `QueryComponentError`'s variants to add more information on the error.

## Migration Guide

- `QueryEntityError`'s variants now have a `QueryEntityErrorDetail` singleton instead of `Entity`, and `QueryDoesNotMatch` also have `QueryEntityMismatchDetail`, you can ignore them in your pattern matching, or get the Entity from `QueryEntityErrorDetail`: `QueryEntityError::QueryDoesNotMatch(entity) => entity` becomes `QueryEntityError::QueryDoesNotMatch(_, error_details) => error_details.requested_entity`.
- `QueryComponentError`'s variants now have a `QueryComponentErrorDetail` singleton, you can just ignore it in your pattern matching: `QueryComponentError::MissingReadAccess => "missing read access"` becomes
 `QueryComponentError::MissingReadAccess(_) => "missing read access"`
