### PR TITLE
Remove unnecessary `clone_weak`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -398,7 +398,7 @@ pub fn extract_uinodes(
             } else {
                 (DEFAULT_IMAGE_HANDLE.typed(), false, false)
             };
-            
+
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
                 transform: transform.compute_matrix(),

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -396,9 +396,9 @@ pub fn extract_uinodes(
                 }
                 (image.texture.clone_weak(), image.flip_x, image.flip_y)
             } else {
-                (DEFAULT_IMAGE_HANDLE.typed().clone_weak(), false, false)
+                (DEFAULT_IMAGE_HANDLE.typed(), false, false)
             };
-
+            
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
                 transform: transform.compute_matrix(),


### PR DESCRIPTION
# Objective

In `extract_uinodes` it's not neccessary to clone the `DEFAULT_IMAGE_HANDLE.typed()` handle.