### PR TITLE
impl `From<Cow<Path>>` for `AssetPath`

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -189,6 +189,12 @@ impl<'a> From<PathBuf> for AssetPath<'a> {
     }
 }
 
+impl<'a> From<Cow<'a, Path>> for AssetPath<'a> {
+    fn from(path: Cow<'a, Path>) -> Self {
+        AssetPath { path, label: None }
+    }
+}
+
 impl<'a> From<String> for AssetPath<'a> {
     fn from(asset_path: String) -> Self {
         let mut parts = asset_path.splitn(2, '#');


### PR DESCRIPTION
# Objective

Creating an `AssetPath` from a `Cow<Path>` is a bit tricky :

```rust
let path: Cow<Path> = _;
let path = match path {
    Cow::Borrowed(path) => AssetPath::new_ref(path, None),
    Cow::Owned(path) => AssetPath::new(path, None),
};
```

## Solution

Implement `From<Cow<Path>>` for `AssetPath`.
