### PR TITLE
Complete initialization of plugins in `App::run`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -71,13 +71,6 @@ impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut App) {
         let run_mode = self.run_mode;
         app.set_runner(move |mut app: App| {
-            while !app.ready() {
-                #[cfg(not(target_arch = "wasm32"))]
-                bevy_tasks::tick_global_task_pools_on_main_thread();
-            }
-            app.finish();
-            app.cleanup();
-
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {


### PR DESCRIPTION
This pull request is mutually exclusive with #9054.

# Objective

Completing plugin initialization in `App::run` will prevent new bugs caused by uninitialized plugins in the runner function.

## Solution

Wait for asynchronous tasks to complete, then for each calls `Plugin::finish` and `Plugin::cleanup` in `App::run`.

---

## Changelog

- Changed to complete initialization of plugins with `App::run`.
- Removed `App::ready`.
- Removed `App::finish`.
- Removed `App::cleanup`.

## Migration Guide

Remove the plugin initialization code in the runner function because plugin initialization is complete in `App::run`.
