### PR TITLE
Add the required features for TonyMcMapface tonemapping to bevy_pbr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,14 +46,11 @@ default = [
   "bevy_ui",
   "png",
   "hdr",
-  "ktx2",
-  "zstd",
   "vorbis",
   "x11",
   "filesystem_watcher",
   "bevy_gizmos",
   "android_shared_stdcxx",
-  "tonemapping_luts",
   "default_font",
   "webgl2",
 ]
@@ -83,7 +80,15 @@ bevy_gilrs = ["bevy_internal/bevy_gilrs"]
 bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
 
 # Adds PBR rendering
-bevy_pbr = ["bevy_internal/bevy_pbr", "bevy_asset", "bevy_render", "bevy_core_pipeline"]
+bevy_pbr = [
+  "bevy_internal/bevy_pbr",
+  "bevy_asset",
+  "bevy_render",
+  "bevy_core_pipeline",
+  "ktx2",
+  "tonemapping_luts",
+  "zstd",
+]
 
 # Provides rendering functionality
 bevy_render = ["bevy_internal/bevy_render"]


### PR DESCRIPTION
# Objective

People keep running into issues with their materials being pink in 3rd party bevy libraries because we switched to TonyMcMapface for tonemapping, and they didn't realize they needed to include the `ktx2`, `tonemapping_luts`, and  `zstd` features for it to work properly.

## Solution

Add `ktx2`, `tonemapping_luts`, and  `zstd` to the `bevy_pbr` feature.

## Changelog

The `bevy_pbr` feature now includes the `ktx2`, `tonemapping_luts`, and  `zstd` features.

## Migration Guide

TODO