### PR TITLE
make accesskit_unix optional again

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 trace = []
 wayland = ["winit/wayland", "winit/wayland-csd-adwaita"]
 x11 = ["winit/x11"]
-accesskit_unix = ["accesskit_winit/accesskit_unix"]
+accesskit_unix = ["accesskit_winit/accesskit_unix", "accesskit_winit/async-io"]
 
 [dependencies]
 # bevy
@@ -29,7 +29,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.11.0-dev" }
 
 # other
 winit = { version = "0.28", default-features = false }
-accesskit_winit = { version = "0.14", default-features = false, features = ["async-io"] }
+accesskit_winit = { version = "0.14", default-features = false }
 approx = { version = "0.5", default-features = false }
 raw-window-handle = "0.5"
 


### PR DESCRIPTION
# Objective

- accesskit_unix is not optional anymore

## Solution

- Enable `async-io` feature of `accesskit_winit` only when `accesskit_unix` is enabled

