### PR TITLE
Include tone_mapping fn in tonemapping_test_patterns

### DIFF
--- a/assets/shaders/tonemapping_test_patterns.wgsl
+++ b/assets/shaders/tonemapping_test_patterns.wgsl
@@ -4,7 +4,7 @@
 #import bevy_pbr::utils               PI
 
 #ifdef TONEMAP_IN_SHADER
-#import bevy_core_pipeline::tonemapping
+#import bevy_core_pipeline::tonemapping tone_mapping
 #endif
 
 // Sweep across hues on y axis with value from 0.0 to +15EV across x axis 


### PR DESCRIPTION
`tonemapping_test_patterns` is missing the tone_mapping function when `TONEMAP_IN_SHADER`