### PR TITLE
Return URect instead of (UVec2, UVec2) in Camera::physical_viewport_rect

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -1,6 +1,6 @@
 use super::downsampling_pipeline::BloomUniforms;
 use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
-use bevy_math::{UVec4, Vec4};
+use bevy_math::{UVec4, Vec4, URect};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 
@@ -196,7 +196,7 @@ impl ExtractComponent for BloomSettings {
             camera.is_active,
             camera.hdr,
         ) {
-            (Some((origin, _)), Some(size), Some(target_size), true, true) => {
+            (Some(URect{min: origin, ..}), Some(size), Some(target_size), true, true) => {
                 let threshold = settings.prefilter_settings.threshold;
                 let threshold_softness = settings.prefilter_settings.threshold_softness;
                 let knee = threshold * threshold_softness.clamp(0.0, 1.0);

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -1,6 +1,6 @@
 use super::downsampling_pipeline::BloomUniforms;
 use bevy_ecs::{prelude::Component, query::QueryItem, reflect::ReflectComponent};
-use bevy_math::{UVec4, Vec4, URect};
+use bevy_math::{URect, UVec4, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 
@@ -196,7 +196,7 @@ impl ExtractComponent for BloomSettings {
             camera.is_active,
             camera.hdr,
         ) {
-            (Some(URect{min: origin, ..}), Some(size), Some(target_size), true, true) => {
+            (Some(URect { min: origin, .. }), Some(size), Some(target_size), true, true) => {
                 let threshold = settings.prefilter_settings.threshold;
                 let threshold_softness = settings.prefilter_settings.threshold_softness;
                 let knee = threshold * threshold_softness.clamp(0.0, 1.0);

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -19,8 +19,8 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         cubic_splines::{BSpline, Bezier, CardinalSpline, CubicGenerator, CubicSegment, Hermite},
-        BVec2, BVec3, BVec4, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect,
-        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4, URect, IRect
+        BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray,
+        Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
     };
 }
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -20,7 +20,7 @@ pub mod prelude {
     pub use crate::{
         cubic_splines::{BSpline, Bezier, CardinalSpline, CubicGenerator, CubicSegment, Hermite},
         BVec2, BVec3, BVec4, EulerRot, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray, Rect,
-        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        UVec2, UVec3, UVec4, Vec2, Vec3, Vec4, URect, IRect
     };
 }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -16,7 +16,7 @@ use crate::{
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
-use bevy_math::{Mat4, Rect, UVec4, Vec2, Vec3, Vec4Swizzles};
+use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
 use bevy_reflect::TypeUuid;
 use bevy_render::texture::DEFAULT_IMAGE_HANDLE;
 use bevy_render::{
@@ -455,7 +455,14 @@ pub fn extract_default_ui_camera_view<T: Component>(
         if matches!(camera_ui, Some(&UiCameraConfig { show_ui: false, .. })) {
             continue;
         }
-        if let (Some(logical_size), Some((physical_origin, _)), Some(physical_size)) = (
+        if let (
+            Some(logical_size),
+            Some(URect {
+                min: physical_origin,
+                ..
+            }),
+            Some(physical_size),
+        ) = (
             camera.logical_viewport_size(),
             camera.physical_viewport_rect(),
             camera.physical_viewport_size(),


### PR DESCRIPTION
# Objective

Continue #7867 now that we have URect #7984
 - Return `URect` instead of `(UVec2, UVec2)` in `Camera::physical_viewport_rect` 
 - Add `URect` and `IRect` to prelude

## Changelog

- Changed `Camera::physical_viewport_rect` return type from `(UVec2, UVec2)` to `URect`
- `URect` and `IRect` were added to prelude

## Migration Guide

Before:

```rust
fn view_physical_camera_rect(camera_query: Query<&Camera>) {
    let camera = camera_query.single();
    let Some((min, max)) = camera.physical_viewport_rect() else { return };
    dbg!(min, max);
}
```

After:

```rust
fn view_physical_camera_rect(camera_query: Query<&Camera>) {
    let camera = camera_query.single();
    let Some(URect { min, max }) = camera.physical_viewport_rect() else { return };
    dbg!(min, max);
}
```

