### PR TITLE
Timestamp mouse, keyboard, and touch inputs with Instant::now

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -6,6 +6,7 @@ use bevy_ecs::{
     system::ResMut,
 };
 use bevy_reflect::Reflect;
+use bevy_utils::Instant;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -35,6 +36,8 @@ pub struct KeyboardInput {
     pub state: ButtonState,
     /// Window that received the input.
     pub window: Entity,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// Updates the [`Input<KeyCode>`] resource with the latest [`KeyboardInput`] events.

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -37,7 +37,8 @@ pub struct KeyboardInput {
     /// Window that received the input.
     pub window: Entity,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// Updates the [`Input<KeyCode>`] resource with the latest [`KeyboardInput`] events.

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -35,7 +35,8 @@ pub struct MouseButtonInput {
     /// Window that received the input.
     pub window: Entity,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// A button on a mouse device.
@@ -86,7 +87,8 @@ pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// The scroll unit.
@@ -135,7 +137,8 @@ pub struct MouseWheel {
     /// Window that received the input.
     pub window: Entity,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -7,6 +7,7 @@ use bevy_ecs::{
 };
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;
+use bevy_utils::Instant;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -33,6 +34,8 @@ pub struct MouseButtonInput {
     pub state: ButtonState,
     /// Window that received the input.
     pub window: Entity,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// A button on a mouse device.
@@ -82,6 +85,8 @@ pub enum MouseButton {
 pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// The scroll unit.
@@ -129,6 +134,8 @@ pub struct MouseWheel {
     pub y: f32,
     /// Window that received the input.
     pub window: Entity,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -50,7 +50,8 @@ pub struct TouchInput {
     /// The unique identifier of the finger.
     pub id: u64,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// A force description of a [`Touch`](crate::touch::Touch) input.

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -2,7 +2,7 @@ use bevy_ecs::event::{Event, EventReader};
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;
-use bevy_utils::HashMap;
+use bevy_utils::{HashMap, Instant};
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -49,6 +49,8 @@ pub struct TouchInput {
     pub force: Option<ForceTouch>,
     /// The unique identifier of the finger.
     pub id: u64,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// A force description of a [`Touch`](crate::touch::Touch) input.

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -134,7 +134,8 @@ pub struct CursorMoved {
     /// The cursor position in logical pixels.
     pub position: Vec2,
     /// Time at which the input occurred.
-    pub time: Instant,
+    #[cfg_attr(feature = "serialize", serde(skip))]
+    pub time: Option<Instant>,
 }
 
 /// An event that is sent whenever the user's cursor enters a window.

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -4,6 +4,7 @@ use bevy_ecs::entity::Entity;
 use bevy_ecs::event::Event;
 use bevy_math::{IVec2, Vec2};
 use bevy_reflect::Reflect;
+use bevy_utils::Instant;
 
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
@@ -132,6 +133,8 @@ pub struct CursorMoved {
     pub window: Entity,
     /// The cursor position in logical pixels.
     pub position: Vec2,
+    /// Time at which the input occurred.
+    pub time: Instant,
 }
 
 /// An event that is sent whenever the user's cursor enters a window.

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -6,17 +6,20 @@ use bevy_input::{
     ButtonState,
 };
 use bevy_math::Vec2;
+use bevy_utils::Instant;
 use bevy_window::{CursorIcon, WindowLevel, WindowTheme};
 
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyboardInput,
     window: Entity,
+    time: Instant,
 ) -> KeyboardInput {
     KeyboardInput {
         scan_code: keyboard_input.scancode,
         state: convert_element_state(keyboard_input.state),
         key_code: keyboard_input.virtual_keycode.map(convert_virtual_key_code),
         window,
+        time,
     }
 }
 
@@ -39,6 +42,7 @@ pub fn convert_mouse_button(mouse_button: winit::event::MouseButton) -> MouseBut
 pub fn convert_touch_input(
     touch_input: winit::event::Touch,
     location: winit::dpi::LogicalPosition<f64>,
+    time: Instant,
 ) -> TouchInput {
     TouchInput {
         phase: match touch_input.phase {
@@ -61,6 +65,7 @@ pub fn convert_touch_input(
             winit::event::Force::Normalized(x) => ForceTouch::Normalized(x),
         }),
         id: touch_input.id,
+        time,
     }
 }
 

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -12,7 +12,7 @@ use bevy_window::{CursorIcon, WindowLevel, WindowTheme};
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyboardInput,
     window: Entity,
-    time: Instant,
+    time: Option<Instant>,
 ) -> KeyboardInput {
     KeyboardInput {
         scan_code: keyboard_input.scancode,
@@ -42,7 +42,7 @@ pub fn convert_mouse_button(mouse_button: winit::event::MouseButton) -> MouseBut
 pub fn convert_touch_input(
     touch_input: winit::event::Touch,
     location: winit::dpi::LogicalPosition<f64>,
-    time: Instant,
+    time: Option<Instant>,
 ) -> TouchInput {
     TouchInput {
         phase: match touch_input.phase {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -455,7 +455,11 @@ pub fn winit_runner(mut app: App) {
                     WindowEvent::KeyboardInput { ref input, .. } => {
                         input_events
                             .keyboard_input
-                            .send(converters::convert_keyboard_input(input, window_entity));
+                            .send(converters::convert_keyboard_input(
+                                input,
+                                window_entity,
+                                Instant::now(),
+                            ));
                     }
                     WindowEvent::CursorMoved { position, .. } => {
                         let physical_position = DVec2::new(position.x, position.y);
@@ -466,6 +470,7 @@ pub fn winit_runner(mut app: App) {
                             window: window_entity,
                             position: (physical_position / window.resolution.scale_factor())
                                 .as_vec2(),
+                            time: Instant::now(),
                         });
                     }
                     WindowEvent::CursorEntered { .. } => {
@@ -485,6 +490,7 @@ pub fn winit_runner(mut app: App) {
                             button: converters::convert_mouse_button(button),
                             state: converters::convert_element_state(state),
                             window: window_entity,
+                            time: Instant::now(),
                         });
                     }
                     WindowEvent::TouchpadMagnify { delta, .. } => {
@@ -504,6 +510,7 @@ pub fn winit_runner(mut app: App) {
                                 x,
                                 y,
                                 window: window_entity,
+                                time: Instant::now(),
                             });
                         }
                         event::MouseScrollDelta::PixelDelta(p) => {
@@ -512,6 +519,7 @@ pub fn winit_runner(mut app: App) {
                                 x: p.x as f32,
                                 y: p.y as f32,
                                 window: window_entity,
+                                time: Instant::now(),
                             });
                         }
                     },
@@ -521,7 +529,11 @@ pub fn winit_runner(mut app: App) {
                         // Event
                         input_events
                             .touch_input
-                            .send(converters::convert_touch_input(touch, location));
+                            .send(converters::convert_touch_input(
+                                touch,
+                                location,
+                                Instant::now(),
+                            ));
                     }
                     WindowEvent::ReceivedCharacter(c) => {
                         input_events.character_input.send(ReceivedCharacter {
@@ -661,6 +673,7 @@ pub fn winit_runner(mut app: App) {
 
                 mouse_motion.send(MouseMotion {
                     delta: Vec2::new(x as f32, y as f32),
+                    time: Instant::now(),
                 });
             }
             event::Event::Suspended => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -458,7 +458,7 @@ pub fn winit_runner(mut app: App) {
                             .send(converters::convert_keyboard_input(
                                 input,
                                 window_entity,
-                                Instant::now(),
+                                Some(Instant::now()),
                             ));
                     }
                     WindowEvent::CursorMoved { position, .. } => {
@@ -470,7 +470,7 @@ pub fn winit_runner(mut app: App) {
                             window: window_entity,
                             position: (physical_position / window.resolution.scale_factor())
                                 .as_vec2(),
-                            time: Instant::now(),
+                            time: Some(Instant::now()),
                         });
                     }
                     WindowEvent::CursorEntered { .. } => {
@@ -490,7 +490,7 @@ pub fn winit_runner(mut app: App) {
                             button: converters::convert_mouse_button(button),
                             state: converters::convert_element_state(state),
                             window: window_entity,
-                            time: Instant::now(),
+                            time: Some(Instant::now()),
                         });
                     }
                     WindowEvent::TouchpadMagnify { delta, .. } => {
@@ -510,7 +510,7 @@ pub fn winit_runner(mut app: App) {
                                 x,
                                 y,
                                 window: window_entity,
-                                time: Instant::now(),
+                                time: Some(Instant::now()),
                             });
                         }
                         event::MouseScrollDelta::PixelDelta(p) => {
@@ -519,7 +519,7 @@ pub fn winit_runner(mut app: App) {
                                 x: p.x as f32,
                                 y: p.y as f32,
                                 window: window_entity,
-                                time: Instant::now(),
+                                time: Some(Instant::now()),
                             });
                         }
                     },
@@ -532,7 +532,7 @@ pub fn winit_runner(mut app: App) {
                             .send(converters::convert_touch_input(
                                 touch,
                                 location,
-                                Instant::now(),
+                                Some(Instant::now()),
                             ));
                     }
                     WindowEvent::ReceivedCharacter(c) => {
@@ -673,7 +673,7 @@ pub fn winit_runner(mut app: App) {
 
                 mouse_motion.send(MouseMotion {
                     delta: Vec2::new(x as f32, y as f32),
-                    time: Instant::now(),
+                    time: Some(Instant::now()),
                 });
             }
             event::Event::Suspended => {


### PR DESCRIPTION
# Objective

- Partially addresses #9087 for mouse, keyboard, and touch events processed by winit.
- Doesn't address gamepad events.

## Solution

Add `time: Option<Instant>` to `KeyboardInput, MouseButtonInput, MouseWheel, MouseMotion, TouchInput, CursorMoved` events.  Populate this with calls to `Instant::now()` in winit event loop.
