### PR TITLE
Fix typos throughout the project

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -48,7 +48,7 @@ pub struct First;
 
 /// The schedule that contains logic that must run before [`Update`]. For example, a system that reads raw keyboard
 /// input OS events into an `Events` resource. This enables systems in [`Update`] to consume the events from the `Events`
-/// resource without actually knowing about (or taking a direct scheduler dependency on) the "os-level keyboard event sytsem".
+/// resource without actually knowing about (or taking a direct scheduler dependency on) the "os-level keyboard event system".
 ///
 /// [`PreUpdate`] exists to do "engine/plugin preparation work" that ensures the APIs consumed in [`Update`] are "ready".
 /// [`PreUpdate`] abstracts out "pre work implementation details".

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -119,7 +119,7 @@ impl BloomSettings {
         composite_mode: BloomCompositeMode::EnergyConserving,
     };
 
-    /// A preset that's similiar to how older games did bloom.
+    /// A preset that's similar to how older games did bloom.
     pub const OLD_SCHOOL: Self = Self {
         intensity: 0.05,
         low_frequency_boost: 0.7,
@@ -159,7 +159,7 @@ impl Default for BloomSettings {
 /// # Considerations
 /// * Changing these settings creates a physically inaccurate image
 /// * Changing these settings makes it easy to make the final result look worse
-/// * Non-default prefilter settings should be used in conjuction with [`BloomCompositeMode::Additive`]
+/// * Non-default prefilter settings should be used in conjunction with [`BloomCompositeMode::Additive`]
 #[derive(Default, Clone, Reflect)]
 pub struct BloomPrefilterSettings {
     /// Baseline of the quadratic threshold curve (default: 0.0).

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -148,7 +148,7 @@ pub struct TemporalAntiAliasSettings {
     /// Set to true to delete the saved temporal history (past frames).
     ///
     /// Useful for preventing ghosting when the history is no longer
-    /// representive of the current frame, such as in sudden camera cuts.
+    /// representative of the current frame, such as in sudden camera cuts.
     ///
     /// After setting this to true, it will automatically be toggled
     /// back to false after one frame.

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -101,7 +101,7 @@ fn parse_component_attr(ast: &DeriveInput) -> Result<Attrs> {
                 };
                 Ok(())
             } else {
-                Err(nested.error("Unsuported attribute"))
+                Err(nested.error("Unsupported attribute"))
             }
         })?;
     }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -905,7 +905,7 @@ mod tests {
 
         assert!(entities.reserve_generations(entity.index, GENERATIONS));
 
-        // The very next entitiy allocated should be a further generation on the same index
+        // The very next entity allocated should be a further generation on the same index
         let next_entity = entities.alloc();
         assert_eq!(next_entity.index(), entity.index());
         assert!(next_entity.generation > entity.generation + GENERATIONS);

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -6,7 +6,7 @@ use crate::{
 use bevy_reflect::FromType;
 
 /// For a specific type of component, this maps any fields with values of type [`Entity`] to a new world.
-/// Since a given `Entity` ID is only valid for the world it came frome, when performing deserialization
+/// Since a given `Entity` ID is only valid for the world it came from, when performing deserialization
 /// any stored IDs need to be re-allocated in the destination world.
 ///
 /// See [`MapEntities`] for more information.

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -246,7 +246,7 @@ pub mod common_conditions {
     /// # let mut app = Schedule::new();
     /// # let mut world = World::new();
     /// app.add_systems(
-    ///     // `resource_exsists` will only return true if the given resource exsists in the world
+    ///     // `resource_exists` will only return true if the given resource exists in the world
     ///     my_system.run_if(resource_exists::<Counter>()),
     /// );
     ///
@@ -324,7 +324,7 @@ pub mod common_conditions {
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_equals` will only return true
-    ///     // if the given resource exsists and equals the given value
+    ///     // if the given resource exists and equals the given value
     ///     my_system.run_if(resource_exists_and_equals(Counter(0))),
     /// );
     ///
@@ -422,7 +422,7 @@ pub mod common_conditions {
     ///     my_system.run_if(
     ///         resource_changed::<Counter>()
     ///         // By default detecting changes will also trigger if the resource was
-    ///         // just added, this won't work with my example so I will addd a second
+    ///         // just added, this won't work with my example so I will add a second
     ///         // condition to make sure the resource wasn't just added
     ///         .and_then(not(resource_added::<Counter>()))
     ///     ),
@@ -471,11 +471,11 @@ pub mod common_conditions {
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_changed` will only return true if the
-    ///     // given resource exsists and was just changed (or added)
+    ///     // given resource exists and was just changed (or added)
     ///     my_system.run_if(
     ///         resource_exists_and_changed::<Counter>()
     ///         // By default detecting changes will also trigger if the resource was
-    ///         // just added, this won't work with my example so I will addd a second
+    ///         // just added, this won't work with my example so I will add a second
     ///         // condition to make sure the resource wasn't just added
     ///         .and_then(not(resource_added::<Counter>()))
     ///     ),
@@ -537,7 +537,7 @@ pub mod common_conditions {
     ///     my_system.run_if(
     ///         resource_changed_or_removed::<Counter>()
     ///         // By default detecting changes will also trigger if the resource was
-    ///         // just added, this won't work with my example so I will addd a second
+    ///         // just added, this won't work with my example so I will add a second
     ///         // condition to make sure the resource wasn't just added
     ///         .and_then(not(resource_added::<Counter>()))
     ///     ),
@@ -665,7 +665,7 @@ pub mod common_conditions {
     ///
     /// app.add_systems(
     ///     // `state_exists` will only return true if the
-    ///     // given state exsists
+    ///     // given state exists
     ///     my_system.run_if(state_exists::<GameState>()),
     /// );
     ///
@@ -764,7 +764,7 @@ pub mod common_conditions {
     ///
     /// app.add_systems((
     ///     // `state_exists_and_equals` will only return true if the
-    ///     // given state exsists and equals the given value
+    ///     // given state exists and equals the given value
     ///     play_system.run_if(state_exists_and_equals(GameState::Playing)),
     ///     pause_system.run_if(state_exists_and_equals(GameState::Paused)),
     /// ));

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -476,7 +476,7 @@ impl MultiThreadedExecutor {
     /// - `world` must have permission to access the world data
     ///   used by the specified system.
     /// - `update_archetype_component_access` must have been called with `world`
-    ///   on the system assocaited with `system_index`.
+    ///   on the system associated with `system_index`.
     unsafe fn spawn_system_task<'scope>(
         &mut self,
         scope: &Scope<'_, 'scope, ()>,

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -239,7 +239,7 @@ mod tests {
                 partially_ordered == [8, 9, 10] || partially_ordered == [10, 8, 9],
                 "partially_ordered must be [8, 9, 10] or [10, 8, 9]"
             );
-            assert!(order.len() == 11, "must have exacty 11 order entries");
+            assert!(order.len() == 11, "must have exactly 11 order entries");
         }
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -94,7 +94,7 @@ impl TableRow {
     }
 }
 
-/// A type-erased contiguous container for data of a homogenous type.
+/// A type-erased contiguous container for data of a homogeneous type.
 ///
 /// Conceptually, a [`Column`] is very similar to a type-erased `Vec<T>`.
 /// It also stores the change detection ticks for its components, kept in two separate

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -426,7 +426,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub fn iter(&self) -> QueryIter<'_, 's, Q::ReadOnly, F::ReadOnly> {
         // SAFETY:
         // - `self.world` has permission to access the required components.
-        // - The query is read-only, so it can be aliased even if it was originaly mutable.
+        // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state
                 .as_readonly()
@@ -492,7 +492,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     ) -> QueryCombinationIter<'_, 's, Q::ReadOnly, F::ReadOnly, K> {
         // SAFETY:
         // - `self.world` has permission to access the required components.
-        // - The query is read-only, so it can be aliased even if it was originaly mutable.
+        // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state.as_readonly().iter_combinations_unchecked_manual(
                 self.world,
@@ -578,7 +578,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     {
         // SAFETY:
         // - `self.world` has permission to access the required components.
-        // - The query is read-only, so it can be aliased even if it was originaly mutable.
+        // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state.as_readonly().iter_many_unchecked_manual(
                 entities,
@@ -734,7 +734,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub fn for_each<'this>(&'this self, f: impl FnMut(ROQueryItem<'this, Q>)) {
         // SAFETY:
         // - `self.world` has permission to access the required components.
-        // - The query is read-only, so it can be aliased even if it was originaly mutable.
+        // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
             self.state.as_readonly().for_each_unchecked_manual(
                 self.world,

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -627,7 +627,7 @@ unsafe impl SystemParam for &'_ World {
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        // SAFETY: Read-only access to the entire world was registerd in `init_state`.
+        // SAFETY: Read-only access to the entire world was registered in `init_state`.
         world.world()
     }
 }

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -571,7 +571,7 @@ pub struct CircleBuilder<'a, 's> {
 }
 
 impl CircleBuilder<'_, '_> {
-    /// Set the number of line-segements for this circle.
+    /// Set the number of line-segments for this circle.
     pub fn segments(mut self, segments: usize) -> Self {
         self.segments = segments;
         self
@@ -598,7 +598,7 @@ pub struct SphereBuilder<'a, 's> {
 }
 
 impl SphereBuilder<'_, '_> {
-    /// Set the number of line-segements per circle for this sphere.
+    /// Set the number of line-segments per circle for this sphere.
     pub fn circle_segments(mut self, segments: usize) -> Self {
         self.circle_segments = segments;
         self
@@ -625,7 +625,7 @@ pub struct Circle2dBuilder<'a, 's> {
 }
 
 impl Circle2dBuilder<'_, '_> {
-    /// Set the number of line-segements for this circle.
+    /// Set the number of line-segments for this circle.
     pub fn segments(mut self, segments: usize) -> Self {
         self.segments = segments;
         self
@@ -651,7 +651,7 @@ pub struct Arc2dBuilder<'a, 's> {
 }
 
 impl Arc2dBuilder<'_, '_> {
-    /// Set the number of line-segements for this arc.
+    /// Set the number of line-segments for this arc.
     pub fn segments(mut self, segments: usize) -> Self {
         self.segments = Some(segments);
         self

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -80,10 +80,10 @@ fn vertex(vertex: VertexInput) -> VertexOutput {
         // depth * (clip.w / depth)^-depth_bias. So that when -depth_bias is 1.0, this is equal to clip.w
         // and when equal to 0.0, it is exactly equal to depth.
         // the epsilon is here to prevent the depth from exceeding clip.w when -depth_bias = 1.0 
-        // clip.w represents the near plane in homogenous clip space in bevy, having a depth
+        // clip.w represents the near plane in homogeneous clip space in bevy, having a depth
         // of this value means nothing can be in front of this
         // The reason this uses an exponential function is that it makes it much easier for the 
-        // user to chose a value that is convinient for them
+        // user to chose a value that is convenient for them
         depth = clip.z * exp2(-line_gizmo.depth_bias * log2(clip.w / clip.z - epsilon));
     }
 

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -289,7 +289,7 @@ impl<'w, 's, 'a> ChildBuilder<'w, 's, 'a> {
 
 /// Trait for removing, adding and replacing children and parents of an entity.
 pub trait BuildChildren {
-    /// Takes a clousre which builds children for this entity using [`ChildBuilder`].
+    /// Takes a closure which builds children for this entity using [`ChildBuilder`].
     fn with_children(&mut self, f: impl FnOnce(&mut ChildBuilder)) -> &mut Self;
     /// Pushes children to the back of the builder's children. For any entities that are
     /// already a child of this one, this method does nothing.
@@ -458,7 +458,7 @@ impl<'w> WorldChildBuilder<'w> {
 
 /// Trait that defines adding, changing and children and parents of an entity directly through the [`World`].
 pub trait BuildWorldChildren {
-    /// Takes a clousre which builds children for this entity using [`WorldChildBuilder`].
+    /// Takes a closure which builds children for this entity using [`WorldChildBuilder`].
     fn with_children(&mut self, spawn_children: impl FnOnce(&mut WorldChildBuilder)) -> &mut Self;
 
     /// Adds a single child.

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -52,7 +52,7 @@ fn add_to_alignment<T: Pod + Default>(buffer: &mut BufferVec<T>) {
         // This panic is stripped at compile time, due to n, t_size and can_align being const
         panic!(
             "BufferVec should contain only types with a size multiple or divisible by {n}, \
-            {} has a size of {t_size}, which is neiter multiple or divisible by {n}",
+            {} has a size of {t_size}, which is neither multiple or divisible by {n}",
             std::any::type_name::<T>()
         );
     }

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -1,6 +1,6 @@
 // If using this WGSL snippet as an #import, the following should be in scope:
 //
-// - the `morph_weigths` uniform of type `MorphWeights`
+// - the `morph_weights` uniform of type `MorphWeights`
 // - the `morph_targets` 3d texture
 //
 // They are defined in `mesh_types.wgsl` and `mesh_bindings.wgsl`.

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -222,7 +222,7 @@ fn point_light(
     // where
     // f(v,l) = (f_d(v,l) + f_r(v,l)) * light_color
     // Φ is luminous power in lumens
-    // our rangeAttentuation = 1 / d^2 multiplied with an attenuation factor for smoothing at the edge of the non-physical maximum light radius
+    // our rangeAttenuation = 1 / d^2 multiplied with an attenuation factor for smoothing at the edge of the non-physical maximum light radius
 
     // For a point light, luminous intensity, I, in lumens per steradian is given by:
     // I = Φ / 4 π

--- a/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/container_attributes.rs
@@ -249,7 +249,7 @@ impl ReflectTraits {
                                 lit: syn::Lit::Bool(lit),
                                 ..
                             }) => {
-                                // Overrride `lit` if this is a `FromReflect` derive.
+                                // Override `lit` if this is a `FromReflect` derive.
                                 // This typically means a user is opting out of the default implementation
                                 // from the `Reflect` derive and using the `FromReflect` derive directly instead.
                                 is_from_reflect_derive

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -567,7 +567,7 @@ impl<'a> EnumVariant<'a> {
 ///     custom_path: None,
 /// };
 ///
-/// // Eqivalent to "core::marker".
+/// // Equivalent to "core::marker".
 /// let module_path = type_path.module_path();
 /// # Ok::<(), syn::Error>(())
 /// ```
@@ -577,7 +577,7 @@ pub(crate) enum ReflectTypePath<'a> {
     Primitive(&'a Ident),
     /// Using `::my_crate::foo::Bar` syntax.
     ///
-    /// May have a seperate custom path used for the `TypePath` implementation.
+    /// May have a separate custom path used for the `TypePath` implementation.
     External {
         path: &'a Path,
         custom_path: Option<Path>,
@@ -587,7 +587,7 @@ pub(crate) enum ReflectTypePath<'a> {
     ///
     /// The type must be able to be reached with just its name.
     ///
-    /// May have a seperate alias path used for the `TypePath` implementation.
+    /// May have a separate alias path used for the `TypePath` implementation.
     ///
     /// Module and crate are found with [`module_path!()`](core::module_path),
     /// if there is no custom path specified.

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -523,7 +523,7 @@ pub fn impl_from_reflect_value(input: TokenStream) -> TokenStream {
 /// it requires an 'absolute' path definition.
 ///
 /// Specifically, a leading `::` denoting a global path must be specified
-/// or a preceeding `(in my_crate::foo)` to specify the custom path must be used.
+/// or a preceding `(in my_crate::foo)` to specify the custom path must be used.
 ///
 /// # Examples
 ///

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -18,7 +18,7 @@ use std::{
 ///
 /// Due to the [type-erasing] nature of the reflection API as a whole,
 /// this trait does not make any guarantees that the implementor's elements
-/// are homogenous (i.e. all the same type).
+/// are homogeneous (i.e. all the same type).
 ///
 /// This trait has a blanket implementation over Rust arrays of up to 32 items.
 /// This implementation can technically contain more than 32,

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -14,7 +14,7 @@ use crate::{FromType, Reflect};
 /// Additionally, some complex types like `Vec<T>` require that their element types
 /// implement this trait.
 /// The reason for such requirements is that some operations require new data to be constructed,
-/// such as swapping to a new variant or pushing data to a homogenous list.
+/// such as swapping to a new variant or pushing data to a homogeneous list.
 ///
 /// See the [crate-level documentation] to see how this trait can be used.
 ///

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1207,7 +1207,7 @@ impl<T: FromReflect + Clone + TypePath> List for Cow<'static, [T]> {
     }
 
     fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
-        // into_owned() is not uneccessary here because it avoids cloning whenever you have a Cow::Owned already
+        // into_owned() is not unnecessary here because it avoids cloning whenever you have a Cow::Owned already
         #[allow(clippy::unnecessary_to_owned)]
         self.into_owned()
             .into_iter()

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -29,7 +29,7 @@ use crate::{
 ///
 /// Due to the [type-erasing] nature of the reflection API as a whole,
 /// this trait does not make any guarantees that the implementor's elements
-/// are homogenous (i.e. all the same type).
+/// are homogeneous (i.e. all the same type).
 ///
 /// # Example
 ///

--- a/crates/bevy_reflect/src/type_path.rs
+++ b/crates/bevy_reflect/src/type_path.rs
@@ -112,7 +112,7 @@ pub trait TypePath: 'static {
         None
     }
 
-    /// Returns the path to the moudle the type is in, or [`None`] if it is [anonymous].
+    /// Returns the path to the module the type is in, or [`None`] if it is [anonymous].
     ///
     /// For `Option<PhantomData>`, this is `"core::option"`.
     ///

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -232,7 +232,7 @@ impl<T: TypedProperty> GenericTypeCell<T> {
     {
         let type_id = TypeId::of::<G>();
 
-        // Put in a seperate scope, so `mapping` is dropped before `f`,
+        // Put in a separate scope, so `mapping` is dropped before `f`,
         // since `f` might want to call `get_or_insert` recursively
         // and we don't want a deadlock!
         {

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -217,7 +217,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                         buffer,
                     } = get_storage_binding_attr(nested_meta_items)?;
                     let visibility =
-                        visibility.hygenic_quote(&quote! { #render_path::render_resource });
+                        visibility.hygienic_quote(&quote! { #render_path::render_resource });
 
                     let field_name = field.ident.as_ref().unwrap();
                     let field_ty = &field.ty;
@@ -271,7 +271,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                     } = tex_attrs.as_ref().unwrap();
 
                     let visibility =
-                        visibility.hygenic_quote(&quote! { #render_path::render_resource });
+                        visibility.hygienic_quote(&quote! { #render_path::render_resource });
 
                     let fallback_image = get_fallback_image(&render_path, *dimension);
 
@@ -310,7 +310,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                         .expect("sampler attribute must have matching texture attribute");
 
                     let visibility =
-                        visibility.hygenic_quote(&quote! { #render_path::render_resource });
+                        visibility.hygienic_quote(&quote! { #render_path::render_resource });
 
                     let fallback_image = get_fallback_image(&render_path, *dimension);
 
@@ -606,7 +606,7 @@ impl VisibilityFlags {
 }
 
 impl ShaderStageVisibility {
-    fn hygenic_quote(&self, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
+    fn hygienic_quote(&self, path: &proc_macro2::TokenStream) -> proc_macro2::TokenStream {
         match self {
             ShaderStageVisibility::All => quote! { #path::ShaderStages::all() },
             ShaderStageVisibility::None => quote! { #path::ShaderStages::NONE },

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -337,7 +337,7 @@ impl Transform {
     /// and [`Transform::up`] points towards `up`.
     ///
     /// In some cases it's not possible to construct a rotation. Another axis will be picked in those cases:
-    /// * if `target` is the same as the transtorm translation, `Vec3::Z` is used instead
+    /// * if `target` is the same as the transform translation, `Vec3::Z` is used instead
     /// * if `up` is zero, `Vec3::Y` is used instead
     /// * if the resulting forward direction is parallel with `up`, an orthogonal vector is used as the "right" direction
     #[inline]

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -281,7 +281,7 @@ pub fn extract_uinode_borders(
         .get_single()
         .map(|window| Vec2::new(window.resolution.width(), window.resolution.height()))
         .unwrap_or(Vec2::ZERO)
-        // The logical window resolutin returned by `Window` only takes into account the window scale factor and not `UiScale`,
+        // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
         // so we have to divide by `UiScale` to get the size of the UI viewport.
         / ui_scale.scale as f32;
 

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -108,7 +108,7 @@ fn fill_stack_recursively(result: &mut Vec<Entity>, stack: &mut StackingContext)
     stack.entries.sort_by_key(|e| e.z_index);
 
     for entry in &mut stack.entries {
-        // Parent node renders before/behind childs nodes
+        // Parent node renders before/behind child nodes
         result.push(entry.entity);
         fill_stack_recursively(result, &mut entry.stack);
     }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -289,13 +289,13 @@ impl Val {
 /// ### Flexbox
 ///
 /// - [MDN: Basic Concepts of Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Basic_Concepts_of_Grid_Layout)
-/// - [A Complete Guide To Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) by CSS Tricks. This is detailed guide with illustrations and comphrehensive written explanation of the different Flexbox properties and how they work.
+/// - [A Complete Guide To Flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/) by CSS Tricks. This is detailed guide with illustrations and comprehensive written explanation of the different Flexbox properties and how they work.
 /// - [Flexbox Froggy](https://flexboxfroggy.com/). An interactive tutorial/game that teaches the essential parts of Flebox in a fun engaging way.
 ///
 /// ### CSS Grid
 ///
 /// - [MDN: Basic Concepts of Flexbox](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Basic_Concepts_of_Flexbox)
-/// - [A Complete Guide To CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) by CSS Tricks. This is detailed guide with illustrations and comphrehensive written explanation of the different CSS Grid properties and how they work.
+/// - [A Complete Guide To CSS Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) by CSS Tricks. This is detailed guide with illustrations and comprehensive written explanation of the different CSS Grid properties and how they work.
 /// - [CSS Grid Garden](https://cssgridgarden.com/). An interactive tutorial/game that teaches the essential parts of CSS Grid in a fun engaging way.
 
 #[derive(Component, Clone, PartialEq, Debug, Reflect)]
@@ -395,7 +395,7 @@ pub struct Style {
     /// For CSS Grid containers:
     ///   - Controls block (vertical) axis alignment of children of this grid container within their grid areas
     ///
-    /// This value is overriden [`JustifySelf`] on the child node is set.
+    /// This value is overridden [`JustifySelf`] on the child node is set.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/align-items>
     pub align_items: AlignItems,
@@ -405,7 +405,7 @@ pub struct Style {
     /// For CSS Grid containers:
     ///   - Sets default inline (horizontal) axis alignment of child items within their grid areas
     ///
-    /// This value is overriden [`JustifySelf`] on the child node is set.
+    /// This value is overridden [`JustifySelf`] on the child node is set.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/justify-items>
     pub justify_items: JustifyItems,
@@ -566,7 +566,7 @@ pub struct Style {
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-auto-rows>
     pub grid_auto_rows: Vec<GridTrack>,
     /// Defines the size of implicitly created columns. Columns are created implicitly when grid items are given explicit placements that are out of bounds
-    /// of the columns explicitly created using `grid_template_columms`.
+    /// of the columns explicitly created using `grid_template_columns`.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns>
     pub grid_auto_columns: Vec<GridTrack>,
@@ -1435,7 +1435,7 @@ impl From<RepeatedGridTrack> for Vec<RepeatedGridTrack> {
 ///
 /// The default `span` is 1. If neither `start` or `end` is set then the item will be placed automatically.
 ///
-/// Generally, at most two fields should be set. If all three fields are specifed then `span` will be ignored. If `end` specifies an earlier
+/// Generally, at most two fields should be set. If all three fields are specified then `span` will be ignored. If `end` specifies an earlier
 /// grid line than `start` then `end` will be ignored and the item will have a span of 1.
 ///
 /// <https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/Line-based_Placement_with_CSS_Grid>

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -99,7 +99,7 @@ fn create_text_measure(
                 content_size.set(TextMeasure { info: measure });
             }
 
-            // Text measure func created succesfully, so set `TextFlags` to schedule a recompute
+            // Text measure func created successfully, so set `TextFlags` to schedule a recompute
             text_flags.needs_new_measure_func = false;
             text_flags.needs_recompute = true;
         }

--- a/crates/bevy_utils/src/syncunsafecell.rs
+++ b/crates/bevy_utils/src/syncunsafecell.rs
@@ -12,7 +12,7 @@ pub use core::cell::UnsafeCell;
 /// This is just an `UnsafeCell`, except it implements `Sync`
 /// if `T` implements `Sync`.
 ///
-/// `UnsafeCell` doesn't implement `Sync`, to prevent accidental mis-use.
+/// `UnsafeCell` doesn't implement `Sync`, to prevent accidental misuse.
 /// You can use `SyncUnsafeCell` instead of `UnsafeCell` to allow it to be
 /// shared between threads, if that's intentional.
 /// Providing proper synchronization is still the task of the user,

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -84,7 +84,7 @@ impl Plugin for PostProcessPlugin {
             // Add a [`Node`] to the [`RenderGraph`]
             // The Node needs to impl FromWorld
             .add_render_graph_node::<PostProcessNode>(
-                // Specifiy the name of the graph, in this case we want the graph for 3d
+                // Specify the name of the graph, in this case we want the graph for 3d
                 core_3d::graph::NAME,
                 // It also needs the name of the node
                 PostProcessNode::NAME,

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -1,6 +1,6 @@
 //! Enable controls for morph targets detected in a loaded scene.
 //!
-//! Collect morph targets and assing keys to them,
+//! Collect morph targets and assign keys to them,
 //! shows on screen additional controls for morph targets.
 //!
 //! Illustrates how to access and modify individual morph target weights.

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -168,7 +168,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ..Default::default()
                         });
                     builder.spawn(TextBundle::from_section(
-                        "The UI Node and its descendants will not be visible and will not be alloted any space in the UI layout.\nThe UI Node will not be visible but will still occupy space in the UI layout.\nThe UI node will inherit the visibility property of its parent. If it has no parent it will be visible.",
+                        "The UI Node and its descendants will not be visible and will not be allotted any space in the UI layout.\nThe UI Node will not be visible but will still occupy space in the UI layout.\nThe UI node will inherit the visibility property of its parent. If it has no parent it will be visible.",
                         text_style
                     ));
             });

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -94,13 +94,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             ..Default::default()
                         })
                         .with_children(|parent| {
-                            for constaint in [
+                            for constraint in [
                                 Constraint::MinWidth,
                                 Constraint::FlexBasis,
                                 Constraint::Width,
                                 Constraint::MaxWidth,
                             ] {
-                                spawn_button_row(parent, constaint, text_style.clone());
+                                spawn_button_row(parent, constraint, text_style.clone());
                             }
                         });
                 });

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -290,7 +290,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ))
                         .with_children(|parent| {
                             // alt text
-                            // This UI node takes up no space in the layout and the `Text` component is used by the accessiblity module
+                            // This UI node takes up no space in the layout and the `Text` component is used by the accessibility module
                             // and is not rendered.
                             parent.spawn((
                                 NodeBundle {

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -109,7 +109,7 @@ fn main() {
 
         if cli.optimize_size {
             cmd!(sh, "wasm-opt -Oz --output examples/wasm/target/wasm_example_bg.wasm.optimized examples/wasm/target/wasm_example_bg.wasm")
-                .run().expect("Failed to optimize for size. Do you have wasm-opt corretly set up?");
+                .run().expect("Failed to optimize for size. Do you have wasm-opt correctly set up?");
         }
 
         if cli.test {


### PR DESCRIPTION
# Objective

Fix typos throughout the project.

## Solution

[`typos`](https://github.com/crate-ci/typos) project was used for scanning, but no automatic corrections were applied. I checked everything by hand before fixing.

Most of the changes are documentation/comments corrections. Also, there are few trivial changes to code (variable name, pub(crate) function name and a few error/panic messages).

## Unsolved

`bevy_reflect_derive` has [typo](https://github.com/ClayenKitten/bevy/blob/1b51053f1958d750cdddffb99828bd0aacb61a78/crates/bevy_reflect/bevy_reflect_derive/src/type_path.rs#L76) in enum variant name that I didn't fix. Enum is `pub(crate)`, so there shouldn't be any trouble if fixed. However, code is tightly coupled with macro usage, so I decided to leave it for more experienced contributor just in case.