### PR TITLE
Update `Camera`'s `Frustum` only when its `GlobalTransform` or `CameraProjection` changed

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -268,7 +268,10 @@ pub fn calculate_bounds(
 }
 
 pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
-    mut views: Query<(&GlobalTransform, &T, &mut Frustum), Or<(Changed<GlobalTransform>, Changed<T>)>>,
+    mut views: Query<
+        (&GlobalTransform, &T, &mut Frustum),
+        Or<(Changed<GlobalTransform>, Changed<T>)>,
+    >,
 ) {
     for (transform, projection, mut frustum) in &mut views {
         let view_projection =

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -268,7 +268,7 @@ pub fn calculate_bounds(
 }
 
 pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
-    mut views: Query<(&GlobalTransform, &T, &mut Frustum)>,
+    mut views: Query<(&GlobalTransform, &T, &mut Frustum), Or<(Changed<GlobalTransform>, Changed<T>)>>,
 ) {
     for (transform, projection, mut frustum) in &mut views {
         let view_projection =


### PR DESCRIPTION
# Objective

Update a camera's frustum only when needed.

- Maybe a performance gain from not having to compute frusta when not needed, at the cost of change detection (?)
- Making "fighting" with `update_frusta` less tedious, see https://github.com/bevyengine/bevy/issues/9077 and https://discord.com/channels/691052431525675048/743663924229963868/1127566087966433322

## Solution

Add change detection filter for `GlobalTransform` or `T: CameraProjection` in `update_frusta`, since those are the cases when the frustum needs to  be updated.

## Note

I don't think a migration guide and changelog are needed, but I'm not 100% sure, I could put something like "if you're fighting against `update_frusta`, you can do it only when there is a change to `GlobalTransform` or `CameraProjection` now", what do you think? It's not really a breaking change with a normal use case.