### PR TITLE
Clarify that wgpu is based on the webGPU API

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Bevy can be built just fine using default configuration on stable Rust. However 
 
 Bevy is only possible because of the hard work put into these foundational technologies:
 
-* [wgpu](https://wgpu.rs/): modern / low-level / cross-platform graphics library inspired by Vulkan
+* [wgpu](https://wgpu.rs/): modern / low-level / cross-platform graphics library based on the [WebGPU](https://gpuweb.github.io/gpuweb/) API.
 * [glam-rs](https://github.com/bitshifter/glam-rs): a simple and fast 3D math library for games and graphics
 * [winit](https://github.com/rust-windowing/winit): cross-platform window creation and management in Rust
 


### PR DESCRIPTION
# Objective

wgpu is not only inspired by Vulkan, so I think it's better to just mention that it's based on WebGPU

## Solution

- Change the description
