### PR TITLE
Fix crash when drawing line gizmo with less than 2 vertices

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -463,7 +463,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineGizmo {
         };
 
         if line_gizmo.vertex_count < 2 {
-            return RenderCommandResult::Failure;
+            return RenderCommandResult::Success;
         }
 
         let instances = if line_gizmo.strip {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -462,6 +462,10 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineGizmo {
             return RenderCommandResult::Failure;
         };
 
+        if line_gizmo.vertex_count < 2 {
+            return RenderCommandResult::Failure;
+        }
+
         let instances = if line_gizmo.strip {
             let item_size = VertexFormat::Float32x3.size();
             let buffer_size = line_gizmo.position_buffer.size() - item_size;


### PR DESCRIPTION
# Objective

Fix #9089

## Solution

Don't try to draw lines with less than 2 vertices. These would not be visible either way.