### PR TITLE
Fix typo in NamedTypePathDef

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -571,7 +571,7 @@ pub fn impl_type_path(input: TokenStream) -> TokenStream {
                 generics,
             }
         }
-        NamedTypePathDef::Primtive(ref ident) => ReflectTypePath::Primitive(ident),
+        NamedTypePathDef::Primitive(ref ident) => ReflectTypePath::Primitive(ident),
     };
 
     let meta = ReflectMeta::new(type_path, ReflectTraits::default());

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_path.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_path.rs
@@ -73,7 +73,7 @@ pub(crate) enum NamedTypePathDef {
         generics: Generics,
         custom_path: Option<CustomPathDef>,
     },
-    Primtive(Ident),
+    Primitive(Ident),
 }
 
 impl Parse for NamedTypePathDef {
@@ -87,7 +87,7 @@ impl Parse for NamedTypePathDef {
         if path.leading_colon.is_none() && custom_path.is_none() {
             if path.segments.len() == 1 {
                 let ident = path.segments.into_iter().next().unwrap().ident;
-                Ok(NamedTypePathDef::Primtive(ident))
+                Ok(NamedTypePathDef::Primitive(ident))
             } else {
                 Err(input.error("non-customized paths must start with a double colon (`::`)"))
             }


### PR DESCRIPTION
# Objective
Fixes #9091 

## Solution
Rename instances of `Primtive` to `Primitive`

## Migration Guide

Before: 

```rust 
let type_path = NamedTypePathDef::Primtive(ident);
```

After: 
```rust
let type_path = NamedTypePathDef::Primitive(ident);
```
