### PR TITLE
Add `GltfLoader::new`.

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -70,21 +70,8 @@ pub enum GltfError {
 
 /// Loads glTF files with all of their data as their corresponding bevy representations.
 pub struct GltfLoader {
-    pub(crate) supported_compressed_formats: CompressedImageFormats,
-    pub(crate) custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
-}
-
-impl GltfLoader {
-    /// Creates a new glTF loader.
-    pub fn new(
-        supported_compressed_formats: CompressedImageFormats,
-        custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
-    ) -> Self {
-        GltfLoader {
-            supported_compressed_formats,
-            custom_vertex_attributes,
-        }
-    }
+    pub supported_compressed_formats: CompressedImageFormats,
+    pub custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
 }
 
 impl AssetLoader for GltfLoader {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -74,6 +74,19 @@ pub struct GltfLoader {
     pub(crate) custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
 }
 
+impl GltfLoader {
+    /// Creates a new glTF loader.
+    pub fn new(
+        supported_compressed_formats: CompressedImageFormats,
+        custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
+    ) -> Self {
+        GltfLoader {
+            supported_compressed_formats,
+            custom_vertex_attributes,
+        }
+    }
+}
+
 impl AssetLoader for GltfLoader {
     fn load<'a>(
         &'a self,


### PR DESCRIPTION
# Objective

In my application, I'm manually wrapping the built-in Bevy loaders with a wrapper loader that stores some metadata before calling into the inner Bevy loader. This worked for the glTF loader in Bevy 0.10, but in Bevy 0.11 it became impossible to do this because the glTF loader became unconstructible outside Bevy due to the new private fields within it. It's now in fact impossible to get a reference to a GltfLoader at all from outside Bevy, because the only way to construct a GltfLoader is to add the GltfPlugin to an App, and the GltfPlugin only hands out references to its GltfLoader to the asset server, which provides no public access to the loaders it manages.

## Solution

This commit fixes the problem by adding a public `new` method to allow manual construction of a glTF loader.
