### PR TITLE
Fix gizmo draw order in 2D

### DIFF
--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -166,7 +166,7 @@ fn queue_line_gizmos_2d(
                 entity,
                 draw_function,
                 pipeline,
-                sort_key: FloatOrd(0.),
+                sort_key: FloatOrd(f32::INFINITY),
                 batch_range: None,
             });
         }


### PR DESCRIPTION
# Objective

Gizmos are intended to draw over everything but for some reason I set the sort key to `0` during #8427 :v

I didn't catch this mistake because it still draws over sprites with a Z translation of `0`.

## Solution

Set the sort key to `f32::INFINITY`.