### PR TITLE
impl `From<&AssetPath>` for `HandleId`

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -40,6 +40,12 @@ impl<'a> From<AssetPath<'a>> for HandleId {
     }
 }
 
+impl<'a, 'b> From<&'a AssetPath<'b>> for HandleId {
+    fn from(value: &'a AssetPath<'b>) -> Self {
+        HandleId::AssetPathId(AssetPathId::from(value))
+    }
+}
+
 impl HandleId {
     /// Creates a random id for an asset of type `T`.
     #[inline]


### PR DESCRIPTION
# Objective

In [`AssetLoader::load()`](https://docs.rs/bevy/0.11.0/bevy/asset/trait.AssetLoader.html#tymethod.load), I have an [`AssetPath`](https://docs.rs/bevy/0.11.0/bevy/asset/struct.AssetPath.html) to a dependency asset.
I get a handle to this dependency asset using [`LoadContext::get_handle()`](https://docs.rs/bevy/0.11.0/bevy/asset/struct.LoadContext.html#method.get_handle) passing the `AssetPath`. But I also need to pass this `AssetPath` to [`LoadedAsset::with_dependency()`](https://docs.rs/bevy/0.11.0/bevy/asset/struct.LoadedAsset.html#method.with_dependency) later.


The current solution for this problem is either use `clone()`, but `AssetPath` may contains owned data.
```rust
let dependency_path: AssetPath = _;
let dependency = load_context.get_handle(dependency_path.clone());
// ...
load_context.set_default_asset(LoadedAsset::new(my_asset).with_dependency(dependency_path));
```

Or to use `AssetPathId::from(&path)` which is a bit verbose.
```rust
let dependency_path: AssetPath = _;
let dependency = load_context.get_handle(AssetPathId::from(&dependency_path));
// ...
load_context.set_default_asset(LoadedAsset::new(my_asset).with_dependency(dependency_path));
```

Ideal solution (introduced by this PR) is to pass a reference to `get_handle()`.
```rust
let dependency_path: AssetPath = _;
let dependency = load_context.get_handle(&dependency_path);
// ...
load_context.set_default_asset(LoadedAsset::new(my_asset).with_dependency(dependency_path));
```

## Solution

Implement `From<&AssetPath>` for `HandleId`

---

## Changelog

- Added: `HandleId` can be build from a reference to `AssetPath`.
