### PR TITLE
doc(ChangeWatcher): add an advice for the delay value

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -70,6 +70,8 @@ pub struct ChangeWatcher {
     ///
     /// If you have a slow hard drive or expect to reload large assets, you may want to increase
     /// this value.
+    ///
+    /// 200 milliseconds is a safe default value.
     pub delay: Duration,
 }
 


### PR DESCRIPTION
# Objective

When I first try to use the new `ChangeWatcher` I was not sure what value to choose for the delay.
I think the doc should provide a recommended value that works for the majority of cases.

## Solution

Add a recommended value for the delay in the doc, based on the value proposed in [the migration guide](https://bevyengine.org/learn/migration-guides/0.10-0.11/#delay-asset-hot-reloading).
