### PR TITLE
fix `clippy::default_constructed_unit_structs` and trybuild errors

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -559,7 +559,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((
             bevy_core::TaskPoolPlugin::default(),
-            bevy_core::TypeRegistrationPlugin::default(),
+            bevy_core::TypeRegistrationPlugin,
             crate::AssetPlugin::default(),
         ));
         app.add_asset::<MyAsset>();

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -390,7 +390,7 @@ impl HandleUntyped {
         Handle {
             handle_type,
             id: self.id,
-            marker: PhantomData::default(),
+            marker: PhantomData,
         }
     }
 }

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -165,7 +165,7 @@ mod tests {
     #[test]
     fn runs_spawn_local_tasks() {
         let mut app = App::new();
-        app.add_plugins((TaskPoolPlugin::default(), TypeRegistrationPlugin::default()));
+        app.add_plugins((TaskPoolPlugin::default(), TypeRegistrationPlugin));
 
         let (async_tx, async_rx) = crossbeam_channel::unbounded();
         AsyncComputeTaskPool::get()
@@ -200,8 +200,8 @@ mod tests {
         let mut app = App::new();
         app.add_plugins((
             TaskPoolPlugin::default(),
-            TypeRegistrationPlugin::default(),
-            FrameCountPlugin::default(),
+            TypeRegistrationPlugin,
+            FrameCountPlugin,
         ));
         app.update();
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1038,10 +1038,7 @@ mod tests {
         events.send_default();
 
         let mut reader = events.get_reader();
-        assert_eq!(
-            get_events(&events, &mut reader),
-            vec![EmptyTestEvent::default()]
-        );
+        assert_eq!(get_events(&events, &mut reader), vec![EmptyTestEvent]);
     }
 
     #[test]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -43,13 +43,13 @@ impl PluginGroup for DefaultPlugins {
         group = group
             .add(bevy_log::LogPlugin::default())
             .add(bevy_core::TaskPoolPlugin::default())
-            .add(bevy_core::TypeRegistrationPlugin::default())
-            .add(bevy_core::FrameCountPlugin::default())
-            .add(bevy_time::TimePlugin::default())
-            .add(bevy_transform::TransformPlugin::default())
-            .add(bevy_hierarchy::HierarchyPlugin::default())
-            .add(bevy_diagnostic::DiagnosticsPlugin::default())
-            .add(bevy_input::InputPlugin::default())
+            .add(bevy_core::TypeRegistrationPlugin)
+            .add(bevy_core::FrameCountPlugin)
+            .add(bevy_time::TimePlugin)
+            .add(bevy_transform::TransformPlugin)
+            .add(bevy_hierarchy::HierarchyPlugin)
+            .add(bevy_diagnostic::DiagnosticsPlugin)
+            .add(bevy_input::InputPlugin)
             .add(bevy_window::WindowPlugin::default())
             .add(bevy_a11y::AccessibilityPlugin);
 
@@ -60,17 +60,17 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "debug_asset_server")]
         {
-            group = group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin::default());
+            group = group.add(bevy_asset::debug_asset_server::DebugAssetServerPlugin);
         }
 
         #[cfg(feature = "bevy_scene")]
         {
-            group = group.add(bevy_scene::ScenePlugin::default());
+            group = group.add(bevy_scene::ScenePlugin);
         }
 
         #[cfg(feature = "bevy_winit")]
         {
-            group = group.add(bevy_winit::WinitPlugin::default());
+            group = group.add(bevy_winit::WinitPlugin);
         }
 
         #[cfg(feature = "bevy_render")]
@@ -83,29 +83,28 @@ impl PluginGroup for DefaultPlugins {
 
             #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
             {
-                group = group
-                    .add(bevy_render::pipelined_rendering::PipelinedRenderingPlugin::default());
+                group = group.add(bevy_render::pipelined_rendering::PipelinedRenderingPlugin);
             }
         }
 
         #[cfg(feature = "bevy_core_pipeline")]
         {
-            group = group.add(bevy_core_pipeline::CorePipelinePlugin::default());
+            group = group.add(bevy_core_pipeline::CorePipelinePlugin);
         }
 
         #[cfg(feature = "bevy_sprite")]
         {
-            group = group.add(bevy_sprite::SpritePlugin::default());
+            group = group.add(bevy_sprite::SpritePlugin);
         }
 
         #[cfg(feature = "bevy_text")]
         {
-            group = group.add(bevy_text::TextPlugin::default());
+            group = group.add(bevy_text::TextPlugin);
         }
 
         #[cfg(feature = "bevy_ui")]
         {
-            group = group.add(bevy_ui::UiPlugin::default());
+            group = group.add(bevy_ui::UiPlugin);
         }
 
         #[cfg(feature = "bevy_pbr")]
@@ -127,12 +126,12 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_gilrs")]
         {
-            group = group.add(bevy_gilrs::GilrsPlugin::default());
+            group = group.add(bevy_gilrs::GilrsPlugin);
         }
 
         #[cfg(feature = "bevy_animation")]
         {
-            group = group.add(bevy_animation::AnimationPlugin::default());
+            group = group.add(bevy_animation::AnimationPlugin);
         }
 
         #[cfg(feature = "bevy_gizmos")]
@@ -165,9 +164,9 @@ impl PluginGroup for MinimalPlugins {
     fn build(self) -> PluginGroupBuilder {
         PluginGroupBuilder::start::<Self>()
             .add(bevy_core::TaskPoolPlugin::default())
-            .add(bevy_core::TypeRegistrationPlugin::default())
-            .add(bevy_core::FrameCountPlugin::default())
-            .add(bevy_time::TimePlugin::default())
+            .add(bevy_core::TypeRegistrationPlugin)
+            .add(bevy_core::FrameCountPlugin)
+            .add(bevy_time::TimePlugin)
             .add(bevy_app::ScheduleRunnerPlugin::default())
     }
 }

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,9 +6,6 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -18,9 +15,6 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -15,6 +18,9 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -28,5 +28,5 @@ note: required for `Foo<NoReflect>` to implement `Reflect`
 4  | #[reflect(from_reflect = false)]
 5  | struct Foo<T> {
    |        ^^^^^^
-   = note: required for the cast from `Foo<NoReflect>` to the object type `dyn Reflect`
+   = note: required for the cast from `Box<Foo<NoReflect>>` to `Box<(dyn Reflect + 'static)>`
    = note: this error originates in the derive macro `Reflect` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/bevy_tasks/src/thread_executor.rs
+++ b/crates/bevy_tasks/src/thread_executor.rs
@@ -78,7 +78,7 @@ impl<'task> ThreadExecutor<'task> {
         if thread::current().id() == self.thread_id {
             return Some(ThreadExecutorTicker {
                 executor: self,
-                _marker: PhantomData::default(),
+                _marker: PhantomData,
             });
         }
         None


### PR DESCRIPTION
# Objective

With Rust `1.71.0` ([released a few minutes ago](https://github.com/rust-lang/rust/releases/tag/1.71.0)), clippy introduced a new lint ([`default_constructed_unit_structs`](https://rust-lang.github.io/rust-clippy/master/index.html#/default_constructed_unit_structs)) wich prevent calling `default()` on unit structs (e.g. `PhantomData::default()`).

## Solution

Apply the lint suggestion.
