### PR TITLE
Rustdoc: Scrape examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -265,6 +265,7 @@ crossbeam-channel = "0.5.0"
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.hello_world]
 hidden = true
@@ -273,6 +274,7 @@ hidden = true
 [[example]]
 name = "bloom_2d"
 path = "examples/2d/bloom_2d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.bloom_2d]
 name = "2D Bloom"
@@ -283,6 +285,7 @@ wasm = true
 [[example]]
 name = "move_sprite"
 path = "examples/2d/move_sprite.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.move_sprite]
 name = "Move Sprite"
@@ -293,6 +296,7 @@ wasm = true
 [[example]]
 name = "rotation"
 path = "examples/2d/rotation.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.rotation]
 name = "2D Rotation"
@@ -303,6 +307,7 @@ wasm = true
 [[example]]
 name = "mesh2d"
 path = "examples/2d/mesh2d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mesh2d]
 name = "Mesh 2D"
@@ -313,6 +318,7 @@ wasm = true
 [[example]]
 name = "mesh2d_manual"
 path = "examples/2d/mesh2d_manual.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mesh2d_manual]
 name = "Manual Mesh 2D"
@@ -323,6 +329,7 @@ wasm = true
 [[example]]
 name = "mesh2d_vertex_color_texture"
 path = "examples/2d/mesh2d_vertex_color_texture.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mesh2d_vertex_color_texture]
 name = "Mesh 2D With Vertex Colors"
@@ -333,6 +340,7 @@ wasm = true
 [[example]]
 name = "2d_shapes"
 path = "examples/2d/2d_shapes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.2d_shapes]
 name = "2D Shapes"
@@ -343,6 +351,7 @@ wasm = true
 [[example]]
 name = "custom_gltf_vertex_attribute"
 path = "examples/2d/custom_gltf_vertex_attribute.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_gltf_vertex_attribute]
 name = "Custom glTF vertex attribute 2D"
@@ -353,6 +362,7 @@ wasm = true
 [[example]]
 name = "2d_gizmos"
 path = "examples/2d/2d_gizmos.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.2d_gizmos]
 name = "2D Gizmos"
@@ -363,6 +373,7 @@ wasm = true
 [[example]]
 name = "sprite"
 path = "examples/2d/sprite.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.sprite]
 name = "Sprite"
@@ -373,6 +384,7 @@ wasm = true
 [[example]]
 name = "sprite_flipping"
 path = "examples/2d/sprite_flipping.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.sprite_flipping]
 name = "Sprite Flipping"
@@ -383,6 +395,7 @@ wasm = true
 [[example]]
 name = "sprite_sheet"
 path = "examples/2d/sprite_sheet.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.sprite_sheet]
 name = "Sprite Sheet"
@@ -393,6 +406,7 @@ wasm = true
 [[example]]
 name = "text2d"
 path = "examples/2d/text2d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text2d]
 name = "Text 2D"
@@ -403,6 +417,7 @@ wasm = true
 [[example]]
 name = "texture_atlas"
 path = "examples/2d/texture_atlas.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.texture_atlas]
 name = "Texture Atlas"
@@ -413,6 +428,7 @@ wasm = false
 [[example]]
 name = "transparency_2d"
 path = "examples/2d/transparency_2d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transparency_2d]
 name = "Transparency in 2D"
@@ -423,6 +439,7 @@ wasm = true
 [[example]]
 name = "pixel_perfect"
 path = "examples/2d/pixel_perfect.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.pixel_perfect]
 name = "Pixel Perfect"
@@ -434,6 +451,7 @@ wasm = true
 [[example]]
 name = "3d_scene"
 path = "examples/3d/3d_scene.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.3d_scene]
 name = "3D Scene"
@@ -444,6 +462,7 @@ wasm = true
 [[example]]
 name = "3d_shapes"
 path = "examples/3d/3d_shapes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.3d_shapes]
 name = "3D Shapes"
@@ -454,6 +473,7 @@ wasm = true
 [[example]]
 name = "generate_custom_mesh"
 path = "examples/3d/generate_custom_mesh.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.generate_custom_mesh]
 name = "Generate Custom Mesh"
@@ -464,6 +484,7 @@ wasm = true
 [[example]]
 name = "anti_aliasing"
 path = "examples/3d/anti_aliasing.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.anti_aliasing]
 name = "Anti-aliasing"
@@ -474,6 +495,7 @@ wasm = false
 [[example]]
 name = "3d_gizmos"
 path = "examples/3d/3d_gizmos.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.3d_gizmos]
 name = "3D Gizmos"
@@ -484,6 +506,7 @@ wasm = true
 [[example]]
 name = "atmospheric_fog"
 path = "examples/3d/atmospheric_fog.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.atmospheric_fog]
 name = "Atmospheric Fog"
@@ -494,6 +517,7 @@ wasm = true
 [[example]]
 name = "fog"
 path = "examples/3d/fog.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.fog]
 name = "Fog"
@@ -504,6 +528,7 @@ wasm = true
 [[example]]
 name = "blend_modes"
 path = "examples/3d/blend_modes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.blend_modes]
 name = "Blend Modes"
@@ -514,6 +539,7 @@ wasm = true
 [[example]]
 name = "lighting"
 path = "examples/3d/lighting.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.lighting]
 name = "Lighting"
@@ -524,6 +550,7 @@ wasm = true
 [[example]]
 name = "lines"
 path = "examples/3d/lines.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.lines]
 name = "Lines"
@@ -534,6 +561,7 @@ wasm = true
 [[example]]
 name = "ssao"
 path = "examples/3d/ssao.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.ssao]
 name = "Screen Space Ambient Occlusion"
@@ -544,6 +572,7 @@ wasm = false
 [[example]]
 name = "spotlight"
 path = "examples/3d/spotlight.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.spotlight]
 name = "Spotlight"
@@ -554,6 +583,7 @@ wasm = true
 [[example]]
 name = "bloom_3d"
 path = "examples/3d/bloom_3d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.bloom_3d]
 name = "3D Bloom"
@@ -564,6 +594,7 @@ wasm = true
 [[example]]
 name = "load_gltf"
 path = "examples/3d/load_gltf.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.load_gltf]
 name = "Load glTF"
@@ -574,6 +605,7 @@ wasm = true
 [[example]]
 name = "tonemapping"
 path = "examples/3d/tonemapping.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.tonemapping]
 name = "Tonemapping"
@@ -584,6 +616,7 @@ wasm = true
 [[example]]
 name = "orthographic"
 path = "examples/3d/orthographic.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.orthographic]
 name = "Orthographic View"
@@ -594,6 +627,7 @@ wasm = true
 [[example]]
 name = "parenting"
 path = "examples/3d/parenting.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.parenting]
 name = "Parenting"
@@ -604,6 +638,7 @@ wasm = true
 [[example]]
 name = "pbr"
 path = "examples/3d/pbr.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.pbr]
 name = "Physically Based Rendering"
@@ -614,6 +649,7 @@ wasm = true
 [[example]]
 name = "parallax_mapping"
 path = "examples/3d/parallax_mapping.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.parallax_mapping]
 name = "Parallax Mapping"
@@ -624,6 +660,7 @@ wasm = true
 [[example]]
 name = "render_to_texture"
 path = "examples/3d/render_to_texture.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.render_to_texture]
 name = "Render to Texture"
@@ -634,6 +671,7 @@ wasm = true
 [[example]]
 name = "shadow_biases"
 path = "examples/3d/shadow_biases.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shadow_biases]
 name = "Shadow Biases"
@@ -644,6 +682,7 @@ wasm = true
 [[example]]
 name = "shadow_caster_receiver"
 path = "examples/3d/shadow_caster_receiver.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shadow_caster_receiver]
 name = "Shadow Caster and Receiver"
@@ -654,6 +693,7 @@ wasm = true
 [[example]]
 name = "skybox"
 path = "examples/3d/skybox.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.skybox]
 name = "Skybox"
@@ -664,6 +704,7 @@ wasm = false
 [[example]]
 name = "spherical_area_lights"
 path = "examples/3d/spherical_area_lights.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.spherical_area_lights]
 name = "Spherical Area Lights"
@@ -674,6 +715,7 @@ wasm = true
 [[example]]
 name = "split_screen"
 path = "examples/3d/split_screen.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.split_screen]
 name = "Split Screen"
@@ -684,6 +726,7 @@ wasm = true
 [[example]]
 name = "texture"
 path = "examples/3d/texture.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.texture]
 name = "Texture"
@@ -694,6 +737,7 @@ wasm = true
 [[example]]
 name = "transparency_3d"
 path = "examples/3d/transparency_3d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transparency_3d]
 name = "Transparency in 3D"
@@ -704,6 +748,7 @@ wasm = true
 [[example]]
 name = "two_passes"
 path = "examples/3d/two_passes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.two_passes]
 name = "Two Passes"
@@ -714,6 +759,7 @@ wasm = true
 [[example]]
 name = "update_gltf_scene"
 path = "examples/3d/update_gltf_scene.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.update_gltf_scene]
 name = "Update glTF Scene"
@@ -724,6 +770,7 @@ wasm = true
 [[example]]
 name = "vertex_colors"
 path = "examples/3d/vertex_colors.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.vertex_colors]
 name = "Vertex Colors"
@@ -734,6 +781,7 @@ wasm = true
 [[example]]
 name = "wireframe"
 path = "examples/3d/wireframe.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.wireframe]
 name = "Wireframe"
@@ -744,6 +792,7 @@ wasm = false
 [[example]]
 name = "no_prepass"
 path = "tests/3d/no_prepass.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.no_prepass]
 hidden = true
@@ -752,6 +801,7 @@ hidden = true
 [[example]]
 name = "animated_fox"
 path = "examples/animation/animated_fox.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.animated_fox]
 name = "Animated Fox"
@@ -762,6 +812,7 @@ wasm = true
 [[example]]
 name = "morph_targets"
 path = "examples/animation/morph_targets.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.morph_targets]
 name = "Morph Targets"
@@ -772,6 +823,7 @@ wasm = true
 [[example]]
 name = "animated_transform"
 path = "examples/animation/animated_transform.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.animated_transform]
 name = "Animated Transform"
@@ -782,6 +834,7 @@ wasm = true
 [[example]]
 name = "cubic_curve"
 path = "examples/animation/cubic_curve.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.cubic_curve]
 name = "Cubic Curve"
@@ -792,6 +845,7 @@ wasm = true
 [[example]]
 name = "custom_skinned_mesh"
 path = "examples/animation/custom_skinned_mesh.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_skinned_mesh]
 name = "Custom Skinned Mesh"
@@ -802,6 +856,7 @@ wasm = true
 [[example]]
 name = "gltf_skinned_mesh"
 path = "examples/animation/gltf_skinned_mesh.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.gltf_skinned_mesh]
 name = "glTF Skinned Mesh"
@@ -813,6 +868,7 @@ wasm = true
 [[example]]
 name = "custom_loop"
 path = "examples/app/custom_loop.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_loop]
 name = "Custom Loop"
@@ -823,6 +879,7 @@ wasm = false
 [[example]]
 name = "drag_and_drop"
 path = "examples/app/drag_and_drop.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.drag_and_drop]
 name = "Drag and Drop"
@@ -833,6 +890,7 @@ wasm = false
 [[example]]
 name = "empty"
 path = "examples/app/empty.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.empty]
 name = "Empty"
@@ -843,6 +901,7 @@ wasm = false
 [[example]]
 name = "empty_defaults"
 path = "examples/app/empty_defaults.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.empty_defaults]
 name = "Empty with Defaults"
@@ -853,6 +912,7 @@ wasm = true
 [[example]]
 name = "headless"
 path = "examples/app/headless.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.headless]
 name = "Headless"
@@ -863,6 +923,7 @@ wasm = false
 [[example]]
 name = "logs"
 path = "examples/app/logs.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.logs]
 name = "Logs"
@@ -873,6 +934,7 @@ wasm = true
 [[example]]
 name = "plugin"
 path = "examples/app/plugin.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.plugin]
 name = "Plugin"
@@ -883,6 +945,7 @@ wasm = true
 [[example]]
 name = "plugin_group"
 path = "examples/app/plugin_group.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.plugin_group]
 name = "Plugin Group"
@@ -893,6 +956,7 @@ wasm = true
 [[example]]
 name = "return_after_run"
 path = "examples/app/return_after_run.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.return_after_run]
 name = "Return after Run"
@@ -903,6 +967,7 @@ wasm = false
 [[example]]
 name = "thread_pool_resources"
 path = "examples/app/thread_pool_resources.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.thread_pool_resources]
 name = "Thread Pool Resources"
@@ -913,6 +978,7 @@ wasm = false
 [[example]]
 name = "no_renderer"
 path = "examples/app/no_renderer.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.no_renderer]
 name = "No Renderer"
@@ -923,6 +989,7 @@ wasm = false
 [[example]]
 name = "without_winit"
 path = "examples/app/without_winit.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.without_winit]
 name = "Without Winit"
@@ -934,6 +1001,7 @@ wasm = false
 [[example]]
 name = "asset_loading"
 path = "examples/asset/asset_loading.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.asset_loading]
 name = "Asset Loading"
@@ -944,6 +1012,7 @@ wasm = false
 [[example]]
 name = "custom_asset"
 path = "examples/asset/custom_asset.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_asset]
 name = "Custom Asset"
@@ -954,6 +1023,7 @@ wasm = true
 [[example]]
 name = "custom_asset_io"
 path = "examples/asset/custom_asset_io.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_asset_io]
 name = "Custom Asset IO"
@@ -964,6 +1034,7 @@ wasm = true
 [[example]]
 name = "hot_asset_reloading"
 path = "examples/asset/hot_asset_reloading.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.hot_asset_reloading]
 name = "Hot Reloading of Assets"
@@ -975,6 +1046,7 @@ wasm = true
 [[example]]
 name = "async_compute"
 path = "examples/async_tasks/async_compute.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.async_compute]
 name = "Async Compute"
@@ -985,6 +1057,7 @@ wasm = false
 [[example]]
 name = "external_source_external_thread"
 path = "examples/async_tasks/external_source_external_thread.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.external_source_external_thread]
 name = "External Source of Data on an External Thread"
@@ -996,6 +1069,7 @@ wasm = false
 [[example]]
 name = "audio"
 path = "examples/audio/audio.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.audio]
 name = "Audio"
@@ -1006,6 +1080,7 @@ wasm = true
 [[example]]
 name = "audio_control"
 path = "examples/audio/audio_control.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.audio_control]
 name = "Audio Control"
@@ -1016,6 +1091,7 @@ wasm = true
 [[example]]
 name = "decodable"
 path = "examples/audio/decodable.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.decodable]
 name = "Decodable"
@@ -1026,6 +1102,7 @@ wasm = true
 [[example]]
 name = "spatial_audio_2d"
 path = "examples/audio/spatial_audio_2d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.spatial_audio_2d]
 name = "Spatial Audio 2D"
@@ -1036,6 +1113,7 @@ wasm = true
 [[example]]
 name = "spatial_audio_3d"
 path = "examples/audio/spatial_audio_3d.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.spatial_audio_3d]
 name = "Spatial Audio 3D"
@@ -1057,6 +1135,7 @@ wasm = true
 [[example]]
 name = "log_diagnostics"
 path = "examples/diagnostics/log_diagnostics.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.log_diagnostics]
 name = "Log Diagnostics"
@@ -1067,6 +1146,7 @@ wasm = true
 [[example]]
 name = "custom_diagnostic"
 path = "examples/diagnostics/custom_diagnostic.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_diagnostic]
 name = "Custom Diagnostic"
@@ -1078,6 +1158,7 @@ wasm = true
 [[example]]
 name = "ecs_guide"
 path = "examples/ecs/ecs_guide.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.ecs_guide]
 name = "ECS Guide"
@@ -1088,6 +1169,7 @@ wasm = false
 [[example]]
 name = "apply_deferred"
 path = "examples/ecs/apply_deferred.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.apply_deferred]
 name = "Apply System Buffers"
@@ -1098,6 +1180,7 @@ wasm = false
 [[example]]
 name = "component_change_detection"
 path = "examples/ecs/component_change_detection.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.component_change_detection]
 name = "Component Change Detection"
@@ -1108,6 +1191,7 @@ wasm = false
 [[example]]
 name = "custom_query_param"
 path = "examples/ecs/custom_query_param.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_query_param]
 name = "Custom Query Parameters"
@@ -1118,6 +1202,7 @@ wasm = false
 [[example]]
 name = "event"
 path = "examples/ecs/event.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.event]
 name = "Event"
@@ -1128,6 +1213,7 @@ wasm = false
 [[example]]
 name = "fixed_timestep"
 path = "examples/ecs/fixed_timestep.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.fixed_timestep]
 name = "Fixed Timestep"
@@ -1138,6 +1224,7 @@ wasm = false
 [[example]]
 name = "generic_system"
 path = "examples/ecs/generic_system.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.generic_system]
 name = "Generic System"
@@ -1148,6 +1235,7 @@ wasm = false
 [[example]]
 name = "hierarchy"
 path = "examples/ecs/hierarchy.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.hierarchy]
 name = "Hierarchy"
@@ -1158,6 +1246,7 @@ wasm = false
 [[example]]
 name = "iter_combinations"
 path = "examples/ecs/iter_combinations.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.iter_combinations]
 name = "Iter Combinations"
@@ -1168,6 +1257,7 @@ wasm = true
 [[example]]
 name = "parallel_query"
 path = "examples/ecs/parallel_query.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.parallel_query]
 name = "Parallel Query"
@@ -1178,6 +1268,7 @@ wasm = false
 [[example]]
 name = "removal_detection"
 path = "examples/ecs/removal_detection.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.removal_detection]
 name = "Removal Detection"
@@ -1188,6 +1279,7 @@ wasm = false
 [[example]]
 name = "run_conditions"
 path = "examples/ecs/run_conditions.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.run_conditions]
 name = "Run Conditions"
@@ -1198,6 +1290,7 @@ wasm = false
 [[example]]
 name = "startup_system"
 path = "examples/ecs/startup_system.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.startup_system]
 name = "Startup System"
@@ -1208,6 +1301,7 @@ wasm = false
 [[example]]
 name = "state"
 path = "examples/ecs/state.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.state]
 name = "State"
@@ -1218,6 +1312,7 @@ wasm = false
 [[example]]
 name = "system_piping"
 path = "examples/ecs/system_piping.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.system_piping]
 name = "System Piping"
@@ -1228,6 +1323,7 @@ wasm = false
 [[example]]
 name = "system_closure"
 path = "examples/ecs/system_closure.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.system_closure]
 name = "System Closure"
@@ -1238,6 +1334,7 @@ wasm = false
 [[example]]
 name = "system_param"
 path = "examples/ecs/system_param.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.system_param]
 name = "System Parameter"
@@ -1248,6 +1345,7 @@ wasm = false
 [[example]]
 name = "timers"
 path = "examples/ecs/timers.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.timers]
 name = "Timers"
@@ -1259,6 +1357,7 @@ wasm = false
 [[example]]
 name = "alien_cake_addict"
 path = "examples/games/alien_cake_addict.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.alien_cake_addict]
 name = "Alien Cake Addict"
@@ -1269,6 +1368,7 @@ wasm = true
 [[example]]
 name = "breakout"
 path = "examples/games/breakout.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.breakout]
 name = "Breakout"
@@ -1279,6 +1379,7 @@ wasm = true
 [[example]]
 name = "contributors"
 path = "examples/games/contributors.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.contributors]
 name = "Contributors"
@@ -1289,6 +1390,7 @@ wasm = true
 [[example]]
 name = "game_menu"
 path = "examples/games/game_menu.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.game_menu]
 name = "Game Menu"
@@ -1300,6 +1402,7 @@ wasm = true
 [[example]]
 name = "char_input_events"
 path = "examples/input/char_input_events.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.char_input_events]
 name = "Char Input Events"
@@ -1310,6 +1413,7 @@ wasm = false
 [[example]]
 name = "gamepad_input"
 path = "examples/input/gamepad_input.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.gamepad_input]
 name = "Gamepad Input"
@@ -1320,6 +1424,7 @@ wasm = false
 [[example]]
 name = "gamepad_input_events"
 path = "examples/input/gamepad_input_events.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.gamepad_input_events]
 name = "Gamepad Input Events"
@@ -1330,6 +1435,7 @@ wasm = false
 [[example]]
 name = "gamepad_rumble"
 path = "examples/input/gamepad_rumble.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.gamepad_rumble]
 name = "Gamepad Rumble"
@@ -1340,6 +1446,7 @@ wasm = false
 [[example]]
 name = "keyboard_input"
 path = "examples/input/keyboard_input.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.keyboard_input]
 name = "Keyboard Input"
@@ -1350,6 +1457,7 @@ wasm = false
 [[example]]
 name = "keyboard_modifiers"
 path = "examples/input/keyboard_modifiers.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.keyboard_modifiers]
 name = "Keyboard Modifiers"
@@ -1360,6 +1468,7 @@ wasm = false
 [[example]]
 name = "keyboard_input_events"
 path = "examples/input/keyboard_input_events.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.keyboard_input_events]
 name = "Keyboard Input Events"
@@ -1370,6 +1479,7 @@ wasm = false
 [[example]]
 name = "mouse_input"
 path = "examples/input/mouse_input.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mouse_input]
 name = "Mouse Input"
@@ -1380,6 +1490,7 @@ wasm = false
 [[example]]
 name = "mouse_input_events"
 path = "examples/input/mouse_input_events.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mouse_input_events]
 name = "Mouse Input Events"
@@ -1390,6 +1501,7 @@ wasm = false
 [[example]]
 name = "mouse_grab"
 path = "examples/input/mouse_grab.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.mouse_grab]
 name = "Mouse Grab"
@@ -1400,6 +1512,7 @@ wasm = false
 [[example]]
 name = "touch_input"
 path = "examples/input/touch_input.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.touch_input]
 name = "Touch Input"
@@ -1410,6 +1523,7 @@ wasm = false
 [[example]]
 name = "touch_input_events"
 path = "examples/input/touch_input_events.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.touch_input_events]
 name = "Touch Input Events"
@@ -1420,6 +1534,7 @@ wasm = false
 [[example]]
 name = "text_input"
 path = "examples/input/text_input.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text_input]
 name = "Text Input"
@@ -1431,6 +1546,7 @@ wasm = false
 [[example]]
 name = "reflection"
 path = "examples/reflection/reflection.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.reflection]
 name = "Reflection"
@@ -1441,6 +1557,7 @@ wasm = false
 [[example]]
 name = "generic_reflection"
 path = "examples/reflection/generic_reflection.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.generic_reflection]
 name = "Generic Reflection"
@@ -1451,6 +1568,7 @@ wasm = false
 [[example]]
 name = "reflection_types"
 path = "examples/reflection/reflection_types.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.reflection_types]
 name = "Reflection Types"
@@ -1461,6 +1579,7 @@ wasm = false
 [[example]]
 name = "trait_reflection"
 path = "examples/reflection/trait_reflection.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.trait_reflection]
 name = "Trait Reflection"
@@ -1472,6 +1591,7 @@ wasm = false
 [[example]]
 name = "scene"
 path = "examples/scene/scene.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.scene]
 name = "Scene"
@@ -1493,6 +1613,7 @@ There are also compute shaders which are used for more general processing levera
 [[example]]
 name = "custom_vertex_attribute"
 path = "examples/shader/custom_vertex_attribute.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.custom_vertex_attribute]
 name = "Custom Vertex Attribute"
@@ -1503,6 +1624,7 @@ wasm = true
 [[example]]
 name = "post_processing"
 path = "examples/shader/post_processing.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.post_processing]
 name = "Post Processing - Custom Render Pass"
@@ -1513,6 +1635,7 @@ wasm = true
 [[example]]
 name = "shader_defs"
 path = "examples/shader/shader_defs.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_defs]
 name = "Shader Defs"
@@ -1523,6 +1646,7 @@ wasm = true
 [[example]]
 name = "shader_material"
 path = "examples/shader/shader_material.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_material]
 name = "Material"
@@ -1533,6 +1657,7 @@ wasm = true
 [[example]]
 name = "shader_prepass"
 path = "examples/shader/shader_prepass.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_prepass]
 name = "Material Prepass"
@@ -1543,6 +1668,7 @@ wasm = false
 [[example]]
 name = "shader_material_screenspace_texture"
 path = "examples/shader/shader_material_screenspace_texture.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_material_screenspace_texture]
 name = "Material - Screenspace Texture"
@@ -1553,6 +1679,7 @@ wasm = true
 [[example]]
 name = "shader_material_glsl"
 path = "examples/shader/shader_material_glsl.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_material_glsl]
 name = "Material - GLSL"
@@ -1563,6 +1690,7 @@ wasm = true
 [[example]]
 name = "shader_instancing"
 path = "examples/shader/shader_instancing.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.shader_instancing]
 name = "Instancing"
@@ -1573,6 +1701,7 @@ wasm = true
 [[example]]
 name = "animate_shader"
 path = "examples/shader/animate_shader.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.animate_shader]
 name = "Animated"
@@ -1583,6 +1712,7 @@ wasm = true
 [[example]]
 name = "compute_shader_game_of_life"
 path = "examples/shader/compute_shader_game_of_life.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.compute_shader_game_of_life]
 name = "Compute - Game of Life"
@@ -1593,6 +1723,7 @@ wasm = false
 [[example]]
 name = "array_texture"
 path = "examples/shader/array_texture.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.array_texture]
 name = "Array Texture"
@@ -1603,6 +1734,7 @@ wasm = true
 [[example]]
 name = "texture_binding_array"
 path = "examples/shader/texture_binding_array.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.texture_binding_array]
 name = "Texture Binding Array (Bindless Textures)"
@@ -1626,6 +1758,7 @@ cargo run --release --example <example name>
 [[example]]
 name = "bevymark"
 path = "examples/stress_tests/bevymark.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.bevymark]
 name = "Bevymark"
@@ -1636,6 +1769,7 @@ wasm = true
 [[example]]
 name = "many_animated_sprites"
 path = "examples/stress_tests/many_animated_sprites.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_animated_sprites]
 name = "Many Animated Sprites"
@@ -1646,6 +1780,7 @@ wasm = true
 [[example]]
 name = "many_buttons"
 path = "examples/stress_tests/many_buttons.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_buttons]
 name = "Many Buttons"
@@ -1656,6 +1791,7 @@ wasm = true
 [[example]]
 name = "many_cubes"
 path = "examples/stress_tests/many_cubes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_cubes]
 name = "Many Cubes"
@@ -1666,6 +1802,7 @@ wasm = true
 [[example]]
 name = "many_gizmos"
 path = "examples/stress_tests/many_gizmos.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_gizmos]
 name = "Many Gizmos"
@@ -1676,6 +1813,7 @@ wasm = true
 [[example]]
 name = "many_foxes"
 path = "examples/stress_tests/many_foxes.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_foxes]
 name = "Many Foxes"
@@ -1686,6 +1824,7 @@ wasm = true
 [[example]]
 name = "many_glyphs"
 path = "examples/stress_tests/many_glyphs.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_glyphs]
 name = "Many Glyphs"
@@ -1696,6 +1835,7 @@ wasm = true
 [[example]]
 name = "many_lights"
 path = "examples/stress_tests/many_lights.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_lights]
 name = "Many Lights"
@@ -1706,6 +1846,7 @@ wasm = true
 [[example]]
 name = "many_sprites"
 path = "examples/stress_tests/many_sprites.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.many_sprites]
 name = "Many Sprites"
@@ -1716,6 +1857,7 @@ wasm = true
 [[example]]
 name = "transform_hierarchy"
 path = "examples/stress_tests/transform_hierarchy.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transform_hierarchy]
 name = "Transform Hierarchy"
@@ -1726,6 +1868,7 @@ wasm = false
 [[example]]
 name = "text_pipeline"
 path = "examples/stress_tests/text_pipeline.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text_pipeline]
 name = "Text Pipeline"
@@ -1737,6 +1880,7 @@ wasm = false
 [[example]]
 name = "scene_viewer"
 path = "examples/tools/scene_viewer/main.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.scene_viewer]
 name = "Scene Viewer"
@@ -1747,6 +1891,7 @@ wasm = true
 [[example]]
 name = "gamepad_viewer"
 path = "examples/tools/gamepad_viewer.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.gamepad_viewer]
 name = "Gamepad Viewer"
@@ -1757,6 +1902,7 @@ wasm = false
 [[example]]
 name = "nondeterministic_system_order"
 path = "examples/ecs/nondeterministic_system_order.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.nondeterministic_system_order]
 name = "Nondeterministic System Order"
@@ -1767,6 +1913,7 @@ wasm = false
 [[example]]
 name = "3d_rotation"
 path = "examples/transforms/3d_rotation.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.3d_rotation]
 name = "3D Rotation"
@@ -1777,6 +1924,7 @@ wasm = true
 [[example]]
 name = "scale"
 path = "examples/transforms/scale.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.scale]
 name = "Scale"
@@ -1787,6 +1935,7 @@ wasm = true
 [[example]]
 name = "transform"
 path = "examples/transforms/transform.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transform]
 name = "Transform"
@@ -1797,6 +1946,7 @@ wasm = true
 [[example]]
 name = "translation"
 path = "examples/transforms/translation.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.translation]
 name = "Translation"
@@ -1808,6 +1958,7 @@ wasm = true
 [[example]]
 name = "borders"
 path = "examples/ui/borders.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.borders]
 name = "Borders"
@@ -1818,6 +1969,7 @@ wasm = true
 [[example]]
 name = "button"
 path = "examples/ui/button.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.button]
 name = "Button"
@@ -1828,6 +1980,7 @@ wasm = true
 [[example]]
 name = "display_and_visibility"
 path = "examples/ui/display_and_visibility.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.display_and_visibility]
 name = "Display and Visibility"
@@ -1838,6 +1991,7 @@ wasm = true
 [[example]]
 name = "window_fallthrough"
 path = "examples/ui/window_fallthrough.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.window_fallthrough]
 name = "Window Fallthrough"
@@ -1848,6 +2002,7 @@ wasm = false
 [[example]]
 name = "font_atlas_debug"
 path = "examples/ui/font_atlas_debug.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.font_atlas_debug]
 name = "Font Atlas Debug"
@@ -1858,6 +2013,7 @@ wasm = true
 [[example]]
 name = "overflow"
 path = "examples/ui/overflow.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.overflow]
 name = "Overflow"
@@ -1868,6 +2024,7 @@ wasm = true
 [[example]]
 name = "overflow_debug"
 path = "examples/ui/overflow_debug.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.overflow_debug]
 name = "Overflow and Clipping Debug"
@@ -1878,6 +2035,7 @@ wasm = true
 [[example]]
 name = "relative_cursor_position"
 path = "examples/ui/relative_cursor_position.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.relative_cursor_position]
 name = "Relative Cursor Position"
@@ -1888,6 +2046,7 @@ wasm = true
 [[example]]
 name = "size_constraints"
 path = "examples/ui/size_constraints.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.size_constraints]
 name = "Size Constraints"
@@ -1898,6 +2057,7 @@ wasm = true
 [[example]]
 name = "text"
 path = "examples/ui/text.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text]
 name = "Text"
@@ -1908,6 +2068,7 @@ wasm = true
 [[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text_debug]
 name = "Text Debug"
@@ -1918,6 +2079,7 @@ wasm = true
 [[example]]
 name = "flex_layout"
 path = "examples/ui/flex_layout.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.flex_layout]
 name = "Flex Layout"
@@ -1928,6 +2090,7 @@ wasm = true
 [[example]]
 name = "text_wrap_debug"
 path = "examples/ui/text_wrap_debug.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.text_wrap_debug]
 name = "Text Wrap Debug"
@@ -1938,6 +2101,7 @@ wasm = true
 [[example]]
 name = "grid"
 path = "examples/ui/grid.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.grid]
 name = "CSS Grid"
@@ -1949,6 +2113,7 @@ wasm = true
 [[example]]
 name = "transparency_ui"
 path = "examples/ui/transparency_ui.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transparency_ui]
 name = "Transparency UI"
@@ -1959,6 +2124,7 @@ wasm = true
 [[example]]
 name = "z_index"
 path = "examples/ui/z_index.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.z_index]
 name = "UI Z-Index"
@@ -1969,6 +2135,7 @@ wasm = true
 [[example]]
 name = "ui"
 path = "examples/ui/ui.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.ui]
 name = "UI"
@@ -1979,6 +2146,7 @@ wasm = true
 [[example]]
 name = "ui_scaling"
 path = "examples/ui/ui_scaling.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.ui_scaling]
 name = "UI Scaling"
@@ -1989,6 +2157,7 @@ wasm = true
 [[example]]
 name = "ui_texture_atlas"
 path = "examples/ui/ui_texture_atlas.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.ui_texture_atlas]
 name = "UI Texture Atlas"
@@ -1999,6 +2168,7 @@ wasm = true
 [[example]]
 name = "viewport_debug"
 path = "examples/ui/viewport_debug.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.viewport_debug]
 name = "Viewport Debug"
@@ -2010,6 +2180,7 @@ wasm = true
 [[example]]
 name = "clear_color"
 path = "examples/window/clear_color.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.clear_color]
 name = "Clear Color"
@@ -2020,6 +2191,7 @@ wasm = true
 [[example]]
 name = "low_power"
 path = "examples/window/low_power.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.low_power]
 name = "Low Power"
@@ -2030,6 +2202,7 @@ wasm = true
 [[example]]
 name = "multiple_windows"
 path = "examples/window/multiple_windows.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.multiple_windows]
 name = "Multiple Windows"
@@ -2040,6 +2213,7 @@ wasm = false
 [[example]]
 name = "scale_factor_override"
 path = "examples/window/scale_factor_override.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.scale_factor_override]
 name = "Scale Factor Override"
@@ -2050,6 +2224,7 @@ wasm = true
 [[example]]
 name = "screenshot"
 path = "examples/window/screenshot.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.screenshot]
 name = "Screenshot"
@@ -2060,6 +2235,7 @@ wasm = true
 [[example]]
 name = "transparent_window"
 path = "examples/window/transparent_window.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.transparent_window]
 name = "Transparent Window"
@@ -2070,6 +2246,7 @@ wasm = false
 [[example]]
 name = "window_settings"
 path = "examples/window/window_settings.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.window_settings]
 name = "Window Settings"
@@ -2080,6 +2257,7 @@ wasm = true
 [[example]]
 name = "resizing"
 path = "tests/window/resizing.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.resizing]
 hidden = true
@@ -2087,6 +2265,7 @@ hidden = true
 [[example]]
 name = "minimising"
 path = "tests/window/minimising.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.minimising]
 hidden = true
@@ -2094,10 +2273,12 @@ hidden = true
 [[example]]
 name = "window_resizing"
 path = "examples/window/window_resizing.rs"
+doc-scrape-examples = true
 
 [[example]]
 name = "fallback_image"
 path = "examples/shader/fallback_image.rs"
+doc-scrape-examples = true
 
 [package.metadata.example.fallback_image]
 hidden = true
@@ -2118,3 +2299,6 @@ codegen-units = 1
 inherits = "release"
 lto = "fat"
 panic = "abort"
+
+[package.metadata.docs.rs]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2301,4 +2301,5 @@ lto = "fat"
 panic = "abort"
 
 [package.metadata.docs.rs]
+all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2301,5 +2301,4 @@ lto = "fat"
 panic = "abort"
 
 [package.metadata.docs.rs]
-all-features = true
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]


### PR DESCRIPTION
# Objective

Provide more usage examples in API docs so that people can see methods being used in context.

## Solution

Enable experimental rustdoc feature "scrape examples". See <https://doc.rust-lang.org/nightly/rustdoc/scraped-examples.html> for official docs.

## Example screenshots of examples :)

<img width="1013" alt="image" src="https://github.com/bevyengine/bevy/assets/20063/7abc8baa-3149-476f-b2f2-ce7693758bee">

<img width="1033" alt="image" src="https://github.com/bevyengine/bevy/assets/20063/163e7e22-c55e-46ab-8f3d-75fb97c3ad7a">

<img width="1009" alt="image" src="https://github.com/bevyengine/bevy/assets/20063/a50b1147-e252-43f3-9adb-81960b8aa6c3">


## Limitations

- Only methods seem to show examples so far
- It may be confusing to have curated examples from doc comments followed by snippets from `examples/`