### PR TITLE
Fix non-visible motion vector text in shader prepass example

### DIFF
--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -242,16 +242,10 @@ fn toggle_prepass_view(
             3 => "motion vectors",
             _ => unreachable!(),
         };
-        let text_color = if *prepass_view == 3 {
-            Color::BLACK
-        } else {
-            Color::WHITE
-        };
-
         let mut text = text.single_mut();
         text.sections[0].value = format!("Prepass Output: {label}\n");
         for section in &mut text.sections {
-            section.style.color = text_color;
+            section.style.color = Color::WHITE;
         }
 
         let handle = material_handle.single();


### PR DESCRIPTION
# Objective

In the shader prepass example, changing to the motion vector output hides the text, because both it and the background are rendererd black.
Seems to have been caused by this commit? https://github.com/bevyengine/bevy/commit/71cf35ce426bf3ab448c9d1e6ff0c22fc5a10336

## Solution

Make the text white on all outputs.
