### PR TITLE
Fix panic whilst loading UASTC encoded ktx2 textures

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -40,20 +40,23 @@ impl GltfPlugin {
 
 impl Plugin for GltfPlugin {
     fn build(&self, app: &mut App) {
+        app.register_type::<GltfExtras>()
+            .add_asset::<Gltf>()
+            .add_asset::<GltfNode>()
+            .add_asset::<GltfPrimitive>()
+            .add_asset::<GltfMesh>();
+    }
+
+    fn finish(&self, app: &mut App) {
         let supported_compressed_formats = match app.world.get_resource::<RenderDevice>() {
             Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
 
-            None => CompressedImageFormats::all(),
+            None => CompressedImageFormats::NONE,
         };
         app.add_asset_loader::<GltfLoader>(GltfLoader {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),
-        })
-        .register_type::<GltfExtras>()
-        .add_asset::<Gltf>()
-        .add_asset::<GltfNode>()
-        .add_asset::<GltfPrimitive>()
-        .add_asset::<GltfMesh>();
+        });
     }
 }
 

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -82,7 +82,7 @@ impl FromWorld for ImageTextureLoader {
         let supported_compressed_formats = match world.get_resource::<RenderDevice>() {
             Some(render_device) => CompressedImageFormats::from_features(render_device.features()),
 
-            None => CompressedImageFormats::all(),
+            None => CompressedImageFormats::NONE,
         };
         Self {
             supported_compressed_formats,

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -70,19 +70,6 @@ impl ImagePlugin {
 
 impl Plugin for ImagePlugin {
     fn build(&self, app: &mut App) {
-        #[cfg(any(
-            feature = "png",
-            feature = "dds",
-            feature = "tga",
-            feature = "jpeg",
-            feature = "bmp",
-            feature = "basis-universal",
-            feature = "ktx2",
-        ))]
-        {
-            app.init_asset_loader::<ImageTextureLoader>();
-        }
-
         #[cfg(feature = "exr")]
         {
             app.init_asset_loader::<ExrTextureLoader>();
@@ -112,6 +99,19 @@ impl Plugin for ImagePlugin {
     }
 
     fn finish(&self, app: &mut App) {
+        #[cfg(any(
+        feature = "png",
+        feature = "dds",
+        feature = "tga",
+        feature = "jpeg",
+        feature = "bmp",
+        feature = "basis-universal",
+        feature = "ktx2",
+        ))]
+        {
+            app.init_asset_loader::<ImageTextureLoader>();
+        }
+
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             let default_sampler = {
                 let device = render_app.world.resource::<RenderDevice>();

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -100,13 +100,13 @@ impl Plugin for ImagePlugin {
 
     fn finish(&self, app: &mut App) {
         #[cfg(any(
-        feature = "png",
-        feature = "dds",
-        feature = "tga",
-        feature = "jpeg",
-        feature = "bmp",
-        feature = "basis-universal",
-        feature = "ktx2",
+            feature = "png",
+            feature = "dds",
+            feature = "tga",
+            feature = "jpeg",
+            feature = "bmp",
+            feature = "basis-universal",
+            feature = "ktx2",
         ))]
         {
             app.init_asset_loader::<ImageTextureLoader>();


### PR DESCRIPTION
# Objective

Fixes #9121

Context:
- `ImageTextureLoader` depends on `RenderDevice` to work out which compressed image formats it can support
- `RenderDevice` is initialised by `RenderPlugin`
- https://github.com/bevyengine/bevy/pull/8336 made `RenderPlugin` initialisation async
- This caused `RenderDevice` to be missing at the time of `ImageTextureLoader` initialisation, which in turn meant UASTC encoded ktx2 textures were being converted to unsupported formats, and thus caused panics

## Solution

- Delay `ImageTextureLoader` initialisation

---

## Changelog

- Moved `ImageTextureLoader` initialisation from `ImagePlugin::build()` to `ImagePlugin::finish()`
- Default to `CompressedImageFormats::NONE` if `RenderDevice` resource is missing
