### PR TITLE
Rename bevy_math::rects conversion methods

### DIFF
--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -311,13 +311,13 @@ impl Rect {
 
     /// Returns self as [`IRect`] (i32)
     #[inline]
-    pub fn as_urect(&self) -> IRect {
+    pub fn as_irect(&self) -> IRect {
         IRect::from_corners(self.min.as_ivec2(), self.max.as_ivec2())
     }
 
     /// Returns self as [`URect`] (u32)
     #[inline]
-    pub fn as_rect(&self) -> URect {
+    pub fn as_urect(&self) -> URect {
         URect::from_corners(self.min.as_uvec2(), self.max.as_uvec2())
     }
 }

--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -332,7 +332,7 @@ impl URect {
 
     /// Returns self as [`IRect`] (i32)
     #[inline]
-    pub fn as_urect(&self) -> IRect {
+    pub fn as_irect(&self) -> IRect {
         IRect::from_corners(self.min.as_ivec2(), self.max.as_ivec2())
     }
 }


### PR DESCRIPTION
# Objective

Some of the conversion methods on the new rect types introduced in #7984 have misleading names.

## Solution

Rename all methods returning an `IRect` to `as_irect` and all methods returning a `URect` to `as_urect`.

## Migration Guide

Replace uses of the old method names with the new method names.