### PR TITLE
example showcase - pagination and can build for WebGL2

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, ValueEnum};
 use xshell::{cmd, Shell};
 
 #[derive(Debug, Copy, Clone, ValueEnum)]
-enum Api {
+enum WebApi {
     Webgl2,
     Webgpu,
 }
@@ -26,9 +26,9 @@ struct Args {
     /// Stop after this number of frames
     frames: Option<usize>,
 
-    #[arg(value_enum, short, long, default_value_t = Api::Webgl2)]
+    #[arg(value_enum, short, long, default_value_t = WebApi::Webgl2)]
     /// Browser API to use for rendering
-    api: Api,
+    api: WebApi,
 
     #[arg(short, long)]
     /// Optimize the wasm file for size with wasm-opt
@@ -50,8 +50,8 @@ fn main() {
     }
 
     match cli.api {
-        Api::Webgl2 => (),
-        Api::Webgpu => {
+        WebApi::Webgl2 => (),
+        WebApi::Webgpu => {
             features.push("animation");
             features.push("bevy_asset");
             features.push("bevy_audio");
@@ -95,7 +95,7 @@ fn main() {
             sh,
             "cargo build {parameters...} --profile release --target wasm32-unknown-unknown --example {example}"
         );
-        if matches!(cli.api, Api::Webgpu) {
+        if matches!(cli.api, WebApi::Webgpu) {
             cmd = cmd.env("RUSTFLAGS", "--cfg=web_sys_unstable_apis");
         }
         cmd.run().expect("Error building example");

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -142,7 +142,16 @@ fn main() {
                 }
             }
 
-            for to_run in examples_to_run {
+            let work_to_do = || {
+                examples_to_run
+                    .iter()
+                    .skip(cli.page.unwrap_or(0) * cli.per_page.unwrap_or(0))
+                    .take(cli.per_page.unwrap_or(usize::MAX))
+            };
+
+            let mut pb = ProgressBar::new(work_to_do().count() as u64);
+
+            for to_run in work_to_do() {
                 let sh = Shell::new().unwrap();
                 let example = &to_run.technical_name;
                 let extra_parameters = extra_parameters.clone();
@@ -179,7 +188,9 @@ fn main() {
                 println!("took {duration:?}");
 
                 thread::sleep(Duration::from_secs(1));
+                pb.inc();
             }
+            pb.finish_print("done");
             if failed_examples.is_empty() {
                 println!("All examples passed!");
             } else {


### PR DESCRIPTION
# Objective

- Building all examples at once in CI takes too long
- Tool can only build for WebGPU

## Solution

- Add pagination to commands
- Add option to build examples for WebGL2
- Add option to build Zola files for WebGL2
