### PR TITLE
Fix UI corruption for AMD gpus with Vulkan

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -821,7 +821,10 @@ pub fn queue_uinodes(
             let pipeline = pipelines.specialize(
                 &pipeline_cache,
                 &ui_pipeline,
-                UiPipelineKey { hdr: view.hdr, msaa_samples: msaa.samples() },
+                UiPipelineKey {
+                    hdr: view.hdr,
+                    msaa_samples: msaa.samples(),
+                },
             );
             for (entity, batch) in &ui_batches {
                 image_bind_groups

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -3,6 +3,7 @@ mod render_pass;
 
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
+use bevy_render::view::Msaa;
 use bevy_render::{ExtractSchedule, Render};
 use bevy_window::{PrimaryWindow, Window};
 pub use pipeline::*;
@@ -794,6 +795,7 @@ pub fn queue_uinodes(
     ui_batches: Query<(Entity, &UiBatch)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
     events: Res<SpriteAssetEvents>,
+    msaa: Res<Msaa>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -819,7 +821,7 @@ pub fn queue_uinodes(
             let pipeline = pipelines.specialize(
                 &pipeline_cache,
                 &ui_pipeline,
-                UiPipelineKey { hdr: view.hdr },
+                UiPipelineKey { hdr: view.hdr, msaa_samples: msaa.samples() },
             );
             for (entity, batch) in &ui_batches {
                 image_bind_groups

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -62,6 +62,7 @@ impl FromWorld for UiPipeline {
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub hdr: bool,
+    pub msaa_samples: u32,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -117,7 +118,7 @@ impl SpecializedRenderPipeline for UiPipeline {
             },
             depth_stencil: None,
             multisample: MultisampleState {
-                count: 1,
+                count: key.msaa_samples,
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -72,7 +72,7 @@ impl Node for UiPassNode {
         };
         let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
             label: Some("ui_pass"),
-            color_attachments: &[Some(target.get_unsampled_color_attachment(Operations {
+            color_attachments: &[Some(target.get_color_attachment(Operations {
                 load: LoadOp::Load,
                 store: true,
             }))],


### PR DESCRIPTION
# Objective

Fixes #8894 
Fixes #7944 

## Solution

The UI pipeline's `MultisampleState::count` is set to 1 whereas the `MultisampleState::count` for the camera's ViewTarget is taken from the `Msaa` resource, and corruption occurs when these two values are different.

This PR solves the problem by setting `MultisampleState::count` for the UI pipeline to the value from the Msaa resource too.

I don't know much about Bevy's rendering internals or graphics hardware, so maybe there is a better solution than this. UI MSAA was probably disabled for a good reason (performance?). 

## Changelog
* Enabled multisampling for the UI pipeline.



