### PR TITLE
improve documentation relating to `WindowPlugin` and `Window`

### DIFF
--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -40,9 +40,10 @@ impl Default for WindowPlugin {
 pub struct WindowPlugin {
     /// Settings for the primary window.
     ///
-    /// By default [`WindowPlugin::primary_window`] resolves to `Some<PrimaryWindow>`
-    /// which spawns marker component [`PrimaryWindow`](PrimaryWindow).
-    /// To run without a primary window set [`WindowPlugin::primary_window`] to `None`.
+    /// `Some(custom_window)` will spawn an entity with `custom_window` and [`PrimaryWindow`] as components.
+    /// `None` will not spawn a primary window.
+    ///
+    /// Defaults to `Some(Window::default())`.
     ///
     /// Note that if there are no windows the App will exit (by default) due to
     /// [`exit_on_all_closed`].

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -38,12 +38,14 @@ impl Default for WindowPlugin {
 
 /// A [`Plugin`] that defines an interface for windowing support in Bevy.
 pub struct WindowPlugin {
-    /// Settings for the primary window. This will be spawned by
-    /// default, with the marker component [`PrimaryWindow`](PrimaryWindow).
-    /// If you want to run without a primary window you should set this to `None`.
+    /// Settings for the primary window.
     ///
-    /// Note that if there are no windows, by default the App will exit,
-    /// due to [`exit_on_all_closed`].
+    /// By default [`WindowPlugin::primary_window`] resolves to `Some<PrimaryWindow>`
+    /// which spawns marker component [`PrimaryWindow`](PrimaryWindow).
+    /// To run without a primary window set [`WindowPlugin::primary_window`] to `None`.
+    ///
+    /// Note that if there are no windows the App will exit (by default) due to
+    /// [`exit_on_all_closed`].
     pub primary_window: Option<Window>,
 
     /// Whether to exit the app when there are no open windows.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -17,7 +17,7 @@ use crate::CursorIcon;
 /// Currently this is assumed to only exist on 1 entity at a time.
 ///
 /// [`WindowPlugin`](crate::WindowPlugin) will spawn a [`Window`] entity
-/// with this component if [`WindowPlugin`](crate::WindowPlugin::primary_window)
+/// with this component if [`primary_window`](crate::WindowPlugin::primary_window)
 /// is `Some`.
 #[derive(Default, Debug, Component, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Reflect)]
 #[reflect(Component)]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -16,8 +16,9 @@ use crate::CursorIcon;
 ///
 /// Currently this is assumed to only exist on 1 entity at a time.
 ///
-/// [`WindowPlugin`](crate::WindowPlugin) will spawn a window entity
-/// with this component if `primary_window` is `Some`.
+/// [`WindowPlugin`](crate::WindowPlugin) will spawn a [`Window`] entity
+/// with this component if [`WindowPlugin`](crate::WindowPlugin::primary_window)
+/// is `Some`.
 #[derive(Default, Debug, Component, PartialEq, Eq, PartialOrd, Ord, Copy, Clone, Reflect)]
 #[reflect(Component)]
 pub struct PrimaryWindow;
@@ -234,16 +235,16 @@ impl Default for Window {
 }
 
 impl Window {
-    /// Setting this to true will attempt to maximize the window.
+    /// Setting to true will attempt to maximize the window.
     ///
-    /// Setting it to false will attempt to un-maximize the window.
+    /// Setting to false will attempt to un-maximize the window.
     pub fn set_maximized(&mut self, maximized: bool) {
         self.internal.maximize_request = Some(maximized);
     }
 
-    /// Setting this to true will attempt to minimize the window.
+    /// Setting to true will attempt to minimize the window.
     ///
-    /// Setting it to false will attempt to un-minimize the window.
+    /// Setting to false will attempt to un-minimize the window.
     pub fn set_minimized(&mut self, minimized: bool) {
         self.internal.minimize_request = Some(minimized);
     }


### PR DESCRIPTION
- attempt to clarify with better docstrings the default behaviour of WindowPlugin and the component type it accepts.

# Objective

- I'm new to Rust and Bevy, I got a bit confused about how to customise some window parameters (title, height, width etc) and while the docs do show the struct code for that field `Option<Window>` I was a bit of a doofus and skipped that to read the docstring entry for `primary_window` and then the `Window` component directly which aren't linked together. This is a minor improvement which I think will help in-case others, like me, have a doofus moment.