### PR TITLE
Add `track_caller` to `App::add_plugins`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -686,6 +686,7 @@ impl App {
     /// Panics if one of the plugins was already added to the application.
     ///
     /// [`PluginGroup`]:super::PluginGroup
+    #[track_caller]
     pub fn add_plugins<M>(&mut self, plugins: impl Plugins<M>) -> &mut Self {
         plugins.add_to_app(self);
         self

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -102,6 +102,7 @@ mod sealed {
     }
 
     impl<P: PluginGroup> Plugins<PluginGroupMarker> for P {
+        #[track_caller]
         fn add_to_app(self, app: &mut App) {
             self.build().finish(app);
         }

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -89,6 +89,7 @@ mod sealed {
     pub struct PluginsTupleMarker;
 
     impl<P: Plugin> Plugins<PluginMarker> for P {
+        #[track_caller]
         fn add_to_app(self, app: &mut App) {
             if let Err(AppError::DuplicatePlugin { plugin_name }) =
                 app.add_boxed_plugin(Box::new(self))
@@ -113,6 +114,7 @@ mod sealed {
                 $($plugins: Plugins<$param>),*
             {
                 #[allow(non_snake_case, unused_variables)]
+                #[track_caller]
                 fn add_to_app(self, app: &mut App) {
                     let ($($plugins,)*) = self;
                     $($plugins.add_to_app(app);)*

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -172,6 +172,7 @@ impl PluginGroupBuilder {
     /// # Panics
     ///
     /// Panics if one of the plugin in the group was already added to the application.
+    #[track_caller]
     pub fn finish(mut self, app: &mut App) {
         for ty in &self.order {
             if let Some(entry) = self.plugins.remove(ty) {


### PR DESCRIPTION
# Objective

Currently the panic message if a duplicate plugin is added isn't really helpful or at least can be made more useful if it includes the location where the plugin was added a second time.

## Solution

Add `track_caller` to `add_plugins` and it's called dependencies.
