### PR TITLE
Add `init_resource_with` methods to `App` and `World`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -482,10 +482,12 @@ impl App {
         self
     }
 
-    /// Inserts a non-send resource to the app.
+    /// Inserts a non-send [`Resource`] to the current [`App`]
+    /// and overwrites any [`Resource`] previously added of the same type.
     ///
     /// You usually want to use [`insert_resource`](Self::insert_resource),
     /// but there are some special cases when a resource cannot be sent across threads.
+    /// Systems with non-send resources are always scheduled on the main thread.
     ///
     /// # Examples
     ///
@@ -542,11 +544,37 @@ impl App {
 
     /// Initialize a non-send [`Resource`] with standard starting values by adding it to the [`World`].
     ///
+    /// If the [`Resource`] already exists, nothing happens.
+    ///
+    /// You usually want to use [`init_resource`](Self::init_resource),
+    /// but there are some special cases when a resource cannot be sent across threads.
+    /// Systems with non-send resources are always scheduled on the main thread.
+    ///
     /// The [`Resource`] must implement the [`FromWorld`] trait.
     /// If the [`Default`] trait is implemented, the [`FromWorld`] trait will use
     /// the [`Default::default`] method to initialize the [`Resource`].
     pub fn init_non_send_resource<R: 'static + FromWorld>(&mut self) -> &mut Self {
         self.world.init_non_send_resource::<R>();
+        self
+    }
+
+    /// Initialize a [`Resource`] with a given value by adding it to the [`World`].
+    ///
+    /// If the [`Resource`] already exists, nothing happens, it won't get overwritten by the given value.
+    pub fn init_resource_with<R: Resource>(&mut self, value: R) -> &mut Self {
+        self.world.init_resource_with(value);
+        self
+    }
+
+    /// Initialize a non-send [`Resource`] with standard starting values by adding it to the [`World`].
+    ///
+    /// If the [`Resource`] already exists, nothing happens, it won't get overwritten by the given value.
+    ///
+    /// You usually want to use [`init_resource_with`](Self::init_resource_with),
+    /// but there are some special cases when a resource cannot be sent across threads.
+    /// Systems with non-send resources are always scheduled on the main thread.
+    pub fn init_non_send_resource_with<R: 'static>(&mut self, value: R) -> &mut Self {
+        self.world.init_non_send_resource_with::<R>(value);
         self
     }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -807,7 +807,7 @@ impl World {
             .map(|e| e.into())
     }
 
-    /// Initializes a new resource and returns the [`ComponentId`] created for it.
+    /// Initializes a new [`Resource`] and returns the [`ComponentId`] created for it.
     ///
     /// If the resource already exists, nothing happens.
     ///
@@ -834,7 +834,29 @@ impl World {
         component_id
     }
 
-    /// Inserts a new resource with the given `value`.
+    /// Initializes a new [`Resource`] with a given value and returns the [`ComponentId`] created for it.
+    ///
+    /// If the resource already exists, nothing happens, it won't get overwritten with the given value.
+    #[inline]
+    pub fn init_resource_with<R: Resource>(&mut self, value: R) -> ComponentId {
+        let component_id = self.components.init_resource::<R>();
+        if self
+            .storages
+            .resources
+            .get(component_id)
+            .map_or(true, |data| !data.is_present())
+        {
+            OwningPtr::make(value, |ptr| {
+                // SAFETY: component_id was just initialized and corresponds to resource of type R.
+                unsafe {
+                    self.insert_resource_by_id(component_id, ptr);
+                }
+            });
+        }
+        component_id
+    }
+
+    /// Inserts a new [`Resource`] with the given `value`.
     ///
     /// Resources are "unique" data of a given type.
     /// If you insert a resource of a type that already exists,
@@ -850,13 +872,17 @@ impl World {
         });
     }
 
-    /// Initializes a new non-send resource and returns the [`ComponentId`] created for it.
+    /// Initializes a new non-send [`Resource`] and returns the [`ComponentId`] created for it.
     ///
     /// If the resource already exists, nothing happens.
     ///
     /// The value given by the [`FromWorld::from_world`] method will be used.
     /// Note that any resource with the `Default` trait automatically implements `FromWorld`,
     /// and those default values will be here instead.
+    ///
+    /// `NonSend` resources cannot be sent across threads,
+    /// and do not need the `Send + Sync` bounds.
+    /// Systems with `NonSend` resources are always scheduled on the main thread.
     ///
     /// # Panics
     ///
@@ -881,7 +907,37 @@ impl World {
         component_id
     }
 
-    /// Inserts a new non-send resource with the given `value`.
+    /// Initializes a new non-send [`Resource`] with a given value and returns the [`ComponentId`] created for it.
+    ///
+    /// If the resource already exists, nothing happens, it won't get overwritten with the given value.
+    ///
+    /// `NonSend` resources cannot be sent across threads,
+    /// and do not need the `Send + Sync` bounds.
+    /// Systems with `NonSend` resources are always scheduled on the main thread.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called from a thread other than the main thread.
+    #[inline]
+    pub fn init_non_send_resource_with<R: 'static>(&mut self, value: R) -> ComponentId {
+        let component_id = self.components.init_non_send::<R>();
+        if self
+            .storages
+            .non_send_resources
+            .get(component_id)
+            .map_or(true, |data| !data.is_present())
+        {
+            OwningPtr::make(value, |ptr| {
+                // SAFETY: component_id was just initialized and corresponds to resource of type R.
+                unsafe {
+                    self.insert_non_send_by_id(component_id, ptr);
+                }
+            });
+        }
+        component_id
+    }
+
+    /// Inserts a new non-send [`Resource`] with the given `value`.
     ///
     /// `NonSend` resources cannot be sent across threads,
     /// and do not need the `Send + Sync` bounds.


### PR DESCRIPTION
# Objective

Currently, in `Plugin` `build`, you can insert a resource with a specific value with `insert_resource`, overriding it if it exists, or you can initialize a resource to its `default` or `from_world` value with `init_resource` only if it doesn't already exist.

It is possible to initialize a resource with a specific value only if it doesn't exist, but there is no straightforward way to do it (it requires using `app.world.get_resource` to check). 
This PR adds `init_resource_with`-like methods to do that.

This use case can be useful for writing a library where you want to offer four options for people to initialize the resource:
1. insert it themselves before the plugin is called
2. insert it themselves after the plugin is called
3. Provide it as a field of the plugin.
4. Use the default of the plugin which will use the default of the resource

Case 2. is trivial, and you can easily do case 3. and 4. using `insert_resource`, or case 1. or 2. using `init_resource`.
But if you want to do all of them at once, you currently have to manually check if the resource exist and then insert it if not.

It could be argued that this PR shouldn't be merged:
- because it's already possible to do that jsut a bit more convoluted
- because it adds methods that wouldn't be widly used
- because wanting to do all 4 cases at once is actually bad practice, like if the end user uses 1. and 3. at the same time, 3. would be ignored (with `insert_resource`, 1. would be ignored)

But I wanted to open the conversation.

## Solution

Add `init_resource_with` and `init_non_send_resource_with` to `App` and `World`.

I could have changed the code of `init_resource` to use `init_resource_with` but that would require calling `from_world` when not necessary so I decided against it.

I modified some documentations to harmonize them.

---

## Changelog

Add `init_resource_with` and `init_non_send_resource_with` methods to `App` and `World`, to init a resource with a specific value if it doesn't already exist.