### PR TITLE
Clarify immediate mode in `Gizmos` documentation

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -26,7 +26,7 @@ pub(crate) struct GizmoStorage {
 /// A [`SystemParam`](bevy_ecs::system::SystemParam) for drawing gizmos.
 ///
 /// They are drawn in immediate mode, which means they will be rendered only for
-/// the frames in which they are defined.
+/// the frames in which they are spawned.
 /// Gizmos should be spawned before the [`Last`](bevy_app::Last) schedule to ensure they are drawn.
 #[derive(SystemParam)]
 pub struct Gizmos<'s> {

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -136,7 +136,7 @@ impl<'s> Gizmos<'s> {
         self.line_gradient(start, start + vector, start_color, end_color);
     }
 
-    /// Draw lines in 3D between a list of points for the current frame.
+    /// Draw a line in 3D made of straight segments between the points for the current frame.
     ///
     /// This should be called for each frame the lines need to be rendered.
     ///
@@ -239,7 +239,7 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe sphere in 3D made out of 3 circles for the current frame.
+    /// Draw a wireframe sphere in 3D made out of 3 circles around the axes for the current frame.
     ///
     /// This should be called for each frame the sphere needs to be rendered.
     ///

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -27,7 +27,7 @@ pub(crate) struct GizmoStorage {
 ///
 /// They are drawn in immediate mode, which means they will be rendered only for
 /// the frames in which they are defined.
-/// They should be defined before the [`Last`](bevy_app::Last) schedule.
+/// Gizmos should be spawned before the [`Last`](bevy_app::Last) schedule to ensure they are drawn.
 #[derive(SystemParam)]
 pub struct Gizmos<'s> {
     buffer: Deferred<'s, GizmoBuffer>,

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -27,6 +27,7 @@ pub(crate) struct GizmoStorage {
 ///
 /// They are drawn in immediate mode, which means they will be rendered only for
 /// the frames in which they are defined.
+/// They should be defined before the [`Last`](bevy_app::Last) schedule.
 #[derive(SystemParam)]
 pub struct Gizmos<'s> {
     buffer: Deferred<'s, GizmoBuffer>,
@@ -53,7 +54,7 @@ impl SystemBuffer for GizmoBuffer {
 impl<'s> Gizmos<'s> {
     /// Draw a line in 3D from `start` to `end` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -73,7 +74,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 3D with a color gradient from `start` to `end` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -93,7 +94,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 3D from `start` to `start + vector` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -112,7 +113,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 3D with a color gradient from `start` to `start + vector` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -137,7 +138,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw lines in 3D between a list of points for the current frame.
     ///
-    /// This should be called every frame when the lines need to be rendered.
+    /// This should be called for each frame the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -161,7 +162,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw lines in 3D between a list of points with a color gradient for the current frame.
     ///
-    /// This should be called every frame when the lines need to be rendered.
+    /// This should be called for each frame the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -202,7 +203,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a circle in 3D at `position` with the flat side facing `normal` for the current frame.
     ///
-    /// This should be called every frame when the circle needs to be rendered.
+    /// This should be called for each frame the circle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -240,7 +241,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a wireframe sphere in 3D made out of 3 circles for the current frame.
     ///
-    /// This should be called every frame when the sphere needs to be rendered.
+    /// This should be called for each frame the sphere needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -278,7 +279,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a wireframe rectangle in 3D for the current frame.
     ///
-    /// This should be called every frame when the rectangle needs to be rendered.
+    /// This should be called for each frame the rectangle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -298,7 +299,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a wireframe cube in 3D for the current frame.
     ///
-    /// This should be called every frame when the cube needs to be rendered.
+    /// This should be called for each frame the cube needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -333,7 +334,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 2D from `start` to `end` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -352,7 +353,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 2D with a color gradient from `start` to `end` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -377,7 +378,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw lines in 2D between a list of points for the current frame.
     ///
-    /// This should be called every frame when the lines need to be rendered.
+    /// This should be called for each frame the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -396,7 +397,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw lines in 2D between a list of points with a color gradient for the current frame.
     ///
-    /// This should be called every frame when the lines need to be rendered.
+    /// This should be called for each frame the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -423,7 +424,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 2D from `start` to `start + vector` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -442,7 +443,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a line in 2D with a color gradient from `start` to `start + vector` for the current frame.
     ///
-    /// This should be called every frame when the line needs to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -467,7 +468,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a circle in 2D for the current frame.
     ///
-    /// This should be called every frame when the circle needs to be rendered.
+    /// This should be called for each frame the circle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -503,7 +504,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw an arc, which is a part of the circumference of a circle, in 2D, for the current frame.
     ///
-    /// This should be called every frame when the arc needs to be rendered.
+    /// This should be called for each frame the arc needs to be rendered.
     ///
     /// # Arguments
     /// - `position` sets the center of this circle.
@@ -550,7 +551,7 @@ impl<'s> Gizmos<'s> {
 
     /// Draw a wireframe rectangle in 2D for the current frame.
     ///
-    /// This should be called every frame when the rectangle needs to be rendered.
+    /// This should be called for each frame the rectangle needs to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -24,6 +24,9 @@ pub(crate) struct GizmoStorage {
 }
 
 /// A [`SystemParam`](bevy_ecs::system::SystemParam) for drawing gizmos.
+///
+/// They are drawned in immediate mode, which means they will be rendered only for
+/// the frames in which they are defined.
 #[derive(SystemParam)]
 pub struct Gizmos<'s> {
     buffer: Deferred<'s, GizmoBuffer>,
@@ -48,7 +51,9 @@ impl SystemBuffer for GizmoBuffer {
 }
 
 impl<'s> Gizmos<'s> {
-    /// Draw a line from `start` to `end`.
+    /// Draw a line in 3D from `start` to `end` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -66,7 +71,9 @@ impl<'s> Gizmos<'s> {
         self.add_list_color(color, 2);
     }
 
-    /// Draw a line with a color gradient from `start` to `end`.
+    /// Draw a line in 3D with a color gradient from `start` to `end` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -84,7 +91,9 @@ impl<'s> Gizmos<'s> {
         self.extend_list_colors([start_color, end_color]);
     }
 
-    /// Draw a line from `start` to `start + vector`.
+    /// Draw a line in 3D from `start` to `start + vector` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -101,7 +110,9 @@ impl<'s> Gizmos<'s> {
         self.line(start, start + vector, color);
     }
 
-    /// Draw a line with a color gradient from `start` to `start + vector`.
+    /// Draw a line in 3D with a color gradient from `start` to `start + vector` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -124,7 +135,9 @@ impl<'s> Gizmos<'s> {
         self.line_gradient(start, start + vector, start_color, end_color);
     }
 
-    /// Draw lines between a list of points.
+    /// Draw lines in 3D between a list of points for the current frame.
+    ///
+    /// This should be called every frame when the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -146,7 +159,9 @@ impl<'s> Gizmos<'s> {
         self.buffer.strip_colors.push([f32::NAN; 4]);
     }
 
-    /// Draw lines between a list of points with a color gradient.
+    /// Draw lines in 3D between a list of points with a color gradient for the current frame.
+    ///
+    /// This should be called every frame when the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -185,7 +200,9 @@ impl<'s> Gizmos<'s> {
         strip_colors.push([f32::NAN; 4]);
     }
 
-    /// Draw a circle at `position` with the flat side facing `normal`.
+    /// Draw a circle in 3D at `position` with the flat side facing `normal` for the current frame.
+    ///
+    /// This should be called every frame when the circle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -221,7 +238,9 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe sphere made out of 3 circles.
+    /// Draw a wireframe sphere in 3D made out of 3 circles for the current frame.
+    ///
+    /// This should be called every frame when the sphere needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -257,7 +276,9 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe rectangle.
+    /// Draw a wireframe rectangle in 3D for the current frame.
+    ///
+    /// This should be called every frame when the rectangle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -275,7 +296,9 @@ impl<'s> Gizmos<'s> {
         self.linestrip([tl, tr, br, bl, tl], color);
     }
 
-    /// Draw a wireframe cube.
+    /// Draw a wireframe cube in 3D for the current frame.
+    ///
+    /// This should be called every frame when the cube needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -308,7 +331,9 @@ impl<'s> Gizmos<'s> {
         self.add_list_color(color, 6);
     }
 
-    /// Draw a line from `start` to `end`.
+    /// Draw a line in 2D from `start` to `end` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -325,7 +350,9 @@ impl<'s> Gizmos<'s> {
         self.line(start.extend(0.), end.extend(0.), color);
     }
 
-    /// Draw a line with a color gradient from `start` to `end`.
+    /// Draw a line in 2D with a color gradient from `start` to `end` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -348,7 +375,9 @@ impl<'s> Gizmos<'s> {
         self.line_gradient(start.extend(0.), end.extend(0.), start_color, end_color);
     }
 
-    /// Draw lines between a list of points.
+    /// Draw lines in 2D between a list of points for the current frame.
+    ///
+    /// This should be called every frame when the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -365,7 +394,9 @@ impl<'s> Gizmos<'s> {
         self.linestrip(positions.into_iter().map(|vec2| vec2.extend(0.)), color);
     }
 
-    /// Draw lines between a list of points with a color gradient.
+    /// Draw lines in 2D between a list of points with a color gradient for the current frame.
+    ///
+    /// This should be called every frame when the lines need to be rendered.
     ///
     /// # Example
     /// ```
@@ -390,7 +421,9 @@ impl<'s> Gizmos<'s> {
         );
     }
 
-    /// Draw a line from `start` to `start + vector`.
+    /// Draw a line in 2D from `start` to `start + vector` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -407,7 +440,9 @@ impl<'s> Gizmos<'s> {
         self.line_2d(start, start + vector, color);
     }
 
-    /// Draw a line with a color gradient from `start` to `start + vector`.
+    /// Draw a line in 2D with a color gradient from `start` to `start + vector` for the current frame.
+    ///
+    /// This should be called every frame when the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -430,7 +465,9 @@ impl<'s> Gizmos<'s> {
         self.line_gradient_2d(start, start + vector, start_color, end_color);
     }
 
-    /// Draw a circle.
+    /// Draw a circle in 2D for the current frame.
+    ///
+    /// This should be called every frame when the circle needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -464,7 +501,9 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw an arc, which is a part of the circumference of a circle.
+    /// Draw an arc, which is a part of the circumference of a circle, in 2D, for the current frame.
+    ///
+    /// This should be called every frame when the arc needs to be rendered.
     ///
     /// # Arguments
     /// - `position` sets the center of this circle.
@@ -509,7 +548,9 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe rectangle.
+    /// Draw a wireframe rectangle in 2D for the current frame.
+    ///
+    /// This should be called every frame when the rectangle needs to be rendered.
     ///
     /// # Example
     /// ```

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -52,7 +52,7 @@ impl SystemBuffer for GizmoBuffer {
 }
 
 impl<'s> Gizmos<'s> {
-    /// Draw a line in 3D from `start` to `end` for the current frame.
+    /// Draw a line in 3D from `start` to `end`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -72,7 +72,7 @@ impl<'s> Gizmos<'s> {
         self.add_list_color(color, 2);
     }
 
-    /// Draw a line in 3D with a color gradient from `start` to `end` for the current frame.
+    /// Draw a line in 3D with a color gradient from `start` to `end`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -92,7 +92,7 @@ impl<'s> Gizmos<'s> {
         self.extend_list_colors([start_color, end_color]);
     }
 
-    /// Draw a line in 3D from `start` to `start + vector` for the current frame.
+    /// Draw a line in 3D from `start` to `start + vector`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -111,7 +111,7 @@ impl<'s> Gizmos<'s> {
         self.line(start, start + vector, color);
     }
 
-    /// Draw a line in 3D with a color gradient from `start` to `start + vector` for the current frame.
+    /// Draw a line in 3D with a color gradient from `start` to `start + vector`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -136,9 +136,9 @@ impl<'s> Gizmos<'s> {
         self.line_gradient(start, start + vector, start_color, end_color);
     }
 
-    /// Draw a line in 3D made of straight segments between the points for the current frame.
+    /// Draw a line in 3D made of straight segments between the points.
     ///
-    /// This should be called for each frame the lines need to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -160,7 +160,7 @@ impl<'s> Gizmos<'s> {
         self.buffer.strip_colors.push([f32::NAN; 4]);
     }
 
-    /// Draw lines in 3D between a list of points with a color gradient for the current frame.
+    /// Draw a line in 3D made of straight segments between the points, with a color gradient.
     ///
     /// This should be called for each frame the lines need to be rendered.
     ///
@@ -201,7 +201,7 @@ impl<'s> Gizmos<'s> {
         strip_colors.push([f32::NAN; 4]);
     }
 
-    /// Draw a circle in 3D at `position` with the flat side facing `normal` for the current frame.
+    /// Draw a circle in 3D at `position` with the flat side facing `normal`.
     ///
     /// This should be called for each frame the circle needs to be rendered.
     ///
@@ -239,7 +239,7 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe sphere in 3D made out of 3 circles around the axes for the current frame.
+    /// Draw a wireframe sphere in 3D made out of 3 circles around the axes.
     ///
     /// This should be called for each frame the sphere needs to be rendered.
     ///
@@ -277,7 +277,7 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe rectangle in 3D for the current frame.
+    /// Draw a wireframe rectangle in 3D.
     ///
     /// This should be called for each frame the rectangle needs to be rendered.
     ///
@@ -297,7 +297,7 @@ impl<'s> Gizmos<'s> {
         self.linestrip([tl, tr, br, bl, tl], color);
     }
 
-    /// Draw a wireframe cube in 3D for the current frame.
+    /// Draw a wireframe cube in 3D.
     ///
     /// This should be called for each frame the cube needs to be rendered.
     ///
@@ -332,7 +332,7 @@ impl<'s> Gizmos<'s> {
         self.add_list_color(color, 6);
     }
 
-    /// Draw a line in 2D from `start` to `end` for the current frame.
+    /// Draw a line in 2D from `start` to `end`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -351,7 +351,7 @@ impl<'s> Gizmos<'s> {
         self.line(start.extend(0.), end.extend(0.), color);
     }
 
-    /// Draw a line in 2D with a color gradient from `start` to `end` for the current frame.
+    /// Draw a line in 2D with a color gradient from `start` to `end`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -376,9 +376,9 @@ impl<'s> Gizmos<'s> {
         self.line_gradient(start.extend(0.), end.extend(0.), start_color, end_color);
     }
 
-    /// Draw lines in 2D between a list of points for the current frame.
+    /// Draw a line in 2D made of straight segments between the points.
     ///
-    /// This should be called for each frame the lines need to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -395,9 +395,9 @@ impl<'s> Gizmos<'s> {
         self.linestrip(positions.into_iter().map(|vec2| vec2.extend(0.)), color);
     }
 
-    /// Draw lines in 2D between a list of points with a color gradient for the current frame.
+    /// Draw a line in 2D made of straight segments between the points, with a color gradient.
     ///
-    /// This should be called for each frame the lines need to be rendered.
+    /// This should be called for each frame the line needs to be rendered.
     ///
     /// # Example
     /// ```
@@ -422,7 +422,7 @@ impl<'s> Gizmos<'s> {
         );
     }
 
-    /// Draw a line in 2D from `start` to `start + vector` for the current frame.
+    /// Draw a line in 2D from `start` to `start + vector`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -441,7 +441,7 @@ impl<'s> Gizmos<'s> {
         self.line_2d(start, start + vector, color);
     }
 
-    /// Draw a line in 2D with a color gradient from `start` to `start + vector` for the current frame.
+    /// Draw a line in 2D with a color gradient from `start` to `start + vector`.
     ///
     /// This should be called for each frame the line needs to be rendered.
     ///
@@ -466,7 +466,7 @@ impl<'s> Gizmos<'s> {
         self.line_gradient_2d(start, start + vector, start_color, end_color);
     }
 
-    /// Draw a circle in 2D for the current frame.
+    /// Draw a circle in 2D.
     ///
     /// This should be called for each frame the circle needs to be rendered.
     ///
@@ -502,15 +502,16 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw an arc, which is a part of the circumference of a circle, in 2D, for the current frame.
+    /// Draw an arc, which is a part of the circumference of a circle, in 2D.
     ///
     /// This should be called for each frame the arc needs to be rendered.
     ///
     /// # Arguments
     /// - `position` sets the center of this circle.
     /// - `radius` controls the distance from `position` to this arc, and thus its curvature.
-    /// - `direction_angle` sets the angle in radians between `position` and the midpoint of the arc.
-    /// -`arc_angle` sets the length of this arc, in radians.
+    /// - `direction_angle` sets the clockwise  angle in radians between `Vec2::Y` and
+    /// the vector from `position` to the midpoint of the arc.
+    /// - `arc_angle` sets the length of this arc, in radians.
     ///
     /// # Example
     /// ```
@@ -549,7 +550,7 @@ impl<'s> Gizmos<'s> {
         }
     }
 
-    /// Draw a wireframe rectangle in 2D for the current frame.
+    /// Draw a wireframe rectangle in 2D.
     ///
     /// This should be called for each frame the rectangle needs to be rendered.
     ///

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -25,7 +25,7 @@ pub(crate) struct GizmoStorage {
 
 /// A [`SystemParam`](bevy_ecs::system::SystemParam) for drawing gizmos.
 ///
-/// They are drawned in immediate mode, which means they will be rendered only for
+/// They are drawn in immediate mode, which means they will be rendered only for
 /// the frames in which they are defined.
 #[derive(SystemParam)]
 pub struct Gizmos<'s> {


### PR DESCRIPTION
# Objective

- Repeat in `Gizmos` that they are drawned in immediate mode, which is said at the module level but not here, and detail what it means.
- Clarify for every method of `Gizmos` that they should be called for every frame.
- Clarify which methods belong to 3D or 2D space (kinda obvious for 2D but still)

The first time I used gizmos I didn't understand how they work and was confused as to why nothing showed up.