### PR TITLE
fix module name for AssetPath shaders

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -214,7 +214,7 @@ impl ShaderCache {
         shaders: &HashMap<Handle<Shader>, Shader>,
         import: &ShaderImport,
     ) -> Result<(), PipelineCacheError> {
-        if !composer.contains_module(import.as_str()) {
+        if !composer.contains_module(&import.module_name()) {
             if let Some(shader_handle) = import_path_shaders.get(import) {
                 if let Some(shader) = shaders.get(shader_handle) {
                     for import in &shader.imports {
@@ -366,7 +366,8 @@ impl ShaderCache {
                 shaders_to_clear.extend(data.dependents.iter().map(|h| h.clone_weak()));
 
                 if let Some(Shader { import_path, .. }) = self.shaders.get(&handle) {
-                    self.composer.remove_composable_module(import_path.as_str());
+                    self.composer
+                        .remove_composable_module(&import_path.module_name());
                 }
             }
         }

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -303,9 +303,10 @@ pub enum ShaderImport {
 }
 
 impl ShaderImport {
-    pub fn as_str(&self) -> &str {
+    pub fn module_name<'a>(&'a self) -> Cow<'a, String> {
         match self {
-            ShaderImport::AssetPath(s) | ShaderImport::Custom(s) => s,
+            ShaderImport::AssetPath(s) => Cow::Owned(format!("\"{s}\"")),
+            ShaderImport::Custom(s) => Cow::Borrowed(s),
         }
     }
 }

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -303,7 +303,7 @@ pub enum ShaderImport {
 }
 
 impl ShaderImport {
-    pub fn module_name<'a>(&'a self) -> Cow<'a, String> {
+    pub fn module_name(&self) -> Cow<'_, String> {
         match self {
             ShaderImport::AssetPath(s) => Cow::Owned(format!("\"{s}\"")),
             ShaderImport::Custom(s) => Cow::Borrowed(s),


### PR DESCRIPTION
# Objective

AssetPath shader imports check if the shader is added using the path without quotes. this causes them to be re-added even if already present, which can cause previous dependents to get unloaded leading to a "missing import" error.

## Solution

fix the module name of AssetPath shaders used for checking if it's already added to correctly use the quoted name.
