### PR TITLE
Add reflect impls to IRect and URect

### DIFF
--- a/crates/bevy_math/src/rects/irect.rs
+++ b/crates/bevy_math/src/rects/irect.rs
@@ -9,7 +9,7 @@ use crate::{IVec2, Rect, URect};
 /// methods instead, which will ensure this invariant is met, unless you already have
 /// the minimum and maximum corners.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct IRect {
     /// The minimum corner point of the rect.

--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -9,7 +9,7 @@ use crate::{IRect, Rect, UVec2};
 /// methods instead, which will ensure this invariant is met, unless you already have
 /// the minimum and maximum corners.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct URect {
     /// The minimum corner point of the rect.

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -1,8 +1,17 @@
 use crate as bevy_reflect;
 use crate::prelude::ReflectDefault;
 use crate::{ReflectDeserialize, ReflectSerialize};
-use bevy_math::{Rect, Vec2};
+use bevy_math::{IRect, IVec2, Rect, URect, UVec2, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;
+
+impl_reflect_struct!(
+    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[type_path = "bevy_math"]
+    struct IRect {
+        min: IVec2,
+        max: IVec2,
+    }
+);
 
 impl_reflect_struct!(
     #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
@@ -10,5 +19,14 @@ impl_reflect_struct!(
     struct Rect {
         min: Vec2,
         max: Vec2,
+    }
+);
+
+impl_reflect_struct!(
+    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[type_path = "bevy_math"]
+    struct URect {
+        min: UVec2,
+        max: UVec2,
     }
 );

--- a/crates/bevy_reflect/src/impls/rect.rs
+++ b/crates/bevy_reflect/src/impls/rect.rs
@@ -5,7 +5,7 @@ use bevy_math::{IRect, IVec2, Rect, URect, UVec2, Vec2};
 use bevy_reflect_derive::impl_reflect_struct;
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Hash, Serialize, Deserialize, Default)]
     #[type_path = "bevy_math"]
     struct IRect {
         min: IVec2,
@@ -23,7 +23,7 @@ impl_reflect_struct!(
 );
 
 impl_reflect_struct!(
-    #[reflect(Debug, PartialEq, Serialize, Deserialize, Default)]
+    #[reflect(Debug, PartialEq, Hash, Serialize, Deserialize, Default)]
     #[type_path = "bevy_math"]
     struct URect {
         min: UVec2,


### PR DESCRIPTION
# Objective

This attempts to make the new IRect and URect structs in bevy_math more similar to the existing Rect struct.

## Solution

Add reflect implementations for IRect and URect, since one already exists for Rect.