### PR TITLE
example showcase: switch default api to webgpu

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -53,7 +53,7 @@ enum Action {
         /// Path to the folder where the content should be created
         content_folder: String,
 
-        #[arg(value_enum, long, default_value_t = WebApi::Webgl2)]
+        #[arg(value_enum, long, default_value_t = WebApi::Webgpu)]
         /// Which API to use for rendering
         api: WebApi,
     },


### PR DESCRIPTION
# Objective

- in #9168 I did some change to the showcase script, introducing the notion of web api and setting the default Web API to webgl2
- that script was actually only called for webgpu example, so that should have been the default value