### PR TITLE
Use `Entity::PLACHOLDER` for dangling entities

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,4 +1,4 @@
-use crate::{entity::Entity, world::World};
+use crate::entity::Entity;
 use bevy_utils::{Entry, HashMap};
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.
@@ -14,7 +14,7 @@ use bevy_utils::{Entry, HashMap};
 ///
 /// ```rust
 /// use bevy_ecs::prelude::*;
-/// use bevy_ecs::entity::{EntityMapper, MapEntities};
+/// use bevy_ecs::entity::{EntityMap, MapEntities};
 ///
 /// #[derive(Component)]
 /// struct Spring {
@@ -23,9 +23,9 @@ use bevy_utils::{Entry, HashMap};
 /// }
 ///
 /// impl MapEntities for Spring {
-///     fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
-///         self.a = entity_mapper.get_or_reserve(self.a);
-///         self.b = entity_mapper.get_or_reserve(self.b);
+///     fn map_entities(&mut self, entity_map: &EntityMap) {
+///         self.a = entity_map.get_or_placeholder(self.a);
+///         self.b = entity_map.get_or_placeholder(self.b);
 ///     }
 /// }
 /// ```
@@ -35,22 +35,16 @@ pub trait MapEntities {
     /// Updates all [`Entity`] references stored inside using `entity_map`.
     ///
     /// Implementors should look up any and all [`Entity`] values stored within and
-    /// update them to the mapped values via `entity_mapper`.
-    fn map_entities(&mut self, entity_mapper: &mut EntityMapper);
+    /// update them to the mapped values via `entity_map`.
+    fn map_entities(&mut self, entity_map: &EntityMap);
 }
 
 /// A mapping from one set of entities to another.
 ///
 /// The API generally follows [`HashMap`], but each [`Entity`] is returned by value, as they are [`Copy`].
 ///
-/// This is typically used to coordinate data transfer between sets of entities, such as between a scene and the world
-/// or over the network. This is required as [`Entity`] identifiers are opaque; you cannot and do not want to reuse
-/// identifiers directly.
-///
-/// On its own, an `EntityMap` is not capable of allocating new entity identifiers, which is needed to map references
-/// to entities that lie outside the source entity set. To do this, an `EntityMap` can be wrapped in an
-/// [`EntityMapper`] which scopes it to a particular destination [`World`] and allows new identifiers to be allocated.
-/// This functionality can be accessed through [`Self::world_scope()`].
+/// This is typically used to coordinate data transfer between sets of entities, such as between a scene and the world or over the network.
+/// This is required as [`Entity`] identifiers are opaque; you cannot and do not want to reuse identifiers directly.
 #[derive(Default, Debug)]
 pub struct EntityMap {
     map: HashMap<Entity, Entity>,
@@ -81,6 +75,11 @@ impl EntityMap {
         self.map.get(&entity).copied()
     }
 
+    /// Returns the corresponding mapped entity or [`Entity::PLACEHOLDER`] if there is no such entity.
+    pub fn get_or_placeholder(&self, entity: Entity) -> Entity {
+        self.get(entity).unwrap_or(Entity::PLACEHOLDER)
+    }
+
     /// An iterator visiting all keys in arbitrary order.
     pub fn keys(&self) -> impl Iterator<Item = Entity> + '_ {
         self.map.keys().cloned()
@@ -104,139 +103,5 @@ impl EntityMap {
     /// An iterator visiting all (key, value) pairs in arbitrary order.
     pub fn iter(&self) -> impl Iterator<Item = (Entity, Entity)> + '_ {
         self.map.iter().map(|(from, to)| (*from, *to))
-    }
-
-    /// Creates an [`EntityMapper`] from this [`EntityMap`] and scoped to the provided [`World`], then calls the
-    /// provided function with it. This allows one to allocate new entity references in the provided `World` that are
-    /// guaranteed to never point at a living entity now or in the future. This functionality is useful for safely
-    /// mapping entity identifiers that point at entities outside the source world. The passed function, `f`, is called
-    /// within the scope of the passed world. Its return value is then returned from `world_scope` as the generic type
-    /// parameter `R`.
-    pub fn world_scope<R>(
-        &mut self,
-        world: &mut World,
-        f: impl FnOnce(&mut World, &mut EntityMapper) -> R,
-    ) -> R {
-        let mut mapper = EntityMapper::new(self, world);
-        let result = f(world, &mut mapper);
-        mapper.finish(world);
-        result
-    }
-}
-
-/// A wrapper for [`EntityMap`], augmenting it with the ability to allocate new [`Entity`] references in a destination
-/// world. These newly allocated references are guaranteed to never point to any living entity in that world.
-///
-/// References are allocated by returning increasing generations starting from an internally initialized base
-/// [`Entity`]. After it is finished being used by [`MapEntities`] implementations, this entity is despawned and the
-/// requisite number of generations reserved.
-pub struct EntityMapper<'m> {
-    /// The wrapped [`EntityMap`].
-    map: &'m mut EntityMap,
-    /// A base [`Entity`] used to allocate new references.
-    dead_start: Entity,
-    /// The number of generations this mapper has allocated thus far.
-    generations: u32,
-}
-
-impl<'m> EntityMapper<'m> {
-    /// Returns the corresponding mapped entity or reserves a new dead entity ID if it is absent.
-    pub fn get_or_reserve(&mut self, entity: Entity) -> Entity {
-        if let Some(mapped) = self.map.get(entity) {
-            return mapped;
-        }
-
-        // this new entity reference is specifically designed to never represent any living entity
-        let new = Entity {
-            generation: self.dead_start.generation + self.generations,
-            index: self.dead_start.index,
-        };
-        self.generations += 1;
-
-        self.map.insert(entity, new);
-
-        new
-    }
-
-    /// Gets a reference to the underlying [`EntityMap`].
-    pub fn get_map(&'m self) -> &'m EntityMap {
-        self.map
-    }
-
-    /// Gets a mutable reference to the underlying [`EntityMap`]
-    pub fn get_map_mut(&'m mut self) -> &'m mut EntityMap {
-        self.map
-    }
-
-    /// Creates a new [`EntityMapper`], spawning a temporary base [`Entity`] in the provided [`World`]
-    fn new(map: &'m mut EntityMap, world: &mut World) -> Self {
-        Self {
-            map,
-            // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
-            dead_start: unsafe { world.entities_mut().alloc() },
-            generations: 0,
-        }
-    }
-
-    /// Reserves the allocated references to dead entities within the world. This frees the temporary base
-    /// [`Entity`] while reserving extra generations via [`crate::entity::Entities::reserve_generations`]. Because this
-    /// renders the [`EntityMapper`] unable to safely allocate any more references, this method takes ownership of
-    /// `self` in order to render it unusable.
-    fn finish(self, world: &mut World) {
-        // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
-        let entities = unsafe { world.entities_mut() };
-        assert!(entities.free(self.dead_start).is_some());
-        assert!(entities.reserve_generations(self.dead_start.index, self.generations));
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{EntityMap, EntityMapper};
-    use crate::{entity::Entity, world::World};
-
-    #[test]
-    fn entity_mapper() {
-        const FIRST_IDX: u32 = 1;
-        const SECOND_IDX: u32 = 2;
-
-        let mut map = EntityMap::default();
-        let mut world = World::new();
-        let mut mapper = EntityMapper::new(&mut map, &mut world);
-
-        let mapped_ent = Entity::new(FIRST_IDX, 0);
-        let dead_ref = mapper.get_or_reserve(mapped_ent);
-
-        assert_eq!(
-            dead_ref,
-            mapper.get_or_reserve(mapped_ent),
-            "should persist the allocated mapping from the previous line"
-        );
-        assert_eq!(
-            mapper.get_or_reserve(Entity::new(SECOND_IDX, 0)).index(),
-            dead_ref.index(),
-            "should re-use the same index for further dead refs"
-        );
-
-        mapper.finish(&mut world);
-        // Next allocated entity should be a further generation on the same index
-        let entity = world.spawn_empty().id();
-        assert_eq!(entity.index(), dead_ref.index());
-        assert!(entity.generation() > dead_ref.generation());
-    }
-
-    #[test]
-    fn world_scope_reserves_generations() {
-        let mut map = EntityMap::default();
-        let mut world = World::new();
-
-        let dead_ref = map.world_scope(&mut world, |_, mapper| {
-            mapper.get_or_reserve(Entity::new(0, 0))
-        });
-
-        // Next allocated entity should be a further generation on the same index
-        let entity = world.spawn_empty().id();
-        assert_eq!(entity.index(), dead_ref.index());
-        assert!(entity.generation() > dead_ref.generation());
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -623,25 +623,6 @@ impl Entities {
         self.meta.get_unchecked_mut(index as usize).location = location;
     }
 
-    /// Increments the `generation` of a freed [`Entity`]. The next entity ID allocated with this
-    /// `index` will count `generation` starting from the prior `generation` + the specified
-    /// value + 1.
-    ///
-    /// Does nothing if no entity with this `index` has been allocated yet.
-    pub(crate) fn reserve_generations(&mut self, index: u32, generations: u32) -> bool {
-        if (index as usize) >= self.meta.len() {
-            return false;
-        }
-
-        let meta = &mut self.meta[index as usize];
-        if meta.location.archetype_id == ArchetypeId::INVALID {
-            meta.generation += generations;
-            true
-        } else {
-            false
-        }
-    }
-
     /// Get the [`Entity`] with a given id, if it exists in this [`Entities`] collection
     /// Returns `None` if this [`Entity`] is outside of the range of currently reserved Entities
     ///
@@ -884,30 +865,5 @@ mod tests {
 
         const C4: u32 = Entity::from_bits(0x00dd_00ff_0000_0000).generation();
         assert_eq!(0x00dd_00ff, C4);
-    }
-
-    #[test]
-    fn reserve_generations() {
-        let mut entities = Entities::new();
-        let entity = entities.alloc();
-        entities.free(entity);
-
-        assert!(entities.reserve_generations(entity.index, 1));
-    }
-
-    #[test]
-    fn reserve_generations_and_alloc() {
-        const GENERATIONS: u32 = 10;
-
-        let mut entities = Entities::new();
-        let entity = entities.alloc();
-        entities.free(entity);
-
-        assert!(entities.reserve_generations(entity.index, GENERATIONS));
-
-        // The very next entity allocated should be a further generation on the same index
-        let next_entity = entities.alloc();
-        assert_eq!(next_entity.index(), entity.index());
-        assert!(next_entity.generation > entity.generation + GENERATIONS);
     }
 }

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{
     component::Component,
-    entity::{Entity, EntityMapper, MapEntities},
+    entity::{Entity, EntityMap, MapEntities},
     prelude::FromWorld,
     reflect::{ReflectComponent, ReflectMapEntities},
     world::World,
@@ -21,9 +21,9 @@ use std::ops::Deref;
 pub struct Children(pub(crate) SmallVec<[Entity; 8]>);
 
 impl MapEntities for Children {
-    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+    fn map_entities(&mut self, entity_map: &EntityMap) {
         for entity in &mut self.0 {
-            *entity = entity_mapper.get_or_reserve(*entity);
+            *entity = entity_map.get_or_placeholder(*entity);
         }
     }
 }

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::{
     component::Component,
-    entity::{Entity, EntityMapper, MapEntities},
+    entity::{Entity, EntityMap, MapEntities},
     reflect::{ReflectComponent, ReflectMapEntities},
     world::{FromWorld, World},
 };
@@ -36,8 +36,8 @@ impl FromWorld for Parent {
 }
 
 impl MapEntities for Parent {
-    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
-        self.0 = entity_mapper.get_or_reserve(self.0);
+    fn map_entities(&mut self, entity_map: &EntityMap) {
+        self.0 = entity_map.get_or_placeholder(self.0);
     }
 }
 

--- a/crates/bevy_render/src/mesh/mesh/skinning.rs
+++ b/crates/bevy_render/src/mesh/mesh/skinning.rs
@@ -1,7 +1,7 @@
 use bevy_asset::Handle;
 use bevy_ecs::{
     component::Component,
-    entity::{Entity, EntityMapper, MapEntities},
+    entity::{Entity, EntityMap, MapEntities},
     prelude::ReflectComponent,
     reflect::ReflectMapEntities,
 };
@@ -17,9 +17,9 @@ pub struct SkinnedMesh {
 }
 
 impl MapEntities for SkinnedMesh {
-    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
+    fn map_entities(&mut self, entity_map: &EntityMap) {
         for joint in &mut self.joints {
-            *joint = entity_mapper.get_or_reserve(*joint);
+            *joint = entity_map.get_or_placeholder(*joint);
         }
     }
 }

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -119,7 +119,7 @@ impl Scene {
 
         for registration in type_registry.iter() {
             if let Some(map_entities_reflect) = registration.data::<ReflectMapEntities>() {
-                map_entities_reflect.map_all_entities(world, &mut instance_info.entity_map);
+                map_entities_reflect.map_all_entities(world, &instance_info.entity_map);
             }
         }
 

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -1,5 +1,5 @@
 use bevy_ecs::{
-    entity::{Entity, EntityMapper, MapEntities},
+    entity::{Entity, EntityMap, MapEntities},
     prelude::{Component, ReflectComponent},
 };
 use bevy_math::{DVec2, IVec2, Vec2};
@@ -58,13 +58,10 @@ impl WindowRef {
 }
 
 impl MapEntities for WindowRef {
-    fn map_entities(&mut self, entity_mapper: &mut EntityMapper) {
-        match self {
-            Self::Entity(entity) => {
-                *entity = entity_mapper.get_or_reserve(*entity);
-            }
-            Self::Primary => {}
-        };
+    fn map_entities(&mut self, entity_map: &EntityMap) {
+        if let Self::Entity(entity) = self {
+            *entity = entity_map.get_or_placeholder(*entity);
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

Prior to this (https://github.com/bevyengine/bevy/pull/7335), when mapping the scene, we used an `EntityMapper` that used `World` to establish a new mapping to a dead entity when the entity is not in the `EntityMap`.

But this means that entity mapping require mutable `World` access. And it may be not desirable for networking if you map entities often. 

## Solution

So in this PR I tried a simpler approach: just mark all invalid entities with `Entity::PLACHOLDER` because this entity is always considered invalid.

The only downside of it is that all dangling entities will correspond to the same entity instead of different entities, but I doubt that anyone want to do anything with these entities. This approach makes the code much simpler, avoids extra `Vec` allocation and allows mapping entities without mutable `World` access.

I also considered returning error instead, but this may not be desirable for scene filtering (hierarchy could contain dangling entities).

---

## Changelog

## Changed

Invalid entities on mapping now always point to `Entity::PLACEHOLDER`.

## Migration Guide

`MapEntities` implementations should change from a &mut EntityMapper parameter to a &EntityMap parameter and return  `Result`. Finally, they should switch from calling `EntityMapper::get_or_reserve` to calling `EntityMap::get_or_placeholder`.