### PR TITLE
Add some more helpful errors to BevyManifest when it doesn't find Cargo.toml

### DIFF
--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -28,10 +28,20 @@ impl Default for BevyManifest {
                 .map(PathBuf::from)
                 .map(|mut path| {
                     path.push("Cargo.toml");
-                    let manifest = std::fs::read_to_string(path).unwrap();
-                    manifest.parse::<Document>().unwrap()
+                    if !path.exists() {
+                        panic!(
+                            "No Cargo manifest found for crate. Expected: {}",
+                            path.display()
+                        );
+                    }
+                    let manifest = std::fs::read_to_string(path.clone()).unwrap_or_else(|_| {
+                        panic!("Unable to read cargo manifest: {}", path.display())
+                    });
+                    manifest.parse::<Document>().unwrap_or_else(|_| {
+                        panic!("Failed to parse cargo manifest: {}", path.display())
+                    })
                 })
-                .unwrap(),
+                .expect("CARGO_MANIFEST_DIR is not defined."),
         }
     }
 }


### PR DESCRIPTION
When building Bevy using Bazel, you don't need a 'Cargo.toml'... except Bevy requires it currently. Hopefully this can help illuminate the requirement.

# Objective

I recently started exploring Bazel and Buck2. Currently Bazel has some great advantages over Cargo for me and I was pretty happy to find that things generally work quite well!

Once I added a target to my test project that depended on bevy but didn't use Cargo, I didn't create a Cargo.toml file for it and things appeared to work, but as soon as I went to derive from Component the build failed with the cryptic error:

```
ERROR: /Users/photex/workspaces/personal/mb-rogue/scratch/BUILD:24:12: Compiling Rust bin hello_bevy (0 files) failed: (Exit 1): process_wrapper failed: error executing command (from target //scratch:hello_bevy) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file ... (remaining 312 arguments skipped)
error: proc-macro derive panicked
 --> scratch/hello_bevy.rs:5:10
  |
5 | #[derive(Component)]
  |          ^^^^^^^^^
  |
  = help: message: called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
error: proc-macro derive panicked
 --> scratch/hello_bevy.rs:8:10
  |
8 | #[derive(Component)]
  |          ^^^^^^^^^
  |
  = help: message: called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }

```

## Solution

After poking around I realized that the proc macros in Bevy all use bevy_macro_utils::BevyManifest, which was attempting to load a Cargo manifest that doesn't exist.

This PR doesn't address the Cargo requirement (I'd love to see if there was a way to support more than Cargo transparently), but it *does* replace some calls to unwrap with expect and hopefully the error messages will be more helpful for other folks like me hoping to pat down a new trail:

```
ERROR: /Users/photex/workspaces/personal/mb-rogue/scratch/BUILD:23:12: Compiling Rust bin hello_bevy (0 files) failed: (Exit 1): process_wrapper failed: error executing command (from target //scratch:hello_bevy) bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/rules_rust/util/process_wrapper/process_wrapper --arg-file ... (remaining 312 arguments skipped)
error: proc-macro derive panicked
 --> scratch/hello_bevy.rs:5:10
  |
5 | #[derive(Component)]
  |          ^^^^^^^^^
  |
  = help: message: Unable to read cargo manifest: /private/var/tmp/_bazel_photex/135f23dc56826c24d6c3c9f6b688b2fe/execroot/__main__/scratch/Cargo.toml: Os { code: 2, kind: NotFound, message: "No such file or directory" }
error: proc-macro derive panicked
 --> scratch/hello_bevy.rs:8:10
  |
8 | #[derive(Component)]
  |          ^^^^^^^^^
  |
  = help: message: Unable to read cargo manifest: /private/var/tmp/_bazel_photex/135f23dc56826c24d6c3c9f6b688b2fe/execroot/__main__/scratch/Cargo.toml: Os { code: 2, kind: NotFound, message: "No such file or directory" }

```
