### PR TITLE
Allow the creation of a Window in a not focused state

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -146,6 +146,10 @@ pub struct Window {
     /// You should also set the window `composite_alpha_mode` to `CompositeAlphaMode::PostMultiplied`.
     pub transparent: bool,
     /// Get/set whether the window is focused.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Android / iOS / X11 / Wayland: Can't be spawned unfocused.
     pub focused: bool,
     /// Where should the window appear relative to other overlapping window.
     ///

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -147,9 +147,14 @@ pub struct Window {
     pub transparent: bool,
     /// Get/set whether the window is focused.
     ///
+    /// It cannot be set unfocused after creation.
+    ///
     /// ## Platform-specific
     ///
-    /// - Android / iOS / X11 / Wayland: Can't be spawned unfocused.
+    /// - iOS / Android / X11 / Wayland: Spawning unfocused is
+    /// [not supported](https://docs.rs/winit/latest/winit/window/struct.WindowBuilder.html#method.with_active).
+    /// - iOS / Android / Web / Wayland Setting focused after creation is
+    /// [not supported](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.focus_window)
     pub focused: bool,
     /// Where should the window appear relative to other overlapping window.
     ///

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -95,7 +95,8 @@ impl WinitWindows {
             .with_theme(window.window_theme.map(convert_window_theme))
             .with_resizable(window.resizable)
             .with_decorations(window.decorations)
-            .with_transparent(window.transparent);
+            .with_transparent(window.transparent)
+            .with_active(window.focused);
 
         let constraints = window.resize_constraints.check_constraints();
         let min_inner_size = LogicalSize {


### PR DESCRIPTION
# Objective

Allow creating a new window without it being focused, when `Window`'s `focused` is `false.

## Solution

Use `winit`'s `WindowBuilder`'s `with_active` method

## Notes

- `winit`'s doc lists [redox's `Orbital`](https://gitlab.redox-os.org/redox-os/orbital) as an unsupported platform, but since Bevy doesn't officially support this platform, I didn't put it in the documentation.
- I only tested on Linux, which is an unsupported platform. I can give you a test code if you want to test on another platform.
- I initially put a line [here](https://github.com/bevyengine/bevy/blob/v0.11.0/crates/bevy_winit/src/system.rs#L72) to set the Bevy `Window`'s `focused` to `winit_window.has_focus()` after window creation to avoid the case where `with_active` is not supported, the window is spawned focused, no `WindowFocused` event is triggered, and Bevy `Window` would be desynced from winit's window. But after testing on Linux (which doesn't support `with_active`) it seems like at that point `has_focus` returns `false` and the event is triggered, so I removed it. Do you think I should add it back to be safe?

## Changelog

- A new unfocused `Window` can be created by setting `focused` to `false`.

## Migration Guide

- If a `Window` is spawned with `focused` set to `false`, it will now start not focused on supported platforms.