### PR TITLE
Extend the default 2d render range to `-1000..1000`

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -35,7 +35,7 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        Self::new_with_far(1000.0)
+        Self::new_with_far(2000.0)
     }
 }
 
@@ -50,10 +50,10 @@ impl Camera2dBundle {
         // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
-            far,
+            far: far + 0.1,
             ..Default::default()
         };
-        let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
+        let transform = Transform::from_xyz(0.0, 0.0, far / 2. + 0.1);
         let view_projection =
             projection.get_projection_matrix() * transform.compute_matrix().inverse();
         let frustum = Frustum::from_view_projection_custom_far(


### PR DESCRIPTION
# Objective

- Fixes #9138

## Solution

- Extend the default `far` value of `Camera2dBundle` so that 2d entities with z values within the range of -1000 to 1000 gets rendered (default `far` value is now `2000`).
- Also the `new_with_far` function of `Camera2dBundle` now means the `far` value will be split in two for both the positive and negative ranges (ex: `new_with_far(1000.)` => `-500..500`, `new_with_far(2000.)` => `-1000..1000`).
