### PR TITLE
Add example for text with the default font

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1896,6 +1896,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_default_font"
+path = "examples/ui/text_default_font.rs"
+
+[package.metadata.example.text_default_font]
+name = "Text (Default Font)"
+description = "Illustrates creating and updating text with Bevy's default font"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "text_debug"
 path = "examples/ui/text_debug.rs"
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -349,6 +349,7 @@ Example | Description
 [Relative Cursor Position](../examples/ui/relative_cursor_position.rs) | Showcases the RelativeCursorPosition component
 [Size Constraints](../examples/ui/size_constraints.rs) | Demonstrates how the to use the size constraints to control the size of a UI node.
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
+[Text (Default Font)](../examples/ui/text_default_font.rs) | Illustrates creating and updating text with Bevy's default font
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
 [Text Wrap Debug](../examples/ui/text_wrap_debug.rs) | Demonstrates text wrapping
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI

--- a/examples/ui/text_default_font.rs
+++ b/examples/ui/text_default_font.rs
@@ -1,0 +1,103 @@
+//! This example illustrates how to create UI text and update it in a system (with bevy's default font).
+//!
+//! It displays the current FPS in the top left corner, as well as text that changes color
+//! in the bottom right. For text within a scene, please see the text2d example.
+
+use bevy::{
+    diagnostic::{DiagnosticsStore, FrameTimeDiagnosticsPlugin},
+    prelude::*,
+};
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, FrameTimeDiagnosticsPlugin))
+        .add_systems(Startup, setup)
+        .add_systems(Update, (text_update_system, text_color_system))
+        .run();
+}
+
+// A unit struct to help identify the FPS UI component, since there may be many Text components
+#[derive(Component)]
+struct FpsText;
+
+// A unit struct to help identify the color-changing Text component
+#[derive(Component)]
+struct ColorText;
+
+fn setup(mut commands: Commands) {
+    // UI camera
+    commands.spawn(Camera2dBundle::default());
+    // Text with one section
+    commands.spawn((
+        // Create a TextBundle that has a Text with a single section.
+        TextBundle::from_section(
+            // Accepts a `String` or any type that converts into a `String`, such as `&str`
+            "hello\nbevy!",
+            TextStyle {
+                font_size: 100.0,
+                color: Color::WHITE,
+                // Use the default font
+                ..default()
+            },
+        ) // Set the alignment of the Text
+        .with_text_alignment(TextAlignment::Center)
+        // Set the style of the TextBundle itself.
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(5.0),
+            right: Val::Px(15.0),
+            ..default()
+        }),
+        ColorText,
+    ));
+    // Text with multiple sections
+    commands.spawn((
+        // Create a TextBundle that has a Text with a list of sections.
+        TextBundle::from_sections([
+            TextSection::new(
+                "FPS: ",
+                TextStyle {
+                    font_size: 60.0,
+                    color: Color::WHITE,
+                    // Use the default font
+                    ..default()
+                },
+            ),
+            TextSection::from_style(TextStyle {
+                font_size: 60.0,
+                color: Color::GOLD,
+                // Use the default font
+                ..default()
+            }),
+        ]),
+        FpsText,
+    ));
+}
+
+fn text_color_system(time: Res<Time>, mut query: Query<&mut Text, With<ColorText>>) {
+    for mut text in &mut query {
+        let seconds = time.elapsed_seconds();
+
+        // Update the color of the first and only section.
+        text.sections[0].style.color = Color::Rgba {
+            red: (1.25 * seconds).sin() / 2.0 + 0.5,
+            green: (0.75 * seconds).sin() / 2.0 + 0.5,
+            blue: (0.50 * seconds).sin() / 2.0 + 0.5,
+            alpha: 1.0,
+        };
+    }
+}
+
+fn text_update_system(
+    diagnostics: Res<DiagnosticsStore>,
+    mut query: Query<&mut Text, With<FpsText>>,
+) {
+    for mut text in &mut query {
+        if let Some(fps) = diagnostics.get(FrameTimeDiagnosticsPlugin::FPS) {
+            if let Some(value) = fps.smoothed() {
+                // Update the value of the second section
+                text.sections[1].value = format!("{value:.2}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Objective

This PR adds a new example for drawing text with Bevy's default font (based on the text example).