### PR TITLE
hacks for running (and screenshotting) the examples in CI on a github runner

### DIFF
--- a/tools/example-showcase/extra-window-resized-events.patch
+++ b/tools/example-showcase/extra-window-resized-events.patch
@@ -6,7 +6,7 @@ index 46b3e3e19..81ffad2b5 100644
                      };
  
                  runner_state.window_event_received = true;
-+                window_events.window_resized.send(WindowResized {
++                event_writers.window_resized.send(WindowResized {
 +                    window: window_entity,
 +                    width: window.width(),
 +                    height: window.height(),

--- a/tools/example-showcase/extra-window-resized-events.patch
+++ b/tools/example-showcase/extra-window-resized-events.patch
@@ -5,7 +5,7 @@ index 46b3e3e19..81ffad2b5 100644
 @@ -432,6 +432,11 @@ pub fn winit_runner(mut app: App) {
                      };
  
-                 winit_state.low_power_event = true;
+                 runner_state.window_event_received = true;
 +                window_events.window_resized.send(WindowResized {
 +                    window: window_entity,
 +                    width: window.width(),

--- a/tools/example-showcase/extra-window-resized-events.patch
+++ b/tools/example-showcase/extra-window-resized-events.patch
@@ -1,0 +1,16 @@
+diff --git a/crates/bevy_winit/src/lib.rs b/crates/bevy_winit/src/lib.rs
+index 46b3e3e19..81ffad2b5 100644
+--- a/crates/bevy_winit/src/lib.rs
++++ b/crates/bevy_winit/src/lib.rs
+@@ -432,6 +432,11 @@ pub fn winit_runner(mut app: App) {
+                     };
+ 
+                 winit_state.low_power_event = true;
++                window_events.window_resized.send(WindowResized {
++                    window: window_entity,
++                    width: window.width(),
++                    height: window.height(),
++                });
+ 
+                 match event {
+                     WindowEvent::Resized(size) => {

--- a/tools/example-showcase/fixed-window-position.patch
+++ b/tools/example-showcase/fixed-window-position.patch
@@ -1,0 +1,13 @@
+diff --git a/crates/bevy_window/src/window.rs b/crates/bevy_window/src/window.rs
+index 10bdd8fe8..dda272569 100644
+--- a/crates/bevy_window/src/window.rs
++++ b/crates/bevy_window/src/window.rs
+@@ -232,7 +232,7 @@ impl Default for Window {
+             cursor: Default::default(),
+             present_mode: Default::default(),
+             mode: Default::default(),
+-            position: Default::default(),
++            position: WindowPosition::Centered(MonitorSelection::Primary),
+             resolution: Default::default(),
+             internal: Default::default(),
+             composite_alpha_mode: Default::default(),

--- a/tools/example-showcase/reduce-light-cluster-config.patch
+++ b/tools/example-showcase/reduce-light-cluster-config.patch
@@ -1,0 +1,15 @@
+diff --git a/crates/bevy_pbr/src/light.rs b/crates/bevy_pbr/src/light.rs
+index 3e8c0d451..07aa7d586 100644
+--- a/crates/bevy_pbr/src/light.rs
++++ b/crates/bevy_pbr/src/light.rs
+@@ -694,8 +694,8 @@ impl Default for ClusterConfig {
+         // 24 depth slices, square clusters with at most 4096 total clusters
+         // use max light distance as clusters max `Z`-depth, first slice extends to 5.0
+         Self::FixedZ {
+-            total: 4096,
+-            z_slices: 24,
++            total: 128,
++            z_slices: 4,
+             z_config: ClusterZConfig::default(),
+             dynamic_resizing: true,
+         }

--- a/tools/example-showcase/remove-desktop-app-mode.patch
+++ b/tools/example-showcase/remove-desktop-app-mode.patch
@@ -1,0 +1,21 @@
+diff --git a/crates/bevy_winit/src/winit_config.rs b/crates/bevy_winit/src/winit_config.rs
+index ec2ff8312..8a6f4133d 100644
+--- a/crates/bevy_winit/src/winit_config.rs
++++ b/crates/bevy_winit/src/winit_config.rs
+@@ -40,15 +40,7 @@ impl WinitSettings {
+ 
+     /// Configure winit with common settings for a desktop application.
+     pub fn desktop_app() -> Self {
+-        WinitSettings {
+-            focused_mode: UpdateMode::Reactive {
+-                max_wait: Duration::from_secs(5),
+-            },
+-            unfocused_mode: UpdateMode::ReactiveLowPower {
+-                max_wait: Duration::from_secs(60),
+-            },
+-            ..Default::default()
+-        }
++        Self::game()
+     }
+ 
+     /// Gets the configured [`UpdateMode`] depending on whether the window is focused or not

--- a/tools/example-showcase/remove-desktop-app-mode.patch
+++ b/tools/example-showcase/remove-desktop-app-mode.patch
@@ -1,21 +1,21 @@
 diff --git a/crates/bevy_winit/src/winit_config.rs b/crates/bevy_winit/src/winit_config.rs
-index ec2ff8312..8a6f4133d 100644
+index c71a92814..b138d07a0 100644
 --- a/crates/bevy_winit/src/winit_config.rs
 +++ b/crates/bevy_winit/src/winit_config.rs
-@@ -40,15 +40,7 @@ impl WinitSettings {
- 
-     /// Configure winit with common settings for a desktop application.
+@@ -47,15 +47,7 @@ impl WinitSettings {
+     /// [`Reactive`](UpdateMode::Reactive) if windows have focus,
+     /// [`ReactiveLowPower`](UpdateMode::ReactiveLowPower) otherwise.
      pub fn desktop_app() -> Self {
 -        WinitSettings {
 -            focused_mode: UpdateMode::Reactive {
--                max_wait: Duration::from_secs(5),
+-                wait: Duration::from_secs(5),
 -            },
 -            unfocused_mode: UpdateMode::ReactiveLowPower {
--                max_wait: Duration::from_secs(60),
+-                wait: Duration::from_secs(60),
 -            },
 -            ..Default::default()
 -        }
 +        Self::game()
      }
  
-     /// Gets the configured [`UpdateMode`] depending on whether the window is focused or not
+     /// Returns the current [`UpdateMode`].

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -142,6 +142,7 @@ fn main() {
                 .exit();
             }
             let example_filter = example_list
+                .as_ref()
                 .map(|path| {
                     let file = fs::read_to_string(path).unwrap();
                     file.lines().map(|l| l.to_string()).collect::<Vec<_>>()
@@ -225,8 +226,7 @@ fn main() {
                     .iter()
                     .filter(|example| example.category != "Stress Tests" || !ignore_stress_tests)
                     .filter(|example| {
-                        example_filter.is_empty()
-                            || example_filter.contains(&example.technical_name)
+                        example_list.is_none() || example_filter.contains(&example.technical_name)
                     })
                     .skip(cli.page.unwrap_or(0) * cli.per_page.unwrap_or(0))
                     .take(cli.per_page.unwrap_or(usize::MAX))

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(200), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(250), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -150,7 +150,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(200))").unwrap();
+                    file.write_all(b"(exit_after: Some(250))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -277,6 +277,8 @@ fn main() {
                         } else {
                             successful_examples.push((to_run, duration));
                         }
+                    } else {
+                        successful_examples.push((to_run, duration));
                     }
                 } else {
                     failed_examples.push((to_run, duration));
@@ -331,21 +333,23 @@ fn main() {
                         .collect::<Vec<_>>()
                         .join("\n"),
                 );
-                let _ = fs::write(
-                    "no_screenshots",
-                    no_screenshot_examples
-                        .iter()
-                        .map(|(example, duration)| {
-                            format!(
-                                "{}/{} - {}",
-                                example.category,
-                                example.technical_name,
-                                duration.as_secs_f32()
-                            )
-                        })
-                        .collect::<Vec<_>>()
-                        .join("\n"),
-                );
+                if screenshot {
+                    let _ = fs::write(
+                        "no_screenshots",
+                        no_screenshot_examples
+                            .iter()
+                            .map(|(example, duration)| {
+                                format!(
+                                    "{}/{} - {}",
+                                    example.category,
+                                    example.technical_name,
+                                    duration.as_secs_f32()
+                                )
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    );
+                }
             }
 
             println!(

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(300), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(250), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -179,7 +179,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(300))").unwrap();
+                    file.write_all(b"(exit_after: Some(250))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(300), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(350), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -158,7 +158,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(300))").unwrap();
+                    file.write_all(b"(exit_after: Some(350))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(350), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(400), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -158,7 +158,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(350))").unwrap();
+                    file.write_all(b"(exit_after: Some(400))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -217,12 +217,15 @@ fn main() {
                 if cmd.run().is_ok() {
                     if screenshot {
                         let _ = fs::create_dir_all(Path::new("screenshots").join(&to_run.category));
-                        let _ = fs::rename(
+                        let renamed_screenshot = fs::rename(
                             "screenshot-100.png",
                             Path::new("screenshots")
                                 .join(&to_run.category)
                                 .join(format!("{}.png", to_run.technical_name)),
                         );
+                        if let Err(err) = renamed_screenshot {
+                            println!("Failed to rename screenshot: {:?}", err);
+                        }
                     }
                 } else {
                     failed_examples.push(to_run);

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -254,7 +254,7 @@ fn main() {
                     "successes",
                     successful_examples
                         .iter()
-                        .map(|example| example.technical_name.as_str())
+                        .map(|example| format!("{}/{}", example.category, example.technical_name))
                         .collect::<Vec<_>>()
                         .join("\n"),
                 );
@@ -262,7 +262,7 @@ fn main() {
                     "failures",
                     failed_examples
                         .iter()
-                        .map(|example| example.technical_name.as_str())
+                        .map(|example| format!("{}/{}", example.category, example.technical_name))
                         .collect::<Vec<_>>()
                         .join("\n"),
                 );
@@ -270,7 +270,7 @@ fn main() {
                     "no_screenshots",
                     no_screenshot_examples
                         .iter()
-                        .map(|example| example.technical_name.as_str())
+                        .map(|example| format!("{}/{}", example.category, example.technical_name))
                         .collect::<Vec<_>>()
                         .join("\n"),
                 );

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -150,7 +150,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(400), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(350), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -158,7 +158,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(400))").unwrap();
+                    file.write_all(b"(exit_after: Some(350))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -171,7 +171,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(350), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(300), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -179,7 +179,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(350))").unwrap();
+                    file.write_all(b"(exit_after: Some(300))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(150), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(200), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -150,7 +150,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(150))").unwrap();
+                    file.write_all(b"(exit_after: Some(200))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -1,7 +1,8 @@
 use std::{
-    collections::HashMap,
+    collections::{hash_map::DefaultHasher, HashMap},
     fmt::Display,
     fs::{self, File},
+    hash::{Hash, Hasher},
     io::Write,
     path::{Path, PathBuf},
     process::exit,
@@ -127,7 +128,7 @@ fn main() {
             ignore_stress_tests,
             report_details,
         } => {
-            let examples_to_run = parse_examples();
+            let mut examples_to_run = parse_examples();
 
             let mut failed_examples = vec![];
             let mut successful_examples = vec![];
@@ -190,6 +191,13 @@ fn main() {
                 )
                 .run()
                 .unwrap();
+
+                // Sort the examples so that they are not run by category
+                examples_to_run.sort_by_key(|example| {
+                    let mut hasher = DefaultHasher::new();
+                    example.hash(&mut hasher);
+                    hasher.finish()
+                });
             }
 
             let work_to_do = || {
@@ -580,7 +588,7 @@ fn parse_examples() -> Vec<Example> {
         .collect()
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
 struct Example {
     technical_name: String,
     path: String,

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -200,6 +200,16 @@ fn main() {
                 .run()
                 .unwrap();
 
+                // Don't use automatic position as it's "random" on Windows and breaks screenshot comparison
+                // using the cursor position
+                let sh = Shell::new().unwrap();
+                cmd!(
+                    sh,
+                    "git apply --ignore-whitespace tools/example-showcase/fixed-window-position.patch"
+                )
+                .run()
+                .unwrap();
+
                 // Setting lights ClusterConfig to have less clusters by default
                 // This is needed as the default config is too much for the CI runner
                 cmd!(

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -142,7 +142,7 @@ fn main() {
                 (false, true) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
                     file.write_all(
-                        b"(exit_after: Some(250), frame_time: Some(0.05), screenshot_frames: [100])",
+                        b"(exit_after: Some(300), frame_time: Some(0.05), screenshot_frames: [100])",
                     )
                     .unwrap();
                     extra_parameters.push("--features");
@@ -150,7 +150,7 @@ fn main() {
                 }
                 (false, false) => {
                     let mut file = File::create("example_showcase_config.ron").unwrap();
-                    file.write_all(b"(exit_after: Some(250))").unwrap();
+                    file.write_all(b"(exit_after: Some(300))").unwrap();
                     extra_parameters.push("--features");
                     extra_parameters.push("bevy_ci_testing");
                 }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -50,6 +50,10 @@ enum Action {
         #[arg(long)]
         /// Running in CI (some adaptation to the code)
         in_ci: bool,
+
+        #[arg(long)]
+        /// Do not run stress test examples
+        ignore_stress_tests: bool,
     },
     /// Build the markdown files for the website
     BuildWebsiteList {
@@ -116,6 +120,7 @@ fn main() {
             manual_stop,
             screenshot,
             in_ci,
+            ignore_stress_tests,
         } => {
             let examples_to_run = parse_examples();
 
@@ -183,6 +188,7 @@ fn main() {
             let work_to_do = || {
                 examples_to_run
                     .iter()
+                    .filter(|example| example.category != "Stress Tests" || !ignore_stress_tests)
                     .skip(cli.page.unwrap_or(0) * cli.per_page.unwrap_or(0))
                     .take(cli.per_page.unwrap_or(usize::MAX))
             };

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -156,28 +156,28 @@ fn main() {
                 let sh = Shell::new().unwrap();
                 cmd!(
                     sh,
-                    "sed -i.bak 's/pub fn desktop_app() -> Self {/pub fn desktop_app() -> Self {Self::game()} pub fn desktop_app_old() -> Self {/' crates/bevy_winit/src/winit_config.rs"
-                    )
-                    .run()
-                    .unwrap();
+                    "git apply tools/example-showcase/remove-desktop-app-mode.patch"
+                )
+                .run()
+                .unwrap();
 
                 // Setting lights ClusterConfig to have less clusters by default
                 // This is needed as the default config is too much for the CI runner
                 cmd!(
                     sh,
-                    "sed -i.bak 's/let config = config.copied().unwrap_or_default();/let config = config.copied().unwrap_or(ClusterConfig::FixedZ {total: 128, z_slices: 4, z_config: ClusterZConfig::default(), dynamic_resizing: true});/' crates/bevy_pbr/src/light.rs"
-                    )
-                    .run()
-                    .unwrap();
+                    "git apply tools/example-showcase/reduce-light-cluster-config.patch"
+                )
+                .run()
+                .unwrap();
 
                 // Sending extra WindowResize events. They are not sent on CI with xvfb x11 server
                 // This is needed for example split_screen that uses the window size to set the panels
                 cmd!(
                     sh,
-                    "sed -i.bak 's/winit_state.low_power_event = true;/winit_state.low_power_event = true; window_events.window_resized.send(WindowResized {window: window_entity, width: window.width(), height: window.height()});/' crates/bevy_winit/src/lib.rs"
-                    )
-                    .run()
-                    .unwrap();
+                    "git apply tools/example-showcase/extra-window-resized-events.patch"
+                )
+                .run()
+                .unwrap();
             }
 
             let work_to_do = || {

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -258,7 +258,6 @@ fn main() {
                 let result = cmd.output();
 
                 let duration = before.elapsed();
-                println!("took {duration:?}");
 
                 if (!report_details && result.is_ok())
                     || (report_details && result.as_ref().unwrap().status.success())

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
                 let sh = Shell::new().unwrap();
                 cmd!(
                     sh,
-                    "git apply tools/example-showcase/remove-desktop-app-mode.patch"
+                    "git apply --ignore-whitespace tools/example-showcase/remove-desktop-app-mode.patch"
                 )
                 .run()
                 .unwrap();
@@ -170,7 +170,7 @@ fn main() {
                 // This is needed as the default config is too much for the CI runner
                 cmd!(
                     sh,
-                    "git apply tools/example-showcase/reduce-light-cluster-config.patch"
+                    "git apply --ignore-whitespace tools/example-showcase/reduce-light-cluster-config.patch"
                 )
                 .run()
                 .unwrap();
@@ -179,7 +179,7 @@ fn main() {
                 // This is needed for example split_screen that uses the window size to set the panels
                 cmd!(
                     sh,
-                    "git apply tools/example-showcase/extra-window-resized-events.patch"
+                    "git apply --ignore-whitespace tools/example-showcase/extra-window-resized-events.patch"
                 )
                 .run()
                 .unwrap();

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -255,6 +255,15 @@ fn main() {
                     .map(|s| s.to_string())
                     .chain(required_features.iter().cloned())
                     .collect::<Vec<_>>();
+                let _ = cmd!(
+                    sh,
+                    "cargo build --profile {profile} --example {example} {local_extra_parameters...}"
+                ).run();
+                let local_extra_parameters = extra_parameters
+                    .iter()
+                    .map(|s| s.to_string())
+                    .chain(required_features.iter().cloned())
+                    .collect::<Vec<_>>();
                 let mut cmd = cmd!(
                     sh,
                     "cargo run --profile {profile} --example {example} {local_extra_parameters...}"


### PR DESCRIPTION
# Objective

- Enable capturing screenshots of all examples in CI on a GitHub runner

## Solution

- Shorten duration of a run
- Disable `desktop_app` mode - as there isn't any input in CI, examples using this take way too long to run
- Change the default `ClusterConfig` - the runner are not able to do all the clusters with the default settings
- Send extra `WindowResized` events - this is needed only for the `split_screen` example, because CI doesn't trigger that event unlike all the other platforms
