### PR TITLE
Register `AlphaMode` type

### DIFF
--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -166,6 +166,7 @@ impl Plugin for PbrPlugin {
         );
 
         app.register_asset_reflect::<StandardMaterial>()
+            .register_type::<AlphaMode>()
             .register_type::<AmbientLight>()
             .register_type::<Cascade>()
             .register_type::<CascadeShadowConfig>()


### PR DESCRIPTION
# Objective

- `AlphaMode` derives `Reflect`, but wasn't registered with the app and type registry

## Solution

- `app.register_type::<AlphaMode>()`