### PR TITLE
use AutoNoVsync in stress tests

### DIFF
--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -17,7 +17,7 @@ fn main() {
     app.add_plugins((
         DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
-                present_mode: PresentMode::Immediate,
+                present_mode: PresentMode::AutoNoVsync,
                 ..default()
             }),
             ..default()

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -14,7 +14,7 @@ fn main() {
         .add_plugins((
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
-                    present_mode: PresentMode::Immediate,
+                    present_mode: PresentMode::AutoNoVsync,
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
# Objective

- Some stress tests use `Immediate` which is not supported everywhere

## Solution

- Use `AutoNoVsync` instead
