### PR TITLE
Add `insert_unique` command

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -528,11 +528,10 @@ impl BundleInfo {
                         // the target table contains the component.
                         unsafe { table.get_column_mut(component_id).debug_checked_unwrap() };
                     // SAFETY: bundle_component is a valid index for this bundle
-                    match bundle_component_status.get_status(bundle_component) {
-                        ComponentStatus::Added => {
-                            column.initialize(table_row, component_ptr, change_tick);
-                        }
-                        _ => (),
+                    if let ComponentStatus::Added =
+                        bundle_component_status.get_status(bundle_component)
+                    {
+                        column.initialize(table_row, component_ptr, change_tick);
                     }
                 }
                 StorageType::SparseSet => {


### PR DESCRIPTION
# Objective

Currently, calling `insert` on an entity will overwrite any components that share the same type, without any way to specify whether that should be the case. There are a couple of workarounds, most of which (in my experience) are either ugly or trigger unwanted change detection. This is less than ideal since there are relatively common use cases for wanting to insert a bundle without overwriting, like wanting to insert a bundle into an entity that already has a transform. 

- Related: #2054

## Solution

- Add an `insert_unique` command for usage when inserting a bundle without overwriting, e.g:

```rs
let mut entity = commands.spawn(TransformBundle::from_transform(Transform::from_xyz(0.0, 1.5, 0.0)));
entity.insert_unique(PbrBundle {
    mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
    material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
    ..default()
});
// Transform components on the entity are NOT affected by the PbrBundle insert
```

Starting as a draft since this is my first time touching `bevy_ecs` so I kept it totally unobtrusive, originally I wanted to separate chunks into inlined functions but I'd rather hear what you guys have to say first :smile: Feel free to make any edits.