### PR TITLE
Revert "Fix UI corruption for AMD gpus with Vulkan (#9169)"

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -3,7 +3,6 @@ mod render_pass;
 
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
-use bevy_render::view::Msaa;
 use bevy_render::{ExtractSchedule, Render};
 use bevy_window::{PrimaryWindow, Window};
 pub use pipeline::*;
@@ -802,7 +801,6 @@ pub fn queue_uinodes(
     ui_batches: Query<(Entity, &UiBatch)>,
     mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
     events: Res<SpriteAssetEvents>,
-    msaa: Res<Msaa>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -828,10 +826,7 @@ pub fn queue_uinodes(
             let pipeline = pipelines.specialize(
                 &pipeline_cache,
                 &ui_pipeline,
-                UiPipelineKey {
-                    hdr: view.hdr,
-                    msaa_samples: msaa.samples(),
-                },
+                UiPipelineKey { hdr: view.hdr },
             );
             for (entity, batch) in &ui_batches {
                 image_bind_groups

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -62,7 +62,6 @@ impl FromWorld for UiPipeline {
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
 pub struct UiPipelineKey {
     pub hdr: bool,
-    pub msaa_samples: u32,
 }
 
 impl SpecializedRenderPipeline for UiPipeline {
@@ -118,7 +117,7 @@ impl SpecializedRenderPipeline for UiPipeline {
             },
             depth_stencil: None,
             multisample: MultisampleState {
-                count: key.msaa_samples,
+                count: 1,
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -72,7 +72,7 @@ impl Node for UiPassNode {
         };
         let mut render_pass = render_context.begin_tracked_render_pass(RenderPassDescriptor {
             label: Some("ui_pass"),
-            color_attachments: &[Some(target.get_color_attachment(Operations {
+            color_attachments: &[Some(target.get_unsampled_color_attachment(Operations {
                 load: LoadOp::Load,
                 store: true,
             }))],


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/9234

re-breaks: The issues that were linked in #9169 

## Solution

Revert the PR that broke tonemapping/postprocessing/etc.

Any passes that are post msaa resolve need to use the main textures, not the msaa texture.

## Changelog

Idk what to put here since it's a revert.