### PR TITLE
Sysinfo improvements

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -24,7 +24,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 # iOS
 [target.'cfg(all(target_os="ios"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-sysinfo = { version = "0.29.0", default-features = false, features = [
+sysinfo = { version = "0.29.6", default-features = false, features = [
     "apple-app-store",
 ] }
 

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -21,13 +21,12 @@ bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 
-# MacOS
-[target.'cfg(all(target_os="macos"))'.dependencies]
+# iOS
+[target.'cfg(all(target_os="ios"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
 sysinfo = { version = "0.29.0", default-features = false, features = [
     "apple-app-store",
 ] }
 
-# Only include when not bevy_dynamic_plugin and on linux/windows/android
-[target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))'.dependencies]
-sysinfo = { version = "0.29.0", default-features = false }
+[target.'cfg(not(target_os = "ios"))'.dependencies]
+sysinfo = { version = "0.29.6", default-features = false }


### PR DESCRIPTION
Keeping a hard-set list of supported targets might not be the best, it'd force the code to be updated every time `sysinfo` supports a new target (which doesn't happen often but I guess it's better to consider it?). For example, `sysinfo` supports `FreeBSD` but it wasn't listed in the supported targets. So instead, just listing known problematic targets in the `cfg`s seems like a better strategy. But maybe it's not what you prefer? In any case, very curious to hear more about it.

For the rest, I simply updated `sysinfo` version since it got a lot of fixes (mostly Windows).