### PR TITLE
bevy_render: Remove direct dep on wgpu-hal.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -58,7 +58,6 @@ image = { version = "0.24", default-features = false }
 
 # misc
 wgpu = { version = "0.16.0", features=["naga"] }
-wgpu-hal = "0.16.0"
 codespan-reporting = "0.11.0"
 naga = { version = "0.12.0", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
This is not used directly within the rendering code.

# Objective

- Remove extraneous dependency on `wgpu-hal` as it is not used.

## Solution

- The dependency has been removed and should have no externally visible impact.
