### PR TITLE
only check for bans if the dependency tree changed

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -29,11 +29,36 @@ jobs:
   check-bans:
     runs-on: ubuntu-latest
     steps:
+      # on main, prepare a new cargo tree output and cache it
+      - name: On main, prepare new cargo tree cache
+        if: github.ref == 'refs/heads/main'
+        run: cargo tree --depth 3 > cargo-tree-from-main
+      - name: On main, save the new cargo tree cache
+        if: github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v3
+        with:
+          path: cargo-tree-from-main
+          key: cargo-tree-from-main    
+      # on other branch, restore the cached cargo tree output
+      - name: On PR, restore cargo tree cache
+        uses: actions/cache/restore@v3
+        if: github.ref != 'refs/heads/main'
+        with:
+          path: cargo-tree-from-main
+          key: cargo-tree-from-main
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      # if not on main, check that the cargo tree output is unchanged
+      - name: Check if the cargo tree changed from main
+        if: github.ref != 'refs/heads/main'
+        continue-on-error: true
+        id: cargo-tree-changed
+        run: diff cargo-tree-from-main <(cargo tree --depth 3)
       - name: Install cargo-deny
         run: cargo install cargo-deny
+      # if the check was not a success (either skipped because on main or failed because of a change), run the check
       - name: Check for banned and duplicated dependencies
+        if: steps.cargo-tree-changed.outcome != 'success'
         run: cargo deny check bans
 
   check-licenses:


### PR DESCRIPTION
# Objective

- CI job `check-bans` fails often for unrelated reasons to a PR. Reduce those failures

## Solution

- Currently, the job only runs if a `Cargo.toml` file changed. This PR would run the job only if the output of `cargo tree --depth 3` is different in a PR from main. the job would still always run on main
