### PR TITLE
Shortcut for `With` and `Without`

### DIFF
--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -799,4 +799,36 @@ mod tests {
         let values = world.query::<&B>().iter(&world).collect::<Vec<&B>>();
         assert_eq!(values, vec![&B(2)]);
     }
+
+    #[test]
+    fn query_filter_tuple() {
+        let mut world = World::new();
+
+        world.spawn(A(0));
+        world.spawn((A(0), B(0)));
+        world.spawn((B(0), C(0)));
+        world.spawn((A(0), B(0), C(0)));
+
+        let tuple_of_with = world
+            .query_filtered::<Entity, (With<A>, With<B>)>()
+            .iter(&world)
+            .collect::<Vec<Entity>>();
+        let with_of_tuple = world
+            .query_filtered::<Entity, With<(A, B)>>()
+            .iter(&world)
+            .collect::<Vec<Entity>>();
+
+        assert_eq!(tuple_of_with, with_of_tuple);
+
+        let tuple_of_without = world
+            .query_filtered::<Entity, (Without<A>, Without<B>)>()
+            .iter(&world)
+            .collect::<Vec<Entity>>();
+        let without_of_tuple = world
+            .query_filtered::<Entity, Without<(A, B)>>()
+            .iter(&world)
+            .collect::<Vec<Entity>>();
+
+        assert_eq!(tuple_of_without, without_of_tuple);
+    }
 }


### PR DESCRIPTION
# Objective

- Solves #9215

This PR implements a proposition to make `With<(A, B, C)>` and `Without<(A, B, C)>` a shortcut for `(With<A>, With<B>, With<C>)` and `(Without<A>, Without<B>, Without<C>)` to help reduce verbosity of queries.

`With<Bundle>` or `Without<Bundle>` are still disallowed as it's considered an anti-pattern.

## Solution

Implements `WorldQuery` and `ReadOnlyWorldQuery` for `Filter<(T0, T1, ...)>` that delegate to `<(Fitler<T0>, Filter<T1>, ...) as WorldQuery>`, where `Filter` is `With` or `Without`.

---

## Changelog

- Query filters like `(With<A>, With<B>, With<C>)` and  `(Without<A>, Without<B>, Without<C>)` can be simplified into `With<(A, B, C)>` and `Without<(A, B, C)>` respectively.