### PR TITLE
Command tracking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,6 +116,9 @@ trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 # Tracing support, with memory profiling, exposing a port for Tracy
 trace_tracy_memory = ["trace", "bevy_internal/trace_tracy", "bevy_internal/trace_tracy_memory"]
 
+# ECS-command caller tracking, for diagnosing errors in deferred command application
+command_tracking = ["bevy_internal/command_tracking"]
+
 # Tracing support
 trace = ["bevy_internal/trace"]
 

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["game-engines", "data-structures"]
 
 [features]
 trace = []
+command_tracking = []
 multi-threaded = ["bevy_tasks/multi-threaded"]
 default = ["bevy_reflect", "multi-threaded"]
 

--- a/crates/bevy_ecs/src/world/call_tracker.rs
+++ b/crates/bevy_ecs/src/world/call_tracker.rs
@@ -1,0 +1,83 @@
+//! Call location tracker which can be stored and later recalled.
+
+/// With feature `command_tracking` this can be used to display the original call site.
+/// When the feature is disabled `CallTracker` is zero-sized, and `CallTracker::track()` will emit the unit type to avoid any overhead.
+#[derive(Debug)]
+pub struct CallTracker {
+    #[cfg(feature = "command_tracking")]
+    caller: String,
+}
+
+#[allow(clippy::derivable_impls)]
+impl Default for CallTracker {
+    #[cfg_attr(feature = "command_tracking", track_caller)]
+    #[cfg_attr(not(feature = "command_tracking"), inline(always))]
+    fn default() -> Self {
+        Self {
+            #[cfg(feature = "command_tracking")]
+            caller: format!(
+                "(Command origin: \"{}\")",
+                std::panic::Location::caller()
+            ),
+        }
+    }
+}
+
+impl CallTracker {
+    // /// Construct a new call tracker with the calling location.
+    // /// This may be called from a function with the [`track_caller`] attribute
+    // /// to use the parent caller's location.
+    // pub fn new() -> Self {
+    //     Self {
+    //         #[cfg(feature = "command_tracking")]
+    //         caller: format!(
+    //             "(Command origin: \"{}\")",
+    //             std::panic::Location::caller().to_string()
+    //         ),
+    //     }
+    // }
+
+    /// Returns the tracked location when the `command_tracking` feature is enabled,
+    /// and unit `()` otherwise.
+    #[cfg(feature = "command_tracking")]
+    pub fn track(&self) -> CallTrackRef {
+        self.caller.as_ref()
+    }
+
+    /// Returns the tracked location when the `command_tracking` feature is enabled,
+    /// and unit `()` otherwise.
+    #[cfg(not(feature = "command_tracking"))]
+    #[inline(always)]
+    pub fn track(&self) -> CallTrackRef {
+        CallTrackRef
+    }
+}
+
+/// Return type of the CallTracker::track() method
+#[cfg(feature = "command_tracking")]
+pub type CallTrackRef<'a> = &'a str;
+/// Return type of the CallTracker::track() method
+#[cfg(not(feature = "command_tracking"))]
+#[derive(Clone, Copy)]
+pub struct CallTrackRef;
+
+/// Display the caller, or a message describing the feature if not enabled
+#[cfg(feature = "command_tracking")]
+#[macro_export]
+macro_rules! show_tracked_caller {
+    ($caller:expr) => {
+        $caller
+    };
+}
+
+/// Display the caller, or a message describing the feature if not enabled
+#[cfg(not(feature = "command_tracking"))]
+#[macro_export]
+macro_rules! show_tracked_caller {
+    ($caller:expr) => {{
+        let _ = $caller;
+        "(Run with `features=\"bevy/command_tracking\"` to show the command origin)"
+    }};
+}
+
+pub use show_tracked_caller;

--- a/crates/bevy_ecs/src/world/call_tracker.rs
+++ b/crates/bevy_ecs/src/world/call_tracker.rs
@@ -15,10 +15,7 @@ impl Default for CallTracker {
     fn default() -> Self {
         Self {
             #[cfg(feature = "command_tracking")]
-            caller: format!(
-                "(Command origin: \"{}\")",
-                std::panic::Location::caller()
-            ),
+            caller: format!("(Command origin: \"{}\")", std::panic::Location::caller()),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/call_tracker.rs
+++ b/crates/bevy_ecs/src/world/call_tracker.rs
@@ -24,19 +24,6 @@ impl Default for CallTracker {
 }
 
 impl CallTracker {
-    // /// Construct a new call tracker with the calling location.
-    // /// This may be called from a function with the [`track_caller`] attribute
-    // /// to use the parent caller's location.
-    // pub fn new() -> Self {
-    //     Self {
-    //         #[cfg(feature = "command_tracking")]
-    //         caller: format!(
-    //             "(Command origin: \"{}\")",
-    //             std::panic::Location::caller().to_string()
-    //         ),
-    //     }
-    // }
-
     /// Returns the tracked location when the `command_tracking` feature is enabled,
     /// and unit `()` otherwise.
     #[cfg(feature = "command_tracking")]

--- a/crates/bevy_ecs/src/world/call_tracker.rs
+++ b/crates/bevy_ecs/src/world/call_tracker.rs
@@ -37,10 +37,10 @@ impl CallTracker {
     }
 }
 
-/// Return type of the CallTracker::track() method
+/// Return type of the `CallTracker::track()` method
 #[cfg(feature = "command_tracking")]
 pub type CallTrackRef<'a> = &'a str;
-/// Return type of the CallTracker::track() method
+/// Return type of the `CallTracker::track()` method
 #[cfg(not(feature = "command_tracking"))]
 #[derive(Clone, Copy)]
 pub struct CallTrackRef;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -295,7 +295,7 @@ impl World {
         }
     }
 
-    /// Tracked version of [`World::entity_mut`] for use in commands with [`CallTracker::track`].
+    /// Tracked version of [`World::entity_mut`] for use in commands with [`CallTracker::track`](call_tracker::CallTracker::track).
     /// When the `command_tracking` feature is enabled, in case of panic it will display the
     /// command call site.
     #[inline]
@@ -677,7 +677,7 @@ impl World {
         }
     }
 
-    /// Tracked version of [`World::despawn`] for use in commands, designed for use with `CallTracker::track`.
+    /// Tracked version of [`World::despawn`] for use in commands, designed for use with [`CallTracker::track`](call_tracker::CallTracker::track).
     /// When the `command_tracking` feature is enabled in case of warning it will display the originating command call site.
     pub fn despawn_tracked(&mut self, entity: Entity, caller: CallTrackRef) -> bool {
         if let Some(entity) = self.get_entity_mut(entity) {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -296,7 +296,7 @@ impl World {
     }
 
     /// Tracked version of [`World::entity_mut`] for use in commands with [`CallTracker::track`].
-    /// When the "command_tracking" features is enabled, in case of panic it will display the 
+    /// When the "command_tracking" features is enabled, in case of panic it will display the
     /// command call site.
     #[inline]
     #[track_caller]

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -296,7 +296,7 @@ impl World {
     }
 
     /// Tracked version of [`World::entity_mut`] for use in commands with [`CallTracker::track`].
-    /// When the "command_tracking" features is enabled, in case of panic it will display the
+    /// When the `command_tracking` feature is enabled, in case of panic it will display the
     /// command call site.
     #[inline]
     #[track_caller]
@@ -678,7 +678,7 @@ impl World {
     }
 
     /// Tracked version of [`World::despawn`] for use in commands, designed for use with `CallTracker::track`.
-    /// When the "command_tracking" features is enabled in case of warning it will display the originating command call site.
+    /// When the `command_tracking` feature is enabled in case of warning it will display the originating command call site.
     pub fn despawn_tracked(&mut self, entity: Entity, caller: CallTrackRef) -> bool {
         if let Some(entity) = self.get_entity_mut(entity) {
             entity.despawn();

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["bevy"]
 
 [features]
 trace = []
+command_tracking = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -26,6 +26,8 @@ wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
 detailed_trace = ["bevy_utils/detailed_trace"]
 
+command_tracking = ["bevy_hierarchy/command_tracking", "bevy_ecs/command_tracking", "bevy_transform/command_tracking"]
+
 # Image format support for texture loading (PNG and HDR are enabled by default)
 exr = ["bevy_render/exr"]
 hdr = ["bevy_render/hdr"]

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -183,7 +183,12 @@ where
 
 #[cfg(test)]
 mod tests {
-    use bevy_ecs::{entity::EntityMap, reflect::AppTypeRegistry, system::Command, world::World};
+    use bevy_ecs::{
+        entity::EntityMap,
+        reflect::AppTypeRegistry,
+        system::Command,
+        world::{call_tracker::CallTracker, World},
+    };
     use bevy_hierarchy::{AddChild, Parent};
 
     use crate::dynamic_scene_builder::DynamicSceneBuilder;
@@ -204,6 +209,7 @@ mod tests {
         AddChild {
             parent: original_parent_entity,
             child: original_child_entity,
+            caller: CallTracker::default(),
         }
         .apply(&mut world);
 
@@ -225,6 +231,7 @@ mod tests {
         AddChild {
             parent: original_child_entity,
             child: from_scene_parent_entity,
+            caller: CallTracker::default(),
         }
         .apply(&mut world);
 

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     event::{Events, ManualEventReader},
     reflect::AppTypeRegistry,
     system::{Command, Resource},
-    world::{Mut, World},
+    world::{call_tracker::CallTracker, Mut, World},
 };
 use bevy_hierarchy::{AddChild, Parent};
 use bevy_utils::{tracing::error, HashMap, HashSet};
@@ -283,6 +283,7 @@ impl SceneSpawner {
                         AddChild {
                             parent,
                             child: entity,
+                            caller: CallTracker::default(),
                         }
                         .apply(world);
                     }

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -22,3 +22,4 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 
 [features]
 serialize = ["dep:serde", "bevy_math/serialize"]
+command_tracking = []

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -48,6 +48,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_ci_testing|Enable systems that allow for automated testing on CI|
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading))|
 |bmp|BMP image format support|
+|command_tracking|ECS-command caller tracking, for diagnosing errors in deferred command application|
 |dds|DDS compressed texture support|
 |debug_asset_server|Enable the "debug asset server" for hot reloading internal assets|
 |detailed_trace|Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in|


### PR DESCRIPTION
# Objective

adds a feature `command_tracking` to show the original construction site of commands that panic or generate warnings. when the feature is not enabled there is no additional overhead.

before:
```
2023-07-23T23:52:09.574217Z  WARN bevy_ecs::world: error[B0003]: Could not despawn entity 7044v4 because
it doesn't exist in this World.
```

after without feature:
```
2023-07-23T23:52:13.024403Z  WARN bevy_ecs::world: error[B0003]: Could not despawn entity 7044v4 because
it doesn't exist in this World. (Run with `features="bevy/command_tracking"` to show the command origin)
```

after with `--features = "bevy/command_tracking"` :
```
2023-07-23T23:53:39.397276Z  WARN bevy_ecs::world: error[B0003]: Could not despawn entity 7044v4 because
it doesn't exist in this World. (Command origin: "crates\scene_runner\src\update_world\gltf_container.rs:157:30")
```

## Solution

most commands now include a `CallTracker` member. when the feature is disabled this is a ZST, and when enabled it contains the call site from which the command was constructed.
the command `apply` functions pass this to `entity_mut_tracked` which displays the caller if it panics.

regarding the "no overhead" claim: godbolt shows no overhead for the CallTracker construction when `#[inline(always)]`'d, but i am not sure how to check if that's still true across crate boundaries.

---

## Migration Guide

many commands now need a `caller` member, which should be `::default`ed. if you want to use your caller's origin for tracking instead of your own location, annotate your function with `[track_caller]`.