### PR TITLE
Fixed typo in line 322

### DIFF
--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -319,7 +319,7 @@ impl FromWorld for PostProcessPipeline {
                     })],
                 }),
                 // All of the following property are not important for this effect so just use the default values.
-                // This struct doesn't have the Default trai implemented because not all field can have a default value.
+                // This struct doesn't have the Default trait implemented because not all field can have a default value.
                 primitive: PrimitiveState::default(),
                 depth_stencil: None,
                 multisample: MultisampleState::default(),

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -318,7 +318,7 @@ impl FromWorld for PostProcessPipeline {
                         write_mask: ColorWrites::ALL,
                     })],
                 }),
-                // All of the following property are not important for this effect so just use the default values.
+                // All of the following properties are not important for this effect so just use the default values.
                 // This struct doesn't have the Default trait implemented because not all field can have a default value.
                 primitive: PrimitiveState::default(),
                 depth_stencil: None,


### PR DESCRIPTION
`trait` was spelled `trai` and used singular instead of plural in documenting comment.