### PR TITLE
Improve selection of iOS device in mobile example

### DIFF
--- a/examples/mobile/Makefile
+++ b/examples/mobile/Makefile
@@ -2,7 +2,7 @@
 
 DEVICE = ${DEVICE_ID}
 ifndef DEVICE_ID
-	DEVICE=$(shell xcrun simctl list devices 'iOS' | grep -v 'unavailable' | grep -v '^--' | grep -v '==' | head -n 1 | cut -d ' ' -f 7 | sed 's/[()]//g')
+	DEVICE=$(shell xcrun simctl list devices 'iOS' | grep -v 'unavailable' | grep -v '^--' | grep -v '==' | head -n 1 | grep -E -o -i "([0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12})")
 endif
 
 run: install


### PR DESCRIPTION
# Objective

- Make sure that users can "just run" the mobile example
- Device descriptions like `iPhone SE (3rd generation) (F647334F-D7C1-4BD6-9B5F-0E3D9713C02B) (Shutdown)` currently fail ([issue found](https://github.com/NiklasEi/bevy_game_template/pull/61#discussion_r1269747507) by @CleanCut)

## Solution

- Improve the script that grabs the device UUID from the device list