### PR TITLE
Remove the `With<Parent>` query filter from `bevy_ui::render::extract_uinode_borders`

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -277,7 +277,7 @@ pub fn extract_uinode_borders(
             Without<ContentSize>,
         >,
     >,
-    parent_node_query: Extract<Query<&Node, With<Parent>>>,
+    parent_node_query: Extract<Query<&Node>>,
 ) {
     let image = bevy_render::texture::DEFAULT_IMAGE_HANDLE.typed();
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -277,7 +277,7 @@ pub fn extract_uinode_borders(
             Without<ContentSize>,
         >,
     >,
-    parent_node_query: Extract<Query<&Node>>,
+    node_query: Extract<Query<&Node>>,
 ) {
     let image = bevy_render::texture::DEFAULT_IMAGE_HANDLE.typed();
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -305,7 +305,7 @@ pub fn extract_uinode_borders(
             // Both vertical and horizontal percentage border values are calculated based on the width of the parent node
             // <https://developer.mozilla.org/en-US/docs/Web/CSS/border-width>
             let parent_width = parent
-                .and_then(|parent| parent_node_query.get(parent.get()).ok())
+                .and_then(|parent| node_query.get(parent.get()).ok())
                 .map(|parent_node| parent_node.size().x)
                 .unwrap_or(ui_logical_viewport_size.x);
             let left =


### PR DESCRIPTION
# Objective

Remove the `With<Parent>` query filter from the `parent_node_query` parameter of the `bevy_ui::render::extract_uinode_borders` function. This is a bug, the query is only used to retrieve the size of the current node's parent. We don't care if that parent node has a `Parent` or not.