### PR TITLE
Fix timers.rs documentation

### DIFF
--- a/examples/ecs/timers.rs
+++ b/examples/ecs/timers.rs
@@ -43,8 +43,8 @@ fn setup(mut commands: Commands) {
     )));
 }
 
-/// This system ticks all the `Timer` components on entities within the scene
-/// using bevy's `Time` resource to get the delta between each update.
+/// This system ticks the `Timer` on the entity with the `PrintOnCompletionTimer`
+/// component using bevy's `Time` resource to get the delta between each update.
 fn print_when_completed(time: Res<Time>, mut query: Query<&mut PrintOnCompletionTimer>) {
     for mut timer in &mut query {
         if timer.tick(time.delta()).just_finished() {


### PR DESCRIPTION
# Objective

The documentation for the `print_when_completed` system stated that this system would tick the `Timer` component on every entity in the scene.

This was incorrect as this system only ticks the `Timer` on entities with the `PrintOnCompletionTimer` component.

## Solution

We suggest a modification to the documentation of this system to make it more clear.

