### PR TITLE
Add `EntityMap::clear`

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -106,6 +106,11 @@ impl EntityMap {
         self.map.iter().map(|(from, to)| (*from, *to))
     }
 
+    /// Clears the map, removing all entity pairs. Keeps the allocated memory for reuse.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+
     /// Creates an [`EntityMapper`] from this [`EntityMap`] and scoped to the provided [`World`], then calls the
     /// provided function with it. This allows one to allocate new entity references in the provided `World` that are
     /// guaranteed to never point at a living entity now or in the future. This functionality is useful for safely


### PR DESCRIPTION
# Objective

If you use `EntityMap` to map entities over network (https://github.com/lifescapegame/bevy_replicon) you need to reset it sometimes, but keep allocated memory for reuse.

## Solution

- Add [clear](https://doc.rust-lang.org/std/collections/struct.HashMap.html#method.clear) method.

---

## Changelog

### Added

- `EntityMap::clear`.