### PR TITLE
Fixed: Default window is now "App" instead of "Bevy App"

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -217,7 +217,7 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            title: "Bevy App".to_owned(),
+            title: "App".to_owned(),
             cursor: Default::default(),
             present_mode: Default::default(),
             mode: Default::default(),


### PR DESCRIPTION
# Objective

Fixes #9298 - Default window title leaks "bevy" context

## Solution

I just replaced the literal string "Bevy App" with "App" in Window's Default trait implementation.
