### PR TITLE
wgpu 0.17

### DIFF
--- a/.github/example-run/minimising.ron
+++ b/.github/example-run/minimising.ron
@@ -1,3 +1,0 @@
-(
-    exit_after: Some(90)
-)

--- a/.github/example-run/resizing.ron
+++ b/.github/example-run/resizing.ron
@@ -1,4 +1,0 @@
-(
-    // Ensures that the full cycle will run
-    exit_after: Some(410)
-)

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -30,7 +30,8 @@ bitflags = "2.3"
 fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
-naga_oil = "0.8"
 radsort = "0.1"
+# naga_oil = "0.8"
+naga_oil = { git = "https://github.com/VitalyAnkh/naga_oil.git", branch = "update-naga-to-0.13" }
 smallvec = "1.6"
 thread_local = "1.0"

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -32,6 +32,6 @@ fixedbitset = "0.4"
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
 # naga_oil = "0.8"
-naga_oil = { git = "https://github.com/VitalyAnkh/naga_oil.git", branch = "update-naga-to-0.13" }
+naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
 smallvec = "1.6"
 thread_local = "1.0"

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -31,7 +31,6 @@ fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
-# naga_oil = "0.8"
-naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
+naga_oil = "0.9"
 smallvec = "1.6"
 thread_local = "1.0"

--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -53,18 +53,10 @@ fn calculate_neighboring_depth_differences(pixel_coordinates: vec2<i32>) -> f32 
     edge_info = saturate((1.0 + bias) - edge_info / scale); // Apply the bias and scale, and invert edge_info so that small values become large, and vice versa
 
     // Pack the edge info into the texture
-    let edge_info_packed = vec4<u32>(mypack4x8unorm(edge_info), 0u, 0u, 0u);
+    let edge_info_packed = vec4<u32>(pack4x8unorm(edge_info), 0u, 0u, 0u);
     textureStore(depth_differences, pixel_coordinates, edge_info_packed);
 
     return depth_center;
-}
-
-// TODO: Remove this once https://github.com/gfx-rs/naga/pull/2353 lands
-fn mypack4x8unorm(e: vec4<f32>) -> u32 {
-    return u32(clamp(e.x, 0.0, 1.0) * 255.0 + 0.5) |
-    u32(clamp(e.y, 0.0, 1.0) * 255.0 + 0.5) << 8u |
-    u32(clamp(e.z, 0.0, 1.0) * 255.0 + 0.5) << 16u |
-    u32(clamp(e.w, 0.0, 1.0) * 255.0 + 0.5) << 24u;
 }
 
 fn load_normal_view_space(uv: vec2<f32>) -> vec3<f32> {

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
@@ -31,11 +31,11 @@ fn spatial_denoise(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let visibility2 = textureGather(0, ambient_occlusion_noisy, point_clamp_sampler, uv, vec2<i32>(0i, 2i));
     let visibility3 = textureGather(0, ambient_occlusion_noisy, point_clamp_sampler, uv, vec2<i32>(2i, 2i));
 
-    let left_edges = myunpack4x8unorm(edges0.x);
-    let right_edges = myunpack4x8unorm(edges1.x);
-    let top_edges = myunpack4x8unorm(edges0.z);
-    let bottom_edges = myunpack4x8unorm(edges2.w);
-    var center_edges = myunpack4x8unorm(edges0.y);
+    let left_edges = unpack4x8unorm(edges0.x);
+    let right_edges = unpack4x8unorm(edges1.x);
+    let top_edges = unpack4x8unorm(edges0.z);
+    let bottom_edges = unpack4x8unorm(edges2.w);
+    var center_edges = unpack4x8unorm(edges0.y);
     center_edges *= vec4<f32>(left_edges.y, right_edges.x, top_edges.w, bottom_edges.z);
 
     let center_weight = 1.2;
@@ -81,12 +81,4 @@ fn spatial_denoise(@builtin(global_invocation_id) global_id: vec3<u32>) {
     let denoised_visibility = sum / sum_weight;
 
     textureStore(ambient_occlusion, pixel_coordinates, vec4<f32>(denoised_visibility, 0.0, 0.0, 0.0));
-}
-
-// TODO: Remove this once https://github.com/gfx-rs/naga/pull/2353 lands in Bevy
-fn myunpack4x8unorm(e: u32) -> vec4<f32> {
-    return vec4<f32>(clamp(f32(e & 0xFFu) / 255.0, 0.0, 1.0),
-        clamp(f32((e >> 8u) & 0xFFu) / 255.0, 0.0, 1.0),
-        clamp(f32((e >> 16u) & 0xFFu) / 255.0, 0.0, 1.0),
-        clamp(f32((e >> 24u) & 0xFFu) / 255.0, 0.0, 1.0));
 }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -72,7 +72,7 @@ hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
 # naga_oil = "0.8"
-naga_oil = { git = "https://github.com/VitalyAnkh/naga_oil.git", branch = "update-naga-to-0.13" }
+naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
 # For ktx2 supercompression
 flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.4.0", optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -57,9 +57,9 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 image = { version = "0.24", default-features = false }
 
 # misc
-wgpu = { version = "0.16.0", features=["naga"] }
+wgpu = { version = "0.17.0", features=["naga"] }
 codespan-reporting = "0.11.0"
-naga = { version = "0.12.0", features = ["wgsl-in"] }
+naga = { version = "0.13.0", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }
@@ -71,7 +71,8 @@ futures-lite = "1.4.0"
 hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
-naga_oil = "0.8"
+# naga_oil = "0.8"
+naga_oil = { git = "https://github.com/VitalyAnkh/naga_oil.git", branch = "update-naga-to-0.13" }
 # For ktx2 supercompression
 flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.4.0", optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -57,13 +57,12 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 image = { version = "0.24", default-features = false }
 
 # misc
+codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
 wgpu = { version = "0.17.0", features = ["naga", "fragile-send-sync-non-atomic-wasm"] }
-codespan-reporting = "0.11.0"
 naga = { version = "0.13.0", features = ["wgsl-in"] }
-# naga_oil = "0.8"
-naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
+naga_oil = "0.9"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -60,7 +60,7 @@ image = { version = "0.24", default-features = false }
 codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
-wgpu = { version = "0.17.0", features = ["naga", "fragile-send-sync-non-atomic-wasm"] }
+wgpu = { version = "0.17.1", features = ["naga", "fragile-send-sync-non-atomic-wasm"] }
 naga = { version = "0.13.0", features = ["wgsl-in"] }
 naga_oil = "0.9"
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -59,9 +59,11 @@ image = { version = "0.24", default-features = false }
 # misc
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
-wgpu = { version = "0.17.0", features=["naga", "fragile-send-sync-non-atomic-wasm"] }
+wgpu = { version = "0.17.0", features = ["naga", "fragile-send-sync-non-atomic-wasm"] }
 codespan-reporting = "0.11.0"
 naga = { version = "0.13.0", features = ["wgsl-in"] }
+# naga_oil = "0.8"
+naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }
@@ -73,8 +75,6 @@ futures-lite = "1.4.0"
 hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
-# naga_oil = "0.8"
-naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "0.13" }
 # For ktx2 supercompression
 flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.4.0", optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -57,7 +57,9 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 image = { version = "0.24", default-features = false }
 
 # misc
-wgpu = { version = "0.17.0", features=["naga"] }
+# `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
+# It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
+wgpu = { version = "0.17.0", features=["naga", "fragile-send-sync-non-atomic-wasm"] }
 codespan-reporting = "0.11.0"
 naga = { version = "0.13.0", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
~~Currently blocked on an upstream bug that causes crashes when minimizing/resizing on dx12 https://github.com/gfx-rs/wgpu/issues/3967~~ wgpu 0.17.1 is out which fixes it

# Objective

Keep wgpu up to date.

## Solution

Update wgpu and naga_oil.

Currently this depends on an unreleased (and unmerged) branch of naga_oil, and hasn't been properly tested yet.

The wgpu side of this seems to have been an extremely trivial upgrade (all the upgrade work seems to be in naga_oil). This also lets us remove the workarounds for pack/unpack4x8unorm in the SSAO shaders.

Lets us close the dx12 part of https://github.com/bevyengine/bevy/issues/8888

related: https://github.com/bevyengine/bevy/issues/9304

---

## Changelog

Update to wgpu 0.17 and naga_oil 0.9
