### PR TITLE
Extend the default render range of 2D camera

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -35,7 +35,32 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        Self::new_with_far(1000.0)
+        let projection = OrthographicProjection {
+            far: 1000.,
+            near: -1000.,
+            ..Default::default()
+        };
+        let transform = Transform::default();
+        let view_projection =
+            projection.get_projection_matrix() * transform.compute_matrix().inverse();
+        let frustum = Frustum::from_view_projection_custom_far(
+            &view_projection,
+            &transform.translation,
+            &transform.back(),
+            projection.far(),
+        );
+        Self {
+            camera_render_graph: CameraRenderGraph::new(crate::core_2d::graph::NAME),
+            projection,
+            visible_entities: VisibleEntities::default(),
+            frustum,
+            transform,
+            global_transform: Default::default(),
+            camera: Camera::default(),
+            camera_2d: Camera2d::default(),
+            tonemapping: Tonemapping::None,
+            deband_dither: DebandDither::Disabled,
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #9138

## Solution

- Calling `Camera2dBundle::default()` will now result in a `Camera2dBundle` with `Vec3::ZERO` transform, `far` value of `1000.` and `near` value of `-1000.`.
- This will enable the rendering of 2d entities in negative z space by default.
- I did not modify `new_with_far` as moving the camera to `Vec3::ZERO` in that function will cause entities in the positive z space to become hidden without further changes. And the further changes cannot be applied without it being a breaking change.