### PR TITLE
Fix shader_material_glsl example after #9254

### DIFF
--- a/assets/shaders/custom_material.vert
+++ b/assets/shaders/custom_material.vert
@@ -16,13 +16,23 @@ layout(set = 0, binding = 0) uniform CameraViewProj {
     float height;
 };
 
-layout(set = 2, binding = 0) uniform Mesh {
+struct Mesh {
     mat4 Model;
     mat4 InverseTransposeModel;
     uint flags;
 };
 
+#ifdef PER_OBJECT_BUFFER_BATCH_SIZE
+layout(set = 2, binding = 0) uniform Mesh Meshes[#{PER_OBJECT_BUFFER_BATCH_SIZE}];
+#else
+layout(set = 2, binding = 0) readonly buffer _Meshes {
+    Mesh Meshes[];
+};
+#endif // PER_OBJECT_BUFFER_BATCH_SIZE
+
 void main() {
     v_Uv = Vertex_Uv;
-    gl_Position = ViewProj * Model * vec4(Vertex_Position, 1.0);
+    gl_Position = ViewProj
+        * Meshes[gl_BaseInstance + gl_InstanceIndex].Model
+        * vec4(Vertex_Position, 1.0);
 }


### PR DESCRIPTION
# Objective

- Fix shader_material_glsl example

## Solution

- Expose the `PER_OBJECT_BUFFER_BATCH_SIZE` shader def through the default `MeshPipeline` specialization.
- Make use of it in the `custom_material.vert` shader to access the mesh binding.

---

## Changelog

- Added: Exposed the `PER_OBJECT_BUFFER_BATCH_SIZE` shader def through the default `MeshPipeline` specialization to use in custom shaders not using bevy_pbr::mesh_bindings that still want to use the mesh binding in some way.