### PR TITLE
bevy_reflect: Default attribute paths

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/field_attributes.rs
@@ -6,7 +6,7 @@
 
 use crate::REFLECT_ATTRIBUTE_NAME;
 use syn::meta::ParseNestedMeta;
-use syn::{Attribute, LitStr, Token};
+use syn::{Attribute, Token};
 
 pub(crate) static IGNORE_SERIALIZATION_ATTR: &str = "skip_serializing";
 pub(crate) static IGNORE_ALL_ATTR: &str = "ignore";
@@ -98,14 +98,13 @@ fn parse_meta(args: &mut ReflectFieldAttr, meta: ParseNestedMeta) -> Result<(), 
     if meta.path.is_ident(DEFAULT_ATTR) {
         // Allow:
         // - `#[reflect(default)]`
-        // - `#[reflect(default = "path::to::func")]`
+        // - `#[reflect(default = path::to::func)]`
         if !matches!(args.default, DefaultBehavior::Required) {
             return Err(meta.error(format!("only one of [{:?}] is allowed", [DEFAULT_ATTR])));
         }
 
         if meta.input.peek(Token![=]) {
-            let lit = meta.value()?.parse::<LitStr>()?;
-            args.default = DefaultBehavior::Func(lit.parse()?);
+            args.default = DefaultBehavior::Func(meta.value()?.parse()?);
         } else {
             args.default = DefaultBehavior::Default;
         }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -228,7 +228,7 @@ pub fn derive_reflect(input: TokenStream) -> TokenStream {
 ///
 /// By default, this attribute denotes that the field's type implements [`Default`].
 /// However, it can also take in a path string to a user-defined function that will return the default value.
-/// This takes the form: `#[reflect(default = "path::to::my_function")]` where `my_function` is a parameterless
+/// This takes the form: `#[reflect(default = path::to::my_function)]` where `my_function` is a parameterless
 /// function that must return some default value for the type.
 ///
 /// Specifying a custom default can be used to give different fields their own specialized defaults,

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -57,7 +57,7 @@ pub trait FromReflect: Reflect + Sized {
 /// ```
 /// # use bevy_reflect::{DynamicTupleStruct, FromReflect, Reflect};
 /// #[derive(Reflect, PartialEq, Eq, Debug)]
-/// struct Foo(#[reflect(default = "default_value")] usize);
+/// struct Foo(#[reflect(default = default_value)] usize);
 ///
 /// fn default_value() -> usize { 123 }
 ///
@@ -77,7 +77,7 @@ pub trait FromReflect: Reflect + Sized {
 /// ```
 /// # use bevy_reflect::{DynamicTupleStruct, Reflect, ReflectFromReflect, Typed, TypeRegistry};
 /// # #[derive(Reflect, PartialEq, Eq, Debug)]
-/// # struct Foo(#[reflect(default = "default_value")] usize);
+/// # struct Foo(#[reflect(default = default_value)] usize);
 /// # fn default_value() -> usize { 123 }
 /// # let mut registry = TypeRegistry::new();
 /// # registry.register::<Foo>();

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -223,7 +223,7 @@
 //!
 //! Fields can be given default values for when a field is missing in the passed value or even ignored.
 //! Ignored fields must either implement [`Default`] or have a default function specified
-//! using `#[reflect(default = "path::to::function")]`.
+//! using `#[reflect(default = path::to::function)]`.
 //!
 //! See the [derive macro documentation](derive@crate::FromReflect) for details.
 //!
@@ -774,11 +774,11 @@ mod tests {
 
             // Use `get_bar_default()`
             #[reflect(ignore)]
-            #[reflect(default = "get_bar_default")]
+            #[reflect(default = get_bar_default)]
             bar: NotReflect,
 
             // Ensure attributes can be combined
-            #[reflect(ignore, default = "get_bar_default")]
+            #[reflect(ignore, default = get_bar_default)]
             baz: NotReflect,
         }
 
@@ -807,7 +807,7 @@ mod tests {
         enum MyEnum {
             Foo(#[reflect(default)] String),
             Bar {
-                #[reflect(default = "get_baz_default")]
+                #[reflect(default = get_baz_default)]
                 #[reflect(ignore)]
                 baz: usize,
             },

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -30,7 +30,7 @@ fn main() {
 /// reflection by using the `#[reflect(ignore)]` attribute.
 /// If you choose to ignore a field, you need to let the automatically-derived `FromReflect` implementation
 /// how to handle the field.
-/// To do this, you can either define a `#[reflect(default = "...")]` attribute on the ignored field, or
+/// To do this, you can either define a `#[reflect(default = ...)]` attribute on the ignored field, or
 /// opt-out of `FromReflect`'s auto-derive using the `#[reflect(from_reflect = false)]` attribute.
 #[derive(Reflect)]
 #[reflect(from_reflect = false)]


### PR DESCRIPTION
# Objective

Followup to #9322 but with a breaking change.

With `syn2`, it's a whole lot easier to customize attributes. One small improvement we could make would be to change the `default` attribute to take a type path directly instead of a stringified path.

## Solution

Updated the parsing logic to take an `ExprPath` directly.

---

## Changelog

- Default functions passed to `#[reflect(default)]` no longer need to be string literals (i.e. they can specify the path directly like `#[reflect(default = path::to::func)]`)

## Migration Guide

The optional function passed to `#[reflect(default)]` is no longer a stringified path. It can now be a standard type path:

```rust
mod defaults {
  fn foo() -> i32 {
    123
  }
}

// BEFORE
#[derive(Reflect)]
struct Foo {
  #[reflect(default = "defaults::foo")]
  value: i32
}

// AFTER
#[derive(Reflect)]
struct Foo {
  #[reflect(default = defaults::foo)]
  value: i32
}
```
