### PR TITLE
Make Anchor Copy

### DIFF
--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -3,7 +3,7 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::color::Color;
 
-#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default)]
 #[repr(C)]
 pub struct Sprite {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -3,7 +3,7 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::color::Color;
 
-#[derive(Component, Debug, Default, Clone, Reflect)]
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
 #[reflect(Component, Default)]
 #[repr(C)]
 pub struct Sprite {
@@ -25,7 +25,7 @@ pub struct Sprite {
 
 /// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).
 /// It defaults to `Anchor::Center`.
-#[derive(Component, Debug, Clone, Default, Reflect)]
+#[derive(Component, Debug, Clone, Copy, Default, Reflect)]
 #[doc(alias = "pivot")]
 pub enum Anchor {
     #[default]


### PR DESCRIPTION
# Objective

In `bevy_sprite`, the `Anchor` type is not `Copy`. It makes interacting with it more difficult than necessary.

## Solution

Derive `Copy` on it. The rust API guidelines are that you should derive `Copy` when possible. <https://rust-lang.github.io/api-guidelines/interoperability.html#types-eagerly-implement-common-traits-c-common-traits>
Regardless, `Anchor` is a very small `enum` which warrants `Copy`.

---

## Changelog

- In `bevy_sprite` `Anchor` is now `Copy`.