### PR TITLE
Improve execution of examples in CI

### DIFF
--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -65,8 +65,8 @@ fn setup_scene(
         .unwrap(),
     );
 
-    for x in -10..10 {
-        for z in -10..10 {
+    for x in -5..5 {
+        for z in -5..5 {
             let mut hasher = DefaultHasher::new();
             (x, z).hash(&mut hasher);
             let rand = (hasher.finish() - 2) % 6;

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -17,6 +17,13 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     asset_server: Res<AssetServer>,
 ) {
+    let sphere_mesh = meshes.add(
+        Mesh::try_from(shape::Icosphere {
+            radius: 0.45,
+            ..default()
+        })
+        .unwrap(),
+    );
     // add entities to the world
     for y in -2..=2 {
         for x in -5..=5 {
@@ -24,13 +31,7 @@ fn setup(
             let y01 = (y + 2) as f32 / 4.0;
             // sphere
             commands.spawn(PbrBundle {
-                mesh: meshes.add(
-                    Mesh::try_from(shape::Icosphere {
-                        radius: 0.45,
-                        subdivisions: 32,
-                    })
-                    .unwrap(),
-                ),
+                mesh: sphere_mesh.clone(),
                 material: materials.add(StandardMaterial {
                     base_color: Color::hex("#ffd891").unwrap(),
                     // vary key PBR parameters on a grid of spheres to show the effect
@@ -45,13 +46,7 @@ fn setup(
     }
     // unlit sphere
     commands.spawn(PbrBundle {
-        mesh: meshes.add(
-            Mesh::try_from(shape::Icosphere {
-                radius: 0.45,
-                subdivisions: 32,
-            })
-            .unwrap(),
-        ),
+        mesh: sphere_mesh,
         material: materials.add(StandardMaterial {
             base_color: Color::hex("#ffd891").unwrap(),
             // vary key PBR parameters on a grid of spheres to show the effect

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -26,7 +26,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let spawn_plane_depth = 500.0f32;
+    let spawn_plane_depth = 300.0f32;
     let spawn_height = 2.0;
     let sphere_radius = 0.25;
 
@@ -84,7 +84,7 @@ fn setup(
         CameraController::default(),
     ));
 
-    for z_i32 in -spawn_plane_depth as i32..=0 {
+    for z_i32 in (-spawn_plane_depth as i32..=0).step_by(2) {
         commands.spawn(PbrBundle {
             mesh: sphere_handle.clone(),
             material: white_handle.clone(),

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -5,7 +5,7 @@ use bevy::{
     pbr::NotShadowCaster,
     prelude::*,
 };
-use rand::{thread_rng, Rng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn main() {
     App::new()
@@ -40,10 +40,10 @@ fn setup(
     });
 
     // cubes
-    let mut rng = thread_rng();
-    for _ in 0..100 {
+    let mut rng = StdRng::seed_from_u64(19878367467713);
+    for _ in 0..40 {
         let x = rng.gen_range(-5.0..5.0);
-        let y = rng.gen_range(-5.0..5.0);
+        let y = rng.gen_range(0.0..3.0);
         let z = rng.gen_range(-5.0..5.0);
         commands.spawn((
             PbrBundle {

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -41,17 +41,19 @@ fn setup(
 
     // cubes
     let mut rng = StdRng::seed_from_u64(19878367467713);
+    let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 0.5 }));
+    let blue = materials.add(StandardMaterial {
+        base_color: Color::BLUE,
+        ..default()
+    });
     for _ in 0..40 {
         let x = rng.gen_range(-5.0..5.0);
         let y = rng.gen_range(0.0..3.0);
         let z = rng.gen_range(-5.0..5.0);
         commands.spawn((
             PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-                material: materials.add(StandardMaterial {
-                    base_color: Color::BLUE,
-                    ..default()
-                }),
+                mesh: cube_mesh.clone(),
+                material: blue.clone(),
                 transform: Transform::from_xyz(x, y, z),
                 ..default()
             },
@@ -65,6 +67,24 @@ fn setup(
         brightness: 0.14,
     });
 
+    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere {
+        radius: 0.05,
+        ..default()
+    }));
+    let sphere_mesh_direction = meshes.add(Mesh::from(shape::UVSphere {
+        radius: 0.1,
+        ..default()
+    }));
+    let red_emissive = materials.add(StandardMaterial {
+        base_color: Color::RED,
+        emissive: Color::rgba_linear(1.0, 0.0, 0.0, 0.0),
+        ..default()
+    });
+    let maroon_emissive = materials.add(StandardMaterial {
+        base_color: Color::MAROON,
+        emissive: Color::rgba_linear(0.369, 0.0, 0.0, 0.0),
+        ..default()
+    });
     for x in 0..4 {
         for z in 0..4 {
             let x = x as f32 - 2.0;
@@ -86,29 +106,15 @@ fn setup(
                 })
                 .with_children(|builder| {
                     builder.spawn(PbrBundle {
-                        mesh: meshes.add(Mesh::from(shape::UVSphere {
-                            radius: 0.05,
-                            ..default()
-                        })),
-                        material: materials.add(StandardMaterial {
-                            base_color: Color::RED,
-                            emissive: Color::rgba_linear(1.0, 0.0, 0.0, 0.0),
-                            ..default()
-                        }),
+                        mesh: sphere_mesh.clone(),
+                        material: red_emissive.clone(),
                         ..default()
                     });
                     builder.spawn((
                         PbrBundle {
                             transform: Transform::from_translation(Vec3::Z * -0.1),
-                            mesh: meshes.add(Mesh::from(shape::UVSphere {
-                                radius: 0.1,
-                                ..default()
-                            })),
-                            material: materials.add(StandardMaterial {
-                                base_color: Color::MAROON,
-                                emissive: Color::rgba_linear(0.369, 0.0, 0.0, 0.0),
-                                ..default()
-                            }),
+                            mesh: sphere_mesh_direction.clone(),
+                            material: maroon_emissive.clone(),
                             ..default()
                         },
                         NotShadowCaster,

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -135,6 +135,10 @@ fn setup_basic_scene(
     }
 
     // spheres
+    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere {
+        radius: 0.125,
+        ..default()
+    }));
     for i in 0..6 {
         let j = i % 3;
         let s_val = if i < 3 { 0.0 } else { 0.2 };
@@ -162,11 +166,7 @@ fn setup_basic_scene(
         };
         commands.spawn((
             PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::UVSphere {
-                    radius: 0.125,
-                    sectors: 128,
-                    stacks: 128,
-                })),
+                mesh: sphere_mesh.clone(),
                 material,
                 transform: Transform::from_xyz(
                     j as f32 * 0.25 + if i < 3 { -0.15 } else { 0.15 } - 0.4,

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -3,7 +3,7 @@
 use bevy::prelude::*;
 // Using crossbeam_channel instead of std as std `Receiver` is `!Sync`
 use crossbeam_channel::{bounded, Receiver};
-use rand::Rng;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 use std::time::{Duration, Instant};
 
 fn main() {
@@ -25,17 +25,19 @@ fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 
     let (tx, rx) = bounded::<u32>(10);
-    std::thread::spawn(move || loop {
-        // Everything here happens in another thread
-        // This is where you could connect to an external data source
-        let mut rng = rand::thread_rng();
-        let start_time = Instant::now();
-        let duration = Duration::from_secs_f32(rng.gen_range(0.0..0.2));
-        while start_time.elapsed() < duration {
-            // Spinning for 'duration', simulating doing hard work!
-        }
+    std::thread::spawn(move || {
+        let mut rng = StdRng::seed_from_u64(19878367467713);
+        loop {
+            // Everything here happens in another thread
+            // This is where you could connect to an external data source
+            let start_time = Instant::now();
+            let duration = Duration::from_secs_f32(rng.gen_range(0.0..0.2));
+            while start_time.elapsed() < duration {
+                // Spinning for 'duration', simulating doing hard work!
+            }
 
-        tx.send(rng.gen_range(0..2000)).unwrap();
+            tx.send(rng.gen_range(0..2000)).unwrap();
+        }
     });
 
     commands.insert_resource(StreamReceiver(rx));
@@ -59,11 +61,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
         commands.spawn(Text2dBundle {
             text: Text::from_section(event.0.to_string(), text_style.clone())
                 .with_alignment(TextAlignment::Center),
-            transform: Transform::from_xyz(
-                per_frame as f32 * 100.0 + rand::thread_rng().gen_range(-40.0..40.0),
-                300.0,
-                0.0,
-            ),
+            transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
             ..default()
         });
     }

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -1,7 +1,7 @@
 //! Shows how to iterate over combinations of query results.
 
 use bevy::{pbr::AmbientLight, prelude::*};
-use rand::{thread_rng, Rng};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 const DELTA_TIME: f32 = 0.01;
 
@@ -56,7 +56,7 @@ fn generate_bodies(
     let color_range = 0.5..1.0;
     let vel_range = -0.5..0.5;
 
-    let mut rng = thread_rng();
+    let mut rng = StdRng::seed_from_u64(19878367467713);
     for _ in 0..NUM_BODIES {
         let radius: f32 = rng.gen_range(0.1..0.7);
         let mass_value = radius.powi(3) * 10.;

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -2,7 +2,7 @@
 
 use bevy::ecs::query::BatchingStrategy;
 use bevy::prelude::*;
-use rand::random;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[derive(Component, Deref)]
 struct Velocity(Vec2);
@@ -10,6 +10,7 @@ struct Velocity(Vec2);
 fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     let texture = asset_server.load("branding/icon.png");
+    let mut rng = StdRng::seed_from_u64(19878367467713);
     for _ in 0..128 {
         commands.spawn((
             SpriteBundle {
@@ -17,7 +18,7 @@ fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                 transform: Transform::from_scale(Vec3::splat(0.1)),
                 ..default()
             },
-            Velocity(20.0 * Vec2::new(random::<f32>() - 0.5, random::<f32>() - 0.5)),
+            Velocity(20.0 * Vec2::new(rng.gen::<f32>() - 0.5, rng.gen::<f32>() - 0.5)),
         ));
     }
 }


### PR DESCRIPTION
# Objective

- Some examples crash in CI because of needing too many resources for the windows runner
- Some examples have random results making it hard to compare screenshots

## Solution

- `bloom_3d`: reduce the number of spheres
- `pbr`:  use simpler spheres and reuse the mesh
- `tonemapping`: use simpler spheres and reuse the mesh
- `shadow_biases`: reduce the number of spheres
- `spotlight`: use a seeded rng, move more cubes in view while reducing the total number of cubes, and reuse meshes and materials
- `external_source_external_thread`, `iter_combinations`, `parallel_query`: use a seeded rng

Examples of errors encountered:
```
Caused by:
    In Device::create_bind_group
      note: label = `bloom_upsampling_bind_group`
    Not enough memory left
```

```
Caused by:
    In Queue::write_buffer
    Parent device is lost
```
```
ERROR wgpu_core::device::life: Mapping failed Device(Lost)
```