### PR TITLE
UI content transform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1997,6 +1997,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "ui_image_symmetries"
+path = "examples/ui/ui_image_symmetries.rs"
+
+[package.metadata.example.ui_image_symmetries]
+name = "UI Image Symmetries"
+description = "Demonstrates how to rotate and flip UI images"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "viewport_debug"
 path = "examples/ui/viewport_debug.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1936,6 +1936,16 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "text_transformed"
+path = "examples/ui/text_transformed.rs"
+
+[package.metadata.example.text_transformed]
+name = "Text Transformed"
+description = "Demonstrates flipped and rotated text."
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "grid"
 path = "examples/ui/grid.rs"
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,7 +1,7 @@
 mod convert;
 pub mod debug;
 
-use crate::{ContentSize, Node, Style, UiContentTransform, UiScale};
+use crate::{ContentSize, Node, Style, UiScale};
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
@@ -93,43 +93,9 @@ impl UiSurface {
     }
 
     /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`].
-    pub fn update_measure(
-        &mut self,
-        entity: Entity,
-        measure_func: taffy::node::MeasureFunc,
-        orientation: UiContentTransform,
-    ) {
+    pub fn update_measure(&mut self, entity: Entity, measure_func: taffy::node::MeasureFunc) {
         let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
-        match orientation {
-            UiContentTransform::North => {
-                self.taffy.set_measure(*taffy_node, Some(measure_func)).ok();
-            }
-            _ => {
-                use std::mem::swap;
-                let measure =
-                    match measure_func {
-                        taffy::node::MeasureFunc::Raw(f) => {
-                            taffy::node::MeasureFunc::Boxed(Box::new(move |mut size: Size<Option<f32>>, mut space: Size<taffy::style::AvailableSpace>| {
-                                swap(&mut size.width, &mut size.height);
-                                swap(&mut space.width, &mut space.height);
-                                let mut out = f(size, space);
-                                swap(&mut out.width, &mut out.height);
-                                out
-                            }))
-                        },
-                        taffy::node::MeasureFunc::Boxed(f) =>{
-                            taffy::node::MeasureFunc::Boxed(Box::new(move |mut size: Size<Option<f32>>, mut space: Size<taffy::style::AvailableSpace>| {
-                                swap(&mut size.width, &mut size.height);
-                                swap(&mut space.width, &mut space.height);
-                                let mut out = f(size, space);
-                                swap(&mut out.width, &mut out.height);
-                                out
-                            }))
-                        },
-                    };
-                self.taffy.set_measure(*taffy_node, Some(measure)).ok();
-            }
-        };
+        self.taffy.set_measure(*taffy_node, Some(measure_func)).ok();
     }
 
     /// Update the children of the taffy node corresponding to the given [`Entity`].
@@ -257,7 +223,7 @@ pub fn ui_layout_system(
     mut ui_surface: ResMut<UiSurface>,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
-    mut measure_query: Query<(Entity, &mut ContentSize, Option<&UiContentTransform>)>,
+    mut measure_query: Query<(Entity, &mut ContentSize)>,
     children_query: Query<(Entity, Ref<Children>), With<Node>>,
     just_children_query: Query<&Children>,
     mut removed_children: RemovedComponents<Children>,
@@ -308,15 +274,9 @@ pub fn ui_layout_system(
         }
     }
 
-    for (entity, mut content_size, orientation) in measure_query.iter_mut() {
+    for (entity, mut content_size) in measure_query.iter_mut() {
         if let Some(measure_func) = content_size.measure_func.take() {
-            ui_surface.update_measure(
-                entity,
-                measure_func,
-                orientation
-                    .cloned()
-                    .unwrap_or(UiContentTransform::default()),
-            );
+            ui_surface.update_measure(entity, measure_func);
         }
     }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,7 +1,7 @@
 mod convert;
 pub mod debug;
 
-use crate::{ContentSize, Node, Style, UiContentOrientation, UiScale};
+use crate::{ContentSize, Node, Style, UiContentTransform, UiScale};
 use bevy_ecs::{
     change_detection::DetectChanges,
     entity::Entity,
@@ -97,11 +97,11 @@ impl UiSurface {
         &mut self,
         entity: Entity,
         measure_func: taffy::node::MeasureFunc,
-        orientation: UiContentOrientation,
+        orientation: UiContentTransform,
     ) {
         let taffy_node = self.entity_to_taffy.get(&entity).unwrap();
         match orientation {
-            UiContentOrientation::North => {
+            UiContentTransform::North => {
                 self.taffy.set_measure(*taffy_node, Some(measure_func)).ok();
             }
             _ => {
@@ -257,7 +257,7 @@ pub fn ui_layout_system(
     mut ui_surface: ResMut<UiSurface>,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,
     style_query: Query<(Entity, Ref<Style>), With<Node>>,
-    mut measure_query: Query<(Entity, &mut ContentSize, Option<&UiContentOrientation>)>,
+    mut measure_query: Query<(Entity, &mut ContentSize, Option<&UiContentTransform>)>,
     children_query: Query<(Entity, Ref<Children>), With<Node>>,
     just_children_query: Query<&Children>,
     mut removed_children: RemovedComponents<Children>,
@@ -315,7 +315,7 @@ pub fn ui_layout_system(
                 measure_func,
                 orientation
                     .cloned()
-                    .unwrap_or(UiContentOrientation::default()),
+                    .unwrap_or(UiContentTransform::default()),
             );
         }
     }

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -1,6 +1,6 @@
 use bevy_ecs::prelude::Component;
 use bevy_ecs::reflect::ReflectComponent;
-use bevy_math::Vec2;
+use bevy_math::{Vec2, Vec2Swizzles};
 use bevy_reflect::Reflect;
 use std::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
@@ -41,6 +41,25 @@ impl Measure for FixedMeasure {
         _: AvailableSpace,
     ) -> Vec2 {
         self.size
+    }
+}
+
+#[derive(Default, Clone)]
+pub struct SwappedMeasure<M: Measure> {
+    pub inner_measure: M,
+}
+
+impl<M: Measure> Measure for SwappedMeasure<M> {
+    fn measure(
+        &self,
+        width: Option<f32>,
+        height: Option<f32>,
+        available_width: AvailableSpace,
+        available_height: AvailableSpace,
+    ) -> Vec2 {
+        self.inner_measure
+            .measure(height, width, available_height, available_width)
+            .yx()
     }
 }
 

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -44,12 +44,15 @@ impl Measure for FixedMeasure {
     }
 }
 
+/// An adapter implementing measure and wrapping another measure. Its `measure` method calls the `measure` method of `inner_measure` with swapped width and height values.
+/// Then the components of the returned `Vec2` are swapped back before it is returned to the caller.
 #[derive(Default, Clone)]
-pub struct SwappedMeasure<M: Measure> {
+pub struct SwappedDimensionsMeasure<M: Measure> {
+    /// The wrapped measure. It is called with swapped width and height values, and then the value it returns is swapped back.
     pub inner_measure: M,
 }
 
-impl<M: Measure> Measure for SwappedMeasure<M> {
+impl<M: Measure> Measure for SwappedDimensionsMeasure<M> {
     fn measure(
         &self,
         width: Option<f32>,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -5,7 +5,7 @@ use crate::widget::TextFlags;
 use crate::{
     widget::{Button, UiImageSize},
     BackgroundColor, BorderColor, ContentSize, FocusPolicy, Interaction, Node, Style,
-    UiContentOrientation, UiImage, UiTextureAtlasImage, ZIndex,
+    UiContentTransform, UiImage, UiTextureAtlasImage, ZIndex,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -51,7 +51,7 @@ pub struct NodeBundle {
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentOrientation,
+    pub content_orientation: UiContentTransform,
 }
 
 impl Default for NodeBundle {
@@ -115,7 +115,7 @@ pub struct ImageBundle {
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentOrientation,
+    pub content_orientation: UiContentTransform,
 }
 
 /// A UI node that is a texture atlas sprite
@@ -162,7 +162,7 @@ pub struct AtlasImageBundle {
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentOrientation,
+    pub content_orientation: UiContentTransform,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -203,7 +203,7 @@ pub struct TextBundle {
     /// The background color that will fill the containing node
     pub background_color: BackgroundColor,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentOrientation,
+    pub content_orientation: UiContentTransform,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -316,7 +316,7 @@ pub struct ButtonBundle {
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentOrientation,
+    pub content_orientation: UiContentTransform,
 }
 
 impl Default for ButtonBundle {

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -4,8 +4,8 @@
 use crate::widget::TextFlags;
 use crate::{
     widget::{Button, UiImageSize},
-    BackgroundColor, BorderColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage,
-    UiTextureAtlasImage, ZIndex,
+    BackgroundColor, BorderColor, ContentSize, FocusPolicy, Interaction, Node, Style,
+    UiContentOrientation, UiImage, UiTextureAtlasImage, ZIndex,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -50,6 +50,8 @@ pub struct NodeBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// Controls the orientation of a node's content
+    pub content_orientation: UiContentOrientation,
 }
 
 impl Default for NodeBundle {
@@ -66,6 +68,7 @@ impl Default for NodeBundle {
             visibility: Default::default(),
             computed_visibility: Default::default(),
             z_index: Default::default(),
+            content_orientation: Default::default(),
         }
     }
 }
@@ -111,6 +114,8 @@ pub struct ImageBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// Controls the orientation of a node's content
+    pub content_orientation: UiContentOrientation,
 }
 
 /// A UI node that is a texture atlas sprite
@@ -156,6 +161,8 @@ pub struct AtlasImageBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// Controls the orientation of a node's content
+    pub content_orientation: UiContentOrientation,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -195,6 +202,8 @@ pub struct TextBundle {
     pub z_index: ZIndex,
     /// The background color that will fill the containing node
     pub background_color: BackgroundColor,
+    /// Controls the orientation of a node's content
+    pub content_orientation: UiContentOrientation,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -215,6 +224,7 @@ impl Default for TextBundle {
             visibility: Default::default(),
             computed_visibility: Default::default(),
             z_index: Default::default(),
+            content_orientation: Default::default(),
         }
     }
 }
@@ -305,6 +315,8 @@ pub struct ButtonBundle {
     pub computed_visibility: ComputedVisibility,
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
+    /// Controls the orientation of a node's content
+    pub content_orientation: UiContentOrientation,
 }
 
 impl Default for ButtonBundle {
@@ -323,6 +335,7 @@ impl Default for ButtonBundle {
             visibility: Default::default(),
             computed_visibility: Default::default(),
             z_index: Default::default(),
+            content_orientation: Default::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -51,7 +51,7 @@ pub struct NodeBundle {
     /// Indicates the depth at which the node should appear in the UI
     pub z_index: ZIndex,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentTransform,
+    pub content_transform: UiContentTransform,
 }
 
 impl Default for NodeBundle {
@@ -68,7 +68,7 @@ impl Default for NodeBundle {
             visibility: Default::default(),
             computed_visibility: Default::default(),
             z_index: Default::default(),
-            content_orientation: Default::default(),
+            content_transform: Default::default(),
         }
     }
 }
@@ -203,7 +203,7 @@ pub struct TextBundle {
     /// The background color that will fill the containing node
     pub background_color: BackgroundColor,
     /// Controls the orientation of a node's content
-    pub content_orientation: UiContentTransform,
+    pub content_transform: UiContentTransform,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -224,7 +224,7 @@ impl Default for TextBundle {
             visibility: Default::default(),
             computed_visibility: Default::default(),
             z_index: Default::default(),
-            content_orientation: Default::default(),
+            content_transform: Default::default(),
         }
     }
 }
@@ -273,6 +273,12 @@ impl TextBundle {
     /// Hard wrapping, where text contains an explicit linebreak such as the escape sequence `\n`, will still occur.
     pub const fn with_no_wrap(mut self) -> Self {
         self.text.linebreak_behavior = BreakLineOn::NoWrap;
+        self
+    }
+
+    /// Returns this [`TextBundle`] with a new [`UiContentTransform`].
+    pub const fn with_content_transform(mut self, content_transform: UiContentTransform) -> Self {
+        self.content_transform = content_transform;
         self
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -733,7 +733,7 @@ pub fn prepare_uinodes(
             positions[3] + positions_diff[3].extend(0.),
         ];
 
-        let transformed_rect_size = extracted_uinode.transform.transform_vector3(rect_size);
+        let transformed_rect_size = extracted_uinode.transform.transform_vector3(rect_size).abs();
 
         // Don't try to cull nodes that have a rotation
         // In a rotation around the Z-axis, this value is 0.0 for an angle of 0.0 or π

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -13,10 +13,11 @@ use crate::{
     Style, UiImage, UiScale, UiStack, UiTextureAtlasImage, Val,
 };
 
+use crate::UiContentOrientation;
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
-use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
+use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec2Swizzles, Vec3, Vec4Swizzles};
 use bevy_reflect::TypeUuid;
 use bevy_render::texture::DEFAULT_IMAGE_HANDLE;
 use bevy_render::{
@@ -160,8 +161,6 @@ pub struct ExtractedUiNode {
     pub image: Handle<Image>,
     pub atlas_size: Option<Vec2>,
     pub clip: Option<Rect>,
-    pub flip_x: bool,
-    pub flip_y: bool,
 }
 
 #[derive(Resource, Default)]
@@ -184,14 +183,23 @@ pub fn extract_atlas_uinodes(
                 Option<&CalculatedClip>,
                 &Handle<TextureAtlas>,
                 &UiTextureAtlasImage,
+                Option<&UiContentOrientation>,
             ),
             Without<UiImage>,
         >,
     >,
 ) {
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok((uinode, transform, color, visibility, clip, texture_atlas_handle, atlas_image)) =
-            uinode_query.get(*entity)
+        if let Ok((
+            uinode,
+            transform,
+            color,
+            visibility,
+            clip,
+            texture_atlas_handle,
+            atlas_image,
+            orientation,
+        )) = uinode_query.get(*entity)
         {
             // Skip invisible and completely transparent nodes
             if !visibility.is_visible() || color.0.a() == 0.0 {
@@ -225,6 +233,11 @@ pub fn extract_atlas_uinodes(
                 continue;
             }
 
+            let mut transform = transform.compute_matrix();
+            if let Some(orientation) = orientation {
+                transform *= Mat4::from(*orientation);
+            }
+
             let scale = uinode.size() / atlas_rect.size();
             atlas_rect.min *= scale;
             atlas_rect.max *= scale;
@@ -232,14 +245,12 @@ pub fn extract_atlas_uinodes(
 
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
-                transform: transform.compute_matrix(),
+                transform,
                 color: color.0,
                 rect: atlas_rect,
                 clip: clip.map(|clip| clip.clip),
                 image,
                 atlas_size: Some(atlas_size),
-                flip_x: atlas_image.flip_x,
-                flip_y: atlas_image.flip_y,
             });
         }
     }
@@ -367,8 +378,6 @@ pub fn extract_uinode_borders(
                         image: image.clone_weak(),
                         atlas_size: None,
                         clip: clip.map(|clip| clip.clip),
-                        flip_x: false,
-                        flip_y: false,
                     });
                 }
             }
@@ -389,13 +398,14 @@ pub fn extract_uinodes(
                 Option<&UiImage>,
                 &ComputedVisibility,
                 Option<&CalculatedClip>,
+                Option<&UiContentOrientation>,
             ),
             Without<UiTextureAtlasImage>,
         >,
     >,
 ) {
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok((uinode, transform, color, maybe_image, visibility, clip)) =
+        if let Ok((uinode, transform, color, maybe_image, visibility, clip, orientation)) =
             uinode_query.get(*entity)
         {
             // Skip invisible and completely transparent nodes
@@ -403,19 +413,24 @@ pub fn extract_uinodes(
                 continue;
             }
 
-            let (image, flip_x, flip_y) = if let Some(image) = maybe_image {
+            let image = if let Some(image) = maybe_image {
                 // Skip loading images
                 if !images.contains(&image.texture) {
                     continue;
                 }
-                (image.texture.clone_weak(), image.flip_x, image.flip_y)
+                image.texture.clone_weak()
             } else {
-                (DEFAULT_IMAGE_HANDLE.typed(), false, false)
+                DEFAULT_IMAGE_HANDLE.typed()
             };
+
+            let mut transform = transform.compute_matrix();
+            if let Some(orientation) = orientation {
+                transform *= Mat4::from(*orientation);
+            }
 
             extracted_uinodes.uinodes.push(ExtractedUiNode {
                 stack_index,
-                transform: transform.compute_matrix(),
+                transform,
                 color: color.0,
                 rect: Rect {
                     min: Vec2::ZERO,
@@ -424,8 +439,6 @@ pub fn extract_uinodes(
                 clip: clip.map(|clip| clip.clip),
                 image,
                 atlas_size: None,
-                flip_x,
-                flip_y,
             });
         };
     }
@@ -519,6 +532,7 @@ pub fn extract_text_uinodes(
             &TextLayoutInfo,
             &ComputedVisibility,
             Option<&CalculatedClip>,
+            Option<&UiContentOrientation>,
         )>,
     >,
 ) {
@@ -532,15 +546,32 @@ pub fn extract_text_uinodes(
     let inverse_scale_factor = (scale_factor as f32).recip();
 
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
-        if let Ok((uinode, global_transform, text, text_layout_info, visibility, clip)) =
-            uinode_query.get(*entity)
+        if let Ok((
+            uinode,
+            global_transform,
+            text,
+            text_layout_info,
+            visibility,
+            clip,
+            orientation,
+        )) = uinode_query.get(*entity)
         {
             // Skip if not visible or if size is set to zero (e.g. when a parent is set to `Display::None`)
             if !visibility.is_visible() || uinode.size().x == 0. || uinode.size().y == 0. {
                 continue;
             }
-            let transform = global_transform.compute_matrix()
-                * Mat4::from_translation(-0.5 * uinode.size().extend(0.));
+            let mut transform = global_transform.compute_matrix();
+
+            if orientation
+                .as_deref()
+                .map(|orientation| orientation.is_sideways())
+                .unwrap_or(false)
+            {
+                transform *= Mat4::from_rotation_z(std::f32::consts::FRAC_PI_2)
+                    * Mat4::from_translation(-0.5 * uinode.size().yx().extend(0.));
+            } else {
+                transform *= Mat4::from_translation(-0.5 * uinode.size().extend(0.));
+            }
 
             let mut color = Color::WHITE;
             let mut current_section = usize::MAX;
@@ -569,8 +600,6 @@ pub fn extract_text_uinodes(
                     image: atlas.texture.clone_weak(),
                     atlas_size: Some(atlas.size * inverse_scale_factor),
                     clip: clip.map(|clip| clip.clip),
-                    flip_x: false,
-                    flip_y: false,
                 });
             }
         }
@@ -664,7 +693,7 @@ pub fn prepare_uinodes(
             UNTEXTURED_QUAD
         };
 
-        let mut uinode_rect = extracted_uinode.rect;
+        let uinode_rect = extracted_uinode.rect;
 
         let rect_size = uinode_rect.size().extend(1.0);
 
@@ -674,7 +703,7 @@ pub fn prepare_uinodes(
 
         // Calculate the effect of clipping
         // Note: this won't work with rotation/scaling, but that's much more complex (may need more that 2 quads)
-        let mut positions_diff = if let Some(clip) = extracted_uinode.clip {
+        let positions_diff = if let Some(clip) = extracted_uinode.clip {
             [
                 Vec2::new(
                     f32::max(clip.min.x - positions[0].x, 0.),
@@ -724,20 +753,6 @@ pub fn prepare_uinodes(
             [Vec2::ZERO, Vec2::X, Vec2::ONE, Vec2::Y]
         } else {
             let atlas_extent = extracted_uinode.atlas_size.unwrap_or(uinode_rect.max);
-            if extracted_uinode.flip_x {
-                std::mem::swap(&mut uinode_rect.max.x, &mut uinode_rect.min.x);
-                positions_diff[0].x *= -1.;
-                positions_diff[1].x *= -1.;
-                positions_diff[2].x *= -1.;
-                positions_diff[3].x *= -1.;
-            }
-            if extracted_uinode.flip_y {
-                std::mem::swap(&mut uinode_rect.max.y, &mut uinode_rect.min.y);
-                positions_diff[0].y *= -1.;
-                positions_diff[1].y *= -1.;
-                positions_diff[2].y *= -1.;
-                positions_diff[3].y *= -1.;
-            }
             [
                 Vec2::new(
                     uinode_rect.min.x + positions_diff[0].x,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     Style, UiImage, UiScale, UiStack, UiTextureAtlasImage, Val,
 };
 
-use crate::UiContentOrientation;
+use crate::UiContentTransform;
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetEvent, Assets, Handle, HandleUntyped};
 use bevy_ecs::prelude::*;
@@ -183,7 +183,7 @@ pub fn extract_atlas_uinodes(
                 Option<&CalculatedClip>,
                 &Handle<TextureAtlas>,
                 &UiTextureAtlasImage,
-                Option<&UiContentOrientation>,
+                Option<&UiContentTransform>,
             ),
             Without<UiImage>,
         >,
@@ -398,7 +398,7 @@ pub fn extract_uinodes(
                 Option<&UiImage>,
                 &ComputedVisibility,
                 Option<&CalculatedClip>,
-                Option<&UiContentOrientation>,
+                Option<&UiContentTransform>,
             ),
             Without<UiTextureAtlasImage>,
         >,
@@ -532,7 +532,7 @@ pub fn extract_text_uinodes(
             &TextLayoutInfo,
             &ComputedVisibility,
             Option<&CalculatedClip>,
-            Option<&UiContentOrientation>,
+            Option<&UiContentTransform>,
         )>,
     >,
 ) {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -81,7 +81,7 @@ impl Default for Node {
 #[derive(Component, Default, Clone, Copy, PartialEq, Debug, Serialize, Deserialize, Reflect)]
 #[reflect(Component, Default)]
 /// Controls the orientation of a node's content
-pub enum UiContentOrientation {
+pub enum UiContentTransform {
     #[default]
     /// Not flipped or rotated
     North,
@@ -101,11 +101,11 @@ pub enum UiContentOrientation {
     FlippedWest,
 }
 
-impl UiContentOrientation {
+impl UiContentTransform {
     /// Rotate the content to the left by 90 degrees
     #[inline]
     pub const fn rotate_left(self) -> Self {
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         match self {
             North => East,
             East => South,
@@ -121,7 +121,7 @@ impl UiContentOrientation {
     /// Rotate The content to the right by 90 degrees
     #[inline]
     pub const fn rotate_right(self) -> Self {
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         match self {
             North => West,
             East => North,
@@ -142,7 +142,7 @@ impl UiContentOrientation {
     /// Flip the content along its x-axis
     #[inline]
     pub const fn flip_x(self) -> Self {
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         match self {
             North => FlippedNorth,
             East => FlippedWest,
@@ -158,7 +158,7 @@ impl UiContentOrientation {
     /// Flip the content along its x-axis
     #[inline]
     pub const fn flip_y(self) -> Self {
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         match self {
             North => FlippedSouth,
             East => FlippedEast,
@@ -177,15 +177,15 @@ impl UiContentOrientation {
     }
 
     pub const fn is_sideways(self) -> bool {
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         matches!(self, East | West | FlippedEast | FlippedWest)
     }
 }
 
-impl From<UiContentOrientation> for Mat4 {
-    fn from(orientation: UiContentOrientation) -> Self {
+impl From<UiContentTransform> for Mat4 {
+    fn from(orientation: UiContentTransform) -> Self {
         use std::f32::consts::*;
-        use UiContentOrientation::*;
+        use UiContentTransform::*;
         let flip = || Mat4::from_scale(Vec3::new(-1., 1., 1.));
         match orientation {
             North => Mat4::IDENTITY,

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -186,16 +186,17 @@ impl From<UiContentTransform> for Mat4 {
     fn from(orientation: UiContentTransform) -> Self {
         use std::f32::consts::*;
         use UiContentTransform::*;
-        let flip = || Mat4::from_scale(Vec3::new(-1., 1., 1.));
+        let flip_x = || Mat4::from_scale(Vec3::new(-1., 1., 1.));
+        let flip_y = || Mat4::from_scale(Vec3::new(1., -1., 1.));
         match orientation {
             North => Mat4::IDENTITY,
             East => Mat4::from_rotation_z(FRAC_PI_2),
             South => Mat4::from_rotation_z(PI),
             West => Mat4::from_rotation_z(3. * FRAC_PI_2),
-            FlippedNorth => flip(),
-            FlippedEast => flip() * Mat4::from_rotation_z(FRAC_PI_2),
-            FlippedSouth => flip() * Mat4::from_rotation_z(PI),
-            FlippedWest => flip() * Mat4::from_rotation_z(3. * FRAC_PI_2),
+            FlippedNorth => flip_x(),
+            FlippedEast => flip_y() * Mat4::from_rotation_z(FRAC_PI_2),
+            FlippedSouth => flip_x() * Mat4::from_rotation_z(PI),
+            FlippedWest => flip_y() * Mat4::from_rotation_z(3. * FRAC_PI_2),
         }
     }
 }
@@ -1722,10 +1723,7 @@ impl Default for UiImage {
 
 impl UiImage {
     pub fn new(texture: Handle<Image>) -> Self {
-        Self {
-            texture,
-            ..Default::default()
-        }
+        Self { texture }
     }
 }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{ContentSize, FixedMeasure, Measure, Node, UiContentOrientation, UiScale};
+use crate::{ContentSize, FixedMeasure, Measure, Node, UiContentTransform, UiScale};
 use bevy_asset::Assets;
 use bevy_ecs::{
     prelude::{Component, DetectChanges},
@@ -238,7 +238,7 @@ pub fn text_system(
     mut text_pipeline: ResMut<TextPipeline>,
     mut text_query: Query<(
         Ref<Node>,
-        Option<Ref<UiContentOrientation>>,
+        Option<Ref<UiContentTransform>>,
         &Text,
         &mut TextLayoutInfo,
         &mut TextFlags,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -52,9 +52,6 @@ impl Measure for TextMeasure {
         available_width: AvailableSpace,
         _available_height: AvailableSpace,
     ) -> Vec2 {
-        println!("width: {width:?}");
-        println!("height: {height:?}");
-        println!("available_width: {available_width:?}");
         let x = width.unwrap_or_else(|| match available_width {
             AvailableSpace::Definite(x) => x.clamp(
                 self.info.min_width_content_size.x,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,5 +1,5 @@
 use crate::{
-    ContentSize, FixedMeasure, Measure, Node, SwappedMeasure, UiContentTransform, UiScale,
+    ContentSize, FixedMeasure, Measure, Node, SwappedDimensionsMeasure, UiContentTransform, UiScale,
 };
 use bevy_asset::Assets;
 use bevy_ecs::{
@@ -102,7 +102,7 @@ fn create_text_measure(
                 };
                 content_size.set(FixedMeasure { size });
             } else if rotated {
-                content_size.set(SwappedMeasure {
+                content_size.set(SwappedDimensionsMeasure {
                     inner_measure: TextMeasure { info: measure },
                 });
             } else {

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -106,7 +106,7 @@ fn setup(
             right: Val::Px(50.0),
             ..default()
         },
-        content_orientation: UiContentOrientation::East,
+        content_transform: UiContentTransform::East,
         ..default()
     });
 

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -102,14 +102,11 @@ fn setup(
         ),
         style: Style {
             position_type: PositionType::Absolute,
-            top: Val::Px(130.0),
-            right: Val::Px(0.0),
+            top: Val::Px(70.0),
+            right: Val::Px(50.0),
             ..default()
         },
-        transform: Transform {
-            rotation: Quat::from_rotation_z(std::f32::consts::PI / 2.0),
-            ..default()
-        },
+        content_orientation: UiContentOrientation::East,
         ..default()
     });
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -354,6 +354,7 @@ Example | Description
 [Text Wrap Debug](../examples/ui/text_wrap_debug.rs) | Demonstrates text wrapping
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI
+[UI Image Symmetries](../examples/ui/ui_image_symmetries.rs) | Demonstrates how to rotate and flip UI images
 [UI Scaling](../examples/ui/ui_scaling.rs) | Illustrates how to scale the UI
 [UI Texture Atlas](../examples/ui/ui_texture_atlas.rs) | Illustrates how to use TextureAtlases in UI
 [UI Z-Index](../examples/ui/z_index.rs) | Demonstrates how to control the relative depth (z-position) of UI elements

--- a/examples/README.md
+++ b/examples/README.md
@@ -351,6 +351,7 @@ Example | Description
 [Size Constraints](../examples/ui/size_constraints.rs) | Demonstrates how the to use the size constraints to control the size of a UI node.
 [Text](../examples/ui/text.rs) | Illustrates creating and updating text
 [Text Debug](../examples/ui/text_debug.rs) | An example for debugging text layout
+[Text Transformed](../examples/ui/text_transformed.rs) | Demonstrates flipped and rotated text.
 [Text Wrap Debug](../examples/ui/text_wrap_debug.rs) | Demonstrates text wrapping
 [Transparency UI](../examples/ui/transparency_ui.rs) | Demonstrates transparency for UI
 [UI](../examples/ui/ui.rs) | Illustrates various features of Bevy UI

--- a/examples/ui/text_transformed.rs
+++ b/examples/ui/text_transformed.rs
@@ -1,0 +1,52 @@
+//! Demonstrates rotated and flipped text
+
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut commands: Commands) {
+    // UI camera
+    commands.spawn(Camera2dBundle::default());
+
+    let root = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                row_gap: Val::Px(20.),
+                column_gap: Val::Px(20.),
+                ..default()
+            },
+            ..default()
+        })
+        .id();
+
+    let mut content_transform = UiContentTransform::default();
+    for i in 0..8 {
+        let text = commands
+            .spawn(
+                TextBundle::from_section(
+                    "hello\n   bevy!",
+                    TextStyle {
+                        font_size: 20.0,
+                        color: Color::WHITE,
+                        ..default()
+                    },
+                )
+                .with_background_color(Color::NAVY)
+                .with_content_transform(content_transform),
+            )
+            .id();
+        commands.entity(root).add_child(text);
+        content_transform = content_transform.rotate_left();
+        if i == 3 {
+            content_transform = content_transform.flip_x();
+        }
+    }
+}

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -285,7 +285,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 },
                                 // a `NodeBundle` is transparent by default, so to see the image we have to its color to `WHITE`
                                 background_color: Color::WHITE.into(),
-                                content_orientation: UiContentOrientation::FlippedWest,
+                                content_orientation: UiContentTransform::FlippedWest,
                                 ..default()
                             },
                             UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -263,7 +263,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Percent(100.0),
                         position_type: PositionType::Absolute,
-                        top: Val::Percent(25.),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::FlexStart,
                         ..default()
@@ -278,14 +277,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         .spawn((
                             NodeBundle {
                                 style: Style {
-                                    width: Val::Px(500.0),
-                                    height: Val::Px(125.0),
+                                    width: Val::Px(125.0),
+                                    height: Val::Px(500.0),
                                     margin: UiRect::top(Val::VMin(5.)),
                                     ..default()
                                 },
                                 // a `NodeBundle` is transparent by default, so to see the image we have to its color to `WHITE`
                                 background_color: Color::WHITE.into(),
-                                content_orientation: UiContentTransform::FlippedWest,
+                                content_transform: UiContentTransform::FlippedWest,
                                 ..default()
                             },
                             UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -263,6 +263,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         width: Val::Percent(100.0),
                         position_type: PositionType::Absolute,
+                        top: Val::Percent(25.),
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::FlexStart,
                         ..default()
@@ -284,6 +285,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 },
                                 // a `NodeBundle` is transparent by default, so to see the image we have to its color to `WHITE`
                                 background_color: Color::WHITE.into(),
+                                content_orientation: UiContentOrientation::FlippedWest,
                                 ..default()
                             },
                             UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),

--- a/examples/ui/ui_image_symmetries.rs
+++ b/examples/ui/ui_image_symmetries.rs
@@ -40,7 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         ..Default::default()
                     },
                     text: Text::from_section(
-                        format!("{:?}", UiContentOrientation::default()),
+                        format!("{:?}", UiContentTransform::default()),
                         text_style.clone(),
                     ),
                     ..Default::default()
@@ -60,7 +60,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn update_orientation(
     input: Res<Input<KeyCode>>,
-    mut orientation_query: Query<&mut UiContentOrientation, With<UiImage>>,
+    mut orientation_query: Query<&mut UiContentTransform, With<UiImage>>,
 ) {
     let mut orientation = orientation_query.single_mut();
     if input.just_pressed(KeyCode::Z) {
@@ -78,7 +78,7 @@ fn update_orientation(
 }
 
 fn update_text(
-    orientation_query: Query<&UiContentOrientation, (With<UiImage>, Changed<UiContentOrientation>)>,
+    orientation_query: Query<&UiContentTransform, (With<UiImage>, Changed<UiContentTransform>)>,
     mut text_query: Query<&mut Text, With<OrientationText>>,
 ) {
     if let Ok(orientation) = orientation_query.get_single() {

--- a/examples/ui/ui_image_symmetries.rs
+++ b/examples/ui/ui_image_symmetries.rs
@@ -1,0 +1,96 @@
+//! Demonstrates how to rotate and flip UI images
+
+use bevy::prelude::*;
+
+#[derive(Component)]
+struct OrientationText;
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+    let text_style = TextStyle {
+        font: asset_server.load("fonts/FiraMono-Medium.ttf"),
+        font_size: 32.,
+        color: Color::WHITE,
+    };
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                flex_direction: FlexDirection::Column,
+                width: Val::Percent(100.),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .with_children(|builder| {
+            builder.spawn(ImageBundle {
+                image: UiImage::new(asset_server.load("branding/icon.png")),
+                ..Default::default()
+            });
+
+            builder.spawn((
+                TextBundle {
+                    style: Style {
+                        margin: UiRect {
+                            top: Val::Px(20.),
+                            bottom: Val::Px(20.),
+                            ..Default::default()
+                        },
+                        ..Default::default()
+                    },
+                    text: Text::from_section(
+                        format!("{:?}", UiContentOrientation::default()),
+                        text_style.clone(),
+                    ),
+                    ..Default::default()
+                },
+                OrientationText,
+            ));
+
+            builder.spawn(TextBundle {
+                text: Text::from_section(
+                    "Z => rotate clockwise\nX => rotate counterclockwise\nC => flip x\nV => flip y",
+                    text_style,
+                ),
+                ..Default::default()
+            });
+        });
+}
+
+fn update_orientation(
+    input: Res<Input<KeyCode>>,
+    mut orientation_query: Query<&mut UiContentOrientation, With<UiImage>>,
+) {
+    let mut orientation = orientation_query.single_mut();
+    if input.just_pressed(KeyCode::Z) {
+        *orientation = orientation.rotate_left();
+    }
+    if input.just_pressed(KeyCode::X) {
+        *orientation = orientation.rotate_right();
+    }
+    if input.just_pressed(KeyCode::C) {
+        *orientation = orientation.flip_x();
+    }
+    if input.just_pressed(KeyCode::V) {
+        *orientation = orientation.flip_y();
+    }
+}
+
+fn update_text(
+    orientation_query: Query<&UiContentOrientation, (With<UiImage>, Changed<UiContentOrientation>)>,
+    mut text_query: Query<&mut Text, With<OrientationText>>,
+) {
+    if let Ok(orientation) = orientation_query.get_single() {
+        let mut text = text_query.single_mut();
+        text.sections[0].value = format!("{:?}", orientation);
+    }
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, (update_orientation, update_text))
+        .run();
+}

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -87,7 +87,7 @@ fn increment_atlas_index(
 
 fn update_orientation(
     input: Res<Input<KeyCode>>,
-    mut orientation_query: Query<&mut UiContentOrientation, With<UiTextureAtlasImage>>,
+    mut orientation_query: Query<&mut UiContentTransform, With<UiTextureAtlasImage>>,
 ) {
     let mut orientation = orientation_query.single_mut();
     if input.just_pressed(KeyCode::Z) {

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -13,7 +13,7 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
-        .add_systems(Update, increment_atlas_index)
+        .add_systems(Update, (increment_atlas_index, update_orientation))
         .run();
 }
 
@@ -82,5 +82,24 @@ fn increment_atlas_index(
         for mut atlas_image in &mut atlas_images {
             atlas_image.index = (atlas_image.index + 1) % 6;
         }
+    }
+}
+
+fn update_orientation(
+    input: Res<Input<KeyCode>>,
+    mut orientation_query: Query<&mut UiContentOrientation, With<UiTextureAtlasImage>>,
+) {
+    let mut orientation = orientation_query.single_mut();
+    if input.just_pressed(KeyCode::Z) {
+        *orientation = orientation.rotate_left();
+    }
+    if input.just_pressed(KeyCode::X) {
+        *orientation = orientation.rotate_right();
+    }
+    if input.just_pressed(KeyCode::C) {
+        *orientation = orientation.flip_x();
+    }
+    if input.just_pressed(KeyCode::V) {
+        *orientation = orientation.flip_y();
     }
 }


### PR DESCRIPTION
# Objective

Allow limited rotation and flipping of a UI node's content without modifying its `Transform` component or breaking the UI layout and clipping.

Fixes #8998

## Solution

Generalization of #6688.

UI nodes have a `UiContentTransform` component, with `identity`, `flip_x`, `flip_y`, `rotate_left` and `rotate_right` methods which you can compose to get whatever orientation you want.

<img width="517" alt="text-content-transform-example" src="https://github.com/bevyengine/bevy/assets/27962798/6327c84e-4aab-4d08-8783-44bf3137605b">
<img width="733" alt="content-transform-ui-example" src="https://github.com/bevyengine/bevy/assets/27962798/19801f64-ddfd-4109-b42e-2c4b46d92181">
<img width="649" alt="pbr_content_transform" src="https://github.com/bevyengine/bevy/assets/27962798/78666a34-05d9-4ef0-b813-c4f7f7c18c67">

Notes:

* The API is a bit mathy and might be quite counterintuitive for some users, particularly when working with text.

* I really hate the naming scheme using cardinal directions for the variants of `UiContentTransform`. There is a long discussion about this at #6688. All the other ideas were terrible too.

* Probably still got a few bugs but it all seems to work mostly. Needs some refactoring and more doc comments.

* In the original design widgets didn't need to be aware of the content transform and layout handled everything. But I realised it wasn't going to work without changes to Taffy (probably coming in Taffy 0.4).

* You can still use the regular `Transform` component to rotate and scale UI elements as before.

* This is a relatively large PR but it doesn't make too many changes, most of the code is examples and helper methods.

---

## Changelog
* Removed the `flip_x` and `flip_y` from the `UiImage` and `UiTextureAtlasImage` components.
* Added the `UiContentTransform` enum component.
* Added `ui_image_symmetries` and `text_transformed` examples.
* Implemented `From<UiContentOrientation>` for `Mat4`
* Added a `content_transform: UiContentTransform` field to all UI node bundles.

## Migration Guide
The `flip_x` and `flip_y` fields have been removed from the `UiImage` and `UiTextureAtlasImage` components. The `flip_x()` and `flip_y()` methods of the `UiContentTransform` component now control image flipping.
