### PR TITLE
include toplevel shader-associated defs

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -304,6 +304,7 @@ impl ShaderCache {
 
                         let shader_defs = shader_defs
                             .into_iter()
+                            .chain(shader.shader_defs.iter().cloned())
                             .map(|def| match def {
                                 ShaderDefVal::Bool(k, v) => {
                                     (k, naga_oil::compose::ShaderDefValue::Bool(v))


### PR DESCRIPTION
# Objective

shader defs associated with a shader via `load_internal_asset!` or `Shader::from_xxx_with_defs` were being accidentally ignored for top-level shaders.

## Solution

include the defs for top level shaders.