### PR TITLE
Fix incorrent doc comment for the set method of `ContentSize`

### DIFF
--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -55,7 +55,7 @@ pub struct ContentSize {
 }
 
 impl ContentSize {
-    /// Set a `Measure` for this function
+    /// Set a `Measure` for the UI node entity with this component
     pub fn set(&mut self, measure: impl Measure) {
         let measure_func = move |size: TaffySize<_>, available: TaffySize<_>| {
             let size = measure.measure(size.width, size.height, available.width, available.height);


### PR DESCRIPTION
# Objective

This doc comment for the `set` method of `ContentSize`:

```
Set a `Measure` for this function
```
doesn't seem to make sense, `ContentSize` is not a function. 

# Solution

Replace it.
