### PR TITLE
Change the default for the `measure_func` field of `ContentSize` to None.

### DIFF
--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::prelude::Component;
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_math::Vec2;
-use bevy_reflect::Reflect;
+use bevy_reflect::{Reflect, std_traits::ReflectDefault};
 use std::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
 use taffy::{node::MeasureFunc, prelude::Size as TaffySize};
@@ -46,8 +46,8 @@ impl Measure for FixedMeasure {
 
 /// A node with a `ContentSize` component is a node where its size
 /// is based on its content.
-#[derive(Component, Reflect)]
-#[reflect(Component)]
+#[derive(Component, Reflect, Default)]
+#[reflect(Component, Default)]
 pub struct ContentSize {
     /// The `Measure` used to compute the intrinsic size
     #[reflect(ignore)]
@@ -65,11 +65,5 @@ impl ContentSize {
             }
         };
         self.measure_func = Some(MeasureFunc::Boxed(Box::new(measure_func)));
-    }
-}
-
-impl Default for ContentSize {
-    fn default() -> Self {
-        Self { measure_func: None }
     }
 }

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -70,8 +70,6 @@ impl ContentSize {
 
 impl Default for ContentSize {
     fn default() -> Self {
-        Self {
-            measure_func: None,
-        }
+        Self { measure_func: None }
     }
 }

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::prelude::Component;
 use bevy_ecs::reflect::ReflectComponent;
 use bevy_math::Vec2;
-use bevy_reflect::{Reflect, std_traits::ReflectDefault};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use std::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
 use taffy::{node::MeasureFunc, prelude::Size as TaffySize};

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -71,7 +71,7 @@ impl ContentSize {
 impl Default for ContentSize {
     fn default() -> Self {
         Self {
-            measure_func: Some(MeasureFunc::Raw(|_, _| TaffySize::ZERO)),
+            measure_func: None,
         }
     }
 }

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -66,4 +66,11 @@ impl ContentSize {
         };
         self.measure_func = Some(MeasureFunc::Boxed(Box::new(measure_func)));
     }
+
+    /// Creates a `ContentSize` with a `Measure` that always returns given `size` argument, regardless of the UI layout's constraints.
+    pub fn fixed_size(size: Vec2) -> ContentSize {
+        let mut content_size = Self::default();
+        content_size.set(FixedMeasure { size });
+        content_size
+    }
 }


### PR DESCRIPTION
# Objective

The default for `ContentSize` should have the `measure_func` field set to `None`, instead of a fixed size of zero. This means that until a measure func is set the size of the UI node will be determined by its `Style` constraints. This is preferable as it allows users to specify the space the Node should take up in the layout while waiting for content to load.  

## Solution

Derive `Default` for `ContentSize`.

The PR also adds a `fixed_size` helper function to make it a bit easier to access the old behaviour.

## Changelog
* Derived `Default` for `ContentSize`
* Added a `fixed_size` helper function to `ContentSize` that creates a new `ContentSize` with a `MeasureFunc` that always returns the same value, regardless of layout constraints.

## Migration Guide
The default for `ContentSize` now sets its `measure_func` to `None`, instead of a fixed size measure that returns `Vec2::ZERO`. 
The helper function `fixed_size` can be called with `ContentSize::fixed_size(Vec2::ZERO)` to get the previous behaviour.
