### PR TITLE
Fix doc warning in bevy_tasks

### DIFF
--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -5,7 +5,7 @@ thread_local! {
     static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = async_executor::LocalExecutor::new();
 }
 
-/// Used to create a TaskPool
+/// Used to create a [`TaskPool`].
 #[derive(Debug, Default, Clone)]
 pub struct TaskPoolBuilder {}
 
@@ -24,7 +24,7 @@ impl<'a> ThreadExecutor<'a> {
 }
 
 impl TaskPoolBuilder {
-    /// Creates a new TaskPoolBuilder instance
+    /// Creates a new `TaskPoolBuilder` instance
     pub fn new() -> Self {
         Self::default()
     }
@@ -76,7 +76,7 @@ impl TaskPool {
         1
     }
 
-    /// Allows spawning non-'static futures on the thread pool. The function takes a callback,
+    /// Allows spawning non-`'static` futures on the thread pool. The function takes a callback,
     /// passing a scope object into it. The scope object provided to the callback can be used
     /// to spawn tasks. This function will await the completion of all tasks before returning.
     ///
@@ -89,7 +89,7 @@ impl TaskPool {
         self.scope_with_executor(false, None, f)
     }
 
-    /// Allows spawning non-`static futures on the thread pool. The function takes a callback,
+    /// Allows spawning non-`'static` futures on the thread pool. The function takes a callback,
     /// passing a scope object into it. The scope object provided to the callback can be used
     /// to spawn tasks. This function will await the completion of all tasks before returning.
     ///
@@ -240,7 +240,8 @@ impl<'scope, 'env, T: Send + 'env> Scope<'scope, 'env, T> {
         let result = Rc::new(RefCell::new(None));
         self.results.borrow_mut().push(result.clone());
         let f = async move {
-            result.borrow_mut().replace(f.await);
+            let temp_result = f.await;
+            result.borrow_mut().replace(temp_result);
         };
         self.executor.spawn(f).detach();
     }


### PR DESCRIPTION
# Objective

- `bevy_tasks` emits warnings under certain conditions

When I run `cargo clippy -p bevy_tasks` the warning doesn't show up, while if I run it with `cargo clippy -p bevy_asset` the warning shows up.

## Solution

- Fix the warnings.

## Longer term solution

We should probably fix CI so that those warnings do not slip through. But that's not the goal of this PR.