### PR TITLE
only take up to the max number of joints

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -258,6 +258,7 @@ impl SkinnedMeshJoints {
             joints
                 .iter_many(&skin.joints)
                 .zip(inverse_bindposes.iter())
+                .take(MAX_JOINTS)
                 .map(|(joint, bindpose)| joint.affine() * *bindpose),
         );
         // iter_many will skip any failed fetches. This will cause it to assign the wrong bones,


### PR DESCRIPTION
# Objective

- Meshes with a higher number of joints than `MAX_JOINTS` are crashing
- Fixes partly #9021 (doesn't crash anymore, but the mesh is not correctly displayed)

## Solution

- Only take up to `MAX_JOINTS` joints when extending the buffer
