### PR TITLE
GLTF loader: handle warning NODE_SKINNED_MESH_WITHOUT_SKIN

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -220,13 +220,13 @@ async fn load_gltf<'a, 'b>(
     let mut meshes_on_non_skinned_nodes = HashSet::default();
     for gltf_node in gltf.nodes() {
         if gltf_node.skin().is_some() {
-            gltf_node.mesh().map(|mesh| {
+            if let Some(mesh) = gltf_node.mesh() {
                 meshes_on_skinned_nodes.insert(mesh.index());
-            });
+            }
         } else {
-            gltf_node.mesh().map(|mesh| {
+            if let Some(mesh) = gltf_node.mesh() {
                 meshes_on_non_skinned_nodes.insert(mesh.index());
-            });
+            }
         }
     }
     for gltf_mesh in gltf.meshes() {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -223,10 +223,8 @@ async fn load_gltf<'a, 'b>(
             if let Some(mesh) = gltf_node.mesh() {
                 meshes_on_skinned_nodes.insert(mesh.index());
             }
-        } else {
-            if let Some(mesh) = gltf_node.mesh() {
-                meshes_on_non_skinned_nodes.insert(mesh.index());
-            }
+        } else if let Some(mesh) = gltf_node.mesh() {
+            meshes_on_non_skinned_nodes.insert(mesh.index());
         }
     }
     for gltf_mesh in gltf.meshes() {


### PR DESCRIPTION
# Objective

- According to the GLTF spec, it should not be possible to have a non skinned mesh on a skinned node
> When the node contains skin, all mesh.primitives MUST contain JOINTS_0 and WEIGHTS_0 attributes
> https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-node
- However, the reverse (a skinned mesh on a non skinned node) is just a warning, see `NODE_SKINNED_MESH_WITHOUT_SKIN` in https://github.com/KhronosGroup/glTF-Validator/blob/main/ISSUES.md#linkerror
- This causes a crash in Bevy because the bind group layout is made from the mesh which is skinned, but filled from the entity which is not
```
thread '<unnamed>' panicked at 'wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 5, Metal)>`
    In a set_bind_group command
      note: bind group = `<BindGroup-(27, 1, Metal)>`
    Bind group 2 expects 2 dynamic offsets. However 1 dynamic offset were provided.
```
- Blender can export GLTF files with this kind of issues

## Solution

- When a skinned mesh is only used on non skinned nodes, ignore skinned information from the mesh and warn the user (this is what three.js is doing)
- When a skinned mesh is used on both skinned and non skinned nodes, log an error
