### PR TITLE
Slightly better message when contributor modifies examples template

### DIFF
--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -117,7 +117,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'The examples readme needs to be updated. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.'
+                body: 'The generated `examples/README.md` is out of sync with the example metadata in `Cargo.toml` or the example readme template. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.'
               });
             }
 

--- a/.github/workflows/ci-comment-failures.yml
+++ b/.github/workflows/ci-comment-failures.yml
@@ -117,7 +117,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issue_number,
-                body: 'You added a new example but didn\'t update the readme. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.'
+                body: 'The examples readme needs to be updated. Please run `cargo run -p build-templated-pages -- update examples` to update it, and commit the file change.'
               });
             }
 


### PR DESCRIPTION
# Objective

Provide a slightly better message when a contributor needs to update the generated example readme file for [any number of reasons](https://github.com/bevyengine/bevy/pull/9372#discussion_r1285876202) but hasn't added any examples.

This recently happened here: https://github.com/bevyengine/bevy/pull/9370#issuecomment-1666776092

The contributor modified the readme template and is being told that they added an example.

## Solution

The advice given is still correct. Just change the message so that it's not accusing the contributor of adding an example.

It may be possible to instead add more specific messages instead if someone is motivated to do that.

edit: reworked this whole PR text