### PR TITLE
Don't panic when applying an `Insert` command

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -953,8 +953,6 @@ where
     fn apply(self, world: &mut World) {
         if let Some(mut entity) = world.get_entity_mut(self.entity) {
             entity.insert(self.bundle);
-        } else {
-            panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", std::any::type_name::<T>(), self.entity);
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/7118

## Solution

- Remove the delayed panic caused by `EntityCommands::insert`, by ignoring the command if its entity has been despawned
- Make all builtin commands behave consistently when acting on an entity that has since been despawned

---

## Changelog

- The `Insert` command now no longer panics when its entity no longer exists.