### PR TITLE
Adding `Copy, Clone, Debug` to derived traits of `ExecutorKind`

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -27,7 +27,7 @@ pub(super) trait SystemExecutor: Send + Sync {
 /// The default depends on the target platform:
 ///  - [`SingleThreaded`](ExecutorKind::SingleThreaded) on WASM.
 ///  - [`MultiThreaded`](ExecutorKind::MultiThreaded) everywhere else.
-#[derive(PartialEq, Eq, Default, Clone)]
+#[derive(PartialEq, Eq, Default, Copy, Clone)]
 pub enum ExecutorKind {
     /// Runs the schedule using a single thread.
     ///

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -27,7 +27,7 @@ pub(super) trait SystemExecutor: Send + Sync {
 /// The default depends on the target platform:
 ///  - [`SingleThreaded`](ExecutorKind::SingleThreaded) on WASM.
 ///  - [`MultiThreaded`](ExecutorKind::MultiThreaded) everywhere else.
-#[derive(PartialEq, Eq, Default, Copy, Clone)]
+#[derive(PartialEq, Eq, Default, Debug, Copy, Clone)]
 pub enum ExecutorKind {
     /// Runs the schedule using a single thread.
     ///

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -27,7 +27,7 @@ pub(super) trait SystemExecutor: Send + Sync {
 /// The default depends on the target platform:
 ///  - [`SingleThreaded`](ExecutorKind::SingleThreaded) on WASM.
 ///  - [`MultiThreaded`](ExecutorKind::MultiThreaded) everywhere else.
-#[derive(PartialEq, Eq, Default)]
+#[derive(PartialEq, Eq, Default, Clone)]
 pub enum ExecutorKind {
     /// Runs the schedule using a single thread.
     ///


### PR DESCRIPTION
While being nobody other's issue as far I can tell, I want to create a trait I plan to implement on `App` where more than one schedule is modified. 
My workaround so far was working with a closure that returns an `ExecutorKind` from a match of the method variable.

It makes it easier for me to being able to clone `ExecutorKind` and I don't see this being controversial for others working with Bevy.

I did nothing more than adding `Clone` to the derived traits, no migration guide needed.

(If this worked out then the GitHub editor is not too shabby.)