### PR TITLE
Add glam swizzles traits to prelude

### DIFF
--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -20,7 +20,8 @@ pub mod prelude {
     pub use crate::{
         cubic_splines::{BSpline, Bezier, CardinalSpline, CubicGenerator, CubicSegment, Hermite},
         BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray,
-        Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec3, Vec4,
+        Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
+        Vec4Swizzles,
     };
 }
 


### PR DESCRIPTION
# Objective

Add possibility to use the glam's swizzles traits without having to manually import them.

```diff
use bevy::prelude::*;
- use bevy::math::Vec3Swizzles;

fn foo(x: Vec3) {
    let y: Vec2 = x.xy();
}
```

## Solution

Add the swizzles traits to bevy's prelude.

---

## Changelog

- `Vec2Swizzles`, `Vec3Swizzles` and `Vec4Swizzles` are now part of the prelude.

