### PR TITLE
Expose `animation_clip` paths

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -102,7 +102,7 @@ impl AnimationClip {
         self.duration
     }
 
-    /// The [`EntityPath`] map.
+    /// The bone ids mapped by their [`EntityPath`].
     #[inline]
     pub fn paths(&self) -> &HashMap<EntityPath, usize> {
         &self.paths

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -102,7 +102,7 @@ impl AnimationClip {
         self.duration
     }
 
-    /// Returns the [`EntityPath`] map
+    /// The [`EntityPath`] map.
     #[inline]
     pub fn paths(&self) -> &HashMap<EntityPath, usize> {
         &self.paths

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -102,6 +102,12 @@ impl AnimationClip {
         self.duration
     }
 
+    /// Returns the [`EntityPath`] map
+    #[inline]
+    pub fn paths(&self) -> &HashMap<EntityPath, usize> {
+        &self.paths
+    }
+
     /// Add a [`VariableCurve`] to an [`EntityPath`].
     pub fn add_curve_to_path(&mut self, path: EntityPath, curve: VariableCurve) {
         // Update the duration of the animation by this curve duration if it's longer


### PR DESCRIPTION
Need this for a custom `AnimationPlayer` that I tick in `FixedUpdate`

# Objective

- Need access to an animation clip's `paths` from outside the module

## Solution

- Add a getter method to return a reference to `paths`
