### PR TITLE
Fix gamepad viewer being marked as a non-wasm example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1752,7 +1752,7 @@ path = "examples/tools/gamepad_viewer.rs"
 name = "Gamepad Viewer"
 description = "Shows a visualization of gamepad buttons, sticks, and triggers"
 category = "Tools"
-wasm = false
+wasm = true
 
 [[example]]
 name = "nondeterministic_system_order"


### PR DESCRIPTION
# Objective

This example stopped being built for the website after the example-building was reworked in (https://github.com/bevyengine/bevy-website/issues/720 + #9168).

This seems to have just been a mistake when defining this particular example's metadata.

See https://github.com/bevyengine/bevy-website/issues/726

## Solution

Update its metadata to indicate that it works with wasm.