### PR TITLE
Use `ShaderDefVal` to avoid redundant code

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -2,24 +2,13 @@
 
 #import bevy_pbr::mesh_types Mesh
 
-#ifdef MESH_BINDGROUP_1
-
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(1) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+
+    @group(#{MESH_BINDGROUP}) @binding(0)
+    var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(1) @binding(0)
-var<storage> mesh: array<Mesh>;
+
+    @group(#{MESH_BINDGROUP}) @binding(0)
+    var<storage> mesh: array<Mesh>;
+
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
-
-#else // MESH_BINDGROUP_1
-
-#ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(2) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
-#else
-@group(2) @binding(0)
-var<storage> mesh: array<Mesh>;
-#endif // PER_OBJECT_BUFFER_BATCH_SIZE
-
-#endif // MESH_BINDGROUP_1

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -11,22 +11,11 @@
 
 #import bevy_pbr::mesh_types MorphWeights
 
-#ifdef MESH_BINDGROUP_1
-
-@group(1) @binding(2)
+@group(#{MESH_BINDGROUP}) @binding(2)
 var<uniform> morph_weights: MorphWeights;
-@group(1) @binding(3)
+
+@group(#{MESH_BINDGROUP}) @binding(3)
 var morph_targets: texture_3d<f32>;
-
-#else
-
-@group(2) @binding(2)
-var<uniform> morph_weights: MorphWeights;
-@group(2) @binding(3)
-var morph_targets: texture_3d<f32>;
-
-#endif
-
 
 // NOTE: Those are the "hardcoded" values found in `MorphAttributes` struct
 // in crates/bevy_render/src/mesh/morph/visitors.rs

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -4,18 +4,8 @@
 
 #ifdef SKINNED
 
-#ifdef MESH_BINDGROUP_1
-
-    @group(1) @binding(1)
-    var<uniform> joint_matrices: SkinnedMesh;
-
-#else 
-
-    @group(2) @binding(1)
-    var<uniform> joint_matrices: SkinnedMesh;
-
-#endif
-
+@group(#{MESH_BINDGROUP}) @binding(1)
+var<uniform> joint_matrices: SkinnedMesh;
 
 fn skin_model(
     indexes: vec4<u32>,


### PR DESCRIPTION
# Objective

The purpose of this pull request is to complete this [issue](https://github.com/bevyengine/bevy/issues/9256) (closes #9256)

### Migration guide

The `MESH_BINDGROUP_1` shader def has been replaced by the `MESH_BINDGROUP` `ShaderDefVal`.

If in your shader you previously used:
```
#ifdef MESH_BINDGROUP_1
@group(1) @binding(0)
var<storage> mesh: array<Mesh>;
#else // MESH_BINDGROUP_1
@group(2) @binding(0)
var<storage> mesh: array<Mesh>;
#endif // MESH_BINDGROUP_1
```

You can now write it:

```
@group(#{MESH_BINDGROUP}) @binding(0)
var<storage> mesh: array<Mesh>;
```

**Other important change**: You should now add the `MESH_BINDGROUP` define even if the binding group is 0.
Add this line to your shader specialization pipeline:

```
shader_defs.push(ShaderDefVal::UInt("MESH_BINDGROUP".into(), 2));
```

