### PR TITLE
Right-aligned text crash fix

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -10,7 +10,7 @@ use glyph_brush_layout::{
 };
 
 use crate::{
-    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, GlyphAtlasInfo,
+    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, GlyphAtlasInfo, Text,
     TextAlignment, TextSettings, YAxisOrientation,
 };
 
@@ -64,6 +64,7 @@ impl GlyphBrush {
         text_settings: &TextSettings,
         font_atlas_warning: &mut FontAtlasWarning,
         y_axis_orientation: YAxisOrientation,
+        text_alignment: TextAlignment,
     ) -> Result<Vec<PositionedGlyph>, TextError> {
         if glyphs.is_empty() {
             return Ok(Vec::new());
@@ -84,7 +85,8 @@ impl GlyphBrush {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let text_bounds = compute_text_bounds(&glyphs, |index| &sections_data[index].3);
+        let text_bounds =
+            compute_text_bounds(&glyphs, |index| &sections_data[index].3, text_alignment);
 
         let mut positioned_glyphs = Vec::new();
         for sg in glyphs {
@@ -206,6 +208,7 @@ impl GlyphPlacementAdjuster {
 pub(crate) fn compute_text_bounds<'a, T>(
     section_glyphs: &[SectionGlyph],
     get_scaled_font: impl Fn(usize) -> &'a PxScaleFont<T>,
+    text_alignment: TextAlignment,
 ) -> bevy_math::Rect
 where
     T: ab_glyph::Font + 'a,
@@ -225,6 +228,10 @@ where
                 glyph.position.y - scaled_font.descent(),
             ),
         });
+    }
+
+    if text_alignment == TextAlignment::Right {
+        text_bounds.max.x = 0.;
     }
 
     text_bounds

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -10,7 +10,7 @@ use glyph_brush_layout::{
 };
 
 use crate::{
-    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, GlyphAtlasInfo, Text,
+    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, GlyphAtlasInfo,
     TextAlignment, TextSettings, YAxisOrientation,
 };
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -10,9 +10,9 @@ use bevy_utils::HashMap;
 use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText};
 
 use crate::{
-    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
-    FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection, TextSettings,
-    YAxisOrientation,
+    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, text, BreakLineOn,
+    Font, FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection,
+    TextSettings, YAxisOrientation,
 };
 
 #[derive(Default, Resource)]
@@ -85,7 +85,12 @@ impl TextPipeline {
             return Ok(TextLayoutInfo::default());
         }
 
-        let size = compute_text_bounds(&section_glyphs, |index| &scaled_fonts[index]).size();
+        let size = compute_text_bounds(
+            &section_glyphs,
+            |index| &scaled_fonts[index],
+            text_alignment,
+        )
+        .size();
 
         let glyphs = self.brush.process_glyphs(
             section_glyphs,
@@ -97,6 +102,7 @@ impl TextPipeline {
             text_settings,
             font_atlas_warning,
             y_axis_orientation,
+            text_alignment,
         )?;
 
         Ok(TextLayoutInfo { glyphs, size })
@@ -213,7 +219,12 @@ impl TextMeasureInfo {
             .line_breaker(self.linebreak_behaviour)
             .calculate_glyphs(&self.fonts, &geom, sections);
 
-        compute_text_bounds(&section_glyphs, |index| &self.scaled_fonts[index]).size()
+        compute_text_bounds(
+            &section_glyphs,
+            |index| &self.scaled_fonts[index],
+            self.text_alignment,
+        )
+        .size()
     }
 
     pub fn compute_size(&self, bounds: Vec2) -> Vec2 {

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -10,9 +10,9 @@ use bevy_utils::HashMap;
 use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText};
 
 use crate::{
-    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, text, BreakLineOn,
-    Font, FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection,
-    TextSettings, YAxisOrientation,
+    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
+    FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection, TextSettings,
+    YAxisOrientation,
 };
 
 #[derive(Default, Resource)]


### PR DESCRIPTION
# Objective

UI text nodes have a `MeasureFunc` the layout algorithm uses to determine how much space in the layout to allot for text.
For this, the `MeasureFunc` requires the `min-content-width` and `max-content-width` values for the text. 
* `min-content-width` is where the text wraps on every soft line breakpoint (i.e. every space), which normally means its value is set to the logical pixel width of the longest word in the text.
* `max-content-width` is the width of the text if it never has to wrap at soft line breakpoints.

These values are precomputed by the `compute_text_bounds` function.

To get the `min-content-width` value we call the `calculate_glyphs` method of `glyph_brush_layout::Layout` with size bounds of zero width by infinite height. `calculate_glyphs` returns a Vec of glyphs with each glyph positioned so that the text will fit within the bounds specified. Each line of glyphs is guaranteed to have at least one word, if possible, even if that word exceeds the width bound. That is, it guarantees the glyphs are returned in a min-content-size arrangement. Then the function `compute_text_bounds` is called to find the minimum bounding Rect that contains all the glyphs. The width of the rect returned by `compute_text_bounds` is our `min-content-width`.

The problem comes with right-aligned text:
* Left-aligned text starts at the origin and then each glyph is placed to the right with increasing positive x coordinates. 
* Right-aligned text starts at a point with x equal to negative of the length of the current line and ends at x = 0.
For left- and center-aligned text `calculate_glyphs` works correctly (at least according to my tests) but for right-aligned text with lines containing leading or inbetween soft-breaks such as:
```
" H\nHH"
```
The soft break characters are positioned as though they are left-aligned instead:

![text-min-content_bug](https://github.com/bevyengine/bevy/assets/27962798/d492eb74-129c-492b-b2e5-30ab9971fd84)

So after `compute_text_bounds`, we have widths of:
* min_content_width = 10 - (-20) = 30
* max_content_width = 0 - (-20) = 20

Then when the layout algorithm runs and calls the `MeasureFunc` for this text with a defined `AvailableSpace` value the `MeasureFunc attempts to clamp the available width here:
```rust
 let x = width.unwrap_or_else(|| match available_width {
            AvailableSpace::Definite(x) => x.clamp(
                self.info.min_width_content_size.x,
                self.info.max_width_content_size.x,
            ),
            AvailableSpace::MinContent => self.info.min_width_content_size.x,
            AvailableSpace::MaxContent => self.info.max_width_content_size.x,
        });
```
Which leads to a panic:
```
min > max, or either was NaN. min = 30, max = 20.
```

fixes #9395

## Solution
The left bound of the text is returned correctly and, for right-aligned text, the right bound will always be zero.

So we just need to check if the text is right-aligned and, if it is, set the right bound of the bounding `Rect` to zero before returning it from `compute_text_bounds`.


## Changelog

* Added a `TextAlignment` parameter to  `compute_text_bounds`.
* If the text is aligned right, `compute_text_bounds` sets the right bound of the text's bounding `Rect` to 0.
