### PR TITLE
Remove redundant check for `AppExit` events in `ScheduleRunnerPlugin`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -89,15 +89,6 @@ impl Plugin for ScheduleRunnerPlugin {
                           -> Result<Option<Duration>, AppExit> {
                         let start_time = Instant::now();
 
-                        if let Some(app_exit_events) =
-                            app.world.get_resource_mut::<Events<AppExit>>()
-                        {
-                            if let Some(exit) = app_exit_event_reader.iter(&app_exit_events).last()
-                            {
-                                return Err(exit.clone());
-                            }
-                        }
-
                         app.update();
 
                         if let Some(app_exit_events) =


### PR DESCRIPTION
# Objective

Fixes #9420

## Solution

Remove one of the two `AppExit` event checks in the `ScheduleRunnerPlugin`'s main loop. Specificially, the check that happens immediately before calling `App.update()`, to be consistent with the `WinitPlugin`.