### PR TITLE
gltf loader: add a temporary loader without compression support

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -44,7 +44,13 @@ impl Plugin for GltfPlugin {
             .add_asset::<Gltf>()
             .add_asset::<GltfNode>()
             .add_asset::<GltfPrimitive>()
-            .add_asset::<GltfMesh>();
+            .add_asset::<GltfMesh>()
+            // Add the gltf loader first without support for compressed formats. This will be overwritten
+            // once the render device is initialized.
+            .add_asset_loader::<GltfLoader>(GltfLoader {
+                supported_compressed_formats: CompressedImageFormats::NONE,
+                custom_vertex_attributes: self.custom_vertex_attributes.clone(),
+            });
     }
 
     fn finish(&self, app: &mut App) {
@@ -53,6 +59,7 @@ impl Plugin for GltfPlugin {
 
             None => CompressedImageFormats::NONE,
         };
+        // Overwrite the gltf loader with support for compressed formats.
         app.add_asset_loader::<GltfLoader>(GltfLoader {
             supported_compressed_formats,
             custom_vertex_attributes: self.custom_vertex_attributes.clone(),


### PR DESCRIPTION
# Objective

- When loading gltf files during app creation (for example using a `FromWorld` impl and adding that as a resource), no loader was found.
- As the gltf loader can load compressed formats, it needs to know what the GPU supports so it's not available at app creation time.

## Solution

- Add a temporary gltf loader without compressed format support. Once the GPU is available, it will be overwritten by a gltf loader with the correct compressed format support
- This is needed for the 0.11.1 to still be able to load gltf files during app creation after https://github.com/bevyengine/bevy/pull/9158
