### PR TITLE
Example Comment Typo Fix

### DIFF
--- a/examples/2d/2d_gizmos.rs
+++ b/examples/2d/2d_gizmos.rs
@@ -50,7 +50,7 @@ fn system(mut gizmos: Gizmos, time: Res<Time>) {
     // You may want to increase this for larger circles.
     gizmos.circle_2d(Vec2::ZERO, 300., Color::NAVY).segments(64);
 
-    // Arcs default amount of segments is linerarly interpolated between
+    // Arcs default amount of segments is linearly interpolated between
     // 1 and 32, using the arc length as scalar.
     gizmos.arc_2d(Vec2::ZERO, sin / 10., PI / 2., 350., Color::ORANGE_RED);
 }


### PR DESCRIPTION
# Objective

Fixes a typo in one of the comments in an example.

## Solution

Fix the typo in the comment.
