### PR TITLE
allow asset loader pre-registration

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,6 +32,7 @@ downcast-rs = "1.2.0"
 fastrand = "1.7.0"
 notify = { version = "6.0.0", optional = true }
 parking_lot = "0.12.1"
+async-channel = "1.4.2"
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_winit = { path = "../bevy_winit", version = "0.12.0-dev" }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -317,6 +317,10 @@ pub trait AddAsset {
     fn add_asset_loader<T>(&mut self, loader: T) -> &mut Self
     where
         T: AssetLoader;
+
+    /// Preregisters a loader for the given extensions, that will block asset loads until a real loader
+    /// is registered.
+    fn preregister_asset_loader(&mut self, extensions: &[&str]) -> &mut Self;
 }
 
 impl AddAsset for App {
@@ -402,6 +406,13 @@ impl AddAsset for App {
         T: AssetLoader,
     {
         self.world.resource_mut::<AssetServer>().add_loader(loader);
+        self
+    }
+
+    fn preregister_asset_loader(&mut self, extensions: &[&str]) -> &mut Self {
+        self.world
+            .resource_mut::<AssetServer>()
+            .preregister_loader(extensions);
         self
     }
 }

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -44,7 +44,8 @@ impl Plugin for GltfPlugin {
             .add_asset::<Gltf>()
             .add_asset::<GltfNode>()
             .add_asset::<GltfPrimitive>()
-            .add_asset::<GltfMesh>();
+            .add_asset::<GltfMesh>()
+            .preregister_asset_loader(&["gltf", "glb"]);
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_render/src/texture/image_texture_loader.rs
+++ b/crates/bevy_render/src/texture/image_texture_loader.rs
@@ -17,7 +17,7 @@ pub struct ImageTextureLoader {
     supported_compressed_formats: CompressedImageFormats,
 }
 
-const FILE_EXTENSIONS: &[&str] = &[
+pub(crate) const IMG_FILE_EXTENSIONS: &[&str] = &[
     #[cfg(feature = "basis-universal")]
     "basis",
     #[cfg(feature = "bmp")]
@@ -73,7 +73,7 @@ impl AssetLoader for ImageTextureLoader {
     }
 
     fn extensions(&self) -> &[&str] {
-        FILE_EXTENSIONS
+        IMG_FILE_EXTENSIONS
     }
 }
 

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -96,6 +96,17 @@ impl Plugin for ImagePlugin {
                 update_texture_cache_system.in_set(RenderSet::Cleanup),
             );
         }
+
+        #[cfg(any(
+            feature = "png",
+            feature = "dds",
+            feature = "tga",
+            feature = "jpeg",
+            feature = "bmp",
+            feature = "basis-universal",
+            feature = "ktx2",
+        ))]
+        app.preregister_asset_loader(IMG_FILE_EXTENSIONS);
     }
 
     fn finish(&self, app: &mut App) {


### PR DESCRIPTION
# Objective

- When loading gltf files during app creation (for example using a FromWorld impl and adding that as a resource), no loader was found.
- As the gltf loader can load compressed formats, it needs to know what the GPU supports so it's not available at app creation time.

## Solution

alternative to #9426

- add functionality to preregister the loader. loading assets with matching extensions will block until a real loader is registered.
- preregister "gltf" and "glb".
- prereigster image formats.

the way this is set up, if a set of extensions are all registered with a single preregistration call, then later a loader is added that matches some of the extensions, assets using the remaining extensions will then fail. i think that should work well for image formats that we don't know are supported until later.