### PR TITLE
Not change window_theme with winit window theme

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -23,10 +23,7 @@ use winit::{
 use crate::web_resize::{CanvasParentResizeEventChannel, WINIT_CANVAS_SELECTOR};
 use crate::{
     accessibility::{AccessKitAdapters, WinitActionHandlers},
-    converters::{
-        self, convert_enabled_buttons, convert_window_level, convert_window_theme,
-        convert_winit_theme,
-    },
+    converters::{self, convert_enabled_buttons, convert_window_level, convert_window_theme},
     get_best_videomode, get_fitting_videomode, WinitWindows,
 };
 

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -67,10 +67,6 @@ pub(crate) fn create_windows<'a>(
             &mut accessibility_requested,
         );
 
-        if let Some(theme) = winit_window.theme() {
-            window.window_theme = Some(convert_winit_theme(theme));
-        }
-
         window
             .resolution
             .set_scale_factor(winit_window.scale_factor());

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -137,6 +137,8 @@ fn toggle_theme(mut windows: Query<&mut Window>, input: Res<Input<KeyCode>>) {
                 WindowTheme::Light => Some(WindowTheme::Dark),
                 WindowTheme::Dark => Some(WindowTheme::Light),
             };
+        } else {
+            window.window_theme = Some(WindowTheme::Dark);
         }
     }
 }


### PR DESCRIPTION
# Objective

- `window_theme` should be prefered theme and can only changed by user code.

For example, if user sets `window_theme` None, actually this field will be changed to `Some(xx)`(following os theme), but we don't maintain this field when os theme changed.