### PR TITLE
Include trailing newlines in text bounds computed by the text pipeline

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -10,8 +10,8 @@ use glyph_brush_layout::{
 };
 
 use crate::{
-    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning,
-    GlyphAtlasInfo, TextAlignment, TextSettings, YAxisOrientation,
+    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, GlyphAtlasInfo,
+    TextAlignment, TextSettings, YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -84,11 +84,11 @@ impl GlyphBrush {
             })
             .collect::<Result<Vec<_>, _>>()?;
 
-        let text_bounds =
-            compute_text_bounds(&glyphs,
-                sections.iter().map(|section| section.text),
-                |index| &sections_data[index].3
-            );
+        let text_bounds = compute_text_bounds(
+            &glyphs,
+            sections.iter().map(|section| section.text),
+            |index| &sections_data[index].3,
+        );
 
         let mut positioned_glyphs = Vec::new();
         for sg in glyphs {
@@ -221,7 +221,8 @@ where
         for ch in line.chars().rev() {
             if ch == '\n' {
                 let scaled_font = get_scaled_font(i);
-                trailing_lines_space += scaled_font.line_gap() + scaled_font.ascent() - scaled_font.descent();
+                trailing_lines_space +=
+                    scaled_font.line_gap() + scaled_font.ascent() - scaled_font.descent();
             } else {
                 break 'outer;
             }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -81,11 +81,12 @@ impl TextPipeline {
             self.brush
                 .compute_glyphs(&sections, bounds, text_alignment, linebreak_behavior)?;
 
-        if section_glyphs.is_empty() {
-            return Ok(TextLayoutInfo::default());
-        }
-
-        let size = compute_text_bounds(&section_glyphs, |index| &scaled_fonts[index]).size();
+        let size = compute_text_bounds(
+            &section_glyphs,
+            sections.iter().map(|section| section.text),
+            |index| &scaled_fonts[index],
+        )
+        .size();
 
         let glyphs = self.brush.process_glyphs(
             section_glyphs,
@@ -213,7 +214,12 @@ impl TextMeasureInfo {
             .line_breaker(self.linebreak_behaviour)
             .calculate_glyphs(&self.fonts, &geom, sections);
 
-        compute_text_bounds(&section_glyphs, |index| &self.scaled_fonts[index]).size()
+        compute_text_bounds(
+            &section_glyphs,
+            sections.iter().map(|section| section.text),
+            |index| &self.scaled_fonts[index],
+        )
+        .size()
     }
 
     pub fn compute_size(&self, bounds: Vec2) -> Vec2 {

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -81,8 +81,9 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
             let messages = [
                 format!("JustifyContent::{justification:?}"),
                 format!("LineBreakOn::{linebreak_behavior:?}"),
-                "Line 1\nLine 2\nLine 3".to_string(),
+                "Line 2\nLine 3\nLine 4".to_string(),
                 "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas auctor, nunc ac faucibus fringilla.".to_string(),
+                "\nbetween empty lines\n".to_string(),
             ];
 
             for (j, message) in messages.into_iter().enumerate() {


### PR DESCRIPTION
# Objective

When computing the bounds for a block of text the text pipeline currently ignores trailing newlines.

## Example

```rust
use bevy::prelude::*;
use bevy::text::TextLayoutInfo;
use bevy::window::WindowResolution;

fn main() {
    App::new()
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                resolution: WindowResolution::default().with_scale_factor_override(1.0),
                ..Default::default()
            }),
            ..Default::default()
        }))
        .add_systems(Startup, setup_ui_text)
        .add_systems(Startup, setup_text_2d)
        .add_systems(Update, spawn_text2d_bounding_sprite_system)
        .run();
}

const TEXT: &[&str] = &[
    "\n",
    "a section after an empty line, ",
    "a section ending in a line break\n",
    "\n",
    "after an empty line. Should end with four empty lines\n",
    "\n\n",
    "\n",
];
const TEXT_NO_TRAILING_LINES: &[&str] = &[
    "\n",
    "a section after an empty line, ",
    "a section ending in a line break\n",
    "\n",
    "after an empty line. Should end here",
];

fn text_style() -> TextStyle {
    TextStyle {
        font_size: 20.0,
        color: Color::WHITE,
        ..Default::default()
    }
}

fn sections(text: &'static [&'static str]) -> impl Iterator<Item = TextSection> {
    text.iter()
        .map(|section| TextSection::new(section.to_string(), text_style()))
}

fn setup_ui_text(mut commands: Commands) {
    commands.spawn(Camera2dBundle::default());
    commands
        .spawn(NodeBundle {
            style: Style {
                justify_content: JustifyContent::Center,
                ..Default::default()
            },
            ..Default::default()
        })
        .with_children(|commands| {
            commands
                .spawn(NodeBundle {
                    style: Style {
                        flex_direction: FlexDirection::Column,
                        align_items: AlignItems::Start,
                        ..Default::default()
                    },
                    ..Default::default()
                })
                .with_children(|commands| {
                    commands.spawn(TextBundle {
                        text: Text::from_sections(sections(TEXT_NO_TRAILING_LINES)),
                        background_color: BackgroundColor(Color::TEAL),
                        ..Default::default()
                    });
                });
            commands
            .spawn(NodeBundle {
                style: Style {
                    flex_direction: FlexDirection::Column,
                    ..Default::default()
                },
                ..Default::default()
            })
            .with_children(|commands| {
                for i in 0..14 {
                    commands.spawn(TextBundle {
                        text: Text::from_section(format!("{i}"), text_style()),
                        background_color: if i % 2 == 1 { Color::BLUE } else { Color::BLACK }.into(),
                        ..Default::default()
                    });
                }
            });

            commands
                .spawn(NodeBundle {
                    style: Style {
                        flex_direction: FlexDirection::Column,
                        align_items: AlignItems::Start,
                        ..Default::default()
                    },
                    ..Default::default()
                })
                .with_children(|commands| {
                    commands.spawn(TextBundle {
                        text: Text::from_sections(sections(TEXT)),
                        background_color: BackgroundColor(Color::RED),
                        ..Default::default()
                    });
                    commands.spawn(TextBundle {
                        text: Text::from_section("\n\n\n", text_style()),
                        style: Style {
                            ..Default::default()
                        },
                        background_color: BackgroundColor(Color::GREEN),
                        ..Default::default()
                    });
                    commands.spawn(TextBundle {
                        text: Text::from_section("after 3 empty lines", text_style()),
                        style: Style {
                            ..Default::default()
                        },
                        background_color: BackgroundColor(Color::BLACK),
                        ..Default::default()
                    });
                });
        });
}

fn setup_text_2d(mut commands: Commands) {
    commands.spawn(Text2dBundle {
        text: Text::from_sections(sections(TEXT)),
        transform: Transform::from_translation(50. * (-Vec3::Y + Vec3::Z)),
        ..Default::default()
    });
}

fn spawn_text2d_bounding_sprite_system(
    mut commands: Commands,
    query: Query<(&TextLayoutInfo, &GlobalTransform), (Changed<TextLayoutInfo>, With<bevy::text::Text2dBounds>)>,
) {
    for (info, global_transform) in query.iter() {
        commands.spawn(SpriteBundle {
            sprite: Sprite {
                color: Color::NAVY,
                custom_size: Some(info.size),
                ..Default::default()
            },
            transform: Transform::from_translation(global_transform.translation() - Vec3::Z),
            ..Default::default()
        });
    }
}
```
<img width="641" alt="text_trailing_lines_main" src="https://github.com/bevyengine/bevy/assets/27962798/7eccb99f-15a9-4e06-9db3-3594fece592e">

## Solution
Add a parameter `sections` that takes an &str iterator to `compute_text_bounds`.
For each trailing `\n` in the text, add the height of an empty line from the respective section's font to the text bounds max y value.

<img width="641" alt="text_trailing_lines_fixed" src="https://github.com/bevyengine/bevy/assets/27962798/bb1663fa-ce1a-44a8-a8e2-3e7bdf19f19f">

---

## Changelog
`bevy_text::glyph_brush::GlyphBrush`:
* Add a parameter `sections` that takes an &str iterator to `compute_text_bounds`.
* The `compute_text_bounds` method now iterates `sections` in reverse and for each trailing `\n` adds space calculated from the sections font for an empty line to the vertical end of the text bounds.

`bevy_text::pipeline::TextPipeline`
* `queue_text` no longer early returns with zero-sized bounds for text where no glyphs are generated.

`text_wrap_debug` example:
* Added a "\nbetween empty lines\n" debug case.

