### PR TITLE
Change `UiScale` to a tuple struct

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -191,7 +191,7 @@ pub fn ui_focus_system(
         .or_else(|| touches_input.first_pressed_position())
         // The cursor position returned by `Window` only takes into account the window scale factor and not `UiScale`.
         // To convert the cursor position to logical UI viewport coordinates we have to divide it by `UiScale`.
-        .map(|cursor_position| cursor_position / ui_scale.scale as f32);
+        .map(|cursor_position| cursor_position / ui_scale.0 as f32);
 
     // prepare an iterator that contains all the nodes that have the cursor in their rect,
     // from the top node to the bottom one. this will also reset the interaction to `None`

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -256,7 +256,7 @@ pub fn ui_layout_system(
         ui_surface.update_window(entity, &window.resolution);
     }
 
-    let scale_factor = logical_to_physical_factor * ui_scale.scale;
+    let scale_factor = logical_to_physical_factor * ui_scale.0;
 
     let layout_context = LayoutContext::new(scale_factor, physical_size);
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -73,6 +73,12 @@ pub struct UiScale {
     pub scale: f64,
 }
 
+impl UiScale {
+    pub const fn new(scale: f64) -> Self {
+        UiScale { scale }
+    }
+}
+
 impl Default for UiScale {
     fn default() -> Self {
         Self { scale: 1.0 }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -22,6 +22,7 @@ pub mod widget;
 #[cfg(feature = "bevy_text")]
 use bevy_render::camera::CameraUpdateSystem;
 use bevy_render::{extract_component::ExtractComponentPlugin, RenderApp};
+use bevy_derive::{Deref, DerefMut};
 pub use focus::*;
 pub use geometry::*;
 pub use layout::*;
@@ -67,8 +68,8 @@ pub enum UiSystem {
 ///
 /// A multiplier to fixed-sized ui values.
 /// **Note:** This will only affect fixed ui values like [`Val::Px`]
-#[derive(Debug, Resource)]
-pub struct UiScale(pub f32);
+#[derive(Debug, Resource, Deref, DerefMut)]
+pub struct UiScale(pub f64);
 
 impl Default for UiScale {
     fn default() -> Self {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -19,10 +19,10 @@ pub mod node_bundles;
 pub mod update;
 pub mod widget;
 
+use bevy_derive::{Deref, DerefMut};
 #[cfg(feature = "bevy_text")]
 use bevy_render::camera::CameraUpdateSystem;
 use bevy_render::{extract_component::ExtractComponentPlugin, RenderApp};
-use bevy_derive::{Deref, DerefMut};
 pub use focus::*;
 pub use geometry::*;
 pub use layout::*;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -74,7 +74,7 @@ pub struct UiScale {
 }
 
 impl UiScale {
-    /// Creates a new UiScale [`World`]
+    /// Creates a new [`UiScale`]
     pub const fn new(scale: f64) -> Self {
         UiScale { scale }
     }

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -68,21 +68,11 @@ pub enum UiSystem {
 /// A multiplier to fixed-sized ui values.
 /// **Note:** This will only affect fixed ui values like [`Val::Px`]
 #[derive(Debug, Resource)]
-pub struct UiScale {
-    /// The scale to be applied.
-    pub scale: f64,
-}
-
-impl UiScale {
-    /// Creates a new [`UiScale`]
-    pub const fn new(scale: f64) -> Self {
-        UiScale { scale }
-    }
-}
+pub struct UiScale(pub f32);
 
 impl Default for UiScale {
     fn default() -> Self {
-        Self { scale: 1.0 }
+        Self(1.0)
     }
 }
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -74,6 +74,7 @@ pub struct UiScale {
 }
 
 impl UiScale {
+    /// Creates a new UiScale [`World`]
     pub const fn new(scale: f64) -> Self {
         UiScale { scale }
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -286,7 +286,7 @@ pub fn extract_uinode_borders(
         .unwrap_or(Vec2::ZERO)
         // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
         // so we have to divide by `UiScale` to get the size of the UI viewport.
-        / ui_scale.scale as f32;
+        / ui_scale.0 as f32;
 
     for (stack_index, entity) in ui_stack.uinodes.iter().enumerate() {
         if let Ok((node, global_transform, style, border_color, parent, visibility, clip)) =
@@ -450,7 +450,7 @@ pub fn extract_default_ui_camera_view<T: Component>(
     ui_scale: Extract<Res<UiScale>>,
     query: Extract<Query<(Entity, &Camera, Option<&UiCameraConfig>), With<T>>>,
 ) {
-    let scale = (ui_scale.scale as f32).recip();
+    let scale = (ui_scale.0 as f32).recip();
     for (entity, camera, camera_ui) in &query {
         // ignore cameras with disabled ui
         if matches!(camera_ui, Some(&UiCameraConfig { show_ui: false, .. })) {
@@ -527,7 +527,7 @@ pub fn extract_text_uinodes(
         .get_single()
         .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.0)
-        * ui_scale.scale;
+        * ui_scale.0;
 
     let inverse_scale_factor = (scale_factor as f32).recip();
 

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -87,7 +87,7 @@ pub fn update_image_content_size_system(
         .get_single()
         .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.)
-        * ui_scale.scale;
+        * ui_scale.0;
 
     for (mut content_size, image, mut image_size) in &mut query {
         if let Some(texture) = textures.get(&image.texture) {
@@ -129,7 +129,7 @@ pub fn update_atlas_content_size_system(
         .get_single()
         .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.)
-        * ui_scale.scale;
+        * ui_scale.0;
 
     for (mut content_size, atlas, atlas_image, mut image_size) in &mut atlas_query {
         if let Some(atlas) = atlases.get(atlas) {

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -135,7 +135,7 @@ pub fn measure_text_system(
         .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.);
 
-    let scale_factor = ui_scale.scale * window_scale_factor;
+    let scale_factor = ui_scale.0 * window_scale_factor;
 
     #[allow(clippy::float_cmp)]
     if *last_scale_factor == scale_factor {
@@ -252,7 +252,7 @@ pub fn text_system(
         .map(|window| window.resolution.scale_factor())
         .unwrap_or(1.);
 
-    let scale_factor = ui_scale.scale * window_scale_factor;
+    let scale_factor = ui_scale.0 * window_scale_factor;
 
     if *last_scale_factor == scale_factor {
         // Scale factor unchanged, only recompute text for modified text nodes

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -136,7 +136,7 @@ fn apply_scaling(
         return;
     }
 
-    ui_scale.scale = target_scale.current_scale();
+    ui_scale.0 = target_scale.current_scale();
 }
 
 fn ease_in_expo(x: f64) -> f64 {

--- a/examples/ui/viewport_debug.rs
+++ b/examples/ui/viewport_debug.rs
@@ -28,7 +28,7 @@ enum Coords {
 
 fn main() {
     App::new()
-        .insert_resource(UiScale { scale: 2.0 })
+        .insert_resource(UiScale(2.0))
         .add_plugins(DefaultPlugins.set(WindowPlugin {
             primary_window: Some(Window {
                 resolution: [1600., 1200.].into(),


### PR DESCRIPTION
# Objective

Inconvenient initialization of `UiScale`

## Solution

Change `UiScale` to a tuple struct

## Migration Guide

Replace initialization of `UiScale` like ```UiScale { scale: 1.0 }``` with ```UiScale(1.0)```