### PR TITLE
input: allow multiple gamepad inputs to be registered for one button in one frame

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -1,6 +1,6 @@
 use crate::converter::{convert_axis, convert_button, convert_gamepad_id};
 use bevy_ecs::event::EventWriter;
-use bevy_ecs::system::{NonSend, NonSendMut, Res};
+use bevy_ecs::system::{NonSend, NonSendMut, Res, ResMut};
 use bevy_input::gamepad::{
     GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadConnection, GamepadConnectionEvent,
     GamepadSettings,
@@ -29,8 +29,8 @@ pub fn gilrs_event_startup_system(
 pub fn gilrs_event_system(
     mut gilrs: NonSendMut<Gilrs>,
     mut events: EventWriter<GamepadEvent>,
+    mut gamepad_buttons: ResMut<Axis<GamepadButton>>,
     gamepad_axis: Res<Axis<GamepadAxis>>,
-    gamepad_buttons: Res<Axis<GamepadButton>>,
     gamepad_settings: Res<GamepadSettings>,
 ) {
     while let Some(gilrs_event) = gilrs
@@ -65,6 +65,9 @@ pub fn gilrs_event_system(
                             GamepadButtonChangedEvent::new(gamepad, button_type, filtered_value)
                                 .into(),
                         );
+                        // Update the current value prematurely so that `old_value` is correct in
+                        // future iterations of the loop.
+                        gamepad_buttons.set(button, filtered_value);
                     }
                 }
             }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1134,7 +1134,6 @@ pub fn gamepad_axis_event_system(
 pub fn gamepad_button_event_system(
     mut button_events: EventReader<GamepadButtonChangedEvent>,
     mut button_input: ResMut<Input<GamepadButton>>,
-    mut button_axis: ResMut<Axis<GamepadButton>>,
     settings: Res<GamepadSettings>,
 ) {
     for button_event in button_events.iter() {
@@ -1149,8 +1148,6 @@ pub fn gamepad_button_event_system(
         } else if button_property.is_pressed(value) {
             button_input.press(button);
         };
-
-        button_axis.set(button, value);
     }
 }
 


### PR DESCRIPTION
# Objective

- Currently, (AFAIC, accidentally) after registering an event for a Gilrs button event, we ignore all subsequent events for the same button in the same frame, because we don't update our filter. This is rare, but I noticed it while adding gamepad support to a terminal app rendering at 15fps.
- Related to #4664, but does not quite fix it.

## Solution

- Move the edit to the `Axis<GamepadButton>` resource to when we read the events from Gilrs.