### PR TITLE
Fix shader_instancing example

### DIFF
--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -24,7 +24,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
     // index in the Mesh array. This index could be passed in via another
     // uniform instead but it's unnecessary for the example.
     out.clip_position = mesh_position_local_to_clip(
-        get_model_matrix(0),
+        get_model_matrix(0u),
         vec4<f32>(position, 1.0)
     );
     out.color = vertex.i_color;


### PR DESCRIPTION
# Objective

- Fix shader compilation issue in `shader_instancing` example.

## Solution

- Fix typo in `instancing.wgsl`
