### PR TITLE
Unchecked shaders

### DIFF
--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -102,6 +102,7 @@ impl SpecializedRenderPipeline for BlitPipeline {
                 ..Default::default()
             },
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -143,6 +143,7 @@ impl SpecializedRenderPipeline for BloomDownsamplingPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
@@ -138,6 +138,7 @@ impl SpecializedRenderPipeline for BloomUpsamplingPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -244,6 +244,7 @@ impl SpecializedRenderPipeline for CASPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -195,6 +195,7 @@ impl SpecializedRenderPipeline for FxaaPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -175,6 +175,7 @@ impl SpecializedRenderPipeline for SkyboxPipeline {
                     write_mask: ColorWrites::ALL,
                 })],
             }),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -415,6 +415,7 @@ impl SpecializedRenderPipeline for TAAPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -220,6 +220,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             depth_stencil: None,
             multisample: MultisampleState::default(),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -113,6 +113,7 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
             },
             label: Some("LineGizmo Pipeline 2D".into()),
             push_constant_ranges: vec![],
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -125,6 +125,7 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
             },
             label: Some("LineGizmo Pipeline".into()),
             push_constant_ranges: vec![],
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -147,6 +147,11 @@ pub trait Material: AsBindGroup + Send + Sync + Clone + TypeUuid + TypePath + Si
         ShaderRef::Default
     }
 
+    /// See [`RenderDevice::create_shader_module_unchecked`]. Defaults to true in release mode, and false in debug mode.
+    fn unchecked() -> bool {
+        cfg!(not(debug_assertions))
+    }
+
     /// Customizes the default [`RenderPipelineDescriptor`] for a specific entity using the entity's
     /// [`MaterialPipelineKey`] and [`MeshVertexBufferLayout`] as input.
     #[allow(unused_variables)]
@@ -478,9 +483,15 @@ pub fn queue_material_meshes<M: Material>(
                     let mut mesh_key =
                         MeshPipelineKey::from_primitive_topology(mesh.primitive_topology)
                             | view_key;
+
+                    if M::unchecked() {
+                        mesh_key |= MeshPipelineKey::UNCHECKED;
+                    }
+
                     if mesh.morph_targets.is_some() {
                         mesh_key |= MeshPipelineKey::MORPH_TARGETS;
                     }
+
                     match material.properties.alpha_mode {
                         AlphaMode::Blend => {
                             mesh_key |= MeshPipelineKey::BLEND_ALPHA;

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -148,7 +148,7 @@ pub trait Material: AsBindGroup + Send + Sync + Clone + TypeUuid + TypePath + Si
     }
 
     /// See [`RenderDevice::create_shader_module_unchecked`]. Defaults to true in release mode, and false in debug mode.
-    fn unchecked() -> bool {
+    fn unchecked_shader_code() -> bool {
         cfg!(not(debug_assertions))
     }
 
@@ -484,7 +484,7 @@ pub fn queue_material_meshes<M: Material>(
                         MeshPipelineKey::from_primitive_topology(mesh.primitive_topology)
                             | view_key;
 
-                    if M::unchecked() {
+                    if M::unchecked_shader_code() {
                         mesh_key |= MeshPipelineKey::UNCHECKED;
                     }
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -536,6 +536,7 @@ where
             },
             push_constant_ranges,
             label: Some("prepass_pipeline".into()),
+            unchecked: key.mesh_key.contains(MeshPipelineKey::UNCHECKED),
         };
 
         // This is a bit risky because it's possible to change something that would

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -694,19 +694,20 @@ bitflags::bitflags! {
     /// MSAA uses the highest 3 bits for the MSAA log2(sample count) to support up to 128x MSAA.
     pub struct MeshPipelineKey: u32 {
         const NONE                              = 0;
-        const HDR                               = (1 << 0);
-        const TONEMAP_IN_SHADER                 = (1 << 1);
-        const DEBAND_DITHER                     = (1 << 2);
-        const DEPTH_PREPASS                     = (1 << 3);
-        const NORMAL_PREPASS                    = (1 << 4);
-        const MOTION_VECTOR_PREPASS             = (1 << 5);
-        const MAY_DISCARD                       = (1 << 6); // Guards shader codepaths that may discard, allowing early depth tests in most cases
+        const UNCHECKED                         = (1 << 0);
+        const HDR                               = (1 << 1);
+        const TONEMAP_IN_SHADER                 = (1 << 2);
+        const DEBAND_DITHER                     = (1 << 3);
+        const DEPTH_PREPASS                     = (1 << 4);
+        const NORMAL_PREPASS                    = (1 << 5);
+        const MOTION_VECTOR_PREPASS             = (1 << 6);
+        const MAY_DISCARD                       = (1 << 7); // Guards shader codepaths that may discard, allowing early depth tests in most cases
                                                             // See: https://www.khronos.org/opengl/wiki/Early_Fragment_Test
-        const ENVIRONMENT_MAP                   = (1 << 7);
-        const SCREEN_SPACE_AMBIENT_OCCLUSION    = (1 << 8);
-        const DEPTH_CLAMP_ORTHO                 = (1 << 9);
-        const TAA                               = (1 << 10);
-        const MORPH_TARGETS                     = (1 << 11);
+        const ENVIRONMENT_MAP                   = (1 << 8);
+        const SCREEN_SPACE_AMBIENT_OCCLUSION    = (1 << 9);
+        const DEPTH_CLAMP_ORTHO                 = (1 << 10);
+        const TAA                               = (1 << 11);
+        const MORPH_TARGETS                     = (1 << 12);
         const BLEND_RESERVED_BITS               = Self::BLEND_MASK_BITS << Self::BLEND_SHIFT_BITS; // ← Bitmask reserving bits for the blend state
         const BLEND_OPAQUE                      = (0 << Self::BLEND_SHIFT_BITS);                   // ← Values are just sequential within the mask, and can range from 0 to 3
         const BLEND_PREMULTIPLIED_ALPHA         = (1 << Self::BLEND_SHIFT_BITS);                   //
@@ -1035,6 +1036,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some(label),
+            unchecked: key.contains(MeshPipelineKey::UNCHECKED),
         })
     }
 }

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -532,6 +532,7 @@ impl FromWorld for SsaoPipelines {
                 shader: PREPROCESS_DEPTH_SHADER_HANDLE.typed(),
                 shader_defs: Vec::new(),
                 entry_point: "preprocess_depth".into(),
+                unchecked: cfg!(not(debug_assertions)),
             });
 
         let spatial_denoise_pipeline =
@@ -545,6 +546,7 @@ impl FromWorld for SsaoPipelines {
                 shader: SPATIAL_DENOISE_SHADER_HANDLE.typed(),
                 shader_defs: Vec::new(),
                 entry_point: "spatial_denoise".into(),
+                unchecked: cfg!(not(debug_assertions)),
             });
 
         Self {
@@ -596,6 +598,7 @@ impl SpecializedComputePipeline for SsaoPipelines {
             shader: GTAO_SHADER_HANDLE.typed(),
             shader_defs,
             entry_point: "gtao".into(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -107,6 +107,8 @@ pub struct RenderPipelineDescriptor {
     pub multisample: MultisampleState,
     /// The compiled fragment stage, its entry point, and the color targets.
     pub fragment: Option<FragmentState>,
+    /// See [`RenderDevice::create_shader_module_unchecked`].
+    pub unchecked: bool,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -185,4 +187,6 @@ pub struct ComputePipelineDescriptor {
     /// The name of the entry point in the compiled shader. There must be a
     /// function with this name in the shader.
     pub entry_point: Cow<'static, str>,
+    /// See [`RenderDevice::create_shader_module_unchecked`].
+    pub unchecked: bool,
 }

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -48,6 +48,19 @@ impl RenderDevice {
         self.device.create_shader_module(desc)
     }
 
+    /// Creates an unchecked [`ShaderModule`](wgpu::ShaderModule) from either SPIR-V or WGSL source code.
+    ///
+    /// Forgoes adding safety checks to the generated shader code to prevent undefined behavior such as indexing out of bounds.
+    ///
+    /// Equivalent to [`RenderDevice::create_shader_module`] on WASM.
+    #[inline]
+    pub unsafe fn create_shader_module_unchecked(
+        &self,
+        desc: wgpu::ShaderModuleDescriptor,
+    ) -> wgpu::ShaderModule {
+        self.device.create_shader_module_unchecked(desc)
+    }
+
     /// Check for resource cleanups and mapping callbacks.
     ///
     /// Return `true` if the queue is empty, or `false` if there are more queue

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -250,6 +250,7 @@ impl SpecializedRenderPipeline for ScreenshotToScreenPipeline {
                 })],
             }),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -125,7 +125,7 @@ pub trait Material2d: AsBindGroup + Send + Sync + Clone + TypeUuid + TypePath + 
     }
 
     /// See [`RenderDevice::create_shader_module_unchecked`]. Defaults to true in release mode, and false in debug mode.
-    fn unchecked() -> bool {
+    fn unchecked_shader_code() -> bool {
         cfg!(not(debug_assertions))
     }
 
@@ -391,7 +391,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                         let mut mesh_key = view_key
                             | Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
 
-                        if M::unchecked() {
+                        if M::unchecked_shader_code() {
                             mesh_key |= Mesh2dPipelineKey::UNCHECKED;
                         }
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -290,9 +290,10 @@ bitflags::bitflags! {
     // FIXME: make normals optional?
     pub struct Mesh2dPipelineKey: u32 {
         const NONE                              = 0;
-        const HDR                               = (1 << 0);
-        const TONEMAP_IN_SHADER                 = (1 << 1);
-        const DEBAND_DITHER                     = (1 << 2);
+        const UNCHECKED                         = (1 << 0);
+        const HDR                               = (1 << 1);
+        const TONEMAP_IN_SHADER                 = (1 << 2);
+        const DEBAND_DITHER                     = (1 << 3);
         const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
         const PRIMITIVE_TOPOLOGY_RESERVED_BITS  = Self::PRIMITIVE_TOPOLOGY_MASK_BITS << Self::PRIMITIVE_TOPOLOGY_SHIFT_BITS;
         const TONEMAP_METHOD_RESERVED_BITS      = Self::TONEMAP_METHOD_MASK_BITS << Self::TONEMAP_METHOD_SHIFT_BITS;
@@ -471,6 +472,7 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some("transparent_mesh2d_pipeline".into()),
+            unchecked: key.contains(Mesh2dPipelineKey::UNCHECKED),
         })
     }
 }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -292,6 +292,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
             },
             label: Some("sprite_pipeline".into()),
             push_constant_ranges: Vec::new(),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -122,6 +122,7 @@ impl SpecializedRenderPipeline for UiPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some("ui_pipeline".into()),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -194,6 +194,7 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
                 alpha_to_coverage_enabled: false,
             },
             label: Some("colored_mesh2d_pipeline".into()),
+            unchecked: cfg!(not(debug_assertions)),
         }
     }
 }

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -314,6 +314,7 @@ impl FromWorld for PostProcessPipeline {
                 depth_stencil: None,
                 multisample: MultisampleState::default(),
                 push_constant_ranges: vec![],
+                unchecked: cfg!(not(debug_assertions)),
             });
 
         Self {


### PR DESCRIPTION
# Objective

- Improve shader performance on non-WASM platforms by disabling runtime shader checks, which costs performance.
- Supersedes https://github.com/bevyengine/bevy/pull/8171.

## Solution

- Builtin bevy shaders generate unchecked shader modules in release mode.
- 3d and 2d materials are controlled by a new unchecked_shader_code() function of the material traits, defaulting to unchecked in release mode.

---

## Changelog

- Added the ability to skip generating undefined behavior checks in shader code to improve performance on non-WASM platforms
  - Added `bevy::render::renderer::RenderDevice::create_shader_module_unchecked()`
  - Added `bevy::pbr::Material::unchecked_shader_code()`
  - Added `bevy::sprite::Material2d::unchecked_shader_code()`

## Migration Guide

- `bevy::pbr::Material` and `bevy::sprite::Material2d` now skip generating undefined behavior checks in shader code to improve performance in release mode on non-WASM platforms. Use the `unchecked_shader_code()` functions of these traits and return `false` to revert to the old behavior.