### PR TITLE
fix asset loader preregistration for multiple assets

### DIFF
--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -236,7 +236,7 @@ impl AssetServer {
             loaders[existing_index] = MaybeAssetLoader::Ready(Arc::new(loader));
             if let Some(sender) = maybe_sender {
                 // notify after replacing the loader
-                let _ = sender.send_blocking(());
+                let _ = sender.close();
             }
         } else {
             loaders.push(MaybeAssetLoader::Ready(Arc::new(loader)));


### PR DESCRIPTION
# Objective

fix #9452

when multiple assets are queued to a preregistered loader, only one gets unblocked when the real loader is registered. 

## Solution

i thought async_channel receivers worked like broadcast channels, but in fact the notification is only received by a single receiver, so only a single waiting asset is unblocked. close the sender instead so that all blocked receivers are unblocked.

