### PR TITLE
ecs: add #[bundle(default(..))] attribute

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -301,7 +301,7 @@ mod tests {
         #[derive(Default, Component, Debug, PartialEq)]
         struct D;
 
-        fn make_b() -> B {
+        fn make_b(_: &BundleWithDefaults) -> B {
             B(500)
         }
 


### PR DESCRIPTION
# Objective

- Sometimes, when deriving `Bundle`, we would like to have some components that are initialized along with a bundle, but not part of the public API of the crate or initialized with a default value. Currently, users are required to create a constructor/builder API for this behaviour but classic constructors have clear ergonomic and clarity benefits in plenty of scenarios.

## Solution

- Introduce a `#[bundle(default(A, B = make_b, C))]` container-level attribute that lets us insert implicit components along with our bundles.

## Considerations / Alternatives

- With the `B = make_b` syntax, `make_b` must resolve to a function with the signature `fn() -> B`, but we could easily make this `fn(&BundleType) -> B`.

- Is `default` the best name? Perhaps something more explicit (ironic) like `implicit_components`.
 
- Is this necessary? I've found myself reaching for something like this a few times, but perhaps we should hint users towards the builder pattern instead. I think its very clear from the following definition which components are inserted, but it might not be so clear from the site where `EnemyBundle` is initialised.
```rust
#[derive(Bundle)]
#[bundle(default(NotExploding, Dry))]
struct EnemyBundle {
    max_health: MaxHealth,
}
```

---

## Changelog

- Introduced a new `#[bundle(default(A, B = make_b, C))]` container-level attribute that lets us insert implicit components along with our bundles.