### PR TITLE
Fix `Window::set_cursor_position`

### DIFF
--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -179,13 +179,7 @@ pub(crate) fn changed_windows(
 
             if window.physical_cursor_position() != cache.window.physical_cursor_position() {
                 if let Some(physical_position) = window.physical_cursor_position() {
-                    let inner_size = winit_window.inner_size();
-
-                    let position = PhysicalPosition::new(
-                        physical_position.x,
-                        // Flip the coordinate space back to winit's context.
-                        inner_size.height as f32 - physical_position.y,
-                    );
+                    let position = PhysicalPosition::new(physical_position.x, physical_position.y);
 
                     if let Err(err) = winit_window.set_cursor_position(position) {
                         error!("could not set cursor position: {:?}", err);


### PR DESCRIPTION
# Objective

Fixes #9455

This change has probably been forgotten in https://github.com/bevyengine/bevy/pull/8306.

## Solution

Remove the inversion of the Y axis when propagates window change back to winit.
