### PR TITLE
Fix unsoundness in `QueryState::is_empty`

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -151,7 +151,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ///
     /// # Safety
     ///
-    /// - `world` must have permission to ready any components required by this instance's `F` [`WorldQuery`].
+    /// - `world` must have permission to read any components required by this instance's `F` [`WorldQuery`].
     /// - `world` must match the one used to create this [`QueryState`].
     #[inline]
     pub(crate) unsafe fn is_empty_unsafe_world_cell(

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -135,7 +135,9 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     #[inline]
     pub fn is_empty(&self, world: &World, last_run: Tick, this_run: Tick) -> bool {
         self.validate_world(world.id());
-        // SAFETY: The world has been validated.
+        // SAFETY:
+        // - We have read-only access to the entire world.
+        // - The world has been validated.
         unsafe {
             self.is_empty_unsafe_world_cell(
                 world.as_unsafe_world_cell_readonly(),
@@ -149,7 +151,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ///
     /// # Safety
     ///
-    /// `world` must match the one used to create this [`QueryState`].
+    /// - `world` mut have permission to ready any components required by this instance's `F` [`WorldQuery`].
+    /// - `world` must match the one used to create this [`QueryState`].
     #[inline]
     pub(crate) unsafe fn is_empty_unsafe_world_cell(
         &self,
@@ -158,9 +161,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         this_run: Tick,
     ) -> bool {
         // SAFETY:
-        // - `as_nop()` ensures no world data is accessed.
-        // - `&self` ensures no one has exclusive access.
-        // - Caller ensures that the world matches.
+        // - The caller ensures that `world` has permission to access any data used by the filter.
+        // - The caller ensures that the world matches.
         unsafe {
             self.as_nop()
                 .iter_unchecked_manual(world, last_run, this_run)

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -130,10 +130,23 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// Checks if the query is empty for the given [`World`], where the last change and current tick are given.
     #[inline]
     pub fn is_empty(&self, world: &World, last_run: Tick, this_run: Tick) -> bool {
-        // SAFETY: NopFetch does not access any members while &self ensures no one has exclusive access
+        self.is_empty_unsafe_world_cell(world.as_unsafe_world_cell_readonly(), last_run, this_run)
+    }
+
+    /// Checks if the query is empty for the given [`UnsafeWorldCell`].
+    #[inline]
+    pub(crate) fn is_empty_unsafe_world_cell(
+        &self,
+        world: UnsafeWorldCell,
+        last_run: Tick,
+        this_run: Tick,
+    ) -> bool {
+        // SAFETY:
+        // - `as_nop()` ensures no world data is accessed.
+        // - `&self` ensures no one has exclusive access.
         unsafe {
             self.as_nop()
-                .iter_unchecked_manual(world.as_unsafe_world_cell_readonly(), last_run, this_run)
+                .iter_unchecked_manual(world, last_run, this_run)
                 .next()
                 .is_none()
         }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -149,7 +149,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ///
     /// # Safety
     ///
-    /// `world` must match the one used to create this [`QuerySate`].
+    /// `world` must match the one used to create this [`QueryState`].
     #[inline]
     pub(crate) unsafe fn is_empty_unsafe_world_cell(
         &self,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -151,7 +151,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     ///
     /// # Safety
     ///
-    /// - `world` mut have permission to ready any components required by this instance's `F` [`WorldQuery`].
+    /// - `world` must have permission to ready any components required by this instance's `F` [`WorldQuery`].
     /// - `world` must match the one used to create this [`QueryState`].
     #[inline]
     pub(crate) unsafe fn is_empty_unsafe_world_cell(

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1366,8 +1366,11 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.state
-            .is_empty_unsafe_world_cell(self.world, self.last_run, self.this_run)
+        // SAFETY: `self.world` matches `self.state`.
+        unsafe {
+            self.state
+                .is_empty_unsafe_world_cell(self.world, self.last_run, self.this_run)
+        }
     }
 
     /// Returns `true` if the given [`Entity`] matches the query.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1366,12 +1366,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.state.is_empty(
-            // SAFETY: `QueryState::is_empty` does not access world data.
-            unsafe { self.world.unsafe_world() },
-            self.last_run,
-            self.this_run,
-        )
+        self.state
+            .is_empty_unsafe_world_cell(self.world, self.last_run, self.this_run)
     }
 
     /// Returns `true` if the given [`Entity`] matches the query.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1366,7 +1366,10 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// ```
     #[inline]
     pub fn is_empty(&self) -> bool {
-        // SAFETY: `self.world` matches `self.state`.
+        // SAFETY:
+        // - `self.world` has permission to read any data required by the WorldQuery.
+        // - `&self` ensures that no one currently has write access.
+        // - `self.world` matches `self.state`.
         unsafe {
             self.state
                 .is_empty_unsafe_world_cell(self.world, self.last_run, self.this_run)


### PR DESCRIPTION
# Objective

`QueryState::is_empty` is unsound, as it does not validate the world. If a mismatched world is passed in, then the query filter may cast a component to an incorrect type, causing undefined behavior.

## Solution

Add world validation. To prevent a performance regression in `Query` (whose world does not need to be validated), the unchecked function `is_empty_unsafe_world_cell` has been added. This also allows us to remove one of the last usages of the private function `UnsafeWorldCell::unsafe_world`, which takes us a step towards being able to remove that method entirely.
