### PR TITLE
Bevy Input Docs : the modules

### DIFF
--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -1,3 +1,5 @@
+//! The generic axis type.
+
 use bevy_ecs::system::Resource;
 use bevy_utils::HashMap;
 use std::hash::Hash;

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,3 +1,5 @@
+//! The gamepad input functionality.
+
 use crate::{Axis, Input};
 use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::{

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -1,3 +1,5 @@
+//! The generic input type.
+
 use bevy_ecs::system::Resource;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::HashSet;

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,3 +1,5 @@
+//! The keyboard input functionality.
+
 use crate::{ButtonState, Input};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::{

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
 
 //! Input functionality for the [Bevy game engine](https://bevyengine.org/).
 //!

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,5 +1,11 @@
 #![allow(clippy::type_complexity)]
 
+//! Input functionality for the [Bevy game engine](https://bevyengine.org/).
+//!
+//! # Supported input devices
+//!
+//! `bevy` currently supports keyboard, mouse, gamepad, and touch inputs.
+
 mod axis;
 /// Common run conditions
 pub mod common_conditions;
@@ -13,6 +19,7 @@ pub mod touchpad;
 pub use axis::*;
 pub use input::*;
 
+/// Most commonly used re-exported types.
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,3 +1,5 @@
+//! The mouse input functionality.
+
 use crate::{ButtonState, Input};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::{

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -1,3 +1,5 @@
+//! The touch input functionality.
+
 use bevy_ecs::event::{Event, EventReader};
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_math::Vec2;

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -1,3 +1,5 @@
+//! The touchpad input functionality.
+
 use bevy_ecs::event::Event;
 use bevy_reflect::Reflect;
 


### PR DESCRIPTION
# Objective

Complete the documentation of `bevy_input` (#3492).

This PR is part of a triptych of PRs :
- https://github.com/bevyengine/bevy/pull/9468
- https://github.com/bevyengine/bevy/pull/9469

## Solution

Add documentation on modules in `bevy_input`.
