### PR TITLE
Bevy Input Docs : lib.rs

### DIFF
--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -156,7 +156,7 @@ pub enum ButtonState {
 }
 
 impl ButtonState {
-    /// Either or not the button is pressed.
+    /// Is this button pressed?
     pub fn is_pressed(&self) -> bool {
         matches!(self, ButtonState::Pressed)
     }

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -52,6 +52,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 #[derive(Default)]
 pub struct InputPlugin;
 
+/// Label for systems that update the input data.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub struct InputSystem;
 
@@ -148,11 +149,14 @@ impl Plugin for InputPlugin {
     reflect(Serialize, Deserialize)
 )]
 pub enum ButtonState {
+    /// The button is pressed.
     Pressed,
+    /// The button is not pressed.
     Released,
 }
 
 impl ButtonState {
+    /// Either or not the button is pressed.
     pub fn is_pressed(&self) -> bool {
         matches!(self, ButtonState::Pressed)
     }


### PR DESCRIPTION
# Objective

Complete the documentation of `bevy_input` (#3492).

This PR is part of a triptych of PRs :
- https://github.com/bevyengine/bevy/pull/9467
- https://github.com/bevyengine/bevy/pull/9469

## Solution

Add missing documentation on items in `lib.rs`.
