### PR TITLE
Store font texture atlas handles in a separate list in TextLayoutInfo

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -10,8 +10,8 @@ use glyph_brush_layout::{
 };
 
 use crate::{
-    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, 
-    TextAlignment, TextSettings, YAxisOrientation, 
+    error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasWarning, TextAlignment,
+    TextSettings, YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -87,7 +87,7 @@ impl GlyphBrush {
         let text_bounds = compute_text_bounds(&glyphs, |index| &sections_data[index].3);
         let mut atlases: Vec<(Handle<TextureAtlas>, usize)> = Vec::new();
         let mut positioned_glyphs = Vec::new();
-        
+
         for sg in glyphs {
             let SectionGlyph {
                 section_index: _,
@@ -99,7 +99,7 @@ impl GlyphBrush {
             let glyph_position = glyph.position;
             let adjust = GlyphPlacementAdjuster::new(&mut glyph);
             let section_data = sections_data[sg.section_index];
-            
+
             if let Some(outlined_glyph) = section_data.1.font.outline_glyph(glyph) {
                 let bounds = outlined_glyph.px_bounds();
                 let handle_font_atlas: Handle<FontAtlasSet> = section_data.0.cast_weak();
@@ -112,7 +112,7 @@ impl GlyphBrush {
                     .unwrap_or_else(|| {
                         font_atlas_set.add_glyph_to_atlas(texture_atlases, textures, outlined_glyph)
                     })?;
-                
+
                 if !text_settings.allow_dynamic_font_size
                     && !font_atlas_warning.warned
                     && font_atlas_set.num_font_atlases() > text_settings.max_font_atlases.get()
@@ -121,9 +121,8 @@ impl GlyphBrush {
                     font_atlas_warning.warned = true;
                 }
 
-
                 let texture_atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                
+
                 let glyph_rect = texture_atlas.textures[atlas_info.glyph_index];
                 let size = Vec2::new(glyph_rect.width(), glyph_rect.height());
 
@@ -146,10 +145,9 @@ impl GlyphBrush {
                     section_index: sg.section_index,
                     byte_index,
                 });
-                
+
                 if let Some((atlas, ref mut end)) = atlases.last_mut() {
                     if atlas_info.texture_atlas.id() == atlas.id() {
-                        
                         // glyph from same texture atlas as last glyph
                         *end = positioned_glyphs.len();
                     } else {

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -142,9 +142,9 @@ impl GlyphBrush {
                 positioned_glyphs.push(PositionedGlyph {
                     position,
                     size,
-                    glyph_index: atlas_info.glyph_index as u32,
-                    section_index: sg.section_index as u32,
-                    byte_index: byte_index as u32,
+                    glyph_index: atlas_info.glyph_index,
+                    section_index: sg.section_index,
+                    byte_index,
                 });
                 
                 if let Some((atlas, ref mut end)) = atlases.last_mut() {
@@ -178,9 +178,9 @@ impl GlyphBrush {
 pub struct PositionedGlyph {
     pub position: Vec2,
     pub size: Vec2,
-    pub glyph_index: u32,
-    pub section_index: u32,
-    pub byte_index: u32,
+    pub glyph_index: usize,
+    pub section_index: usize,
+    pub byte_index: usize,
 }
 
 #[cfg(feature = "subpixel_glyph_atlas")]

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -135,13 +135,11 @@ impl GlyphBrush {
                 };
 
                 let position = adjust.position(Vec2::new(x, y));
-
                 positioned_glyphs.push(PositionedGlyph {
                     position,
-                    size,
-                    atlas_info,
-                    section_index: sg.section_index,
-                    byte_index,
+                    glyph_index: atlas_info.glyph_index as u32,
+                    section_index: sg.section_index as u32,
+                    byte_index: byte_index as u32,
                 });
             }
         }
@@ -160,10 +158,9 @@ impl GlyphBrush {
 #[derive(Debug, Clone)]
 pub struct PositionedGlyph {
     pub position: Vec2,
-    pub size: Vec2,
-    pub atlas_info: GlyphAtlasInfo,
-    pub section_index: usize,
-    pub byte_index: usize,
+    pub glyph_index: u32,
+    pub section_index: u32,
+    pub byte_index: u32,
 }
 
 #[cfg(feature = "subpixel_glyph_atlas")]

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -26,6 +26,7 @@ pub struct TextPipeline {
 ///  Contains scaled glyphs and their size. Generated via [`TextPipeline::queue_text`].
 #[derive(Component, Clone, Default, Debug)]
 pub struct TextLayoutInfo {
+    pub atlases: Vec<(Handle<TextureAtlas>, usize)>,
     pub glyphs: Vec<PositionedGlyph>,
     pub size: Vec2,
 }

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -11,8 +11,8 @@ use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText};
 
 use crate::{
     compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
-    FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection, TextSettings,
-    YAxisOrientation,
+    FontAtlasSet, FontAtlasWarning, PositionedGlyph, PositionedGlyphBatch, TextAlignment,
+    TextSection, TextSettings, YAxisOrientation,
 };
 
 #[derive(Default, Resource)]
@@ -26,7 +26,7 @@ pub struct TextPipeline {
 ///  Contains scaled glyphs and their size. Generated via [`TextPipeline::queue_text`].
 #[derive(Component, Clone, Default, Debug)]
 pub struct TextLayoutInfo {
-    pub atlases: Vec<(Handle<TextureAtlas>, usize)>,
+    pub batches: Vec<PositionedGlyphBatch>,
     pub glyphs: Vec<PositionedGlyph>,
     pub size: Vec2,
 }
@@ -88,7 +88,7 @@ impl TextPipeline {
 
         let size = compute_text_bounds(&section_glyphs, |index| &scaled_fonts[index]).size();
 
-        let (atlases, glyphs) = self.brush.process_glyphs(
+        let (batches, glyphs) = self.brush.process_glyphs(
             section_glyphs,
             &sections,
             font_atlas_set_storage,
@@ -101,7 +101,7 @@ impl TextPipeline {
         )?;
 
         Ok(TextLayoutInfo {
-            atlases,
+            batches,
             glyphs,
             size,
         })

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -88,7 +88,7 @@ impl TextPipeline {
 
         let size = compute_text_bounds(&section_glyphs, |index| &scaled_fonts[index]).size();
 
-        let glyphs = self.brush.process_glyphs(
+        let (atlases, glyphs) = self.brush.process_glyphs(
             section_glyphs,
             &sections,
             font_atlas_set_storage,
@@ -100,7 +100,7 @@ impl TextPipeline {
             y_axis_orientation,
         )?;
 
-        Ok(TextLayoutInfo { glyphs, size })
+        Ok(TextLayoutInfo { atlases, glyphs,  size })
     }
 
     pub fn create_text_measure(

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -100,7 +100,11 @@ impl TextPipeline {
             y_axis_orientation,
         )?;
 
-        Ok(TextLayoutInfo { atlases, glyphs,  size })
+        Ok(TextLayoutInfo {
+            atlases,
+            glyphs,
+            size,
+        })
     }
 
     pub fn create_text_measure(

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -114,7 +114,7 @@ pub fn extract_text2d_sprite(
         let mut current_section = usize::MAX;
         let mut start = 0;
         for (atlas_handle, end) in &text_layout_info.atlases {
-            let atlas =  texture_atlases.get(atlas_handle).unwrap();
+            let atlas = texture_atlases.get(atlas_handle).unwrap();
             for i in start..*end {
                 let PositionedGlyph {
                     position,
@@ -123,10 +123,13 @@ pub fn extract_text2d_sprite(
                     ..
                 } = &text_layout_info.glyphs[i];
                 if *section_index != current_section {
-                    color = text.sections[*section_index as usize].style.color.as_rgba_linear();
+                    color = text.sections[*section_index as usize]
+                        .style
+                        .color
+                        .as_rgba_linear();
                     current_section = *section_index;
                 }
-                
+
                 extracted_sprites.sprites.push(ExtractedSprite {
                     entity,
                     transform: transform * GlobalTransform::from_translation(position.extend(0.)),
@@ -139,7 +142,7 @@ pub fn extract_text2d_sprite(
                     anchor: Anchor::Center.as_vec(),
                 });
             }
-            start = *end;   
+            start = *end;
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -123,10 +123,7 @@ pub fn extract_text2d_sprite(
                     ..
                 } = &text_layout_info.glyphs[i];
                 if *section_index != current_section {
-                    color = text.sections[*section_index]
-                        .style
-                        .color
-                        .as_rgba_linear();
+                    color = text.sections[*section_index].style.color.as_rgba_linear();
                     current_section = *section_index;
                 }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -112,6 +112,12 @@ pub fn extract_text2d_sprite(
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut color = Color::WHITE;
         let mut current_section = usize::MAX;
+
+        let Some(mut atlas) = text_layout_info.glyphs.get(0)
+            .map(|glyph| texture_atlases.get(&glyph.atlas_info.texture_atlas).unwrap()) else {
+            continue;
+        };
+
         for PositionedGlyph {
             position,
             atlas_info,
@@ -120,11 +126,11 @@ pub fn extract_text2d_sprite(
         } in &text_layout_info.glyphs
         {
             if *section_index != current_section {
+                atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
                 color = text.sections[*section_index].style.color.as_rgba_linear();
                 current_section = *section_index;
             }
-            let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-
+            
             extracted_sprites.sprites.push(ExtractedSprite {
                 entity,
                 transform: transform * GlobalTransform::from_translation(position.extend(0.)),

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -112,34 +112,34 @@ pub fn extract_text2d_sprite(
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut color = Color::WHITE;
         let mut current_section = u32::MAX;
-
-        for (atlas_handle, count) in &text_layout_info.atlases {
+        let mut start = 0;
+        for (atlas_handle, end) in &text_layout_info.atlases {
             let atlas =  texture_atlases.get(atlas_handle).unwrap();
-            for _ in 0..*count {
-                for PositionedGlyph {
+            for i in start..*end {
+                let PositionedGlyph {
                     position,
                     glyph_index,
                     section_index,
                     ..
-                } in &text_layout_info.glyphs {
-                    if *section_index != current_section {
-                        color = text.sections[*section_index as usize].style.color.as_rgba_linear();
-                        current_section = *section_index;
-                    }
-                    
-                    extracted_sprites.sprites.push(ExtractedSprite {
-                        entity,
-                        transform: transform * GlobalTransform::from_translation(position.extend(0.)),
-                        color,
-                        rect: Some(atlas.textures[*glyph_index as usize]),
-                        custom_size: None,
-                        image_handle_id: atlas.texture.id(),
-                        flip_x: false,
-                        flip_y: false,
-                        anchor: Anchor::Center.as_vec(),
-                    });
+                } = &text_layout_info.glyphs[i];
+                if *section_index != current_section {
+                    color = text.sections[*section_index as usize].style.color.as_rgba_linear();
+                    current_section = *section_index;
                 }
+                
+                extracted_sprites.sprites.push(ExtractedSprite {
+                    entity,
+                    transform: transform * GlobalTransform::from_translation(position.extend(0.)),
+                    color,
+                    rect: Some(atlas.textures[*glyph_index as usize]),
+                    custom_size: None,
+                    image_handle_id: atlas.texture.id(),
+                    flip_x: false,
+                    flip_y: false,
+                    anchor: Anchor::Center.as_vec(),
+                });
             }
+            start = *end;   
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -123,7 +123,7 @@ pub fn extract_text2d_sprite(
                     ..
                 } = &text_layout_info.glyphs[i];
                 if *section_index != current_section {
-                    color = text.sections[*section_index as usize]
+                    color = text.sections[*section_index]
                         .style
                         .color
                         .as_rgba_linear();
@@ -134,7 +134,7 @@ pub fn extract_text2d_sprite(
                     entity,
                     transform: transform * GlobalTransform::from_translation(position.extend(0.)),
                     color,
-                    rect: Some(atlas.textures[*glyph_index as usize]),
+                    rect: Some(atlas.textures[*glyph_index]),
                     custom_size: None,
                     image_handle_id: atlas.texture.id(),
                     flip_x: false,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -111,7 +111,7 @@ pub fn extract_text2d_sprite(
             * scaling
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut color = Color::WHITE;
-        let mut current_section = u32::MAX;
+        let mut current_section = usize::MAX;
         let mut start = 0;
         for (atlas_handle, end) in &text_layout_info.atlases {
             let atlas =  texture_atlases.get(atlas_handle).unwrap();

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -112,16 +112,15 @@ pub fn extract_text2d_sprite(
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut color = Color::WHITE;
         let mut current_section = usize::MAX;
-        let mut start = 0;
-        for (atlas_handle, end) in &text_layout_info.atlases {
-            let atlas = texture_atlases.get(atlas_handle).unwrap();
-            for i in start..*end {
-                let PositionedGlyph {
-                    position,
-                    glyph_index,
-                    section_index,
-                    ..
-                } = &text_layout_info.glyphs[i];
+        for batch in &text_layout_info.batches {
+            let atlas = texture_atlases.get(&batch.texture_atlas).unwrap();
+            for PositionedGlyph {
+                position,
+                glyph_index,
+                section_index,
+                ..
+            } in &text_layout_info.glyphs[batch.range.start..batch.range.end]
+            {
                 if *section_index != current_section {
                     color = text.sections[*section_index].style.color.as_rgba_linear();
                     current_section = *section_index;
@@ -139,7 +138,6 @@ pub fn extract_text2d_sprite(
                     anchor: Anchor::Center.as_vec(),
                 });
             }
-            start = *end;
         }
     }
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -544,16 +544,16 @@ pub fn extract_text_uinodes(
 
             let mut color = Color::WHITE;
             let mut current_section = usize::MAX;
-            let mut start = 0;
-            for (atlas_handle, end) in &text_layout_info.atlases {
-                let atlas = texture_atlases.get(atlas_handle).unwrap();
-                for i in start..*end {
-                    let PositionedGlyph {
-                        position,
-                        glyph_index,
-                        section_index,
-                        ..
-                    } = &text_layout_info.glyphs[i];
+
+            for batch in &text_layout_info.batches {
+                let atlas = texture_atlases.get(&batch.texture_atlas).unwrap();
+                for PositionedGlyph {
+                    position,
+                    glyph_index,
+                    section_index,
+                    ..
+                } in &text_layout_info.glyphs[batch.range.start..batch.range.end]
+                {
                     if *section_index != current_section {
                         color = text.sections[*section_index].style.color.as_rgba_linear();
                         current_section = *section_index;
@@ -574,7 +574,6 @@ pub fn extract_text_uinodes(
                         flip_y: false,
                     });
                 }
-                start = *end;
             }
         }
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -543,26 +543,22 @@ pub fn extract_text_uinodes(
                 * Mat4::from_translation(-0.5 * uinode.size().extend(0.));
 
             let mut color = Color::WHITE;
-            let mut current_section = usize::MAX;
-            let Some(mut atlas) = text_layout_info.glyphs.get(0)
-            .map(|glyph| texture_atlases.get(&glyph.atlas_info.texture_atlas).unwrap()) else {
-            continue;
-            };
-            for (atlas_handle, count) in &text_layout_info.atlases {
-                let atlas =  texture_atlases.get(atlas_handle).unwrap();
-                for PositionedGlyph {
-                    position,
-                    glyph_index,
-                    section_index,
-                    ..
-                } in &text_layout_info.glyphs
-                {
+            let mut current_section = u32::MAX;
+            let mut start = 0;
+            for (atlas_handle, end) in &text_layout_info.atlases {
+                let atlas = texture_atlases.get(atlas_handle).unwrap();
+                for i in start..*end {
+                    let PositionedGlyph {
+                        position,
+                        glyph_index,
+                        section_index,
+                        ..
+                    } = &text_layout_info.glyphs[i];
                     if *section_index != current_section {
                         color = text.sections[*section_index as usize].style.color.as_rgba_linear();
                         current_section = *section_index;
                     }
-
-                    let mut rect = atlas.textures[glyph_index as usize];
+                    let mut rect = atlas.textures[*glyph_index as usize];
                     rect.min *= inverse_scale_factor;
                     rect.max *= inverse_scale_factor;
                     extracted_uinodes.uinodes.push(ExtractedUiNode {
@@ -577,7 +573,8 @@ pub fn extract_text_uinodes(
                         flip_x: false,
                         flip_y: false,
                     });
-                }
+                }      
+                start = *end;      
             }
         }
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -544,6 +544,10 @@ pub fn extract_text_uinodes(
 
             let mut color = Color::WHITE;
             let mut current_section = usize::MAX;
+            let Some(mut atlas) = text_layout_info.glyphs.get(0)
+            .map(|glyph| texture_atlases.get(&glyph.atlas_info.texture_atlas).unwrap()) else {
+            continue;
+            };
             for PositionedGlyph {
                 position,
                 atlas_info,
@@ -552,10 +556,10 @@ pub fn extract_text_uinodes(
             } in &text_layout_info.glyphs
             {
                 if *section_index != current_section {
+                    atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
                     color = text.sections[*section_index].style.color.as_rgba_linear();
                     current_section = *section_index;
                 }
-                let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
                 let mut rect = atlas.textures[atlas_info.glyph_index];
                 rect.min *= inverse_scale_factor;

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -543,7 +543,7 @@ pub fn extract_text_uinodes(
                 * Mat4::from_translation(-0.5 * uinode.size().extend(0.));
 
             let mut color = Color::WHITE;
-            let mut current_section = u32::MAX;
+            let mut current_section = usize::MAX;
             let mut start = 0;
             for (atlas_handle, end) in &text_layout_info.atlases {
                 let atlas = texture_atlases.get(atlas_handle).unwrap();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -555,13 +555,10 @@ pub fn extract_text_uinodes(
                         ..
                     } = &text_layout_info.glyphs[i];
                     if *section_index != current_section {
-                        color = text.sections[*section_index as usize]
-                            .style
-                            .color
-                            .as_rgba_linear();
+                        color = text.sections[*section_index].style.color.as_rgba_linear();
                         current_section = *section_index;
                     }
-                    let mut rect = atlas.textures[*glyph_index as usize];
+                    let mut rect = atlas.textures[*glyph_index];
                     rect.min *= inverse_scale_factor;
                     rect.max *= inverse_scale_factor;
                     extracted_uinodes.uinodes.push(ExtractedUiNode {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -555,7 +555,10 @@ pub fn extract_text_uinodes(
                         ..
                     } = &text_layout_info.glyphs[i];
                     if *section_index != current_section {
-                        color = text.sections[*section_index as usize].style.color.as_rgba_linear();
+                        color = text.sections[*section_index as usize]
+                            .style
+                            .color
+                            .as_rgba_linear();
                         current_section = *section_index;
                     }
                     let mut rect = atlas.textures[*glyph_index as usize];
@@ -573,8 +576,8 @@ pub fn extract_text_uinodes(
                         flip_x: false,
                         flip_y: false,
                     });
-                }      
-                start = *end;      
+                }
+                start = *end;
             }
         }
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -548,34 +548,36 @@ pub fn extract_text_uinodes(
             .map(|glyph| texture_atlases.get(&glyph.atlas_info.texture_atlas).unwrap()) else {
             continue;
             };
-            for PositionedGlyph {
-                position,
-                atlas_info,
-                section_index,
-                ..
-            } in &text_layout_info.glyphs
-            {
-                if *section_index != current_section {
-                    atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                    color = text.sections[*section_index].style.color.as_rgba_linear();
-                    current_section = *section_index;
-                }
+            for (atlas_handle, count) in &text_layout_info.atlases {
+                let atlas =  texture_atlases.get(atlas_handle).unwrap();
+                for PositionedGlyph {
+                    position,
+                    glyph_index,
+                    section_index,
+                    ..
+                } in &text_layout_info.glyphs
+                {
+                    if *section_index != current_section {
+                        color = text.sections[*section_index as usize].style.color.as_rgba_linear();
+                        current_section = *section_index;
+                    }
 
-                let mut rect = atlas.textures[atlas_info.glyph_index];
-                rect.min *= inverse_scale_factor;
-                rect.max *= inverse_scale_factor;
-                extracted_uinodes.uinodes.push(ExtractedUiNode {
-                    stack_index,
-                    transform: transform
-                        * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
-                    color,
-                    rect,
-                    image: atlas.texture.clone_weak(),
-                    atlas_size: Some(atlas.size * inverse_scale_factor),
-                    clip: clip.map(|clip| clip.clip),
-                    flip_x: false,
-                    flip_y: false,
-                });
+                    let mut rect = atlas.textures[glyph_index as usize];
+                    rect.min *= inverse_scale_factor;
+                    rect.max *= inverse_scale_factor;
+                    extracted_uinodes.uinodes.push(ExtractedUiNode {
+                        stack_index,
+                        transform: transform
+                            * Mat4::from_translation(position.extend(0.) * inverse_scale_factor),
+                        color,
+                        rect,
+                        image: atlas.texture.clone_weak(),
+                        atlas_size: Some(atlas.size * inverse_scale_factor),
+                        clip: clip.map(|clip| clip.clip),
+                        flip_x: false,
+                        flip_y: false,
+                    });
+                }
             }
         }
     }


### PR DESCRIPTION
# Objective

Most displayed text only uses one `TextureAtlas` asset but:

* `TextLayoutInfo` stores a texture atlas handle per individual glyph.
* The text extraction functions retrieve the texture atlas from assets per glyph.

fixes #9278 

## Solution

Remove the texture atlas asset handle from `PositionedGlyph`. 
Add a new field `batches: Vec<PostionedGlyphBatch>` to `TextureLayoutInfo`.
Each `PositionedGlyphBatch` consists of a texture atlas handle and a range. These ranges partition the `PositionedGlyph` list into contiguous sections sharing the same texture atlas.

Before leaving `GlyphBrush::process_glyphs` we sort the `PositionedGlyphBatch` vector by texture atlas handle ensuring that glyphs sharing the same texture are batched together during rendering.

```
cargo run --profile stress-test --features trace_tracy --example many_glyphs
```

<img width="495" alt="extract_text_uinodes_textlayoutinfo_refactor" src="https://github.com/bevyengine/bevy/assets/27962798/3c1f90c7-9681-4f0a-baf8-be891a7856e0">

<img width="539" alt="extract_text2d_textlayoutinfo_refactor" src="https://github.com/bevyengine/bevy/assets/27962798/7f8ddb67-5916-4d1c-bca9-aafe269977ba">


The Bevy stress test examples don't capture the batching change improvements. This example reports 25% better fps on the textlayout-refactor branch compared to main on my computer:

```rust
use bevy::{
    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
    prelude::*,
    text::BreakLineOn,
    window::{PresentMode, WindowPlugin},
};

fn main() {
    let mut app = App::new();
    app.add_plugins((
        DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                present_mode: PresentMode::AutoNoVsync,
                ..default()
            }),
            ..default()
        }),
        FrameTimeDiagnosticsPlugin,
        LogDiagnosticsPlugin::default(),
    ))
    .add_systems(Startup, setup);
    app.run();
}

fn setup(mut commands: Commands) {
    commands.spawn(Camera2dBundle::default());
    let sections = 
        (0..1_000).map(|n| {
            TextSection {
                value: "0123456789".to_string(),
                style: TextStyle {
                    font_size: 10. * (1 + n % 5) as f32,
                    color: Color::WHITE,
                    ..default()
                },
            }
        }).collect();

    let text = Text {
        sections,
        alignment: TextAlignment::Left,
        linebreak_behavior: BreakLineOn::AnyCharacter,
    };

    commands
        .spawn(NodeBundle {
            style: Style {
                flex_basis: Val::Percent(100.),
                align_items: AlignItems::Center,
                justify_content: JustifyContent::Center,
                ..default()
            },
            ..default()
        })
        .with_children(|commands| {
            commands.spawn(TextBundle {
                text: text.clone(),
                style: Style {
                    width: Val::Px(1000.),
                    ..Default::default()
                },
                ..Default::default()
            });
        });
}
```

---

## Changelog
`TextLayoutInfo`
* Added a field `atlases: Vec<(Handle<TextureAtlas>, usize)>` to hold the atlas handles for the fonts instead of individual `PositionedGlyphs`.

`PositionedGlyph`:
* Removed `atlas_info` field. 
* Added `glyph_index: usize` field.

`extract_text2d_sprite` & `extract_text_uinodes`:
* Added an outer loop to text extraction that iterates through `TextLayoutInfo`'s atlas handle list.

`GlyphBrush::process_glyphs`:
* Generates and returns a second vector holding the list of texture atlas handles.

## Migration Guide
`TextLayoutInfo` no longer stores texture atlas handles per glyph but instead in a separate vector `atlases`.