### PR TITLE
support running bevy off the main thread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,11 @@ bevy_asset = ["bevy_internal/bevy_asset"]
 bevy_audio = ["bevy_internal/bevy_audio"]
 
 # Provides cameras and other basic render pipeline features
-bevy_core_pipeline = ["bevy_internal/bevy_core_pipeline", "bevy_asset", "bevy_render"]
+bevy_core_pipeline = [
+  "bevy_internal/bevy_core_pipeline",
+  "bevy_asset",
+  "bevy_render",
+]
 
 # Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading))
 bevy_dynamic_plugin = ["bevy_internal/bevy_dynamic_plugin"]
@@ -84,7 +88,12 @@ bevy_gilrs = ["bevy_internal/bevy_gilrs"]
 bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
 
 # Adds PBR rendering
-bevy_pbr = ["bevy_internal/bevy_pbr", "bevy_asset", "bevy_render", "bevy_core_pipeline"]
+bevy_pbr = [
+  "bevy_internal/bevy_pbr",
+  "bevy_asset",
+  "bevy_render",
+  "bevy_core_pipeline",
+]
 
 # Provides rendering functionality
 bevy_render = ["bevy_internal/bevy_render"]
@@ -99,7 +108,12 @@ bevy_sprite = ["bevy_internal/bevy_sprite", "bevy_render", "bevy_core_pipeline"]
 bevy_text = ["bevy_internal/bevy_text", "bevy_asset", "bevy_sprite"]
 
 # A custom ECS-driven UI framework
-bevy_ui = ["bevy_internal/bevy_ui", "bevy_core_pipeline", "bevy_text", "bevy_sprite"]
+bevy_ui = [
+  "bevy_internal/bevy_ui",
+  "bevy_core_pipeline",
+  "bevy_text",
+  "bevy_sprite",
+]
 
 # winit window and input backend
 bevy_winit = ["bevy_internal/bevy_winit"]
@@ -114,7 +128,11 @@ trace_chrome = ["trace", "bevy_internal/trace_chrome"]
 trace_tracy = ["trace", "bevy_internal/trace_tracy"]
 
 # Tracing support, with memory profiling, exposing a port for Tracy
-trace_tracy_memory = ["trace", "bevy_internal/trace_tracy", "bevy_internal/trace_tracy_memory"]
+trace_tracy_memory = [
+  "trace",
+  "bevy_internal/trace_tracy",
+  "bevy_internal/trace_tracy_memory",
+]
 
 # Tracing support
 trace = ["bevy_internal/trace"]
@@ -202,6 +220,9 @@ serialize = ["bevy_internal/serialize"]
 
 # Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.
 multi-threaded = ["bevy_internal/multi-threaded"]
+
+# Enable running winit off the main thread on Windows or Linux
+window-off-main = ["bevy_internal/window-off-main"]
 
 # Wayland display server support
 wayland = ["bevy_internal/wayland"]
@@ -2274,6 +2295,19 @@ hidden = true
 name = "window_resizing"
 path = "examples/window/window_resizing.rs"
 doc-scrape-examples = true
+
+
+[[example]]
+name = "window_off_main"
+path = "examples/window/window_off_main.rs"
+doc-scrape-examples = true
+required-features = ["window-off-main"]
+
+[package.metadata.example.window_off_main]
+name = "Window Off Main"
+description = "Illustrates running bevy on a secondary thread"
+category = "Window"
+wasm = false
 
 [[example]]
 name = "fallback_image"

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -17,10 +17,10 @@ trace = [
     "bevy_log/trace",
     "bevy_render?/trace",
     "bevy_hierarchy/trace",
-    "bevy_winit?/trace"
+    "bevy_winit?/trace",
 ]
-trace_chrome = [ "bevy_log/tracing-chrome" ]
-trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy" ]
+trace_chrome = ["bevy_log/tracing-chrome"]
+trace_tracy = ["bevy_render?/tracing-tracy", "bevy_log/tracing-tracy"]
 trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 debug_asset_server = ["bevy_asset/debug_asset_server"]
@@ -65,8 +65,19 @@ shader_format_spirv = ["bevy_render/shader_format_spirv"]
 # Enable watching file system for asset hot reload
 filesystem_watcher = ["bevy_asset/filesystem_watcher"]
 
-serialize = ["bevy_core/serialize", "bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize", "bevy_scene/serialize"]
+serialize = [
+    "bevy_core/serialize",
+    "bevy_input/serialize",
+    "bevy_time/serialize",
+    "bevy_window/serialize",
+    "bevy_transform/serialize",
+    "bevy_math/serialize",
+    "bevy_scene/serialize",
+]
 multi-threaded = ["bevy_ecs/multi-threaded", "bevy_tasks/multi-threaded"]
+
+# Enable running winit off the main thread on Windows or Linux
+window-off-main = ["bevy_winit/window-off-main"]
 
 # Display server protocol support (X11 is enabled by default)
 wayland = ["bevy_winit/wayland"]
@@ -76,10 +87,20 @@ x11 = ["bevy_winit/x11"]
 subpixel_glyph_atlas = ["bevy_text/subpixel_glyph_atlas"]
 
 # Optimise for WebGL2
-webgl = ["bevy_core_pipeline?/webgl", "bevy_pbr?/webgl", "bevy_render?/webgl", "bevy_gizmos?/webgl"]
+webgl = [
+    "bevy_core_pipeline?/webgl",
+    "bevy_pbr?/webgl",
+    "bevy_render?/webgl",
+    "bevy_gizmos?/webgl",
+]
 
 # enable systems that allow for automated testing on CI
-bevy_ci_testing = ["bevy_app/bevy_ci_testing", "bevy_time/bevy_ci_testing", "bevy_render?/bevy_ci_testing", "bevy_render?/ci_limits"]
+bevy_ci_testing = [
+    "bevy_app/bevy_ci_testing",
+    "bevy_time/bevy_ci_testing",
+    "bevy_render?/bevy_ci_testing",
+    "bevy_render?/ci_limits",
+]
 
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]
@@ -118,7 +139,9 @@ bevy_input = { path = "../bevy_input", version = "0.12.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.12.0-dev" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = ["bevy"] }
+bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = [
+    "bevy",
+] }
 bevy_time = { path = "../bevy_time", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -13,6 +13,7 @@ trace = []
 wayland = ["winit/wayland", "winit/wayland-csd-adwaita"]
 x11 = ["winit/x11"]
 accesskit_unix = ["accesskit_winit/accesskit_unix", "accesskit_winit/async-io"]
+window-off-main = []
 
 [dependencies]
 # bevy
@@ -34,7 +35,9 @@ approx = { version = "0.5", default-features = false }
 raw-window-handle = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.28", default-features = false, features = ["android-native-activity"] }
+winit = { version = "0.28", default-features = false, features = [
+    "android-native-activity",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -100,7 +100,7 @@ impl Plugin for WinitPlugin {
 
         #[cfg(all(target_os = "linux", feature = "window-off-main", feature = "x11"))]
         {
-            use winit::platform::wayland::EventLoopBuilderExtX11;
+            use winit::platform::x11::EventLoopBuilderExtX11;
             event_loop_builder.with_any_thread(true);
         }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -86,6 +86,24 @@ impl Plugin for WinitPlugin {
             );
         }
 
+        #[cfg(all(target_os = "windows", feature = "window-off-main"))]
+        {
+            use winit::platform::windows::EventLoopBuilderExtWindows;
+            event_loop_builder.with_any_thread(true);
+        }
+
+        #[cfg(all(target_os = "linux", feature = "window-off-main", feature = "wayland"))]
+        {
+            use winit::platform::wayland::EventLoopBuilderExtWayland;
+            event_loop_builder.with_any_thread(true);
+        }
+
+        #[cfg(all(target_os = "linux", feature = "window-off-main", feature = "x11"))]
+        {
+            use winit::platform::wayland::EventLoopBuilderExtX11;
+            event_loop_builder.with_any_thread(true);
+        }
+
         app.init_non_send_resource::<WinitWindows>()
             .init_resource::<WinitSettings>()
             .set_runner(winit_runner)
@@ -422,20 +440,20 @@ pub fn winit_runner(mut app: App) {
                     event_writer_system_state.get_mut(&mut app.world);
 
                 let Some(window_entity) = winit_windows.get_window_entity(window_id) else {
-                        warn!(
-                            "Skipped event {:?} for unknown winit Window Id {:?}",
-                            event, window_id
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Skipped event {:?} for unknown winit Window Id {:?}",
+                        event, window_id
+                    );
+                    return;
+                };
 
                 let Ok((mut window, mut cache)) = windows.get_mut(window_entity) else {
-                        warn!(
-                            "Window {:?} is missing `Window` component, skipping event {:?}",
-                            window_entity, event
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Window {:?} is missing `Window` component, skipping event {:?}",
+                        window_entity, event
+                    );
+                    return;
+                };
 
                 runner_state.window_event_received = true;
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -78,4 +78,5 @@ The default feature set enables most of the expected features of a game engine, 
 |wayland|Wayland display server support|
 |webp|WebP image format support|
 |wgpu_trace|Save a trace of all wgpu calls|
+|window-off-main|Enable running winit off the main thread on Windows or Linux|
 |zlib|For KTX2 supercompression|

--- a/examples/README.md
+++ b/examples/README.md
@@ -372,6 +372,7 @@ Example | Description
 [Transparent Window](../examples/window/transparent_window.rs) | Illustrates making the window transparent and hiding the window decoration
 [Window Resizing](../examples/window/window_resizing.rs) | Demonstrates resizing and responding to resizing a window
 [Window Settings](../examples/window/window_settings.rs) | Demonstrates customizing default window settings
+[Window Off Main](../examples/window/window_off_main.rs) | Demonstrates running the window calls off the main thread, allowing Bevy to be launched in a secondary thread. Note that this only works on Windows & Linux.
 
 # Tests
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -370,9 +370,9 @@ Example | Description
 [Scale Factor Override](../examples/window/scale_factor_override.rs) | Illustrates how to customize the default window settings
 [Screenshot](../examples/window/screenshot.rs) | Shows how to save screenshots to disk
 [Transparent Window](../examples/window/transparent_window.rs) | Illustrates making the window transparent and hiding the window decoration
+[Window Off Main](../examples/window/window_off_main.rs) | Illustrates running bevy on a secondary thread
 [Window Resizing](../examples/window/window_resizing.rs) | Demonstrates resizing and responding to resizing a window
 [Window Settings](../examples/window/window_settings.rs) | Demonstrates customizing default window settings
-[Window Off Main](../examples/window/window_off_main.rs) | Demonstrates running the window calls off the main thread, allowing Bevy to be launched in a secondary thread. Note that this only works on Windows & Linux.
 
 # Tests
 

--- a/examples/window/window_off_main.rs
+++ b/examples/window/window_off_main.rs
@@ -3,9 +3,7 @@
 use std::sync::mpsc;
 
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
 };
 use bevy_internal::winit::WinitSettings;
 

--- a/examples/window/window_off_main.rs
+++ b/examples/window/window_off_main.rs
@@ -31,10 +31,10 @@ fn main() {
         if typed == "exit" {
             return;
         }
-            if end_rx.try_recv().is_ok() {
-                return;
-            }
-            tx.send(typed);
+        if end_rx.try_recv().is_ok() {
+            return;
+        }
+        let _ = tx.send(typed);
     }
 }
 
@@ -58,7 +58,7 @@ fn run_bevy(rx: mpsc::Receiver<String>, end_tx: mpsc::Sender<()>) {
             .add_systems(Update, system)
             .run();
         println!("Exited the window - press anything to exit the app");
-        end_tx.send(());
+        let _ = end_tx.send(());
     });
 }
 

--- a/examples/window/window_off_main.rs
+++ b/examples/window/window_off_main.rs
@@ -20,23 +20,21 @@ fn main() {
         let typed: String = line.unwrap_or_default();
         if typed == "exit" {
             return;
-        } else {
-            run_bevy(rx, end_tx);
-            println!("Spawned a bevy window!");
-            println!("Now - type things in the terminal, and they will show up in the bevy UI, or type 'exit' to exit");
         }
+        run_bevy(rx, end_tx);
+        println!("Spawned a bevy window!");
+        println!("Now - type things in the terminal, and they will show up in the bevy UI, or type 'exit' to exit");
     }
 
     for line in std::io::stdin().lines() {
         let typed: String = line.unwrap_or_default();
         if typed == "exit" {
             return;
-        } else {
+        }
             if end_rx.try_recv().is_ok() {
                 return;
             }
             tx.send(typed);
-        }
     }
 }
 

--- a/examples/window/window_off_main.rs
+++ b/examples/window/window_off_main.rs
@@ -2,9 +2,7 @@
 
 use std::sync::mpsc;
 
-use bevy::{
-    prelude::*,
-};
+use bevy::prelude::*;
 use bevy_internal::winit::WinitSettings;
 
 fn main() {

--- a/examples/window/window_off_main.rs
+++ b/examples/window/window_off_main.rs
@@ -1,0 +1,117 @@
+//! Illustrates how to use bevy off the main thread
+
+use std::sync::mpsc;
+
+use bevy::{
+    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    prelude::*,
+    window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
+};
+use bevy_internal::winit::WinitSettings;
+
+fn main() {
+    println!("Press Enter to spawn the bevy thread, or type 'exit' to exit");
+
+    let (tx, rx) = mpsc::channel();
+    let (end_tx, end_rx) = mpsc::channel();
+
+    {
+        let Some(line) = std::io::stdin().lines().next() else {
+            eprintln!("No Lines");
+            return;
+        };
+
+        let typed: String = line.unwrap_or_default();
+        if typed == "exit" {
+            return;
+        } else {
+            run_bevy(rx, end_tx);
+            println!("Spawned a bevy window!");
+            println!("Now - type things in the terminal, and they will show up in the bevy UI, or type 'exit' to exit");
+        }
+    }
+
+    for line in std::io::stdin().lines() {
+        let typed: String = line.unwrap_or_default();
+        if typed == "exit" {
+            return;
+        } else {
+            if end_rx.try_recv().is_ok() {
+                return;
+            }
+            tx.send(typed);
+        }
+    }
+}
+
+fn run_bevy(rx: mpsc::Receiver<String>, end_tx: mpsc::Sender<()>) {
+    std::thread::spawn(move || {
+        App::new()
+            .insert_resource(WinitSettings {
+                return_from_run: true,
+                ..default()
+            })
+            .insert_resource(ClearColor(Color::WHITE))
+            .insert_non_send_resource(TextReceiver(rx))
+            .add_plugins(DefaultPlugins.set(WindowPlugin {
+                primary_window: Some(Window {
+                    title: "Close the window to return to the main function".into(),
+                    ..default()
+                }),
+                ..default()
+            }))
+            .add_systems(Startup, setup)
+            .add_systems(Update, system)
+            .run();
+        println!("Exited the window - press anything to exit the app");
+        end_tx.send(());
+    });
+}
+
+struct TextReceiver(mpsc::Receiver<String>);
+
+#[derive(Component)]
+struct Root;
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn((
+        Root,
+        NodeBundle {
+            style: Style {
+                flex_direction: FlexDirection::Column,
+                position_type: PositionType::Absolute,
+                top: Val::Px(0.),
+                left: Val::Px(0.),
+                bottom: Val::Px(0.),
+                right: Val::Px(0.),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ));
+}
+
+fn system(
+    rx: NonSend<TextReceiver>,
+    mut commands: Commands,
+    root: Query<Entity, With<Root>>,
+    asset_server: Res<AssetServer>,
+) {
+    if let Ok(msg) = rx.0.try_recv() {
+        if let Ok(root) = root.get_single() {
+            commands.entity(root).with_children(|p| {
+                p.spawn(TextBundle::from_section(
+                    msg,
+                    TextStyle {
+                        font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                        font_size: 30.0,
+                        color: Color::BLACK,
+                    },
+                ));
+            });
+        }
+    }
+}


### PR DESCRIPTION
# Objective

Adds support for running bevy off the main thread on Windows & Linux. This would be useful for embedding bevy (with it's built in winit plugin) in a non-bevy app while allowing sharing data using things like channels rather than inter-process communication. It's also needed by my hot-reload plugin, which currently forks bevy-winit.

## Solution

Set up a `window-off-main` feature for bevy-winit, and if so set the winit `with_any_thread` flag to true on supported systems.

---

## Changelog
- Added a `window-off-main` feature to bevy-winit, bevy-internal and bevy
- Added 3 feature & target gated sections - one for windows, one for wayland and one for x11 - each containing a single function call to set `with_any_thread`.
- Added a `window_off_main` example in the "window" section of the examples folder, and added the corresponding reference in the readme and in the root cargo.toml