### PR TITLE
Asset IO `read_directory` No Longer Panics on Absolute Path

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -33,6 +33,7 @@ fastrand = "1.7.0"
 notify = { version = "6.0.0", optional = true }
 parking_lot = "0.12.1"
 async-channel = "1.4.2"
+pathdiff = "0.2.1"
 
 [target.'cfg(target_os = "android")'.dependencies]
 bevy_winit = { path = "../bevy_winit", version = "0.12.0-dev" }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -117,7 +117,7 @@ impl AssetIo for FileAssetIo {
         Ok(Box::new(fs::read_dir(root_path.join(path))?.map(
             move |entry| {
                 let path = entry.unwrap().path();
-                path.strip_prefix(&root_path).unwrap().to_owned()
+                pathdiff::diff_paths(path, root_path.as_path()).unwrap()
             },
         )))
     }

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -117,7 +117,8 @@ impl AssetIo for FileAssetIo {
         Ok(Box::new(fs::read_dir(root_path.join(path))?.map(
             move |entry| {
                 let path = entry.unwrap().path();
-                pathdiff::diff_paths(path, root_path.as_path()).unwrap()
+                pathdiff::diff_paths(path, root_path.as_path())
+                    .expect("Cannot create a relative path from 'root_path' to 'path'")
             },
         )))
     }


### PR DESCRIPTION
# Objective

- Fixes #9458

## Solution

- Used `pathdiff::diff_paths` to explicitly create the desired path, which handles the edge case where a provided path is actually an absolute path already, and thus cannot be stripped of a prefix of the general root path for the Asset IO.
- Based on [my previous comment](https://github.com/bevyengine/bevy/issues/9458#issuecomment-1681602799)

---

## Changelog

- Added `pathdiff` crate to `bevy_asset` to allow for the creation of relative paths in a platform agnostic manner.
- Fixed `read_directory` incorrectly assuming `a.join(b).strip_prefix(a) == Ok(b)` 
