### PR TITLE
Remove Resource and add Debug to TaskPoolOptions

### DIFF
--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -1,10 +1,9 @@
-use bevy_ecs::prelude::Resource;
 use bevy_tasks::{AsyncComputeTaskPool, ComputeTaskPool, IoTaskPool, TaskPoolBuilder};
 use bevy_utils::tracing::trace;
 
 /// Defines a simple way to determine how many threads to use given the number of remaining cores
 /// and number of total cores
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct TaskPoolThreadAssignmentPolicy {
     /// Force using at least this many threads
     pub min_threads: usize,
@@ -33,7 +32,7 @@ impl TaskPoolThreadAssignmentPolicy {
 
 /// Helper for configuring and creating the default task pools. For end-users who want full control,
 /// set up [`TaskPoolPlugin`](super::TaskPoolPlugin)
-#[derive(Clone, Resource)]
+#[derive(Clone, Debug)]
 pub struct TaskPoolOptions {
     /// If the number of physical cores is less than min_total_threads, force using
     /// min_total_threads


### PR DESCRIPTION
# Objective

PR #6360 changed `TaskPoolOptions` so it is no longer used as a Resource, but didn't remove the `Resource` derive.

## Solution

Remove the Resource derive from `TaskPoolOptions`, as it is no longer needed. Also add a Debug derive, because it didn't have it before.

---

## Changelog

- `TaskPoolOptions` no longer derives Resource, and `TaskPoolOptions` & `TaskPoolThreadAssignmentPolicy` now derive Debug.

## Migration Guide

If for some reason anyone is still using `TaskPoolOptions` as a Resource, they would now have to use a wrapper type:
```rust
#[derive(Resource)]
pub struct MyTaskPoolOptions(pub TaskPoolOptions);
```