### PR TITLE
Make `GridPlacement`'s fields non-zero and add accessor functions.

### DIFF
--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -278,8 +278,8 @@ impl From<GridAutoFlow> for taffy::style::GridAutoFlow {
 
 impl From<GridPlacement> for taffy::geometry::Line<taffy::style::GridPlacement> {
     fn from(value: GridPlacement) -> Self {
-        let span = value.span.unwrap_or(1).max(1);
-        match (value.start, value.end) {
+        let span = value.get_span().unwrap_or(1);
+        match (value.get_start(), value.get_end()) {
             (Some(start), Some(end)) => taffy::geometry::Line {
                 start: style_helpers::line(start),
                 end: style_helpers::line(end),
@@ -463,8 +463,8 @@ mod tests {
                 GridTrack::min_content(),
                 GridTrack::max_content(),
             ],
-            grid_column: GridPlacement::start(4),
-            grid_row: GridPlacement::span(3),
+            grid_column: GridPlacement::start(4).unwrap(),
+            grid_row: GridPlacement::span(3).unwrap(),
         };
         let viewport_values = LayoutContext::new(1.0, bevy_math::Vec2::new(800., 600.));
         let taffy_style = from_style(&viewport_values, &bevy_style);

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -53,7 +53,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                     style: Style {
                         display: Display::Grid,
                         /// Make this node span two grid columns so that it takes up the entire top tow
-                        grid_column: GridPlacement::span(2),
+                        grid_column: GridPlacement::span(2).unwrap(),
                         padding: UiRect::all(Val::Px(6.0)),
                         ..default()
                     },
@@ -162,7 +162,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
             builder.spawn(NodeBundle {
                 style: Style {
                     // Make this node span two grid column so that it takes up the entire bottom row
-                    grid_column: GridPlacement::span(2),
+                    grid_column: GridPlacement::span(2).unwrap(),
                     ..default()
                 },
                 background_color: BackgroundColor(Color::WHITE),


### PR DESCRIPTION
# Objective

* There is no way to read the fields of `GridPlacement` once set. 
* Values of `0` for `GridPlacement`'s fields are invalid but can be set.
* Non-zero representation would be half the size.

fixes #9474

## Solution
* Add `get_start`, `get_end` and `get_span` accessor methods.
* Change`GridPlacement`'s constructor functions to return a result, with errors on arguments of zero.
* Use non-zero types instead of primitives for `GridPlacement`'s fields.

---

## Changelog

`bevy_ui::ui_node::GridPlacement`:
* Field types have been changed to `Option<NonZeroI16>` and `Option<NonZeroU16>`. This is because zero values are not valid for `GridPlacement`. Previously, Taffy interpreted these as auto variants.
* Constructor functions for `GridPlacement` that accept numeric values now return `Result<GridPlacement, GridPlacementError>`. Arguments of `0` are invalid, resulting in a `GridPlacementError`.
* Added accessor functions: `get_start`, `get_end`, and `get_span`. These return the inner primitive value (if present) of the respective fields.

## Migration Guide

Constructor functions for `GridPlacement` that accept numeric values now return `Result<GridPlacement, GridPlacementError>`. Arguments of `0` are invalid, resulting in a `GridPlacementError`.
