### PR TITLE
Fix panic when using `.load_folder()` with absolute paths

### DIFF
--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -114,10 +114,11 @@ impl AssetIo for FileAssetIo {
         path: &Path,
     ) -> Result<Box<dyn Iterator<Item = PathBuf>>, AssetIoError> {
         let root_path = self.root_path.to_owned();
-        Ok(Box::new(fs::read_dir(root_path.join(path))?.map(
+        let path = path.to_owned();
+        Ok(Box::new(fs::read_dir(root_path.join(&path))?.map(
             move |entry| {
-                let path = entry.unwrap().path();
-                path.strip_prefix(&root_path).unwrap().to_owned()
+                let file_name = entry.unwrap().file_name();
+                path.join(file_name)
             },
         )))
     }


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/9458.

On case-insensitive filesystems (Windows, Mac, NTFS mounted in Linux, etc.), a path can be represented in a multiple ways:

 - `c:\users\user\rust\assets\hello\world`
 - `c:/users/user/rust/assets/hello/world`
 - `C:\USERS\USER\rust\assets\hello\world`

If user specifies a path variant that doesn't match asset folder path bevy calculates, `path.strip_prefix()` will fail, as demonstrated below:

```rs
dbg!(Path::new("c:/foo/bar/baz").strip_prefix("c:/foo"));
// Ok("bar/baz")

dbg!(Path::new("c:/FOO/bar/baz").strip_prefix("c:/foo"));
// StripPrefixError(())
```

This commit rewrites the code in question in a way that prefix stripping is no longer necessary.

I've tested with the following paths on my computer:

```rs
let res = asset_server.load_folder("C:\\Users\\user\\rust\\assets\\foo\\bar");
dbg!(res);

let res = asset_server.load_folder("c:\\users\\user\\rust\\assets\\foo\\bar");
dbg!(res);

let res = asset_server.load_folder("C:/Users/user/rust/assets/foo/bar");
dbg!(res);
```