### PR TITLE
Fix point light radius

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -858,7 +858,7 @@ fn load_node(
                             // For a point light, luminous power = 4 * pi * luminous intensity
                             intensity: light.intensity() * std::f32::consts::PI * 4.0,
                             range: light.range().unwrap_or(20.0),
-                            radius: light.range().unwrap_or(0.0),
+                            radius: 0.0,
                             ..Default::default()
                         },
                         ..Default::default()


### PR DESCRIPTION
# Objective

Fixes #9488

## Solution

Set point light radius to always be 0.0. Reading this value from glTF would require using application specific extras property.

---

## Changelog

### Fixed

- #9488 Point Lights use Range for Radius when importing from GLTF

