### PR TITLE
fix wireframe after MeshUniform size reduction

### DIFF
--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -23,7 +23,7 @@ fn vertex(vertex: Vertex) -> VertexOutput {
 #ifdef SKINNED
     let model = bevy_pbr::skinning::skin_model(vertex.joint_indexes, vertex.joint_weights);
 #else
-    let model = get_model_matrix(vertex_no_morph.instance_index);
+    let model = get_model_matrix(vertex.instance_index);
 #endif
 
     var out: VertexOutput;


### PR DESCRIPTION
# Objective

- Wireframe currently don't display since #9416
- There is an error
```
2023-08-20T10:06:54.190347Z ERROR bevy_render::render_resource::pipeline_cache: failed to process shader:
error: no definition in scope for identifier: 'vertex_no_morph'
   ┌─ crates/bevy_pbr/src/render/wireframe.wgsl:26:94
   │
26 │     let model = bevy_pbr::mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
   │                                                                                              ^^^^^^^^^^^^^^^ unknown identifier
   │
   = no definition in scope for identifier: 'vertex_no_morph'
```

## Solution

- Use the correct identifier
