### PR TITLE
bevy_reflect: Implement Reflect support for various rand_* crates

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -39,6 +39,10 @@ smallvec = { version = "1.6", features = [
 ], optional = true }
 glam = { version = "0.24", features = ["serde"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
+rand_chacha = { version = "0.3", features = ["serde1"], optional = true }
+wyrand = { version = "0.1", features = ["serde1"], optional = true }
+rand_pcg = { version = "0.3", features = ["serde1"], optional = true }
+rand_xoshiro = { version = "0.6", features = ["serde1"], optional = true }
 
 [dev-dependencies]
 ron = "0.8.0"

--- a/crates/bevy_reflect/src/impls/rand_chacha.rs
+++ b/crates/bevy_reflect/src/impls/rand_chacha.rs
@@ -1,0 +1,24 @@
+use crate::{self as bevy_reflect};
+use crate::{ReflectDeserialize, ReflectSerialize};
+use bevy_reflect_derive::impl_reflect_value;
+
+impl_reflect_value!(::rand_chacha::ChaCha8Rng(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_chacha::ChaCha12Rng(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_chacha::ChaCha20Rng(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));

--- a/crates/bevy_reflect/src/impls/rand_pcg.rs
+++ b/crates/bevy_reflect/src/impls/rand_pcg.rs
@@ -1,0 +1,14 @@
+use crate::{self as bevy_reflect};
+use crate::{ReflectDeserialize, ReflectSerialize};
+use bevy_reflect_derive::impl_reflect_value;
+
+impl_reflect_value!(::rand_pcg::Pcg32(Debug, PartialEq, Serialize, Deserialize));
+
+impl_reflect_value!(::rand_pcg::Pcg64(Debug, PartialEq, Serialize, Deserialize));
+
+impl_reflect_value!(::rand_pcg::Pcg64Mcg(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));

--- a/crates/bevy_reflect/src/impls/rand_xoshiro.rs
+++ b/crates/bevy_reflect/src/impls/rand_xoshiro.rs
@@ -1,0 +1,94 @@
+use crate::{self as bevy_reflect};
+use crate::{ReflectDeserialize, ReflectSerialize};
+use bevy_reflect_derive::impl_reflect_value;
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro512StarStar(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro512PlusPlus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro512Plus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro256StarStar(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro256PlusPlus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro256Plus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro128StarStar(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro128PlusPlus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoshiro128Plus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoroshiro128StarStar(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoroshiro128PlusPlus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::Xoroshiro128Plus(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));
+
+impl_reflect_value!(::rand_xoshiro::SplitMix64(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize
+));

--- a/crates/bevy_reflect/src/impls/wyrand.rs
+++ b/crates/bevy_reflect/src/impls/wyrand.rs
@@ -1,0 +1,5 @@
+use crate::{self as bevy_reflect};
+use crate::{ReflectDeserialize, ReflectSerialize};
+use bevy_reflect_derive::impl_reflect_value;
+
+impl_reflect_value!(::wyrand::WyRand(Debug, PartialEq, Serialize, Deserialize));

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -484,24 +484,40 @@ mod type_uuid_impl;
 mod impls {
     #[cfg(feature = "glam")]
     mod glam;
+    #[cfg(feature = "rand_chacha")]
+    mod rand_chacha;
+    #[cfg(feature = "rand_pcg")]
+    mod rand_pcg;
+    #[cfg(feature = "rand_xoshiro")]
+    mod rand_xoshiro;
     #[cfg(feature = "bevy_math")]
     mod rect;
     #[cfg(feature = "smallvec")]
     mod smallvec;
     #[cfg(feature = "smol_str")]
     mod smol_str;
+    #[cfg(feature = "wyrand")]
+    mod wyrand;
 
     mod std;
     mod uuid;
 
     #[cfg(feature = "glam")]
     pub use self::glam::*;
+    #[cfg(feature = "rand_chacha")]
+    pub use self::rand_chacha::*;
+    #[cfg(feature = "rand_pcg")]
+    pub use self::rand_pcg::*;
+    #[cfg(feature = "rand_xoshiro")]
+    pub use self::rand_xoshiro::*;
     #[cfg(feature = "bevy_math")]
     pub use self::rect::*;
     #[cfg(feature = "smallvec")]
     pub use self::smallvec::*;
     pub use self::std::*;
     pub use self::uuid::*;
+    #[cfg(feature = "wyrand")]
+    pub use self::wyrand::*;
 }
 
 mod enums;


### PR DESCRIPTION
# Objective

As a follow-up to https://github.com/bevyengine/bevy/pull/9140, implementing `Reflect` on various rand PRNG crates will allow `bevy_rand` to do away with the `TypePath` override and have fully stable `TypePath` without any `std::any:type_name` fallback for the generic wrapper component/resource.

## Solution

Provide opt-in reflection implementations for several `rand` crates. The features for each crate are optional and require explicit opt-in in `bevy_reflect`, so this will not add any additional dependencies on a default bevy install.

A number of crates were chosen on providing a selection of PRNG algorithm choices (ChaCha for cryptographically secure PRNG, PCG + Xoshiro + Wyrand for non-cryptographic PRNGs) so users can select the best ones for their needs. `rand` types like `StdRng` and `SmallRng` are not provided as they are not portable/stable. They have no guarantees that the underlying algorithms will be stable between different versions of `rand`, and for `SmallRng`, it has a different algorithm depending if you are on a 64-bit or 32-bit platform. As such, those who are prioritising usage of those types are not going to care about determinism nor about serialising/deserialising these types, and will be using them directly (via `thread_rng` et al) instead of trying to integrate them into the ECS. `OsRng` is based on hardware/OS sources, so it is not a serialisable type anyway. `rand` itself recommends from their docs that if one wants to prioritise stability/portability of PRNGs, to use the algorithm crates like `rand_chacha` directly.

This fixes issues in `bevy_rand` with it having non-stable `TypePath`.

---

## Changelog

### Added

- Implement Reflect support for various rand_* crates
