### PR TITLE
Remove the bevy_dylib feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ default = [
 ]
 
 # Force dynamic linking, which improves iterative compile times
-dynamic_linking = ["bevy_dylib", "bevy_internal/dynamic_linking"]
+dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
 
 # Provides animation functionality
 bevy_animation = ["bevy_internal/bevy_animation"]


### PR DESCRIPTION
# Objective

There is a `bevy_dylib` feature that cargo automatically creates due to the bevy_dylib crate being optional. 

This can be a footgun as I think we want users to always use the `dynamic_linking` feature for this. For example `bevy_dylib` was used in [ridiculous_bevy_hot_reloading:lib.rs#L93](https://github.com/DGriffin91/ridiculous_bevy_hot_reloading/blob/400099bcc10f4ef974af491f55e8acefe273e4bc/src/lib.rs#L93) and since I was using dynamic_linking it ended up hot reloading with a slightly different configured library causing hot reloading to fail.

## Solution

Use "dep:" syntax in the `dynamic_linking` feature to prevent bevy_dylib automatically becoming a cargo feature. This is documented here: https://doc.rust-lang.org/cargo/reference/features.html#optional-dependencies

It will now raise this error when you try to compile with the bevy_dylib feature:

> error: Package `bevy v0.12.0-dev (C:\Users\Paul\Projects\Rust\bevy)` does not have feature `bevy_dylib`. It has an optional dependency with that name, but that dependency uses the "dep:" syntax in the features table, so it does not have an implicit feature with that name.


---

## Changelog

`bevy_dylib` is no longer a feature

## Migration Guide

If you were using Bevy's `bevy_dylib` feature, use Bevy's `dynamic_linking` feature instead.

```shell
# 0.11
cargo run --features bevy/bevy_dylib

# 0.12
cargo run --features bevy/dynamic_linking
```

```toml
[dependencies]
# 0.11
bevy = { version = "0.11", features = ["bevy_dylib"] }

# 0.12
bevy = { version = "0.12", features = ["dynamic_linking"] }
```
