### PR TITLE
Add `Without<Parent>` filter to `sync_simple_transforms`' orphaned entities query

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -511,9 +511,13 @@ mod test {
         // Child should be positioned relative to its parent
         let parent_global_transform = *world.entity(parent).get::<GlobalTransform>().unwrap();
         let child_global_transform = *world.entity(child).get::<GlobalTransform>().unwrap();
-        assert!(parent_global_transform.translation().abs_diff_eq(translation, 0.1));
-        assert!(child_global_transform.translation().abs_diff_eq(2.* translation, 0.1));
-        
+        assert!(parent_global_transform
+            .translation()
+            .abs_diff_eq(translation, 0.1));
+        assert!(child_global_transform
+            .translation()
+            .abs_diff_eq(2. * translation, 0.1));
+
         // Reparent child
         world.entity_mut(child).remove_parent();
         world.entity_mut(parent).add_child(child);
@@ -522,7 +526,13 @@ mod test {
         schedule.run(&mut world);
 
         // Translations should be unchanged after update
-        assert_eq!(parent_global_transform, *world.entity(parent).get::<GlobalTransform>().unwrap());
-        assert_eq!(child_global_transform, *world.entity(child).get::<GlobalTransform>().unwrap());
+        assert_eq!(
+            parent_global_transform,
+            *world.entity(parent).get::<GlobalTransform>().unwrap()
+        );
+        assert_eq!(
+            child_global_transform,
+            *world.entity(child).get::<GlobalTransform>().unwrap()
+        );
     }
 }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -183,7 +183,7 @@ mod test {
     use bevy_app::prelude::*;
     use bevy_ecs::prelude::*;
     use bevy_ecs::system::CommandQueue;
-    use bevy_math::vec3;
+    use bevy_math::{vec3, Vec3};
     use bevy_tasks::{ComputeTaskPool, TaskPool};
 
     use crate::components::{GlobalTransform, Transform};
@@ -480,5 +480,55 @@ mod test {
         );
 
         app.update();
+    }
+
+    #[test]
+    fn global_transform_should_not_be_overwritten_after_reparenting() {
+        let mut world = World::new();
+
+        // Create transform propagation schedule
+        let mut schedule = Schedule::default();
+        schedule.add_systems((sync_simple_transforms, propagate_transforms));
+
+        // Spawn a `TransformBundle` entity with a local translation of `Vec3::ONE`
+        let mut spawn_transform_bundle = || {
+            world
+                .spawn(TransformBundle::from_transform(
+                    Transform::from_translation(Vec3::ONE),
+                ))
+                .id()
+        };
+
+        // Spawn parent and child with the same transform
+        let parent = spawn_transform_bundle();
+        let child = spawn_transform_bundle();
+        world.entity_mut(parent).add_child(child);
+
+        // Run schedule to propagate transforms
+        schedule.run(&mut world);
+
+        let check_translation = |world: &World, entity, translation: Vec3| {
+            assert!(world
+                .entity(entity)
+                .get::<GlobalTransform>()
+                .unwrap()
+                .translation()
+                .abs_diff_eq(translation, 0.001))
+        };
+
+        // Child should be positioned relative to its parent
+        check_translation(&world, parent, Vec3::ONE);
+        check_translation(&world, child, 2. * Vec3::ONE);
+
+        // Reparent child
+        world.entity_mut(child).remove_parent();
+        world.entity_mut(parent).add_child(child);
+
+        // Run schedule to propagate transforms
+        schedule.run(&mut world);
+
+        // Translations should be unchanged after update
+        check_translation(&world, parent, Vec3::ONE);
+        check_translation(&world, child, 2. * Vec3::ONE);
     }
 }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -21,7 +21,7 @@ pub fn sync_simple_transforms(
                 Without<Children>,
             ),
         >,
-        Query<(Ref<Transform>, &mut GlobalTransform), Without<Children>>,
+        Query<(Ref<Transform>, &mut GlobalTransform), (Without<Parent>, Without<Children>)>,
     )>,
     mut orphaned: RemovedComponents<Parent>,
 ) {


### PR DESCRIPTION
# Objective

`sync_simple_transforms` only checks for removed parents and doesn't filter for `Without<Parent>`, so it overwrites the `GlobalTransform` of non-orphan entities that were orphaned and then reparented since the last update.

Introduced by #7264

## Solution

Filter for `Without<Parent>`.

Fixes #9517, #9492

## Changelog

`sync_simple_transforms`:
* Added a `Without<Parent>` filter to the orphaned entities query.