### PR TITLE
Add bent normals to SSAO

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -34,10 +34,10 @@ use bevy_render::{
         PipelineCache, PolygonMode, PrimitiveState, PushConstantRange, RenderPipelineDescriptor,
         Shader, ShaderRef, ShaderStages, ShaderType, SpecializedMeshPipeline,
         SpecializedMeshPipelineError, SpecializedMeshPipelines, StencilFaceState, StencilState,
-        TextureSampleType, TextureViewDimension, VertexState,
+        TextureFormat, TextureSampleType, TextureViewDimension, VertexState,
     },
     renderer::{RenderDevice, RenderQueue},
-    texture::{FallbackImagesDepth, FallbackImagesMsaa},
+    texture::{BevyDefault, FallbackImagesDepth, FallbackImagesMsaa},
     view::{ExtractedView, Msaa, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
@@ -605,7 +605,7 @@ pub fn get_bindings<'a>(
     };
 
     let normal_motion_vectors_fallback = &fallback_images
-        .image_for_samplecount(msaa.samples())
+        .image_for_samplecount(msaa.samples(), TextureFormat::bevy_default())
         .texture_view;
 
     let normal_view = match prepass_textures.and_then(|x| x.normal.as_ref()) {

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -579,7 +579,7 @@ impl FromWorld for MeshPipeline {
                     visibility: ShaderStages::FRAGMENT,
                     ty: BindingType::Texture {
                         multisampled: false,
-                        sample_type: TextureSampleType::Float { filterable: false },
+                        sample_type: TextureSampleType::Uint,
                         view_dimension: TextureViewDimension::D2,
                     },
                     count: None,
@@ -1188,7 +1188,7 @@ pub fn queue_mesh_view_bind_groups(
         ) in &views
         {
             let fallback_ssao = fallback_images
-                .image_for_samplecount(1)
+                .image_for_samplecount(1, TextureFormat::R8Uint)
                 .texture_view
                 .clone();
 

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -49,7 +49,7 @@ var<uniform> globals: Globals;
 var<uniform> fog: types::Fog;
 
 @group(0) @binding(11)
-var screen_space_ambient_occlusion_texture: texture_2d<f32>;
+var screen_space_ambient_occlusion_texture: texture_2d<u32>;
 
 @group(0) @binding(12)
 var environment_map_diffuse: texture_cube<f32>;

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -15,7 +15,7 @@
 #import bevy_pbr::prepass_utils
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
-#import bevy_pbr::gtao_utils gtao_multibounce
+#import bevy_pbr::gtao_utils unpack_ssao, gtao_multibounce
 #endif
 
 @fragment
@@ -100,9 +100,11 @@ fn fragment(
         }
 #endif
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
-        let ssao = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
-        let ssao_multibounce = gtao_multibounce(ssao, pbr_input.material.base_color.rgb);
-        occlusion = min(occlusion, ssao_multibounce);
+        let ssao_packed = textureLoad(screen_space_ambient_occlusion_texture, vec2<i32>(in.position.xy), 0i).r;
+        let ssao = unpack_ssao(ssao_packed);
+        let ao_multibounce = gtao_multibounce(ssao.w, pbr_input.material.base_color.rgb);
+        occlusion = min(occlusion, ao_multibounce);
+        pbr_input.bent_normal = normalize(ssao.xyz);
 #endif
         pbr_input.occlusion = occlusion;
 

--- a/crates/bevy_pbr/src/ssao/gtao_utils.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao_utils.wgsl
@@ -12,6 +12,16 @@ fn gtao_multibounce(visibility: f32, base_color: vec3<f32>) -> vec3<f32> {
     return max(x, ((x * a + b) * x + c) * x);
 }
 
+// TODO: Octahedral normal encoding?
+fn pack_ssao(visibility: f32, bent_normal: vec3<f32>) -> u32 {
+    return pack4x8unorm(vec4(bent_normal * 0.5 + 0.5, visibility));
+}
+
+fn unpack_ssao(ssao: u32) -> vec4<f32> {
+    let t = unpack4x8unorm(ssao);
+    return vec4(t.xyz * 2.0 - 1.0, t.w);
+}
+
 fn fast_sqrt(x: f32) -> f32 {
     return bitcast<f32>(0x1fbd1df5 + (bitcast<i32>(x) >> 1u));
 }

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -30,7 +30,7 @@ use bevy_render::{
         TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType, TextureUsages,
         TextureView, TextureViewDescriptor, TextureViewDimension,
     },
-    renderer::{RenderAdapter, RenderContext, RenderDevice, RenderQueue},
+    renderer::{RenderContext, RenderDevice, RenderQueue},
     texture::{CachedTexture, TextureCache},
     view::{Msaa, ViewUniform, ViewUniformOffset, ViewUniforms},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
@@ -87,17 +87,6 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
 
     fn finish(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
-
-        if !render_app
-            .world
-            .resource::<RenderAdapter>()
-            .get_texture_format_features(TextureFormat::R16Float)
-            .allowed_usages
-            .contains(TextureUsages::STORAGE_BINDING)
-        {
-            warn!("ScreenSpaceAmbientOcclusionPlugin not loaded. GPU lacks support: TextureFormat::R16Float does not support TextureUsages::STORAGE_BINDING.");
-            return;
-        }
 
         if render_app
             .world
@@ -159,7 +148,7 @@ pub struct ScreenSpaceAmbientOcclusionBundle {
 /// TAA ([`bevy_core_pipeline::experimental::taa::TemporalAntiAliasSettings`]).
 /// Doing so greatly reduces SSAO noise.
 ///
-/// SSAO is not supported on `WebGL2`, and is not currently supported on `WebGPU` or `DirectX12`.
+/// SSAO is not supported on `WebGL2`.
 #[derive(Component, ExtractComponent, Reflect, PartialEq, Eq, Hash, Clone, Default)]
 #[reflect(Component)]
 pub struct ScreenSpaceAmbientOcclusionSettings {
@@ -456,7 +445,7 @@ impl FromWorld for SsaoPipelines {
                         visibility: ShaderStages::COMPUTE,
                         ty: BindingType::StorageTexture {
                             access: StorageTextureAccess::WriteOnly,
-                            format: TextureFormat::R16Float,
+                            format: TextureFormat::R32Uint,
                             view_dimension: TextureViewDimension::D2,
                         },
                         count: None,
@@ -492,7 +481,7 @@ impl FromWorld for SsaoPipelines {
                         binding: 0,
                         visibility: ShaderStages::COMPUTE,
                         ty: BindingType::Texture {
-                            sample_type: TextureSampleType::Float { filterable: false },
+                            sample_type: TextureSampleType::Uint,
                             view_dimension: TextureViewDimension::D2,
                             multisampled: false,
                         },
@@ -513,7 +502,7 @@ impl FromWorld for SsaoPipelines {
                         visibility: ShaderStages::COMPUTE,
                         ty: BindingType::StorageTexture {
                             access: StorageTextureAccess::WriteOnly,
-                            format: TextureFormat::R16Float,
+                            format: TextureFormat::R32Uint,
                             view_dimension: TextureViewDimension::D2,
                         },
                         count: None,
@@ -669,7 +658,7 @@ fn prepare_ssao_textures(
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: TextureDimension::D2,
-                format: TextureFormat::R16Float,
+                format: TextureFormat::R32Uint,
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             },
@@ -683,7 +672,7 @@ fn prepare_ssao_textures(
                 mip_level_count: 1,
                 sample_count: 1,
                 dimension: TextureDimension::D2,
-                format: TextureFormat::R16Float,
+                format: TextureFormat::R32Uint,
                 usage: TextureUsages::STORAGE_BINDING | TextureUsages::TEXTURE_BINDING,
                 view_formats: &[],
             },

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -209,13 +209,13 @@ impl FromWorld for FallbackImageCubemap {
 
 // TODO these could be combined in one FallbackImage cache.
 
-/// A Cache of fallback textures that uses the sample count as a key
+/// A Cache of fallback textures that uses the sample count and `TextureFormat` as a key
 ///
 /// # WARNING
 /// Images using MSAA with sample count > 1 are not initialized with data, therefore,
 /// you shouldn't sample them before writing data to them first.
 #[derive(Resource, Deref, DerefMut, Default)]
-pub struct FallbackImageMsaaCache(HashMap<u32, GpuImage>);
+pub struct FallbackImageFormatMsaaCache(HashMap<(u32, TextureFormat), GpuImage>);
 
 /// A Cache of fallback depth textures that uses the sample count as a key
 ///
@@ -227,20 +227,20 @@ pub struct FallbackImageDepthCache(HashMap<u32, GpuImage>);
 
 #[derive(SystemParam)]
 pub struct FallbackImagesMsaa<'w> {
-    cache: ResMut<'w, FallbackImageMsaaCache>,
+    cache: ResMut<'w, FallbackImageFormatMsaaCache>,
     render_device: Res<'w, RenderDevice>,
     render_queue: Res<'w, RenderQueue>,
     default_sampler: Res<'w, DefaultImageSampler>,
 }
 
 impl<'w> FallbackImagesMsaa<'w> {
-    pub fn image_for_samplecount(&mut self, sample_count: u32) -> &GpuImage {
-        self.cache.entry(sample_count).or_insert_with(|| {
+    pub fn image_for_samplecount(&mut self, sample_count: u32, format: TextureFormat) -> &GpuImage {
+        self.cache.entry((sample_count, format)).or_insert_with(|| {
             fallback_image_new(
                 &self.render_device,
                 &self.render_queue,
                 &self.default_sampler,
-                TextureFormat::bevy_default(),
+                format,
                 TextureViewDimension::D2,
                 sample_count,
                 255,

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -133,7 +133,7 @@ impl Plugin for ImagePlugin {
                 .init_resource::<FallbackImage>()
                 .init_resource::<FallbackImageZero>()
                 .init_resource::<FallbackImageCubemap>()
-                .init_resource::<FallbackImageMsaaCache>()
+                .init_resource::<FallbackImageFormatMsaaCache>()
                 .init_resource::<FallbackImageDepthCache>();
         }
     }


### PR DESCRIPTION
# Objective

- Improve indirect lighting quality by estimating the direction of least occlusion while calculating SSAO, and using that as the normal for indirect lighting calculations
- Add support for WebGPU to SSAO
- Should not be merged until after #9302 

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
