### PR TITLE
Replace the f32 `font_size` value of `TextStyle` with a `FontSize` enum

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -22,7 +22,7 @@ pub use text2d::*;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle};
+    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle, DefaultFontSize, FontSize};
 }
 
 use bevy_app::prelude::*;
@@ -88,6 +88,7 @@ impl Plugin for TextPlugin {
             .init_asset_loader::<FontLoader>()
             .init_resource::<TextSettings>()
             .init_resource::<FontAtlasWarning>()
+            .init_resource::<DefaultFontSize>()
             .insert_resource(TextPipeline::default())
             .add_systems(
                 PostUpdate,

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -10,9 +10,9 @@ use bevy_utils::HashMap;
 use glyph_brush_layout::{FontId, GlyphPositioner, SectionGeometry, SectionText};
 
 use crate::{
-    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
+    compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, BreakLineOn, Font,
     FontAtlasSet, FontAtlasWarning, PositionedGlyph, TextAlignment, TextSection, TextSettings,
-    YAxisOrientation,
+    YAxisOrientation, DefaultFontSize,
 };
 
 #[derive(Default, Resource)]
@@ -54,6 +54,8 @@ impl TextPipeline {
         text_settings: &TextSettings,
         font_atlas_warning: &mut FontAtlasWarning,
         y_axis_orientation: YAxisOrientation,
+        viewport_height: f32,
+        default_font_size: DefaultFontSize,
     ) -> Result<TextLayoutInfo, TextError> {
         let mut scaled_fonts = Vec::with_capacity(sections.len());
         let sections = sections
@@ -63,7 +65,9 @@ impl TextPipeline {
                     .get(&section.style.font)
                     .ok_or(TextError::NoSuchFont)?;
                 let font_id = self.get_or_insert_font_id(&section.style.font, font);
-                let font_size = scale_value(section.style.font_size, scale_factor);
+                // let resolved_font_size = section.style.font_size.resolve(default_font_size, viewport_height);
+                // let font_size = scale_value(resolved_font_size, scale_factor);
+                let font_size = section.style.font_size.resolve(default_font_size, viewport_height, scale_factor);
 
                 scaled_fonts.push(ab_glyph::Font::as_scaled(&font.font, font_size));
 
@@ -109,6 +113,8 @@ impl TextPipeline {
         scale_factor: f64,
         text_alignment: TextAlignment,
         linebreak_behaviour: BreakLineOn,
+        viewport_height: f32,
+        default_font_size: DefaultFontSize,
     ) -> Result<TextMeasureInfo, TextError> {
         let mut auto_fonts = Vec::with_capacity(sections.len());
         let mut scaled_fonts = Vec::with_capacity(sections.len());
@@ -119,7 +125,7 @@ impl TextPipeline {
                 let font = fonts
                     .get(&section.style.font)
                     .ok_or(TextError::NoSuchFont)?;
-                let font_size = scale_value(section.style.font_size, scale_factor);
+                let font_size = section.style.font_size.resolve(default_font_size, viewport_height, scale_factor);
                 auto_fonts.push(font.font.clone());
                 let px_scale_font = ab_glyph::Font::into_scaled(font.font.clone(), font_size);
                 scaled_fonts.push(px_scale_font);

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -36,7 +36,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextStyle {
                 // This font is loaded and will be used instead of the default font.
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                font_size: 100.0,
+                font_size: FontSize::Vh(50.0),
                 color: Color::WHITE,
             },
         ) // Set the alignment of the Text
@@ -59,12 +59,12 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextStyle {
                     // This font is loaded and will be used instead of the default font.
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    font_size: 60.0,
+                    font_size: FontSize::Px(60.0),
                     color: Color::WHITE,
                 },
             ),
             TextSection::from_style(TextStyle {
-                font_size: 60.0,
+                font_size: FontSize::Px(60.0),
                 color: Color::GOLD,
                 // If no font is specified, it will use the default font.
                 ..default()


### PR DESCRIPTION
# Objective

Replace the `font_size` field of `TextStyle` with an enum similar to Bevy UI's `Val` type enabling users to set font sizes that depend on the size of the viewport or the text's parent container.

## Solution

Replaces f32 font size with a `FontSize` enum. Variants:
* `Px`: size in logical pixels,
* `Vh`: size in percentage of viewport height,
* `Default`: use default font size contained in the new `DefaultFontSize` resource.

Only updated `text.rs` example so far, want feedback on the API etc before rewriting every example.

Many problems left to solve:
* Expect a lot of bugs with scale factor and Text2d.
* The `hello bevy` text in the `text` example scales correctly when you resize the window but almost immediately runs out of font atlases.
* Should there be `Vw`, `VMin` and `VMax` variants, or is only `Vh` really useful?
* How should percentage values be implemented?
* Is using `Default` for the name of an enum variant bad style?

---

## Changelog
* Added `FontSize` enum with `Px`, `Vh` and `Default` variants. 
* The `font_size` field of `TextStyle` is now a `FontSize`.
* Added `DefaultFontSize` resource. Also implemented as an enum with `Px` and `Vh` variants but no `Default` variant.

## Migration Guide
The `font_size` field of `TextStyle` is now a `FontSize`. The `FontSize::Px` variant is the equivalent to setting an f32 value previously.
