### PR TITLE
Added `TypeMap` Type Alias Which Uses `BTreeMap`

### DIFF
--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -1,5 +1,5 @@
 use crate::{App, AppError, Plugin};
-use bevy_utils::{tracing::debug, tracing::warn, HashMap};
+use bevy_utils::{tracing::debug, tracing::warn, TypeMap};
 use std::any::TypeId;
 
 /// Combines multiple [`Plugin`]s into a single unit.
@@ -33,7 +33,7 @@ impl PluginGroup for PluginGroupBuilder {
 /// can be disabled, enabled or reordered.
 pub struct PluginGroupBuilder {
     group_name: String,
-    plugins: HashMap<TypeId, PluginEntry>,
+    plugins: TypeMap<PluginEntry>,
     order: Vec<TypeId>,
 }
 

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -1,6 +1,6 @@
 use crate::{serde::Serializable, Reflect, TypeInfo, Typed};
 use bevy_ptr::{Ptr, PtrMut};
-use bevy_utils::{HashMap, HashSet};
+use bevy_utils::{HashMap, HashSet, TypeMap};
 use downcast_rs::{impl_downcast, Downcast};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::Deserialize;
@@ -19,7 +19,7 @@ use std::{any::TypeId, fmt::Debug, sync::Arc};
 /// [Registering]: TypeRegistry::register
 /// [crate-level documentation]: crate
 pub struct TypeRegistry {
-    registrations: HashMap<TypeId, TypeRegistration>,
+    registrations: TypeMap<TypeRegistration>,
     short_name_to_id: HashMap<String, TypeId>,
     full_name_to_id: HashMap<String, TypeId>,
     ambiguous_names: HashSet<String>,
@@ -304,7 +304,7 @@ impl TypeRegistryArc {
 /// [crate-level documentation]: crate
 pub struct TypeRegistration {
     short_name: String,
-    data: HashMap<TypeId, Box<dyn TypeData>>,
+    data: TypeMap<Box<dyn TypeData>>,
     type_info: &'static TypeInfo,
 }
 
@@ -362,7 +362,7 @@ impl TypeRegistration {
     pub fn of<T: Reflect + Typed>() -> Self {
         let type_name = std::any::type_name::<T>();
         Self {
-            data: HashMap::default(),
+            data: TypeMap::default(),
             short_name: bevy_utils::get_short_name(type_name),
             type_info: T::type_info(),
         }
@@ -385,7 +385,7 @@ impl TypeRegistration {
 
 impl Clone for TypeRegistration {
     fn clone(&self) -> Self {
-        let mut data = HashMap::default();
+        let mut data = TypeMap::default();
         for (id, type_data) in &self.data {
             data.insert(*id, (*type_data).clone_type_data());
         }

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     system::{ReadOnlySystemParam, Resource, SystemParam, SystemParamItem, SystemState},
     world::World,
 };
-use bevy_utils::{all_tuples, HashMap};
+use bevy_utils::{all_tuples, TypeMap};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::{any::TypeId, fmt::Debug, hash::Hash};
 
@@ -43,7 +43,7 @@ pub struct DrawFunctionId(u32);
 /// For retrieval, the [`Draw`] functions are mapped to their respective [`TypeId`]s.
 pub struct DrawFunctionsInternal<P: PhaseItem> {
     pub draw_functions: Vec<Box<dyn Draw<P>>>,
-    pub indices: HashMap<TypeId, DrawFunctionId>,
+    pub indices: TypeMap<DrawFunctionId>,
 }
 
 impl<P: PhaseItem> DrawFunctionsInternal<P> {
@@ -107,7 +107,7 @@ impl<P: PhaseItem> Default for DrawFunctions<P> {
         Self {
             internal: RwLock::new(DrawFunctionsInternal {
                 draw_functions: Vec::new(),
-                indices: HashMap::default(),
+                indices: TypeMap::default(),
             }),
         }
     }

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use crate::{DynamicSceneBuilder, Scene, SceneSpawnError};
 use anyhow::Result;
 use bevy_ecs::{
@@ -8,7 +6,7 @@ use bevy_ecs::{
     world::World,
 };
 use bevy_reflect::{Reflect, TypePath, TypeRegistryArc, TypeUuid};
-use bevy_utils::HashMap;
+use bevy_utils::TypeMap;
 
 #[cfg(feature = "serialize")]
 use crate::serde::SceneSerializer;
@@ -93,7 +91,7 @@ impl DynamicScene {
         // of which entities in the scene use that component.
         // This is so we can update the scene-internal references to references
         // of the actual entities in the world.
-        let mut scene_mappings: HashMap<TypeId, Vec<Entity>> = HashMap::default();
+        let mut scene_mappings: TypeMap<Vec<Entity>> = TypeMap::default();
 
         for scene_entity in &self.entities {
             // Fetch the entity with the given entity id from the `entity_map`

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -40,7 +40,7 @@ use std::{
     marker::PhantomData,
     mem::ManuallyDrop,
     ops::Deref,
-    pin::Pin,
+    pin::Pin, any::TypeId, collections::BTreeMap,
 };
 
 /// An owned and dynamically typed Future used when you can't statically type your result or need to add some indirection.
@@ -307,3 +307,6 @@ macro_rules! detailed_trace {
         }
     }
 }
+
+/// Map type for storing arbitrary data of type `T` against a [`TypeId`].
+pub type TypeMap<T> = BTreeMap<TypeId, T>;


### PR DESCRIPTION
# Objective

- Closes #8393

## Solution

- Created a type alias `TypeMap<T>` for instances of `HashMap<TypeId, T>`.
- Set `TypeMap` as `BTreeMap` instead of a `HashMap`

## Details

An experimental replacement of `HashMap<TypeId, T>` with `BTreeMap<TypeId, T>`. I suspect that the hashing algorithm used is substantially less performant than the tree traversal since `TypeId` is only 64 bits of data, and AHash uses (at least parts of) AES. I am aware that `HashMap` is amortised `O(1)` whereas `BTreeMap` is `O(log(n))`, which means the `HashMap` _should_ be faster. However, for maps over `TypeId`, I suspect that `BTreeMap` will perform at least as good, or better. My reason for this suspicion is that `TypeId` is only 64 bits of information, so in the absolute worst-case scenario, we're looking at 64 traversals. However, I believe the actual `BTreeMap` implementation in the standard library uses some optimisations to reduce that even further.

I've tested this branch before and after using `bevymark` and can't observe a meaningful performance difference. Likely because it doesn't stress the ECS enough to induce a difference in implementations. Is there anyone who has an ECS focussed benchmark who could review this change?