### PR TITLE
Update defaults for OrthographicProjection

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -197,6 +197,8 @@ pub enum ScalingMode {
 ///
 /// Note that the scale of the projection and the apparent size of objects are inversely proportional.
 /// As the size of the projection increases, the size of objects decreases.
+///
+/// Note also that the view frustum is centered at the origin.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct OrthographicProjection {
@@ -204,7 +206,7 @@ pub struct OrthographicProjection {
     ///
     /// Objects closer than this will not be rendered.
     ///
-    /// Defaults to `0.0`
+    /// Defaults to `-1000.0`
     pub near: f32,
     /// The distance of the far clipping plane in world units.
     ///
@@ -315,7 +317,7 @@ impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
             scale: 1.0,
-            near: 0.0,
+            near: -1000.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize(1.0),


### PR DESCRIPTION
# Objective

These new defaults match what is used by `Camera2dBundle::default()`, removing a potential footgun from overriding a field in the projection component of the bundle.

## Solution

Adjusted the near clipping plane of `OrthographicProjection::default()` to `-1000.`.

---

## Changelog

Changed: `OrthographicProjection::default()` now matches the value used in `Camera2dBundle::default()`

## Migration Guide

Workarounds used to keep the projection consistent with the bundle defaults are no longer required. Meanwhile, uses of `OrthographicProjection` in 2D scenes may need to be adjusted; the `near` clipping plane default was changed from `0.0` to `-1000.0`.