### PR TITLE
Added `with_query` to `EntityCommands`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -968,11 +968,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         Q: WorldQuery + 'static,
         F: ReadOnlyWorldQuery + 'static,
     {
-        self.commands.add(WithQuery::<Q, F> {
-            entity: self.entity,
-            function: Box::new(function),
-            _phantom: PhantomData,
-        });
+        self.commands.add(WithQuery::<Q, F>::new(self.entity, function));
         self
     }
 }
@@ -1208,6 +1204,24 @@ where
     entity: Entity,
     function: Box<dyn for<'t> FnOnce(Q::Item<'t>) + Send + Sync>,
     _phantom: PhantomData<fn(Q, F) -> ()>,
+}
+
+impl<Q, F> WithQuery<Q, F>
+where
+    Q: WorldQuery,
+    F: ReadOnlyWorldQuery,
+{
+    /// Create a new [`WithQuery`] [`EntityCommand`] from the provided [`Entity`] and closure.
+    pub fn new(
+        entity: Entity,
+        function: impl for<'t> FnOnce(Q::Item<'t>) + Send + Sync + 'static
+    ) -> Self {
+        Self {
+            entity,
+            function: Box::new(function),
+            _phantom: PhantomData,
+        }
+    }
 }
 
 impl<Q, F> Command for WithQuery<Q, F>

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1199,7 +1199,7 @@ impl Command for LogComponents {
     }
 }
 
-/// [`Command`] to query an [`Entity`].
+/// [`Command`] to query an [`Entity`], and read or mutate its components via a provided function.
 pub struct WithQuery<Q, F = ()>
 where
     Q: WorldQuery,

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -968,7 +968,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
         Q: WorldQuery + 'static,
         F: ReadOnlyWorldQuery + 'static,
     {
-        self.commands.add(WithQuery::<Q, F>::new(self.entity, function));
+        self.add(WithQuery::<Q, F>::new(function));
         self
     }
 }
@@ -1201,7 +1201,6 @@ where
     Q: WorldQuery,
     F: ReadOnlyWorldQuery,
 {
-    entity: Entity,
     function: Box<dyn for<'t> FnOnce(Q::Item<'t>) + Send + Sync>,
     _phantom: PhantomData<fn(Q, F) -> ()>,
 }
@@ -1213,26 +1212,24 @@ where
 {
     /// Create a new [`WithQuery`] [`EntityCommand`] from the provided [`Entity`] and closure.
     pub fn new(
-        entity: Entity,
         function: impl for<'t> FnOnce(Q::Item<'t>) + Send + Sync + 'static
     ) -> Self {
         Self {
-            entity,
             function: Box::new(function),
             _phantom: PhantomData,
         }
     }
 }
 
-impl<Q, F> Command for WithQuery<Q, F>
+impl<Q, F> EntityCommand for WithQuery<Q, F>
 where
     Q: WorldQuery,
     F: ReadOnlyWorldQuery,
     WithQuery<Q, F>: Send + Sync + 'static,
 {
-    fn apply(self, world: &mut World) {
+    fn apply(self, entity: Entity, world: &mut World) {
         let Self {
-            entity, function, ..
+            function, ..
         } = self;
 
         let mut query = world.query_filtered::<Q, F>();

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1211,9 +1211,7 @@ where
     F: ReadOnlyWorldQuery,
 {
     /// Create a new [`WithQuery`] [`EntityCommand`] from the provided [`Entity`] and closure.
-    pub fn new(
-        function: impl for<'t> FnOnce(Q::Item<'t>) + Send + Sync + 'static
-    ) -> Self {
+    pub fn new(function: impl for<'t> FnOnce(Q::Item<'t>) + Send + Sync + 'static) -> Self {
         Self {
             function: Box::new(function),
             _phantom: PhantomData,
@@ -1228,9 +1226,7 @@ where
     WithQuery<Q, F>: Send + Sync + 'static,
 {
     fn apply(self, entity: Entity, world: &mut World) {
-        let Self {
-            function, ..
-        } = self;
+        let Self { function, .. } = self;
 
         let mut query = world.query_filtered::<Q, F>();
 


### PR DESCRIPTION
# Objective

- Fixes #4917 

## Solution

- Added a convenience method to `EntityCommands`, `with_query` which allows a mutable query to be run for a specific `Entity`.
- Added documentation and unit tests as appropriate.

---

## Example

```rust
commands
    .entity(player.entity)
    .insert(ReallyComplexPlayerBundle::default()) // This adds Health to the Entity
    .with_query::<&mut Health>(|mut health| {
        health.0 = 100;
    });
```
