### PR TITLE
Added `Query::for_each_combinations(_mut)`, Updated `Query::for_each(_mut)`

### DIFF
--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
@@ -1,3 +1,47 @@
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/query_lifetime_safety.rs:78:35
+   |
+76 |             let mut opt_data: Option<&Foo> = None;
+   |                 ------------ `opt_data` declared here, outside of the closure body
+77 |             let mut opt_data_2: Option<Mut<Foo>> = None;
+78 |             query.for_each(|data| opt_data = Some(data));
+   |                             ----  ^^^^^^^^^^^^^^^^^^^^^ `data` escapes the closure body here
+   |                             |
+   |                             `data` is a reference that is only valid in the closure body
+
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/query_lifetime_safety.rs:79:39
+   |
+77 |             let mut opt_data_2: Option<Mut<Foo>> = None;
+   |                 -------------- `opt_data_2` declared here, outside of the closure body
+78 |             query.for_each(|data| opt_data = Some(data));
+79 |             query.for_each_mut(|data| opt_data_2 = Some(data));
+   |                                 ----  ^^^^^^^^^^^^^^^^^^^^^^^ `data` escapes the closure body here
+   |                                 |
+   |                                 `data` is a reference that is only valid in the closure body
+
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/query_lifetime_safety.rs:86:39
+   |
+84 |             let mut opt_data_2: Option<Mut<Foo>> = None;
+   |                 -------------- `opt_data_2` declared here, outside of the closure body
+85 |             let mut opt_data: Option<&Foo> = None;
+86 |             query.for_each_mut(|data| opt_data_2 = Some(data));
+   |                                 ----  ^^^^^^^^^^^^^^^^^^^^^^^ `data` escapes the closure body here
+   |                                 |
+   |                                 `data` is a reference that is only valid in the closure body
+
+error[E0521]: borrowed data escapes outside of closure
+  --> tests/ui/query_lifetime_safety.rs:87:35
+   |
+85 |             let mut opt_data: Option<&Foo> = None;
+   |                 ------------ `opt_data` declared here, outside of the closure body
+86 |             query.for_each_mut(|data| opt_data_2 = Some(data));
+87 |             query.for_each(|data| opt_data = Some(data));
+   |                             ----  ^^^^^^^^^^^^^^^^^^^^^ `data` escapes the closure body here
+   |                             |
+   |                             `data` is a reference that is only valid in the closure body
+
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_lifetime_safety.rs:17:39
    |
@@ -97,23 +141,3 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
    |                              ^^^^^^^^^^^^ immutable borrow occurs here
 72 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
-
-error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
-  --> tests/ui/query_lifetime_safety.rs:79:13
-   |
-78 |             query.for_each(|data| opt_data = Some(data));
-   |             -------------------------------------------- immutable borrow occurs here
-79 |             query.for_each_mut(|data| opt_data_2 = Some(data));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
-80 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
-   |                        -------- immutable borrow later used here
-
-error[E0502]: cannot borrow `query` as immutable because it is also borrowed as mutable
-  --> tests/ui/query_lifetime_safety.rs:87:13
-   |
-86 |             query.for_each_mut(|data| opt_data_2 = Some(data));
-   |             -------------------------------------------------- mutable borrow occurs here
-87 |             query.for_each(|data| opt_data = Some(data));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
-88 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
-   |                                                 ---------- mutable borrow later used here


### PR DESCRIPTION
Also updated function signatures of `Query::for_each(_mut)` to use a more restrictive lifetime on their borrows. This is a breaking change, but I believe it is the more "correct" API only recently made possible.

I also don't believe this breaking change is significant, as I don't believe there are any circumstances where you would need to escape a borrow out of a closure inside a `for_each` statement. `iter().map(...)` should provide all the required functionality in those cases anyway.

# Objective

- Fixes #4704

## Solution

- Added `Query::for_each_combinations` and `Query::for_each_combinations_mut` with appropriate documentation.
- Updated `Query::for_each` and `Query::for_each_mut` to use closure-specific lifetime through `for<'item>`

---

## Changelog

- `Query::for_each` and `Query::for_each_mut` provide references to their closures that no longer have the same lifetime as `&self`, and instead only last as long as the execution of the closure through the use of `for<'item>`. This is a breaking change.

## Migration Guide

Code which used `Query::for_each` or `Query::for_each_mut` to borrow data from a query should instead use `Query::iter` or `Query::iter_mut` with `.map(...)` to achieve the same result. In practice, I don't believe there are many instances where this breaking change would actually affect real projects, as it appears to be a poor way to borrow data from a `Query`.

```rust
// Now fails to compile.
{
    let mut borrows: Vec<&Foo> = Vec::new();
    query.for_each(|data| borrows.push(data));
}
/*
error[E0521]: borrowed data escapes outside of closure
  --> tests/ui/query_lifetime_safety.rs:93:35
   |
 2 |     let mut borrows: Vec<&Foo> = Vec::new();
   |         ----------- `borrows` declared here, outside of the closure body
 3 |     query.for_each(|data| borrows.push(data));
   |                     ----  ^^^^^^^^^^^^^^^^^^ `data` escapes the closure body here
   |                     |
   |                     `data` is a reference that is only valid in the closure body
*/

// Proposed replacement.
{
    let _borrows: Vec<&Foo> = query.iter().collect();
}
```
