### PR TITLE
fix bevy imports. windows_settings.rs example

### DIFF
--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -4,9 +4,8 @@
 use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
+    window::{CursorGrabMode, PresentMode, PrimaryWindow, WindowLevel, WindowTheme},
 };
-use bevy_internal::window::PrimaryWindow;
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

In #9355 was added an import using bevy_internal.
This change the import to use `bevy::window` instead of a `bevy_internal` to run the example outside of the bevy repo.
