### PR TITLE
`round_ties_up` fix

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -398,18 +398,8 @@ mod tests {
     use crate::layout::round_layout_coords;
     use bevy_math::vec2;
 
-    use super::round_ties_up;
     #[test]
-    fn round_ties_up_must_round_up() {
-        for x in -100..100 {
-            let x = x as f32 / 4.;
-            assert_eq!(x.fract(), 0.);
-            assert!(x <= round_ties_up(x));
-        }
-    }
-
-    #[test]
-    fn round_layout_coords_must_round_up() {
+    fn round_layout_coords_must_round_ties_up() {
         assert_eq!(round_layout_coords(vec2(-50.5, 49.5)), vec2(-50., 50.));
     }
 }

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -366,9 +366,9 @@ pub fn ui_layout_system(
 }
 
 #[inline]
-/// Round `value` to the closest whole integer, with ties (values with a fractional part equal to 0.5) rounded towards positive infinity.
+/// Round `value` to the nearest whole integer, with ties (values with a fractional part equal to 0.5) rounded towards positive infinity.
 fn round_ties_up(value: f32) -> f32 {
-    if 0. <= value || value.fract() != 0.5 {
+    if value.fract() != -0.5 {
         // The `round` function rounds ties away from zero. For positive numbers "away from zero" is towards positive infinity.
         // So for all positive values, and negative values with a fractional part not equal to 0.5, `round` returns the correct result.
         value.round()
@@ -379,13 +379,37 @@ fn round_ties_up(value: f32) -> f32 {
 }
 
 #[inline]
-/// Rust `f32` only has support for rounding ties away from zero.
-/// When rounding the layout coordinates we need to round ties up, otherwise we can gain a pixel.
-/// For example consider a node with left and right bounds of -50.5 and 49.5 (width: 49.5 - (-50.5) == 100).
-/// After rounding left and right away from zero we get -51 and 50 (width: 50 - (-51) == 101), gaining a pixel.
+/// Rounds layout coordinates by rounding ties upwards.
+///
+/// Rounding ties up avoids gaining a pixel when rounding bounds that span from negative to positive.
+///
+/// Example: The width between bounds of -50.5 and 49.5 before rounding is 100, using:
+/// - `f32::round`: width becomes 101 (rounds to -51 and 50).
+/// - `round_ties_up`: width is 100 (rounds to -50 and 50).
 fn round_layout_coords(value: Vec2) -> Vec2 {
     Vec2 {
         x: round_ties_up(value.x),
         y: round_ties_up(value.y),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::layout::round_layout_coords;
+    use bevy_math::vec2;
+
+    use super::round_ties_up;
+    #[test]
+    fn round_ties_up_must_round_up() {
+        for x in -100..100 {
+            let x = x as f32 / 4.;
+            assert_eq!(x.fract(), 0.);
+            assert!(x <= round_ties_up(x));
+        }
+    }
+
+    #[test]
+    fn round_layout_coords_must_round_up() {
+        assert_eq!(round_layout_coords(vec2(-50.5, 49.5)), vec2(-50., 50.));
     }
 }


### PR DESCRIPTION
# Objective
`round_ties_up` checks the predicate:
```rust
0. <= value || value.fract() != 0.5
```
which is meant to determine if the value is negative with a fractional part of `0.5`.

However given a negative value, `fract` returns a negative fraction so the predicate is true for all numeric values and `ceil` is never called.

## Solution

Changed the predicate to `value.fract() != -0.5` and added a test.
Also improved the comments a bit.
