### PR TITLE
bevy_derive: Fix `#[deref]` breaking other attributes

### DIFF
--- a/crates/bevy_derive/src/derefs.rs
+++ b/crates/bevy_derive/src/derefs.rs
@@ -68,9 +68,11 @@ fn get_deref_field(ast: &DeriveInput, is_mut: bool) -> syn::Result<(Member, &Typ
             let mut selected_field: Option<(Member, &Type)> = None;
             for (index, field) in data_struct.fields.iter().enumerate() {
                 for attr in &field.attrs {
-                    if !attr.meta.require_path_only()?.is_ident(DEREF_ATTR) {
+                    if !attr.meta.path().is_ident(DEREF_ATTR) {
                         continue;
                     }
+
+                    attr.meta.require_path_only()?;
 
                     if selected_field.is_some() {
                         return Err(syn::Error::new_spanned(

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_derive/multiple_fields.pass.rs
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_derive/multiple_fields.pass.rs
@@ -5,9 +5,13 @@ struct TupleStruct(usize, #[deref] String);
 
 #[derive(Deref)]
 struct Struct {
+    // Works with other attributes
+    #[cfg(test)]
     foo: usize,
     #[deref]
     bar: String,
+    /// Also works with doc comments.
+    baz: i32,
 }
 
 fn main() {
@@ -15,8 +19,10 @@ fn main() {
     let _: &String = &*value;
 
     let value = Struct {
+        #[cfg(test)]
         foo: 123,
         bar: "Hello world!".to_string(),
+        baz: 321,
     };
     let _: &String = &*value;
 }

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -15,6 +18,9 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10


### PR DESCRIPTION
# Objective

Fixes #9550

## Solution

Removes a check that asserts that _all_ attribute metas are path-only.

---

## Changelog

- Fixes an issue where deriving `Deref` with `#[deref]` on a field causes other attributes to sometimes result in a compile error
