### PR TITLE
Add support for KHR_materials_emissive_strength

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -28,9 +28,10 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 
 # other
-gltf = { version = "1.0.0", default-features = false, features = [
+gltf = { version = "1.3.0", default-features = false, features = [
     "KHR_lights_punctual",
     "KHR_materials_unlit",
+    "KHR_materials_emissive_strength",
     "extras",
     "names",
     "utils",

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -678,7 +678,8 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
                 Some(Face::Back)
             },
             occlusion_texture,
-            emissive: Color::rgb_linear(emissive[0], emissive[1], emissive[2]),
+            emissive: Color::rgb_linear(emissive[0], emissive[1], emissive[2])
+                * material.emssive_strength().unwrap_or(1.0),
             emissive_texture,
             unlit: material.unlit(),
             alpha_mode: alpha_mode(material),

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -679,7 +679,7 @@ fn load_material(material: &Material, load_context: &mut LoadContext) -> Handle<
             },
             occlusion_texture,
             emissive: Color::rgb_linear(emissive[0], emissive[1], emissive[2])
-                * material.emssive_strength().unwrap_or(1.0),
+                * material.emissive_strength().unwrap_or(1.0),
             emissive_texture,
             unlit: material.unlit(),
             alpha_mode: alpha_mode(material),


### PR DESCRIPTION
# Objective

- Fix blender gltf imports with emissive materials
- Progress towards https://github.com/bevyengine/bevy/issues/5178

## Solution

- Upgrade to gltf-rs 1.3 supporiting [KHR_materials_emissive_strength](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_emissive_strength/README.md)

---

## Changelog

- GLTF files using `emissiveStrength` (such as those exported by blender) are now supported

## Migration Guide

- The GLTF asset loader will now factor in `emissiveStrength` when converting to Bevy's `StandardMaterial::emissive`. Blender will export emissive materials using this field. Remove the field from your GLTF files or manually modify your materials post-asset-load to match how Bevy would load these files in previous versions. 