### PR TITLE
Rename `Bezier` to `CubicBezier` for clarity

### DIFF
--- a/benches/benches/bevy_math/bezier.rs
+++ b/benches/benches/bevy_math/bezier.rs
@@ -14,7 +14,7 @@ fn easing(c: &mut Criterion) {
 }
 
 fn cubic_2d(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec2(0.0, 0.0),
         vec2(0.0, 1.0),
         vec2(1.0, 0.0),
@@ -27,7 +27,7 @@ fn cubic_2d(c: &mut Criterion) {
 }
 
 fn cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),
@@ -40,7 +40,7 @@ fn cubic(c: &mut Criterion) {
 }
 
 fn cubic_vec3(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3(0.0, 0.0, 0.0),
         vec3(0.0, 1.0, 0.0),
         vec3(1.0, 0.0, 0.0),
@@ -53,7 +53,7 @@ fn cubic_vec3(c: &mut Criterion) {
 }
 
 fn build_pos_cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),
@@ -66,7 +66,7 @@ fn build_pos_cubic(c: &mut Criterion) {
 }
 
 fn build_accel_cubic(c: &mut Criterion) {
-    let bezier = Bezier::new([[
+    let bezier = CubicBezier::new([[
         vec3a(0.0, 0.0, 0.0),
         vec3a(0.0, 1.0, 0.0),
         vec3a(1.0, 0.0, 0.0),

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -28,7 +28,7 @@ impl Point for Vec3A {}
 impl Point for Vec2 {}
 impl Point for f32 {}
 
-/// A spline composed of a series of cubic Bezier curves.
+/// A spline composed of a single cubic Bezier curve.
 ///
 /// Useful for user-drawn curves with local control, or animation easing. See
 /// [`CubicSegment::new_bezier`] for use in easing.
@@ -53,22 +53,22 @@ impl Point for f32 {}
 ///     vec2(5.0, 3.0),
 ///     vec2(9.0, 8.0),
 /// ]];
-/// let bezier = Bezier::new(points).to_curve();
+/// let bezier = CubicBezier::new(points).to_curve();
 /// let positions: Vec<_> = bezier.iter_positions(100).collect();
 /// ```
-pub struct Bezier<P: Point> {
+pub struct CubicBezier<P: Point> {
     control_points: Vec<[P; 4]>,
 }
 
-impl<P: Point> Bezier<P> {
-    /// Create a new Bezier curve from sets of control points.
+impl<P: Point> CubicBezier<P> {
+    /// Create a new cubic Bezier curve from sets of control points.
     pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Self {
         Self {
             control_points: control_points.into(),
         }
     }
 }
-impl<P: Point> CubicGenerator<P> for Bezier<P> {
+impl<P: Point> CubicGenerator<P> for CubicBezier<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         let char_matrix = [
@@ -340,7 +340,7 @@ impl CubicSegment<Vec2> {
     /// example, the ubiquitous "ease-in-out" is defined as `(0.25, 0.1), (0.25, 1.0)`.
     pub fn new_bezier(p1: impl Into<Vec2>, p2: impl Into<Vec2>) -> Self {
         let (p0, p3) = (Vec2::ZERO, Vec2::ONE);
-        let bezier = Bezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
+        let bezier = CubicBezier::new([[p0, p1.into(), p2.into(), p3]]).to_curve();
         bezier.segments[0].clone()
     }
 
@@ -553,7 +553,7 @@ impl<P: Point> CubicCurve<P> {
 mod tests {
     use glam::{vec2, Vec2};
 
-    use crate::cubic_splines::{Bezier, CubicGenerator, CubicSegment};
+    use crate::cubic_splines::{CubicBezier, CubicGenerator, CubicSegment};
 
     /// How close two floats can be and still be considered equal
     const FLOAT_EQ: f32 = 1e-5;
@@ -568,7 +568,7 @@ mod tests {
             vec2(5.0, 3.0),
             vec2(9.0, 8.0),
         ]];
-        let bezier = Bezier::new(points).to_curve();
+        let bezier = CubicBezier::new(points).to_curve();
         for i in 0..=N_SAMPLES {
             let t = i as f32 / N_SAMPLES as f32; // Check along entire length
             assert!(bezier.position(t).distance(cubic_manual(t, points[0])) <= FLOAT_EQ);

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -20,7 +20,9 @@ pub use rects::*;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        cubic_splines::{BSpline, Bezier, CardinalSpline, CubicGenerator, CubicSegment, Hermite},
+        cubic_splines::{
+            BSpline, CardinalSpline, CubicBezier, CubicGenerator, CubicSegment, Hermite,
+        },
         BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray,
         Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
         Vec4Swizzles,

--- a/examples/animation/cubic_curve.rs
+++ b/examples/animation/cubic_curve.rs
@@ -33,7 +33,7 @@ fn setup(
     ]];
 
     // Make a CubicCurve
-    let bezier = Bezier::new(points).to_curve();
+    let bezier = CubicBezier::new(points).to_curve();
 
     // Spawning a cube to experiment on
     commands.spawn((


### PR DESCRIPTION
# Objective

A Bezier curve is a curve defined by two or more control points. In the simplest form, it's just a line. The (arguably) most common type of Bezier curve is a cubic Bezier, defined by four control points. These are often used in animation, etc. Bevy has a Bezier curve struct called `Bezier`. However, this is technically a misnomer as it only represents cubic Bezier curves.

## Solution

This PR changes the struct name to `CubicBezier` to more accurately reflect the struct's usage. Since it's exposed in Bevy's prelude, it can potentially collide with other `Bezier` implementations. While that might instead be an argument for removing it from the prelude, there's also something to be said for adding a more general `Bezier` into Bevy, in which case we'd likely want to use the name `Bezier`. As a final motivator, not only is the struct located in `cubic_spines.rs`, there are also several other spline-related structs which follow the `CubicXxx` naming convention where applicable. For example, `CubicSegment` represents a cubic Bezier curve (with coefficients pre-baked).

---

## Migration Guide

- Change all `Bezier` references to `CubicBezier`