### PR TITLE
ktx2: Fix Rgb8 -> Rgba8Unorm conversion

### DIFF
--- a/crates/bevy_render/src/texture/ktx2.rs
+++ b/crates/bevy_render/src/texture/ktx2.rs
@@ -139,7 +139,7 @@ pub fn ktx2_buffer_to_image(
                                     rgba[i * 4 + 2] = level_data[offset + 2];
                                     offset += 3;
                                 }
-                                transcoded[level].extend_from_slice(&rgba[0..n_pixels]);
+                                transcoded[level].extend_from_slice(&rgba[0..n_pixels * 4]);
                             }
                         }
                     }


### PR DESCRIPTION
# Objective

- Fixes #9552 

## Solution

- Only n_pixels bytes of data was being copied instead of 1 byte per component, i.e. n_pixels * 4

---

## Changelog

- Fixed: loading of Rgb8 ktx2 files.