### PR TITLE
Fix CI for Rust 1.72

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -341,9 +341,13 @@ fn verify_no_ancestor_player(
     player_parent: Option<&Parent>,
     parents: &Query<(Option<With<AnimationPlayer>>, Option<&Parent>)>,
 ) -> bool {
-    let Some(mut current) = player_parent.map(Parent::get) else { return true };
+    let Some(mut current) = player_parent.map(Parent::get) else {
+        return true;
+    };
     loop {
-        let Ok((maybe_player, parent)) = parents.get(current) else { return true };
+        let Ok((maybe_player, parent)) = parents.get(current) else {
+            return true;
+        };
         if maybe_player.is_some() {
             return false;
         }
@@ -506,7 +510,9 @@ fn apply_animation(
         for (path, bone_id) in &animation_clip.paths {
             let cached_path = &mut animation.path_cache[*bone_id];
             let curves = animation_clip.get_curves(*bone_id).unwrap();
-            let Some(target) = entity_from_path(root, path, children, names, cached_path) else { continue };
+            let Some(target) = entity_from_path(root, path, children, names, cached_path) else {
+                continue;
+            };
             // SAFETY: The verify_no_ancestor_player check above ensures that two animation players cannot alias
             // any of their descendant Transforms.
             //
@@ -519,7 +525,9 @@ fn apply_animation(
             // This means only the AnimationPlayers closest to the root of the hierarchy will be able
             // to run their animation. Any players in the children or descendants will log a warning
             // and do nothing.
-            let Ok(mut transform) = (unsafe { transforms.get_unchecked(target) }) else { continue };
+            let Ok(mut transform) = (unsafe { transforms.get_unchecked(target) }) else {
+                continue;
+            };
             let mut morphs = unsafe { morphs.get_unchecked(target) };
             for curve in curves {
                 // Some curves have only one keyframe used to set a transform

--- a/crates/bevy_asset/src/asset_server.rs
+++ b/crates/bevy_asset/src/asset_server.rs
@@ -790,7 +790,8 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.png", true)
+        else {
             panic!();
         };
 
@@ -802,7 +803,8 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.PNG", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.PNG", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "png");
@@ -855,7 +857,9 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakePngLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test-v1.2.3.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) =
+            asset_server.get_path_asset_loader("test-v1.2.3.png", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "png");
@@ -866,7 +870,9 @@ mod test {
         let asset_server = setup(".");
         asset_server.add_loader(FakeMultipleDotLoader);
 
-        let Ok(MaybeAssetLoader::Ready(t)) = asset_server.get_path_asset_loader("test.test.png", true) else {
+        let Ok(MaybeAssetLoader::Ready(t)) =
+            asset_server.get_path_asset_loader("test.test.png", true)
+        else {
             panic!();
         };
         assert_eq!(t.extensions()[0], "test.png");

--- a/crates/bevy_asset/src/io/file_asset_io.rs
+++ b/crates/bevy_asset/src/io/file_asset_io.rs
@@ -201,7 +201,9 @@ pub fn filesystem_watcher_system(
             } = event
             {
                 for path in &paths {
-                    let Some(set) = watcher.path_map.get(path) else {continue};
+                    let Some(set) = watcher.path_map.get(path) else {
+                        continue;
+                    };
                     for to_reload in set {
                         // When an asset is modified, note down the timestamp (overriding any previous modification events)
                         changed.insert(to_reload.to_owned(), Instant::now());

--- a/crates/bevy_core_pipeline/src/blit/mod.rs
+++ b/crates/bevy_core_pipeline/src/blit/mod.rs
@@ -19,7 +19,7 @@ impl Plugin for BlitPlugin {
 
     fn finish(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         render_app

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -163,7 +163,10 @@ impl ViewNode for BloomNode {
             pipeline_cache.get_render_pipeline(downsampling_pipeline_ids.main),
             pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_main),
             pipeline_cache.get_render_pipeline(upsampling_pipeline_ids.id_final),
-        ) else { return Ok(()) };
+        )
+        else {
+            return Ok(());
+        };
 
         render_context.command_encoder().push_debug_group("bloom");
 

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
@@ -53,10 +53,15 @@ impl Node for CASNode {
         let sharpening_pipeline = world.resource::<CASPipeline>();
         let uniforms = world.resource::<ComponentUniforms<CASUniform>>();
 
-        let Ok((target, pipeline, uniform_index)) = self.query.get_manual(world, view_entity) else { return Ok(()) };
+        let Ok((target, pipeline, uniform_index)) = self.query.get_manual(world, view_entity)
+        else {
+            return Ok(());
+        };
 
         let uniforms_id = uniforms.buffer().unwrap().id();
-        let Some(uniforms) = uniforms.binding() else { return Ok(()) };
+        let Some(uniforms) = uniforms.binding() else {
+            return Ok(());
+        };
 
         let pipeline = pipeline_cache.get_render_pipeline(pipeline.0).unwrap();
 

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -21,7 +21,7 @@ pub struct MsaaWritebackPlugin;
 impl Plugin for MsaaWritebackPlugin {
     fn build(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         render_app.add_systems(

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -57,7 +57,9 @@ impl Plugin for TemporalAntiAliasPlugin {
         app.insert_resource(Msaa::Off)
             .register_type::<TemporalAntiAliasSettings>();
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .init_resource::<SpecializedRenderPipelines<TAAPipeline>>()
@@ -86,7 +88,9 @@ impl Plugin for TemporalAntiAliasPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<TAAPipeline>();
     }
@@ -188,11 +192,7 @@ impl ViewNode for TAANode {
         ) else {
             return Ok(());
         };
-        let (
-            Some(taa_pipeline),
-            Some(prepass_motion_vectors_texture),
-            Some(prepass_depth_texture),
-        ) = (
+        let (Some(taa_pipeline), Some(prepass_motion_vectors_texture), Some(prepass_depth_texture)) = (
             pipeline_cache.get_render_pipeline(taa_pipeline_id.0),
             &prepass_textures.motion_vectors,
             &prepass_textures.depth,

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -135,7 +135,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
             "#[derive(WorldQuery)]` only supports structs",
         )
         .into_compile_error()
-        .into()
+        .into();
     };
 
     let mut field_attrs = Vec::new();

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -251,10 +251,17 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
 pub fn derive_system_param(input: TokenStream) -> TokenStream {
     let token_stream = input.clone();
     let ast = parse_macro_input!(input as DeriveInput);
-    let syn::Data::Struct(syn::DataStruct { fields: field_definitions, .. }) = ast.data else {
-        return syn::Error::new(ast.span(), "Invalid `SystemParam` type: expected a `struct`")
-            .into_compile_error()
-            .into();
+    let syn::Data::Struct(syn::DataStruct {
+        fields: field_definitions,
+        ..
+    }) = ast.data
+    else {
+        return syn::Error::new(
+            ast.span(),
+            "Invalid `SystemParam` type: expected a `struct`",
+        )
+        .into_compile_error()
+        .into();
     };
     let path = bevy_ecs_path();
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -550,8 +550,8 @@ impl ScheduleGraph {
                     let Some(prev) = config_iter.next() else {
                         return AddSystemsInnerResult {
                             nodes: Vec::new(),
-                            densely_chained: true
-                        }
+                            densely_chained: true,
+                        };
                     };
                     let mut previous_result = self.add_systems_inner(prev, true);
                     densely_chained = previous_result.densely_chained;

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -83,7 +83,7 @@ impl<T> Hash for SystemTypeSet<T> {
 }
 impl<T> Clone for SystemTypeSet<T> {
     fn clone(&self) -> Self {
-        Self(PhantomData)
+        *self
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1770,8 +1770,9 @@ impl World {
         f: impl FnOnce(&mut World, &mut Schedule) -> R,
     ) -> Result<R, TryRunScheduleError> {
         let label = label.as_ref();
-        let Some((extracted_label, mut schedule))
-            = self.get_resource_mut::<Schedules>().and_then(|mut s| s.remove_entry(label))
+        let Some((extracted_label, mut schedule)) = self
+            .get_resource_mut::<Schedules>()
+            .and_then(|mut s| s.remove_entry(label))
         else {
             return Err(TryRunScheduleError(label.dyn_clone()));
         };

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ArchetypeFilter`:
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
-             (F0, F1, F2, F3, F4, F5, F6, F7)
+             With<T>
+             Without<T>
+             Or<()>
+             Or<(F0,)>
+             Or<(F0, F1)>
+             Or<(F0, F1, F2)>
+             Or<(F0, F1, F2, F3)>
+             Or<(F0, F1, F2, F3, F4)>
            and $N others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`
@@ -32,14 +32,14 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ArchetypeFilter`:
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
-             (F0, F1, F2, F3, F4, F5, F6, F7)
+             With<T>
+             Without<T>
+             Or<()>
+             Or<(F0,)>
+             Or<(F0, F1)>
+             Or<(F0, F1, F2)>
+             Or<(F0, F1, F2, F3)>
+             Or<(F0, F1, F2, F3, F4)>
            and $N others
    = note: required for `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>` to implement `ExactSizeIterator`
 note: required by a bound in `is_exact_size_iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryCombinationIter<'_, '_, &mut A, (), _>` to implement `Iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -7,14 +7,14 @@ error[E0277]: the trait bound `&mut A: ReadOnlyWorldQuery` is not satisfied
    |     required by a bound introduced by this call
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&A`, but not for `&mut A`
    = note: required for `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>` to implement `Iterator`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -13,14 +13,14 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
    |                       ^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
+             AnyOf<(F0, F1, F2)>
+             AnyOf<(F0, F1, F2, F3)>
+             AnyOf<(F0, F1, F2, F3, F4)>
            and $N others
    = note: `ReadOnlyWorldQuery` is implemented for `&'static Foo`, but not for `&'static mut Foo`
    = note: required for `bevy_ecs::system::Query<'_, '_, &'static mut Foo>` to implement `ReadOnlySystemParam`

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -5,14 +5,14 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyWorldQuery` is not sati
   |        ^^^^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `&'static mut Foo`
   |
   = help: the following other types implement trait `ReadOnlyWorldQuery`:
-            &T
-            ()
-            (F0, F1)
-            (F0, F1, F2)
-            (F0, F1, F2, F3)
-            (F0, F1, F2, F3, F4)
-            (F0, F1, F2, F3, F4, F5)
-            (F0, F1, F2, F3, F4, F5, F6)
+            MutableUnmarked
+            MutableMarkedReadOnly
+            NestedMutableUnmarked
+            bevy_ecs::change_detection::Ref<'__w, T>
+            Has<T>
+            AnyOf<()>
+            AnyOf<(F0,)>
+            AnyOf<(F0, F1)>
           and $N others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
@@ -28,14 +28,14 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyWorldQuery` is not satisfi
    |        ^^^^^^^^^^^^^ the trait `ReadOnlyWorldQuery` is not implemented for `MutableMarked`
    |
    = help: the following other types implement trait `ReadOnlyWorldQuery`:
-             &T
-             ()
-             (F0, F1)
-             (F0, F1, F2)
-             (F0, F1, F2, F3)
-             (F0, F1, F2, F3, F4)
-             (F0, F1, F2, F3, F4, F5)
-             (F0, F1, F2, F3, F4, F5, F6)
+             MutableUnmarked
+             MutableMarkedReadOnly
+             NestedMutableUnmarked
+             bevy_ecs::change_detection::Ref<'__w, T>
+             Has<T>
+             AnyOf<()>
+             AnyOf<(F0,)>
+             AnyOf<(F0, F1)>
            and $N others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -152,7 +152,7 @@ impl<'s> Gizmos<'s> {
     /// ```
     #[inline]
     pub fn linestrip(&mut self, positions: impl IntoIterator<Item = Vec3>, color: Color) {
-        self.extend_strip_positions(positions.into_iter());
+        self.extend_strip_positions(positions);
         let len = self.buffer.strip_positions.len();
         self.buffer
             .strip_colors

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -96,7 +96,9 @@ impl Plugin for GizmoPlugin {
                     .after(TransformSystem::TransformPropagate),
             );
 
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return; };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_systems(ExtractSchedule, extract_gizmo_data)
@@ -109,7 +111,9 @@ impl Plugin for GizmoPlugin {
     }
 
     fn finish(&self, app: &mut bevy_app::App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return; };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         let render_device = render_app.world.resource::<RenderDevice>();
         let layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -27,7 +27,9 @@ pub struct LineGizmo2dPlugin;
 
 impl Plugin for LineGizmo2dPlugin {
     fn build(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_render_command::<Transparent2d, DrawLineGizmo2d>()
@@ -36,7 +38,9 @@ impl Plugin for LineGizmo2dPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<LineGizmoPipeline>();
     }
@@ -151,7 +155,9 @@ fn queue_line_gizmos_2d(
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
-            let Some(line_gizmo) = line_gizmo_assets.get(handle) else { continue };
+            let Some(line_gizmo) = line_gizmo_assets.get(handle) else {
+                continue;
+            };
 
             let pipeline = pipelines.specialize(
                 &pipeline_cache,

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -25,7 +25,9 @@ use bevy_render::{
 pub struct LineGizmo3dPlugin;
 impl Plugin for LineGizmo3dPlugin {
     fn build(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app
             .add_render_command::<Transparent3d, DrawLineGizmo3d>()
@@ -34,7 +36,9 @@ impl Plugin for LineGizmo3dPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         render_app.init_resource::<LineGizmoPipeline>();
     }
@@ -164,7 +168,9 @@ fn queue_line_gizmos_3d(
             | MeshPipelineKey::from_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
-            let Some(line_gizmo) = line_gizmo_assets.get(handle) else { continue };
+            let Some(line_gizmo) = line_gizmo_assets.get(handle) else {
+                continue;
+            };
 
             let pipeline = pipelines.specialize(
                 &pipeline_cache,

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -15,6 +18,9 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,9 +6,6 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -15,9 +15,6 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -133,10 +133,7 @@ impl<P: Point> Hermite<P> {
         tangents: impl IntoIterator<Item = P>,
     ) -> Self {
         Self {
-            control_points: control_points
-                .into_iter()
-                .zip(tangents.into_iter())
-                .collect(),
+            control_points: control_points.into_iter().zip(tangents).collect(),
         }
     }
 }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -809,7 +809,9 @@ pub fn queue_prepass_material_meshes<M: Material>(
         let rangefinder = view.rangefinder3d();
 
         for visible_entity in &visible_entities.entities {
-            let Ok((material_handle, mesh_handle, mesh_transforms, batch_indices)) = material_meshes.get(*visible_entity) else {
+            let Ok((material_handle, mesh_handle, mesh_transforms, batch_indices)) =
+                material_meshes.get(*visible_entity)
+            else {
                 continue;
             };
 

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -86,7 +86,9 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else { return };
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
 
         if !render_app
             .world
@@ -226,7 +228,8 @@ impl ViewNode for SsaoNode {
             pipeline_cache.get_compute_pipeline(pipelines.preprocess_depth_pipeline),
             pipeline_cache.get_compute_pipeline(pipelines.spatial_denoise_pipeline),
             pipeline_cache.get_compute_pipeline(pipeline_id.0),
-        ) else {
+        )
+        else {
             return Ok(());
         };
 
@@ -640,7 +643,9 @@ fn prepare_ssao_textures(
     views: Query<(Entity, &ExtractedCamera), With<ScreenSpaceAmbientOcclusionSettings>>,
 ) {
     for (entity, camera) in &views {
-        let Some(physical_viewport_size) = camera.physical_viewport_size else { continue };
+        let Some(physical_viewport_size) = camera.physical_viewport_size else {
+            continue;
+        };
         let size = Extent3d {
             width: physical_viewport_size.x,
             height: physical_viewport_size.y,

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -195,7 +195,8 @@ impl<'a> ReflectDerive<'a> {
                     let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit),
                         ..
-                    }) = &pair.value else {
+                    }) = &pair.value
+                    else {
                         return Err(syn::Error::new(
                             pair.span(),
                             format_args!("`#[{TYPE_PATH_ATTRIBUTE_NAME} = \"...\"]` must be a string literal"),
@@ -211,7 +212,8 @@ impl<'a> ReflectDerive<'a> {
                     let syn::Expr::Lit(syn::ExprLit {
                         lit: syn::Lit::Str(lit),
                         ..
-                    }) = &pair.value else {
+                    }) = &pair.value
+                    else {
                         return Err(syn::Error::new(
                             pair.span(),
                             format_args!("`#[{TYPE_NAME_ATTRIBUTE_NAME} = \"...\"]` must be a string literal"),

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn test_into_iter() {
-        let expected = vec!["foo", "bar", "baz"];
+        let expected = ["foo", "bar", "baz"];
 
         let mut map = DynamicMap::default();
         map.insert(0usize, expected[0].to_string());

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -507,7 +507,7 @@ impl Debug for DynamicStruct {
 /// Returns [`None`] if the comparison couldn't even be performed.
 #[inline]
 pub fn struct_partial_eq<S: Struct>(a: &S, b: &dyn Reflect) -> Option<bool> {
-    let ReflectRef::Struct(struct_value) = b.reflect_ref()  else {
+    let ReflectRef::Struct(struct_value) = b.reflect_ref() else {
         return Some(false);
     };
 

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -11,14 +11,14 @@ error[E0277]: the trait bound `NoReflect: Reflect` is not satisfied
    |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Reflect` is not implemented for `NoReflect`
    |
    = help: the following other types implement trait `Reflect`:
-             &'static Path
-             ()
-             (A, B)
-             (A, B, C)
-             (A, B, C, D)
-             (A, B, C, D, E)
-             (A, B, C, D, E, F)
-             (A, B, C, D, E, F, G)
+             bool
+             char
+             isize
+             i8
+             i16
+             i32
+             i64
+             i128
            and $N others
 note: required for `Foo<NoReflect>` to implement `Reflect`
   --> tests/reflect_derive/generics.fail.rs:3:10

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -1990,8 +1990,14 @@ mod tests {
         let hsla = Color::hsla(0., 0., 0., 0.);
         let lcha = Color::lcha(0., 0., 0., 0.);
         assert_eq!(rgba_l, rgba_l.as_rgba_linear());
-        let Color::RgbaLinear { .. } = rgba.as_rgba_linear() else { panic!("from Rgba") };
-        let Color::RgbaLinear { .. } = hsla.as_rgba_linear() else { panic!("from Hsla") };
-        let Color::RgbaLinear { .. } = lcha.as_rgba_linear() else { panic!("from Lcha") };
+        let Color::RgbaLinear { .. } = rgba.as_rgba_linear() else {
+            panic!("from Rgba")
+        };
+        let Color::RgbaLinear { .. } = hsla.as_rgba_linear() else {
+            panic!("from Hsla")
+        };
+        let Color::RgbaLinear { .. } = lcha.as_rgba_linear() else {
+            panic!("from Lcha")
+        };
     }
 }

--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -74,8 +74,11 @@ impl MorphTargetImage {
             return Err(MorphBuildError::TooManyTargets { target_count });
         }
         let component_count = (vertex_count * MorphAttributes::COMPONENT_COUNT) as u32;
-        let Some((Rect(width, height), padding)) = lowest_2d(component_count , max) else {
-            return Err(MorphBuildError::TooManyAttributes { vertex_count, component_count });
+        let Some((Rect(width, height), padding)) = lowest_2d(component_count, max) else {
+            return Err(MorphBuildError::TooManyAttributes {
+                vertex_count,
+                component_count,
+            });
         };
         let data = targets
             .flat_map(|mut attributes| {

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -111,7 +111,9 @@ impl Plugin for PipelinedRenderingPlugin {
                         s.spawn(async { app_to_render_receiver.recv().await });
                     })
                     .pop();
-                let Some(Ok(mut render_app)) = sent_app else { break };
+                let Some(Ok(mut render_app)) = sent_app else {
+                    break;
+                };
 
                 {
                     #[cfg(feature = "trace")]

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -125,7 +125,9 @@ impl RenderGraph {
     /// It simply won't create a new edge.
     pub fn add_node_edges(&mut self, edges: &[&'static str]) {
         for window in edges.windows(2) {
-            let [a, b] = window else { break; };
+            let [a, b] = window else {
+                break;
+            };
             if let Err(err) = self.try_add_node_edge(*a, *b) {
                 match err {
                     // Already existing edges are very easy to produce with this api

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -398,10 +398,9 @@ where
         render_context: &mut RenderContext,
         world: &World,
     ) -> Result<(), NodeRunError> {
-        let Ok(view) = self
-            .view_query
-            .get_manual(world, graph.view_entity())
-        else { return Ok(()); };
+        let Ok(view) = self.view_query.get_manual(world, graph.view_entity()) else {
+            return Ok(());
+        };
 
         ViewNode::run(&self.node, graph, render_context, view, world)?;
         Ok(())

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -49,10 +49,10 @@ impl Node for UiPassNode {
         let input_view_entity = graph.view_entity();
 
         let Ok((transparent_phase, target, camera_ui)) =
-                self.ui_view_query.get_manual(world, input_view_entity)
-             else {
-                return Ok(());
-            };
+            self.ui_view_query.get_manual(world, input_view_entity)
+        else {
+            return Ok(());
+        };
         if transparent_phase.items.is_empty() {
             return Ok(());
         }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -422,20 +422,20 @@ pub fn winit_runner(mut app: App) {
                     event_writer_system_state.get_mut(&mut app.world);
 
                 let Some(window_entity) = winit_windows.get_window_entity(window_id) else {
-                        warn!(
-                            "Skipped event {:?} for unknown winit Window Id {:?}",
-                            event, window_id
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Skipped event {:?} for unknown winit Window Id {:?}",
+                        event, window_id
+                    );
+                    return;
+                };
 
                 let Ok((mut window, mut cache)) = windows.get_mut(window_entity) else {
-                        warn!(
-                            "Window {:?} is missing `Window` component, skipping event {:?}",
-                            window_entity, event
-                        );
-                        return;
-                    };
+                    warn!(
+                        "Window {:?} is missing `Window` component, skipping event {:?}",
+                        window_entity, event
+                    );
+                    return;
+                };
 
                 runner_state.window_event_received = true;
 

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -56,7 +56,10 @@ fn setup(
     for handle in &rpg_sprite_handles.handles {
         let handle = handle.typed_weak();
         let Some(texture) = textures.get(&handle) else {
-            warn!("{:?} did not resolve to an `Image` asset.", asset_server.get_handle_path(handle));
+            warn!(
+                "{:?} did not resolve to an `Image` asset.",
+                asset_server.get_handle_path(handle)
+            );
             continue;
         };
 

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -75,7 +75,7 @@ fn setup_scene(
                 0 => material_emissive1.clone(),
                 1 => material_emissive2.clone(),
                 2 => material_emissive3.clone(),
-                3 | 4 | 5 => material_non_emissive.clone(),
+                3..=5 => material_non_emissive.clone(),
                 _ => unreachable!(),
             };
 

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -88,8 +88,12 @@ fn name_morphs(
         return;
     }
 
-    let Some(mesh) = meshes.get(&morph_data.mesh) else { return };
-    let Some(names) = mesh.morph_target_names() else { return };
+    let Some(mesh) = meshes.get(&morph_data.mesh) else {
+        return;
+    };
+    let Some(names) = mesh.morph_target_names() else {
+        return;
+    };
     for name in names {
         println!("  {name}");
     }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -249,11 +249,6 @@ fn setup(
     commands.spawn(WallBundle::new(WallLocation::Top));
 
     // Bricks
-    // Negative scales result in flipped sprites / meshes,
-    // which is definitely not what we want here
-    assert!(BRICK_SIZE.x > 0.0);
-    assert!(BRICK_SIZE.y > 0.0);
-
     let total_width_of_bricks = (RIGHT_WALL - LEFT_WALL) - 2. * GAP_BETWEEN_BRICKS_AND_SIDES;
     let bottom_edge_of_bricks = paddle_y + GAP_BETWEEN_PADDLE_AND_BRICKS;
     let total_height_of_bricks = TOP_WALL - bottom_edge_of_bricks - GAP_BETWEEN_BRICKS_AND_CEILING;

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -158,7 +158,8 @@ impl ViewNode for PostProcessNode {
         let pipeline_cache = world.resource::<PipelineCache>();
 
         // Get the pipeline from the cache
-        let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id) else {
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(post_process_pipeline.pipeline_id)
+        else {
             return Ok(());
         };
 

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -37,7 +37,7 @@ impl Plugin for GpuFeatureSupportChecker {
 
     fn finish(&self, app: &mut App) {
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
-            return
+            return;
         };
 
         let render_device = render_app.world.resource::<RenderDevice>();

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -91,7 +91,10 @@ fn setup(mut commands: Commands) {
 fn ui_system(mut query: Query<&mut Text>, config: Res<Config>, diag: Res<DiagnosticsStore>) {
     let mut text = query.single_mut();
 
-    let Some(fps) = diag.get(FrameTimeDiagnosticsPlugin::FPS).and_then(|fps| fps.smoothed()) else {
+    let Some(fps) = diag
+        .get(FrameTimeDiagnosticsPlugin::FPS)
+        .and_then(|fps| fps.smoothed())
+    else {
         return;
     };
 

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -181,7 +181,9 @@ fn update_text(
     mut text: Query<&mut Text>,
     morphs: Query<&MorphWeights>,
 ) {
-    let Some(mut controls) = controls else { return; };
+    let Some(mut controls) = controls else {
+        return;
+    };
     for (i, target) in controls.weights.iter_mut().enumerate() {
         let Ok(weights) = morphs.get(target.entity) else {
             continue;
@@ -203,7 +205,9 @@ fn update_morphs(
     input: Res<Input<KeyCode>>,
     time: Res<Time>,
 ) {
-    let Some(mut controls) = controls else { return; };
+    let Some(mut controls) = controls else {
+        return;
+    };
     for (i, target) in controls.weights.iter_mut().enumerate() {
         if !AVAILABLE_KEYS[i].active(&input) {
             continue;

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -102,7 +102,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 })
                 .with_children(|parent| {
                     parent.spawn(TextBundle::from_section(
-                        vec![
+                        [
                             "Toggle Overflow (O)",
                             "Next Container Size (S)",
                             "Toggle Animation (space)",

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -19,11 +19,11 @@ bitflags! {
 
 const CLIPPY_FLAGS: [&str; 8] = [
     "-Aclippy::type_complexity",
+    "-Aclippy::explicit_iter_loop",
     "-Wclippy::doc_markdown",
     "-Wclippy::redundant_else",
     "-Wclippy::match_same_arms",
     "-Wclippy::semicolon_if_nothing_returned",
-    "-Wclippy::explicit_iter_loop",
     "-Wclippy::map_flatten",
     "-Dwarnings",
 ];


### PR DESCRIPTION
# Objective

[Rust 1.72.0](https://blog.rust-lang.org/2023/08/24/Rust-1.72.0.html) is now stable.

# Notes

- `let-else` formatting has arrived!
- I chose to allow `explicit_iter_loop` due to https://github.com/rust-lang/rust-clippy/issues/11074.
  
  We didn't hit any of the false positives that prevent compilation, but fixing this did produce a lot of the "symbol soup" mentioned, e.g. `for image in &mut *image_events {`.
  
  Happy to undo this if there's consensus the other way.
