### PR TITLE
Cache depth texture based on usage

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -374,7 +374,7 @@ pub fn prepare_core_3d_depth_textures(
                     height: physical_target_size.y,
                 };
 
-                let usage = render_target_usage
+                let usage = *render_target_usage
                     .get(&camera.target.clone())
                     .expect("The depth texture usage should already exist for this target");
 
@@ -386,7 +386,7 @@ pub fn prepare_core_3d_depth_textures(
                     dimension: TextureDimension::D2,
                     // PERF: vulkan docs recommend using 24 bit depth for better performance
                     format: TextureFormat::Depth32Float,
-                    usage: *usage,
+                    usage,
                     view_formats: &[],
                 };
 

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -350,16 +350,16 @@ pub fn prepare_core_3d_depth_textures(
             continue;
         };
 
-        let cached_texture = textures
-            .entry(camera.target.clone())
-            .or_insert_with(|| {
-                // Default usage required to write to the depth texture
-                let mut usage = camera_3d.depth_texture_usages.into();
-                if depth_prepass.is_some() {
-                    // Required to read the output of the prepass
-                    usage |= TextureUsages::COPY_SRC;
-                }
+        // Default usage required to write to the depth texture
+        let mut usage = camera_3d.depth_texture_usages.into();
+        if depth_prepass.is_some() {
+            // Required to read the output of the prepass
+            usage |= TextureUsages::COPY_SRC;
+        }
 
+        let cached_texture = textures
+            .entry((camera.target.clone(), usage))
+            .or_insert_with(|| {
                 // The size of the depth texture
                 let size = Extent3d {
                     depth_or_array_layers: 1,


### PR DESCRIPTION
# Objective

- Currently, the depth textures are cached based on the target. If multiple camera have the same target but a different `depth_texture_usage` bevy will just use the same texture and ignore that setting.

## Solution

- Add the usage as a cache key