### PR TITLE
Added `Val::ZERO` Constant

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -66,6 +66,13 @@ impl UiRect {
         bottom: Val::ZERO,
     };
 
+    pub const ZERO: Self = Self {
+        left: Val::ZERO,
+        right: Val::ZERO,
+        top: Val::ZERO,
+        bottom: Val::ZERO,
+    };
+
     /// Creates a new [`UiRect`] from the values specified.
     ///
     /// # Example

--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -60,10 +60,10 @@ pub struct UiRect {
 
 impl UiRect {
     pub const DEFAULT: Self = Self {
-        left: Val::Px(0.),
-        right: Val::Px(0.),
-        top: Val::Px(0.),
-        bottom: Val::Px(0.),
+        left: Val::ZERO,
+        right: Val::ZERO,
+        top: Val::ZERO,
+        bottom: Val::ZERO,
     };
 
     /// Creates a new [`UiRect`] from the values specified.
@@ -166,7 +166,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `left` and `right` take the given value,
-    /// and `top` and `bottom` set to zero `Val::Px(0.)`.
+    /// and `top` and `bottom` set to zero `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -177,8 +177,8 @@ impl UiRect {
     ///
     /// assert_eq!(ui_rect.left, Val::Px(10.0));
     /// assert_eq!(ui_rect.right, Val::Px(10.0));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn horizontal(value: Val) -> Self {
         UiRect {
@@ -189,7 +189,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `top` and `bottom` take the given value,
-    /// and `left` and `right` are set to `Val::Px(0.)`.
+    /// and `left` and `right` are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -198,8 +198,8 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::vertical(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
     /// assert_eq!(ui_rect.top, Val::Px(10.0));
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
     /// ```
@@ -235,7 +235,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `left` takes the given value, and
-    /// the other fields are set to `Val::Px(0.)`.
+    /// the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -245,9 +245,9 @@ impl UiRect {
     /// let ui_rect = UiRect::left(Val::Px(10.0));
     ///
     /// assert_eq!(ui_rect.left, Val::Px(10.0));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.right, Val::ZERO);
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn left(value: Val) -> Self {
         UiRect {
@@ -257,7 +257,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `right` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -266,10 +266,10 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::right(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
     /// assert_eq!(ui_rect.right, Val::Px(10.0));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.top, Val::ZERO);
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn right(value: Val) -> Self {
         UiRect {
@@ -279,7 +279,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `top` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -288,10 +288,10 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::top(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
     /// assert_eq!(ui_rect.top, Val::Px(10.0));
-    /// assert_eq!(ui_rect.bottom, Val::Px(0.));
+    /// assert_eq!(ui_rect.bottom, Val::ZERO);
     /// ```
     pub fn top(value: Val) -> Self {
         UiRect {
@@ -301,7 +301,7 @@ impl UiRect {
     }
 
     /// Creates a new [`UiRect`] where `bottom` takes the given value,
-    /// and the other fields are set to `Val::Px(0.)`.
+    /// and the other fields are set to `Val::ZERO`.
     ///
     /// # Example
     ///
@@ -310,9 +310,9 @@ impl UiRect {
     /// #
     /// let ui_rect = UiRect::bottom(Val::Px(10.0));
     ///
-    /// assert_eq!(ui_rect.left, Val::Px(0.));
-    /// assert_eq!(ui_rect.right, Val::Px(0.));
-    /// assert_eq!(ui_rect.top, Val::Px(0.));
+    /// assert_eq!(ui_rect.left, Val::ZERO);
+    /// assert_eq!(ui_rect.right, Val::ZERO);
+    /// assert_eq!(ui_rect.top, Val::ZERO);
     /// assert_eq!(ui_rect.bottom, Val::Px(10.0));
     /// ```
     pub fn bottom(value: Val) -> Self {
@@ -338,10 +338,10 @@ mod tests {
         assert_eq!(
             UiRect::default(),
             UiRect {
-                left: Val::Px(0.),
-                right: Val::Px(0.),
-                top: Val::Px(0.),
-                bottom: Val::Px(0.)
+                left: Val::ZERO,
+                right: Val::ZERO,
+                top: Val::ZERO,
+                bottom: Val::ZERO
             }
         );
         assert_eq!(UiRect::default(), UiRect::DEFAULT);

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -404,8 +404,8 @@ mod tests {
             display: Display::Flex,
             position_type: PositionType::Absolute,
             left: Val::ZERO,
-            right: Val::ZERO,
-            top: Val::Auto,
+            right: Val::Percent(50.),
+            top: Val::Px(12.),
             bottom: Val::Auto,
             direction: crate::Direction::Inherit,
             flex_direction: FlexDirection::ColumnReverse,
@@ -418,21 +418,21 @@ mod tests {
             justify_content: JustifyContent::SpaceEvenly,
             margin: UiRect {
                 left: Val::ZERO,
-                right: Val::ZERO,
-                top: Val::Auto,
+                right: Val::Px(10.),
+                top: Val::Percent(15.),
                 bottom: Val::Auto,
             },
             padding: UiRect {
-                left: Val::ZERO,
-                right: Val::ZERO,
-                top: Val::ZERO,
+                left: Val::Percent(13.),
+                right: Val::Px(21.),
+                top: Val::Auto,
                 bottom: Val::ZERO,
             },
             border: UiRect {
-                left: Val::ZERO,
+                left: Val::Px(14.),
                 right: Val::ZERO,
                 top: Val::Auto,
-                bottom: Val::ZERO,
+                bottom: Val::Percent(31.),
             },
             flex_grow: 1.,
             flex_shrink: 0.,
@@ -477,11 +477,11 @@ mod tests {
         );
         assert_eq!(
             taffy_style.inset.right,
-            taffy::style::LengthPercentageAuto::ZERO
+            taffy::style::LengthPercentageAuto::Percent(0.5)
         );
         assert_eq!(
             taffy_style.inset.top,
-            taffy::style::LengthPercentageAuto::Auto
+            taffy::style::LengthPercentageAuto::Points(12.)
         );
         assert_eq!(
             taffy_style.inset.bottom,
@@ -516,11 +516,11 @@ mod tests {
         );
         assert_eq!(
             taffy_style.margin.right,
-            taffy::style::LengthPercentageAuto::ZERO
+            taffy::style::LengthPercentageAuto::Points(10.)
         );
         assert_eq!(
             taffy_style.margin.top,
-            taffy::style::LengthPercentageAuto::Auto
+            taffy::style::LengthPercentageAuto::Percent(0.15)
         );
         assert_eq!(
             taffy_style.margin.bottom,
@@ -528,11 +528,11 @@ mod tests {
         );
         assert_eq!(
             taffy_style.padding.left,
-            taffy::style::LengthPercentage::ZERO
+            taffy::style::LengthPercentage::Percent(0.13)
         );
         assert_eq!(
             taffy_style.padding.right,
-            taffy::style::LengthPercentage::ZERO
+            taffy::style::LengthPercentage::Points(21.)
         );
         assert_eq!(
             taffy_style.padding.top,
@@ -544,7 +544,7 @@ mod tests {
         );
         assert_eq!(
             taffy_style.border.left,
-            taffy::style::LengthPercentage::ZERO
+            taffy::style::LengthPercentage::Points(14.)
         );
         assert_eq!(
             taffy_style.border.right,
@@ -553,7 +553,7 @@ mod tests {
         assert_eq!(taffy_style.border.top, taffy::style::LengthPercentage::ZERO);
         assert_eq!(
             taffy_style.border.bottom,
-            taffy::style::LengthPercentage::ZERO
+            taffy::style::LengthPercentage::Percent(0.31)
         );
         assert_eq!(taffy_style.flex_grow, 1.);
         assert_eq!(taffy_style.flex_shrink, 0.);

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -397,13 +397,14 @@ mod tests {
 
     #[test]
     fn test_convert_from() {
+        use sh::TaffyZero;
         use taffy::style_helpers as sh;
 
         let bevy_style = crate::Style {
             display: Display::Flex,
             position_type: PositionType::Absolute,
-            left: Val::Px(0.),
-            right: Val::Percent(0.),
+            left: Val::ZERO,
+            right: Val::ZERO,
             top: Val::Auto,
             bottom: Val::Auto,
             direction: crate::Direction::Inherit,
@@ -416,36 +417,36 @@ mod tests {
             justify_self: JustifySelf::Center,
             justify_content: JustifyContent::SpaceEvenly,
             margin: UiRect {
-                left: Val::Percent(0.),
-                right: Val::Px(0.),
+                left: Val::ZERO,
+                right: Val::ZERO,
                 top: Val::Auto,
                 bottom: Val::Auto,
             },
             padding: UiRect {
-                left: Val::Percent(0.),
-                right: Val::Px(0.),
-                top: Val::Percent(0.),
-                bottom: Val::Percent(0.),
+                left: Val::ZERO,
+                right: Val::ZERO,
+                top: Val::ZERO,
+                bottom: Val::ZERO,
             },
             border: UiRect {
-                left: Val::Px(0.),
-                right: Val::Px(0.),
+                left: Val::ZERO,
+                right: Val::ZERO,
                 top: Val::Auto,
-                bottom: Val::Px(0.),
+                bottom: Val::ZERO,
             },
             flex_grow: 1.,
             flex_shrink: 0.,
-            flex_basis: Val::Px(0.),
-            width: Val::Px(0.),
+            flex_basis: Val::ZERO,
+            width: Val::ZERO,
             height: Val::Auto,
-            min_width: Val::Px(0.),
-            min_height: Val::Percent(0.),
+            min_width: Val::ZERO,
+            min_height: Val::ZERO,
             max_width: Val::Auto,
-            max_height: Val::Px(0.),
+            max_height: Val::ZERO,
             aspect_ratio: None,
             overflow: crate::Overflow::clip(),
-            column_gap: Val::Px(0.),
-            row_gap: Val::Percent(0.),
+            column_gap: Val::ZERO,
+            row_gap: Val::ZERO,
             grid_auto_flow: GridAutoFlow::ColumnDense,
             grid_template_rows: vec![
                 GridTrack::px(10.0),
@@ -470,22 +471,22 @@ mod tests {
         let taffy_style = from_style(&viewport_values, &bevy_style);
         assert_eq!(taffy_style.display, taffy::style::Display::Flex);
         assert_eq!(taffy_style.position, taffy::style::Position::Absolute);
-        assert!(matches!(
+        assert_eq!(
             taffy_style.inset.left,
-            taffy::style::LengthPercentageAuto::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.inset.right,
-            taffy::style::LengthPercentageAuto::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.inset.top,
             taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             taffy_style.inset.bottom,
             taffy::style::LengthPercentageAuto::Auto
-        ));
+        );
         assert_eq!(
             taffy_style.flex_direction,
             taffy::style::FlexDirection::ColumnReverse
@@ -509,93 +510,63 @@ mod tests {
             taffy_style.justify_self,
             Some(taffy::style::JustifySelf::Center)
         );
-        assert!(matches!(
+        assert_eq!(
             taffy_style.margin.left,
-            taffy::style::LengthPercentageAuto::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.margin.right,
-            taffy::style::LengthPercentageAuto::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentageAuto::ZERO
+        );
+        assert_eq!(
             taffy_style.margin.top,
             taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             taffy_style.margin.bottom,
             taffy::style::LengthPercentageAuto::Auto
-        ));
-        assert!(matches!(
+        );
+        assert_eq!(
             taffy_style.padding.left,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.padding.right,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.padding.top,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.padding.bottom,
-            taffy::style::LengthPercentage::Percent(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.border.left,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(
             taffy_style.border.right,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.border.top,
-            taffy::style::LengthPercentage::Points(_)
-        ));
-        assert!(matches!(
+            taffy::style::LengthPercentage::ZERO
+        );
+        assert_eq!(taffy_style.border.top, taffy::style::LengthPercentage::ZERO);
+        assert_eq!(
             taffy_style.border.bottom,
-            taffy::style::LengthPercentage::Points(_)
-        ));
+            taffy::style::LengthPercentage::ZERO
+        );
         assert_eq!(taffy_style.flex_grow, 1.);
         assert_eq!(taffy_style.flex_shrink, 0.);
-        assert!(matches!(
-            taffy_style.flex_basis,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.size.width,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.size.height,
-            taffy::style::Dimension::Auto
-        ));
-        assert!(matches!(
-            taffy_style.min_size.width,
-            taffy::style::Dimension::Points(_)
-        ));
-        assert!(matches!(
-            taffy_style.min_size.height,
-            taffy::style::Dimension::Percent(_)
-        ));
-        assert!(matches!(
-            taffy_style.max_size.width,
-            taffy::style::Dimension::Auto
-        ));
-        assert!(matches!(
-            taffy_style.max_size.height,
-            taffy::style::Dimension::Points(_)
-        ));
+        assert_eq!(taffy_style.flex_basis, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.size.width, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.size.height, taffy::style::Dimension::Auto);
+        assert_eq!(taffy_style.min_size.width, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.min_size.height, taffy::style::Dimension::ZERO);
+        assert_eq!(taffy_style.max_size.width, taffy::style::Dimension::Auto);
+        assert_eq!(taffy_style.max_size.height, taffy::style::Dimension::ZERO);
         assert_eq!(taffy_style.aspect_ratio, None);
-        assert_eq!(
-            taffy_style.gap.width,
-            taffy::style::LengthPercentage::Points(0.)
-        );
-        assert_eq!(
-            taffy_style.gap.height,
-            taffy::style::LengthPercentage::Percent(0.)
-        );
+        assert_eq!(taffy_style.gap.width, taffy::style::LengthPercentage::ZERO);
+        assert_eq!(taffy_style.gap.height, taffy::style::LengthPercentage::ZERO);
         assert_eq!(
             taffy_style.grid_auto_flow,
             taffy::style::GridAutoFlow::ColumnDense

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -237,7 +237,7 @@ fn setup(
                     TextBundle::from_section(label, label_text_style.clone())
                         .with_style(Style {
                             position_type: PositionType::Absolute,
-                            bottom: Val::Px(0.),
+                            bottom: Val::ZERO,
                             ..default()
                         })
                         .with_no_wrap(),

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -98,7 +98,7 @@ fn setup(
         style: Style {
             position_type: PositionType::Absolute,
             top: Val::Px(130.0),
-            right: Val::Px(0.0),
+            right: Val::ZERO,
             ..default()
         },
         transform: Transform {

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -50,7 +50,7 @@ fn atlas_render_system(
                 image: texture_atlas.texture.clone().into(),
                 style: Style {
                     position_type: PositionType::Absolute,
-                    top: Val::Px(0.0),
+                    top: Val::ZERO,
                     left: Val::Px(512.0 * x_offset),
                     ..default()
                 },
@@ -83,7 +83,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
             background_color: Color::NONE.into(),
             style: Style {
                 position_type: PositionType::Absolute,
-                bottom: Val::Px(0.0),
+                bottom: Val::ZERO,
                 ..default()
             },
             ..default()


### PR DESCRIPTION
# Objective

- Fixes #9533

## Solution

* Added `Val::ZERO` as a constant which is defined as `Val::Px(0.)`.
* Added manual `PartialEq` implementation for `Val` which allows any zero value to equal any other zero value. E.g., `Val::Px(0.) == Val::Percent(0.)` etc. This is technically a breaking change, as `Val::Px(0.) == Val::Percent(0.)` now equals `true` instead of `false` (as an example)
* Replaced instances of `Val::Px(0.)`, `Val::Percent(0.)`, etc. with `Val::ZERO`
* Fixed `bevy_ui::layout::convert::tests::test_convert_from` test to account for Taffy not equating `Points(0.)` and `Percent(0.)`. These tests now use `assert_eq!(...)` instead of `assert!(matches!(...))` which gives easier to diagnose error messages.