### PR TITLE
[WIP] Motion Vectors for morph targets & skinned meshes

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -343,7 +343,7 @@ type DrawMaterial<M> = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
     SetMaterialBindGroup<M, 1>,
-    SetMeshBindGroup<2>,
+    SetMeshBindGroup<2, false>,
     DrawMesh,
 );
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -80,7 +80,7 @@ where
         load_internal_asset!(
             app,
             PREPASS_BINDINGS_SHADER_HANDLE,
-            "prepass_bindings.wgsl",
+            "prepass_view_bindings.wgsl",
             Shader::from_wgsl
         );
 
@@ -843,17 +843,17 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
             Option<&'_ PreviousViewProjectionUniformOffset>,
         ),
         _entity: (),
-        prepass_view_bind_group: SystemParamItem<'w, '_, Self::Param>,
+        bind_groups: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let prepass_view_bind_group = prepass_view_bind_group.into_inner();
+        let bind_groups = bind_groups.into_inner();
 
         if let Some(previous_view_projection_uniform_offset) =
             previous_view_projection_uniform_offset
         {
             pass.set_bind_group(
                 I,
-                prepass_view_bind_group.motion_vectors.as_ref().unwrap(),
+                bind_groups.motion_vectors.as_ref().unwrap(),
                 &[
                     view_uniform_offset.offset,
                     previous_view_projection_uniform_offset.offset,
@@ -862,7 +862,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
         } else {
             pass.set_bind_group(
                 I,
-                prepass_view_bind_group.no_motion_vectors.as_ref().unwrap(),
+                bind_groups.no_motion_vectors.as_ref().unwrap(),
                 &[view_uniform_offset.offset],
             );
         }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -802,7 +802,7 @@ pub type DrawPrepass<M> = (
     SetItemPipeline,
     SetPrepassViewBindGroup<0>,
     SetMaterialBindGroup<M, 1>,
-    SetMeshBindGroup<2>,
+    SetMeshBindGroup<2, true>,
     DrawMesh,
 );
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -80,7 +80,7 @@ where
         load_internal_asset!(
             app,
             PREPASS_BINDINGS_SHADER_HANDLE,
-            "prepass_view_bindings.wgsl",
+            "prepass_bindings.wgsl",
             Shader::from_wgsl
         );
 

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -143,21 +143,23 @@ fn vertex(
 
 #ifdef MOTION_VECTOR_PREPASS
 
+    var old_model = bevy_pbr::mesh_functions::get_previous_model_matrix(instance_index);
+    var old_position = vertex.position;
 #ifdef MORPH_TARGETS
     // Replace the vertex position with the old one
-    vertex.position = morph_last_position(vertex_no_morph);
+    old_position = morph_last_position(vertex_no_morph);
 #endif // MORPH_TARGETS
 #ifdef SKINNED
     // Replace the model with the one computed from old skinning weights
-    model = bevy_pbr::skinning::last_skin_model(vertex.joint_indices, vertex.joint_weights);
+    old_model = bevy_pbr::skinning::last_skin_model(vertex.joint_indices, vertex.joint_weights);
 #endif // SKINNED
 
     out.world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
     // Use instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416
     out.previous_world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(
-        bevy_pbr::mesh_functions::get_previous_model_matrix(instance_index),
-        vec4<f32>(vertex.position, 1.0)
+        old_model,
+        vec4<f32>(old_position, 1.0)
     );
 #endif // MOTION_VECTOR_PREPASS
 

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -1,14 +1,14 @@
-#import bevy_pbr::prepass_bindings
+#import bevy_pbr::prepass_view_bindings
 #import bevy_pbr::mesh_functions
 #import bevy_pbr::skinning
 #import bevy_pbr::morph
+#import bevy_pbr::morph morph
 #import bevy_pbr::mesh_bindings mesh
 #import bevy_render::instance_index get_instance_index
 
 // Most of these attributes are not used in the default prepass fragment shader, but they are still needed so we can
 // pass them to custom prepass shaders like pbr_prepass.wgsl.
 struct Vertex {
-    @builtin(instance_index) instance_index: u32,
     @location(0) position: vec3<f32>,
 
 #ifdef VERTEX_UVS
@@ -65,20 +65,37 @@ fn morph_vertex(vertex_in: Vertex) -> Vertex {
         if weight == 0.0 {
             continue;
         }
-        vertex.position += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::position_offset, i);
+        vertex.position += weight * morph(vertex.index, bevy_pbr::morph::position_offset, i);
 #ifdef VERTEX_NORMALS
-        vertex.normal += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::normal_offset, i);
+        vertex.normal += weight * morph(vertex.index, bevy_pbr::morph::normal_offset, i);
 #endif
 #ifdef VERTEX_TANGENTS
-        vertex.tangent += vec4(weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
+        vertex.tangent += vec4(weight * morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
 #endif
     }
     return vertex;
 }
+fn morph_old_position(vertex: Vertex) -> vec3 {
+    var vertex_position = vertex.position;
+    let weight_count = bevy_pbr::morph::layer_count();
+    for (var i: u32 = 0u; i < weight_count; i ++) {
+        let weight = bevy_pbr::morph::weight_at(i);
+        if weight == 0.0 {
+            continue;
+        }
+        vertex_position += weight * morph(vertex.index, bevy_pbr::morph::position_offset, i);
+    }
+    return vertex_position;
+}
 #endif
 
 @vertex
-fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
+fn vertex(
+    vertex_no_morph: Vertex,
+    // Use instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416
+    @builtin(instance_index) instance_index: u32,
+) -> VertexOutput {
     var out: VertexOutput;
 
 #ifdef MORPH_TARGETS
@@ -90,9 +107,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #ifdef SKINNED
     var model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else // SKINNED
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416
-    var model = bevy_pbr::mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
+    var model = bevy_pbr::mesh_functions::get_model_matrix(instance_index);
 #endif // SKINNED
 
     out.clip_position = bevy_pbr::mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
@@ -111,9 +126,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #else // SKINNED
     out.world_normal = bevy_pbr::mesh_functions::mesh_normal_local_to_world(
         vertex.normal,
-        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-        // See https://github.com/gfx-rs/naga/issues/2416
-        get_instance_index(vertex_no_morph.instance_index)
+        get_instance_index(instance_index)
     );
 #endif // SKINNED
 
@@ -121,19 +134,25 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.world_tangent = bevy_pbr::mesh_functions::mesh_tangent_local_to_world(
         model,
         vertex.tangent,
-        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-        // See https://github.com/gfx-rs/naga/issues/2416
-        get_instance_index(vertex_no_morph.instance_index)
+        get_instance_index(instance_index)
     );
 #endif // VERTEX_TANGENTS
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
+
+#ifdef MORPH_TARGETS
+    var old_vertex_position = morph_old_position(vertex_no_morph);
+#endif // MORPH_TARGETS
+#ifdef SKINNED
+    var old_model = skin_old_weights(vertex.joint_indices, vertex.joint_weights);
+#else // SKINNED
+
     out.world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // Use instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416
     out.previous_world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(
-        bevy_pbr::mesh_functions::get_previous_model_matrix(vertex_no_morph.instance_index),
+        bevy_pbr::mesh_functions::get_previous_model_matrix(instance_index),
         vec4<f32>(vertex.position, 1.0)
     );
 #endif // MOTION_VECTOR_PREPASS
@@ -188,9 +207,9 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #endif // DEPTH_CLAMP_ORTHO
 
 #ifdef MOTION_VECTOR_PREPASS
-    let clip_position_t = bevy_pbr::prepass_bindings::view.unjittered_view_proj * in.world_position;
+    let clip_position_t = bevy_pbr::prepass_view_bindings::view.unjittered_view_proj * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = bevy_pbr::prepass_bindings::previous_view_proj * in.previous_world_position;
+    let previous_clip_position_t = bevy_pbr::prepass_view_bindings::previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -149,7 +149,7 @@ fn vertex(
 #endif // MORPH_TARGETS
 #ifdef SKINNED
     // Replace the model with the one computed from old skinning weights
-    model = last_skin_model(vertex.joint_indices, vertex.joint_weights);
+    model = bevy_pbr::skinning::last_skin_model(vertex.joint_indices, vertex.joint_weights);
 #endif // SKINNED
 
     out.world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -13,16 +13,6 @@ var<uniform> globals: Globals;
 @group(0) @binding(2)
 var<uniform> previous_view_proj: mat4x4<f32>;
 
-#ifdef SKINNED
-@group(0) @binding(3)
-var<uniform> previous_joint_matrices: SkinnedMesh;
-#endif // SKINNED
-
-#ifdef MORPH_TARGETS
-@group(0) @binding(4)
-var<uniform> previous_morph_weights: MorphWeights;
-#endif // MORPH_TARGETS
-
 #endif // MOTION_VECTOR_PREPASS
 
 // Material bindings will be in @group(1)

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -9,8 +9,20 @@ var<uniform> view: View;
 var<uniform> globals: Globals;
 
 #ifdef MOTION_VECTOR_PREPASS
+
 @group(0) @binding(2)
 var<uniform> previous_view_proj: mat4x4<f32>;
+
+#ifdef SKINNED
+@group(0) @binding(3)
+var<uniform> previous_joint_matrices: SkinnedMesh;
+#endif // SKINNED
+
+#ifdef MORPH_TARGETS
+@group(0) @binding(4)
+var<uniform> previous_morph_weights: MorphWeights;
+#endif // MORPH_TARGETS
+
 #endif // MOTION_VECTOR_PREPASS
 
 // Material bindings will be in @group(1)

--- a/crates/bevy_pbr/src/render/double_buffer.rs
+++ b/crates/bevy_pbr/src/render/double_buffer.rs
@@ -58,7 +58,9 @@ impl<T: Pod> DoubleBufferVec<T> {
             Side::A => &self.b,
             Side::B => &self.a,
         };
-        old_buffer.buffer()
+        old_buffer
+            .buffer()
+            .or_else(|| self.current_buffer().buffer())
     }
     pub fn is_empty(&self) -> bool {
         self.current_buffer().is_empty()

--- a/crates/bevy_pbr/src/render/double_buffer.rs
+++ b/crates/bevy_pbr/src/render/double_buffer.rs
@@ -1,0 +1,75 @@
+use std::mem;
+
+use bevy_render::{
+    render_resource::{Buffer, BufferUsages, BufferVec},
+    renderer::{RenderDevice, RenderQueue},
+};
+use bytemuck::Pod;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    A,
+    B,
+}
+impl Side {
+    fn toggle(&mut self) {
+        *self = match self {
+            Side::A => Side::B,
+            Side::B => Side::A,
+        }
+    }
+}
+pub struct DoubleBufferVec<T: Pod> {
+    a: BufferVec<T>,
+    b: BufferVec<T>,
+    current: Side,
+}
+impl<T: Pod> Extend<T> for DoubleBufferVec<T> {
+    #[inline]
+    fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
+        self.current_buffer_mut().extend(iter);
+    }
+}
+impl<T: Pod> DoubleBufferVec<T> {
+    pub const fn new(buffer_usage: BufferUsages) -> Self {
+        DoubleBufferVec {
+            a: BufferVec::new(buffer_usage),
+            b: BufferVec::new(buffer_usage),
+            current: Side::A,
+        }
+    }
+    pub(crate) const fn current_buffer(&self) -> &BufferVec<T> {
+        match self.current {
+            Side::A => &self.a,
+            Side::B => &self.b,
+        }
+    }
+    pub(crate) fn current_buffer_mut(&mut self) -> &mut BufferVec<T> {
+        match self.current {
+            Side::A => &mut self.a,
+            Side::B => &mut self.b,
+        }
+    }
+    pub fn buffer(&self) -> Option<&Buffer> {
+        self.current_buffer().buffer()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.current_buffer().is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.current_buffer().len()
+    }
+    pub fn clear(&mut self) {
+        self.current_buffer_mut().clear();
+    }
+    pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
+        self.current_buffer_mut().reserve(capacity, device);
+    }
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
+        self.current_buffer_mut().write_buffer(device, queue);
+    }
+    pub fn flip(&mut self) {
+        self.current.toggle();
+        mem::swap(&mut self.a, &mut self.b);
+    }
+}

--- a/crates/bevy_pbr/src/render/double_buffer.rs
+++ b/crates/bevy_pbr/src/render/double_buffer.rs
@@ -53,6 +53,13 @@ impl<T: Pod> DoubleBufferVec<T> {
     pub fn buffer(&self) -> Option<&Buffer> {
         self.current_buffer().buffer()
     }
+    pub fn old_buffer(&self) -> Option<&Buffer> {
+        let old_buffer = match self.current {
+            Side::A => &self.b,
+            Side::B => &self.a,
+        };
+        old_buffer.buffer()
+    }
     pub fn is_empty(&self) -> bool {
         self.current_buffer().is_empty()
     }
@@ -60,6 +67,7 @@ impl<T: Pod> DoubleBufferVec<T> {
         self.current_buffer().len()
     }
     pub fn clear(&mut self) {
+        self.current.toggle();
         self.current_buffer_mut().clear();
     }
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
@@ -67,9 +75,5 @@ impl<T: Pod> DoubleBufferVec<T> {
     }
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
         self.current_buffer_mut().write_buffer(device, queue);
-    }
-    pub fn flip(&mut self) {
-        self.current.toggle();
-        mem::swap(&mut self.a, &mut self.b);
     }
 }

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1470,6 +1470,16 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMeshBindGroup<I> {
             dynamic_offsets[index_count] = morph_index.index;
             index_count += 1;
         }
+        if is_mv {
+            if let Some(skin_index) = skin_index {
+                dynamic_offsets[index_count] = skin_index.index;
+                index_count += 1;
+            }
+            if let Some(morph_index) = morph_index {
+                dynamic_offsets[index_count] = morph_index.index;
+                index_count += 1;
+            }
+        }
         pass.set_bind_group(I, bind_group, &dynamic_offsets[..index_count]);
 
         RenderCommandResult::Success

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -806,7 +806,7 @@ impl MeshPipelineKey {
     }
 }
 
-fn is_skinned(layout: &Hashed<InnerMeshVertexBufferLayout>) -> bool {
+pub(crate) fn is_skinned(layout: &Hashed<InnerMeshVertexBufferLayout>) -> bool {
     layout.contains(Mesh::ATTRIBUTE_JOINT_INDEX) && layout.contains(Mesh::ATTRIBUTE_JOINT_WEIGHT)
 }
 pub fn setup_morph_and_skinning_defs(

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -18,7 +18,7 @@ pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 mod layout_entry {
     use super::MORPH_BUFFER_SIZE;
     use crate::MeshUniform;
-    use crate::{render::mesh::JOINT_BUFFER_SIZE, PreviousViewProjection};
+    use crate::{render::skinning::JOINT_BUFFER_SIZE, PreviousViewProjection};
     use bevy_render::{
         globals::GlobalsUniform,
         render_resource::{
@@ -94,7 +94,7 @@ mod layout_entry {
 /// for bind groups.
 mod entry {
     use super::MORPH_BUFFER_SIZE;
-    use crate::render::mesh::JOINT_BUFFER_SIZE;
+    use crate::render::skinning::JOINT_BUFFER_SIZE;
     use bevy_render::render_resource::{
         BindGroupEntry, BindingResource, Buffer, BufferBinding, BufferSize, TextureView,
     };

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -5,21 +5,17 @@
 #ifdef MESH_BINDGROUP_1
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(1) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+    @group(1) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(1) @binding(0)
-var<storage> mesh: array<Mesh>;
+    @group(1) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
 
 #else // MESH_BINDGROUP_1
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(2) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+    @group(2) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(2) @binding(0)
-var<storage> mesh: array<Mesh>;
+    @group(2) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
 
 #endif // MESH_BINDGROUP_1

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -4,8 +4,10 @@ mod light;
 pub(crate) mod mesh;
 mod mesh_bindings;
 mod morph;
+mod skinning;
 
 pub use fog::*;
 pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::{MeshLayouts, MotionVectorsPrepassLayouts};
+pub use skinning::{extract_skins, prepare_skins, SkinIndex, SkinUniform, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -8,4 +8,4 @@ mod morph;
 pub use fog::*;
 pub use light::*;
 pub use mesh::*;
-pub use mesh_bindings::{MeshLayouts, PrepassLayouts};
+pub use mesh_bindings::{MeshLayouts, MotionVectorsPrepassLayouts};

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -1,3 +1,4 @@
+mod double_buffer;
 mod fog;
 mod light;
 pub(crate) mod mesh;
@@ -7,4 +8,4 @@ mod morph;
 pub use fog::*;
 pub use light::*;
 pub use mesh::*;
-pub use mesh_bindings::MeshLayouts;
+pub use mesh_bindings::{MeshLayouts, PrepassLayouts};

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -10,18 +10,20 @@ use bevy_render::{
 };
 use bytemuck::Pod;
 
+use super::double_buffer::DoubleBufferVec;
+
 #[derive(Component)]
 pub struct MorphIndex {
     pub(super) index: u32,
 }
 #[derive(Resource)]
 pub struct MorphUniform {
-    pub buffer: BufferVec<f32>,
+    pub buffer: DoubleBufferVec<f32>,
 }
 impl Default for MorphUniform {
     fn default() -> Self {
         Self {
-            buffer: BufferVec::new(BufferUsages::UNIFORM),
+            buffer: DoubleBufferVec::new(BufferUsages::UNIFORM),
         }
     }
 }
@@ -86,7 +88,7 @@ pub fn extract_morphs(
         let weights = morph_weights.weights();
         let legal_weights = weights.iter().take(MAX_MORPH_WEIGHTS).copied();
         uniform.buffer.extend(legal_weights);
-        add_to_alignment::<f32>(&mut uniform.buffer);
+        add_to_alignment::<f32>(uniform.buffer.current_buffer_mut());
 
         let index = (start * mem::size_of::<f32>()) as u32;
         values.push((entity, MorphIndex { index }));

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -36,9 +36,10 @@ pub fn prepare_morphs(
     if uniform.buffer.is_empty() {
         return;
     }
-    let buffer = &mut uniform.buffer;
-    buffer.reserve(buffer.len(), &device);
-    buffer.write_buffer(&device, &queue);
+
+    let len = uniform.buffer.len();
+    uniform.buffer.reserve(len, &device);
+    uniform.buffer.write_buffer(&device, &queue);
 }
 
 const fn can_align(step: usize, target: usize) -> bool {

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -18,6 +18,9 @@ var<uniform> morph_weights: MorphWeights;
 @group(1) @binding(3)
 var morph_targets: texture_3d<f32>;
 
+#ifdef MOTION_VECTOR_PREPASS
+    @group(1) @binding(5) var<uniform> last_morph_weights: MorphWeights;
+#endif
 #else
 
 @group(2) @binding(2)
@@ -25,6 +28,9 @@ var<uniform> morph_weights: MorphWeights;
 @group(2) @binding(3)
 var morph_targets: texture_3d<f32>;
 
+#ifdef MOTION_VECTOR_PREPASS
+    @group(2) @binding(5) var<uniform> last_morph_weights: MorphWeights;
+#endif
 #endif
 
 
@@ -64,5 +70,12 @@ fn morph(vertex_index: u32, component_offset: u32, weight_index: u32) -> vec3<f3
         morph_pixel(vertex_index, component_offset + 2u, weight_index),
     );
 }
+
+#ifdef MOTION_VECTOR_PREPASS
+fn last_weight_at(weight_index: u32) -> f32 {
+    let i = weight_index;
+    return last_morph_weights.weights[i / 4u][i % 4u];
+}
+#endif
 
 #endif // MORPH_TARGETS

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::prepass_view_bindings
+#import bevy_pbr::prepass_bindings
 #import bevy_pbr::pbr_bindings
 #import bevy_pbr::pbr_types
 #ifdef NORMAL_PREPASS
@@ -40,7 +40,7 @@ fn prepass_alpha_discard(in: FragmentInput) {
 
 #ifdef VERTEX_UVS
     if (bevy_pbr::pbr_bindings::material.flags & bevy_pbr::pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u {
-        output_color = output_color * textureSampleBias(bevy_pbr::pbr_bindings::base_color_texture, bevy_pbr::pbr_bindings::base_color_sampler, in.uv, bevy_pbr::prepass_view_bindings::view.mip_bias);
+        output_color = output_color * textureSampleBias(bevy_pbr::pbr_bindings::base_color_texture, bevy_pbr::pbr_bindings::base_color_sampler, in.uv, bevy_pbr::prepass_bindings::view.mip_bias);
     }
 #endif // VERTEX_UVS
 
@@ -107,7 +107,7 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #ifdef VERTEX_UVS
             in.uv,
 #endif // VERTEX_UVS
-            bevy_pbr::prepass_view_bindings::view.mip_bias,
+            bevy_pbr::prepass_bindings::view.mip_bias,
         );
 
         out.normal = vec4(normal * 0.5 + vec3(0.5), 1.0);
@@ -117,9 +117,9 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    let clip_position_t = bevy_pbr::prepass_view_bindings::view.unjittered_view_proj * in.world_position;
+    let clip_position_t = bevy_pbr::prepass_bindings::view.unjittered_view_proj * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = bevy_pbr::prepass_view_bindings::previous_view_proj * in.previous_world_position;
+    let previous_clip_position_t = bevy_pbr::prepass_bindings::previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::prepass_bindings
+#import bevy_pbr::prepass_view_bindings
 #import bevy_pbr::pbr_bindings
 #import bevy_pbr::pbr_types
 #ifdef NORMAL_PREPASS
@@ -40,7 +40,7 @@ fn prepass_alpha_discard(in: FragmentInput) {
 
 #ifdef VERTEX_UVS
     if (bevy_pbr::pbr_bindings::material.flags & bevy_pbr::pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u {
-        output_color = output_color * textureSampleBias(bevy_pbr::pbr_bindings::base_color_texture, bevy_pbr::pbr_bindings::base_color_sampler, in.uv, bevy_pbr::prepass_bindings::view.mip_bias);
+        output_color = output_color * textureSampleBias(bevy_pbr::pbr_bindings::base_color_texture, bevy_pbr::pbr_bindings::base_color_sampler, in.uv, bevy_pbr::prepass_view_bindings::view.mip_bias);
     }
 #endif // VERTEX_UVS
 
@@ -107,7 +107,7 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #ifdef VERTEX_UVS
             in.uv,
 #endif // VERTEX_UVS
-            bevy_pbr::prepass_bindings::view.mip_bias,
+            bevy_pbr::prepass_view_bindings::view.mip_bias,
         );
 
         out.normal = vec4(normal * 0.5 + vec3(0.5), 1.0);
@@ -117,9 +117,9 @@ fn fragment(in: FragmentInput) -> FragmentOutput {
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    let clip_position_t = bevy_pbr::prepass_bindings::view.unjittered_view_proj * in.world_position;
+    let clip_position_t = bevy_pbr::prepass_view_bindings::view.unjittered_view_proj * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = bevy_pbr::prepass_bindings::previous_view_proj * in.previous_world_position;
+    let previous_clip_position_t = bevy_pbr::prepass_view_bindings::previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the

--- a/crates/bevy_pbr/src/render/skinning.rs
+++ b/crates/bevy_pbr/src/render/skinning.rs
@@ -1,0 +1,113 @@
+use bevy_asset::Assets;
+use bevy_ecs::prelude::*;
+use bevy_math::Mat4;
+use bevy_render::{
+    mesh::skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
+    render_resource::BufferUsages,
+    renderer::{RenderDevice, RenderQueue},
+    view::ViewVisibility,
+    Extract,
+};
+use bevy_transform::prelude::GlobalTransform;
+
+use super::double_buffer::DoubleBufferVec;
+
+/// Maximum number of joints supported for skinned meshes.
+pub const MAX_JOINTS: usize = 256;
+const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
+pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
+
+#[derive(Component)]
+pub struct SkinIndex {
+    pub index: u32,
+}
+#[derive(Resource)]
+pub struct SkinUniform {
+    pub buffer: DoubleBufferVec<Mat4>,
+}
+impl Default for SkinUniform {
+    fn default() -> Self {
+        Self {
+            buffer: DoubleBufferVec::new(BufferUsages::UNIFORM),
+        }
+    }
+}
+
+pub fn prepare_skins(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut uniform: ResMut<SkinUniform>,
+) {
+    if uniform.buffer.is_empty() {
+        return;
+    }
+
+    let len = uniform.buffer.len();
+    uniform.buffer.reserve(len, &render_device);
+    uniform.buffer.write_buffer(&render_device, &render_queue);
+}
+
+impl SkinIndex {
+    /// Updated index to be in address space based on [`SkinnedMeshUniform`] size.
+    pub fn to_buffer_index(mut self) -> Self {
+        self.index *= std::mem::size_of::<Mat4>() as u32;
+        self
+    }
+}
+
+pub fn extract_skins(
+    mut commands: Commands,
+    mut previous_len: Local<usize>,
+    mut uniform: ResMut<SkinUniform>,
+    query: Extract<Query<(Entity, &ViewVisibility, &SkinnedMesh)>>,
+    inverse_bindposes: Extract<Res<Assets<SkinnedMeshInverseBindposes>>>,
+    joints: Extract<Query<&GlobalTransform>>,
+) {
+    uniform.buffer.clear();
+
+    let mut values = Vec::with_capacity(*previous_len);
+    let mut last_start = 0;
+
+    for (entity, view_visibility, skin) in &query {
+        if !view_visibility.get() {
+            continue;
+        }
+        // PERF: This can be expensive, can we move this to prepare?
+        let buffer = uniform.buffer.current_buffer_mut();
+        let Some(inverse_bindposes) = inverse_bindposes.get(&skin.inverse_bindposes) else {
+            continue;
+        };
+        let start = buffer.len();
+        let target = start + skin.joints.len().min(MAX_JOINTS);
+        buffer.extend(
+            joints
+                .iter_many(&skin.joints)
+                .zip(inverse_bindposes.iter())
+                .take(MAX_JOINTS)
+                .map(|(joint, bindpose)| joint.affine() * *bindpose),
+        );
+        // iter_many will skip any failed fetches. This will cause it to assign the wrong bones,
+        // so just bail by truncating to the start.
+        if buffer.len() != target {
+            buffer.truncate(start);
+            continue;
+        }
+
+        // Pad to 256 byte alignment
+        while buffer.len() % 4 != 0 {
+            buffer.push(Mat4::ZERO);
+        }
+        let index = start as u32;
+        let skin_index = SkinIndex { index };
+        last_start = last_start.max(skin_index.index as usize);
+        values.push((entity, skin_index.to_buffer_index()));
+    }
+
+    // Pad out the buffer to ensure that there's enough space for bindings
+    while uniform.buffer.len() - last_start < MAX_JOINTS {
+        uniform.buffer.current_buffer_mut().push(Mat4::ZERO);
+    }
+
+    *previous_len = values.len();
+    commands.insert_or_spawn_batch(values);
+}

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -9,10 +9,18 @@
     @group(1) @binding(1)
     var<uniform> joint_matrices: SkinnedMesh;
 
+#ifdef MOTION_VECTOR_PREPASS
+    @group(1) @binding(4) var<uniform> last_joint_matrices: SkinnedMesh;
+#endif
+
 #else 
 
     @group(2) @binding(1)
     var<uniform> joint_matrices: SkinnedMesh;
+
+#ifdef MOTION_VECTOR_PREPASS
+    @group(2) @binding(4) var<uniform> last_joint_matrices: SkinnedMesh;
+#endif
 
 #endif
 
@@ -54,4 +62,15 @@ fn skin_normals(
     );
 }
 
+#ifdef MOTION_VECTOR_PREPASS
+fn last_skin_model(
+    indexes: vec4<u32>,
+    weights: vec4<f32>,
+) -> mat4x4<f32> {
+    return weights.x * last_joint_matrices.data[indexes.x]
+        + weights.y * last_joint_matrices.data[indexes.y]
+        + weights.z * last_joint_matrices.data[indexes.z]
+        + weights.w * last_joint_matrices.data[indexes.w];
+}
+#endif
 #endif

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -11,18 +11,18 @@
 
 #ifdef MOTION_VECTOR_PREPASS
     @group(1) @binding(4) var<uniform> last_joint_matrices: SkinnedMesh;
-#endif
+#endif // MVP
 
-#else 
+#else  // MB1
 
     @group(2) @binding(1)
     var<uniform> joint_matrices: SkinnedMesh;
 
 #ifdef MOTION_VECTOR_PREPASS
     @group(2) @binding(4) var<uniform> last_joint_matrices: SkinnedMesh;
-#endif
+#endif // MVP
 
-#endif
+#endif // MB1
 
 
 fn skin_model(
@@ -72,5 +72,5 @@ fn last_skin_model(
         + weights.z * last_joint_matrices.data[indexes.z]
         + weights.w * last_joint_matrices.data[indexes.w];
 }
-#endif
-#endif
+#endif // MVP
+#endif // SKINNED

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -180,6 +180,6 @@ fn queue_wireframes(
 type DrawWireframes = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
+    SetMeshBindGroup<1, false>,
     DrawMesh,
 );

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -230,7 +230,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
 type DrawCustom = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
+    SetMeshBindGroup<1, false>,
     DrawMeshInstanced,
 );
 

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -16,8 +16,8 @@ fn bevy_log_plugin() -> LogPlugin {
         level: bevy::log::Level::TRACE,
         filter: "\
           gilrs_core=info,gilrs=info,\
-          naga=info,wgpu=warn,wgpu_hal=warn,\
-          bevy_app=info,bevy_render::render_resource::pipeline_cache=debug,\
+          naga=info,wgpu=debug,wgpu_hal=debug,\
+          bevy_app=info,bevy_render::render_resource::pipeline_cache=trace,\
           bevy_render::view::window=debug,bevy_ecs::world::entity_ref=info"
             .to_string(),
     }

--- a/examples/tools/scene_viewer/animation_plugin.rs
+++ b/examples/tools/scene_viewer/animation_plugin.rs
@@ -32,36 +32,31 @@ impl Clips {
 /// earlier in this file.
 fn assign_clips(
     mut players: Query<(Entity, &mut AnimationPlayer, &Name)>,
-    scene_handle: Res<SceneHandle>,
     clips: Res<Assets<AnimationClip>>,
     gltf_assets: Res<Assets<Gltf>>,
     assets: Res<AssetServer>,
     mut commands: Commands,
     mut setup: Local<bool>,
 ) {
-    if scene_handle.is_loaded && !*setup {
-        *setup = true;
-    } else {
-        return;
-    }
-    let gltf = gltf_assets.get(&scene_handle.gltf_handle).unwrap();
-    let animations = &gltf.animations;
-    if !animations.is_empty() {
-        let count = animations.len();
-        let plural = if count == 1 { "" } else { "s" };
-        info!("Found {} animation{plural}", animations.len());
-        let names: Vec<_> = gltf.named_animations.keys().collect();
-        info!("Animation names: {names:?}");
-    }
-    for (entity, mut player, name) in &mut players {
-        let clips = clips
-            .iter()
-            .filter_map(|(k, v)| v.compatible_with(name).then_some(k))
-            .map(|id| assets.get_id_handle(id).unwrap())
-            .collect();
-        let animations = Clips::new(clips);
-        player.play(animations.current()).repeat();
-        commands.entity(entity).insert(animations);
+    for (_, gltf) in gltf_assets.iter() {
+        let animations = &gltf.animations;
+        if !animations.is_empty() {
+            let count = animations.len();
+            let plural = if count == 1 { "" } else { "s" };
+            info!("Found {} animation{plural}", animations.len());
+            let names: Vec<_> = gltf.named_animations.keys().collect();
+            info!("Animation names: {names:?}");
+        }
+        for (entity, mut player, name) in &mut players {
+            let clips = clips
+                .iter()
+                .filter_map(|(k, v)| v.compatible_with(name).then_some(k))
+                .map(|id| assets.get_id_handle(id).unwrap())
+                .collect();
+            let animations = Clips::new(clips);
+            player.play(animations.current()).repeat();
+            commands.entity(entity).insert(animations);
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Add TAA support when using morph targets and skinned meshes

## Solution

- General solution: Keep track of the `SkinnedMeshUniform` and `MorphUniform` buffers from last frame
- To do that: Add a `DoubleBufferVec` struct. A double buffers that keeps around the old values in the buffer.
- Replace the `BufferVec` in  `SkinnedMeshUniform` and `MorphUniform` by that.
- Upload the old buffer in addition to the new one for the prepass shader
- Probably a lot of issues I didn't think of yet.

### Alternatives

- #7502 would allow use to keep around the old vertex positions, likely could be useful and much more performant.

---

## Changelog

- Add a `DoubleBufferVec` struct. A double buffers that keeps around the old values in the buffer.
- Add handling of morph target & skinned mesh animation in the TAA shader.


## Migration Guide

- The `PrepassPipeline`'s `view_layout_no_motion_vectors` and  `view_layout_motion_vectors` fields are now consolidated in a `layouts: PrepassLayouts` field
- `PrepassBindGroup` is now `PrepassBindGroups`, since it has several bind groups.
- Most likely more to come