### PR TITLE
Make `run_if_inner` public and rename to `run_if_dyn`

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -167,6 +167,7 @@ impl SystemConfigs {
         }
     }
 
+    /// Adds a new condition
     pub fn run_if_inner(&mut self, condition: BoxedCondition) {
         match self {
             SystemConfigs::SystemConfig(config) => {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -167,7 +167,7 @@ impl SystemConfigs {
         }
     }
 
-    pub(crate) fn run_if_inner(&mut self, condition: BoxedCondition) {
+    pub fn run_if_inner(&mut self, condition: BoxedCondition) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.conditions.push(condition);

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -168,7 +168,7 @@ impl SystemConfigs {
     }
 
     /// Adds a new condition
-    pub fn run_if_inner(&mut self, condition: BoxedCondition) {
+    pub fn run_if_dyn(&mut self, condition: BoxedCondition) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.conditions.push(condition);
@@ -342,7 +342,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
     }
 
     fn run_if<M>(mut self, condition: impl Condition<M>) -> SystemConfigs {
-        self.run_if_inner(new_condition(condition));
+        self.run_if_dyn(new_condition(condition));
         self
     }
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -170,8 +170,8 @@ impl SystemConfigs {
 
     /// Adds a new boxed run condition to the systems.
     ///
-    /// This is exposed to allow users to create custom scheduling abstractions:
-    /// it is generally only useful when working with boxed run conditions with an unknown dynamic type.
+    /// This is useful if you have a run condition whose concrete type is unknown.
+    /// Prefer `run_if` for run conditions whose type is known at compile time.
     pub fn run_if_dyn(&mut self, condition: BoxedCondition) {
         match self {
             SystemConfigs::SystemConfig(config) => {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -83,14 +83,15 @@ impl SystemConfigs {
         })
     }
 
-    pub(crate) fn in_set_inner(&mut self, set: BoxedSystemSet) {
+    /// Adds a new boxed system set to the systems.
+    pub fn in_set_dyn(&mut self, set: BoxedSystemSet) {
         match self {
             SystemConfigs::SystemConfig(config) => {
                 config.graph_info.sets.push(set);
             }
             SystemConfigs::Configs { configs, .. } => {
                 for config in configs {
-                    config.in_set_inner(set.dyn_clone());
+                    config.in_set_dyn(set.dyn_clone());
                 }
             }
         }
@@ -308,7 +309,7 @@ impl IntoSystemConfigs<()> for SystemConfigs {
             "adding arbitrary systems to a system type set is not allowed"
         );
 
-        self.in_set_inner(set.dyn_clone());
+        self.in_set_dyn(set.dyn_clone());
 
         self
     }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -532,7 +532,7 @@ impl ScheduleGraph {
                     if more_than_one_entry {
                         let set = AnonymousSet::new();
                         for config in &mut configs {
-                            config.in_set_inner(set.dyn_clone());
+                            config.in_set_dyn(set.dyn_clone());
                         }
                         let mut set_config = set.into_config();
                         set_config.conditions.extend(collective_conditions);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -539,7 +539,7 @@ impl ScheduleGraph {
                         self.configure_set(set_config);
                     } else {
                         for condition in collective_conditions {
-                            configs[0].run_if_inner(condition);
+                            configs[0].run_if_dyn(condition);
                         }
                     }
                 }


### PR DESCRIPTION
# Objective

Sometimes you want to create a plugin with a custom run condition. In a function, you take the `Condition` trait and then make a `BoxedCondition` from it to store it. And then you want to add that condition to a system, but you can't, because there is only the `run_if` function available which takes `impl Condition<M>` instead of `BoxedCondition`. So you have to create a wrapper type for the `BoxedCondition` and implement the `System` and `ReadOnlySystem` traits for the wrapper (Like it's done in the picture below). It's very inconvenient and boilerplate. But there is an easy solution for that: make the `run_if_inner` system that takes a `BoxedCondition` public. Also, it makes sense to make `in_set_inner` function public as well with the same motivation.

![image](https://github.com/bevyengine/bevy/assets/61053971/a4455180-7e0c-4c2b-9372-cd8b4a9e682e)
A chunk of the source code of the `bevy-inspector-egui` crate.

## Solution

Make `run_if_inner` function public.
Rename `run_if_inner` to `run_if_dyn`.

Make `in_set_inner` function public.
Rename `in_set_inner` to `in_set_dyn`.

## Changelog

Changed visibility of `run_if_inner` from `pub(crate)` to `pub`.
Renamed `run_if_inner` to `run_if_dyn`.

Changed visibility of `in_set_inner` from `pub(crate)` to `pub`.
Renamed `in_set_inner` to `in_set_dyn`.

## Migration Guide

