### PR TITLE
Make MESH_BINDGROUP_1 shader def apply to bevy_sprite as well

### DIFF
--- a/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
@@ -2,5 +2,12 @@
 
 #import bevy_sprite::mesh2d_types
 
+#ifdef MESH_BINDGROUP_1
+@group(1) @binding(0)
+var<uniform> mesh: bevy_sprite::mesh2d_types::Mesh2d;
+
+#else
 @group(2) @binding(0)
 var<uniform> mesh: bevy_sprite::mesh2d_types::Mesh2d;
+
+#endif


### PR DESCRIPTION
# Objective

Fixes MESH_BINDGROUP_1 not working when importing bevy_sprite::mesh2d_bindings

## Solution

Implement the shader def the same way it's implemented in bevy_pbr::mesh_bindings
