### PR TITLE
change 'collapse_type_name' to retain enum types

### DIFF
--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -67,7 +67,7 @@ fn collapse_type_name(string: &str) -> &str {
         return last;
     };
 
-    if second_last.starts_with(|c: char| c.is_uppercase()) {
+    if second_last.starts_with(char::is_uppercase) {
         let index = string.len() - last.len() - second_last.len() - 2;
         &string[index..]
     } else {

--- a/crates/bevy_utils/src/short_names.rs
+++ b/crates/bevy_utils/src/short_names.rs
@@ -59,7 +59,20 @@ pub fn get_short_name(full_name: &str) -> String {
 
 #[inline(always)]
 fn collapse_type_name(string: &str) -> &str {
-    string.split("::").last().unwrap()
+    // Enums types are retained.
+    // As heuristic, we assume the enum type to be uppercase.
+    let mut segments = string.rsplit("::");
+    let (last, second_last): (&str, Option<&str>) = (segments.next().unwrap(), segments.next());
+    let Some(second_last) = second_last else {
+        return last;
+    };
+
+    if second_last.starts_with(|c: char| c.is_uppercase()) {
+        let index = string.len() - last.len() - second_last.len() - 2;
+        &string[index..]
+    } else {
+        last
+    }
 }
 
 #[cfg(test)]
@@ -100,6 +113,19 @@ mod name_formatting_tests {
     #[test]
     fn multiple_type_parameters() {
         assert_eq!(get_short_name("a<B, C>"), "a<B, C>".to_string());
+    }
+
+    #[test]
+    fn enums() {
+        assert_eq!(get_short_name("Option::None"), "Option::None".to_string());
+        assert_eq!(
+            get_short_name("Option::Some(2)"),
+            "Option::Some(2)".to_string()
+        );
+        assert_eq!(
+            get_short_name("bevy_render::RenderSet::Prepare"),
+            "RenderSet::Prepare".to_string()
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Objective

Fixes #9509 

## Solution
We use the assumption, that enum types are uppercase in contrast to module names.
[`collapse_type_name`](crates/bevy_util/src/short_names) is now retaining the second last segment, if it starts with a uppercase character. 
