### PR TITLE
Improve various `Debug` implementations

### DIFF
--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -39,12 +39,11 @@ pub struct QueryState<Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
 
 impl<Q: WorldQuery, F: ReadOnlyWorldQuery> std::fmt::Debug for QueryState<Q, F> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "QueryState<Q, F> matched_table_ids: {} matched_archetype_ids: {}",
-            self.matched_table_ids.len(),
-            self.matched_archetype_ids.len()
-        )
+        f.debug_struct("QueryState")
+            .field("world_id", &self.world_id)
+            .field("matched_table_count", &self.matched_table_ids.len())
+            .field("matched_archetype_count", &self.matched_archetype_ids.len())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -149,21 +149,13 @@ pub(crate) fn check_system_change_tick(last_run: &mut Tick, this_run: Tick, syst
     }
 }
 
-impl Debug for dyn System<In = (), Out = ()> {
+impl<In: 'static, Out: 'static> Debug for dyn System<In = In, Out = Out> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "System {}: {{{}}}", self.name(), {
-            if self.is_send() {
-                if self.is_exclusive() {
-                    "is_send is_exclusive"
-                } else {
-                    "is_send"
-                }
-            } else if self.is_exclusive() {
-                "is_exclusive"
-            } else {
-                ""
-            }
-        },)
+        f.debug_struct("System")
+            .field("name", &self.name())
+            .field("is_exclusive", &self.is_exclusive())
+            .field("is_send", &self.is_send())
+            .finish_non_exhaustive()
     }
 }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -679,19 +679,11 @@ unsafe impl SystemParam for &'_ World {
 /// // .add_systems(reset_to_system(my_config))
 /// # assert_is_system(reset_to_system(Config(10)));
 /// ```
+#[derive(Debug)]
 pub struct Local<'s, T: FromWorld + Send + 'static>(pub(crate) &'s mut T);
 
 // SAFETY: Local only accesses internal state
 unsafe impl<'s, T: FromWorld + Send + 'static> ReadOnlySystemParam for Local<'s, T> {}
-
-impl<'s, T: FromWorld + Send + Sync + 'static> Debug for Local<'s, T>
-where
-    T: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_tuple("Local").field(&self.0).finish()
-    }
-}
 
 impl<'s, T: FromWorld + Send + Sync + 'static> Deref for Local<'s, T> {
     type Target = T;

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1292,14 +1292,13 @@ unsafe impl SystemParam for SystemChangeTick {
 ///
 /// This is not a reliable identifier, it is more so useful for debugging
 /// purposes of finding where a system parameter is being used incorrectly.
-pub struct SystemName<'s> {
-    name: &'s str,
-}
+#[derive(Debug)]
+pub struct SystemName<'s>(&'s str);
 
 impl<'s> SystemName<'s> {
     /// Gets the name of the system.
     pub fn name(&self) -> &str {
-        self.name
+        self.0
     }
 }
 
@@ -1318,14 +1317,7 @@ impl<'s> AsRef<str> for SystemName<'s> {
 
 impl<'s> From<SystemName<'s>> for &'s str {
     fn from(name: SystemName<'s>) -> &'s str {
-        name.name
-    }
-}
-
-impl<'s> std::fmt::Debug for SystemName<'s> {
-    #[inline(always)]
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        f.debug_tuple("SystemName").field(&self.name()).finish()
+        name.0
     }
 }
 
@@ -1352,7 +1344,7 @@ unsafe impl SystemParam for SystemName<'_> {
         _world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        SystemName { name }
+        SystemName(name)
     }
 }
 


### PR DESCRIPTION
# Objective

* `Local` and `SystemName` implement `Debug` manually, but they could derive it.
* `QueryState` and `dyn System` have unconventional debug formatting.
