### PR TITLE
Rename `ManualEventIterator`

### DIFF
--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -427,6 +427,13 @@ pub struct EventIterator<'a, E: Event> {
     iter: EventIteratorWithId<'a, E>,
 }
 
+/// An iterator that yields any unread events from an [`EventReader`] or [`ManualEventReader`].
+///
+/// This is a type alias for [`EventIterator`], which used to be called `ManualEventIterator`.
+/// This type alias will be removed in the next release of bevy, so you should use [`EventIterator`] directly instead.
+#[deprecated = "This type has been renamed to `EventIterator`."]
+pub type ManualEventIterator<'a, E> = EventIterator<'a, E>;
+
 impl<'a, E: Event> Iterator for EventIterator<'a, E> {
     type Item = &'a E;
     fn next(&mut self) -> Option<Self::Item> {
@@ -466,6 +473,13 @@ pub struct EventIteratorWithId<'a, E: Event> {
     chain: Chain<Iter<'a, EventInstance<E>>, Iter<'a, EventInstance<E>>>,
     unread: usize,
 }
+
+/// An iterator that yields any unread events (and their IDs) from an [`EventReader`] or [`ManualEventReader`].
+///
+/// This is a type alias for [`EventIteratorWithId`], which used to be called `ManualEventIteratorWithId`.
+/// This type alias will be removed in the next release of bevy, so you should use [`EventIteratorWithId`] directly instead.
+#[deprecated = "This type has been renamed to `EventIteratorWithId`."]
+pub type ManualEventIteratorWithId<'a, E> = EventIteratorWithId<'a, E>;
 
 impl<'a, E: Event> EventIteratorWithId<'a, E> {
     /// Creates a new iterator that yields any `events` that have not yet been seen by `reader`.

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -4,9 +4,7 @@ use crate::{
     self as bevy_ecs,
     component::{Component, ComponentId, ComponentIdFor, Tick},
     entity::Entity,
-    event::{
-        Event, EventId, Events, ManualEventIterator, ManualEventIteratorWithId, ManualEventReader,
-    },
+    event::{Event, EventId, EventIterator, EventIteratorWithId, Events, ManualEventReader},
     prelude::Local,
     storage::SparseSet,
     system::{ReadOnlySystemParam, SystemMeta, SystemParam},
@@ -145,7 +143,7 @@ pub struct RemovedComponents<'w, 's, T: Component> {
 ///
 /// See [`RemovedComponents`].
 pub type RemovedIter<'a> = iter::Map<
-    iter::Flatten<option::IntoIter<iter::Cloned<ManualEventIterator<'a, RemovedComponentEntity>>>>,
+    iter::Flatten<option::IntoIter<iter::Cloned<EventIterator<'a, RemovedComponentEntity>>>>,
     fn(RemovedComponentEntity) -> Entity,
 >;
 
@@ -153,7 +151,7 @@ pub type RemovedIter<'a> = iter::Map<
 ///
 /// See [`RemovedComponents`].
 pub type RemovedIterWithId<'a> = iter::Map<
-    iter::Flatten<option::IntoIter<ManualEventIteratorWithId<'a, RemovedComponentEntity>>>,
+    iter::Flatten<option::IntoIter<EventIteratorWithId<'a, RemovedComponentEntity>>>,
     fn(
         (&RemovedComponentEntity, EventId<RemovedComponentEntity>),
     ) -> (Entity, EventId<RemovedComponentEntity>),


### PR DESCRIPTION
# Objective

The name `ManualEventIterator` is long and unnecessary, as this is the iterator type used for both `EventReader` and `ManualEventReader`.

## Solution

Rename `ManualEventIterator` to `EventIterator`. To ease migration, add a deprecated type alias with the old name.

---

## Changelog

- The types `ManualEventIterator{WithId}` have been renamed to `EventIterator{WithId}`.

## Migration Guide

The type `ManualEventIterator` has been renamed to `EventIterator`. Additonally, `ManualEventIteratorWithId` has been renamed to `EventIteratorWithId`.
