### PR TITLE
Swap TransparentUi to use a stable sort

### DIFF
--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -113,6 +113,11 @@ impl PhaseItem for TransparentUi {
     }
 
     #[inline]
+    fn sort(items: &mut [Self]) {
+        items.sort_by_key(|item| item.sort_key());
+    }
+
+    #[inline]
     fn batch_size(&self) -> usize {
         self.batch_size
     }


### PR DESCRIPTION
# Objective

- Fix the `borders`, `ui` and `text_wrap_debug` examples.

## Solution

- Swap `TransparentUi` to use a stable sort

---

This is the smallest change to fix the examples but ideally this is fixed by setting better sort keys for the UI elements such that we can swap back to an unstable sort.
