### PR TITLE
default 16bit rgb/rgba textures to unorm instead of uint

### DIFF
--- a/crates/bevy_render/src/texture/dds.rs
+++ b/crates/bevy_render/src/texture/dds.rs
@@ -88,7 +88,7 @@ pub fn dds_format_to_texture_format(
                     TextureFormat::Bc3RgbaUnorm
                 }
             }
-            D3DFormat::A16B16G16R16 => TextureFormat::Rgba16Uint,
+            D3DFormat::A16B16G16R16 => TextureFormat::Rgba16Unorm,
             D3DFormat::Q16W16V16U16 => TextureFormat::Rgba16Sint,
             D3DFormat::R16F => TextureFormat::R16Float,
             D3DFormat::G16R16F => TextureFormat::Rg16Float,

--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -79,34 +79,20 @@ impl Image {
 
                 data = cast_slice(&raw_data).to_owned();
             }
-            DynamicImage::ImageRgb16(image) => {
-                width = image.width();
-                height = image.height();
-                format = TextureFormat::Rgba16Uint;
+            DynamicImage::ImageRgb16(i) => {
+                let i = DynamicImage::ImageRgb16(i).into_rgba16();
+                width = i.width();
+                height = i.height();
+                format = TextureFormat::Rgba16Unorm;
 
-                let mut local_data =
-                    Vec::with_capacity(width as usize * height as usize * format.pixel_size());
+                let raw_data = i.into_raw();
 
-                for pixel in image.into_raw().chunks_exact(3) {
-                    // TODO: use the array_chunks method once stabilised
-                    // https://github.com/rust-lang/rust/issues/74985
-                    let r = pixel[0];
-                    let g = pixel[1];
-                    let b = pixel[2];
-                    let a = u16::max_value();
-
-                    local_data.extend_from_slice(&r.to_ne_bytes());
-                    local_data.extend_from_slice(&g.to_ne_bytes());
-                    local_data.extend_from_slice(&b.to_ne_bytes());
-                    local_data.extend_from_slice(&a.to_ne_bytes());
-                }
-
-                data = local_data;
+                data = cast_slice(&raw_data).to_owned();
             }
             DynamicImage::ImageRgba16(i) => {
                 width = i.width();
                 height = i.height();
-                format = TextureFormat::Rgba16Uint;
+                format = TextureFormat::Rgba16Unorm;
 
                 let raw_data = i.into_raw();
 

--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -14,8 +14,8 @@ impl Image {
         let format: TextureFormat;
 
         match dyn_img {
-            DynamicImage::ImageLuma8(i) => {
-                let i = DynamicImage::ImageLuma8(i).into_rgba8();
+            DynamicImage::ImageLuma8(image) => {
+                let i = DynamicImage::ImageLuma8(image).into_rgba8();
                 width = i.width();
                 height = i.height();
                 format = if is_srgb {
@@ -26,8 +26,8 @@ impl Image {
 
                 data = i.into_raw();
             }
-            DynamicImage::ImageLumaA8(i) => {
-                let i = DynamicImage::ImageLumaA8(i).into_rgba8();
+            DynamicImage::ImageLumaA8(image) => {
+                let i = DynamicImage::ImageLumaA8(image).into_rgba8();
                 width = i.width();
                 height = i.height();
                 format = if is_srgb {
@@ -38,8 +38,8 @@ impl Image {
 
                 data = i.into_raw();
             }
-            DynamicImage::ImageRgb8(i) => {
-                let i = DynamicImage::ImageRgb8(i).into_rgba8();
+            DynamicImage::ImageRgb8(image) => {
+                let i = DynamicImage::ImageRgb8(image).into_rgba8();
                 width = i.width();
                 height = i.height();
                 format = if is_srgb {
@@ -50,37 +50,37 @@ impl Image {
 
                 data = i.into_raw();
             }
-            DynamicImage::ImageRgba8(i) => {
-                width = i.width();
-                height = i.height();
+            DynamicImage::ImageRgba8(image) => {
+                width = image.width();
+                height = image.height();
                 format = if is_srgb {
                     TextureFormat::Rgba8UnormSrgb
                 } else {
                     TextureFormat::Rgba8Unorm
                 };
 
-                data = i.into_raw();
+                data = image.into_raw();
             }
-            DynamicImage::ImageLuma16(i) => {
-                width = i.width();
-                height = i.height();
+            DynamicImage::ImageLuma16(image) => {
+                width = image.width();
+                height = image.height();
                 format = TextureFormat::R16Uint;
 
-                let raw_data = i.into_raw();
+                let raw_data = image.into_raw();
 
                 data = cast_slice(&raw_data).to_owned();
             }
-            DynamicImage::ImageLumaA16(i) => {
-                width = i.width();
-                height = i.height();
+            DynamicImage::ImageLumaA16(image) => {
+                width = image.width();
+                height = image.height();
                 format = TextureFormat::Rg16Uint;
 
-                let raw_data = i.into_raw();
+                let raw_data = image.into_raw();
 
                 data = cast_slice(&raw_data).to_owned();
             }
-            DynamicImage::ImageRgb16(i) => {
-                let i = DynamicImage::ImageRgb16(i).into_rgba16();
+            DynamicImage::ImageRgb16(image) => {
+                let i = DynamicImage::ImageRgb16(image).into_rgba16();
                 width = i.width();
                 height = i.height();
                 format = TextureFormat::Rgba16Unorm;
@@ -89,12 +89,12 @@ impl Image {
 
                 data = cast_slice(&raw_data).to_owned();
             }
-            DynamicImage::ImageRgba16(i) => {
-                width = i.width();
-                height = i.height();
+            DynamicImage::ImageRgba16(image) => {
+                width = image.width();
+                height = image.height();
                 format = TextureFormat::Rgba16Unorm;
 
-                let raw_data = i.into_raw();
+                let raw_data = image.into_raw();
 
                 data = cast_slice(&raw_data).to_owned();
             }


### PR DESCRIPTION
# Objective

fix  #8185, #6710
replace #7005 (closed)

rgb and rgba 16 bit textures currently default to `Rgba16Uint`, the more common use is `Rgba16Unorm`, which also matches the default type of rgb8 and rgba8 textures.

## Solution

Change default to `Rgba16Unorm`