### PR TITLE
Check for bevy_internal imports in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,16 +334,16 @@ jobs:
           name: msrv
           path: msrv/
 
-  check-bevy-internal-imports-in-examples:
+  check-bevy-internal-imports:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
-      - name: Check for bevy_internal imports in examples
+      - name: Check for bevy_internal imports
         shell: bash
         run: |
           errors=""
-          for file in $(find examples -name '*.rs'); do
+          for file in $(find examples tests -name '*.rs'); do
               if grep -q "use bevy_internal" "$file"; then
                   errors+="ERROR: Detected 'use bevy_internal' in $file\n"
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -350,7 +350,7 @@ jobs:
           done
           if [ -n "$errors" ]; then
               echo "$errors"
-              echo " Avoid importing bevy_internal, it should not be used direclty"
+              echo " Avoid importing bevy_internal, it should not be used directly"
               echo " Fix the issue by replacing 'bevy_internal' with 'bevy'"
               echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"
               exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,3 +333,25 @@ jobs:
         with:
           name: msrv
           path: msrv/
+
+  check-bevy-internal-imports-in-examples:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check for bevy_internal imports in examples
+        shell: bash
+        run: |
+          errors=""
+          for file in $(find examples -name '*.rs'); do
+              if grep -q "use bevy_internal" "$file"; then
+                  errors+="ERROR: Detected 'use bevy_internal' in $file\n"
+              fi
+          done
+          if [ -n "$errors" ]; then
+              echo "$errors"
+              echo " Avoid importing bevy_internal, it should not be used direclty"
+              echo " Fix the issue by replacing 'bevy_internal' with 'bevy'"
+              echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"
+              exit 1
+          fi                  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
               fi
           done
           if [ -n "$errors" ]; then
-              echo "$errors"
+              echo -e "$errors"
               echo " Avoid importing bevy_internal, it should not be used directly"
               echo " Fix the issue by replacing 'bevy_internal' with 'bevy'"
               echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -3,9 +3,7 @@
 use std::f32::consts::PI;
 use std::time::Duration;
 
-use bevy::animation::RepeatAnimation;
-use bevy::pbr::CascadeShadowConfigBuilder;
-use bevy::prelude::*;
+use bevy::{animation::RepeatAnimation, pbr::CascadeShadowConfigBuilder, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -3,9 +3,9 @@
 use std::f32::consts::PI;
 use std::time::Duration;
 
+use bevy::animation::RepeatAnimation;
 use bevy::pbr::CascadeShadowConfigBuilder;
 use bevy::prelude::*;
-use bevy_internal::animation::RepeatAnimation;
 
 fn main() {
     App::new()


### PR DESCRIPTION
# Objective

- Avoid using bevy_internal imports in examples. 

## Solution

- Add CI to check for bevy_internal imports like suggested in https://github.com/bevyengine/bevy/pull/9547#issuecomment-1689377999
- Fix another import

I don't know much about CI so I don't know if this is the better approach, but I think is better than doing a pull request every time I found this lol, any suggestion is welcome.
