### PR TITLE
Remove unused regex dep from bevy_render

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -71,7 +71,6 @@ futures-lite = "1.4.0"
 anyhow = "1.0"
 hexasphere = "9.0"
 parking_lot = "0.12.1"
-regex = "1.5"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
 naga_oil = "0.8"


### PR DESCRIPTION
# Objective

As far as I can tell, this is no longer needed since the switch to fancier shader imports via `naga_oil`.

This shouldn't have any affect on compile times because it's in our tree from `naga_oil`, `tracing-subscriber`, and `rodio`.