### PR TITLE
fix orthographic cluster aabb for spotlight culling

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1050,20 +1050,8 @@ fn compute_aabb_for_cluster(
 
         // Convert to view space at the cluster near and far planes
         // NOTE: 1.0 is the near plane due to using reverse z projections
-        let mut p_min = screen_to_view(
-            screen_size,
-            inverse_projection,
-            p_min,
-            0.0,
-        )
-        .xyz();
-        let mut p_max = screen_to_view(
-            screen_size,
-            inverse_projection,
-            p_max,
-            0.0,
-        )
-        .xyz();
+        let mut p_min = screen_to_view(screen_size, inverse_projection, p_min, 0.0).xyz();
+        let mut p_max = screen_to_view(screen_size, inverse_projection, p_max, 0.0).xyz();
 
         // calculate cluster depth using z_near and z_far
         p_min.z = -z_near + (z_near - z_far) * ijk.z / cluster_dimensions.z as f32;

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1050,20 +1050,26 @@ fn compute_aabb_for_cluster(
 
         // Convert to view space at the cluster near and far planes
         // NOTE: 1.0 is the near plane due to using reverse z projections
-        let p_min = screen_to_view(
+        let mut p_min = screen_to_view(
             screen_size,
             inverse_projection,
             p_min,
             1.0 - (ijk.z / cluster_dimensions.z as f32),
         )
         .xyz();
-        let p_max = screen_to_view(
+        let mut p_max = screen_to_view(
             screen_size,
             inverse_projection,
             p_max,
             1.0 - ((ijk.z + 1.0) / cluster_dimensions.z as f32),
         )
         .xyz();
+
+        // translate the view depth into cluster depth 
+        // - z_far is the extent of the clusters
+        // - inverse_projection.z_axis.z is the far plane of the camera
+        p_min.z *= z_far / inverse_projection.z_axis.z;
+        p_max.z *= z_far / inverse_projection.z_axis.z;
 
         cluster_min = p_min.min(p_max);
         cluster_max = p_min.max(p_max);

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1054,22 +1054,20 @@ fn compute_aabb_for_cluster(
             screen_size,
             inverse_projection,
             p_min,
-            1.0 - (ijk.z / cluster_dimensions.z as f32),
+            0.0,
         )
         .xyz();
         let mut p_max = screen_to_view(
             screen_size,
             inverse_projection,
             p_max,
-            1.0 - ((ijk.z + 1.0) / cluster_dimensions.z as f32),
+            0.0,
         )
         .xyz();
 
-        // translate the view depth into cluster depth 
-        let cam_far = inverse_projection.w_axis.z;
-        let cam_near = inverse_projection.z_axis.z + inverse_projection.w_axis.z;
-        p_min.z = -(((p_min.z - cam_near) / cam_far) * (z_far - z_near) + z_near);
-        p_max.z = -(((p_max.z - cam_near) / cam_far) * (z_far - z_near) + z_near);
+        // calculate cluster depth using z_near and z_far
+        p_min.z = -z_near + (z_near - z_far) * ijk.z / cluster_dimensions.z as f32;
+        p_max.z = -z_near + (z_near - z_far) * (ijk.z + 1.0) / cluster_dimensions.z as f32;
 
         cluster_min = p_min.min(p_max);
         cluster_max = p_min.max(p_max);

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1433,9 +1433,6 @@ pub(crate) fn assign_lights_to_clusters(
 
         let inverse_projection = camera.projection_matrix().inverse();
 
-        println!("proj: {:?}", camera.projection_matrix());
-        println!("inv {:?}", camera.projection_matrix().inverse());
-
         for lights in &mut clusters.lights {
             lights.entities.clear();
             lights.point_light_count = 0;

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1066,10 +1066,10 @@ fn compute_aabb_for_cluster(
         .xyz();
 
         // translate the view depth into cluster depth 
-        // - z_far is the extent of the clusters
-        // - inverse_projection.z_axis.z is the far plane of the camera
-        p_min.z *= z_far / inverse_projection.z_axis.z;
-        p_max.z *= z_far / inverse_projection.z_axis.z;
+        let cam_far = inverse_projection.w_axis.z;
+        let cam_near = inverse_projection.z_axis.z + inverse_projection.w_axis.z;
+        p_min.z = -(((p_min.z - cam_near) / cam_far) * (z_far - z_near) + z_near);
+        p_max.z = -(((p_max.z - cam_near) / cam_far) * (z_far - z_near) + z_near);
 
         cluster_min = p_min.min(p_max);
         cluster_max = p_min.max(p_max);
@@ -1434,6 +1434,9 @@ pub(crate) fn assign_lights_to_clusters(
         );
 
         let inverse_projection = camera.projection_matrix().inverse();
+
+        println!("proj: {:?}", camera.projection_matrix());
+        println!("inv {:?}", camera.projection_matrix().inverse());
 
         for lights in &mut clusters.lights {
             lights.entities.clear();


### PR DESCRIPTION
# Objective

fix #9605

spotlight culling uses an incorrect cluster aabb for orthographic projections: it does not take into account the near and far cluster bounds at all.

## Solution

use z_near and z_far to determine cluster aabb in orthographic mode.

i'm not 100% sure this is the only change that's needed, but i am sure this change is needed, and the example seems to work well now (CLUSTERED_FORWARD_DEBUG_CLUSTER_LIGHT_COMPLEXITY shows good bounds around the cone for a variety of orthographic setups).