### PR TITLE
Replace uses of `entity.insert` with tuple bundles in `game_menu` example

### DIFF
--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -654,16 +654,19 @@ mod menu {
                                     DisplayQuality::Medium,
                                     DisplayQuality::High,
                                 ] {
-                                    let mut entity = parent.spawn(ButtonBundle {
-                                        style: Style {
-                                            width: Val::Px(150.0),
-                                            height: Val::Px(65.0),
-                                            ..button_style.clone()
+                                    let mut entity = parent.spawn((
+                                        ButtonBundle {
+                                            style: Style {
+                                                width: Val::Px(150.0),
+                                                height: Val::Px(65.0),
+                                                ..button_style.clone()
+                                            },
+                                            background_color: NORMAL_BUTTON.into(),
+                                            ..default()
                                         },
-                                        background_color: NORMAL_BUTTON.into(),
-                                        ..default()
-                                    });
-                                    entity.insert(quality_setting).with_children(|parent| {
+                                        quality_setting,
+                                    ));
+                                    entity.with_children(|parent| {
                                         parent.spawn(TextBundle::from_section(
                                             format!("{quality_setting:?}"),
                                             button_text_style.clone(),
@@ -746,16 +749,18 @@ mod menu {
                                     button_text_style.clone(),
                                 ));
                                 for volume_setting in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] {
-                                    let mut entity = parent.spawn(ButtonBundle {
-                                        style: Style {
-                                            width: Val::Px(30.0),
-                                            height: Val::Px(65.0),
-                                            ..button_style.clone()
+                                    let mut entity = parent.spawn((
+                                        ButtonBundle {
+                                            style: Style {
+                                                width: Val::Px(30.0),
+                                                height: Val::Px(65.0),
+                                                ..button_style.clone()
+                                            },
+                                            background_color: NORMAL_BUTTON.into(),
+                                            ..default()
                                         },
-                                        background_color: NORMAL_BUTTON.into(),
-                                        ..default()
-                                    });
-                                    entity.insert(Volume(volume_setting));
+                                        Volume(volume_setting),
+                                    ));
                                     if *volume == Volume(volume_setting) {
                                         entity.insert(SelectedOption);
                                     }


### PR DESCRIPTION
# Objective

Change two places where `entity.insert` is used to add components individually to spawn a tuple bundle instead.