### PR TITLE
Do not panic on non-UI child of UI entity

### DIFF
--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -37,8 +37,10 @@ fn update_clipping(
     entity: Entity,
     maybe_inherited_clip: Option<Rect>,
 ) {
-    let (node, global_transform, style, maybe_calculated_clip) =
-        node_query.get_mut(entity).unwrap();
+    let Ok((node, global_transform, style, maybe_calculated_clip)) = node_query.get_mut(entity)
+    else {
+        return;
+    };
 
     // Update this node's CalculatedClip component
     if let Some(mut calculated_clip) = maybe_calculated_clip {


### PR DESCRIPTION
Legitimately, bevy emits a WARN when encountering entities in UI trees without NodeBunlde components.

Bevy pretty much always panics when such a thing happens, due to the update_clipping system.

However, sometimes, it's perfectly legitimate to have a child without UI nodes in a UI tree. For example, as a "seed" entity that is consumed by a 3rd party plugin, which will later spawn a valid UI tree. In loading scenarios, you are pretty much guaranteed to have incomplete children.

The presence of the WARN hints that bevy does not intend to panic on such occasion (otherwise the warn! would be a panic!) so I assume panic is an unintended behavior, aka a bug.

## Solution

Early-return instead of panicking.

I did only test that it indeed fixed the panic, not checked for UI inconsistencies. Though on a logical level, it can only have changed code that would otherwise panic.

## Alternatives

Instead of early-returning on invalid entity in `update_clipping`, do not call it with invalid entity in its recursive call.

---

## Changelog

- Do not panic on non-UI child of UI entity