### PR TITLE
Add `ReflectFromWorld` and replace the `FromWorld` requirement on `ReflectComponent` and `ReflectBundle` with `FromReflect`

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -28,7 +28,9 @@ pub use bevy_ptr as ptr;
 pub mod prelude {
     #[doc(hidden)]
     #[cfg(feature = "bevy_reflect")]
-    pub use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectResource};
+    pub use crate::reflect::{
+        AppTypeRegistry, ReflectComponent, ReflectFromWorld, ReflectResource,
+    };
     #[doc(hidden)]
     pub use crate::{
         bundle::Bundle,

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -1,4 +1,5 @@
 //! Definitions for [`Bundle`] reflection.
+//! This allows inserting, updating and/or removing bundles whose type is only known at runtime.
 //!
 //! This module exports two types: [`ReflectBundleFns`] and [`ReflectBundle`].
 //!
@@ -10,7 +11,7 @@ use bevy_reflect::{FromReflect, FromType, Reflect, ReflectRef, TypeRegistry};
 
 use super::ReflectComponent;
 
-/// A struct used to operate on reflected [`Bundle`] of a type.
+/// A struct used to operate on reflected [`Bundle`] trait of a type.
 ///
 /// A [`ReflectBundle`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -145,7 +145,7 @@ impl<B: Bundle + Reflect + FromReflect> FromType<B> for ReflectBundle {
                 if let Some(reflect_component) =
                     registry.get_type_data::<ReflectComponent>(TypeId::of::<B>())
                 {
-                    reflect_component.apply_or_insert(entity, reflected_bundle);
+                    reflect_component.apply_or_insert(entity, reflected_bundle, registry);
                 } else {
                     match reflected_bundle.reflect_ref() {
                         ReflectRef::Struct(bundle) => bundle
@@ -201,7 +201,7 @@ fn apply_or_insert_field(
     registry: &TypeRegistry,
 ) {
     if let Some(reflect_component) = registry.get_type_data::<ReflectComponent>(field.type_id()) {
-        reflect_component.apply_or_insert(entity, field);
+        reflect_component.apply_or_insert(entity, field, registry);
     } else if let Some(reflect_bundle) = registry.get_type_data::<ReflectBundle>(field.type_id()) {
         reflect_bundle.apply_or_insert(entity, field, registry);
     } else {

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -1,4 +1,6 @@
 //! Definitions for [`Component`] reflection.
+//! This allows inserting, updating, removing and generally interacting with components
+//! whose types are only known at runtime.
 //!
 //! This module exports two types: [`ReflectComponentFns`] and [`ReflectComponent`].
 //!
@@ -66,7 +68,7 @@ use crate::{
 };
 use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
 
-/// A struct used to operate on reflected [`Component`] of a type.
+/// A struct used to operate on reflected [`Component`] trait of a type.
 ///
 /// A [`ReflectComponent`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -331,7 +331,7 @@ fn from_reflect_or_world<T: FromReflect>(
     let Some(reflect_from_world) = registry.get_type_data::<ReflectFromWorld>(TypeId::of::<T>())
     else {
         panic!(
-            "no `ReflectFromWorld` registration found for `{}`",
+            "`FromReflect` failed and no `ReflectFromWorld` registration found for `{}`",
             // FIXME: once we have unique reflect, use `TypePath`.
             std::any::type_name::<T>(),
         );
@@ -343,7 +343,7 @@ fn from_reflect_or_world<T: FromReflect>(
         .downcast::<T>()
     else {
         panic!(
-            "the `ReflectFromWorld` for `{}` produced a value of a different type",
+            "the `ReflectFromWorld` registration for `{}` produced a value of a different type",
             // FIXME: once we have unique reflect, use `TypePath`.
             std::any::type_name::<T>(),
         );

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -305,7 +305,12 @@ fn from_reflect_or_world<T: FromReflect>(reflected: &dyn Reflect, world: &mut Wo
         .get_type_data::<ReflectFromWorld>(TypeId::of::<T>())
         .unwrap()
         .clone();
-    let mut base = reflect_from_world.from_world(world);
-    base.apply(reflected);
-    T::take_from_reflect(base).ok().unwrap()
+    let mut value = *reflect_from_world
+        .from_world(world)
+        .into_any()
+        .downcast::<T>()
+        .ok()
+        .unwrap();
+    value.apply(reflected);
+    value
 }

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -83,7 +83,7 @@ pub struct ReflectComponent(ReflectComponentFns);
 /// > will not need.
 /// > Usually a [`ReflectComponent`] is created for a type by deriving [`Reflect`]
 /// > and adding the `#[reflect(Component)]` attribute.
-/// > After adding the component to the [`TypeRegistry`][bevy_reflect::TypeRegistry],
+/// > After adding the component to the [`TypeRegistry`],
 /// > its [`ReflectComponent`] can then be retrieved when needed.
 ///
 /// Creating a custom [`ReflectComponent`] may be useful if you need to create new component types

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -245,7 +245,8 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
     fn from_type() -> Self {
         ReflectComponent(ReflectComponentFns {
             insert: |entity, reflected_component| {
-                let component = C::from_reflect(reflected_component).unwrap();
+                let component: C =
+                    entity.world_scope(|world| from_reflect_or_world(reflected_component, world));
                 entity.insert(component);
             },
             apply: |entity, reflected_component| {

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -294,11 +294,21 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
     }
 }
 
+/// Creates a `T` from a `&dyn Reflect`.
+///
+/// The first approach uses `T`'s implementation of `FromReflect`.
+/// If this fails, it falls back to default-initializing a new instance of `T` using its
+/// `ReflectFromWorld` data from the `world`'s `AppTypeRegistry` and `apply`ing the
+/// `&dyn Reflect` on it.
+///
+/// Panics if both approaches fail.
 fn from_reflect_or_world<T: FromReflect>(reflected: &dyn Reflect, world: &mut World) -> T {
     if let Some(value) = T::from_reflect(reflected) {
         return value;
     }
 
+    // Clone the `ReflectFromWorld` because it's cheap and "frees"
+    // the borrow of `world` so that it can be passed to `from_world`.
     let reflect_from_world = world
         .resource::<AppTypeRegistry>()
         .read()

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -202,7 +202,7 @@ fn insert_reflect(
     let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
         panic!("Could not get ReflectComponent data (for component type {type_path}) because it doesn't exist in this TypeRegistration.");
     };
-    reflect_component.insert(&mut entity, &*component);
+    reflect_component.insert(&mut entity, &*component, type_registry);
 }
 
 /// A [`Command`] that adds the boxed reflect component to an entity using the data in

--- a/crates/bevy_ecs/src/reflect/from_world.rs
+++ b/crates/bevy_ecs/src/reflect/from_world.rs
@@ -1,0 +1,84 @@
+//! Definitions for [`FromWorld`] reflection.
+//!
+//! This module exports two types: [`ReflectFromWorldFns`] and [`ReflectFromWorld`].
+//!
+//! Same as [`super::component`], but for [`FromWorld`].
+
+use bevy_reflect::{FromType, Reflect};
+
+use crate::world::{FromWorld, World};
+
+/// A struct used to operate on reflected [`FromWorld`] of a type.
+///
+/// A [`ReflectFromWorld`] for type `T` can be obtained via
+/// [`bevy_reflect::TypeRegistration::data`].
+#[derive(Clone)]
+pub struct ReflectFromWorld(ReflectFromWorldFns);
+
+/// The raw function pointers needed to make up a [`ReflectFromWorld`].
+#[derive(Clone)]
+pub struct ReflectFromWorldFns {
+    /// Function pointer implementing [`ReflectFromWorld::from_world()`].
+    pub from_world: fn(&mut World) -> Box<dyn Reflect>,
+}
+
+impl ReflectFromWorldFns {
+    /// Get the default set of [`ReflectFromWorldFns`] for a specific type using its
+    /// [`FromType`] implementation.
+    ///
+    /// This is useful if you want to start with the default implementation before overriding some
+    /// of the functions to create a custom implementation.
+    pub fn new<T: Reflect + FromWorld>() -> Self {
+        <ReflectFromWorld as FromType<T>>::from_type().0
+    }
+}
+
+impl ReflectFromWorld {
+    /// Constructs default reflected [`FromWorld`] from world using [`from_world()`](FromWorld::from_world).
+    pub fn from_world(&self, world: &mut World) -> Box<dyn Reflect> {
+        (self.0.from_world)(world)
+    }
+
+    /// Create a custom implementation of [`ReflectFromWorld`].
+    ///
+    /// This is an advanced feature,
+    /// useful for scripting implementations,
+    /// that should not be used by most users
+    /// unless you know what you are doing.
+    ///
+    /// Usually you should derive [`Reflect`] and add the `#[reflect(FromWorld)]` bundle
+    /// to generate a [`ReflectFromWorld`] implementation automatically.
+    ///
+    /// See [`ReflectFromWorldFns`] for more information.
+    pub fn new(fns: ReflectFromWorldFns) -> Self {
+        Self(fns)
+    }
+
+    /// The underlying function pointers implementing methods on `ReflectFromWorld`.
+    ///
+    /// This is useful when you want to keep track locally of an individual
+    /// function pointer.
+    ///
+    /// Calling [`TypeRegistry::get`] followed by
+    /// [`TypeRegistration::data::<ReflectFromWorld>`] can be costly if done several
+    /// times per frame. Consider cloning [`ReflectFromWorld`] and keeping it
+    /// between frames, cloning a `ReflectFromWorld` is very cheap.
+    ///
+    /// If you only need a subset of the methods on `ReflectFromWorld`,
+    /// use `fn_pointers` to get the underlying [`ReflectFromWorldFns`]
+    /// and copy the subset of function pointers you care about.
+    ///
+    /// [`TypeRegistration::data::<ReflectFromWorld>`]: bevy_reflect::TypeRegistration::data
+    /// [`TypeRegistry::get`]: bevy_reflect::TypeRegistry::get
+    pub fn fn_pointers(&self) -> &ReflectFromWorldFns {
+        &self.0
+    }
+}
+
+impl<B: Reflect + FromWorld> FromType<B> for ReflectFromWorld {
+    fn from_type() -> Self {
+        ReflectFromWorld(ReflectFromWorldFns {
+            from_world: |world| Box::new(B::from_world(world)),
+        })
+    }
+}

--- a/crates/bevy_ecs/src/reflect/from_world.rs
+++ b/crates/bevy_ecs/src/reflect/from_world.rs
@@ -1,4 +1,6 @@
 //! Definitions for [`FromWorld`] reflection.
+//! This allows creating instaces of types that are known only at runtime and
+//! require an `&mut World` to be initialized.
 //!
 //! This module exports two types: [`ReflectFromWorldFns`] and [`ReflectFromWorld`].
 //!
@@ -8,7 +10,7 @@ use bevy_reflect::{FromType, Reflect};
 
 use crate::world::{FromWorld, World};
 
-/// A struct used to operate on the reflected [`FromWorld`] of a type.
+/// A struct used to operate on the reflected [`FromWorld`] trait of a type.
 ///
 /// A [`ReflectFromWorld`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].

--- a/crates/bevy_ecs/src/reflect/from_world.rs
+++ b/crates/bevy_ecs/src/reflect/from_world.rs
@@ -8,7 +8,7 @@ use bevy_reflect::{FromType, Reflect};
 
 use crate::world::{FromWorld, World};
 
-/// A struct used to operate on reflected [`FromWorld`] of a type.
+/// A struct used to operate on the reflected [`FromWorld`] of a type.
 ///
 /// A [`ReflectFromWorld`] for type `T` can be obtained via
 /// [`bevy_reflect::TypeRegistration::data`].

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -9,12 +9,14 @@ use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize, Typ
 mod bundle;
 mod component;
 mod entity_commands;
+mod from_world;
 mod map_entities;
 mod resource;
 
 pub use bundle::{ReflectBundle, ReflectBundleFns};
 pub use component::{ReflectComponent, ReflectComponentFns};
 pub use entity_commands::ReflectCommandExt;
+pub use from_world::{ReflectFromWorld, ReflectFromWorldFns};
 pub use map_entities::ReflectMapEntities;
 pub use resource::{ReflectResource, ReflectResourceFns};
 

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -139,7 +139,7 @@ impl DynamicScene {
                 // If the entity already has the given component attached,
                 // just apply the (possibly) new value, otherwise add the
                 // component to the entity.
-                reflect_component.apply_or_insert(entity_mut, &**component);
+                reflect_component.apply_or_insert(entity_mut, &**component, &type_registry);
             }
         }
 

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -117,7 +117,13 @@ impl Scene {
                                 }
                             })
                         })?;
-                    reflect_component.copy(&self.world, world, scene_entity.id(), entity);
+                    reflect_component.copy(
+                        &self.world,
+                        world,
+                        scene_entity.id(),
+                        entity,
+                        &type_registry,
+                    );
                 }
             }
         }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -34,7 +34,7 @@ struct ComponentA {
 // trait comes into play. `FromWorld` gives you access to your App's current ECS `Resources`
 // when you construct your component.
 #[derive(Component, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, FromWorld)]
 struct ComponentB {
     pub value: String,
     #[reflect(skip_serializing)]


### PR DESCRIPTION
# Objective

- `FromType<T>` for `ReflectComponent` and `ReflectBundle` currently require `T: FromWorld` for two reasons:
    - they include a `from_world` method;
    - they create dummy `T`s using `FromWorld` and then `apply` a `&dyn Reflect` to it to simulate `FromReflect`.
- However `FromWorld`/`Default` may be difficult/weird/impractical to implement, while `FromReflect` is easier and also more natural for the job.
- See also https://discord.com/channels/691052431525675048/1146022009554337792

## Solution

- Split `from_world` from `ReflectComponent` and `ReflectBundle` into its own `ReflectFromWorld` struct.
- Replace the requirement on `FromWorld` in `ReflectComponent` and `ReflectBundle` with `FromReflect`

---

## Changelog

- `ReflectComponent` and `ReflectBundle` no longer offer a `from_world` method.
- `ReflectComponent` and `ReflectBundle`'s `FromType<T>` implementation no longer requires `T: FromWorld`, but now requires `FromReflect`.
- `ReflectComponent::insert`, `ReflectComponent::apply_or_insert` and `ReflectComponent::copy` now take an extra `&TypeRegistry` parameter.
- There is now a new `ReflectFromWorld` struct.

## Migration Guide

- Existing uses of `ReflectComponent::from_world` and `ReflectBundle::from_world` will have to be changed to `ReflectFromWorld::from_world`.
- Users of `#[reflect(Component)]` and `#[reflect(Bundle)]` will need to also implement/derive `FromReflect`.
- Users of `#[reflect(Component)]` and `#[reflect(Bundle)]` may now want to also add `FromWorld` to the list of reflected traits in case their `FromReflect` implementation may fail.
- Users of `ReflectComponent` will now need to pass a `&TypeRegistry` to its `insert`, `apply_or_insert` and `copy` methods.
