### PR TITLE
remove VecSwizzles imports

### DIFF
--- a/examples/2d/rotation.rs
+++ b/examples/2d/rotation.rs
@@ -1,6 +1,6 @@
 //! Demonstrates rotating entities in 2D using quaternions.
 
-use bevy::{math::Vec3Swizzles, prelude::*};
+use bevy::prelude::*;
 
 const TIME_STEP: f32 = 1.0 / 60.0;
 const BOUNDS: Vec2 = Vec2::new(1200.0, 640.0);

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -2,7 +2,6 @@
 
 use std::f32::consts::PI;
 
-use bevy::math::Vec3Swizzles;
 use bevy::prelude::*;
 
 // Define a component to keep information for the scaled object.


### PR DESCRIPTION
# Objective

- Since #9387, there is no need to import VecSwizzles separately, it is already included in the prelude.

## Solution

- Remove the imports.
