### PR TITLE
Add a method to compute a bounding box enclosing a set of points

### DIFF
--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use bevy_ecs::{component::Component, prelude::Entity, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Mat3A, Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles};
 use bevy_reflect::Reflect;
@@ -47,6 +49,34 @@ impl Aabb {
             center,
             half_extents,
         }
+    }
+
+    /// Returns a bounding box enclosing the specified set of points.
+    ///
+    /// Returns `None` if the iterator is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_math::{Vec3, Vec3A};
+    /// # use bevy_render::primitives::Aabb;
+    /// let bb = Aabb::enclosing([Vec3::X, Vec3::Z * 2.0, Vec3::Y * -0.5]).unwrap();
+    /// assert_eq!(bb.min(), Vec3A::new(0.0, -0.5, 0.0));
+    /// assert_eq!(bb.max(), Vec3A::new(1.0, 0.0, 2.0));
+    /// ```
+    pub fn enclosing<T: Borrow<Vec3>>(iter: impl IntoIterator<Item = T>) -> Option<Self> {
+        let mut iter = iter.into_iter().map(|p| *p.borrow());
+        let mut min = iter.next()?;
+        let mut max = min;
+        for Vec3 { x, y, z } in iter {
+            min.x = f32::min(min.x, x);
+            min.y = f32::min(min.y, y);
+            min.z = f32::min(min.z, z);
+            max.x = f32::max(max.x, x);
+            max.y = f32::max(max.y, y);
+            max.z = f32::max(max.z, z);
+        }
+        Some(Self::from_min_max(min, max))
     }
 
     /// Calculate the relative radius of the AABB with respect to a plane


### PR DESCRIPTION
# Objective

Make it easier to create bounding boxes in user code by providing a constructor that computes a box surrounding an arbitrary number of points.

## Solution

Add `Aabb::enclosing`, which accepts iterators, slices, or arrays.