### PR TITLE
Refactor `EventReader::iter` to `read`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -94,7 +94,7 @@ impl Plugin for ScheduleRunnerPlugin {
                         if let Some(app_exit_events) =
                             app.world.get_resource_mut::<Events<AppExit>>()
                         {
-                            if let Some(exit) = app_exit_event_reader.iter(&app_exit_events).last()
+                            if let Some(exit) = app_exit_event_reader.read(&app_exit_events).last()
                             {
                                 return Err(exit.clone());
                             }

--- a/crates/bevy_ecs/examples/events.rs
+++ b/crates/bevy_ecs/examples/events.rs
@@ -52,7 +52,7 @@ fn sending_system(mut event_writer: EventWriter<MyEvent>) {
 // This system listens for events of the type MyEvent
 // If an event is received it will be printed to the console
 fn receiving_system(mut event_reader: EventReader<MyEvent>) {
-    for my_event in event_reader.iter() {
+    for my_event in event_reader.read() {
         println!(
             "    Received message {:?}, with random value of {}",
             my_event.message, my_event.random_value

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -407,8 +407,22 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
         self.reader.iter(&self.events)
     }
 
+    /// Iterates over the events this [`EventReader`] has not seen yet. This updates the
+    /// [`EventReader`]'s event counter, which means subsequent event reads will not include events
+    /// that happened before now.
+    #[deprecated = "use `.read()` instead."]
+    pub fn iter(&mut self) -> EventIterator<'_, E> {
+        self.reader.iter(&self.events)
+    }
+
     /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
     pub fn read_with_id(&mut self) -> EventIteratorWithId<'_, E> {
+        self.reader.iter_with_id(&self.events)
+    }
+
+    /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
+    #[deprecated = "use `.read_with_id() instead."]
+    pub fn iter_with_id(&mut self) -> EventIteratorWithId<'_, E> {
         self.reader.iter_with_id(&self.events)
     }
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -403,12 +403,12 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
     /// Iterates over the events this [`EventReader`] has not seen yet. This updates the
     /// [`EventReader`]'s event counter, which means subsequent event reads will not include events
     /// that happened before now.
-    pub fn iter(&mut self) -> EventIterator<'_, E> {
+    pub fn read(&mut self) -> EventIterator<'_, E> {
         self.reader.iter(&self.events)
     }
 
     /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
-    pub fn iter_with_id(&mut self) -> EventIteratorWithId<'_, E> {
+    pub fn read_with_id(&mut self) -> EventIteratorWithId<'_, E> {
         self.reader.iter_with_id(&self.events)
     }
 
@@ -1028,7 +1028,7 @@ mod tests {
 
         let mut schedule = Schedule::default();
         schedule.add_systems(|mut events: EventReader<TestEvent>| {
-            let mut iter = events.iter();
+            let mut iter = events.read();
 
             assert_eq!(iter.next(), Some(&TestEvent { i: 0 }));
             assert_eq!(iter.nth(2), Some(&TestEvent { i: 3 }));
@@ -1048,7 +1048,7 @@ mod tests {
 
         let mut reader =
             IntoSystem::into_system(|mut events: EventReader<TestEvent>| -> Option<TestEvent> {
-                events.iter().last().copied()
+                events.read().last().copied()
             });
         reader.initialize(&mut world);
 

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -415,7 +415,7 @@ impl<'w, 's, E: Event> EventReader<'w, 's, E> {
         self.reader.read(&self.events)
     }
 
-    /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
+    /// Like [`read`](Self::read), except also returning the [`EventId`] of the events.
     pub fn read_with_id(&mut self) -> EventIteratorWithId<'_, E> {
         self.reader.read_with_id(&self.events)
     }
@@ -559,7 +559,7 @@ impl<E: Event> Default for ManualEventReader<E> {
 
 #[allow(clippy::len_without_is_empty)] // Check fails since the is_empty implementation has a signature other than `(&self) -> bool`
 impl<E: Event> ManualEventReader<E> {
-    /// See [`EventReader::iter`]
+    /// See [`EventReader::read`]
     pub fn read<'a>(&'a mut self, events: &'a Events<E>) -> EventIterator<'a, E> {
         self.read_with_id(events).without_id()
     }
@@ -570,7 +570,7 @@ impl<E: Event> ManualEventReader<E> {
         self.read_with_id(events).without_id()
     }
 
-    /// See [`EventReader::iter_with_id`]
+    /// See [`EventReader::read_with_id`]
     pub fn read_with_id<'a>(&'a mut self, events: &'a Events<E>) -> EventIteratorWithId<'a, E> {
         EventIteratorWithId::new(self, events)
     }

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -202,7 +202,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
     /// that happened before now.
     pub fn iter(&mut self) -> RemovedIter<'_> {
         self.reader_mut_with_events()
-            .map(|(reader, events)| reader.iter(events).cloned())
+            .map(|(reader, events)| reader.read(events).cloned())
             .into_iter()
             .flatten()
             .map(RemovedComponentEntity::into)
@@ -211,7 +211,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
     /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
     pub fn iter_with_id(&mut self) -> RemovedIterWithId<'_> {
         self.reader_mut_with_events()
-            .map(|(reader, events)| reader.iter_with_id(events))
+            .map(|(reader, events)| reader.read_with_id(events))
             .into_iter()
             .flatten()
             .map(map_id_events)

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -895,7 +895,7 @@ pub mod common_conditions {
         // calls of the run condition. Simply checking `is_empty` would not be enough.
         // PERF: note that `count` is efficient (not actually looping/iterating),
         // due to Bevy having a specialized implementation for events.
-        move |mut reader: EventReader<T>| reader.iter().count() > 0
+        move |mut reader: EventReader<T>| reader.read().count() > 0
     }
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -136,7 +136,7 @@ pub(crate) fn play_gilrs_rumble(
         .retain(|_gamepad, rumbles| !rumbles.is_empty());
 
     // Add new effects.
-    for rumble in requests.iter().cloned() {
+    for rumble in requests.read().cloned() {
         let gamepad = rumble.gamepad();
         match handle_rumble_request(&mut running_rumbles, &mut gilrs, rumble, current_time) {
             Ok(()) => {}

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1023,7 +1023,7 @@ pub fn gamepad_connection_system(
     mut button_axis: ResMut<Axis<GamepadButton>>,
     mut button_input: ResMut<Input<GamepadButton>>,
 ) {
-    for connection_event in connection_events.iter() {
+    for connection_event in connection_events.read() {
         let gamepad = connection_event.gamepad;
 
         if let GamepadConnection::Connected(info) = &connection_event.connection {
@@ -1168,7 +1168,7 @@ pub fn gamepad_axis_event_system(
     mut gamepad_axis: ResMut<Axis<GamepadAxis>>,
     mut axis_events: EventReader<GamepadAxisChangedEvent>,
 ) {
-    for axis_event in axis_events.iter() {
+    for axis_event in axis_events.read() {
         let axis = GamepadAxis::new(axis_event.gamepad, axis_event.axis_type);
         gamepad_axis.set(axis, axis_event.value);
     }
@@ -1181,7 +1181,7 @@ pub fn gamepad_button_event_system(
     mut button_input_events: EventWriter<GamepadButtonInput>,
     settings: Res<GamepadSettings>,
 ) {
-    for button_event in button_changed_events.iter() {
+    for button_event in button_changed_events.read() {
         let button = GamepadButton::new(button_event.gamepad, button_event.button_type);
         let value = button_event.value;
         let button_property = settings.get_button_settings(button);
@@ -1258,7 +1258,7 @@ pub fn gamepad_event_system(
     mut button_input: ResMut<Input<GamepadButton>>,
 ) {
     button_input.bypass_change_detection().clear();
-    for gamepad_event in gamepad_events.iter() {
+    for gamepad_event in gamepad_events.read() {
         match gamepad_event {
             GamepadEvent::Connection(connection_event) => {
                 connection_events.send(connection_event.clone());

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -53,7 +53,7 @@ pub fn keyboard_input_system(
     // Avoid clearing if it's not empty to ensure change detection is not triggered.
     scan_input.bypass_change_detection().clear();
     key_input.bypass_change_detection().clear();
-    for event in keyboard_input_events.iter() {
+    for event in keyboard_input_events.read() {
         let KeyboardInput {
             scan_code, state, ..
         } = event;

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -144,7 +144,7 @@ pub fn mouse_button_input_system(
     mut mouse_button_input_events: EventReader<MouseButtonInput>,
 ) {
     mouse_button_input.bypass_change_detection().clear();
-    for event in mouse_button_input_events.iter() {
+    for event in mouse_button_input_events.read() {
         match event.state {
             ButtonState::Pressed => mouse_button_input.press(event.button),
             ButtonState::Released => mouse_button_input.release(event.button),

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -366,7 +366,7 @@ pub fn touch_screen_input_system(
 ) {
     touch_state.update();
 
-    for event in touch_input_events.iter() {
+    for event in touch_input_events.read() {
         touch_state.process_touch_event(event);
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -608,7 +608,7 @@ pub fn extract_materials<M: Material>(
 ) {
     let mut changed_assets = HashSet::default();
     let mut removed = Vec::new();
-    for event in events.iter() {
+    for event in events.read() {
         match event {
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                 changed_assets.insert(handle.clone_weak());

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -575,11 +575,11 @@ pub fn camera_system<T: CameraProjection + Component>(
     let primary_window = primary_window.iter().next();
 
     let mut changed_window_ids = HashSet::new();
-    changed_window_ids.extend(window_created_events.iter().map(|event| event.window));
-    changed_window_ids.extend(window_resized_events.iter().map(|event| event.window));
+    changed_window_ids.extend(window_created_events.read().map(|event| event.window));
+    changed_window_ids.extend(window_resized_events.read().map(|event| event.window));
 
     let changed_image_handles: HashSet<&Handle<Image>> = image_asset_events
-        .iter()
+        .read()
         .filter_map(|event| {
             if let AssetEvent::Modified { handle } = event {
                 Some(handle)

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -136,7 +136,7 @@ fn extract_render_asset<A: RenderAsset>(
 ) {
     let mut changed_assets = HashSet::default();
     let mut removed = Vec::new();
-    for event in events.iter() {
+    for event in events.read() {
         match event {
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                 changed_assets.insert(handle.clone_weak());

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -832,7 +832,7 @@ impl PipelineCache {
         shaders: Extract<Res<Assets<Shader>>>,
         mut events: Extract<EventReader<AssetEvent<Shader>>>,
     ) {
-        for event in events.iter() {
+        for event in events.read() {
             match event {
                 AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                     if let Some(shader) = shaders.get(handle) {

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -161,7 +161,7 @@ fn extract_windows(
         }
     }
 
-    for closed_window in closed.iter() {
+    for closed_window in closed.read() {
         extracted_windows.remove(&closed_window.window);
     }
     // This lock will never block because `callbacks` is `pub(crate)` and this is the singular callsite where it's locked.

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -354,7 +354,7 @@ pub fn scene_spawner_system(world: &mut World) {
         let scene_spawner = &mut *scene_spawner;
         for event in scene_spawner
             .scene_asset_event_reader
-            .iter(scene_asset_events)
+            .read(scene_asset_events)
         {
             if let AssetEvent::Modified { handle } = event {
                 if scene_spawner.spawned_dynamic_scenes.contains_key(handle) {

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -467,7 +467,7 @@ pub fn extract_materials_2d<M: Material2d>(
 ) {
     let mut changed_assets = HashSet::default();
     let mut removed = Vec::new();
-    for event in events.iter() {
+    for event in events.read() {
         match event {
             AssetEvent::Created { handle } | AssetEvent::Modified { handle } => {
                 changed_assets.insert(handle.clone_weak());

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -327,7 +327,7 @@ pub fn extract_sprite_events(
     let SpriteAssetEvents { ref mut images } = *events;
     images.clear();
 
-    for image in image_events.iter() {
+    for image in image_events.read() {
         // AssetEvent: !Clone
         images.push(match image {
             AssetEvent::Created { handle } => AssetEvent::Created {

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -165,7 +165,7 @@ pub fn update_text2d_layout(
     mut text_query: Query<(Entity, Ref<Text>, Ref<Text2dBounds>, &mut TextLayoutInfo)>,
 ) {
     // We need to consume the entire iterator, hence `last`
-    let factor_changed = scale_factor_changed.iter().last().is_some();
+    let factor_changed = scale_factor_changed.read().last().is_some();
 
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = windows

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -248,7 +248,7 @@ pub fn ui_layout_system(
         };
 
     let resized = resize_events
-        .iter()
+        .read()
         .any(|resized_window| resized_window.window == primary_window_entity);
 
     // update window root nodes

--- a/crates/bevy_window/src/system.rs
+++ b/crates/bevy_window/src/system.rs
@@ -41,7 +41,7 @@ pub fn exit_on_primary_closed(
 ///
 /// [`WindowPlugin`]: crate::WindowPlugin
 pub fn close_when_requested(mut commands: Commands, mut closed: EventReader<WindowCloseRequested>) {
-    for event in closed.iter() {
+    for event in closed.read() {
         commands.entity(event.window).despawn();
     }
 }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -46,7 +46,7 @@ fn handle_window_focus(
     adapters: NonSend<AccessKitAdapters>,
     mut focused: EventReader<WindowFocused>,
 ) {
-    for event in focused.iter() {
+    for event in focused.read() {
         if let Some(adapter) = adapters.get(&event.window) {
             adapter.update_if_active(|| {
                 let focus_id = (*focus).unwrap_or_else(|| event.window);
@@ -68,7 +68,7 @@ fn window_closed(
     mut receivers: ResMut<WinitActionHandlers>,
     mut events: EventReader<WindowClosed>,
 ) {
-    for WindowClosed { window, .. } in events.iter() {
+    for WindowClosed { window, .. } in events.read() {
         adapters.remove(window);
         receivers.remove(window);
     }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -356,7 +356,7 @@ pub fn winit_runner(mut app: App) {
             }
 
             if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
-                if app_exit_event_reader.iter(app_exit_events).last().is_some() {
+                if app_exit_event_reader.read(app_exit_events).last().is_some() {
                     *control_flow = ControlFlow::Exit;
                     return;
                 }
@@ -723,14 +723,14 @@ pub fn winit_runner(mut app: App) {
                         if let Some(app_redraw_events) =
                             app.world.get_resource::<Events<RequestRedraw>>()
                         {
-                            if redraw_event_reader.iter(app_redraw_events).last().is_some() {
+                            if redraw_event_reader.read(app_redraw_events).last().is_some() {
                                 runner_state.redraw_requested = true;
                                 *control_flow = ControlFlow::Poll;
                             }
                         }
 
                         if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
-                            if app_exit_event_reader.iter(app_exit_events).last().is_some() {
+                            if app_exit_event_reader.read(app_exit_events).last().is_some() {
                                 *control_flow = ControlFlow::Exit;
                             }
                         }

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -277,7 +277,7 @@ fn camera_controller(
 
     // Handle mouse input
     let mut mouse_delta = Vec2::ZERO;
-    for mouse_event in mouse_events.iter() {
+    for mouse_event in mouse_events.read() {
         mouse_delta += mouse_event.delta;
     }
 

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -291,7 +291,7 @@ pub fn camera_controller(
         // Handle mouse input
         let mut mouse_delta = Vec2::ZERO;
         if mouse_button_input.pressed(options.mouse_key_enable_mouse) || *move_toggled {
-            for mouse_event in mouse_events.iter() {
+            for mouse_event in mouse_events.read() {
                 mouse_delta += mouse_event.delta;
             }
         }

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -95,7 +95,7 @@ fn set_camera_viewports(
     // We need to dynamically resize the camera's viewports whenever the window size changes
     // so then each camera always takes up half the screen.
     // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.
-    for resize_event in resize_events.iter() {
+    for resize_event in resize_events.read() {
         let window = windows.get(resize_event.window).unwrap();
         let mut left_camera = left_camera.single_mut();
         left_camera.viewport = Some(Viewport {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -307,7 +307,7 @@ fn update_image_viewer(
 ) {
     let mut new_image: Option<Handle<Image>> = None;
 
-    for event in drop_events.iter() {
+    for event in drop_events.read() {
         match event {
             FileDragAndDrop::DroppedFile { path_buf, .. } => {
                 new_image = Some(asset_server.load(path_buf.to_string_lossy().to_string()));
@@ -328,7 +328,7 @@ fn update_image_viewer(
                 }
             }
 
-            for event in image_events.iter() {
+            for event in image_events.read() {
                 let image_changed_h = match event {
                     AssetEvent::Created { handle } | AssetEvent::Modified { handle } => handle,
                     _ => continue,

--- a/examples/app/drag_and_drop.rs
+++ b/examples/app/drag_and_drop.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn file_drag_and_drop_system(mut events: EventReader<FileDragAndDrop>) {
-    for event in events.iter() {
+    for event in events.read() {
         info!("{:?}", event);
     }
 }

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -57,7 +57,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
         ..default()
     };
 
-    for (per_frame, event) in reader.iter().enumerate() {
+    for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {
             text: Text::from_section(event.0.to_string(), text_style.clone())
                 .with_alignment(TextAlignment::Center),

--- a/examples/audio/pitch.rs
+++ b/examples/audio/pitch.rs
@@ -28,7 +28,7 @@ fn play_pitch(
     mut events: EventReader<PlayPitch>,
     mut commands: Commands,
 ) {
-    for _ in events.iter() {
+    for _ in events.read() {
         info!("playing pitch with frequency: {}", frequency.0);
         commands.spawn(PitchBundle {
             source: pitch_assets.add(Pitch::new(frequency.0, Duration::new(1, 0))),

--- a/examples/ecs/event.rs
+++ b/examples/ecs/event.rs
@@ -51,13 +51,13 @@ fn event_trigger(
 
 // prints events as they come in
 fn event_listener(mut events: EventReader<MyEvent>) {
-    for my_event in events.iter() {
+    for my_event in events.read() {
         info!("{}", my_event.message);
     }
 }
 
 fn sound_player(mut play_sound_events: EventReader<PlaySound>) {
-    for _ in play_sound_events.iter() {
+    for _ in play_sound_events.read() {
         info!("Playing a sound");
     }
 }

--- a/examples/input/char_input_events.rs
+++ b/examples/input/char_input_events.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// This system prints out all char events as they come in
 fn print_char_event_system(mut char_input_events: EventReader<ReceivedCharacter>) {
-    for event in char_input_events.iter() {
+    for event in char_input_events.read() {
         info!("{:?}: '{}'", event, event.char);
     }
 }

--- a/examples/input/gamepad_input_events.rs
+++ b/examples/input/gamepad_input_events.rs
@@ -27,16 +27,16 @@ fn gamepad_events(
     // this event is emmitted.
     mut button_input_events: EventReader<GamepadButtonInput>,
 ) {
-    for connection_event in connection_events.iter() {
+    for connection_event in connection_events.read() {
         info!("{:?}", connection_event);
     }
-    for axis_changed_event in axis_changed_events.iter() {
+    for axis_changed_event in axis_changed_events.read() {
         info!(
             "{:?} of {:?} is changed to {}",
             axis_changed_event.axis_type, axis_changed_event.gamepad, axis_changed_event.value
         );
     }
-    for button_changed_event in button_changed_events.iter() {
+    for button_changed_event in button_changed_events.read() {
         info!(
             "{:?} of {:?} is changed to {}",
             button_changed_event.button_type,
@@ -44,7 +44,7 @@ fn gamepad_events(
             button_changed_event.value
         );
     }
-    for button_input_event in button_input_events.iter() {
+    for button_input_event in button_input_events.read() {
         info!("{:?}", button_input_event);
     }
 }
@@ -53,7 +53,7 @@ fn gamepad_events(
 // stream directly. For standard use-cases, reading the events individually or using the
 // `Input<T>` or `Axis<T>` resources is preferable.
 fn gamepad_ordered_events(mut gamepad_events: EventReader<GamepadEvent>) {
-    for gamepad_event in gamepad_events.iter() {
+    for gamepad_event in gamepad_events.read() {
         match gamepad_event {
             GamepadEvent::Connection(connection_event) => info!("{:?}", connection_event),
             GamepadEvent::Button(button_event) => info!("{:?}", button_event),

--- a/examples/input/keyboard_input_events.rs
+++ b/examples/input/keyboard_input_events.rs
@@ -11,7 +11,7 @@ fn main() {
 
 /// This system prints out all keyboard events as they come in
 fn print_keyboard_event_system(mut keyboard_input_events: EventReader<KeyboardInput>) {
-    for event in keyboard_input_events.iter() {
+    for event in keyboard_input_events.read() {
         info!("{:?}", event);
     }
 }

--- a/examples/input/mouse_input_events.rs
+++ b/examples/input/mouse_input_events.rs
@@ -24,29 +24,29 @@ fn print_mouse_events_system(
     mut touchpad_magnify_events: EventReader<TouchpadMagnify>,
     mut touchpad_rotate_events: EventReader<TouchpadRotate>,
 ) {
-    for event in mouse_button_input_events.iter() {
+    for event in mouse_button_input_events.read() {
         info!("{:?}", event);
     }
 
-    for event in mouse_motion_events.iter() {
+    for event in mouse_motion_events.read() {
         info!("{:?}", event);
     }
 
-    for event in cursor_moved_events.iter() {
+    for event in cursor_moved_events.read() {
         info!("{:?}", event);
     }
 
-    for event in mouse_wheel_events.iter() {
-        info!("{:?}", event);
-    }
-
-    // This event will only fire on macOS
-    for event in touchpad_magnify_events.iter() {
+    for event in mouse_wheel_events.read() {
         info!("{:?}", event);
     }
 
     // This event will only fire on macOS
-    for event in touchpad_rotate_events.iter() {
+    for event in touchpad_magnify_events.read() {
+        info!("{:?}", event);
+    }
+
+    // This event will only fire on macOS
+    for event in touchpad_rotate_events.read() {
         info!("{:?}", event);
     }
 }

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -142,7 +142,7 @@ fn listen_ime_events(
     mut status_text: Query<&mut Text, With<Node>>,
     mut edit_text: Query<&mut Text, (Without<Node>, Without<Bubble>)>,
 ) {
-    for event in events.iter() {
+    for event in events.read() {
         match event {
             Ime::Preedit { value, cursor, .. } if !cursor.is_none() => {
                 status_text.single_mut().sections[5].value = format!("IME buffer: {value}");
@@ -168,7 +168,7 @@ fn listen_received_character_events(
     mut events: EventReader<ReceivedCharacter>,
     mut edit_text: Query<&mut Text, (Without<Node>, Without<Bubble>)>,
 ) {
-    for event in events.iter() {
+    for event in events.read() {
         edit_text.single_mut().sections[0].value.push(event.char);
     }
 }
@@ -178,7 +178,7 @@ fn listen_keyboard_input_events(
     mut events: EventReader<KeyboardInput>,
     mut edit_text: Query<(Entity, &mut Text), (Without<Node>, Without<Bubble>)>,
 ) {
-    for event in events.iter() {
+    for event in events.read() {
         match event.key_code {
             Some(KeyCode::Return) => {
                 let (entity, text) = edit_text.single();

--- a/examples/input/touch_input_events.rs
+++ b/examples/input/touch_input_events.rs
@@ -10,7 +10,7 @@ fn main() {
 }
 
 fn touch_event_system(mut touch_events: EventReader<TouchInput>) {
-    for event in touch_events.iter() {
+    for event in touch_events.read() {
         info!("{:?}", event);
     }
 }

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -31,7 +31,7 @@ fn touch_camera(
 ) {
     let window = windows.single();
 
-    for touch in touches.iter() {
+    for touch in touches.read() {
         if touch.phase == TouchPhase::Started {
             *last_position = None;
         }

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -466,7 +466,7 @@ fn update_button_values(
     mut events: EventReader<GamepadButtonChangedEvent>,
     mut query: Query<(&mut Text, &TextWithButtonValue)>,
 ) {
-    for button_event in events.iter() {
+    for button_event in events.read() {
         for (mut text, text_with_button_value) in query.iter_mut() {
             if button_event.button_type == **text_with_button_value {
                 text.sections[0].value = format!("{:.3}", button_event.value);
@@ -480,7 +480,7 @@ fn update_axes(
     mut query: Query<(&mut Transform, &MoveWithAxes)>,
     mut text_query: Query<(&mut Text, &TextWithAxes)>,
 ) {
-    for axis_event in axis_events.iter() {
+    for axis_event in axis_events.read() {
         let axis_type = axis_event.axis_type;
         let value = axis_event.value;
         for (mut transform, move_with) in query.iter_mut() {

--- a/examples/tools/scene_viewer/camera_controller_plugin.rs
+++ b/examples/tools/scene_viewer/camera_controller_plugin.rs
@@ -174,7 +174,7 @@ fn camera_controller(
                 window.cursor.visible = false;
             }
 
-            for mouse_event in mouse_events.iter() {
+            for mouse_event in mouse_events.read() {
                 mouse_delta += mouse_event.delta;
             }
         }

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -364,7 +364,7 @@ fn update_radio_buttons_colors(
     mut text_query: Query<&mut Text>,
     children_query: Query<&Children>,
 ) {
-    for &ButtonActivatedEvent(button_id) in event_reader.iter() {
+    for &ButtonActivatedEvent(button_id) in event_reader.read() {
         let target_constraint = button_query.get_component::<Constraint>(button_id).unwrap();
         for (id, constraint, interaction) in button_query.iter() {
             if target_constraint == constraint {

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -316,7 +316,7 @@ fn mouse_scroll(
     mut query_list: Query<(&mut ScrollingList, &mut Style, &Parent, &Node)>,
     query_node: Query<&Node>,
 ) {
-    for mouse_wheel_event in mouse_wheel_events.iter() {
+    for mouse_wheel_event in mouse_wheel_events.read() {
         for (mut scrolling_list, mut style, parent, list_node) in &mut query_list {
             let items_height = list_node.size().y;
             let container_height = query_node.get(parent.get()).unwrap().size().y;

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -86,7 +86,7 @@ fn on_resize_system(
     mut resize_reader: EventReader<WindowResized>,
 ) {
     let mut text = q.single_mut();
-    for e in resize_reader.iter() {
+    for e in resize_reader.read() {
         // When resolution is being changed
         text.sections[0].value = format!("{:.1} x {:.1}", e.width, e.height);
     }

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -13,7 +13,7 @@ struct EnemyDied(u32);
 struct Score(u32);
 
 fn update_score(mut dead_enemies: EventReader<EnemyDied>, mut score: ResMut<Score>) {
-    for value in dead_enemies.iter() {
+    for value in dead_enemies.read() {
         score.0 += value.0;
     }
 }

--- a/tests/how_to_test_systems.rs
+++ b/tests/how_to_test_systems.rs
@@ -109,7 +109,7 @@ fn did_despawn_enemy() {
     // Get `EnemyDied` event reader
     let enemy_died_events = app.world.resource::<Events<EnemyDied>>();
     let mut enemy_died_reader = enemy_died_events.get_reader();
-    let enemy_died = enemy_died_reader.iter(enemy_died_events).next().unwrap();
+    let enemy_died = enemy_died_reader.read(enemy_died_events).next().unwrap();
 
     // Check the event has been sent
     assert_eq!(enemy_died.0, 1);


### PR DESCRIPTION
# Objective

- The current `EventReader::iter` has been determined to cause confusion among new Bevy users. It was suggested by @JoJoJet to rename the method to better clarify its usage.
- Solves #9624 

## Solution

- Rename `EventReader::iter` to `EventReader::read`.
- Rename `EventReader::iter_with_id` to `EventReader::read_with_id`.
- Rename `ManualEventReader::iter` to `ManualEventReader::read`.
- Rename `ManualEventReader::iter_with_id` to `ManualEventReader::read_with_id`.

---

## Changelog

- `EventReader::iter` has been renamed to `EventReader::read`.
- `EventReader::iter_with_id` has been renamed to `EventReader::read_with_id`.
- `ManualEventReader::iter` has been renamed to `ManualEventReader::read`.
- `ManualEventReader::iter_with_id` has been renamed to `ManualEventReader::read_with_id`.
- Deprecated `EventReader::iter`
- Deprecated `EventReader::iter_with_id`
- Deprecated `ManualEventReader::iter`
- Deprecated `ManualEventReader::iter_with_id`

## Migration Guide

- Existing usages of `EventReader::iter` and `EventReader::iter_with_id` will have to be changed to `EventReader::read` and `EventReader::read_with_id` respectively.
- Existing usages of `ManualEventReader::iter` and `ManualEventReader::iter_with_id` will have to be changed to `ManualEventReader::read` and `ManualEventReader::read_with_id` respectively.