### PR TITLE
Move default docs

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -168,11 +168,11 @@ pub struct Schedule {
 #[derive(ScheduleLabel, Hash, PartialEq, Eq, Debug, Clone)]
 struct DefaultSchedule;
 
-/// Creates a schedule with a default label. Only use in situations where
-/// where you don't care about the [`ScheduleLabel`]. Inserting a default schedule
-/// into the world risks overwriting another schedule. For most situations you should use
-/// [`Schedule::new`].
 impl Default for Schedule {
+    /// Creates a schedule with a default label. Only use in situations where
+    /// where you don't care about the [`ScheduleLabel`]. Inserting a default schedule
+    /// into the world risks overwriting another schedule. For most situations you should use
+    /// [`Schedule::new`].
     fn default() -> Self {
         Self::new(DefaultSchedule)
     }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -170,9 +170,9 @@ struct DefaultSchedule;
 
 impl Default for Schedule {
     /// Creates a schedule with a default label. Only use in situations where
-    /// where you don't care about the [`ScheduleLabel`]. Inserting a default schedule
-    /// into the world risks overwriting another schedule. For most situations you should use
-    /// [`Schedule::new`].
+    /// you don't care about the [`ScheduleLabel`]. Inserting a default schedule
+    /// into the world risks overwriting another schedule. For most situations
+    /// you should use [`Schedule::new`].
     fn default() -> Self {
         Self::new(DefaultSchedule)
     }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -39,7 +39,7 @@ impl std::iter::FromIterator<Layer> for RenderLayers {
 }
 
 impl Default for RenderLayers {
-    /// Defaults to containing to layer `0`, the first layer.
+    /// By default, this structure includes layer `0`, which represents the first layer.
     fn default() -> Self {
         RenderLayers::layer(0)
     }

--- a/crates/bevy_render/src/view/visibility/render_layers.rs
+++ b/crates/bevy_render/src/view/visibility/render_layers.rs
@@ -38,8 +38,8 @@ impl std::iter::FromIterator<Layer> for RenderLayers {
     }
 }
 
-/// Defaults to containing to layer `0`, the first layer.
 impl Default for RenderLayers {
+    /// Defaults to containing to layer `0`, the first layer.
     fn default() -> Self {
         RenderLayers::layer(0)
     }


### PR DESCRIPTION
# Objective

- Make the default docs more useful like suggested in https://github.com/bevyengine/bevy/pull/9600#issuecomment-1696452118

## Solution

- Move the documentation to the `fn default()` method instead of the `impl Default`.

Allows you to view the docs directly on the function without having to go to the implementation.

### Before
![Screenshot 2023-08-29 at 18 21 03](https://github.com/bevyengine/bevy/assets/104745335/6d31591e-f190-4b8e-8bc3-a570ada294f0)

### After
![Screenshot 2023-08-29 at 18 19 54](https://github.com/bevyengine/bevy/assets/104745335/e2442ec1-593d-47f3-b539-8c77a170f0b6)



