### PR TITLE
Change `Urect::width` & `Urect::height` to be const

### DIFF
--- a/crates/bevy_math/src/rects/urect.rs
+++ b/crates/bevy_math/src/rects/urect.rs
@@ -130,7 +130,7 @@ impl URect {
     /// assert_eq!(r.width(), 5);
     /// ```
     #[inline]
-    pub fn width(&self) -> u32 {
+    pub const fn width(&self) -> u32 {
         self.max.x - self.min.x
     }
 
@@ -144,7 +144,7 @@ impl URect {
     /// assert_eq!(r.height(), 1);
     /// ```
     #[inline]
-    pub fn height(&self) -> u32 {
+    pub const fn height(&self) -> u32 {
         self.max.y - self.min.y
     }
 


### PR DESCRIPTION
# Objective
The two functions
[`Urect::height`](https://docs.rs/bevy_math/latest/bevy_math/struct.URect.html#method.height),
[`Urect::width`](https://docs.rs/bevy_math/latest/bevy_math/struct.URect.html#method.width)
 are currently not const. 
Since the methods are very unlikely to change (ever) and are useful to be const for some games, they should be.
