### PR TITLE
Add flag to control drawing of gizmo #9643

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -206,6 +206,8 @@ pub struct AabbGizmo {
     ///
     /// The default color from the [`GizmoConfig`] resource is used if `None`,
     pub color: Option<Color>,
+    /// Whether to draw the entity's bounding box
+    pub draw: bool,
 }
 
 fn draw_aabbs(
@@ -214,6 +216,10 @@ fn draw_aabbs(
     mut gizmos: Gizmos,
 ) {
     for (entity, &aabb, &transform, gizmo) in &query {
+        if !gizmo.draw {
+            continue;
+        }
+
         let color = gizmo
             .color
             .or(config.aabb.default_color)


### PR DESCRIPTION
# Objective

The `AabbGizmo` provides an easy way to view the bounding box of an entity but in order to hide that gizmo is to remove the component entirely.

Fixes #9643 

## Solution

Added a flag `draw` that controls whether the gizmo will be drawn.