### PR TITLE
fix ambiguity reporting

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -1014,7 +1014,7 @@ mod tests {
 
             let ambiguities: Vec<_> = schedule
                 .graph()
-                .conflicts_to_string(world.components())
+                .conflicts_to_string(schedule.graph().conflicting_systems(), world.components())
                 .collect();
 
             let expected = &[

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1553,7 +1553,7 @@ impl ScheduleGraph {
             Consider adding `before`, `after`, or `ambiguous_with` relationships between these:\n",
         );
 
-        for (name_a, name_b, conflicts) in self.conflicts_to_string(components) {
+        for (name_a, name_b, conflicts) in self.conflicts_to_string(ambiguities, components) {
             writeln!(message, " -- {name_a} and {name_b}").unwrap();
 
             if !conflicts.is_empty() {
@@ -1571,9 +1571,10 @@ impl ScheduleGraph {
     /// convert conflics to human readable format
     pub fn conflicts_to_string<'a>(
         &'a self,
+        ambiguities: &'a [(NodeId, NodeId, Vec<ComponentId>)],
         components: &'a Components,
     ) -> impl Iterator<Item = (String, String, Vec<&str>)> + 'a {
-        self.conflicting_systems
+        ambiguities
             .iter()
             .map(move |(system_a, system_b, conflicts)| {
                 let name_a = self.get_node_name(system_a);


### PR DESCRIPTION
# Objective

- I broke ambiguity reporting in one of my refactors. `conflicts_to_string` should have been using the passed in parameter rather than the one stored on self.