### PR TITLE
Fix erronenous glam version

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
-glam = "0.24"
+glam = "0.24.1"
 rand = "0.8"
 rand_chacha = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.24", features = ["bytemuck"] }
+glam = { version = "0.24.1", features = ["bytemuck"] }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [features]

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -11,7 +11,7 @@ license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 
 [dependencies]
-glam = "0.24"
+glam = "0.24.1"
 
 [[example]]
 name = "generate"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -37,7 +37,7 @@ smallvec = { version = "1.6", features = [
     "union",
     "const_generics",
 ], optional = true }
-glam = { version = "0.24", features = ["serde"], optional = true }
+glam = { version = "0.24.1", features = ["serde"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
# Objective

- Fix compilation issue with wrongly specified glam version
- bevy uses `Vec2::INFINITY`, depends on `0.24` (equivalent to `0.24.0`) yet it was only introduced in version `0.24.1`

Context: https://discord.com/channels/691052431525675048/692572690833473578/1146586570787397794

## Solution

- Bump glam version.
