### PR TITLE
Change `Window::physical_cursor_position` to use the physical size of the window

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -330,7 +330,14 @@ impl Window {
         match self.internal.physical_cursor_position {
             Some(position) => {
                 let position = position.as_vec2();
-                if Rect::new(0., 0., self.width(), self.height()).contains(position) {
+                if Rect::new(
+                    0.,
+                    0.,
+                    self.physical_width() as f32,
+                    self.physical_height() as f32,
+                )
+                .contains(position)
+                {
                     Some(position)
                 } else {
                     None


### PR DESCRIPTION
# Objective

`Window::physical_cursor_position` checks to see if the cursor's position is inside the window but it constructs the bounding rect for the window using its logical size and then checks to see if it contains the cursor's physical position. When the physical size is smaller than the logical size, this leaves a dead zone where the cursor is over the window but its position is unreported.

fixes: #9656

## Solution

Use the physical size of the window.

