### PR TITLE
Add font size warning to TextSection

### DIFF
--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -17,6 +17,7 @@ default_font = []
 bevy_app = { path = "../bevy_app", version = "0.12.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = ["bevy"] }
 bevy_render = { path = "../bevy_render", version = "0.12.0-dev" }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -124,8 +124,16 @@ pub struct TextSection {
 impl TextSection {
     /// Create a new [`TextSection`].
     pub fn new(value: impl Into<String>, style: TextStyle) -> Self {
+        let text_value = value.into();
+        if style.font_size <= 0.0 {
+            bevy_log::warn!(
+                "TextSection \"{}\" is unable to be displayed due to a font size of {}.",
+                text_value,
+                style.font_size
+            );
+        }
         Self {
-            value: value.into(),
+            value: text_value,
             style,
         }
     }


### PR DESCRIPTION
# Objective

- `TextSection`s are unable to display their text value if the `font_size` is less than or equal to 0, thus @ickshonpe suggested we emit a warning to the console whenever this occurs.
- Fixes #9655

## Solution

- Emit a warning if we detect that the font_size is less than or equal to 0.
- Add `bevy_log` as a dependency to `bevy_text` to be able to access the `warn!` macro.