### PR TITLE
Add `EntityMut::remove_by_id` and `EntityCommands::remove_by_id` methods

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -716,10 +716,7 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// # bevy_ecs::system::assert_is_system(add_combat_stats_system);
     /// ```
     pub fn insert(&mut self, bundle: impl Bundle) -> &mut Self {
-        self.commands.add(Insert {
-            entity: self.entity,
-            bundle,
-        });
+        self.add(Insert { bundle });
         self
     }
 
@@ -947,21 +944,17 @@ impl Command for Despawn {
 
 /// A [`Command`] that adds the components in a [`Bundle`] to an entity.
 pub struct Insert<T> {
-    /// The entity to which the components will be added.
-    pub entity: Entity,
     /// The [`Bundle`] containing the components that will be added to the entity.
     pub bundle: T,
 }
 
-impl<T> Command for Insert<T>
+impl<T> EntityCommand for Insert<T>
 where
-    T: Bundle + 'static,
+    T: Bundle,
 {
-    fn apply(self, world: &mut World) {
-        if let Some(mut entity) = world.get_entity_mut(self.entity) {
-            entity.insert(self.bundle);
-        } else {
-            panic!("error[B0003]: Could not insert a bundle (of type `{}`) for entity {:?} because it doesn't exist in this World.", std::any::type_name::<T>(), self.entity);
+    fn apply(self, id: Entity, world: &mut World) {
+        if let Some(mut entity_mut) = world.get_entity_mut(id) {
+            entity_mut.insert(self.bundle);
         }
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -890,6 +890,75 @@ impl<'w> EntityWorldMut<'w> {
         self
     }
 
+    /// Removes a dynamic [`Component`] from the entity.
+    ///
+    /// You should prefer to use the typed API [`EntityWorldMut::remove`] where possible.
+    ///
+    /// # Safety
+    ///
+    /// - [`ComponentId`] must be from the same world as [`EntityWorldMut`]
+    pub unsafe fn remove_by_id(&mut self, component_id: ComponentId) -> &mut Self {
+        let archetypes = &mut self.world.archetypes;
+        let storages = &mut self.world.storages;
+        let components = &mut self.world.components;
+        let entities = &mut self.world.entities;
+        let removed_components = &mut self.world.removed_components;
+
+        let (bundle_info, _storage_type) = self
+            .world
+            .bundles
+            .init_component_info(components, component_id);
+
+        let old_location = self.location;
+        // SAFETY: `archetype_id` exists because it is referenced in the old `EntityLocation` which is valid,
+        // components exist in `bundle_info` because `Bundles::init_info` initializes a `BundleInfo` containing all components of the bundle type `T`
+        let new_archetype_id = remove_bundle_from_archetype(
+            archetypes,
+            storages,
+            components,
+            old_location.archetype_id,
+            bundle_info,
+            true,
+        )
+        .expect("intersections should always return a result");
+
+        if new_archetype_id == old_location.archetype_id {
+            return self;
+        }
+
+        let old_archetype = &mut archetypes[old_location.archetype_id];
+        let entity = self.entity;
+        if old_archetype.contains(component_id) {
+            removed_components.send(component_id, entity);
+
+            // Make sure to drop components stored in sparse sets.
+            // Dense components are dropped later in `move_to_and_drop_missing_unchecked`.
+            if let Some(StorageType::SparseSet) = old_archetype.get_storage_type(component_id) {
+                storages
+                    .sparse_sets
+                    .get_mut(component_id)
+                    .unwrap()
+                    .remove(entity);
+            }
+        }
+
+        // TODO: document why this is safe
+        {
+            Self::move_entity_from_remove::<true>(
+                entity,
+                &mut self.location,
+                old_location.archetype_id,
+                old_location,
+                entities,
+                archetypes,
+                storages,
+                new_archetype_id,
+            );
+        }
+
+        self
+    }
+
     /// Despawns the current entity.
     pub fn despawn(self) {
         debug!("Despawning entity {:?}", self.entity);
@@ -1575,6 +1644,20 @@ mod tests {
             .collect();
 
         assert_eq!(dynamic_components, static_components);
+    }
+
+    #[test]
+    fn entity_mut_remove_by_id() {
+        let mut world = World::new();
+        let test_component_id = world.init_component::<TestComponent>();
+
+        let mut entity = world.spawn(TestComponent(42));
+        // SAFETY: `test_component_id` matches the component id
+        unsafe { entity.remove_by_id(test_component_id) };
+
+        let components: Vec<_> = world.query::<&TestComponent>().iter(&world).collect();
+
+        assert_eq!(components, vec![] as Vec<&TestComponent>);
     }
 
     #[derive(Component)]


### PR DESCRIPTION
# Objective

- Add missing methods to `EntityCommands` and `EntityMut`.
- Fix #9261 

## Solution

- I have checked out some existing code and also based myself on the useful informations provided in this [comment](https://github.com/bevyengine/bevy/issues/9261#issuecomment-1697299482) by @Selene-Amanita to implement these three new methods. These methods have been developed to address specific requirements that were previously lacking.

---

## Changelog

- Added `EntityMut::remove_by_id` method and its tests.
- Added `EntityCommands::remove_by_id` method and its tests.
- Refactor `EntityCommands::insert` and `Insert` to use `EntityCommand`