### PR TITLE
Fix some nightly warnings

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -349,7 +349,7 @@ impl BundleInfo {
         &'b self,
         entities: &'a mut Entities,
         archetypes: &'a mut Archetypes,
-        components: &mut Components,
+        components: &Components,
         storages: &'a mut Storages,
         archetype_id: ArchetypeId,
         change_tick: Tick,
@@ -409,7 +409,7 @@ impl BundleInfo {
         &'b self,
         entities: &'a mut Entities,
         archetypes: &'a mut Archetypes,
-        components: &mut Components,
+        components: &Components,
         storages: &'a mut Storages,
         change_tick: Tick,
     ) -> BundleSpawner<'a, 'b> {
@@ -495,7 +495,7 @@ impl BundleInfo {
         &self,
         archetypes: &mut Archetypes,
         storages: &mut Storages,
-        components: &mut Components,
+        components: &Components,
         archetype_id: ArchetypeId,
     ) -> ArchetypeId {
         if let Some(add_bundle_id) = archetypes[archetype_id].edges().get_add_bundle(self.id) {
@@ -853,7 +853,7 @@ impl Bundles {
     /// provided [`Components`].
     pub(crate) fn init_dynamic_info(
         &mut self,
-        components: &mut Components,
+        components: &Components,
         component_ids: &[ComponentId],
     ) -> (&BundleInfo, &Vec<StorageType>) {
         let bundle_infos = &mut self.bundle_infos;
@@ -883,7 +883,7 @@ impl Bundles {
     /// Panics if the provided [`ComponentId`] does not exist in the provided [`Components`].
     pub(crate) fn init_component_info(
         &mut self,
-        components: &mut Components,
+        components: &Components,
         component_id: ComponentId,
     ) -> (&BundleInfo, StorageType) {
         let bundle_infos = &mut self.bundle_infos;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -576,7 +576,7 @@ impl<'w> EntityWorldMut<'w> {
         let mut bundle_inserter = bundle_info.get_bundle_inserter(
             &mut self.world.entities,
             &mut self.world.archetypes,
-            &mut self.world.components,
+            &self.world.components,
             &mut self.world.storages,
             self.location.archetype_id,
             change_tick,
@@ -613,7 +613,7 @@ impl<'w> EntityWorldMut<'w> {
         let bundle_inserter = bundle_info.get_bundle_inserter(
             &mut self.world.entities,
             &mut self.world.archetypes,
-            &mut self.world.components,
+            &self.world.components,
             &mut self.world.storages,
             self.location.archetype_id,
             change_tick,
@@ -656,7 +656,7 @@ impl<'w> EntityWorldMut<'w> {
         let bundle_inserter = bundle_info.get_bundle_inserter(
             &mut self.world.entities,
             &mut self.world.archetypes,
-            &mut self.world.components,
+            &self.world.components,
             &mut self.world.storages,
             self.location.archetype_id,
             change_tick,
@@ -1084,7 +1084,7 @@ unsafe fn insert_dynamic_bundle<
 unsafe fn remove_bundle_from_archetype(
     archetypes: &mut Archetypes,
     storages: &mut Storages,
-    components: &mut Components,
+    components: &Components,
     archetype_id: ArchetypeId,
     bundle_info: &BundleInfo,
     intersection: bool,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -740,7 +740,7 @@ impl World {
             let mut spawner = bundle_info.get_bundle_spawner(
                 &mut self.entities,
                 &mut self.archetypes,
-                &mut self.components,
+                &self.components,
                 &mut self.storages,
                 change_tick,
             );
@@ -1448,7 +1448,7 @@ impl World {
         let mut spawn_or_insert = SpawnOrInsert::Spawn(bundle_info.get_bundle_spawner(
             &mut self.entities,
             &mut self.archetypes,
-            &mut self.components,
+            &self.components,
             &mut self.storages,
             change_tick,
         ));
@@ -1471,7 +1471,7 @@ impl World {
                             let mut inserter = bundle_info.get_bundle_inserter(
                                 &mut self.entities,
                                 &mut self.archetypes,
-                                &mut self.components,
+                                &self.components,
                                 &mut self.storages,
                                 location.archetype_id,
                                 change_tick,
@@ -1491,7 +1491,7 @@ impl World {
                         let mut spawner = bundle_info.get_bundle_spawner(
                             &mut self.entities,
                             &mut self.archetypes,
-                            &mut self.components,
+                            &self.components,
                             &mut self.storages,
                             change_tick,
                         );

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -41,7 +41,7 @@ where
         let mut spawner = bundle_info.get_bundle_spawner(
             &mut world.entities,
             &mut world.archetypes,
-            &mut world.components,
+            &world.components,
             &mut world.storages,
             change_tick,
         );

--- a/crates/bevy_reflect/src/path/parse.rs
+++ b/crates/bevy_reflect/src/path/parse.rs
@@ -152,7 +152,7 @@ impl fmt::Display for Token<'_> {
     }
 }
 impl<'a> Token<'a> {
-    const SYMBOLS: &[u8] = b".#[]";
+    const SYMBOLS: &'static [u8] = b".#[]";
     fn symbol_from_byte(byte: u8) -> Option<Self> {
         match byte {
             b'.' => Some(Self::Dot),

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -139,7 +139,7 @@ impl SceneSpawner {
         let spawned = self
             .spawned_dynamic_scenes
             .entry(scene_handle.clone())
-            .or_insert_with(Vec::new);
+            .or_default();
         spawned.push(instance_id);
         Ok(())
     }
@@ -186,10 +186,7 @@ impl SceneSpawner {
                 scene.write_to_world_with(world, &world.resource::<AppTypeRegistry>().clone())?;
 
             self.spawned_instances.insert(instance_id, instance_info);
-            let spawned = self
-                .spawned_scenes
-                .entry(scene_handle)
-                .or_insert_with(Vec::new);
+            let spawned = self.spawned_scenes.entry(scene_handle).or_default();
             spawned.push(instance_id);
             Ok(instance_id)
         })

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -44,7 +44,7 @@ pub(crate) fn create_windows<'a>(
     mut winit_windows: NonSendMut<WinitWindows>,
     mut adapters: NonSendMut<AccessKitAdapters>,
     mut handlers: ResMut<WinitActionHandlers>,
-    mut accessibility_requested: ResMut<AccessibilityRequested>,
+    accessibility_requested: ResMut<AccessibilityRequested>,
     #[cfg(target_arch = "wasm32")] event_channel: ResMut<CanvasParentResizeEventChannel>,
 ) {
     for (entity, mut window) in created_windows {
@@ -64,7 +64,7 @@ pub(crate) fn create_windows<'a>(
             &window,
             &mut adapters,
             &mut handlers,
-            &mut accessibility_requested,
+            &accessibility_requested,
         );
 
         if let Some(theme) = winit_window.theme() {

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -46,7 +46,7 @@ impl WinitWindows {
         window: &Window,
         adapters: &mut AccessKitAdapters,
         handlers: &mut WinitActionHandlers,
-        accessibility_requested: &mut AccessibilityRequested,
+        accessibility_requested: &AccessibilityRequested,
     ) -> &winit::window::Window {
         let mut winit_window_builder = winit::window::WindowBuilder::new();
 


### PR DESCRIPTION
# Objective

Fix some nightly warnings found by running

`cargo +nightly clippy`

## Solution

Fix the following warnings:
- [x] [elided_lifetimes_in_associated_constant](https://github.com/rust-lang/rust/issues/115010) https://github.com/bevyengine/bevy/commit/221986134d8e6b0c1a665679dba15627c155b1a0
- [x] [unwrap_or_default](https://rust-lang.github.io/rust-clippy/master/index.html#/unwrap_or_default) https://github.com/bevyengine/bevy/commit/32e21c78f929dfad71df64b78348314d529d12f5
- [x] [needless_pass_by_ref_mut](https://rust-lang.github.io/rust-clippy/master/index.html#/needless_pass_by_ref_mut) https://github.com/bevyengine/bevy/commit/c85d6d4a101ba35c3b89455b173fe880a10316ad

There is no breaking change, some internal `bevy_ecs` code no longer uses a few mutable references but I don't think it should cause any regression or be performance sensitive, but there might be some ECS magic I'm unaware of that could break because of those changes