### PR TITLE
Explicitly make instance_index vertex output @interpolate(flat)

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_vertex_output.wgsl
@@ -16,6 +16,6 @@ struct MeshVertexOutput {
     @location(4) color: vec4<f32>,
     #endif
     #ifdef VERTEX_OUTPUT_INSTANCE_INDEX
-    @location(5) instance_index: u32,
+    @location(5) @interpolate(flat) instance_index: u32,
     #endif
 }


### PR DESCRIPTION
The WGSL spec says that all scalar or vector integer vertex stage outputs and fragment stage inputs must be marked as @interpolate(flat). I think wgpu fixed this up for us, but being explicit is more correct.