### PR TITLE
Fix bugs in the Game of Life example

### DIFF
--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,3 +1,7 @@
+// The shader reads the previous frame's state from the `input` texture, and writes the new state of
+// each pixel to the `output` texture. The textures are flipped each step to progress the
+// simulation.
+
 @group(0) @binding(0)
 var input: texture_storage_2d<rgba8unorm, read>;
 

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -20,7 +20,7 @@ fn randomFloat(value: u32) -> f32 {
 fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_workgroups) num_workgroups: vec3<u32>) {
     let location = vec2<i32>(i32(invocation_id.x), i32(invocation_id.y));
 
-    let randomNumber = randomFloat(invocation_id.y * num_workgroups.x + invocation_id.x);
+    let randomNumber = randomFloat(invocation_id.y << 16u | invocation_id.x);
     let alive = randomNumber > 0.9;
     let color = vec4<f32>(f32(alive));
 

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,5 +1,8 @@
 @group(0) @binding(0)
-var texture: texture_storage_2d<rgba8unorm, read_write>;
+var input: texture_storage_2d<rgba8unorm, read>;
+
+@group(0) @binding(1)
+var output: texture_storage_2d<rgba8unorm, write>;
 
 fn hash(value: u32) -> u32 {
     var state = value;
@@ -24,11 +27,11 @@ fn init(@builtin(global_invocation_id) invocation_id: vec3<u32>, @builtin(num_wo
     let alive = randomNumber > 0.9;
     let color = vec4<f32>(f32(alive));
 
-    textureStore(texture, location, color);
+    textureStore(output, location, color);
 }
 
 fn is_alive(location: vec2<i32>, offset_x: i32, offset_y: i32) -> i32 {
-    let value: vec4<f32> = textureLoad(texture, location + vec2<i32>(offset_x, offset_y));
+    let value: vec4<f32> = textureLoad(input, location + vec2<i32>(offset_x, offset_y));
     return i32(value.x);
 }
 
@@ -60,7 +63,5 @@ fn update(@builtin(global_invocation_id) invocation_id: vec3<u32>) {
     }
     let color = vec4<f32>(f32(alive));
 
-    storageBarrier();
-
-    textureStore(texture, location, color);
+    textureStore(output, location, color);
 }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/9353 (the shader uses an incorrect barrier)
- Fixes the overly repetitive initialization pattern by using a better RNG seed

## Solution

- Create two textures and bind groups, and flip between them between each update