### PR TITLE
Add `DiagnosticsStore::iter_mut`

### DIFF
--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -227,9 +227,14 @@ impl DiagnosticsStore {
             .and_then(|diagnostic| diagnostic.measurement())
     }
 
-    /// Return an iterator over all [`Diagnostic`].
+    /// Return an iterator over all [`Diagnostic`]s.
     pub fn iter(&self) -> impl Iterator<Item = &Diagnostic> {
         self.diagnostics.values()
+    }
+
+    /// Return an iterator over all [`Diagnostic`]s, by mutable reference.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut Diagnostic> {
+        self.diagnostics.values_mut()
     }
 }
 


### PR DESCRIPTION
# Objective

Allow mutably iterating over all registered diagnostics. This is a useful utility method when exposing bevy's diagnostics in an editor that allows toggling whether the diagnostic is enabled.

## Solution

- Add `iter_mut`, mirroring what `iter` does, just mutably.

---

## Changelog

### Added

- Added `DiagnosticsStore::iter_mut` for mutably iterating over all registered diagnostics.