### PR TITLE
Merge `_Reflect` and `_WithRegistry` commands

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -21,6 +21,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_ecs_macros = { path = "macros", version = "0.12.0-dev" }
 
+parking_lot = "0.12.1"
 async-channel = "1.4"
 event-listener = "2.5"
 thread_local = "1.1.4"

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -1,42 +1,20 @@
 //! Types that enable reflection support.
 
-use std::ops::{Deref, DerefMut};
-
-use crate as bevy_ecs;
-use crate::{entity::Entity, system::Resource};
-use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize, TypeRegistryArc};
+use crate::entity::Entity;
+use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize};
 
 mod bundle;
 mod component;
 mod entity_commands;
 mod map_entities;
+mod registry;
 mod resource;
 
 pub use bundle::{ReflectBundle, ReflectBundleFns};
 pub use component::{ReflectComponent, ReflectComponentFns};
 pub use entity_commands::ReflectCommandExt;
 pub use map_entities::ReflectMapEntities;
+pub use registry::{AppTypeRegistry, ReadTypeRegistry};
 pub use resource::{ReflectResource, ReflectResourceFns};
-
-/// A [`Resource`] storing [`TypeRegistry`](bevy_reflect::TypeRegistry) for
-/// type registrations relevant to a whole app.
-#[derive(Resource, Clone, Default)]
-pub struct AppTypeRegistry(pub TypeRegistryArc);
-
-impl Deref for AppTypeRegistry {
-    type Target = TypeRegistryArc;
-
-    #[inline]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for AppTypeRegistry {
-    #[inline]
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
 
 impl_reflect_value!((in bevy_ecs) Entity(Hash, PartialEq, Serialize, Deserialize));

--- a/crates/bevy_ecs/src/reflect/registry.rs
+++ b/crates/bevy_ecs/src/reflect/registry.rs
@@ -1,0 +1,60 @@
+use std::ops::{Deref, DerefMut};
+
+use bevy_reflect::{TypeRegistry, TypeRegistryArc};
+use parking_lot::RwLockReadGuard;
+
+use crate as bevy_ecs;
+use crate::system::Resource;
+
+/// A [`Resource`] storing [`TypeRegistry`](bevy_reflect::TypeRegistry) for
+/// type registrations relevant to a whole app.
+#[derive(Resource, Clone, Default)]
+pub struct AppTypeRegistry(pub TypeRegistryArc);
+
+impl Deref for AppTypeRegistry {
+    type Target = TypeRegistryArc;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for AppTypeRegistry {
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// A type that can access a [`TypeRegistry`].
+///
+/// This is used with the [`ReflectCommandExt`] methods to identify and extract
+/// a type registry to use to insert/remove [`Reflect`] components.
+///
+/// It is implemented for [`AppTypeRegistry`] and any `Resource` that implements
+/// `AsRef<TypeRegistry>`.
+///
+/// [`ReflectCommandExt`]: super::ReflectCommandExt
+/// [`Reflect`]: bevy_reflect::Reflect
+pub trait ReadTypeRegistry {
+    /// The type holding the [`TypeRegistry`] to read from.
+    type Target<'t>: Deref<Target = TypeRegistry>
+    where
+        Self: 't;
+
+    /// Read the [`TypeRegistry`] from `Self`.
+    fn type_registry(&self) -> Self::Target<'_>;
+}
+impl<T: AsRef<TypeRegistry>> ReadTypeRegistry for T {
+    type Target<'t> = &'t TypeRegistry where Self: 't;
+    fn type_registry(&self) -> Self::Target<'_> {
+        self.as_ref()
+    }
+}
+impl ReadTypeRegistry for AppTypeRegistry {
+    type Target<'t> = RwLockReadGuard<'t, TypeRegistry> where Self: 't;
+    fn type_registry(&self) -> Self::Target<'_> {
+        self.read()
+    }
+}


### PR DESCRIPTION
# Objective

While code was already effectively deduplicated, this further deduplicates it, by removing `InsertReflect` and `RemoveReflect`, since they were just specialized version of their `_WithRegistry` counterparts.

## Solution

- Add `ReadTypeRegistry` trait, implemented for `AsRef<TypeRegistry>` and `AppTypeRegistry`
- Add default impl for `ReflectCommandExt` `insert_reflect` and `remove_reflect` methods
- Remove `InsertReflect` and `RemoveReflect` in favor of `InsertReflectWithRegistry<AppTypeRegistry>` and equivalent.