### PR TITLE
don't create windows on winit StartCause::Init event

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -48,7 +48,7 @@ use bevy_window::{
 pub use winit::platform::android::activity::AndroidApp;
 
 use winit::{
-    event::{self, DeviceEvent, Event, StartCause, WindowEvent},
+    event::{self, DeviceEvent, Event, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
 };
 
@@ -365,48 +365,6 @@ pub fn winit_runner(mut app: App) {
 
         match event {
             event::Event::NewEvents(start_cause) => match start_cause {
-                StartCause::Init => {
-                    #[cfg(any(target_os = "android", target_os = "ios", target_os = "macos"))]
-                    {
-                        #[cfg(not(target_arch = "wasm32"))]
-                        let (
-                            commands,
-                            mut windows,
-                            event_writer,
-                            winit_windows,
-                            adapters,
-                            handlers,
-                            accessibility_requested,
-                        ) = create_window_system_state.get_mut(&mut app.world);
-
-                        #[cfg(target_arch = "wasm32")]
-                        let (
-                            commands,
-                            mut windows,
-                            event_writer,
-                            winit_windows,
-                            adapters,
-                            handlers,
-                            accessibility_requested,
-                            event_channel,
-                        ) = create_window_system_state.get_mut(&mut app.world);
-
-                        create_windows(
-                            event_loop,
-                            commands,
-                            windows.iter_mut(),
-                            event_writer,
-                            winit_windows,
-                            adapters,
-                            handlers,
-                            accessibility_requested,
-                            #[cfg(target_arch = "wasm32")]
-                            event_channel,
-                        );
-
-                        create_window_system_state.apply(&mut app.world);
-                    }
-                }
                 _ => {
                     if let Some(t) = runner_state.scheduled_update {
                         let now = Instant::now();

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -48,7 +48,7 @@ use bevy_window::{
 pub use winit::platform::android::activity::AndroidApp;
 
 use winit::{
-    event::{self, DeviceEvent, Event, WindowEvent},
+    event::{self, DeviceEvent, Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},
 };
 
@@ -364,13 +364,57 @@ pub fn winit_runner(mut app: App) {
         }
 
         match event {
-            event::Event::NewEvents(_) => {
-                if let Some(t) = runner_state.scheduled_update {
-                    let now = Instant::now();
-                    let remaining = t.checked_duration_since(now).unwrap_or(Duration::ZERO);
-                    runner_state.wait_elapsed = remaining.is_zero();
+            event::Event::NewEvents(start_cause) => match start_cause {
+                StartCause::Init => {
+                    #[cfg(any(target_os = "ios", target_os = "macos"))]
+                    {
+                        #[cfg(not(target_arch = "wasm32"))]
+                        let (
+                            commands,
+                            mut windows,
+                            event_writer,
+                            winit_windows,
+                            adapters,
+                            handlers,
+                            accessibility_requested,
+                        ) = create_window_system_state.get_mut(&mut app.world);
+
+                        #[cfg(target_arch = "wasm32")]
+                        let (
+                            commands,
+                            mut windows,
+                            event_writer,
+                            winit_windows,
+                            adapters,
+                            handlers,
+                            accessibility_requested,
+                            event_channel,
+                        ) = create_window_system_state.get_mut(&mut app.world);
+
+                        create_windows(
+                            event_loop,
+                            commands,
+                            windows.iter_mut(),
+                            event_writer,
+                            winit_windows,
+                            adapters,
+                            handlers,
+                            accessibility_requested,
+                            #[cfg(target_arch = "wasm32")]
+                            event_channel,
+                        );
+
+                        create_window_system_state.apply(&mut app.world);
+                    }
                 }
-            }
+                _ => {
+                    if let Some(t) = runner_state.scheduled_update {
+                        let now = Instant::now();
+                        let remaining = t.checked_duration_since(now).unwrap_or(Duration::ZERO);
+                        runner_state.wait_elapsed = remaining.is_zero();
+                    }
+                }
+            },
             event::Event::WindowEvent {
                 event, window_id, ..
             } => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -364,15 +364,13 @@ pub fn winit_runner(mut app: App) {
         }
 
         match event {
-            event::Event::NewEvents(start_cause) => match start_cause {
-                _ => {
-                    if let Some(t) = runner_state.scheduled_update {
-                        let now = Instant::now();
-                        let remaining = t.checked_duration_since(now).unwrap_or(Duration::ZERO);
-                        runner_state.wait_elapsed = remaining.is_zero();
-                    }
+            event::Event::NewEvents(_) => {
+                if let Some(t) = runner_state.scheduled_update {
+                    let now = Instant::now();
+                    let remaining = t.checked_duration_since(now).unwrap_or(Duration::ZERO);
+                    runner_state.wait_elapsed = remaining.is_zero();
                 }
-            },
+            }
             event::Event::WindowEvent {
                 event, window_id, ..
             } => {


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/7609 broke Android support

```
8721  8770 I event crates/bevy_winit/src/system.rs:55:  Creating new window "App" (0v0)
8721  8769 I RustStdoutStderr: thread '<unnamed>' panicked at 'Cannot get the native window, it's null and will always be null before Event::Resumed and after Event::Suspended. Make sure you only call this function between those events.', winit-0.28.6/src/platform_impl/android/mod.rs:1058:13
```
## Solution

- Don't create windows on `StartCause::Init` as it's too early
