### PR TITLE
Moved `get_component(_unchecked_mut)` from `Query` to `QueryState`

### DIFF
--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -126,3 +126,26 @@ impl std::fmt::Display for QueryComponentError {
         }
     }
 }
+
+/// An error that occurs when evaluating a [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState) as a single expected result via
+/// [`get_single`](crate::system::Query::get_single) or [`get_single_mut`](crate::system::Query::get_single_mut).
+#[derive(Debug)]
+pub enum QuerySingleError {
+    /// No entity fits the query.
+    NoEntities(&'static str),
+    /// Multiple entities fit the query.
+    MultipleEntities(&'static str),
+}
+
+impl std::error::Error for QuerySingleError {}
+
+impl std::fmt::Display for QuerySingleError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            QuerySingleError::NoEntities(query) => write!(f, "No entities fit the query {query}"),
+            QuerySingleError::MultipleEntities(query) => {
+                write!(f, "Multiple entities fit the query {query}!")
+            }
+        }
+    }
+}

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use crate::entity::Entity;
 
-/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`Query`](crate::system::Query) or [`QueryState`].
+/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`Query`](crate::system::Query) or [`QueryState`](crate::query::QueryState).
 // TODO: return the type_name as part of this error
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum QueryEntityError {
@@ -14,7 +14,7 @@ pub enum QueryEntityError {
     NoSuchEntity(Entity),
     /// The [`Entity`] was requested mutably more than once.
     ///
-    /// See [`QueryState::get_many_mut`] for an example.
+    /// See [`QueryState::get_many_mut`](crate::query::QueryState::get_many_mut) for an example.
     AliasedMutability(Entity),
 }
 

--- a/crates/bevy_ecs/src/query/error.rs
+++ b/crates/bevy_ecs/src/query/error.rs
@@ -1,0 +1,128 @@
+use std::fmt;
+
+use crate::entity::Entity;
+
+/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`Query`](crate::system::Query) or [`QueryState`].
+// TODO: return the type_name as part of this error
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum QueryEntityError {
+    /// The given [`Entity`]'s components do not match the query.
+    ///
+    /// Either it does not have a requested component, or it has a component which the query filters out.
+    QueryDoesNotMatch(Entity),
+    /// The given [`Entity`] does not exist.
+    NoSuchEntity(Entity),
+    /// The [`Entity`] was requested mutably more than once.
+    ///
+    /// See [`QueryState::get_many_mut`] for an example.
+    AliasedMutability(Entity),
+}
+
+impl std::error::Error for QueryEntityError {}
+
+impl fmt::Display for QueryEntityError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            QueryEntityError::QueryDoesNotMatch(_) => {
+                write!(f, "The given entity's components do not match the query.")
+            }
+            QueryEntityError::NoSuchEntity(_) => write!(f, "The requested entity does not exist."),
+            QueryEntityError::AliasedMutability(_) => {
+                write!(f, "The entity was requested mutably more than once.")
+            }
+        }
+    }
+}
+
+/// An error that occurs when retrieving a specific [`Entity`]'s component from a [`Query`](crate::system::Query).
+#[derive(Debug, PartialEq, Eq)]
+pub enum QueryComponentError {
+    /// The [`Query`](crate::system::Query) does not have read access to the requested component.
+    ///
+    /// This error occurs when the requested component is not included in the original query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, query::QueryComponentError};
+    /// #
+    /// # #[derive(Component)]
+    /// # struct OtherComponent;
+    /// #
+    /// # #[derive(Component, PartialEq, Debug)]
+    /// # struct RequestedComponent;
+    /// #
+    /// # #[derive(Resource)]
+    /// # struct SpecificEntity {
+    /// #     entity: Entity,
+    /// # }
+    /// #
+    /// fn get_missing_read_access_error(query: Query<&OtherComponent>, res: Res<SpecificEntity>) {
+    ///     assert_eq!(
+    ///         query.get_component::<RequestedComponent>(res.entity),
+    ///         Err(QueryComponentError::MissingReadAccess),
+    ///     );
+    ///     println!("query doesn't have read access to RequestedComponent because it does not appear in Query<&OtherComponent>");
+    /// }
+    /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
+    /// ```
+    MissingReadAccess,
+    /// The [`Query`](crate::system::Query) does not have write access to the requested component.
+    ///
+    /// This error occurs when the requested component is not included in the original query, or the mutability of the requested component is mismatched with the original query.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, query::QueryComponentError};
+    /// #
+    /// # #[derive(Component, PartialEq, Debug)]
+    /// # struct RequestedComponent;
+    /// #
+    /// # #[derive(Resource)]
+    /// # struct SpecificEntity {
+    /// #     entity: Entity,
+    /// # }
+    /// #
+    /// fn get_missing_write_access_error(mut query: Query<&RequestedComponent>, res: Res<SpecificEntity>) {
+    ///     assert_eq!(
+    ///         query.get_component::<RequestedComponent>(res.entity),
+    ///         Err(QueryComponentError::MissingWriteAccess),
+    ///     );
+    ///     println!("query doesn't have write access to RequestedComponent because it doesn't have &mut in Query<&RequestedComponent>");
+    /// }
+    /// # bevy_ecs::system::assert_is_system(get_missing_write_access_error);
+    /// ```
+    MissingWriteAccess,
+    /// The given [`Entity`] does not have the requested component.
+    MissingComponent,
+    /// The requested [`Entity`] does not exist.
+    NoSuchEntity,
+}
+
+impl std::error::Error for QueryComponentError {}
+
+impl std::fmt::Display for QueryComponentError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            QueryComponentError::MissingReadAccess => {
+                write!(
+                    f,
+                    "This query does not have read access to the requested component."
+                )
+            }
+            QueryComponentError::MissingWriteAccess => {
+                write!(
+                    f,
+                    "This query does not have write access to the requested component."
+                )
+            }
+            QueryComponentError::MissingComponent => {
+                write!(f, "The given entity does not have the requested component.")
+            }
+            QueryComponentError::NoSuchEntity => {
+                write!(f, "The requested entity does not exist.")
+            }
+        }
+    }
+}

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -1,6 +1,7 @@
 //! Contains APIs for retrieving component data from the world.
 
 mod access;
+mod error;
 mod fetch;
 mod filter;
 mod iter;
@@ -8,6 +9,7 @@ mod par_iter;
 mod state;
 
 pub use access::*;
+pub use error::*;
 pub use fetch::*;
 pub use filter::*;
 pub use iter::*;

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -16,7 +16,10 @@ use bevy_utils::tracing::Instrument;
 use fixedbitset::FixedBitSet;
 use std::{any::TypeId, borrow::Borrow, fmt, mem::MaybeUninit};
 
-use super::{NopWorldQuery, QueryManyIter, ROQueryItem, ReadOnlyWorldQuery};
+use super::{
+    NopWorldQuery, QueryComponentError, QueryEntityError, QueryManyIter, ROQueryItem,
+    ReadOnlyWorldQuery,
+};
 
 /// Provides scoped access to a [`World`] state according to a given [`WorldQuery`] and query filter.
 #[repr(C)]
@@ -1491,131 +1494,6 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
             (Some(_), _) => Err(QuerySingleError::MultipleEntities(std::any::type_name::<
                 Self,
             >())),
-        }
-    }
-}
-
-/// An error that occurs when retrieving a specific [`Entity`]'s query result from [`Query`](crate::system::Query) or [`QueryState`].
-// TODO: return the type_name as part of this error
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum QueryEntityError {
-    /// The given [`Entity`]'s components do not match the query.
-    ///
-    /// Either it does not have a requested component, or it has a component which the query filters out.
-    QueryDoesNotMatch(Entity),
-    /// The given [`Entity`] does not exist.
-    NoSuchEntity(Entity),
-    /// The [`Entity`] was requested mutably more than once.
-    ///
-    /// See [`QueryState::get_many_mut`] for an example.
-    AliasedMutability(Entity),
-}
-
-impl std::error::Error for QueryEntityError {}
-
-impl fmt::Display for QueryEntityError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            QueryEntityError::QueryDoesNotMatch(_) => {
-                write!(f, "The given entity's components do not match the query.")
-            }
-            QueryEntityError::NoSuchEntity(_) => write!(f, "The requested entity does not exist."),
-            QueryEntityError::AliasedMutability(_) => {
-                write!(f, "The entity was requested mutably more than once.")
-            }
-        }
-    }
-}
-
-/// An error that occurs when retrieving a specific [`Entity`]'s component from a [`Query`](crate::system::Query).
-#[derive(Debug, PartialEq, Eq)]
-pub enum QueryComponentError {
-    /// The [`Query`](crate::system::Query) does not have read access to the requested component.
-    ///
-    /// This error occurs when the requested component is not included in the original query.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_ecs::{prelude::*, query::QueryComponentError};
-    /// #
-    /// # #[derive(Component)]
-    /// # struct OtherComponent;
-    /// #
-    /// # #[derive(Component, PartialEq, Debug)]
-    /// # struct RequestedComponent;
-    /// #
-    /// # #[derive(Resource)]
-    /// # struct SpecificEntity {
-    /// #     entity: Entity,
-    /// # }
-    /// #
-    /// fn get_missing_read_access_error(query: Query<&OtherComponent>, res: Res<SpecificEntity>) {
-    ///     assert_eq!(
-    ///         query.get_component::<RequestedComponent>(res.entity),
-    ///         Err(QueryComponentError::MissingReadAccess),
-    ///     );
-    ///     println!("query doesn't have read access to RequestedComponent because it does not appear in Query<&OtherComponent>");
-    /// }
-    /// # bevy_ecs::system::assert_is_system(get_missing_read_access_error);
-    /// ```
-    MissingReadAccess,
-    /// The [`Query`](crate::system::Query) does not have write access to the requested component.
-    ///
-    /// This error occurs when the requested component is not included in the original query, or the mutability of the requested component is mismatched with the original query.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// # use bevy_ecs::{prelude::*, query::QueryComponentError};
-    /// #
-    /// # #[derive(Component, PartialEq, Debug)]
-    /// # struct RequestedComponent;
-    /// #
-    /// # #[derive(Resource)]
-    /// # struct SpecificEntity {
-    /// #     entity: Entity,
-    /// # }
-    /// #
-    /// fn get_missing_write_access_error(mut query: Query<&RequestedComponent>, res: Res<SpecificEntity>) {
-    ///     assert_eq!(
-    ///         query.get_component::<RequestedComponent>(res.entity),
-    ///         Err(QueryComponentError::MissingWriteAccess),
-    ///     );
-    ///     println!("query doesn't have write access to RequestedComponent because it doesn't have &mut in Query<&RequestedComponent>");
-    /// }
-    /// # bevy_ecs::system::assert_is_system(get_missing_write_access_error);
-    /// ```
-    MissingWriteAccess,
-    /// The given [`Entity`] does not have the requested component.
-    MissingComponent,
-    /// The requested [`Entity`] does not exist.
-    NoSuchEntity,
-}
-
-impl std::error::Error for QueryComponentError {}
-
-impl std::fmt::Display for QueryComponentError {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            QueryComponentError::MissingReadAccess => {
-                write!(
-                    f,
-                    "This query does not have read access to the requested component."
-                )
-            }
-            QueryComponentError::MissingWriteAccess => {
-                write!(
-                    f,
-                    "This query does not have write access to the requested component."
-                )
-            }
-            QueryComponentError::MissingComponent => {
-                write!(f, "The given entity does not have the requested component.")
-            }
-            QueryComponentError::NoSuchEntity => {
-                write!(f, "The requested entity does not exist.")
-            }
         }
     }
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -604,7 +604,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
             .archetype_component_access
             .has_write(archetype_component)
         {
-            // SEMI-SAFETY: It is the responsibility of the caller to ensure it is sound to get a
+            // SAFETY: It is the responsibility of the caller to ensure it is sound to get a
             // mutable reference to this entity's component `T`.
             let result = unsafe { entity_ref.get_mut_using_ticks::<T>(last_run, this_run) };
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -614,38 +614,6 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         }
     }
 
-    /// Returns a mutable reference to the component `T` of the given entity.
-    ///
-    /// # Panics
-    ///
-    /// Panics in case of a nonexisting entity or mismatched component.
-    ///
-    /// # Safety
-    ///
-    /// This function makes it possible to violate Rust's aliasing guarantees.
-    /// You must make sure this call does not result in multiple mutable references to the same component.
-    #[inline]
-    pub(crate) unsafe fn component_unchecked_mut<'w, 's, 'r, T: Component>(
-        &'s self,
-        world: UnsafeWorldCell<'w>,
-        entity: Entity,
-        last_run: Tick,
-        this_run: Tick,
-    ) -> Mut<'r, T>
-    where
-        'w: 'r,
-    {
-        match self.get_component_unchecked_mut(world, entity, last_run, this_run) {
-            Ok(component) => component,
-            Err(error) => {
-                panic!(
-                    "Cannot get component `{:?}` from {entity:?}: {error}",
-                    TypeId::of::<T>()
-                )
-            }
-        }
-    }
-
     /// Gets the read-only query results for the given [`World`] and array of [`Entity`], where the last change and
     /// the current change tick are given.
     ///
@@ -676,30 +644,6 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
         // SAFETY: Each value has been fully initialized.
         Ok(values.map(|x| x.assume_init()))
-    }
-
-    /// Gets the read-only query results for the given [`World`] and array of [`Entity`], where the last change and
-    /// the current change tick are given.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any item cannot be retrieved.
-    ///
-    /// # Safety
-    ///
-    /// This must be called on the same `World` that the `Query` was generated from:
-    /// use `QueryState::validate_world` to verify this.
-    pub(crate) unsafe fn many_read_only_manual<'w, const N: usize>(
-        &self,
-        world: &'w World,
-        entities: [Entity; N],
-        last_run: Tick,
-        this_run: Tick,
-    ) -> [ROQueryItem<'w, Q>; N] {
-        match self.get_many_read_only_manual(world, entities, last_run, this_run) {
-            Ok(items) => items,
-            Err(error) => panic!("Cannot get query results: {error}"),
-        }
     }
 
     /// Gets the query results for the given [`World`] and array of [`Entity`], where the last change and
@@ -737,33 +681,6 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
 
         // SAFETY: Each value has been fully initialized.
         Ok(values.map(|x| x.assume_init()))
-    }
-
-    /// Gets the query results for the given [`World`] and array of [`Entity`], where the last change and
-    /// the current change tick are given.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any item cannot be retrieved.
-    ///
-    /// # Safety
-    ///
-    /// This does not check for unique access to subsets of the entity-component data.
-    /// To be safe, make sure mutable queries have unique access to the components they query.
-    ///
-    /// This must be called on the same `World` that the `Query` was generated from:
-    /// use `QueryState::validate_world` to verify this.
-    pub(crate) unsafe fn many_unchecked_manual<'w, const N: usize>(
-        &self,
-        world: UnsafeWorldCell<'w>,
-        entities: [Entity; N],
-        last_run: Tick,
-        this_run: Tick,
-    ) -> [Q::Item<'w>; N] {
-        match self.get_many_unchecked_manual(world, entities, last_run, this_run) {
-            Ok(items) => items,
-            Err(error) => panic!("Cannot get query result: {error}"),
-        }
     }
 
     /// Returns an [`Iterator`] over the query results for the given [`World`].

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -548,8 +548,8 @@ mod tests {
             Schedule,
         },
         system::{
-            Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query,
-            QueryComponentError, Res, ResMut, Resource, System, SystemState,
+            Commands, In, IntoSystem, Local, NonSend, NonSendMut, ParamSet, Query, Res, ResMut,
+            Resource, System, SystemState,
         },
         world::{FromWorld, World},
     };
@@ -1759,6 +1759,8 @@ mod tests {
 
     #[test]
     fn readonly_query_get_mut_component_fails() {
+        use crate::query::QueryComponentError;
+
         let mut world = World::new();
         let entity = world.spawn(W(42u32)).id();
         run_system(&mut world, move |q: Query<&mut W<u32>>| {

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1212,36 +1212,6 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         }
     }
 
-    /// Returns a mutable reference to the component `T` of the given entity.
-    ///
-    /// # Panics
-    ///
-    /// Panics in case of a nonexisting entity or mismatched component.
-    ///
-    /// # Safety
-    ///
-    /// This function makes it possible to violate Rust's aliasing guarantees.
-    /// You must make sure this call does not result in multiple mutable references to the same component.
-    ///
-    /// # See also
-    ///
-    /// - [`get_component_mut`](Self::get_component_mut) for the safe version.
-    #[inline]
-    pub unsafe fn component_unchecked_mut<T: Component>(&self, entity: Entity) -> Mut<'_, T> {
-        // This check is required to ensure soundness in the case of `to_readonly().get_component_mut()`
-        // See the comments on the `force_read_only_component_access` field for more info.
-        if self.force_read_only_component_access {
-            panic!("Missing write access");
-        }
-
-        // SAFETY: The above check ensures we are not a readonly query.
-        // It is the callers responsibility to ensure multiple mutable access is not provided.
-        unsafe {
-            self.state
-                .component_unchecked_mut(self.world, entity, self.last_run, self.this_run)
-        }
-    }
-
     /// Returns a single read-only query item when there is exactly one entity matching the query.
     ///
     /// # Panics

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1178,7 +1178,10 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     #[track_caller]
     pub fn component_mut<T: Component>(&mut self, entity: Entity) -> Mut<'_, T> {
         // SAFETY: unique access to query (preventing aliased access)
-        unsafe { self.component_unchecked_mut(entity) }
+        unsafe {
+            self.state
+                .component_unchecked_mut(self.world, entity, self.last_run, self.this_run)
+        }
     }
 
     /// Returns a mutable reference to the component `T` of the given entity.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -426,8 +426,6 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`for_each`](Self::for_each) for the closure based alternative.
     #[inline]
     pub fn iter(&self) -> QueryIter<'_, 's, Q::ReadOnly, F::ReadOnly> {
-        let state = self.state.as_readonly();
-
         // SAFETY:
         // - `self.world` has permission to access the required components.
         // - The query is read-only, so it can be aliased even if it was originally mutable.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1136,12 +1136,14 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         &self,
         entity: Entity,
     ) -> Result<Mut<'_, T>, QueryComponentError> {
+        // This check is required to ensure soundness in the case of `to_readonly().get_component_mut()`
+        // See the comments on the `force_read_only_component_access` field for more info.
         if self.force_read_only_component_access {
             return Err(QueryComponentError::MissingWriteAccess);
         }
 
-        // SAFETY: this check is required to ensure soundness in the case of `to_readonly().get_component_mut()`
-        // See the comments on the `force_read_only_component_access` field for more info.
+        // SAFETY: The above check ensures we are not a readonly query.
+        // It is the callers responsibility to ensure multiple mutable access is not provided.
         unsafe {
             self.state
                 .get_component_unchecked_mut(self.world, entity, self.last_run, self.this_run)

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1171,10 +1171,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     #[inline]
     #[track_caller]
     pub fn component_mut<T: Component>(&mut self, entity: Entity) -> Mut<'_, T> {
-        // SAFETY: unique access to query (preventing aliased access)
-        let result = unsafe { self.get_component_unchecked_mut(entity) };
-
-        match result {
+        match self.get_component_mut(entity) {
             Ok(component) => component,
             Err(error) => {
                 panic!(

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -734,13 +734,16 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// - [`iter`](Self::iter) for the iterator based alternative.
     #[inline]
     pub fn for_each<'this>(&'this self, f: impl FnMut(ROQueryItem<'this, Q>)) {
-        let state = self.state.as_readonly();
-
         // SAFETY:
         // - `self.world` has permission to access the required components.
         // - The query is read-only, so it can be aliased even if it was originally mutable.
         unsafe {
-            state.for_each_unchecked_manual(self.world, f, self.last_run, self.this_run);
+            self.state.as_readonly().for_each_unchecked_manual(
+                self.world,
+                f,
+                self.last_run,
+                self.this_run,
+            );
         };
     }
 


### PR DESCRIPTION
# Objective

- Fixes #9683

## Solution

- Moved `get_component` from `Query` to `QueryState`.
- Moved `get_component_unchecked_mut` from `Query` to `QueryState`.
- Moved `QueryComponentError` from `bevy_ecs::system` to `bevy_ecs::query`. Minor Breaking Change.
- Narrowed scope of `unsafe` blocks in `Query` methods.

---

## Migration Guide

- `use bevy_ecs::system::QueryComponentError;` -> `use bevy_ecs::query::QueryComponentError;`

## Notes

I am not very familiar with unsafe Rust nor its use within Bevy, so I may have committed a Rust faux pas during the migration.