### PR TITLE
Wait before making window visible

### DIFF
--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -35,7 +35,6 @@ fn main() {
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin,
         ))
-        .add_systems(Startup, setup)
         .add_systems(
             Update,
             (
@@ -46,16 +45,21 @@ fn main() {
                 toggle_window_controls,
                 cycle_cursor_icon,
                 switch_level,
+                toggle_visible,
             ),
         )
         .run();
 }
 
-fn setup(mut primary_window: Query<&mut Window, With<PrimaryWindow>>) {
-    // At this point the gpu is ready to show the app so we can make the window visible
-    // There might still be a white frame when doing it in startup.
-    // Alternatively, you could have a system that waits a few seconds before making the window visible.
-    primary_window.single_mut().visible = true;
+fn toggle_visible(mut primary_window: Query<&mut Window, With<PrimaryWindow>>, time: Res<Time>) {
+    let mut window = primary_window.single_mut();
+    // The delay may be different for your app or system.
+    if !window.visible && time.elapsed_seconds() >= 1.0 {
+        // At this point the gpu is ready to show the app so we can make the window visible.
+        // Alternatively, you could toggle the visibility in Startup.
+        // It will work, but it will have one white frame before it starts rendering
+        window.visible = true;
+    }
 }
 
 /// This system toggles the vsync mode when pressing the button V.

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -2,9 +2,10 @@
 //! the mouse pointer in various ways.
 
 use bevy::{
+    core::FrameCount,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
-    window::{CursorGrabMode, PresentMode, PrimaryWindow, WindowLevel, WindowTheme},
+    window::{CursorGrabMode, PresentMode, WindowLevel, WindowTheme},
 };
 
 fn main() {
@@ -51,14 +52,13 @@ fn main() {
         .run();
 }
 
-fn toggle_visible(mut primary_window: Query<&mut Window, With<PrimaryWindow>>, time: Res<Time>) {
-    let mut window = primary_window.single_mut();
+fn toggle_visible(mut window: Query<&mut Window>, frames: Res<FrameCount>) {
     // The delay may be different for your app or system.
-    if !window.visible && time.elapsed_seconds() >= 1.0 {
+    if frames.0 == 3 {
         // At this point the gpu is ready to show the app so we can make the window visible.
         // Alternatively, you could toggle the visibility in Startup.
         // It will work, but it will have one white frame before it starts rendering
-        window.visible = true;
+        window.single_mut().visible = true;
     }
 }
 

--- a/examples/window/window_settings.rs
+++ b/examples/window/window_settings.rs
@@ -26,7 +26,7 @@ fn main() {
                         ..Default::default()
                     },
                     // This will spawn an invisible window
-                    // The window will be made visible in the setup() function
+                    // The window will be made visible in the make_visible() system after 3 frames.
                     // This is useful when you want to avoid the white window that shows up before the GPU is ready to render the app.
                     visible: false,
                     ..default()
@@ -46,13 +46,13 @@ fn main() {
                 toggle_window_controls,
                 cycle_cursor_icon,
                 switch_level,
-                toggle_visible,
+                make_visible,
             ),
         )
         .run();
 }
 
-fn toggle_visible(mut window: Query<&mut Window>, frames: Res<FrameCount>) {
+fn make_visible(mut window: Query<&mut Window>, frames: Res<FrameCount>) {
     // The delay may be different for your app or system.
     if frames.0 == 3 {
         // At this point the gpu is ready to show the app so we can make the window visible.


### PR DESCRIPTION
# Objective

- The current example still has one white frame before it starts rendering.

## Solution

- Wait 3 frames before toggling visibility