### PR TITLE
Fix doc link in transparent_window example

### DIFF
--- a/examples/window/transparent_window.rs
+++ b/examples/window/transparent_window.rs
@@ -1,7 +1,7 @@
 //! Shows how to display a window in transparent mode.
 //!
 //! This feature works as expected depending on the platform. Please check the
-//! [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.WindowDescriptor.html#structfield.transparent)
+//! [documentation](https://docs.rs/bevy/latest/bevy/prelude/struct.Window.html#structfield.transparent)
 //! for more details.
 
 #[cfg(target_os = "macos")]


### PR DESCRIPTION
# Objective

This link became invalid after #5589.

## Solution

The docs that were being linked to still exist, but they're on `Window` now.

This PR just updates that link.