### PR TITLE
warn and min for different vertex count

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -360,7 +360,7 @@ impl Mesh {
         let mut attributes_interleaved_buffer = vec![0; vertex_count * vertex_size];
         // bundle into interleaved buffers
         let mut attribute_offset = 0;
-        for attribute_data in self.attributes.values() {
+        for attribute_data in self.attributes.values().take(vertex_count) {
             let attribute_size = attribute_data.attribute.format.get_size() as usize;
             let attributes_bytes = attribute_data.values.get_bytes();
             for (vertex_index, attribute_bytes) in

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1,5 +1,6 @@
 mod conversions;
 pub mod skinning;
+use bevy_log::warn;
 pub use wgpu::PrimitiveTopology;
 
 use crate::{
@@ -330,10 +331,13 @@ impl Mesh {
         for (attribute_id, attribute_data) in &self.attributes {
             let attribute_len = attribute_data.values.len();
             if let Some(previous_vertex_count) = vertex_count {
-                assert_eq!(previous_vertex_count, attribute_len,
-                        "{attribute_id:?} has a different vertex count ({attribute_len}) than other attributes ({previous_vertex_count}) in this mesh.");
+                if previous_vertex_count != attribute_len {
+                    warn!("{attribute_id:?} has a different vertex count ({attribute_len}) than other attributes ({previous_vertex_count}) in this mesh.");
+                    vertex_count = Some(std::cmp::min(previous_vertex_count, attribute_len));
+                }
+            } else {
+                vertex_count = Some(attribute_len);
             }
-            vertex_count = Some(attribute_len);
         }
 
         vertex_count.unwrap_or(0)

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -346,9 +346,9 @@ impl Mesh {
     /// Computes and returns the vertex data of the mesh as bytes.
     /// Therefore the attributes are located in the order of their [`MeshVertexAttribute::id`].
     /// This is used to transform the vertex data into a GPU friendly format.
-    ///
-    /// # Panics
-    /// Panics if the attributes have different vertex counts.
+    /// 
+    /// If the vertex attributes have different lengths, they are all truncated to
+    /// the length of the smallest.
     pub fn get_vertex_buffer_data(&self) -> Vec<u8> {
         let mut vertex_size = 0;
         for attribute_data in self.attributes.values() {

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -346,7 +346,7 @@ impl Mesh {
     /// Computes and returns the vertex data of the mesh as bytes.
     /// Therefore the attributes are located in the order of their [`MeshVertexAttribute::id`].
     /// This is used to transform the vertex data into a GPU friendly format.
-    /// 
+    ///
     /// If the vertex attributes have different lengths, they are all truncated to
     /// the length of the smallest.
     pub fn get_vertex_buffer_data(&self) -> Vec<u8> {

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -324,15 +324,15 @@ impl Mesh {
 
     /// Counts all vertices of the mesh.
     ///
-    /// # Panics
-    /// Panics if the attributes have different vertex counts.
+    /// If the attributes have different vertex counts, the smallest is returned.
     pub fn count_vertices(&self) -> usize {
         let mut vertex_count: Option<usize> = None;
         for (attribute_id, attribute_data) in &self.attributes {
             let attribute_len = attribute_data.values.len();
             if let Some(previous_vertex_count) = vertex_count {
                 if previous_vertex_count != attribute_len {
-                    warn!("{attribute_id:?} has a different vertex count ({attribute_len}) than other attributes ({previous_vertex_count}) in this mesh.");
+                    warn!("{attribute_id:?} has a different vertex count ({attribute_len}) than other attributes ({previous_vertex_count}) in this mesh, \
+                        all attributes will be truncated to match the smallest.");
                     vertex_count = Some(std::cmp::min(previous_vertex_count, attribute_len));
                 }
             } else {


### PR DESCRIPTION
# Objective

Bevy currently crashes when meshes with different vertex counts for attributes are provided. 

## Solution

Instead of crashing we can warn and take the min length of all the given attributes.