### PR TITLE
Dynamic plugin loading: Make it work, make it more economic, add an example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -263,6 +263,13 @@ futures-lite = "1.11.3"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
 
+# Needed for the dynamic linking examples
+libloading = { version = "0.8" }
+parking_lot = "0.12.1"
+bevy_dynamic_plugin = { path = "crates/bevy_dynamic_plugin" }
+# bevy must be dynamically linked into the examples, or else dynamic plugin libraries get their own private copy of bevy and chaos ensues
+bevy = { path = ".", features = ["dynamic_linking"] }
+
 [[example]]
 name = "hello_world"
 path = "examples/hello_world.rs"
@@ -2289,6 +2296,25 @@ name = "Window Resizing"
 description = "Demonstrates resizing and responding to resizing a window"
 category = "Window"
 wasm = true
+
+[[example]]
+name = "dynamic_plugin"
+path = "examples/ecs/dynamic_plugin.rs"
+# remember to use `-Zshare-generics=n` on Windows, see the template .cargo/config_fast_builds
+crate-type = ["dylib"]
+doc-scrape-examples = false
+
+[package.metadata.example.dynamic_plugin]
+name = "Dynamic Plugin"
+description = "A dynamic plugin in a shared library loaded by the load_dynamic_plugin example at run time"
+
+[[example]]
+name = "load_dynamic_plugin"
+path = "examples/ecs/load_dynamic_plugin.rs"
+
+[package.metadata.example.load_dynamic_plugin]
+name = "Dynamic Plugin Loading"
+description = "Demonstrates loading a dynamic plugin from a shared library"
 
 [profile.wasm-release]
 inherits = "release"

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -2,6 +2,7 @@ use downcast_rs::{impl_downcast, Downcast};
 
 use crate::App;
 use std::any::Any;
+use std::ops::Deref;
 
 /// A collection of Bevy app logic and configuration.
 ///
@@ -59,6 +60,32 @@ pub trait Plugin: Downcast + Any + Send + Sync {
 }
 
 impl_downcast!(Plugin);
+
+impl<T: Deref<Target = dyn Plugin> + Send + Sync + 'static> Plugin for T {
+    fn build(&self, app: &mut App) {
+        self.deref().build(app);
+    }
+
+    fn ready(&self, app: &App) -> bool {
+        self.deref().ready(app)
+    }
+
+    fn finish(&self, app: &mut App) {
+        self.deref().finish(app);
+    }
+
+    fn cleanup(&self, app: &mut App) {
+        self.deref().cleanup(app);
+    }
+
+    fn name(&self) -> &str {
+        self.deref().name()
+    }
+
+    fn is_unique(&self) -> bool {
+        self.deref().is_unique()
+    }
+}
 
 /// A type representing an unsafe function that returns a mutable pointer to a [`Plugin`].
 /// It is used for dynamically loading plugins.

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -64,7 +64,7 @@ impl_downcast!(Plugin);
 /// It is used for dynamically loading plugins.
 ///
 /// See `bevy_dynamic_plugin/src/loader.rs#dynamically_load_plugin`.
-pub type CreatePlugin = unsafe fn() -> *mut dyn Plugin;
+pub type CreatePlugin = unsafe extern "Rust" fn() -> *mut dyn Plugin;
 
 /// Types that represent a set of [`Plugin`]s.
 ///

--- a/crates/bevy_derive/src/app_plugin.rs
+++ b/crates/bevy_derive/src/app_plugin.rs
@@ -8,7 +8,7 @@ pub fn derive_dynamic_plugin(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         #[no_mangle]
-        pub extern "C" fn _bevy_create_plugin() -> *mut dyn bevy::app::Plugin {
+        pub extern "Rust" fn _bevy_create_plugin() -> *mut dyn bevy::app::Plugin {
             // make sure the constructor is the correct type.
             let object = #struct_name {};
             let boxed = Box::new(object);

--- a/examples/ecs/dynamic_plugin.rs
+++ b/examples/ecs/dynamic_plugin.rs
@@ -1,0 +1,18 @@
+//! A dynamic library that contains a dynamically loaded plugin. See the `load_dynamic_plugin` on how to load such a plugin.
+
+use bevy::prelude::*;
+
+/// Derive DynamicPlugin on one main plugin, which will then be loaded by [`bevy_dynamic_plugin::load_dynamic_plugin`].
+#[derive(DynamicPlugin)]
+struct MyDynamicPlugin;
+
+impl Plugin for MyDynamicPlugin {
+    fn build(&self, app: &mut App) {
+        info!("Plugin is being loaded...");
+        app.add_systems(Update, say_hello);
+    }
+}
+
+fn say_hello() {
+    info!("Hello from the dynamic plugin!");
+}

--- a/examples/ecs/load_dynamic_plugin.rs
+++ b/examples/ecs/load_dynamic_plugin.rs
@@ -1,0 +1,33 @@
+//! Loads a dynamic plugin from the shared library `dynamic_plugin`
+
+use std::path::PathBuf;
+
+use bevy::prelude::*;
+use bevy_dynamic_plugin::dynamically_load_plugin;
+use libloading::Library;
+use parking_lot::Mutex;
+
+/// If the library wasn't stored here, libloading would unload it as soon as we were done with it below.
+/// This would cause the program to crash/segfault later when bevy tries to invoke the plugin's systems.
+/// Therefore, libraries should be stored such that they outlive the [`App`].
+/// A simple method is to use a global mutex.
+static LIBRARY: Mutex<Option<Library>> = Mutex::new(None);
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins(DefaultPlugins);
+
+    #[cfg(any(target_family = "windows", target_family = "unix"))]
+    {
+        // The ending can be the default library ending of the operating system (e.g. .dll, .so).
+        let plugin_name = PathBuf::from("dynamic_plugin");
+
+        let (library, plugin) = unsafe { dynamically_load_plugin(plugin_name) }.unwrap();
+        app.add_plugins(plugin);
+        info!("Loaded plugin!");
+        // Make sure the plugin stays alive by storing it in a global variable:
+        *LIBRARY.lock() = Some(library);
+    }
+
+    app.run();
+}


### PR DESCRIPTION
# Objective

- Fixes #9700
- Fixes an ABI mismatch bug that results in dynamic plugin loading via `DynamicPlugin` being always broken currently.
- Add a dynamic plugin loading example (consisting of two binaries, obviously).

---

## Changelog
### Always use extern "Rust" for dynamic plugins

Previously, one side used the C calling convention instead, which would
lead to an ABI mismatch and always segfault the program.

### Implement Plugin for any derefable plugin container

This allows Box<dyn Plugin> from the dynamic plugin system, as well as
other smart pointer types, to be used as regular plugins, since they
just need to delegate plugin functionality.

### Add dynamic linking example

This was a little tricky to get working:
- Add a few extra dependencies to the dev-dependencies which are
  required by the two libraries.
- The plugin library itself will not be automatically compiled with the
  binary that loads it, but there's no way in Cargo to fix that without
  making them direct dependencies (which we explicitly don't want)
- For both binaries (executable and library) to use the same bevy
  library instance, it needs to be dynamically linked. The only real way
  (while keeping both as "example" binaries) to do this is to include
  the dynamic library version of bevy as a dev dependency, thereby
  making tests and example use the dynamically-linked bevy.


## Migration Guide

(no breaking changes)