### PR TITLE
derive Clone/Copy/Debug trio for shape::Cylinder

### DIFF
--- a/crates/bevy_render/src/mesh/shape/cylinder.rs
+++ b/crates/bevy_render/src/mesh/shape/cylinder.rs
@@ -2,6 +2,7 @@ use crate::mesh::{Indices, Mesh};
 use wgpu::PrimitiveTopology;
 
 /// A cylinder which stands on the XZ plane
+#[derive(Clone, Copy, Debug)]
 pub struct Cylinder {
     /// Radius in the XZ plane.
     pub radius: f32,


### PR DESCRIPTION
# Objective

I needed to copy a cylinder. Can be done with other shapes already.

## Solution

Add proper `#[derive(..)]` attribute,