### PR TITLE
Text2d visibility fix

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -80,7 +80,7 @@ impl Plugin for SpritePlugin {
                 .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
                 .init_resource::<SpriteMeta>()
                 .init_resource::<ExtractedSprites>()
-                .init_resource::<ExtractedGlyphs>()
+                .init_resource::<ExtractedSpriteBatches>()
                 .init_resource::<SpriteAssetEvents>()
                 .add_render_command::<Transparent2d, DrawSprite>()
                 .add_systems(

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -80,6 +80,7 @@ impl Plugin for SpritePlugin {
                 .init_resource::<SpecializedRenderPipelines<SpritePipeline>>()
                 .init_resource::<SpriteMeta>()
                 .init_resource::<ExtractedSprites>()
+                .init_resource::<ExtractedGlyphs>()
                 .init_resource::<SpriteAssetEvents>()
                 .add_render_command::<Transparent2d, DrawSprite>()
                 .add_systems(

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -689,7 +689,11 @@ pub fn prepare_sprites(
             for item_index in 0..transparent_phase.items.len() {
                 let item = transparent_phase.items[item_index].entity;
                 let mut batch_image_changed = false;
-                if let Some(extracted_sprite) = extracted_sprites.sprites.get(item).or_else(|| extracted_batches.sprites.get(item)) {
+                if let Some(extracted_sprite) = extracted_sprites
+                    .sprites
+                    .get(item)
+                    .or_else(|| extracted_batches.sprites.get(item))
+                {
                     if batch_image_handle != extracted_sprite.image_handle_id {
                         batch_image_changed = true;
                     }
@@ -795,7 +799,7 @@ pub fn prepare_sprites(
                     // done by invalidating the batch_image_handle
                     batch_image_handle = HandleId::Id(Uuid::nil(), u64::MAX);
                     continue;
-                };   
+                };
             }
         }
         sprite_meta
@@ -915,5 +919,4 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
         pass.draw_indexed(0..6, 0, batch.range.clone());
         RenderCommandResult::Success
     }
-
 }

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -328,14 +328,13 @@ pub struct ExtractedSprite {
     pub anchor: Vec2,
 }
 
-
 #[derive(Resource, Default)]
 pub struct ExtractedSprites {
     pub sprites: SparseSet<Entity, ExtractedSprite>,
 }
 
 /// Allows extraction of multiply sprites for a single entity that all share that entity's id for visibility resolution.
-/// Not designed for efficiency, extracting sprite entities individually should be more performant. 
+/// Not designed for efficiency, extracting sprite entities individually should be more performant.
 #[derive(Resource, Default)]
 pub struct ExtractedSpriteBatches {
     /// maps the entity id for each batch to a range of indices into `sprite_ids`

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -18,8 +18,7 @@ use bevy_render::{
     Extract,
 };
 use bevy_sprite::{
-    Anchor, ExtractedGlyph, ExtractedGlyphSection, ExtractedGlyphText, ExtractedGlyphs,
-    TextureAtlas,
+    Anchor, TextureAtlas, ExtractedSpriteBatches, ExtractedSprite,
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_utils::HashSet;
@@ -83,7 +82,7 @@ pub struct Text2dBundle {
 
 pub fn extract_text2d_sprite(
     mut commands: Commands,
-    mut extracted_glyphs: ResMut<ExtractedGlyphs>,
+    mut extracted_batches: ResMut<ExtractedSpriteBatches>,
     texture_atlases: Extract<Res<Assets<TextureAtlas>>>,
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
     text2d_query: Extract<
@@ -97,9 +96,8 @@ pub fn extract_text2d_sprite(
         )>,
     >,
 ) {
-    extracted_glyphs.glyphs.clear();
-    extracted_glyphs.sections.clear();
-    extracted_glyphs.texts.clear();
+    extracted_batches.batches.clear();
+    extracted_batches.sprites.clear();
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = windows
         .get_single()
@@ -110,7 +108,6 @@ pub fn extract_text2d_sprite(
     for (entity, view_visibility, text, text_layout_info, anchor, global_transform) in
         text2d_query.iter()
     {
-        println!("Extract Text entity: {entity:?}");
         if !view_visibility.get() {
             continue;
         }
@@ -121,8 +118,8 @@ pub fn extract_text2d_sprite(
             * scaling
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut current_section = usize::MAX;
-        let mut section_ids = Vec::with_capacity(text.sections.len());
-        let mut count = 0;
+        let mut glyph_ids = vec![];
+        let mut color = Color::WHITE;
         for PositionedGlyph {
             position,
             atlas_info,
@@ -131,45 +128,29 @@ pub fn extract_text2d_sprite(
         } in &text_layout_info.glyphs
         {
             if *section_index != current_section {
-                println!("section: {section_index}, start: {count}");
-                let section_id = commands.spawn_empty().id();
-                section_ids.push(section_id);
-                let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
-                let extracted_section = ExtractedGlyphSection {
-                    transform,
-                    color: text.sections[*section_index].style.color,
-                    atlas_id: atlas.texture.id(),
-                    range: extracted_glyphs.glyphs.len()..extracted_glyphs.glyphs.len(),
-                };
-
-                extracted_glyphs
-                    .sections
-                    .insert(section_id, extracted_section);
-
+                color = text.sections[*section_index].style.color.as_rgba_linear();
                 current_section = *section_index;
             }
 
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
-            extracted_glyphs.glyphs.push(ExtractedGlyph {
-                rect: atlas.textures[atlas_info.glyph_index],
-                position: *position,
-            });
-            count +=1;
-            extracted_glyphs
-                .sections
-                .get_mut(*section_ids.last().unwrap())
-                .unwrap()
-                .range
-                .end += 1;
+            let sprite_id = commands.spawn_empty().id();
+            let sprite = ExtractedSprite {
+                transform: transform * GlobalTransform::from_translation(position.extend(0.)),
+                color,
+                rect: Some(atlas.textures[atlas_info.glyph_index]),
+                custom_size: None,
+                image_handle_id: atlas.texture.id(),
+                flip_x: false,
+                flip_y: false,
+                anchor: Anchor::Center.as_vec(),
+            };
+            glyph_ids.push(sprite_id);
+            extracted_batches.sprites.insert(sprite_id, sprite);
         }
-        println!("total glyph count: {count}");
-        println!("extracted glyphs len {}:", extracted_glyphs.glyphs.len());
-        extracted_glyphs.texts.insert(
+        extracted_batches.batches.insert(
             entity,
-            ExtractedGlyphText {
-                sections: section_ids,
-            },
+            glyph_ids,
         );
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -94,8 +94,7 @@ pub fn extract_text2d_sprite(
         )>,
     >,
 ) {
-    extracted_batches.batches.clear();
-    extracted_batches.sprites.clear();
+    extracted_batches.clear();
     // TODO: Support window-independent scaling: https://github.com/bevyengine/bevy/issues/5621
     let scale_factor = windows
         .get_single()
@@ -109,14 +108,13 @@ pub fn extract_text2d_sprite(
         if !view_visibility.get() {
             continue;
         }
-
+        let start = extracted_batches.sprite_ids.len();
         let text_anchor = -(anchor.as_vec() + 0.5);
         let alignment_translation = text_layout_info.size * text_anchor;
         let transform = *global_transform
             * scaling
             * GlobalTransform::from_translation(alignment_translation.extend(0.));
         let mut current_section = usize::MAX;
-        let mut glyph_ids = vec![];
         let mut color = Color::WHITE;
         for PositionedGlyph {
             position,
@@ -143,10 +141,11 @@ pub fn extract_text2d_sprite(
                 flip_y: false,
                 anchor: Anchor::Center.as_vec(),
             };
-            glyph_ids.push(sprite_id);
+            extracted_batches.sprite_ids.push(sprite_id);
             extracted_batches.sprites.insert(sprite_id, sprite);
         }
-        extracted_batches.batches.insert(entity, glyph_ids);
+        let indices = start..extracted_batches.sprite_ids.len();
+        extracted_batches.batches.insert(entity, indices);
     }
 }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -17,9 +17,7 @@ use bevy_render::{
     view::{InheritedVisibility, ViewVisibility, Visibility},
     Extract,
 };
-use bevy_sprite::{
-    Anchor, TextureAtlas, ExtractedSpriteBatches, ExtractedSprite,
-};
+use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSpriteBatches, TextureAtlas};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_utils::HashSet;
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
@@ -148,10 +146,7 @@ pub fn extract_text2d_sprite(
             glyph_ids.push(sprite_id);
             extracted_batches.sprites.insert(sprite_id, sprite);
         }
-        extracted_batches.batches.insert(
-            entity,
-            glyph_ids,
-        );
+        extracted_batches.batches.insert(entity, glyph_ids);
     }
 }
 


### PR DESCRIPTION
# Objective

Text drawn with `Text2d` isn't visible in main. 

fixes #9676

## Solution

Add an `ExtractedSpriteBatches` resource that allows the extraction of sprites in batches that all share the same entity for visibility checks. 

In `extract_text2d_sprite` extract to `ExtractedSpriteBatches` rather than `ExtractedSprites`. 

This is a bit of a hack but it's harmless and minimal. 

My first attempt had three buffers:
1. Set of all `Text2d` entities with their  `Entity`, `Transform`, and a range into buffer 2.
2. `Vec` of `ExtractedGlyphSections`. Each `ExtractedGlyphSection` has a handle for the font's atlas texture, color, and a range of indices into buffer 3.
3. `Vec` of `ExtractedGlyphs`. Each `ExtractedGlyph` has a position (relative to the transform) and a `Rect` containing coords of the glyph in the font's atlas texture.

I struggled to get it to work though. It was almost there but there were some weird texturing issues I couldn't work out even after spending half a day on it: 

<img width="961" alt="Capture-text2d" src="https://github.com/bevyengine/bevy/assets/27962798/17a7fa36-2dda-4350-bee4-5909590c1c30">
---

I still don't understand Bevy's rendering internals very well, so it could be anything.

Anyway, I decided to switch approach. This PR is deliberately as simple as I could make it. It fixes `Text2d` rendering and shouldn't introduce any new problems or have any significant performance costs. The implementations of `ExtractedSpriteBatches` and `extract_text2d_sprites` aren't super efficient, but naive benchmarks suggest this `Text2d` is faster than 0.11.2's `Text2d` by about 5-10% (probably entirely due to the improvements in bevy_sprites).

```
cargo run --profile stress-test --features trace_tracy --example many_sprites
```
<img width="448" alt="Capture-many-sprites" src="https://github.com/bevyengine/bevy/assets/27962798/c3b78972-a56c-4211-a65c-48396fee2a4d">

(yellow is this PR, red is main)

The main drawback is that `ExtractedSpriteBatches` is exposed as public, I'd rather have kept it private as it's not really suitable for much else except text rendering.

---

## Changelog

* Added `ExtractedSpriteBatches`. 
* Modified `queue_sprites` and `prepare_sprites` so they also add the sprites from `ExtractedSpriteBatches`.
* `extract_text2d_sprite` extracts to `ExtractedSpriteBatches` instead of `ExtractedSprites`. 

