### PR TITLE
allow to explicitly define the z-order

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -326,6 +326,7 @@ pub struct ExtractedSprite {
     pub flip_x: bool,
     pub flip_y: bool,
     pub anchor: Vec2,
+    pub z_index: f32,
 }
 
 #[derive(Resource, Default)]
@@ -389,6 +390,9 @@ pub fn extract_sprites(
         if !view_visibility.get() {
             continue;
         }
+
+        let z_index = sprite.z_index.unwrap_or(transform.translation().z);
+
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
         extracted_sprites.sprites.insert(
             entity,
@@ -402,6 +406,7 @@ pub fn extract_sprites(
                 flip_y: sprite.flip_y,
                 image_handle_id: handle.id(),
                 anchor: sprite.anchor.as_vec(),
+                z_index,
             },
         );
     }
@@ -424,6 +429,8 @@ pub fn extract_sprites(
                         )
                     }),
             );
+
+            let z_index = atlas_sprite.z_index.unwrap_or(transform.translation().z);
             extracted_sprites.sprites.insert(
                 entity,
                 ExtractedSprite {
@@ -437,6 +444,7 @@ pub fn extract_sprites(
                     flip_y: atlas_sprite.flip_y,
                     image_handle_id: texture_atlas.texture.id(),
                     anchor: atlas_sprite.anchor.as_vec(),
+                    z_index,
                 },
             );
         }
@@ -567,7 +575,7 @@ pub fn queue_sprites(
             }
 
             // These items will be sorted by depth with other phase items
-            let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
+            let sort_key = FloatOrd(extracted_sprite.z_index);
 
             // Add the item to the render phase
             if extracted_sprite.color != Color::WHITE {

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -21,6 +21,8 @@ pub struct Sprite {
     pub rect: Option<Rect>,
     /// [`Anchor`] point of the sprite in the world
     pub anchor: Anchor,
+    /// An optional z_index to decide which sprite is rendered first (defaults to the z coordinate).
+    pub z_index: Option<f32>,
 }
 
 /// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -39,6 +39,8 @@ pub struct TextureAtlasSprite {
     pub custom_size: Option<Vec2>,
     /// [`Anchor`] point of the sprite in the world
     pub anchor: Anchor,
+    /// An optional z_index to decide which sprite is rendered first (defaults to the z coordinate).
+    pub z_index: Option<f32>,
 }
 
 impl Default for TextureAtlasSprite {
@@ -50,6 +52,7 @@ impl Default for TextureAtlasSprite {
             flip_y: false,
             custom_size: None,
             anchor: Anchor::default(),
+            z_index: None,
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -124,11 +124,14 @@ pub fn extract_text2d_sprite(
                 current_section = *section_index;
             }
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
+            let resolved_transform =
+                transform * GlobalTransform::from_translation(position.extend(0.));
+            let z_index = resolved_transform.translation().z;
 
             extracted_sprites.sprites.insert(
                 commands.spawn_empty().id(),
                 ExtractedSprite {
-                    transform: transform * GlobalTransform::from_translation(position.extend(0.)),
+                    transform: resolved_transform,
                     color,
                     rect: Some(atlas.textures[atlas_info.glyph_index]),
                     custom_size: None,
@@ -136,6 +139,7 @@ pub fn extract_text2d_sprite(
                     flip_x: false,
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
+                    z_index,
                 },
             );
         }


### PR DESCRIPTION
# Objective

This allows to specify an explicit z value for ordering instead of relying on the z translation value which might already be used for actual positioning. 

## Solution

We add an extra optional field that can be set. The default behavior of using the z translation does not change.

---

## Changelog

### Added
- Allows to specify an explicit sprite ordering value when using the 2D renderer

