### PR TITLE
create imported asset directory if needed

### DIFF
--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -1,4 +1,4 @@
-use async_fs::{DirBuilder, File};
+use async_fs::File;
 use bevy_log::error;
 use bevy_utils::HashSet;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -1,4 +1,4 @@
-use async_fs::File;
+use async_fs::{DirBuilder, File};
 use bevy_log::error;
 use bevy_utils::HashSet;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
@@ -87,6 +87,13 @@ impl ProcessorTransactionLog {
                     error!("Failed to remove previous log file {}", err);
                 }
             }
+        }
+
+        if let Some(parent_folder) = path.parent() {
+            DirBuilder::new()
+                .recursive(true)
+                .create(parent_folder)
+                .await?;
         }
 
         Ok(Self {

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -90,10 +90,7 @@ impl ProcessorTransactionLog {
         }
 
         if let Some(parent_folder) = path.parent() {
-            DirBuilder::new()
-                .recursive(true)
-                .create(parent_folder)
-                .await?;
+            async_fs::create_dir_all(parent_folder).await?;
         }
 
         Ok(Self {


### PR DESCRIPTION
# Objective

- Related to #9715 
- Example `asset_processing` logs the following error:
```
thread 'IO Task Pool (1)' panicked at 'Failed to initialize asset processor log. This cannot be recovered. Try restarting. If that doesn't work, try deleting processed asset folder. No such file or directory (os error 2)', crates/bevy_asset/src/processor/mod.rs:867:25
```

## Solution

- Create the log directory if needed
