### PR TITLE
Fix some warnings

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -86,10 +86,10 @@ impl Default for AssetPlugin {
 }
 
 impl AssetPlugin {
-    const DEFAULT_FILE_SOURCE: &str = "assets";
+    const DEFAULT_FILE_SOURCE: &'static str = "assets";
     /// NOTE: this is in the Default sub-folder to make this forward compatible with "import profiles"
     /// and to allow us to put the "processor transaction log" at `imported_assets/log`
-    const DEFAULT_FILE_DESTINATION: &str = "imported_assets/Default";
+    const DEFAULT_FILE_DESTINATION: &'static str = "imported_assets/Default";
 
     /// Returns the default [`AssetPlugin::Processed`] configuration
     pub fn processed() -> Self {

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -44,6 +44,7 @@ use crate::{
 #[reflect(Component, Default)]
 pub struct PointLight {
     pub color: Color,
+    /// Luminous power in lumens
     pub intensity: f32,
     pub range: f32,
     pub radius: f32,
@@ -59,7 +60,6 @@ impl Default for PointLight {
     fn default() -> Self {
         PointLight {
             color: Color::rgb(1.0, 1.0, 1.0),
-            /// Luminous power in lumens
             intensity: 800.0, // Roughly a 60W non-halogen incandescent bulb
             range: 20.0,
             radius: 0.0,
@@ -95,6 +95,7 @@ impl Default for PointLightShadowMap {
 #[reflect(Component, Default)]
 pub struct SpotLight {
     pub color: Color,
+    /// Luminous power in lumens
     pub intensity: f32,
     pub range: f32,
     pub radius: f32,
@@ -127,7 +128,6 @@ impl Default for SpotLight {
         // a quarter arc attenuating from the center
         Self {
             color: Color::rgb(1.0, 1.0, 1.0),
-            /// Luminous power in lumens
             intensity: 800.0, // Roughly a 60W non-halogen incandescent bulb
             range: 20.0,
             radius: 0.0,


### PR DESCRIPTION
# Objective

- Fix these warnings 

```rust
warning: unused doc comment
  --> /bevy/crates/bevy_pbr/src/light.rs:62:13
   |
62 |             /// Luminous power in lumens
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
63 |             intensity: 800.0, // Roughly a 60W non-halogen incandescent bulb
   |             ---------------- rustdoc does not generate documentation for expression fields
   |
   = help: use `//` for a plain comment
   = note: `#[warn(unused_doc_comments)]` on by default
```

```rust
warning: `&` without an explicit lifetime name cannot be used here
  --> /bevy/crates/bevy_asset/src/lib.rs:89:32
   |
89 |     const DEFAULT_FILE_SOURCE: &str = "assets";
   |                                ^
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
   = note: for more information, see issue #115010 <https://github.com/rust-lang/rust/issues/115010>
   = note: `#[warn(elided_lifetimes_in_associated_constant)]` on by default
help: use the `'static` lifetime
   |
89 |     const DEFAULT_FILE_SOURCE: &'static str = "assets";
   |   
```


