### PR TITLE
Remove z-axis scaling in `extract_text2d_sprite`

### DIFF
--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -13,7 +13,7 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Local, Query, Res, ResMut},
 };
-use bevy_math::{Vec2, Vec3};
+use bevy_math::Vec2;
 use bevy_reflect::Reflect;
 use bevy_render::{
     prelude::Color,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -97,7 +97,7 @@ pub fn extract_text2d_sprite(
         .get_single()
         .map(|window| window.resolution.scale_factor() as f32)
         .unwrap_or(1.0);
-    let scaling = GlobalTransform::from_scale(Vec3::splat(scale_factor.recip()));
+    let scaling = GlobalTransform::from_scale(Vec2::splat(scale_factor.recip()).extend(1.));
 
     for (view_visibility, text, text_layout_info, anchor, global_transform) in text2d_query.iter() {
         if !view_visibility.get() {


### PR DESCRIPTION
# Objective

In `extract_text2d_sprite` the scaling by the scale factor should be only be applied to the x and y axes but it's also applied to the z axis.

# Solution

Remove the scaling in the z axis

