### PR TITLE
Increase iteration count for asset tests

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -533,7 +533,7 @@ mod tests {
         panic!("Ran out of loops to return `Some` from `predicate`");
     }
 
-    const LARGE_ITERATION_COUNT: usize = 50;
+    const LARGE_ITERATION_COUNT: usize = 10000;
 
     fn get<A: Asset>(world: &World, id: AssetId<A>) -> Option<&A> {
         world.resource::<Assets<A>>().get(id)


### PR DESCRIPTION
This needs to be much higher to avoid failures in CI. I don't love the "loop until" test methodology generally, but this is testing internal state and making this event driven would change the nature of the test.