### PR TITLE
Simplify the display_and_visibility example

### DIFF
--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -80,6 +80,87 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     };
 
     commands.spawn(Camera2dBundle::default());
+
+    let title = commands.spawn(TextBundle {
+        text: Text::from_section(
+            "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",
+            text_style.clone(),
+        ).with_alignment(TextAlignment::Center),
+        style: Style {
+            margin: UiRect::bottom(Val::Px(10.)),
+            ..Default::default()
+        },
+        ..Default::default()
+    }).id();
+
+    let left_frame = commands.spawn(NodeBundle {
+        style: Style {
+            width: Val::Percent(50.),
+            height: Val::Px(520.),
+            justify_content: JustifyContent::Center,
+            ..Default::default()
+        },
+        ..Default::default()
+    }).id();
+    let (left_panel, target_ids) = spawn_left_panel(&mut commands, &palette);
+    commands.entity(left_frame).add_child(left_panel);
+
+    let right_frame = commands.spawn(NodeBundle {
+        style: Style {
+            width: Val::Percent(50.),
+            justify_content: JustifyContent::Center,
+            ..Default::default()
+        },
+        ..Default::default()
+    }).id();
+    let right_panel = spawn_right_panel(&mut commands, text_style, &palette, target_ids);
+    commands.entity(right_frame).add_child(right_panel);
+
+    let top_frame = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                ..Default::default()
+            },
+            ..Default::default()
+        })
+        .push_children(&[left_panel, right_frame])
+        .id();
+
+    let bottom_frame = commands.spawn(NodeBundle {
+        style: Style {
+            flex_direction: FlexDirection::Row,
+            align_items: AlignItems::Start,
+            justify_content: JustifyContent::Start,
+            column_gap: Val::Px(10.),
+            ..Default::default()
+        },
+        ..default() })
+        .with_children(|builder| {
+            let text_style = TextStyle {
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
+                font_size: 20.0,
+                color: Color::WHITE,
+            };
+            builder.spawn(TextBundle {
+                text: Text::from_section(
+                    "Display::None\nVisibility::Hidden\nVisibility::Inherited",
+                    TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
+                ).with_alignment(TextAlignment::Center),
+                ..Default::default()
+            });
+            builder.spawn(TextBundle {
+                text: Text::from_section(
+                    "-\n-\n-",
+                    TextStyle { color: Color::DARK_GRAY, ..text_style.clone() }
+                ).with_alignment(TextAlignment::Center),
+                ..Default::default()
+            });
+            builder.spawn(TextBundle::from_section(
+                "The UI Node and its descendants will not be visible and will not be allotted any space in the UI layout.\nThe UI Node will not be visible but will still occupy space in the UI layout.\nThe UI node will inherit the visibility property of its parent. If it has no parent it will be visible.",
+                text_style
+            ));
+        }).id();
     commands.spawn(NodeBundle {
         style: Style {
             flex_direction: FlexDirection::Column,
@@ -90,94 +171,39 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
         background_color: BackgroundColor(Color::BLACK),
         ..Default::default()
-    }).with_children(|parent| {
-        parent.spawn(TextBundle {
-            text: Text::from_section(
-                "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",                
-                text_style.clone(),
-            ).with_alignment(TextAlignment::Center),
-            style: Style {
-                margin: UiRect::bottom(Val::Px(10.)),
-                ..Default::default()
-            },
-            ..Default::default()
-        });
-
-        parent
-            .spawn(NodeBundle {
-                style: Style {
-                    width: Val::Percent(100.),
-                    ..Default::default()
-                },
-                ..Default::default()
-            })
-            .with_children(|parent| {
-                let mut target_ids = vec![];
-                parent.spawn(NodeBundle {
-                    style: Style {
-                        width: Val::Percent(50.),
-                        height: Val::Px(520.),
-                        justify_content: JustifyContent::Center,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }).with_children(|parent| {
-                    target_ids = spawn_left_panel(parent, &palette);
-                });
-
-                parent.spawn(NodeBundle {
-                    style: Style {
-                        width: Val::Percent(50.),
-                        justify_content: JustifyContent::Center,
-                        ..Default::default()
-                    },
-                    ..Default::default()
-                }).with_children(|parent| {
-                    spawn_right_panel(parent, text_style, &palette, target_ids);
-                });
-            });
-
-            parent.spawn(NodeBundle {
-                style: Style {
-                    flex_direction: FlexDirection::Row,
-                    align_items: AlignItems::Start,
-                    justify_content: JustifyContent::Start,
-                    column_gap: Val::Px(10.),
-                    ..Default::default()
-                },
-                ..default() })
-            .with_children(|builder| {
-                let text_style = TextStyle {
-                    font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                    font_size: 20.0,
-                    color: Color::WHITE,
-                };
-
-                builder.spawn(TextBundle {
-                    text: Text::from_section(
-                        "Display::None\nVisibility::Hidden\nVisbility::Inherited",
-                        TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
-                        ).with_alignment(TextAlignment::Center),
-                    ..Default::default()
-                    });
-                    builder.spawn(TextBundle {
-                        text: Text::from_section(
-                            "-\n-\n-",
-                            TextStyle { color: Color::DARK_GRAY, ..text_style.clone() }
-                            ).with_alignment(TextAlignment::Center),
-                        ..Default::default()
-                        });
-                    builder.spawn(TextBundle::from_section(
-                        "The UI Node and its descendants will not be visible and will not be allotted any space in the UI layout.\nThe UI Node will not be visible but will still occupy space in the UI layout.\nThe UI node will inherit the visibility property of its parent. If it has no parent it will be visible.",
-                        text_style
-                    ));
-            });
-    });
+    }).push_children(&[title, top_frame, bottom_frame]);
 }
 
-fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Entity> {
+// Spawn a simple square node with a background color
+fn spawn_square_node(commands: &mut Commands,
+                     color: Color,
+                     width: f32,
+                     height: f32,
+) -> Entity {
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Px(width),
+                height: Val::Px(height),
+                flex_direction: FlexDirection::Column,
+                align_items: AlignItems::FlexEnd,
+                justify_content: JustifyContent::SpaceBetween,
+                padding: UiRect {
+                    left: Val::Px(5.),
+                    top: Val::Px(5.),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            background_color: BackgroundColor(color),
+            ..Default::default()
+        }).id()
+}
+
+// Spawn the left panel with squares that will be affected by the buttons on the right panel
+fn spawn_left_panel(commands: &mut Commands, palette: &[Color; 4]) -> (Entity, Vec<Entity>)  {
     let mut target_ids = vec![];
-    builder
+    let frame = commands
         .spawn(NodeBundle {
             style: Style {
                 padding: UiRect::all(Val::Px(10.)),
@@ -185,116 +211,34 @@ fn spawn_left_panel(builder: &mut ChildBuilder, palette: &[Color; 4]) -> Vec<Ent
             },
             background_color: BackgroundColor(Color::WHITE),
             ..Default::default()
-        })
-        .with_children(|parent| {
-            parent
-                .spawn(NodeBundle {
-                    style: Style {
-                        ..Default::default()
-                    },
-                    background_color: BackgroundColor(Color::BLACK),
-                    ..Default::default()
-                })
-                .with_children(|parent| {
-                    let id = parent
-                        .spawn(NodeBundle {
-                            style: Style {
-                                align_items: AlignItems::FlexEnd,
-                                justify_content: JustifyContent::FlexEnd,
-                                ..Default::default()
-                            },
-                            background_color: BackgroundColor(palette[0]),
-                            ..Default::default()
-                        })
-                        .with_children(|parent| {
-                            parent.spawn(NodeBundle {
-                                style: Style {
-                                    width: Val::Px(100.),
-                                    height: Val::Px(500.),
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            });
+        }).id();
 
-                            let id = parent
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        height: Val::Px(400.),
-                                        align_items: AlignItems::FlexEnd,
-                                        justify_content: JustifyContent::FlexEnd,
-                                        ..Default::default()
-                                    },
-                                    background_color: BackgroundColor(palette[1]),
-                                    ..Default::default()
-                                })
-                                .with_children(|parent| {
-                                    parent.spawn(NodeBundle {
-                                        style: Style {
-                                            width: Val::Px(100.),
-                                            height: Val::Px(400.),
-                                            ..Default::default()
-                                        },
-                                        ..Default::default()
-                                    });
+    // build all
+    let mut parent_node = frame;
+    for i in 0..4 {
+        // create a square of the right size, that will affect the corresponding square on the left panel
+        let width = 500. - i as f32 * 100.;
+        let height = width;
+        let node = spawn_square_node(commands, palette[i], width, height);
 
-                                    let id = parent
-                                        .spawn(NodeBundle {
-                                            style: Style {
-                                                height: Val::Px(300.),
-                                                align_items: AlignItems::FlexEnd,
-                                                justify_content: JustifyContent::FlexEnd,
-                                                ..Default::default()
-                                            },
-                                            background_color: BackgroundColor(palette[2]),
-                                            ..Default::default()
-                                        })
-                                        .with_children(|parent| {
-                                            parent.spawn(NodeBundle {
-                                                style: Style {
-                                                    width: Val::Px(100.),
-                                                    height: Val::Px(300.),
-                                                    ..Default::default()
-                                                },
-                                                ..Default::default()
-                                            });
+        // each square is a child of the previous one
+        commands.entity(parent_node).add_child(node);
+        parent_node = node;
 
-                                            let id = parent
-                                                .spawn(NodeBundle {
-                                                    style: Style {
-                                                        width: Val::Px(200.),
-                                                        height: Val::Px(200.),
-                                                        ..Default::default()
-                                                    },
-                                                    background_color: BackgroundColor(palette[3]),
-                                                    ..Default::default()
-                                                })
-                                                .id();
-                                            target_ids.push(id);
-                                        })
-                                        .id();
-                                    target_ids.push(id);
-                                })
-                                .id();
-                            target_ids.push(id);
-                        })
-                        .id();
-                    target_ids.push(id);
-                });
-        });
-    target_ids
+        // the entities will be stored from outer square to inner square
+        target_ids.push(node);
+    }
+    (frame, target_ids)
 }
 
+// Spawn the right panel with buttons that will affect the corresponding squares on the left panel
 fn spawn_right_panel(
-    parent: &mut ChildBuilder,
+    commands: &mut Commands,
     text_style: TextStyle,
     palette: &[Color; 4],
-    mut target_ids: Vec<Entity>,
-) {
-    let spawn_buttons = |parent: &mut ChildBuilder, target_id| {
-        spawn_button::<Display>(parent, text_style.clone(), target_id);
-        spawn_button::<Visibility>(parent, text_style.clone(), target_id);
-    };
-    parent
+    target_ids: Vec<Entity>,
+) -> Entity {
+    let frame = commands
         .spawn(NodeBundle {
             style: Style {
                 padding: UiRect::all(Val::Px(10.)),
@@ -302,107 +246,46 @@ fn spawn_right_panel(
             },
             background_color: BackgroundColor(Color::WHITE),
             ..Default::default()
-        })
-        .with_children(|parent| {
-            parent
-                .spawn(NodeBundle {
+        }).id();
+
+    // build all
+    let mut parent_node = frame;
+    for i in 0..4 {
+        // create a square of the right size
+        let width = 500. - i as f32 * 100.;
+        let height = width;
+        let node = spawn_square_node(commands, palette[i], width, height);
+
+        // add buttons that will affect the corresponding square on the left panel
+        let target_id = target_ids.get(i).unwrap();
+        commands.entity(node).with_children(|parent| {
+            spawn_button::<Display>(parent, text_style.clone(), *target_id);
+            spawn_button::<Visibility>(parent, text_style.clone(), *target_id);
+        });
+
+        // each square is a child of the previous one
+        commands.entity(parent_node).add_child(node);
+        parent_node = node;
+
+        // NOTE: apparently this invisible node is necessary so that the 'Visibility::Inherited' button
+        // is aligned correctly on the last square
+        if i == 3 {
+            commands.entity(node).with_children(|parent| {
+                parent.spawn(NodeBundle {
                     style: Style {
-                        width: Val::Px(500.),
-                        height: Val::Px(500.),
-                        flex_direction: FlexDirection::Column,
-                        align_items: AlignItems::FlexEnd,
-                        justify_content: JustifyContent::SpaceBetween,
-                        padding: UiRect {
-                            left: Val::Px(5.),
-                            top: Val::Px(5.),
-                            ..Default::default()
-                        },
+                        width: Val::Px(100.),
+                        height: Val::Px(100.),
                         ..Default::default()
                     },
-                    background_color: BackgroundColor(palette[0]),
                     ..Default::default()
-                })
-                .with_children(|parent| {
-                    spawn_buttons(parent, target_ids.pop().unwrap());
-
-                    parent
-                        .spawn(NodeBundle {
-                            style: Style {
-                                width: Val::Px(400.),
-                                height: Val::Px(400.),
-                                flex_direction: FlexDirection::Column,
-                                align_items: AlignItems::FlexEnd,
-                                justify_content: JustifyContent::SpaceBetween,
-                                padding: UiRect {
-                                    left: Val::Px(5.),
-                                    top: Val::Px(5.),
-                                    ..Default::default()
-                                },
-                                ..Default::default()
-                            },
-                            background_color: BackgroundColor(palette[1]),
-                            ..Default::default()
-                        })
-                        .with_children(|parent| {
-                            spawn_buttons(parent, target_ids.pop().unwrap());
-
-                            parent
-                                .spawn(NodeBundle {
-                                    style: Style {
-                                        width: Val::Px(300.),
-                                        height: Val::Px(300.),
-                                        flex_direction: FlexDirection::Column,
-                                        align_items: AlignItems::FlexEnd,
-                                        justify_content: JustifyContent::SpaceBetween,
-                                        padding: UiRect {
-                                            left: Val::Px(5.),
-                                            top: Val::Px(5.),
-                                            ..Default::default()
-                                        },
-                                        ..Default::default()
-                                    },
-                                    background_color: BackgroundColor(palette[2]),
-                                    ..Default::default()
-                                })
-                                .with_children(|parent| {
-                                    spawn_buttons(parent, target_ids.pop().unwrap());
-
-                                    parent
-                                        .spawn(NodeBundle {
-                                            style: Style {
-                                                width: Val::Px(200.),
-                                                height: Val::Px(200.),
-                                                align_items: AlignItems::FlexStart,
-                                                justify_content: JustifyContent::SpaceBetween,
-                                                flex_direction: FlexDirection::Column,
-                                                padding: UiRect {
-                                                    left: Val::Px(5.),
-                                                    top: Val::Px(5.),
-                                                    ..Default::default()
-                                                },
-                                                ..Default::default()
-                                            },
-                                            background_color: BackgroundColor(palette[3]),
-                                            ..Default::default()
-                                        })
-                                        .with_children(|parent| {
-                                            spawn_buttons(parent, target_ids.pop().unwrap());
-
-                                            parent.spawn(NodeBundle {
-                                                style: Style {
-                                                    width: Val::Px(100.),
-                                                    height: Val::Px(100.),
-                                                    ..Default::default()
-                                                },
-                                                ..Default::default()
-                                            });
-                                        });
-                                });
-                        });
                 });
-        });
+            });
+        }
+    }
+    frame
 }
 
+// Spawn a button that will affect the corresponding square on the left panel
 fn spawn_button<T>(parent: &mut ChildBuilder, text_style: TextStyle, target: Entity)
 where
     T: Default + std::fmt::Debug + Send + Sync + 'static,
@@ -432,6 +315,7 @@ where
         });
 }
 
+// System that will run to handle button presses
 fn buttons_handler<T>(
     mut left_panel_query: Query<&mut <Target<T> as TargetUpdate>::TargetComponent>,
     mut visibility_button_query: Query<(&Target<T>, &Interaction, &Children), Changed<Interaction>>,
@@ -459,6 +343,7 @@ fn buttons_handler<T>(
     }
 }
 
+// System that will run to handle text hover
 fn text_hover(
     mut button_query: Query<(&Interaction, &mut BackgroundColor, &Children), Changed<Interaction>>,
     mut text_query: Query<&mut Text>,

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -219,11 +219,11 @@ fn spawn_left_panel(commands: &mut Commands, palette: &[Color; 4]) -> (Entity, V
 
     // build all
     let mut parent_node = frame;
-    for i in 0..4 {
+    for (i, &color) in palette.iter().enumerate() {
         // create a square of the right size, that will affect the corresponding square on the left panel
         let width = 500. - i as f32 * 100.;
         let height = width;
-        let node = spawn_square_node(commands, palette[i], width, height);
+        let node = spawn_square_node(commands, color, width, height);
 
         // each square is a child of the previous one
         commands.entity(parent_node).add_child(node);
@@ -255,11 +255,11 @@ fn spawn_right_panel(
 
     // build all
     let mut parent_node = frame;
-    for i in 0..4 {
+    for (i, &color) in palette.iter().enumerate() {
         // create a square of the right size
         let width = 500. - i as f32 * 100.;
         let height = width;
-        let node = spawn_square_node(commands, palette[i], width, height);
+        let node = spawn_square_node(commands, color, width, height);
 
         // add buttons that will affect the corresponding square on the left panel
         let target_id = target_ids.get(i).unwrap();

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -93,26 +93,30 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..Default::default()
     }).id();
 
-    let left_frame = commands.spawn(NodeBundle {
-        style: Style {
-            width: Val::Percent(50.),
-            height: Val::Px(520.),
-            justify_content: JustifyContent::Center,
+    let left_frame = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(50.),
+                height: Val::Px(520.),
+                justify_content: JustifyContent::Center,
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    }).id();
+        })
+        .id();
     let (left_panel, target_ids) = spawn_left_panel(&mut commands, &palette);
     commands.entity(left_frame).add_child(left_panel);
 
-    let right_frame = commands.spawn(NodeBundle {
-        style: Style {
-            width: Val::Percent(50.),
-            justify_content: JustifyContent::Center,
+    let right_frame = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(50.),
+                justify_content: JustifyContent::Center,
+                ..Default::default()
+            },
             ..Default::default()
-        },
-        ..Default::default()
-    }).id();
+        })
+        .id();
     let right_panel = spawn_right_panel(&mut commands, text_style, &palette, target_ids);
     commands.entity(right_frame).add_child(right_panel);
 
@@ -161,25 +165,23 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 text_style
             ));
         }).id();
-    commands.spawn(NodeBundle {
-        style: Style {
-            flex_direction: FlexDirection::Column,
-            flex_basis: Val::Percent(100.),
-            align_items: AlignItems::Center,
-            justify_content: JustifyContent::SpaceEvenly,
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                flex_direction: FlexDirection::Column,
+                flex_basis: Val::Percent(100.),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::SpaceEvenly,
+                ..Default::default()
+            },
+            background_color: BackgroundColor(Color::BLACK),
             ..Default::default()
-        },
-        background_color: BackgroundColor(Color::BLACK),
-        ..Default::default()
-    }).push_children(&[title, top_frame, bottom_frame]);
+        })
+        .push_children(&[title, top_frame, bottom_frame]);
 }
 
 // Spawn a simple square node with a background color
-fn spawn_square_node(commands: &mut Commands,
-                     color: Color,
-                     width: f32,
-                     height: f32,
-) -> Entity {
+fn spawn_square_node(commands: &mut Commands, color: Color, width: f32, height: f32) -> Entity {
     commands
         .spawn(NodeBundle {
             style: Style {
@@ -197,11 +199,12 @@ fn spawn_square_node(commands: &mut Commands,
             },
             background_color: BackgroundColor(color),
             ..Default::default()
-        }).id()
+        })
+        .id()
 }
 
 // Spawn the left panel with squares that will be affected by the buttons on the right panel
-fn spawn_left_panel(commands: &mut Commands, palette: &[Color; 4]) -> (Entity, Vec<Entity>)  {
+fn spawn_left_panel(commands: &mut Commands, palette: &[Color; 4]) -> (Entity, Vec<Entity>) {
     let mut target_ids = vec![];
     let frame = commands
         .spawn(NodeBundle {
@@ -211,7 +214,8 @@ fn spawn_left_panel(commands: &mut Commands, palette: &[Color; 4]) -> (Entity, V
             },
             background_color: BackgroundColor(Color::WHITE),
             ..Default::default()
-        }).id();
+        })
+        .id();
 
     // build all
     let mut parent_node = frame;
@@ -246,7 +250,8 @@ fn spawn_right_panel(
             },
             background_color: BackgroundColor(Color::WHITE),
             ..Default::default()
-        }).id();
+        })
+        .id();
 
     // build all
     let mut parent_node = frame;


### PR DESCRIPTION
# Objective

Address https://github.com/bevyengine/bevy/issues/9735 by removing the level of nesting and simplifying the example.
Also added some comments

fixes https://github.com/bevyengine/bevy/issues/9735

## Solution

Use `commands.entity(entity).add_child()` instead of `with_children` in order to remove the level of nesting and to be able to work with loops.

## TODO

I have two remaining problems with this PR that I wasn't able to fix (and i need help on them):
- the alignment of the squares on the left is wrong for some reason, I don't really get why
- the alignment of the last "visibility" button is wrong on the right unless I add an invisible NodeBundle (which was present in the original example)