### PR TITLE
Adjust Color::ALICE_BLUE

### DIFF
--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -59,7 +59,7 @@ pub enum Color {
 
 impl Color {
     /// <div style="background-color:rgb(94%, 97%, 100%); width: 10px; padding: 10px; border: 1px solid;"></div>
-    pub const ALICE_BLUE: Color = Color::rgb(0.94, 0.97, 1.0);
+    pub const ALICE_BLUE: Color = Color::rgb(0.61, 0.84, 0.894);
     /// <div style="background-color:rgb(98%, 92%, 84%); width: 10px; padding: 10px; border: 1px solid;"></div>
     pub const ANTIQUE_WHITE: Color = Color::rgb(0.98, 0.92, 0.84);
     /// <div style="background-color:rgb(49%, 100%, 83%); width: 10px; padding: 10px; border: 1px solid;"></div>

--- a/crates/bevy_render/src/color/mod.rs
+++ b/crates/bevy_render/src/color/mod.rs
@@ -58,7 +58,7 @@ pub enum Color {
 }
 
 impl Color {
-    /// <div style="background-color:rgb(94%, 97%, 100%); width: 10px; padding: 10px; border: 1px solid;"></div>
+    /// <div style="background-color:rgb(61%, 84%, 89.4%); width: 10px; padding: 10px; border: 1px solid;"></div>
     pub const ALICE_BLUE: Color = Color::rgb(0.61, 0.84, 0.894);
     /// <div style="background-color:rgb(98%, 92%, 84%); width: 10px; padding: 10px; border: 1px solid;"></div>
     pub const ANTIQUE_WHITE: Color = Color::rgb(0.98, 0.92, 0.84);


### PR DESCRIPTION
# Objective

- The `Color::ALICE_BLUE` constant is currently an off-white color, which is confusing when there is an actual [Alice Blue](https://en.wikipedia.org/wiki/Alice_blue) shade that is well-known to be light blue.

## Solution

- Change the color to match the shade defined in the Wikipedia article. I used just enough precision in the floating point values so that the math would result in the matching `u8` value in the wikipedia article if multiplied by `255`.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- The `Color::ALICE_BLUE` constant is now the correct shade of blue, rather than an off-white shade.
