### PR TITLE
Implement `Reflect` for `State<S>` and `NextState<S>`

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
 #[cfg(feature = "bevy_reflect")]
-use crate::reflect::ReflectResource;
+use crate::reflect::{ReflectDefault, ReflectResource};
 use crate::schedule::ScheduleLabel;
 use crate::system::Resource;
 use crate::world::World;
@@ -80,7 +80,7 @@ pub struct OnTransition<S: States> {
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(bevy_reflect::Reflect),
-    reflect(Resource)
+    reflect(Resource, Default)
 )]
 pub struct State<S: States>(S);
 
@@ -121,7 +121,7 @@ impl<S: States> Deref for State<S> {
 #[cfg_attr(
     feature = "bevy_reflect",
     derive(bevy_reflect::Reflect),
-    reflect(Resource)
+    reflect(Resource, Default)
 )]
 pub struct NextState<S: States>(pub Option<S>);
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -5,6 +5,8 @@ use std::ops::Deref;
 
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
+#[cfg(feature = "bevy_reflect")]
+use crate::reflect::ReflectResource;
 use crate::schedule::ScheduleLabel;
 use crate::system::Resource;
 use crate::world::World;
@@ -75,6 +77,11 @@ pub struct OnTransition<S: States> {
 ///
 /// The starting state is defined via the [`Default`] implementation for `S`.
 #[derive(Resource, Default, Debug)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(bevy_reflect::Reflect),
+    reflect(Resource)
+)]
 pub struct State<S: States>(S);
 
 impl<S: States> State<S> {
@@ -111,6 +118,11 @@ impl<S: States> Deref for State<S> {
 /// Note that these transitions can be overridden by other systems:
 /// only the actual value of this resource at the time of [`apply_state_transition`] matters.
 #[derive(Resource, Default, Debug)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(bevy_reflect::Reflect),
+    reflect(Resource)
+)]
 pub struct NextState<S: States>(pub Option<S>);
 
 impl<S: States> NextState<S> {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -6,10 +6,12 @@ use std::ops::Deref;
 use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
 #[cfg(feature = "bevy_reflect")]
-use crate::reflect::{ReflectDefault, ReflectResource};
+use crate::reflect::ReflectResource;
 use crate::schedule::ScheduleLabel;
 use crate::system::Resource;
 use crate::world::World;
+#[cfg(feature = "bevy_reflect")]
+use bevy_reflect::std_traits::ReflectDefault;
 
 pub use bevy_ecs_macros::States;
 


### PR DESCRIPTION
# Objective

- Make it possible to snapshot/save states
- Useful for re-using parts of the state system for rollback safe states
- Or to save states with scenes/savegames

## Solution

- Conditionally add the derive if the `bevy_reflect` is enabled

---

## Changelog

- `NextState<S>` and `State<S>` now implement `Reflect` as long as `S` does.
