### PR TITLE
Fix naming on "tick" Column and ComponentSparseSet methods

### DIFF
--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -574,7 +574,7 @@ impl_tick_filter!(
     Added,
     AddedFetch,
     Column::get_added_ticks_slice,
-    ComponentSparseSet::get_added_ticks
+    ComponentSparseSet::get_added_tick
 );
 
 impl_tick_filter!(
@@ -612,7 +612,7 @@ impl_tick_filter!(
     Changed,
     ChangedFetch,
     Column::get_changed_ticks_slice,
-    ComponentSparseSet::get_changed_ticks
+    ComponentSparseSet::get_changed_tick
 );
 
 /// A marker trait to indicate that the filter works at an archetype level.

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -161,10 +161,10 @@ impl<const SEND: bool> ResourceData<SEND> {
         if self.is_present() {
             self.validate_access();
             self.column.replace_untracked(Self::ROW, value);
-            *self.column.get_added_ticks_unchecked(Self::ROW).deref_mut() = change_ticks.added;
+            *self.column.get_added_tick_unchecked(Self::ROW).deref_mut() = change_ticks.added;
             *self
                 .column
-                .get_changed_ticks_unchecked(Self::ROW)
+                .get_changed_tick_unchecked(Self::ROW)
                 .deref_mut() = change_ticks.changed;
         } else {
             if !SEND {

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -231,8 +231,8 @@ impl ComponentSparseSet {
             Some((
                 self.dense.get_data_unchecked(dense_index),
                 TickCells {
-                    added: self.dense.get_added_ticks_unchecked(dense_index),
-                    changed: self.dense.get_changed_ticks_unchecked(dense_index),
+                    added: self.dense.get_added_tick_unchecked(dense_index),
+                    changed: self.dense.get_changed_tick_unchecked(dense_index),
                 },
             ))
         }
@@ -242,7 +242,7 @@ impl ComponentSparseSet {
     ///
     /// Returns `None` if `entity` does not have a component in the sparse set.
     #[inline]
-    pub fn get_added_ticks(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
+    pub fn get_added_tick(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -250,7 +250,7 @@ impl ComponentSparseSet {
         unsafe {
             Some(
                 self.dense
-                    .get_added_ticks_unchecked(TableRow::new(dense_index)),
+                    .get_added_tick_unchecked(TableRow::new(dense_index)),
             )
         }
     }
@@ -259,7 +259,7 @@ impl ComponentSparseSet {
     ///
     /// Returns `None` if `entity` does not have a component in the sparse set.
     #[inline]
-    pub fn get_changed_ticks(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
+    pub fn get_changed_tick(&self, entity: Entity) -> Option<&UnsafeCell<Tick>> {
         let dense_index = *self.sparse.get(entity.index())? as usize;
         #[cfg(debug_assertions)]
         assert_eq!(entity, self.entities[dense_index]);
@@ -267,7 +267,7 @@ impl ComponentSparseSet {
         unsafe {
             Some(
                 self.dense
-                    .get_changed_ticks_unchecked(TableRow::new(dense_index)),
+                    .get_changed_tick_unchecked(TableRow::new(dense_index)),
             )
         }
     }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -404,7 +404,7 @@ impl Column {
         self.data.get_unchecked_mut(row.index())
     }
 
-    /// Fetches the "added" change detection ticks for the value at `row`.
+    /// Fetches the "added" change detection tick for the value at `row`.
     ///
     /// Returns `None` if `row` is out of bounds.
     ///
@@ -414,11 +414,11 @@ impl Column {
     ///
     /// [`UnsafeCell`]: std::cell::UnsafeCell
     #[inline]
-    pub fn get_added_ticks(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
+    pub fn get_added_tick(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
         self.added_ticks.get(row.index())
     }
 
-    /// Fetches the "changed" change detection ticks for the value at `row`.
+    /// Fetches the "changed" change detection tick for the value at `row`.
     ///
     /// Returns `None` if `row` is out of bounds.
     ///
@@ -428,7 +428,7 @@ impl Column {
     ///
     /// [`UnsafeCell`]: std::cell::UnsafeCell
     #[inline]
-    pub fn get_changed_ticks(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
+    pub fn get_changed_tick(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
         self.changed_ticks.get(row.index())
     }
 
@@ -445,24 +445,24 @@ impl Column {
         }
     }
 
-    /// Fetches the "added" change detection ticks for the value at `row`. Unlike [`Column::get_added_ticks`]
+    /// Fetches the "added" change detection tick for the value at `row`. Unlike [`Column::get_added_tick`]
     /// this function does not do any bounds checking.
     ///
     /// # Safety
     /// `row` must be within the range `[0, self.len())`.
     #[inline]
-    pub unsafe fn get_added_ticks_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
+    pub unsafe fn get_added_tick_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
         debug_assert!(row.index() < self.added_ticks.len());
         self.added_ticks.get_unchecked(row.index())
     }
 
-    /// Fetches the "changed" change detection ticks for the value at `row`. Unlike [`Column::get_changed_ticks`]
+    /// Fetches the "changed" change detection tick for the value at `row`. Unlike [`Column::get_changed_tick`]
     /// this function does not do any bounds checking.
     ///
     /// # Safety
     /// `row` must be within the range `[0, self.len())`.
     #[inline]
-    pub unsafe fn get_changed_ticks_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
+    pub unsafe fn get_changed_tick_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
         debug_assert!(row.index() < self.changed_ticks.len());
         self.changed_ticks.get_unchecked(row.index())
     }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -953,8 +953,8 @@ unsafe fn get_component_and_ticks(
             Some((
                 components.get_data_unchecked(location.table_row),
                 TickCells {
-                    added: components.get_added_ticks_unchecked(location.table_row),
-                    changed: components.get_changed_ticks_unchecked(location.table_row),
+                    added: components.get_added_tick_unchecked(location.table_row),
+                    changed: components.get_changed_tick_unchecked(location.table_row),
                 },
             ))
         }


### PR DESCRIPTION
# Objective

- The tick access methods mention "ticks" (as in: plural). Yet, most of them only access a single tick.

## Solution

- Rename those methods and fix docs to reflect the singular aspect of the return values

---

## Migration Guide

The following method names were renamed, from `foo_ticks_bar` to `foo_tick_bar` (`ticks` is now singular, `tick`):
- `ComponentSparseSet::get_added_ticks` → `get_added_tick`
- `ComponentSparseSet::get_changed_ticks` → `get_changed_tick`
- `Column::get_added_ticks` → `get_added_tick`
- `Column::get_changed_ticks` → `get_changed_tick`
- `Column::get_added_ticks_unchecked` → `get_added_tick_unchecked`
- `Column::get_changed_ticks_unchecked` → `get_changed_tick_unchecked`