### PR TITLE
Return an error when loading non-existent labels

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -101,6 +101,12 @@ impl<'a> AssetPath<'a> {
         self.label.as_deref()
     }
 
+    /// Gets the "sub-asset label".
+    #[inline]
+    pub fn label_cow(&self) -> Option<CowArc<'a, str>> {
+        self.label.clone()
+    }
+
     /// Gets the path to the asset in the "virtual filesystem".
     #[inline]
     pub fn path(&self) -> &Path {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -285,6 +285,7 @@ impl AssetServer {
     }
 
     /// Performs an async asset load.
+    ///
     /// `input_handle` must only be [`Some`] if `should_load` was true when retrieving `input_handle`. This is an optimization to
     /// avoid looking up `should_load` twice, but it means you _must_ be sure a load is necessary when calling this function with [`Some`].
     async fn load_internal<'a>(

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -873,7 +873,7 @@ pub enum AssetLoadError {
         loader: &'static str,
         error: AssetLoaderError,
     },
-    #[error("The asset at '{base_path}' does not contain the labeled asset '{label}'.")]
+    #[error("The file at '{base_path}' does not contain the labeled asset '{label}'.")]
     MissingLabel {
         base_path: AssetPath<'static>,
         label: String,


### PR DESCRIPTION
# Objective

Calling `asset_server.load("scene.gltf#SomeLabel")` will silently fail if `SomeLabel` does not exist.

Referenced in #9714 

## Solution

We now detect this case and return an error. I also slightly refactored `load_internal` to make the logic / dataflow much clearer.