### PR TITLE
Asset v2: Asset path serialization fix

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -93,12 +93,10 @@ pub struct StrongHandle {
 
 impl Drop for StrongHandle {
     fn drop(&mut self) {
-        if let Err(err) = self.drop_sender.send(DropEvent {
+        let _ = self.drop_sender.send(DropEvent {
             id: self.id.internal(),
             asset_server_managed: self.asset_server_managed,
-        }) {
-            println!("Failed to send DropEvent for StrongHandle {:?}", err);
-        }
+        });
     }
 }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -34,6 +34,7 @@ pub use reflect::*;
 pub use server::*;
 
 pub use anyhow;
+pub use bevy_utils::BoxedFuture;
 
 use crate::{
     io::{processor_gated::ProcessorGatedReader, AssetProvider, AssetProviders},

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -231,10 +231,7 @@ impl<'a> Serialize for AssetPath<'a> {
     where
         S: serde::Serializer,
     {
-        let mut state = serializer.serialize_tuple_struct("AssetPath", 1)?;
-        let string = self.to_string();
-        state.serialize_field(&string)?;
-        state.end()
+        self.to_string().serialize(serializer)
     }
 }
 
@@ -243,7 +240,7 @@ impl<'de> Deserialize<'de> for AssetPath<'static> {
     where
         D: serde::Deserializer<'de>,
     {
-        deserializer.deserialize_tuple_struct("AssetPath", 1, AssetPathVisitor)
+        deserializer.deserialize_string(AssetPathVisitor)
     }
 }
 

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,6 +1,6 @@
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_utils::CowArc;
-use serde::{de::Visitor, ser::SerializeTupleStruct, Deserialize, Serialize};
+use serde::{de::Visitor, Deserialize, Serialize};
 use std::{
     fmt::{Debug, Display},
     hash::Hash,


### PR DESCRIPTION
# Objective

- Silence `Failed to send DropEvent for StrongHandle "SendError(..)"` errors when `StrongHandle` were dropped during application shutdown.
- Re-export `BoxedFuture` considering that it's used everywhere in bevy_asset
- Fixed an issue introduced by #9729. 
  ```
  Asset 'final_gather.rgen' encountered an error in dust_render::shader::spirv::SpirvLoader: Failed to deserialize asset meta: SpannedError { code: InvalidValueForType { expected: "string AssetPath", found: "a sequence" }, position: Position { line: 9, col: 24 } }
  ```
  Basically, for processed assets with dependencies, bevy will serialize the metafile as follows:
  ```
  (
    meta_format_version: "1.0",
    processed_info: Some((
        hash: (203, 239, 108, 156, 180, 23, 157, 217, 159, 36, 158, 193, 185, 253, 242, 156),
        full_hash: (77, 58, 30, 200, 21, 180, 221, 133, 151, 83, 247, 47, 193, 70, 228, 97),
        process_dependencies: [
            (
                full_hash: (56, 46, 55, 118, 3, 6, 213, 250, 124, 26, 153, 87, 15, 85, 4, 89),
                path: ("standard.glsl"), # <<---------- See here
            ),
        ],
    )),
    asset: Load(
        loader: "dust_render::shader::spirv::SpirvLoader",
        settings: (),
    ),
  )
  ```
  `AssetPath` gets serialized as `("standard.glsl")` which was then deserialized as a sequence instead of our `AssetPath`.

## Solution

- Serialize `AssetPath` directly as a string instead. The above metafile would be serialized as follows:
 ```
  (
    meta_format_version: "1.0",
    processed_info: Some((
        hash: (203, 239, 108, 156, 180, 23, 157, 217, 159, 36, 158, 193, 185, 253, 242, 156),
        full_hash: (77, 58, 30, 200, 21, 180, 221, 133, 151, 83, 247, 47, 193, 70, 228, 97),
        process_dependencies: [
            (
                full_hash: (56, 46, 55, 118, 3, 6, 213, 250, 124, 26, 153, 87, 15, 85, 4, 89),
                path: "standard.glsl", # <<------- No longer a tuple struct
            ),
        ],
    )),
    asset: Load(
        loader: "dust_render::shader::spirv::SpirvLoader",
        settings: (),
    ),
  )
  ```

---

