### PR TITLE
Better TextStyle construct function parameters using Borrow<T>

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -189,6 +189,18 @@ impl Default for TextStyle {
     }
 }
 
+impl AsRef<TextStyle> for TextStyle {
+    fn as_ref(&self) -> &TextStyle {
+        &self
+    }
+}
+
+impl AsMut<TextStyle> for TextStyle {
+    fn as_mut(&mut self) -> &mut TextStyle {
+        self
+    }
+}
+
 /// Determines how lines will be broken when preventing text from running out of bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -1,3 +1,5 @@
+use std::borrow::Borrow;
+
 use bevy_asset::Handle;
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_reflect::prelude::*;
@@ -59,7 +61,7 @@ impl Text {
     /// ) // You can still add an alignment.
     /// .with_alignment(TextAlignment::Center);
     /// ```
-    pub fn from_section(value: impl Into<String>, style: TextStyle) -> Self {
+    pub fn from_section(value: impl Into<String>, style: impl Borrow<TextStyle>) -> Self {
         Self {
             sections: vec![TextSection::new(value, style)],
             ..default()
@@ -123,10 +125,10 @@ pub struct TextSection {
 
 impl TextSection {
     /// Create a new [`TextSection`].
-    pub fn new(value: impl Into<String>, style: TextStyle) -> Self {
+    pub fn new(value: impl Into<String>, style: impl Borrow<TextStyle>) -> Self {
         Self {
             value: value.into(),
-            style,
+            style: style.borrow().to_owned(),
         }
     }
 
@@ -189,17 +191,6 @@ impl Default for TextStyle {
     }
 }
 
-impl AsRef<TextStyle> for TextStyle {
-    fn as_ref(&self) -> &TextStyle {
-        &self
-    }
-}
-
-impl AsMut<TextStyle> for TextStyle {
-    fn as_mut(&mut self) -> &mut TextStyle {
-        self
-    }
-}
 
 /// Determines how lines will be broken when preventing text from running out of bounds.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing scale
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("scale", &text_style).with_alignment(text_alignment),
+            text: Text::from_section("scale", text_style).with_alignment(text_alignment),
             ..default()
         },
         AnimateScale,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -44,7 +44,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing translation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("translation", text_style.clone())
+            text: Text::from_section("translation", &text_style)
                 .with_alignment(text_alignment),
             ..default()
         },
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing rotation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("rotation", text_style.clone()).with_alignment(text_alignment),
+            text: Text::from_section("rotation", &text_style).with_alignment(text_alignment),
             ..default()
         },
         AnimateRotation,
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing scale
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("scale", text_style).with_alignment(text_alignment),
+            text: Text::from_section("scale", &text_style).with_alignment(text_alignment),
             ..default()
         },
         AnimateScale,
@@ -89,7 +89,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 text: Text {
                     sections: vec![TextSection::new(
                         "this text wraps in the box\n(Unicode linebreaks)",
-                        slightly_smaller_text_style.clone(),
+                        &slightly_smaller_text_style,
                     )],
                     alignment: TextAlignment::Left,
                     linebreak_behavior: BreakLineOn::WordBoundary,
@@ -121,7 +121,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 text: Text {
                     sections: vec![TextSection::new(
                         "this text wraps in the box\n(AnyCharacter linebreaks)",
-                        slightly_smaller_text_style.clone(),
+                        &slightly_smaller_text_style,
                     )],
                     alignment: TextAlignment::Left,
                     linebreak_behavior: BreakLineOn::AnyCharacter,


### PR DESCRIPTION
# Objective

**Make using parameter structs less annoying.**

If you are making a function that takes in a struct with defining info like TextStyle, you will probably think that taking a borrow is better than ownership. But that depends on the use case. Sometimes the user will create the struct beforehand and will pass out references to it. Or sometimes he initiates the struct directly in the argument with something like `::new()`.
```rust
fn foo (style: &TextStyle) {
   style.do_something()
}

foo(&style);
foo(TextStyle::new()); // Doesnt compile, forced to add "&"
```
In the latter case, he is forced to write `"&TextStyle::new()"` instead of just `"TextStyle::new()"`, which is bothersome. But the other case is taking an ownership, which if he used it like the first example, he would need to do `.clone()` which is even worse.

But what if there is a way to do both at once?

```rust
fn foo (style: impl Borrow<TextStyle>) {
   style.borrow().do_something()
}

foo(&style);
foo(TextStyle::new()); // Works just fine
```

It allows us to leave out the "&" where it is not needed. You might think it is an unnecessary change, but I think it's quite nice UX improvement without any sacrifice (Maybe it's less clear what `impl Borrow<TextStyle>` is but that's about it)

I have been using this in [Bevy-Lunex](https://github.com/bytestring-net/bevy-lunex) for a while and it's quite pleasant.
