### PR TITLE
don't ignore some EventKind::Modify

### DIFF
--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -46,17 +46,6 @@ impl FileWatcher {
                                     let (path, _) = get_asset_path(&owned_root, &event.paths[0]);
                                     sender.send(AssetSourceEvent::AddedFolder(path)).unwrap();
                                 }
-                                notify::EventKind::Modify(ModifyKind::Any) => {
-                                    let (path, is_meta) =
-                                        get_asset_path(&owned_root, &event.paths[0]);
-                                    if event.paths[0].is_dir() {
-                                        // modified folder means nothing in this case
-                                    } else if is_meta {
-                                        sender.send(AssetSourceEvent::ModifiedMeta(path)).unwrap();
-                                    } else {
-                                        sender.send(AssetSourceEvent::ModifiedAsset(path)).unwrap();
-                                    };
-                                }
                                 notify::EventKind::Access(AccessKind::Close(AccessMode::Write)) => {
                                     let (path, is_meta) =
                                         get_asset_path(&owned_root, &event.paths[0]);
@@ -133,6 +122,17 @@ impl FileWatcher {
                                             }
                                         }
                                     }
+                                }
+                                notify::EventKind::Modify(_) => {
+                                    let (path, is_meta) =
+                                        get_asset_path(&owned_root, &event.paths[0]);
+                                    if event.paths[0].is_dir() {
+                                        // modified folder means nothing in this case
+                                    } else if is_meta {
+                                        sender.send(AssetSourceEvent::ModifiedMeta(path)).unwrap();
+                                    } else {
+                                        sender.send(AssetSourceEvent::ModifiedAsset(path)).unwrap();
+                                    };
                                 }
                                 notify::EventKind::Remove(RemoveKind::File) => {
                                     let (path, is_meta) =


### PR DESCRIPTION
# Objective

- File modification don't trigger hot reload on macOS 

## Solution

- [`EventKind::Modify`](https://docs.rs/notify/latest/notify/event/enum.EventKind.html#variant.Modify) can have several reasons
- [`ModifyKind::Any`](https://docs.rs/notify/latest/notify/event/enum.ModifyKind.html) was used to react to change events, and later ModifyKind::Name for file name change. It left other variants of change ignored (`Data`, `Metadata`, `Other`)
- move the modification handling after the rename so that it handles all other variants
