### PR TITLE
Fix animate_scale scaling z value in text2d example

### DIFF
--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -187,6 +187,9 @@ fn animate_scale(
     // rendered quad, resulting in a pixellated look.
     for mut transform in &mut query {
         transform.translation = Vec3::new(400.0, 0.0, 0.0);
-        transform.scale = Vec3::splat((time.elapsed_seconds().sin() + 1.1) * 2.0);
+
+        let scale = (time.elapsed_seconds().sin() + 1.1) * 2.0;
+        transform.scale.x = scale;
+        transform.scale.y = scale;
     }
 }


### PR DESCRIPTION
# Objective

I noticed this while testing #9733.

It's not causing any problems, but we shouldn't teach users to scale 2d stuff in z.

## Solution

Only scale in x and y.

