### PR TITLE
Return a Result from Camera::viewport_to_world

### DIFF
--- a/crates/bevy_pbr/src/cluster/assign.rs
+++ b/crates/bevy_pbr/src/cluster/assign.rs
@@ -213,7 +213,7 @@ pub(crate) fn assign_lights_to_clusters(
         let view_inv_scale = camera_transform.compute_transform().scale.recip();
         let view_inv_scale_max = view_inv_scale.abs().max_element();
         let inverse_view_transform = view_transform.inverse();
-        let is_orthographic = camera.projection_matrix().w_axis.w == 1.0;
+        let is_orthographic = camera.projection_matrix_unchecked().w_axis.w == 1.0;
 
         let far_z = match config.far_z_mode() {
             ClusterFarZMode::MaxLightRange => {
@@ -239,7 +239,8 @@ pub(crate) fn assign_lights_to_clusters(
                 // 3,2 = r * far and 2,2 = r where r = 1.0 / (far - near)
                 // rearranging r = 1.0 / (far - near), r * (far - near) = 1.0, r * far - 1.0 = r * near, near = (r * far - 1.0) / r
                 // = (3,2 - 1.0) / 2,2
-                (camera.projection_matrix().w_axis.z - 1.0) / camera.projection_matrix().z_axis.z
+                (camera.projection_matrix_unchecked().w_axis.z - 1.0)
+                    / camera.projection_matrix_unchecked().z_axis.z
             }
             (false, 1) => config.first_slice_depth().max(far_z),
             _ => config.first_slice_depth(),
@@ -271,7 +272,7 @@ pub(crate) fn assign_lights_to_clusters(
                 let (light_aabb_min, light_aabb_max) = cluster_space_light_aabb(
                     inverse_view_transform,
                     view_inv_scale,
-                    camera.projection_matrix(),
+                    camera.projection_matrix_unchecked(),
                     &light_sphere,
                 );
 
@@ -337,7 +338,7 @@ pub(crate) fn assign_lights_to_clusters(
             clusters.dimensions.x * clusters.dimensions.y * clusters.dimensions.z <= 4096
         );
 
-        let inverse_projection = camera.projection_matrix().inverse();
+        let inverse_projection = camera.projection_matrix_unchecked().inverse();
 
         for lights in &mut clusters.lights {
             lights.entities.clear();
@@ -434,7 +435,7 @@ pub(crate) fn assign_lights_to_clusters(
                     cluster_space_light_aabb(
                         inverse_view_transform,
                         view_inv_scale,
-                        camera.projection_matrix(),
+                        camera.projection_matrix_unchecked(),
                         &light_sphere,
                     );
 
@@ -477,7 +478,7 @@ pub(crate) fn assign_lights_to_clusters(
                     )
                 });
                 let light_center_clip =
-                    camera.projection_matrix() * view_light_sphere.center.extend(1.0);
+                    camera.projection_matrix_unchecked() * view_light_sphere.center.extend(1.0);
                 let light_center_ndc = light_center_clip.xyz() / light_center_clip.w;
                 let cluster_coordinates = ndc_position_to_cluster(
                     clusters.dimensions,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -207,7 +207,7 @@ pub fn update_previous_view_data(
         let inverse_view = camera_transform.compute_matrix().inverse();
         commands.entity(entity).try_insert(PreviousViewData {
             inverse_view,
-            view_proj: camera.projection_matrix() * inverse_view,
+            view_proj: camera.projection_matrix_unchecked() * inverse_view,
         });
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -358,19 +358,18 @@ impl Camera {
             .computed
             .projection_matrix
             .ok_or(BadProjectionMatrixError::ProjectionMatrixUndefined)?;
-        match projection_matrix.is_finite() {
-            false => Err(BadProjectionMatrixError::BadProjectionMatrixValues(
-                projection_matrix,
-            )),
-            true => {
-                if projection_matrix == Mat4::ZERO {
-                    Err(BadProjectionMatrixError::BadProjectionMatrixValues(
-                        projection_matrix,
-                    ))
-                } else {
-                    Ok(projection_matrix)
-                }
+        if projection_matrix.is_finite() {
+            if projection_matrix == Mat4::ZERO {
+                Err(BadProjectionMatrixError::BadProjectionMatrixValues(
+                    projection_matrix,
+                ))
+            } else {
+                Ok(projection_matrix)
             }
+        } else {
+            Err(BadProjectionMatrixError::BadProjectionMatrixValues(
+                projection_matrix,
+            ))
         }
     }
 
@@ -379,9 +378,10 @@ impl Camera {
         camera_transform: &GlobalTransform,
     ) -> Result<Mat4, CameraTransformNotFiniteError> {
         let camera_transform_matrix = camera_transform.compute_matrix();
-        match camera_transform_matrix.is_finite() {
-            true => Ok(camera_transform_matrix),
-            false => Err(CameraTransformNotFiniteError(camera_transform_matrix)),
+        if camera_transform_matrix.is_finite() {
+            Ok(camera_transform_matrix)
+        } else {
+            Err(CameraTransformNotFiniteError(camera_transform_matrix))
         }
     }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -353,7 +353,6 @@ impl Camera {
         self.computed.projection_matrix.unwrap_or_default()
     }
 
-    #[inline]
     fn projection_matrix(&self) -> Result<Mat4, BadProjectionMatrixError> {
         let projection_matrix = self
             .computed

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -349,12 +349,12 @@ impl Camera {
 
     /// The projection matrix computed using this camera's [`CameraProjection`].
     #[inline]
-    pub fn projection_matrix(&self) -> Mat4 {
+    pub fn projection_matrix_unchecked(&self) -> Mat4 {
         self.computed.projection_matrix.unwrap_or_default()
     }
 
     #[inline]
-    fn checked_projection_matrix(&self) -> Result<Mat4, BadProjectionMatrixError> {
+    fn projection_matrix(&self) -> Result<Mat4, BadProjectionMatrixError> {
         let projection_matrix = self
             .computed
             .projection_matrix
@@ -443,7 +443,7 @@ impl Camera {
         let camera_transform_matrix = Self::finite_camera_transform_matrix(camera_transform)
             .map_err(ViewportToWorldError::CameraTransformNotFinite)?;
         let projection_matrix = self
-            .checked_projection_matrix()
+            .projection_matrix()
             .map_err(ViewportToWorldError::ProjectionMatrixNotFinite)?;
 
         let ndc_to_world = camera_transform_matrix * projection_matrix.inverse();
@@ -505,7 +505,7 @@ impl Camera {
             .map_err(WorldToNdcError::CameraTransformNotFinite)?;
 
         let projection_matrix = self
-            .checked_projection_matrix()
+            .projection_matrix()
             .map_err(WorldToNdcError::ProjectionMatrixNotFinite)?;
 
         // Build a transformation matrix to convert from world space to NDC using camera data
@@ -537,7 +537,7 @@ impl Camera {
             .map_err(NdcToWorldError::CameraTransformNotFinite)?;
 
         let projection_matrix = self
-            .checked_projection_matrix()
+            .projection_matrix()
             .map_err(NdcToWorldError::ProjectionMatrixNotFinite)?;
 
         // Build a transformation matrix to convert from NDC to world space using camera data
@@ -1037,7 +1037,7 @@ pub fn extract_cameras(
                         .unwrap_or_else(|| Exposure::default().exposure()),
                 },
                 ExtractedView {
-                    projection: camera.projection_matrix(),
+                    projection: camera.projection_matrix_unchecked(),
                     transform: *transform,
                     view_projection: None,
                     hdr: camera.hdr,

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -41,7 +41,7 @@ fn calc_bounds(
     if let Ok((camera, camera_transform)) = camera.get_single() {
         for (mut accessible, node, transform) in &mut nodes {
             if node.is_changed() || transform.is_changed() {
-                if let Some(translation) =
+                if let Ok(translation) =
                     camera.world_to_viewport(camera_transform, transform.translation())
                 {
                     let bounds = Rect::new(

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -231,7 +231,7 @@ pub fn extract_uinode_background_colors(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -373,7 +373,7 @@ pub fn extract_uinode_images(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -544,7 +544,7 @@ pub fn extract_uinode_borders(
         let ui_logical_viewport_size = camera_query
             .get(camera_entity)
             .ok()
-            .and_then(|(_, c)| c.logical_viewport_size())
+            .and_then(|(_, c)| c.logical_viewport_size().ok())
             .unwrap_or(Vec2::ZERO)
             // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
             // so we have to divide by `UiScale` to get the size of the UI viewport.
@@ -733,7 +733,7 @@ pub fn extract_default_ui_camera_view(
         }
 
         if let (
-            Some(logical_size),
+            Ok(logical_size),
             Some(URect {
                 min: physical_origin,
                 ..

--- a/examples/2d/2d_viewport_to_world.rs
+++ b/examples/2d/2d_viewport_to_world.rs
@@ -22,7 +22,7 @@ fn draw_cursor(
     };
 
     // Calculate a world position based on the cursor's position.
-    let Some(point) = camera.viewport_to_world_2d(camera_transform, cursor_position) else {
+    let Ok(point) = camera.viewport_to_world_2d(camera_transform, cursor_position) else {
         return;
     };
 

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -24,7 +24,7 @@ fn draw_cursor(
     };
 
     // Calculate a ray pointing from the camera into the world based on the cursor's position.
-    let Some(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
+    let Ok(ray) = camera.viewport_to_world(camera_transform, cursor_position) else {
         return;
     };
 

--- a/examples/3d/irradiance_volumes.rs
+++ b/examples/3d/irradiance_volumes.rs
@@ -483,7 +483,7 @@ fn handle_mouse_clicks(
     };
 
     // Figure out where the user clicked on the plane.
-    let Some(ray) = camera.viewport_to_world(camera_transform, mouse_position) else {
+    let Ok(ray) = camera.viewport_to_world(camera_transform, mouse_position) else {
         return;
     };
     let Some(ray_distance) = ray.intersect_plane(Vec3::ZERO, InfinitePlane3d::new(Vec3::Y)) else {

--- a/examples/games/desk_toy.rs
+++ b/examples/games/desk_toy.rs
@@ -222,9 +222,11 @@ fn get_cursor_world_pos(
     let primary_window = q_primary_window.single();
     let (main_camera, main_camera_transform) = q_camera.single();
     // Get the cursor position in the world
-    cursor_world_pos.0 = primary_window
-        .cursor_position()
-        .and_then(|cursor_pos| main_camera.viewport_to_world_2d(main_camera_transform, cursor_pos));
+    cursor_world_pos.0 = primary_window.cursor_position().and_then(|cursor_pos| {
+        main_camera
+            .viewport_to_world_2d(main_camera_transform, cursor_pos)
+            .ok()
+    });
 }
 
 /// Update whether the window is clickable or not


### PR DESCRIPTION
# Objective

This is a follow-up to [8841](https://github.com/bevyengine/bevy/pull/8841)

The objective is to create a better UX when something goes wrong in Camera::viewport_to_world and related methods.

## Solution

Move from using Option to detailed Result variants. The user no longer has to guess what the error was.

---

## Changelog

Improve errors related to functions converting coordinates between camera, viewport, and world.

## Migration Guide

Replace code that expects Option with code that expects Result. An easy way is to append a `.ok()` to the returned Result to transform it into an Option.

Change references to Camera::projection_matrix to Camera::projection_matrix_unchecked.
