### PR TITLE
bevy_reflect: `TypeData` and registration callbacks

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -724,7 +724,7 @@ impl App {
     #[cfg(feature = "bevy_reflect")]
     pub fn register_type_data<
         T: bevy_reflect::Reflect + 'static,
-        D: bevy_reflect::TypeData + bevy_reflect::FromType<T>,
+        D: bevy_reflect::BaseTypeData + bevy_reflect::TypeData<T>,
     >(
         &mut self,
     ) -> &mut Self {

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -1,7 +1,7 @@
 use std::any::{Any, TypeId};
 
 use bevy_ecs::world::{unsafe_world_cell::UnsafeWorldCell, World};
-use bevy_reflect::{FromReflect, FromType, Reflect};
+use bevy_reflect::{FromReflect, Reflect, TypeData};
 
 use crate::{Asset, Assets, Handle, UntypedAssetId, UntypedHandle};
 
@@ -122,8 +122,8 @@ impl ReflectAsset {
     }
 }
 
-impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
-    fn from_type() -> Self {
+impl<A: Asset + FromReflect> TypeData<A> for ReflectAsset {
+    fn create_type_data() -> Self {
         ReflectAsset {
             handle_type_id: TypeId::of::<Handle<A>>(),
             assets_resource_type_id: TypeId::of::<Assets<A>>(),
@@ -217,8 +217,8 @@ impl ReflectHandle {
     }
 }
 
-impl<A: Asset> FromType<Handle<A>> for ReflectHandle {
-    fn from_type() -> Self {
+impl<A: Asset> TypeData<Handle<A>> for ReflectHandle {
+    fn create_type_data() -> Self {
         ReflectHandle {
             asset_type_id: TypeId::of::<A>(),
             downcast_handle_untyped: |handle: &dyn Any| {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -902,7 +902,7 @@ impl std::fmt::Debug for MutUntyped<'_> {
 mod tests {
     use bevy_ecs_macros::Resource;
     use bevy_ptr::PtrMut;
-    use bevy_reflect::{FromType, ReflectFromPtr};
+    use bevy_reflect::{ReflectFromPtr, TypeData};
 
     use crate::{
         self as bevy_ecs,
@@ -1160,7 +1160,7 @@ mod tests {
             ticks,
         };
 
-        let reflect_from_ptr = <ReflectFromPtr as FromType<i32>>::from_type();
+        let reflect_from_ptr = <ReflectFromPtr as TypeData<i32>>::create_type_data();
 
         let mut new = value.map_unchanged(|ptr| {
             // SAFETY: The underlying type of `ptr` matches `reflect_from_ptr`.

--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -9,7 +9,7 @@ use crate::{
     prelude::Bundle,
     world::{EntityWorldMut, FromWorld, World},
 };
-use bevy_reflect::{FromType, Reflect, ReflectRef, TypeRegistry};
+use bevy_reflect::{Reflect, ReflectRef, TypeData, TypeRegistry};
 
 use super::ReflectComponent;
 
@@ -39,12 +39,12 @@ pub struct ReflectBundleFns {
 
 impl ReflectBundleFns {
     /// Get the default set of [`ReflectBundleFns`] for a specific bundle type using its
-    /// [`FromType`] implementation.
+    /// [`TypeData`] implementation.
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
     pub fn new<T: Bundle + Reflect + FromWorld>() -> Self {
-        <ReflectBundle as FromType<T>>::from_type().0
+        <ReflectBundle as TypeData<T>>::create_type_data().0
     }
 }
 
@@ -124,8 +124,8 @@ impl ReflectBundle {
     }
 }
 
-impl<B: Bundle + Reflect + FromWorld> FromType<B> for ReflectBundle {
-    fn from_type() -> Self {
+impl<B: Bundle + Reflect + FromWorld> TypeData<B> for ReflectBundle {
+    fn create_type_data() -> Self {
         ReflectBundle(ReflectBundleFns {
             from_world: |world| Box::new(B::from_world(world)),
             insert: |entity, reflected_bundle| {

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -34,7 +34,7 @@ pub trait ReflectCommandExt {
     ///
     /// # use bevy_ecs::prelude::*;
     /// # use bevy_ecs::reflect::ReflectCommandExt;
-    /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
+    /// # use bevy_reflect::{FromReflect, Reflect, TypeRegistry};
     /// // A resource that can hold any component that implements reflect as a boxed reflect component
     /// #[derive(Resource)]
     /// struct Prefab{
@@ -104,7 +104,7 @@ pub trait ReflectCommandExt {
     ///
     /// # use bevy_ecs::prelude::*;
     /// # use bevy_ecs::reflect::ReflectCommandExt;
-    /// # use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
+    /// # use bevy_reflect::{FromReflect, Reflect, TypeRegistry};
     ///
     /// // A resource that can hold any component that implements reflect as a boxed reflect component
     /// #[derive(Resource)]

--- a/crates/bevy_ecs/src/reflect/map_entities.rs
+++ b/crates/bevy_ecs/src/reflect/map_entities.rs
@@ -3,7 +3,7 @@ use crate::{
     entity::{Entity, EntityMapper, MapEntities},
     world::World,
 };
-use bevy_reflect::FromType;
+use bevy_reflect::TypeData;
 use bevy_utils::HashMap;
 
 /// For a specific type of component, this maps any fields with values of type [`Entity`] to a new world.
@@ -49,8 +49,8 @@ impl ReflectMapEntities {
     }
 }
 
-impl<C: Component + MapEntities> FromType<C> for ReflectMapEntities {
-    fn from_type() -> Self {
+impl<C: Component + MapEntities> TypeData<C> for ReflectMapEntities {
+    fn create_type_data() -> Self {
         ReflectMapEntities {
             map_entities: |world, entity_mapper, entities| {
                 for &entity in entities {

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -9,7 +9,7 @@ use crate::{
     system::Resource,
     world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
-use bevy_reflect::{FromType, Reflect};
+use bevy_reflect::{Reflect, TypeData};
 
 /// A struct used to operate on reflected [`Resource`] of a type.
 ///
@@ -61,12 +61,12 @@ pub struct ReflectResourceFns {
 
 impl ReflectResourceFns {
     /// Get the default set of [`ReflectResourceFns`] for a specific resource type using its
-    /// [`FromType`] implementation.
+    /// [`TypeData`] implementation.
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
     pub fn new<T: Resource + Reflect + FromWorld>() -> Self {
-        <ReflectResource as FromType<T>>::from_type().0
+        <ReflectResource as TypeData<T>>::create_type_data().0
     }
 }
 
@@ -164,8 +164,8 @@ impl ReflectResource {
     }
 }
 
-impl<C: Resource + Reflect + FromWorld> FromType<C> for ReflectResource {
-    fn from_type() -> Self {
+impl<C: Resource + Reflect + FromWorld> TypeData<C> for ReflectResource {
+    fn create_type_data() -> Self {
         ReflectResource(ReflectResourceFns {
             insert: |world, reflected_resource| {
                 let mut resource = C::from_world(world);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -299,7 +299,7 @@ pub fn derive_type_uuid(input: TokenStream) -> TokenStream {
 /// Because of this, **it can only be used on [object-safe] traits.**
 ///
 /// For a trait named `MyTrait`, this will generate the struct `ReflectMyTrait`.
-/// The generated struct can be created using `FromType` with any type that implements the trait.
+/// The generated struct can be created using `TypeData` with any type that implements the trait.
 /// The creation and registration of this generated struct as type data can be automatically handled
 /// by [`#[derive(Reflect)]`](Reflect).
 ///
@@ -324,7 +324,7 @@ pub fn derive_type_uuid(input: TokenStream) -> TokenStream {
 /// }
 ///
 /// // We can create the type data manually if we wanted:
-/// let my_trait: ReflectMyTrait = FromType::<SomeStruct>::from_type();
+/// let my_trait: ReflectMyTrait = TypeData::<SomeStruct>::create_type_data();
 ///
 /// // Or we can simply get it from the registry:
 /// let mut registry = TypeRegistry::default();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/trait_reflection.rs
@@ -75,8 +75,8 @@ pub(crate) fn reflect_trait(_args: &TokenStream, input: TokenStream) -> TokenStr
             }
         }
 
-        impl<T: #trait_ident + #bevy_reflect_path::Reflect> #bevy_reflect_path::FromType<T> for #reflect_trait_ident {
-            fn from_type() -> Self {
+        impl<T: #trait_ident + #bevy_reflect_path::Reflect> #bevy_reflect_path::TypeData<T> for #reflect_trait_ident {
+            fn create_type_data() -> Self {
                 Self {
                     get_func: |reflect_value| {
                         <dyn #bevy_reflect_path::Reflect>::downcast_ref::<T>(reflect_value).map(|value| value as &dyn #trait_ident)

--- a/crates/bevy_reflect/src/from_reflect.rs
+++ b/crates/bevy_reflect/src/from_reflect.rs
@@ -1,4 +1,4 @@
-use crate::{FromType, Reflect};
+use crate::{Reflect, TypeData};
 
 /// A trait that enables types to be dynamically constructed from reflected data.
 ///
@@ -111,8 +111,8 @@ impl ReflectFromReflect {
     }
 }
 
-impl<T: FromReflect> FromType<T> for ReflectFromReflect {
-    fn from_type() -> Self {
+impl<T: FromReflect> TypeData<T> for ReflectFromReflect {
+    fn create_type_data() -> Self {
         Self {
             from_reflect: |reflect_value| {
                 T::from_reflect(reflect_value).map(|value| Box::new(value) as Box<dyn Reflect>)

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -4,9 +4,9 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter,
-    Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypeRegistration, Typed,
+    self as bevy_reflect, FromReflect, GetTypeRegistration, List, ListInfo, ListIter, Reflect,
+    ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration,
+    Typed,
 };
 
 impl<T: smallvec::Array + TypePath + Send + Sync> List for SmallVec<T>
@@ -176,8 +176,6 @@ where
     T::Item: FromReflect,
 {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<SmallVec<T>>();
-        registration.insert::<ReflectFromPtr>(FromType::<SmallVec<T>>::from_type());
-        registration
+        TypeRegistration::of::<SmallVec<T>>().register::<Self, ReflectFromPtr>()
     }
 }

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -2,10 +2,10 @@ use crate::std_traits::ReflectDefault;
 use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwned};
 use crate::{
     impl_type_path, map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum,
-    DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
-    ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    ReflectSerialize, TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed,
-    UnitVariantInfo, UnnamedField, ValueInfo, VariantFieldIter, VariantInfo, VariantType,
+    DynamicMap, Enum, EnumInfo, FromReflect, GetTypeRegistration, List, ListInfo, ListIter, Map,
+    MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef, ReflectSerialize,
+    TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed, UnitVariantInfo, UnnamedField,
+    ValueInfo, VariantFieldIter, VariantInfo, VariantType,
 };
 
 use crate::utility::{
@@ -353,9 +353,7 @@ macro_rules! impl_reflect_for_veclike {
 
         impl<T: FromReflect + TypePath> GetTypeRegistration for $ty {
             fn get_type_registration() -> TypeRegistration {
-                let mut registration = TypeRegistration::of::<$ty>();
-                registration.insert::<ReflectFromPtr>(FromType::<$ty>::from_type());
-                registration
+                TypeRegistration::of::<$ty>().register::<Self, ReflectFromPtr>()
             }
         }
 
@@ -576,9 +574,7 @@ macro_rules! impl_reflect_for_hashmap {
             S: TypePath + BuildHasher + Send + Sync,
         {
             fn get_type_registration() -> TypeRegistration {
-                let mut registration = TypeRegistration::of::<Self>();
-                registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
-                registration
+                TypeRegistration::of::<Self>().register::<Self, ReflectFromPtr>()
             }
         }
 
@@ -770,7 +766,7 @@ impl<T: Reflect + TypePath, const N: usize> TypePath for [T; N] {
 }
 
 // TODO:
-// `FromType::from_type` requires `Deserialize<'de>` to be implemented for `T`.
+// `TypeData::create_type_data` requires `Deserialize<'de>` to be implemented for `T`.
 // Currently serde only supports `Deserialize<'de>` for arrays up to size 32.
 // This can be changed to use const generics once serde utilizes const generics for arrays.
 // Tracking issue: https://github.com/serde-rs/serde/issues/1937
@@ -1152,11 +1148,10 @@ impl TypePath for Cow<'static, str> {
 
 impl GetTypeRegistration for Cow<'static, str> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Cow<'static, str>>();
-        registration.insert::<ReflectDeserialize>(FromType::<Cow<'static, str>>::from_type());
-        registration.insert::<ReflectFromPtr>(FromType::<Cow<'static, str>>::from_type());
-        registration.insert::<ReflectSerialize>(FromType::<Cow<'static, str>>::from_type());
-        registration
+        TypeRegistration::of::<Cow<'static, str>>()
+            .register::<Self, ReflectDeserialize>()
+            .register::<Self, ReflectFromPtr>()
+            .register::<Self, ReflectSerialize>()
     }
 }
 
@@ -1444,9 +1439,7 @@ impl TypePath for &'static Path {
 
 impl GetTypeRegistration for &'static Path {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
-        registration
+        TypeRegistration::of::<Self>().register::<Self, ReflectFromPtr>()
     }
 }
 
@@ -1560,12 +1553,11 @@ impl FromReflect for Cow<'static, Path> {
 
 impl GetTypeRegistration for Cow<'static, Path> {
     fn get_type_registration() -> TypeRegistration {
-        let mut registration = TypeRegistration::of::<Self>();
-        registration.insert::<ReflectDeserialize>(FromType::<Self>::from_type());
-        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
-        registration.insert::<ReflectSerialize>(FromType::<Self>::from_type());
-        registration.insert::<ReflectFromReflect>(FromType::<Self>::from_type());
-        registration
+        TypeRegistration::of::<Self>()
+            .register::<Self, ReflectDeserialize>()
+            .register::<Self, ReflectFromPtr>()
+            .register::<Self, ReflectSerialize>()
+            .register::<Self, ReflectFromReflect>()
     }
 }
 

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -446,7 +446,7 @@
 //! [`'static` lifetime]: https://doc.rust-lang.org/rust-by-example/scope/lifetime/static_lifetime.html#trait-bound
 //! [derive macro documentation]: derive@crate::Reflect
 //! [deriving `Reflect`]: derive@crate::Reflect
-//! [type data]: TypeData
+//! [type data]: BaseTypeData
 //! [`ReflectDefault`]: std_traits::ReflectDefault
 //! [object-safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
 //! [`serde`]: ::serde
@@ -476,6 +476,7 @@ mod reflect;
 mod struct_trait;
 mod tuple;
 mod tuple_struct;
+mod type_data;
 mod type_info;
 mod type_path;
 mod type_registry;
@@ -530,6 +531,7 @@ pub use reflect::*;
 pub use struct_trait::*;
 pub use tuple::*;
 pub use tuple_struct::*;
+pub use type_data::*;
 pub use type_info::*;
 pub use type_path::*;
 pub use type_registry::*;

--- a/crates/bevy_reflect/src/std_traits.rs
+++ b/crates/bevy_reflect/src/std_traits.rs
@@ -1,8 +1,8 @@
-use crate::{FromType, Reflect};
+use crate::{Reflect, TypeData};
 
 /// A struct used to provide the default value of a type.
 ///
-/// A [`ReflectDefault`] for type `T` can be obtained via [`FromType::from_type`].
+/// A [`ReflectDefault`] for type `T` can be obtained via [`TypeData::create_type_data`].
 #[derive(Clone)]
 pub struct ReflectDefault {
     default: fn() -> Box<dyn Reflect>,
@@ -14,8 +14,8 @@ impl ReflectDefault {
     }
 }
 
-impl<T: Reflect + Default> FromType<T> for ReflectDefault {
-    fn from_type() -> Self {
+impl<T: Reflect + Default> TypeData<T> for ReflectDefault {
+    fn create_type_data() -> Self {
         ReflectDefault {
             default: || Box::<T>::default(),
         }

--- a/crates/bevy_reflect/src/type_data.rs
+++ b/crates/bevy_reflect/src/type_data.rs
@@ -1,0 +1,166 @@
+use crate::TypeRegistry;
+use core::fmt::{Debug, Formatter};
+use downcast_rs::{impl_downcast, Downcast};
+
+/// Type-erased [`TypeData`].
+///
+/// Type data can be registered to the [`TypeRegistry`] and stored on a type's [`TypeRegistration`].
+///
+/// While type data is often generated using the [`#[reflect_trait]`](crate::reflect_trait) macro,
+/// almost any type that implements [`Clone`] can be considered "type data".
+/// This is because it has a blanket implementation over all `T` where `T: Clone + Send + Sync + 'static`.
+///
+/// See the [crate-level documentation] for more information on type data and type registration.
+///
+/// [`TypeRegistration`]: crate::TypeRegistration
+/// [crate-level documentation]: crate
+pub trait BaseTypeData: Downcast + Send + Sync {
+    fn type_name(&self) -> &'static str;
+    fn clone_type_data(&self) -> Box<dyn BaseTypeData>;
+}
+impl_downcast!(BaseTypeData);
+
+impl<T: 'static + Send + Sync> BaseTypeData for T
+where
+    T: Clone,
+{
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<T>()
+    }
+
+    fn clone_type_data(&self) -> Box<dyn BaseTypeData> {
+        Box::new(self.clone())
+    }
+}
+
+impl Debug for dyn BaseTypeData {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str(self.type_name())
+    }
+}
+
+/// Trait used for generating data for a type to be stored in a [`TypeRegistry`].
+///
+/// This is used to provide additional information about a type that can be used
+/// dynamically at runtime.
+/// Most often, this data is tied to a trait so that the trait may be used dynamically.
+///
+/// # Naming Convention
+///
+/// The [derive macro] requires that type data be prefixed with `Reflect`.
+/// This is done so that the macro's registrations are less visually noisy.
+/// For example, the type data for [`Default`] is called [`ReflectDefault`],
+/// and would be registered via the derive macro like `#[reflect(Default)]`.
+///
+/// # Example
+///
+/// Let's say we have the following code and want to be able to use the trait dynamically:
+///
+/// ```
+/// # use bevy_reflect::{Reflect};
+/// trait Animal {
+///   fn speak(&self) -> &'static str;
+/// }
+///
+/// #[derive(Reflect)]
+/// struct Dog(String);
+///
+/// impl Animal for Dog {
+///   fn speak(&self) -> &'static str {
+///     "woof"
+///   }
+/// }
+/// ```
+///
+/// To do this, we can create a type data struct that implements [`TypeData`]:
+///
+/// ```
+/// # use bevy_reflect::{TypeData, Reflect, FromReflect};
+/// # trait Animal {
+/// #   fn speak(&self) -> &'static str;
+/// # }
+/// #
+/// # #[derive(Reflect)]
+/// # struct Dog(String);
+/// #
+/// # impl Animal for Dog {
+/// #   fn speak(&self) -> &'static str {
+/// #     "woof"
+/// #   }
+/// # }
+/// #
+/// #[derive(Clone)]
+/// struct ReflectAnimal {
+///   speak: fn(&dyn Reflect) -> &'static str,
+/// }
+///
+/// impl ReflectAnimal {
+///   pub fn speak(&self, animal: &dyn Reflect) -> &'static str {
+///     (self.speak)(animal)
+///   }
+/// }
+///
+/// impl<T: Animal + FromReflect> TypeData<T> for ReflectAnimal {
+///   fn create_type_data() -> Self {
+///     Self {
+///       speak: |animal| {
+///         T::from_reflect(animal).unwrap().speak()
+///       }
+///     }
+///   }
+/// }
+///
+/// // Usage
+/// let dog = Dog("Fido".to_string());
+/// let data = <ReflectAnimal as TypeData<Dog>>::create_type_data();
+/// assert_eq!(data.speak(&dog), "woof");
+/// ```
+///
+/// Alternatively, we can use the [`reflect_trait`] macro to generate a type data struct for us.
+/// Note that this only works with [object-safe] traits.
+///
+/// ```
+/// # use bevy_reflect::{TypeData, Reflect, FromReflect};
+/// # use bevy_reflect_derive::reflect_trait;
+/// #[reflect_trait]
+/// trait Animal {
+///   fn speak(&self) -> &'static str;
+/// }
+///
+/// # #[derive(Reflect)]
+/// # struct Dog(String);
+/// #
+/// # impl Animal for Dog {
+/// #   fn speak(&self) -> &'static str {
+/// #     "woof"
+/// #   }
+/// # }
+/// #
+/// // Usage
+/// let dog = Dog("Fido".to_string());
+/// let data = <ReflectAnimal as TypeData<Dog>>::create_type_data();
+/// assert_eq!(data.get(&dog).unwrap().speak(), "woof");
+/// ```
+///
+/// [derive macro]: bevy_reflect_derive::Reflect
+/// [`ReflectDefault`]: crate::std_traits::ReflectDefault
+/// [`reflect_trait`]: crate::reflect_trait
+/// [object-safe]: https://doc.rust-lang.org/reference/items/traits.html#object-safety
+pub trait TypeData<T>: BaseTypeData + Clone {
+    /// Create a new instance of this type data.
+    fn create_type_data() -> Self;
+
+    /// Callback for when the type data is fully registered.
+    ///
+    /// Type data becomes fully registered in one of the following ways:
+    /// * The containing [`TypeRegistration`] is inserted into a [`TypeRegistry`]
+    /// * This type data is inserted with [`TypeRegistry::register_type_data`]
+    ///
+    /// This can be used to register additional type data when this type data is registered.
+    /// For example, to register the same data for related types or to register it
+    /// for container types (e.g. `Vec<T>`, `Option<T>`, etc).
+    ///
+    /// [`TypeRegistration`]: crate::TypeRegistration
+    #[allow(unused_variables)]
+    fn on_register(registry: &mut TypeRegistry) {}
+}

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -1,7 +1,7 @@
+use crate::type_data::{BaseTypeData, TypeData};
 use crate::{serde::Serializable, Reflect, TypeInfo, Typed};
 use bevy_ptr::{Ptr, PtrMut};
 use bevy_utils::{HashMap, HashSet};
-use downcast_rs::{impl_downcast, Downcast};
 use parking_lot::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use serde::Deserialize;
 use std::{any::TypeId, fmt::Debug, sync::Arc};
@@ -123,8 +123,16 @@ impl TypeRegistry {
         }
         self.full_name_to_id
             .insert(registration.type_name().to_string(), registration.type_id());
-        self.registrations
-            .insert(registration.type_id(), registration);
+
+        let entry = self
+            .registrations
+            .entry(registration.type_id())
+            .insert(registration);
+
+        let register_queue = entry.get().register_queue.clone();
+        for on_register in register_queue.iter().rev() {
+            on_register(self);
+        }
     }
 
     /// Registers the type data `D` for type `T`.
@@ -143,15 +151,16 @@ impl TypeRegistry {
     /// type_registry.register_type_data::<Option<String>, ReflectSerialize>();
     /// type_registry.register_type_data::<Option<String>, ReflectDeserialize>();
     /// ```
-    pub fn register_type_data<T: Reflect + 'static, D: TypeData + FromType<T>>(&mut self) {
-        let data = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
+    pub fn register_type_data<T: Reflect + 'static, D: TypeData<T>>(&mut self) {
+        let registration = self.get_mut(TypeId::of::<T>()).unwrap_or_else(|| {
             panic!(
                 "attempted to call `TypeRegistry::register_type_data` for type `{T}` with data `{D}` without registering `{T}` first",
                 T = std::any::type_name::<T>(),
                 D = std::any::type_name::<D>(),
             )
         });
-        data.insert(D::from_type());
+        registration.insert_internal(D::create_type_data());
+        D::on_register(self);
     }
 
     /// Returns a reference to the [`TypeRegistration`] of the type with the
@@ -220,7 +229,7 @@ impl TypeRegistry {
             .and_then(|id| self.registrations.get_mut(id))
     }
 
-    /// Returns a reference to the [`TypeData`] of type `T` associated with the given [`TypeId`].
+    /// Returns a reference to the [`BaseTypeData`] of type `T` associated with the given [`TypeId`].
     ///
     /// The returned value may be used to downcast [`Reflect`] trait objects to
     /// trait objects of the trait used to generate `T`, provided that the
@@ -229,16 +238,16 @@ impl TypeRegistry {
     ///
     /// If the specified type has not been registered, or if `T` is not present
     /// in its type registration, returns `None`.
-    pub fn get_type_data<T: TypeData>(&self, type_id: TypeId) -> Option<&T> {
+    pub fn get_type_data<T: BaseTypeData>(&self, type_id: TypeId) -> Option<&T> {
         self.get(type_id)
             .and_then(|registration| registration.data::<T>())
     }
 
-    /// Returns a mutable reference to the [`TypeData`] of type `T` associated with the given [`TypeId`].
+    /// Returns a mutable reference to the [`BaseTypeData`] of type `T` associated with the given [`TypeId`].
     ///
     /// If the specified type has not been registered, or if `T` is not present
     /// in its type registration, returns `None`.
-    pub fn get_type_data_mut<T: TypeData>(&mut self, type_id: TypeId) -> Option<&mut T> {
+    pub fn get_type_data_mut<T: BaseTypeData>(&mut self, type_id: TypeId) -> Option<&mut T> {
         self.get_mut(type_id)
             .and_then(|registration| registration.data_mut::<T>())
     }
@@ -283,20 +292,20 @@ impl TypeRegistryArc {
 /// an implementation of the [`GetTypeRegistration`] trait.
 ///
 /// Along with the type's [`TypeInfo`] and [short name],
-/// this struct also contains a type's registered [`TypeData`].
+/// this struct also contains a type's registered [`BaseTypeData`].
 ///
 /// See the [crate-level documentation] for more information on type registration.
 ///
 /// # Example
 ///
 /// ```
-/// # use bevy_reflect::{TypeRegistration, std_traits::ReflectDefault, FromType};
-/// let mut registration = TypeRegistration::of::<Option<String>>();
+/// # use bevy_reflect::{TypeRegistration, std_traits::ReflectDefault};
+/// let registration = TypeRegistration::of::<Option<String>>();
 ///
 /// assert_eq!("core::option::Option<alloc::string::String>", registration.type_name());
 /// assert_eq!("Option<String>", registration.short_name());
 ///
-/// registration.insert::<ReflectDefault>(FromType::<Option<String>>::from_type());
+/// let registration = registration.register::<Option<String>, ReflectDefault>();
 /// assert!(registration.data::<ReflectDefault>().is_some())
 /// ```
 ///
@@ -304,8 +313,11 @@ impl TypeRegistryArc {
 /// [crate-level documentation]: crate
 pub struct TypeRegistration {
     short_name: String,
-    data: HashMap<TypeId, Box<dyn TypeData>>,
+    data: HashMap<TypeId, Box<dyn BaseTypeData>>,
     type_info: &'static TypeInfo,
+    /// A queue of callbacks to dispatch whenever this registration is registered
+    /// into a [`TypeRegistry`].
+    register_queue: Vec<fn(&mut TypeRegistry)>,
 }
 
 impl Debug for TypeRegistration {
@@ -313,6 +325,7 @@ impl Debug for TypeRegistration {
         f.debug_struct("TypeRegistration")
             .field("short_name", &self.short_name)
             .field("type_info", &self.type_info)
+            .field("data", &self.data.values())
             .finish()
     }
 }
@@ -330,7 +343,7 @@ impl TypeRegistration {
     /// data.
     ///
     /// Returns `None` if no such value exists.
-    pub fn data<T: TypeData>(&self) -> Option<&T> {
+    pub fn data<T: BaseTypeData>(&self) -> Option<&T> {
         self.data
             .get(&TypeId::of::<T>())
             .and_then(|value| value.downcast_ref())
@@ -340,7 +353,7 @@ impl TypeRegistration {
     /// registration's type data.
     ///
     /// Returns `None` if no such value exists.
-    pub fn data_mut<T: TypeData>(&mut self) -> Option<&mut T> {
+    pub fn data_mut<T: BaseTypeData>(&mut self) -> Option<&mut T> {
         self.data
             .get_mut(&TypeId::of::<T>())
             .and_then(|value| value.downcast_mut())
@@ -351,11 +364,33 @@ impl TypeRegistration {
         self.type_info
     }
 
-    /// Inserts an instance of `T` into this registration's type data.
+    /// Inserts an instance of `D` into this registration's type data.
     ///
-    /// If another instance of `T` was previously inserted, it is replaced.
-    pub fn insert<T: TypeData>(&mut self, data: T) {
-        self.data.insert(TypeId::of::<T>(), Box::new(data));
+    /// If another instance of `D` was previously inserted, it is replaced.
+    pub fn register<T: 'static, D: TypeData<T>>(self) -> Self {
+        self.insert(D::create_type_data(), Some(D::on_register))
+    }
+
+    /// Inserts an instance of `T` into this registration's type data,
+    /// replacing any existing instance.
+    ///
+    /// This method should be used for dynamic type data that can't implement [`TypeData`].
+    /// It's preferable to use [`TypeRegistration::register`] for all other `TypeData`.
+    ///
+    /// An optional callback can be provided to modify the [`TypeRegistry`] when
+    /// this registration is registered.
+    pub fn insert<T: BaseTypeData>(
+        mut self,
+        data: T,
+        on_register: Option<fn(&mut TypeRegistry)>,
+    ) -> Self {
+        if let Some(on_register) = on_register {
+            self.register_queue.push(on_register);
+        }
+
+        self.insert_internal(data);
+
+        self
     }
 
     /// Creates type registration information for `T`.
@@ -365,6 +400,7 @@ impl TypeRegistration {
             data: HashMap::default(),
             short_name: bevy_utils::get_short_name(type_name),
             type_info: T::type_info(),
+            register_queue: Vec::new(),
         }
     }
 
@@ -381,6 +417,11 @@ impl TypeRegistration {
     pub fn type_name(&self) -> &'static str {
         self.type_info.type_name()
     }
+
+    /// Inserts the given instance of `T` into this registration's type data.
+    fn insert_internal<T: BaseTypeData>(&mut self, data: T) {
+        self.data.insert(TypeId::of::<T>(), Box::new(data));
+    }
 }
 
 impl Clone for TypeRegistration {
@@ -394,54 +435,21 @@ impl Clone for TypeRegistration {
             data,
             short_name: self.short_name.clone(),
             type_info: self.type_info,
+            register_queue: self.register_queue.clone(),
         }
     }
 }
 
-/// A trait used to type-erase type metadata.
-///
-/// Type data can be registered to the [`TypeRegistry`] and stored on a type's [`TypeRegistration`].
-///
-/// While type data is often generated using the [`#[reflect_trait]`](crate::reflect_trait) macro,
-/// almost any type that implements [`Clone`] can be considered "type data".
-/// This is because it has a blanket implementation over all `T` where `T: Clone + Send + Sync + 'static`.
-///
-/// See the [crate-level documentation] for more information on type data and type registration.
-///
-/// [crate-level documentation]: crate
-pub trait TypeData: Downcast + Send + Sync {
-    fn clone_type_data(&self) -> Box<dyn TypeData>;
-}
-impl_downcast!(TypeData);
-
-impl<T: 'static + Send + Sync> TypeData for T
-where
-    T: Clone,
-{
-    fn clone_type_data(&self) -> Box<dyn TypeData> {
-        Box::new(self.clone())
-    }
-}
-
-/// Trait used to generate [`TypeData`] for trait reflection.
-///
-/// This is used by the `#[derive(Reflect)]` macro to generate an implementation
-/// of [`TypeData`] to pass to [`TypeRegistration::insert`].
-pub trait FromType<T> {
-    fn from_type() -> Self;
-}
-
 /// A struct used to serialize reflected instances of a type.
 ///
-/// A `ReflectSerialize` for type `T` can be obtained via
-/// [`FromType::from_type`].
+/// A `ReflectSerialize` for type `T` can be obtained via [`TypeData::create_type_data`].
 #[derive(Clone)]
 pub struct ReflectSerialize {
     get_serializable: for<'a> fn(value: &'a dyn Reflect) -> Serializable,
 }
 
-impl<T: Reflect + erased_serde::Serialize> FromType<T> for ReflectSerialize {
-    fn from_type() -> Self {
+impl<T: Reflect + erased_serde::Serialize> TypeData<T> for ReflectSerialize {
+    fn create_type_data() -> Self {
         ReflectSerialize {
             get_serializable: |value| {
                 let value = value.downcast_ref::<T>().unwrap_or_else(|| {
@@ -463,7 +471,7 @@ impl ReflectSerialize {
 /// A struct used to deserialize reflected instances of a type.
 ///
 /// A `ReflectDeserialize` for type `T` can be obtained via
-/// [`FromType::from_type`].
+/// [`TypeData::create_type_data`].
 #[derive(Clone)]
 pub struct ReflectDeserialize {
     pub func: fn(
@@ -487,8 +495,8 @@ impl ReflectDeserialize {
     }
 }
 
-impl<T: for<'a> Deserialize<'a> + Reflect> FromType<T> for ReflectDeserialize {
-    fn from_type() -> Self {
+impl<T: for<'a> Deserialize<'a> + Reflect> TypeData<T> for ReflectDeserialize {
+    fn create_type_data() -> Self {
         ReflectDeserialize {
             func: |deserializer| Ok(Box::new(T::deserialize(deserializer)?)),
         }
@@ -555,8 +563,8 @@ impl ReflectFromPtr {
     }
 }
 
-impl<T: Reflect> FromType<T> for ReflectFromPtr {
-    fn from_type() -> Self {
+impl<T: Reflect> TypeData<T> for ReflectFromPtr {
+    fn create_type_data() -> Self {
         ReflectFromPtr {
             type_id: std::any::TypeId::of::<T>(),
             to_reflect: |ptr| {


### PR DESCRIPTION
# Objective

## Background

Many libraries are powered by Bevy's reflection crate. Oftentimes, they will define what's known as "type data" in order to call trait methods in a dynamic context.

For example:

```rust
trait UiButton {
  fn on_press(&self, ui: &mut UiContext);
}

#[derive(Clone)]
struct ReflectUiButton {
  on_press: fn(&dyn Reflect, &mut UiContext)
}

impl<T: Reflect + UiButton> FromType<T> for ReflectUiButton {
  fn from_type() -> Self {
    Self {
      on_press: |value, ui| {
        value.downcast_ref::<T>.unwrap().on_press(ui);
      }
    }
  }
}
```

Users can then register this type data on their types like so:

```rust
#[derive(Reflect, UiButton)]
#[reflect(UiButton)]
struct MyButton;
```

Now when we register `MyButton`, it will automatically register `ReflectUiButton`.

## Problem

While this is great for simple type data, it's not always enough for more complex traits and type data.

For example, let's modify the `UiButton` trait so that we can save and load its state. We'll do this by specifying an associated type which we can serialize into and deserialize from.

```rust
trait UiButton {
  type State: FromReflect

  // ...
}
```

Now the user needs to not only register their `MyButton` type, but also the type they use for `State`.

As the library author, we can slightly reduce this pain point by creating a helper function or extension trait:

```rust
trait UiButtonAppExt {
  fn register_ui_button<T: UiButton>(&mut self) -> &mut Self;
}

impl UiButtonAppExt for App {
  fn register_ui_button<T: UiButton>(&mut self) -> &mut Self {
    self.register_type::<T>()
      .register_type_data::<T, ReflectUiButton>()
      .register_type::<T::State>()
      // We may also need to register other types as well:
      .register_type::<Option<T::State>>()
      .register_type::<UiButtonManager<T>>()
  }
}
```

While this works, it isn't very clean and requires a bit more effort on both the library author and the user. It would be nicer if we could inject these hidden registrations into the registration for `ReflectUiButton`.

## Solution

Added a callback for when type data is registered. This allows the type data to register other kinds of type data when it itself is registered.

This callback is added to `FromType`, which has been renamed `TypeData` to make it clear what it's for.

Now we can define our `ReflectUiButton` type data like so:

```rust
impl<T: Reflect + UiButton> TypeData<T> for ReflectUiButton {
  fn create_type_data() -> Self {
    Self {
      on_press: |value, ui| {
        value.downcast_ref::<T>.unwrap().on_press(ui);
      }
    }
  }

  fn on_register(registry: &mut TypeRegistry) {
    registry
      .register_type_data::<T, ReflectUiButton>()
      .register::<T::State>()
      .register::<Option<T::State>>()
      .register::<UiButtonManager<T>>()
  }
}
```

The associated `on_register` function will be called whenever `MyButton` is registered (or whenever `ReflectUiButton` is manually registered via `register_type_data`).

### `TypeRegistration`

One issue with this approach is that users can currently get a mutable reference to the `TypeRegistration` and insert data that way. Unfortunately, this means we can't automatically dispatch the `on_register` callbacks when that happens.

To solve this issue, this PR makes it so that adding type data on a `TypeRegistration` requires ownership of that registration. This changes how type data can be added to `TypeRegistration` and also increases the number of hash lookups needed (since, presumably, users can now only manually add new type data via `TypeRegistry::register_type_data`).

Because of this...

- [ ] Should we keep this behavior? Should we revert back to the original and just leave a note telling implementors to manually dispatch these callbacks? Any other solutions?

Another option would be to have a dedicated `TypeRegistrationMut` which blocks access to those methods and then add a `TypeRegistry::scope` method to access the full `&mut TypeRegistration`.

---

## Changelog

- Renamed trait `FromType<T>` to `TypeData<T>`
  - Renamed method `FromType::<T>::from_type` to `TypeData::<T>::create_type_data`
  - Added method `TypeData::<T>::on_register`
- Type data can now register registration callbacks
- `TypeRegistration::insert` split into `TypeRegistration::insert` and `TypeRegistration::register`
  - Both `TypeRegistration::insert` and `TypeRegistration::register` take ownership

## Migration Guide

`FromType<T>` and has been renamed to `TypeData<T>` along with its methods. Implementors and callers will need to update their code.

```rust
// BEFORE
impl<T: Reflect + Foo> FromType<T> for ReflectFoo {
  fn from_type() -> Self {
    // ...
  }
}

// AFTER
impl<T: Reflect + Foo> TypeData<T> for ReflectFoo {
  fn create_type_data() -> Self {
    // ...
  }
}
```

```rust
// BEFORE
let data = <ReflectFoo as FromType<MyStruct>>::from_type();

// AFTER
let data = <ReflectFoo as TypeData<MyStruct>>::create_type_data();
```

Additionally, `TypeRegistration::insert` has been split into two methods: `TypeRegistration::insert` and `TypeRegistration::register`. `TypeRegistration::register` is the preferred way of registering data. Both methods now also require ownership of the `TypeRegistration`.

```rust
// BEFORE
let mut registration = TypeRegistration::of::<MyStruct>();
registration.insert<ReflectFoo>(FromType::<MyStruct>::from_type());
registration.insert(SomeOtherTypeData::new());

// AFTER
let registration = TypeRegistration::of::<MyStruct>()
  .register<MyStruct, ReflectFoo>()
  .insert(SomeOtherTypeData::new(), None);
```

