### PR TITLE
Rename RemovedComponents::iter/iter_with_id to read/read_with_id

### DIFF
--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -256,17 +256,6 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
     }
 }
 
-impl<'a, 'w, 's: 'a, T> IntoIterator for &'a mut RemovedComponents<'w, 's, T>
-where
-    T: Component,
-{
-    type Item = Entity;
-    type IntoIter = RemovedIter<'a>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.read()
-    }
-}
-
 // SAFETY: Only reads World removed component events
 unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentEvents {}
 

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -213,11 +213,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
     /// that happened before now.
     #[deprecated = "use `.read()` instead."]
     pub fn iter(&mut self) -> RemovedIter<'_> {
-        self.reader_mut_with_events()
-            .map(|(reader, events)| reader.read(events).cloned())
-            .into_iter()
-            .flatten()
-            .map(RemovedComponentEntity::into)
+        self.read()
     }
 
     /// Like [`read`](Self::read), except also returning the [`EventId`] of the events.
@@ -232,11 +228,7 @@ impl<'w, 's, T: Component> RemovedComponents<'w, 's, T> {
     /// Like [`iter`](Self::iter), except also returning the [`EventId`] of the events.
     #[deprecated = "use `.read_with_id()` instead."]
     pub fn iter_with_id(&mut self) -> RemovedIterWithId<'_> {
-        self.reader_mut_with_events()
-            .map(|(reader, events)| reader.read_with_id(events))
-            .into_iter()
-            .flatten()
-            .map(map_id_events)
+        self.read_with_id()
     }
 
     /// Determines the number of removal events available to be read from this [`RemovedComponents`] without consuming any.

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -943,7 +943,7 @@ pub mod common_conditions {
         // Simply checking `is_empty` would not be enough.
         // PERF: note that `count` is efficient (not actually looping/iterating),
         // due to Bevy having a specialized implementation for events.
-        move |mut removals: RemovedComponents<T>| removals.iter().count() != 0
+        move |mut removals: RemovedComponents<T>| removals.read().count() != 0
     }
 
     /// Generates a [`Condition`](super::Condition) that inverses the result of passed one.

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1172,7 +1172,7 @@ mod tests {
             mut n_systems: ResMut<NSystems>,
         ) {
             assert_eq!(
-                removed_i32.iter().collect::<Vec<_>>(),
+                removed_i32.read().collect::<Vec<_>>(),
                 &[despawned.0],
                 "despawning causes the correct entity to show up in the 'RemovedComponent' system parameter."
             );
@@ -1200,7 +1200,7 @@ mod tests {
             // The despawned entity from the previous frame was
             // double buffered so we now have it in this system as well.
             assert_eq!(
-                removed_i32.iter().collect::<Vec<_>>(),
+                removed_i32.read().collect::<Vec<_>>(),
                 &[despawned.0, removed.0],
                 "removing a component causes the correct entity to show up in the 'RemovedComponent' system parameter."
             );

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -34,7 +34,7 @@ pub fn sync_simple_transforms(
         });
     // Update orphaned entities.
     let mut query = query.p1();
-    let mut iter = query.iter_many_mut(orphaned.iter());
+    let mut iter = query.iter_many_mut(orphaned.read());
     while let Some((transform, mut global_transform)) = iter.fetch_next() {
         if !transform.is_changed() && !global_transform.is_added() {
             *global_transform = GlobalTransform::from(*transform);
@@ -57,7 +57,7 @@ pub fn propagate_transforms(
     mut orphaned_entities: Local<Vec<Entity>>,
 ) {
     orphaned_entities.clear();
-    orphaned_entities.extend(orphaned.iter());
+    orphaned_entities.extend(orphaned.read());
     orphaned_entities.sort_unstable();
     root_query.par_iter_mut().for_each(
         |(entity, children, transform, mut global_transform)| {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -281,10 +281,10 @@ pub fn ui_layout_system(
     }
 
     // clean up removed nodes
-    ui_surface.remove_entities(removed_nodes.iter());
+    ui_surface.remove_entities(removed_nodes.read());
 
     // When a `ContentSize` component is removed from an entity, we need to remove the measure from the corresponding taffy node.
-    for entity in removed_content_sizes.iter() {
+    for entity in removed_content_sizes.read() {
         ui_surface.try_remove_measure(entity);
     }
 
@@ -292,7 +292,7 @@ pub fn ui_layout_system(
     ui_surface.set_window_children(primary_window_entity, root_node_query.iter());
 
     // update and remove children
-    for entity in removed_children.iter() {
+    for entity in removed_children.read() {
         ui_surface.try_remove_children(entity);
     }
     for (entity, children) in &children_query {

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -110,7 +110,7 @@ pub(crate) fn despawn_windows(
     mut close_events: EventWriter<WindowClosed>,
     mut winit_windows: NonSendMut<WinitWindows>,
 ) {
-    for window in closed.iter() {
+    for window in closed.read() {
         info!("Closing window {:?}", window);
         // Guard to verify that the window is in fact actually gone,
         // rather than having the component added and removed in the same frame.

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -51,7 +51,7 @@ fn remove_component(
 }
 
 fn react_on_removal(mut removed: RemovedComponents<MyComponent>, mut query: Query<&mut Sprite>) {
-    // `RemovedComponents<T>::iter()` returns an iterator with the `Entity`s that had their
+    // `RemovedComponents<T>::read()` returns an iterator with the `Entity`s that had their
     // `Component` `T` (in this case `MyComponent`) removed at some point earlier during the frame.
     for entity in &mut removed {
         if let Ok(mut sprite) = query.get_mut(entity) {

--- a/examples/ecs/removal_detection.rs
+++ b/examples/ecs/removal_detection.rs
@@ -53,7 +53,7 @@ fn remove_component(
 fn react_on_removal(mut removed: RemovedComponents<MyComponent>, mut query: Query<&mut Sprite>) {
     // `RemovedComponents<T>::read()` returns an iterator with the `Entity`s that had their
     // `Component` `T` (in this case `MyComponent`) removed at some point earlier during the frame.
-    for entity in &mut removed {
+    for entity in removed.read() {
         if let Ok(mut sprite) = query.get_mut(entity) {
             sprite.color.set_r(0.0);
         }


### PR DESCRIPTION
# Objective

Rename RemovedComponents::iter/iter_with_id to read/read_with_id to make it clear that it consume the data

Fixes #9755.

(It's my first pull request, if i've made any mistake, please let me know)

## Solution

Refactor RemovedComponents::iter/iter_with_id to read/read_with_id



## Changelog

Refactor RemovedComponents::iter/iter_with_id to read/read_with_id

Deprecate RemovedComponents::iter/iter_with_id

Remove IntoIterator implementation

Update removal_detection example accordingly

---

## Migration Guide

Rename calls of RemovedComponents::iter/iter_with_id to  read/read_with_id

Replace IntoIterator iteration (&mut <RemovedComponents>) with .read()