### PR TITLE
Implement `Reflect` for `Mesh`

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -15,7 +15,7 @@ use bevy_derive::EnumVariantMeta;
 use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
 use bevy_log::warn;
 use bevy_math::*;
-use bevy_reflect::TypePath;
+use bevy_reflect::Reflect;
 use bevy_utils::{tracing::error, Hashed};
 use std::{collections::BTreeMap, hash::Hash, iter::FusedIterator};
 use thiserror::Error;
@@ -110,13 +110,15 @@ pub const VERTEX_ATTRIBUTE_BUFFER_ID: u64 = 10;
 /// is the side of the triangle from where the vertices appear in a *counter-clockwise* order.
 ///
 // TODO: allow values to be unloaded after been submitting to the GPU to conserve memory
-#[derive(Asset, Debug, TypePath, Clone)]
+#[derive(Asset, Debug, Clone, Reflect)]
 pub struct Mesh {
+    #[reflect(ignore)]
     primitive_topology: PrimitiveTopology,
     /// `std::collections::BTreeMap` with all defined vertex attributes (Positions, Normals, ...)
     /// for this mesh. Attribute ids to attribute values.
     /// Uses a BTreeMap because, unlike HashMap, it has a defined iteration order,
     /// which allows easy stable VertexBuffers (i.e. same buffer order)
+    #[reflect(ignore)]
     attributes: BTreeMap<MeshVertexAttributeId, MeshAttributeData>,
     indices: Option<Indices>,
     morph_targets: Option<Handle<Image>>,
@@ -834,7 +836,7 @@ impl From<&VertexAttributeValues> for VertexFormat {
 /// An array of indices into the [`VertexAttributeValues`] for a mesh.
 ///
 /// It describes the order in which the vertex attributes should be joined into faces.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Reflect)]
 pub enum Indices {
     U16(Vec<u16>),
     U32(Vec<u32>),

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -18,6 +18,7 @@ impl Plugin for MeshPlugin {
     fn build(&self, app: &mut App) {
         app.init_asset::<Mesh>()
             .init_asset::<skinning::SkinnedMeshInverseBindposes>()
+            .register_asset_reflect::<Mesh>()
             .register_type::<skinning::SkinnedMesh>()
             .register_type::<Vec<Entity>>()
             // 'Mesh' must be prepared after 'Image' as meshes rely on the morph target image being ready

--- a/crates/bevy_render/src/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mod.rs
@@ -8,7 +8,7 @@ pub use mesh::*;
 
 use crate::{prelude::Image, render_asset::RenderAssetPlugin};
 use bevy_app::{App, Plugin};
-use bevy_asset::AssetApp;
+use bevy_asset::{AssetApp, Handle};
 use bevy_ecs::entity::Entity;
 
 /// Adds the [`Mesh`] as an asset and makes sure that they are extracted and prepared for the GPU.
@@ -19,6 +19,10 @@ impl Plugin for MeshPlugin {
         app.init_asset::<Mesh>()
             .init_asset::<skinning::SkinnedMeshInverseBindposes>()
             .register_asset_reflect::<Mesh>()
+            .register_type::<Option<Handle<Image>>>()
+            .register_type::<Option<Vec<String>>>()
+            .register_type::<Option<Indices>>()
+            .register_type::<Indices>()
             .register_type::<skinning::SkinnedMesh>()
             .register_type::<Vec<Entity>>()
             // 'Mesh' must be prepared after 'Image' as meshes rely on the morph target image being ready


### PR DESCRIPTION
# Objective

- I want to associate `TypeData` with `Mesh`, to make it editable/inspectable in my reflection-based editor. `Mesh` has to implement `Reflect` for that. The precise reflection behavior does not matter.

## Solution

- `#[derive(Reflect)]`, ignore fields whose types aren't reflectable.
- Call `App::register_asset_reflect` in the `MeshPlugin`.

---

## Changelog

- `Mesh` now implements `Reflect`.