### PR TITLE
Fix `lines.rs` example for WebGL

### DIFF
--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -1,14 +1,12 @@
 //! Create a custom material to draw basic lines in 3D
 
 use bevy::{
-    pbr::{MaterialPipeline, MaterialPipelineKey},
     prelude::*,
     reflect::TypePath,
     render::{
-        mesh::{MeshVertexBufferLayout, PrimitiveTopology},
+        mesh::{PrimitiveTopology},
         render_resource::{
-            AsBindGroup, PolygonMode, RenderPipelineDescriptor, ShaderRef,
-            SpecializedMeshPipelineError,
+            AsBindGroup, ShaderRef,
         },
     },
 };
@@ -70,17 +68,6 @@ struct LineMaterial {
 impl Material for LineMaterial {
     fn fragment_shader() -> ShaderRef {
         "shaders/line_material.wgsl".into()
-    }
-
-    fn specialize(
-        _pipeline: &MaterialPipeline<Self>,
-        descriptor: &mut RenderPipelineDescriptor,
-        _layout: &MeshVertexBufferLayout,
-        _key: MaterialPipelineKey<Self>,
-    ) -> Result<(), SpecializedMeshPipelineError> {
-        // This is the important part to tell bevy to render this material as a line between vertices
-        descriptor.primitive.polygon_mode = PolygonMode::Line;
-        Ok(())
     }
 }
 

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -4,10 +4,8 @@ use bevy::{
     prelude::*,
     reflect::TypePath,
     render::{
-        mesh::{PrimitiveTopology},
-        render_resource::{
-            AsBindGroup, ShaderRef,
-        },
+        mesh::PrimitiveTopology,
+        render_resource::{AsBindGroup, ShaderRef},
     },
 };
 


### PR DESCRIPTION
# Objective

The [`3d/lines`](https://bevyengine.org/examples/3D%20Rendering/lines/) example doesn't work on WebGL (at least on all 3 major browser on macOS), and generates the following error:

```
[Error] panicked at 'wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `opaque_mesh_pipeline`
    Features Features(POLYGON_MODE_LINE) are required but not enabled on the device
```

This is due to setting the `RenderPipelineDescriptor`'s `descriptor.primitive.polygon_mode` to `PolygonMode::Line`, which requires `POLYGON_MODE_LINE`. This extension is [unsupported](https://wgpu.rs/doc/wgpu/struct.Features.html#associatedconstant.POLYGON_MODE_LINE) on WebGL.

Note that contrary to what wgpu's docs currently indicates (https://github.com/gfx-rs/wgpu/issues/4131), `POLYGON_MODE_LINE` _is_ supported on WebGPU, and indeed the [WebGPU `3d/lines`](https://bevyengine.org/examples-webgpu/3D%20Rendering/lines/) example works properly.

## Solution

The solution is to leave the `polygon_mode` to it's default (`PolygonMode::Fill`), with doesn't affect the rendering of this examples which is exclusively based on `PrimitiveTopology::LineList`.

I've tested this on all 3 major browsers, as well as native on macOS.
