### PR TITLE
doc: Remove reference to `clippy::manual-strip`.

### DIFF
--- a/docs/linters.md
+++ b/docs/linters.md
@@ -13,7 +13,7 @@ cargo fmt --all
 Can be automatically run with [`cargo run -p ci`](../tools/ci) (which also runs other checks) or manually with this command:
 
 ```bash
-cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity -A clippy::manual-strip
+cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity
 ```
 
 Explanation:


### PR DESCRIPTION
This should have been removed in 8a9f475edb51ea45c976c000113ca55bac751f96 when the rest of the references to / usages of `clippy::manual-strip` were removed. It was originally needed in the long ago past when supporting Rust 1.45 was a concern.

# Objective

- Docs on linting should match the actual current practice.
- Docs currently mention `-A clippy::manual-strip` which hasn't been needed in a long time.

## Solution

- Remove reference to `-A clippy::manual-strip`.