### PR TITLE
Allow `clippy::type_complexity` in more places.

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::type_complexity)]
+
 pub mod io;
 pub mod meta;
 pub mod processor;

--- a/docs/linters.md
+++ b/docs/linters.md
@@ -13,13 +13,12 @@ cargo fmt --all
 Can be automatically run with [`cargo run -p ci`](../tools/ci) (which also runs other checks) or manually with this command:
 
 ```bash
-cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::type_complexity
+cargo clippy --workspace --all-targets --all-features -- -D warnings
 ```
 
 Explanation:
 
 * `-D warnings`: No warnings are allowed in the codebase.
-* `-A clippy::type_complexity`: type complexity must be ignored because we use huge templates for queries.
 
 ## [super-linter](https://github.com/github/super-linter)
 

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -1,5 +1,9 @@
 //! This example compares MSAA (Multi-Sample Anti-aliasing), FXAA (Fast Approximate Anti-aliasing), and TAA (Temporal Anti-aliasing).
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use std::f32::consts::PI;
 
 use bevy::{

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -1,5 +1,9 @@
 //! Demonstrates how to prevent meshes from casting/receiving shadows in a 3d scene.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use std::f32::consts::PI;
 
 use bevy::{

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -1,5 +1,9 @@
 //! A scene showcasing screen space ambient occlusion.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{
     core_pipeline::experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin},
     pbr::{

--- a/examples/ecs/custom_query_param.rs
+++ b/examples/ecs/custom_query_param.rs
@@ -12,6 +12,10 @@
 //!
 //! For more details on the `WorldQuery` derive macro, see the trait documentation.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{ecs::query::WorldQuery, prelude::*};
 use std::fmt::Debug;
 

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -5,6 +5,10 @@
 //!
 //! In this case, we're transitioning from a `Menu` state to an `InGame` state.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::prelude::*;
 
 fn main() {

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -1,5 +1,9 @@
 //! Eat the cakes. Eat them all. An example 3D game.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use std::f32::consts::PI;
 
 use bevy::prelude::*;

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -2,6 +2,10 @@
 //! change some settings or quit. There is no actual game, it will just display the current
 //! settings for 5 seconds before going back to the menu.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::prelude::*;
 
 const TEXT_COLOR: Color = Color::rgb(0.9, 0.9, 0.9);

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -4,6 +4,10 @@
 //! Clicking toggle IME (Input Method Editor) support, but the font used as limited support of characters.
 //! You should change the provided font with another one to test other languages input.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{input::keyboard::KeyboardInput, prelude::*};
 
 fn main() {

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -1,3 +1,7 @@
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
 
 // the `bevy_main` proc_macro generates the required boilerplate for iOS and Android

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -3,6 +3,10 @@
 //! - Copy the code for the `SceneViewerPlugin` and add the plugin to your App.
 //! - Insert an initialized `SceneHandle` resource into your App's `AssetServer`.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{
     asset::LoadState, gltf::Gltf, input::common_conditions::input_just_pressed, prelude::*,
     scene::InstanceId,

--- a/examples/ui/button.rs
+++ b/examples/ui/button.rs
@@ -1,6 +1,10 @@
 //! This example illustrates how to create a button that changes color and text based on its
 //! interaction state.
 
+// This lint usually gives bad advice in the context of Bevy -- hiding complex queries behind
+// type aliases tends to obfuscate code while offering no improvement in code cleanliness.
+#![allow(clippy::type_complexity)]
+
 use bevy::{prelude::*, winit::WinitSettings};
 
 fn main() {

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,8 +17,7 @@ bitflags! {
     }
 }
 
-const CLIPPY_FLAGS: [&str; 7] = [
-    "-Aclippy::type_complexity",
+const CLIPPY_FLAGS: [&str; 6] = [
     "-Wclippy::doc_markdown",
     "-Wclippy::redundant_else",
     "-Wclippy::match_same_arms",


### PR DESCRIPTION
# Objective

- See fewer warnings when running `cargo clippy` locally.

## Solution

- allow `clippy::type_complexity` in more places, which also signals to users they should do the same.
