### PR TITLE
Unified identifer for entities & relations

### DIFF
--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,4 +1,8 @@
-use crate::{entity::Entity, identifier::masks::IdentifierMask, world::World};
+use crate::{
+    entity::Entity,
+    identifier::masks::{IdentifierMask, HIGH_MASK},
+    world::World,
+};
 use bevy_utils::EntityHashMap;
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.
@@ -72,7 +76,9 @@ impl<'m> EntityMapper<'m> {
             self.dead_start.index(),
             IdentifierMask::inc_masked_high_by(self.dead_start.generation, self.generations),
         );
-        self.generations += 1;
+
+        // Prevent generations counter from being a greater value than HIGH_MASK.
+        self.generations = (self.generations + 1) & HIGH_MASK;
 
         self.map.insert(entity, new);
 

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -68,7 +68,7 @@ impl<'m> EntityMapper<'m> {
         }
 
         // this new entity reference is specifically designed to never represent any living entity
-        let new = Entity::new(
+        let new = Entity::from_raw_and_generation(
             self.dead_start.index(),
             IdentifierMask::inc_masked_high_by(self.dead_start.generation, self.generations),
         );

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -1,7 +1,5 @@
-use crate::{entity::Entity, world::World};
+use crate::{entity::Entity, identifier::masks::IdentifierMask, world::World};
 use bevy_utils::EntityHashMap;
-
-use super::inc_generation_by;
 
 /// Operation to map all contained [`Entity`] fields in a type to new values.
 ///
@@ -70,10 +68,10 @@ impl<'m> EntityMapper<'m> {
         }
 
         // this new entity reference is specifically designed to never represent any living entity
-        let new = Entity {
-            generation: inc_generation_by(self.dead_start.generation, self.generations),
-            index: self.dead_start.index,
-        };
+        let new = Entity::new(
+            self.dead_start.index(),
+            IdentifierMask::inc_masked_high_by(self.dead_start.generation, self.generations),
+        );
         self.generations += 1;
 
         self.map.insert(entity, new);
@@ -109,7 +107,7 @@ impl<'m> EntityMapper<'m> {
         // SAFETY: Entities data is kept in a valid state via `EntityMap::world_scope`
         let entities = unsafe { world.entities_mut() };
         assert!(entities.free(self.dead_start).is_some());
-        assert!(entities.reserve_generations(self.dead_start.index, self.generations));
+        assert!(entities.reserve_generations(self.dead_start.index(), self.generations));
     }
 
     /// Creates an [`EntityMapper`] from a provided [`World`] and [`EntityHashMap<Entity, Entity>`], then calls the

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -42,7 +42,7 @@ pub use map_entities::*;
 
 use crate::{
     archetype::{ArchetypeId, ArchetypeRow},
-    identifier::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask, Identifier},
+    identifier::{error::IdentifierError, kinds::IdKind, masks::{IdentifierMask, HIGH_MASK}, Identifier},
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use serde::{Deserialize, Serialize};
@@ -189,8 +189,12 @@ pub(crate) enum AllocAtWithoutReplacement {
 }
 
 impl Entity {
+    /// Construct an [`Entity`] from a raw `index` value and a non-zero `generation` value.
+    /// Ensure that the generation value is never greater than `0x7FFF_FFFF`.
     #[inline(always)]
     pub(crate) const fn from_raw_and_generation(index: u32, generation: NonZeroU32) -> Entity {
+        debug_assert!(generation.get() <= HIGH_MASK);
+
         Self { index, generation }
     }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -42,7 +42,12 @@ pub use map_entities::*;
 
 use crate::{
     archetype::{ArchetypeId, ArchetypeRow},
-    identifier::{error::IdentifierError, kinds::IdKind, masks::{IdentifierMask, HIGH_MASK}, Identifier},
+    identifier::{
+        error::IdentifierError,
+        kinds::IdKind,
+        masks::{IdentifierMask, HIGH_MASK},
+        Identifier,
+    },
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_ecs/src/identifier/error.rs
+++ b/crates/bevy_ecs/src/identifier/error.rs
@@ -1,0 +1,29 @@
+//! Error types for [`super::Identifier`] conversions. An ID can be converted
+//! to various kinds, but these can fail if they are not valid forms of those
+//! kinds. The error type in this module encapsulates the various failure modes.
+use std::fmt;
+
+/// An  Error type for [`super::Identifier`], mostly for providing error
+/// handling for convertions of an ID to a type abstracting over the ID bits.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[non_exhaustive]
+pub enum IdentifierError {
+    /// A given ID has an invalid value for initialising to a [`crate::identifier::Identifier`].
+    InvalidIdentifier,
+    /// A given ID has an invalid configuration of bits for converting to an [`crate::entity::Entity`].
+    InvalidEntityId(u64),
+}
+
+impl fmt::Display for IdentifierError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidIdentifier => write!(
+                f,
+                "The given id contains a zero value high component, which is invalid"
+            ),
+            Self::InvalidEntityId(_) => write!(f, "The given id is not a valid entity."),
+        }
+    }
+}
+
+impl std::error::Error for IdentifierError {}

--- a/crates/bevy_ecs/src/identifier/kinds.rs
+++ b/crates/bevy_ecs/src/identifier/kinds.rs
@@ -1,0 +1,11 @@
+/// The kinds of ID that [`super::Identifier`] can represent. Each
+/// variant imposes different usages of the low/high segments
+/// of the ID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[repr(u8)]
+pub enum IdKind {
+    /// An ID variant that is compatible with [`crate::entity::Entity`].
+    Entity = 0,
+    /// A future ID variant.
+    Placeholder = 0b1000_0000,
+}

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -5,7 +5,7 @@ use super::kinds::IdKind;
 /// Mask for extracting the value portion of a 32-bit high segment. This
 /// yields 31-bits of total value, as the final bit (the most significant)
 /// is reserved as a flag bit. Can be negated to extract the flag bit.
-const HIGH_MASK: u32 = 0x7FFF_FFFF;
+pub(crate) const HIGH_MASK: u32 = 0x7FFF_FFFF;
 
 /// Abstraction over masks needed to extract values/components of an [`super::Identifier`].
 pub(crate) struct IdentifierMask;

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -1,0 +1,234 @@
+use std::num::NonZeroU32;
+
+use super::kinds::IdKind;
+
+/// Mask for extracting the lower 32-bit segment of a `u64` value. Can be
+/// negated to extract the higher 32-bit segment.
+const LOW_MASK: u64 = 0x0000_0000_FFFF_FFFF;
+/// Mask for extracting the value portion of a 32-bit high segment. This
+/// yields 31-bits of total value, as the final bit (the most significant)
+/// is reserved as a flag bit. Can be negated to extract the flag bit.
+const HIGH_MASK: u32 = 0x7FFF_FFFF;
+
+/// Abstraction over masks needed to extract values/components of an [`super::Identifier`].
+pub(crate) struct IdentifierMask;
+
+impl IdentifierMask {
+    /// Returns the low component from a `u64` value
+    #[inline(always)]
+    pub(crate) const fn get_low(value: u64) -> u32 {
+        (value & LOW_MASK) as u32
+    }
+
+    /// Returns the high component from a `u64` value
+    #[inline(always)]
+    pub(crate) const fn get_high(value: u64) -> u32 {
+        ((value & !LOW_MASK) >> u32::BITS) as u32
+    }
+
+    /// Pack a low and high `u32` values into a single `u64` value.
+    #[inline(always)]
+    pub(crate) const fn pack_into_u64(low: u32, high: u32) -> u64 {
+        ((high as u64) << u32::BITS) | (low as u64)
+    }
+
+    /// Pack the [`IdKind`] bits into a high segment.
+    #[inline(always)]
+    pub(crate) const fn pack_kind_into_high(value: u32, kind: IdKind) -> u32 {
+        value | ((kind as u32) << 24)
+    }
+
+    /// Extract the value component from a high segment of an [`super::Identifier`].
+    #[inline(always)]
+    pub(crate) const fn extract_value_from_high(value: u32) -> u32 {
+        value & HIGH_MASK
+    }
+
+    /// Extract the ID kind component from a high segment of an [`super::Identifier`].
+    #[inline(always)]
+    pub(crate) const fn extract_kind_from_high(value: u32) -> IdKind {
+        // The negated HIGH_MASK will extract just the bit we need for kind.
+        let kind_mask = !HIGH_MASK;
+        let bit = value & kind_mask;
+
+        if bit == kind_mask {
+            IdKind::Placeholder
+        } else {
+            IdKind::Entity
+        }
+    }
+
+    /// Offsets a masked generation value by the specified amount, wrapping to 1 instead of 0.
+    /// Will never be greater than [`HIGH_MASK`] or less than `1`, and increments are masked to
+    /// never be greater than [`HIGH_MASK`].
+    #[inline(always)]
+    pub(crate) const fn inc_masked_high_by(lhs: NonZeroU32, rhs: u32) -> NonZeroU32 {
+        let lo = (lhs.get() & HIGH_MASK).wrapping_add(rhs & HIGH_MASK);
+        // Checks high 32 bit for whether we have overflowed 31 bits.
+        let overflowed = lo >> 31;
+
+        // SAFETY:
+        // - Adding the overflow flag will offet overflows to start at 1 instead of 0
+        // - The sum of `0x7FFF_FFFF` + `u32::MAX` + 1 (overflow) == `0x7FFF_FFFF`
+        // - If the operation doesn't overflow at 31 bits, no offsetting takes place
+        unsafe { NonZeroU32::new_unchecked(lo.wrapping_add(overflowed) & HIGH_MASK) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn get_u64_parts() {
+        // Two distinct bit patterns per low/high component
+        let value: u64 = 0x7FFF_FFFF_0000_000C;
+
+        assert_eq!(IdentifierMask::get_low(value), 0x0000_000C);
+        assert_eq!(IdentifierMask::get_high(value), 0x7FFF_FFFF);
+    }
+
+    #[test]
+    fn extract_kind() {
+        // All bits are ones.
+        let high: u32 = 0xFFFF_FFFF;
+
+        assert_eq!(
+            IdentifierMask::extract_kind_from_high(high),
+            IdKind::Placeholder
+        );
+
+        // Second and second to last bits are ones.
+        let high: u32 = 0x4000_0002;
+
+        assert_eq!(IdentifierMask::extract_kind_from_high(high), IdKind::Entity);
+    }
+
+    #[test]
+    fn extract_high_value() {
+        // All bits are ones.
+        let high: u32 = 0xFFFF_FFFF;
+
+        // Excludes the most significant bit as that is a flag bit.
+        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x7FFF_FFFF);
+
+        // Start bit and end bit are ones.
+        let high: u32 = 0x8000_0001;
+
+        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x0000_0001);
+
+        // Classic bit pattern.
+        let high: u32 = 0xDEAD_BEEF;
+
+        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x5EAD_BEEF);
+    }
+
+    #[test]
+    fn pack_kind_bits() {
+        // All bits are ones expect the most significant bit, which is zero
+        let high: u32 = 0x7FFF_FFFF;
+
+        assert_eq!(
+            IdentifierMask::pack_kind_into_high(high, IdKind::Placeholder),
+            0xFFFF_FFFF
+        );
+
+        // Arbitrary bit pattern
+        let high: u32 = 0x00FF_FF00;
+
+        assert_eq!(
+            IdentifierMask::pack_kind_into_high(high, IdKind::Entity),
+            // Remains unchanged as before
+            0x00FF_FF00
+        );
+
+        // Bit pattern that almost spells a word
+        let high: u32 = 0x40FF_EEEE;
+
+        assert_eq!(
+            IdentifierMask::pack_kind_into_high(high, IdKind::Placeholder),
+            0xC0FF_EEEE // Milk and no sugar, please.
+        );
+    }
+
+    #[test]
+    fn pack_into_u64() {
+        let high: u32 = 0x7FFF_FFFF;
+        let low: u32 = 0x0000_00CC;
+
+        assert_eq!(
+            IdentifierMask::pack_into_u64(low, high),
+            0x7FFF_FFFF_0000_00CC
+        );
+    }
+
+    #[test]
+    fn incrementing_masked_nonzero_high_is_safe() {
+        // Adding from lowest value with lowest to highest increment
+        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        assert_eq!(
+            NonZeroU32::MIN,
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 0)
+        );
+        assert_eq!(
+            NonZeroU32::new(2).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 1)
+        );
+        assert_eq!(
+            NonZeroU32::new(3).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 2)
+        );
+        assert_eq!(
+            NonZeroU32::MIN,
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, HIGH_MASK)
+        );
+        assert_eq!(
+            NonZeroU32::MIN,
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, u32::MAX)
+        );
+        // Adding from absolute highest value with lowest to highest increment
+        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 0)
+        );
+        assert_eq!(
+            NonZeroU32::MIN,
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 1)
+        );
+        assert_eq!(
+            NonZeroU32::new(2).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 2)
+        );
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, HIGH_MASK)
+        );
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, u32::MAX)
+        );
+        // Adding from actual highest value with lowest to highest increment
+        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 0)
+        );
+        assert_eq!(
+            NonZeroU32::MIN,
+            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 1)
+        );
+        assert_eq!(
+            NonZeroU32::new(2).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 2)
+        );
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), HIGH_MASK)
+        );
+        assert_eq!(
+            NonZeroU32::new(HIGH_MASK).unwrap(),
+            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), u32::MAX)
+        );
+    }
+}

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -2,9 +2,6 @@ use std::num::NonZeroU32;
 
 use super::kinds::IdKind;
 
-/// Mask for extracting the lower 32-bit segment of a `u64` value. Can be
-/// negated to extract the higher 32-bit segment.
-const LOW_MASK: u64 = 0x0000_0000_FFFF_FFFF;
 /// Mask for extracting the value portion of a 32-bit high segment. This
 /// yields 31-bits of total value, as the final bit (the most significant)
 /// is reserved as a flag bit. Can be negated to extract the flag bit.
@@ -17,13 +14,15 @@ impl IdentifierMask {
     /// Returns the low component from a `u64` value
     #[inline(always)]
     pub(crate) const fn get_low(value: u64) -> u32 {
-        (value & LOW_MASK) as u32
+        // This will truncate to the lowest 32 bits
+        value as u32
     }
 
     /// Returns the high component from a `u64` value
     #[inline(always)]
     pub(crate) const fn get_high(value: u64) -> u32 {
-        ((value & !LOW_MASK) >> u32::BITS) as u32
+        // This will discard the lowest 32 bits
+        (value >> u32::BITS) as u32
     }
 
     /// Pack a low and high `u32` values into a single `u64` value.

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -218,7 +218,7 @@ mod tests {
         assert!(Identifier::new(123, 789, IdKind::Entity).unwrap() != Identifier::new(123, 456, IdKind::Entity).unwrap());
         assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() != Identifier::new(123, 789, IdKind::Entity).unwrap());
         assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() != Identifier::new(456, 123, IdKind::Entity).unwrap());
-        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap()!= Identifier::new(123, 456, IdKind::Placeholder).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() != Identifier::new(123, 456, IdKind::Placeholder).unwrap());
 
         // ordering is by flag then high then by low
 
@@ -235,7 +235,7 @@ mod tests {
 
         assert!(Identifier::new(1, 1, IdKind::Entity).unwrap() < Identifier::new(2, 1, IdKind::Entity).unwrap());
         assert!(Identifier::new(1, 1, IdKind::Entity).unwrap() <= Identifier::new(2, 1, IdKind::Entity).unwrap());
-        assert!(Identifier::new(2, 2, IdKind::Entity).unwrap()> Identifier::new(1, 2, IdKind::Entity).unwrap());
+        assert!(Identifier::new(2, 2, IdKind::Entity).unwrap() > Identifier::new(1, 2, IdKind::Entity).unwrap());
         assert!(Identifier::new(2, 2, IdKind::Entity).unwrap() >= Identifier::new(1, 2, IdKind::Entity).unwrap());
     }
 }

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -1,0 +1,241 @@
+//! A module for the unified [`Identifier`] ID struct, for use as a representation
+//! of multiple types of IDs in a single, packed type. Allows for describing an [`crate::entity::Entity`],
+//! or other IDs that can be packed and expressed within a `u64` sized type.
+//! [`Identifier`]s cannot be created directly, only able to be converted from other
+//! compatible IDs.
+use self::{error::IdentifierError, kinds::IdKind, masks::IdentifierMask};
+use std::{hash::Hash, num::NonZeroU32};
+
+pub mod error;
+pub(crate) mod kinds;
+pub(crate) mod masks;
+
+/// A unified identifier for all entity and similar IDs.
+/// Has the same size as a `u64` integer, but the layout is split between a 32-bit low
+/// segment, a 31-bit high segment, and the significant bit reserved as type flags to denote
+/// entity kinds.
+#[derive(Debug, Clone, Copy)]
+// Alignment repr necessary to allow LLVM to better output
+// optimised codegen for `to_bits`, `PartialEq` and `Ord`.
+#[repr(C, align(8))]
+pub struct Identifier {
+    // Do not reorder the fields here. The ordering is explicitly used by repr(C)
+    // to make this struct equivalent to a u64.
+    #[cfg(target_endian = "little")]
+    low: u32,
+    high: NonZeroU32,
+    #[cfg(target_endian = "big")]
+    low: u32,
+}
+
+impl Identifier {
+    /// Construct a new [`Identifier`]. The `high` parameter is masked with the
+    /// `kind` so to pack the high value and bit flags into the same field.
+    #[inline(always)]
+    pub const fn new(low: u32, high: u32, kind: IdKind) -> Result<Self, IdentifierError> {
+        // the high bits are masked to cut off the most significant bit
+        // as these are used for the type flags. This means that the high
+        // portion is only 31 bits, but this still provides 2^31
+        // values/kinds/ids that can be stored in this segment.
+        let masked_value = IdentifierMask::extract_value_from_high(high);
+
+        let packed_high = IdentifierMask::pack_kind_into_high(masked_value, kind);
+
+        // If the packed high component ends up being zero, that means that we tried
+        // to initialise an Identifier into an invalid state.
+        if packed_high == 0 {
+            Err(IdentifierError::InvalidIdentifier)
+        } else {
+            // SAFETY: The high value has been checked to ensure it is never
+            // zero.
+            unsafe {
+                Ok(Self {
+                    low,
+                    high: NonZeroU32::new_unchecked(packed_high),
+                })
+            }
+        }
+    }
+
+    /// Returns the value of the low segment of the [`Identifier`].
+    #[inline(always)]
+    pub const fn low(self) -> u32 {
+        self.low
+    }
+
+    /// Returns the value of the high segment of the [`Identifier`]. This
+    /// does not apply any masking.
+    #[inline(always)]
+    pub const fn high(self) -> NonZeroU32 {
+        self.high
+    }
+
+    /// Returns the masked value of the high segment of the [`Identifier`].
+    /// Does not include the flag bits.
+    #[inline(always)]
+    pub const fn masked_high(self) -> u32 {
+        IdentifierMask::extract_value_from_high(self.high.get())
+    }
+
+    /// Returns the kind of [`Identifier`] from the high segment.
+    #[inline(always)]
+    pub const fn kind(self) -> IdKind {
+        IdentifierMask::extract_kind_from_high(self.high.get())
+    }
+
+    /// Convert the [`Identifier`] into a `u64`.
+    #[inline(always)]
+    pub const fn to_bits(self) -> u64 {
+        IdentifierMask::pack_into_u64(self.low, self.high.get())
+    }
+
+    /// Convert a `u64` into an [`Identifier`].
+    ///
+    /// # Panics
+    ///
+    /// This method will likely panic if given `u64` values that did not come from [`Identifier::to_bits`].
+    #[inline(always)]
+    pub const fn from_bits(value: u64) -> Self {
+        let id = Self::try_from_bits(value);
+
+        match id {
+            Ok(id) => id,
+            Err(_) => panic!("Attempted to initialise invalid bits as an id"),
+        }
+    }
+
+    /// Convert a `u64` into an [`Identifier`].
+    ///
+    /// This method is the fallible counterpart to [`Identifier::from_bits`].
+    #[inline(always)]
+    pub const fn try_from_bits(value: u64) -> Result<Self, IdentifierError> {
+        let high = NonZeroU32::new(IdentifierMask::get_high(value));
+
+        match high {
+            Some(high) => Ok(Self {
+                low: IdentifierMask::get_low(value),
+                high,
+            }),
+            None => Err(IdentifierError::InvalidIdentifier),
+        }
+    }
+}
+
+// By not short-circuiting in comparisons, we get better codegen.
+// See <https://github.com/rust-lang/rust/issues/117800>
+impl PartialEq for Identifier {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        // By using `to_bits`, the codegen can be optimised out even
+        // further potentially. Relies on the correct alignment/field
+        // order of `Entity`.
+        self.to_bits() == other.to_bits()
+    }
+}
+
+impl Eq for Identifier {}
+
+// The derive macro codegen output is not optimal and can't be optimised as well
+// by the compiler. This impl resolves the issue of non-optimal codegen by relying
+// on comparing against the bit representation of `Entity` instead of comparing
+// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// far beyond what the derive macro can.
+// See <https://github.com/rust-lang/rust/issues/106107>
+impl PartialOrd for Identifier {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // Make use of our `Ord` impl to ensure optimal codegen output
+        Some(self.cmp(other))
+    }
+}
+
+// The derive macro codegen output is not optimal and can't be optimised as well
+// by the compiler. This impl resolves the issue of non-optimal codegen by relying
+// on comparing against the bit representation of `Entity` instead of comparing
+// the fields. The result is then LLVM is able to optimise the codegen for Entity
+// far beyond what the derive macro can.
+// See <https://github.com/rust-lang/rust/issues/106107>
+impl Ord for Identifier {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // This will result in better codegen for ordering comparisons, plus
+        // avoids pitfalls with regards to macro codegen relying on property
+        // position when we want to compare against the bit representation.
+        self.to_bits().cmp(&other.to_bits())
+    }
+}
+
+impl Hash for Identifier {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.to_bits().hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_construction() {
+        let id = Identifier::new(12, 55, IdKind::Entity).unwrap();
+
+        assert_eq!(id.low(), 12);
+        assert_eq!(id.high().get(), 55);
+        assert_eq!(
+            IdentifierMask::extract_kind_from_high(id.high().get()),
+            IdKind::Entity
+        );
+    }
+
+    #[test]
+    fn from_bits() {
+        // This high value should correspond to the max high() value
+        // and also Entity flag.
+        let high = 0x7FFFFFFF;
+        let low = 0xC;
+        let bits: u64 = high << u32::BITS | low;
+
+        let id = Identifier::try_from_bits(bits).unwrap();
+
+        assert_eq!(id.to_bits(), 0x7FFFFFFF0000000C);
+        assert_eq!(id.low(), low as u32);
+        assert_eq!(id.high().get(), 0x7FFFFFFF);
+        assert_eq!(
+            IdentifierMask::extract_kind_from_high(id.high().get()),
+            IdKind::Entity
+        );
+    }
+
+    #[rustfmt::skip]
+    #[test]
+    fn id_comparison() {
+        // This is intentionally testing `lt` and `ge` as separate functions.
+        #![allow(clippy::nonminimal_bool)]
+
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() == Identifier::new(123, 456, IdKind::Entity).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Placeholder).unwrap() == Identifier::new(123, 456, IdKind::Placeholder).unwrap());
+        assert!(Identifier::new(123, 789, IdKind::Entity).unwrap() != Identifier::new(123, 456, IdKind::Entity).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() != Identifier::new(123, 789, IdKind::Entity).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() != Identifier::new(456, 123, IdKind::Entity).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap()!= Identifier::new(123, 456, IdKind::Placeholder).unwrap());
+
+        // ordering is by flag then high then by low
+
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() >= Identifier::new(123, 456, IdKind::Entity).unwrap());
+        assert!(Identifier::new(123, 456, IdKind::Entity).unwrap() <= Identifier::new(123, 456, IdKind::Entity).unwrap());
+        assert!(!(Identifier::new(123, 456, IdKind::Entity).unwrap() < Identifier::new(123, 456, IdKind::Entity).unwrap()));
+        assert!(!(Identifier::new(123, 456, IdKind::Entity).unwrap() > Identifier::new(123, 456, IdKind::Entity).unwrap()));
+
+        assert!(Identifier::new(9, 1, IdKind::Entity).unwrap() < Identifier::new(1, 9, IdKind::Entity).unwrap());
+        assert!(Identifier::new(1, 9, IdKind::Entity).unwrap() > Identifier::new(9, 1, IdKind::Entity).unwrap());
+
+        assert!(Identifier::new(9, 1, IdKind::Entity).unwrap() < Identifier::new(9, 1, IdKind::Placeholder).unwrap());
+        assert!(Identifier::new(1, 9, IdKind::Placeholder).unwrap() > Identifier::new(1, 9, IdKind::Entity).unwrap());
+
+        assert!(Identifier::new(1, 1, IdKind::Entity).unwrap() < Identifier::new(2, 1, IdKind::Entity).unwrap());
+        assert!(Identifier::new(1, 1, IdKind::Entity).unwrap() <= Identifier::new(2, 1, IdKind::Entity).unwrap());
+        assert!(Identifier::new(2, 2, IdKind::Entity).unwrap()> Identifier::new(1, 2, IdKind::Entity).unwrap());
+        assert!(Identifier::new(2, 2, IdKind::Entity).unwrap() >= Identifier::new(1, 2, IdKind::Entity).unwrap());
+    }
+}

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -10,6 +10,7 @@ pub mod change_detection;
 pub mod component;
 pub mod entity;
 pub mod event;
+pub mod identifier;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
@@ -69,6 +70,7 @@ mod tests {
         world::{EntityRef, Mut, World},
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
+    use std::num::NonZeroU32;
     use std::{
         any::TypeId,
         marker::PhantomData,
@@ -1590,7 +1592,7 @@ mod tests {
             "spawning into existing `world_b` entities works"
         );
 
-        let e4_mismatched_generation = Entity::new(3, 2).unwrap();
+        let e4_mismatched_generation = Entity::new(3, NonZeroU32::new(2).unwrap());
         assert!(
             world_b.get_or_spawn(e4_mismatched_generation).is_none(),
             "attempting to spawn on top of an entity with a mismatched entity generation fails"
@@ -1685,7 +1687,7 @@ mod tests {
         let e0 = world.spawn(A(0)).id();
         let e1 = Entity::from_raw(1);
         let e2 = world.spawn_empty().id();
-        let invalid_e2 = Entity::new(e2.index(), 2).unwrap();
+        let invalid_e2 = Entity::new(e2.index(), NonZeroU32::new(2).unwrap());
 
         let values = vec![(e0, (B(0), C)), (e1, (B(1), C)), (invalid_e2, (B(2), C))];
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1592,7 +1592,8 @@ mod tests {
             "spawning into existing `world_b` entities works"
         );
 
-        let e4_mismatched_generation = Entity::new(3, NonZeroU32::new(2).unwrap());
+        let e4_mismatched_generation =
+            Entity::from_raw_and_generation(3, NonZeroU32::new(2).unwrap());
         assert!(
             world_b.get_or_spawn(e4_mismatched_generation).is_none(),
             "attempting to spawn on top of an entity with a mismatched entity generation fails"
@@ -1687,7 +1688,7 @@ mod tests {
         let e0 = world.spawn(A(0)).id();
         let e1 = Entity::from_raw(1);
         let e2 = world.spawn_empty().id();
-        let invalid_e2 = Entity::new(e2.index(), NonZeroU32::new(2).unwrap());
+        let invalid_e2 = Entity::from_raw_and_generation(e2.index(), NonZeroU32::new(2).unwrap());
 
         let values = vec![(e0, (B(0), C)), (e1, (B(1), C)), (invalid_e2, (B(2), C))];
 


### PR DESCRIPTION
# Objective

The purpose of this PR is to begin putting together a unified identifier structure that can be used by entities and later components (as entities) as well as relationship pairs for relations, to enable all of these to be able to use the same storages. For the moment, to keep things  small and focused, only `Entity` is being changed to make use of the new `Identifier` type, keeping `Entity`'s API and serialization/deserialization the same. Further changes are for follow-up PRs.

## Solution

`Identifier` is a wrapper around `u64` split into two `u32` segments with the idea of being generalised to not impose restrictions on variants. That is for `Entity` to do. Instead, it is a general API for taking bits to then merge and map into a `u64` integer. It exposes low/high  methods to return the two value portions as `u32` integers, with then the MSB masked for usage as a type flag, enabling entity kind discrimination and future activation/deactivation semantics.

The layout in this PR for `Identifier` is described as below, going from MSB -> LSB.

```
|F| High value                    | Low value                      |
|_|_______________________________|________________________________|
|1| 31                            | 32                             |

F = Bit Flags
```

The high component in this implementation has only 31 bits, but that still leaves 2^31 or 2,147,483,648 values that can be stored still, more than enough for any generation/relation kinds/etc usage. The low part is a full 32-bit index. The flags allow for 1 bit to be used for entity/pair discrimination, as these have different usages for the low/high portions of the `Identifier`. More bits can be reserved for more variants or activation/deactivation purposes, but this currently has no use in bevy.

More bits could be reserved for future features at the cost of bits for the high component, so how much to reserve is up for discussion. Also, naming of the struct and methods are also subject to further bikeshedding and feedback.

Also, because IDs can have different variants, I wonder if `Entity::from_bits` needs to return a `Result` instead of potentially panicking on receiving an invalid ID.

PR is provided as an early WIP to obtain feedback and notes on whether this approach is viable.

---

## Changelog

### Added

New `Identifier` struct for unifying IDs.

### Changed

`Entity` changed to use new `Identifier`/`IdentifierMask` as the underlying ID logic.
