### PR TITLE
Return a boolean from `set_if_neq`

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -125,12 +125,13 @@ pub trait DetectChangesMut: DetectChanges {
     /// you are trying to synchronize representations using change detection and need to avoid infinite recursion.
     fn bypass_change_detection(&mut self) -> &mut Self::Inner;
 
-    /// Overwrites this smart pointer with the given value, if and only if `*self != value`
+    /// Overwrites this smart pointer with the given value, if and only if `*self != value`.
+    /// Returns `true` if the value was overwritten, and returns `false` if it was not.
     ///
     /// This is useful to ensure change detection is only triggered when the underlying value
     /// changes, instead of every time it is mutably accessed.
     ///
-    /// If you need to handle the previous value, use [`replace_if_neq`](DetectChangesMut::replace_if_neq).
+    /// If you need the previous value, use [`replace_if_neq`](DetectChangesMut::replace_if_neq).
     ///
     /// # Examples
     ///
@@ -160,7 +161,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// # assert!(!score_changed.run((), &mut world));
     /// ```
     #[inline]
-    fn set_if_neq(&mut self, value: Self::Inner)
+    fn set_if_neq(&mut self, value: Self::Inner) -> bool
     where
         Self::Inner: Sized + PartialEq,
     {
@@ -168,16 +169,19 @@ pub trait DetectChangesMut: DetectChanges {
         if *old != value {
             *old = value;
             self.set_changed();
+            true
+        } else {
+            false
         }
     }
 
-    /// Overwrites this smart pointer with the given value, if and only if `*self != value`
+    /// Overwrites this smart pointer with the given value, if and only if `*self != value`,
     /// returning the previous value if this occurs.
     ///
     /// This is useful to ensure change detection is only triggered when the underlying value
     /// changes, instead of every time it is mutably accessed.
     ///
-    /// If you don't need to handle the previous value, use [`set_if_neq`](DetectChangesMut::set_if_neq).
+    /// If you don't need the previous value, use [`set_if_neq`](DetectChangesMut::set_if_neq).
     ///
     /// # Examples
     ///


### PR DESCRIPTION
# Objective

When using `set_if_neq`, sometimes you'd like to know if the new value was different from the old value so that you can perform some additional branching.

## Solution

Return a bool from this function, which indicates whether or not the value was overwritten.

---

## Changelog

* `DetectChangesMut::set_if_neq` now returns a boolean indicating whether or not the value was changed.

## Migration Guide

The trait method `DetectChangesMut::set_if_neq` now returns a boolean value indicating whether or not the value was changed. If you were implementing this function manually, you must now return `true` if the value was overwritten and `false` if the value was not.