### PR TITLE
"serialize" feature no longer enables the optional "bevy_scene" feature if it's not enabled from elsewhere

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ symphonia-vorbis = ["bevy_internal/symphonia-vorbis"]
 symphonia-wav = ["bevy_internal/symphonia-wav"]
 
 # Enable serialization support through serde
-serialize = ["bevy_internal/serialize"]
+serialize = ["bevy_internal/serialize", "bevy_asset"]
 
 # Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.
 multi-threaded = ["bevy_internal/multi-threaded"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ symphonia-vorbis = ["bevy_internal/symphonia-vorbis"]
 symphonia-wav = ["bevy_internal/symphonia-wav"]
 
 # Enable serialization support through serde
-serialize = ["bevy_internal/serialize", "bevy_asset"]
+serialize = ["bevy_internal/serialize"]
 
 # Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.
 multi-threaded = ["bevy_internal/multi-threaded"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -61,7 +61,7 @@ symphonia-wav = ["bevy_audio/symphonia-wav"]
 shader_format_glsl = ["bevy_render/shader_format_glsl"]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 
-serialize = ["bevy_core/serialize", "bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize", "bevy_scene/serialize"]
+serialize = ["bevy_core/serialize", "bevy_input/serialize", "bevy_time/serialize", "bevy_window/serialize", "bevy_transform/serialize", "bevy_math/serialize", "bevy_scene?/serialize"]
 multi-threaded = ["bevy_asset/multi-threaded", "bevy_ecs/multi-threaded", "bevy_tasks/multi-threaded"]
 
 # Display server protocol support (X11 is enabled by default)


### PR DESCRIPTION
# Objective

Fixes #9787

## Solution

~~"serialize" feature enables "bevy_asset" now~~
"serialize" feature no longer enables the optional "bevy_scene" feature if it's not enabled from elsewhere (thanks to @mockersf)