### PR TITLE
Add `VertexBufferLayout::offset_locations`

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -158,6 +158,24 @@ impl VertexBufferLayout {
             attributes,
         }
     }
+
+    /// Returns a [`VertexBufferLayout`] with the shader location of every attribute offset by
+    /// `location`.
+    pub fn offset_locations(self, location: u32) -> Self {
+        Self {
+            array_stride: self.array_stride,
+            step_mode: self.step_mode,
+            attributes: self
+                .attributes
+                .into_iter()
+                .map(|attr| VertexAttribute {
+                    format: attr.format,
+                    offset: attr.offset,
+                    shader_location: attr.shader_location + location,
+                })
+                .collect(),
+        }
+    }
 }
 
 /// Describes the fragment process in a render pipeline.

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -161,7 +161,7 @@ impl VertexBufferLayout {
 
     /// Returns a [`VertexBufferLayout`] with the shader location of every attribute offset by
     /// `location`.
-    pub fn offset_locations(self, location: u32) -> Self {
+    pub fn offset_locations(mut self, location: u32) -> Self {
         self.attributes.iter_mut().for_each(|attr| {
             attr.shader_location += location;
         });

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -162,19 +162,10 @@ impl VertexBufferLayout {
     /// Returns a [`VertexBufferLayout`] with the shader location of every attribute offset by
     /// `location`.
     pub fn offset_locations(self, location: u32) -> Self {
-        Self {
-            array_stride: self.array_stride,
-            step_mode: self.step_mode,
-            attributes: self
-                .attributes
-                .into_iter()
-                .map(|attr| VertexAttribute {
-                    format: attr.format,
-                    offset: attr.offset,
-                    shader_location: attr.shader_location + location,
-                })
-                .collect(),
-        }
+        self.attributes.iter_mut().for_each(|attr| {
+            attr.shader_location += location;
+        });
+        self
     }
 }
 

--- a/crates/bevy_render/src/render_resource/pipeline.rs
+++ b/crates/bevy_render/src/render_resource/pipeline.rs
@@ -161,7 +161,7 @@ impl VertexBufferLayout {
 
     /// Returns a [`VertexBufferLayout`] with the shader location of every attribute offset by
     /// `location`.
-    pub fn offset_locations(mut self, location: u32) -> Self {
+    pub fn offset_locations_by(mut self, location: u32) -> Self {
         self.attributes.iter_mut().for_each(|attr| {
             attr.shader_location += location;
         });


### PR DESCRIPTION
# Objective

When using instancing, 2 `VertexBufferLayout`s are needed, one for per-vertex and one for per-instance data. Shader locations of all attributes must not overlap, so one of the layouts needs to start its locations at an offset. However, `VertexBufferLayout::from_vertex_formats` will always start locations at 0, requiring manual adjustment, which is currently pretty verbose.

## Solution

Add `VertexBufferLayout::offset_locations`, which adds an offset to all attribute locations.

Code using this method looks like this:

```rust
VertexState {
    shader: BACKBUFFER_SHADER_HANDLE.typed(),
    shader_defs: Vec::new(),
    entry_point: "vertex".into(),
    buffers: vec![
        VertexBufferLayout::from_vertex_formats(
            VertexStepMode::Vertex,
            [VertexFormat::Float32x2],
        ),
        VertexBufferLayout::from_vertex_formats(
            VertexStepMode::Instance,
            [VertexFormat::Float32x2, VertexFormat::Float32x3],
        )
        .offset_locations(1),
    ],
}
```

Alternative solutions include:

- Pass the starting location to `from_vertex_formats` – this is a bit simpler than my solution here, but most calls don't need an offset, so they'd always pass 0 there.
- Do nothing and make the user hand-write this.

---

## Changelog

- Add `VertexBufferLayout::offset_locations` to simplify buffer layout construction when using instancing.