### PR TITLE
Minor refactor of render window code

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -22,6 +22,7 @@ use bevy_math::{Mat4, UVec4, Vec3, Vec4, Vec4Swizzles};
 use bevy_reflect::Reflect;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
+use std::fmt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc,
@@ -92,6 +93,16 @@ pub enum Msaa {
     #[default]
     Sample4 = 4,
     Sample8 = 8,
+}
+impl fmt::Display for Msaa {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Msaa::Off => f.write_str("no MSAA"),
+            Msaa::Sample2 => f.write_str("MSAA 2x"),
+            Msaa::Sample4 => f.write_str("MSAA 4x"),
+            Msaa::Sample8 => f.write_str("MSAA 8x"),
+        }
+    }
 }
 
 impl Msaa {


### PR DESCRIPTION
# Objective

- The prepare_windows system was very large, and difficult to gork

## Solution

- Split it a bit so that the code used in the system is more focused
- implement `fmt::Display` for MSAA instead of building strings for log messages
- Also use `unwrap` instead of `expect`, I feel like the error message description didn't warrant `expect`.
