### PR TITLE
Remove TypeRegistry re-export rename

### DIFF
--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -60,11 +60,8 @@ pub mod ptr {
 }
 
 pub mod reflect {
-    // TODO: remove these renames once TypeRegistryArc is no longer required
     //! Type reflection used for dynamically interacting with rust types.
-    pub use bevy_reflect::{
-        TypeRegistry as TypeRegistryInternal, TypeRegistryArc as TypeRegistry, *,
-    };
+    pub use bevy_reflect::*;
 }
 
 #[cfg(feature = "bevy_scene")]


### PR DESCRIPTION
# Objective

The rename is confusing. Each time I import `TypeRegistry` I have to think at least 10 seconds about how to import it. And I've been working a lot with bevy reflect, which multiplies the papercut.

In my crates, you can find lots of:

```rust
use bevy::reflect::{TypeRegistryInternal as TypeRegistry};
```

When I "go to definition" on `TypeRegistry` I get to `TypeRegistryArc`. And when I mean `TypeRegistry` in my function signature, 100% of the time I mean `TypeRegistry`, not the arc wrapper.

Rust has borrowing, and most use-cases of the TypeRegistry accepts borrow of the registry, with no need to mutate it.

`TypeRegistryInternal` is also confusing. In bevy crates, it doesn't exist. The bevy crate documentation often refers to `TypeRegistry` and link to `TypeRegistryInternal`. It only exists in the bevy re-exports. It makes it hard to understand which names qualifies which types.

## Solution

Remove the rename, keep the type names as they are in `bevy_reflect`

---

## Changelog

- Remove `TypeRegistry` and `TypeRegistryArc` renames from bevy `bevy_reflect` re-exports.

## Migration Guide

- `TypeRegistry` as re-exported by the wrapper `bevy` crate is now `TypeRegistryArc`
- `TypeRegistryInternal` as re-exported by the wrapper `bevy` crate is now `TypeRegistry`