### PR TITLE
Made the `UiVertex` and `UiMeta` fields publicly available.

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -600,7 +600,7 @@ pub fn extract_text_uinodes(
 
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
-struct UiVertex {
+pub struct UiVertex {
     pub position: [f32; 3],
     pub uv: [f32; 2],
     pub color: [f32; 4],
@@ -609,8 +609,8 @@ struct UiVertex {
 
 #[derive(Resource)]
 pub struct UiMeta {
-    vertices: BufferVec<UiVertex>,
-    view_bind_group: Option<BindGroup>,
+    pub vertices: BufferVec<UiVertex>,
+    pub view_bind_group: Option<BindGroup>,
 }
 
 impl Default for UiMeta {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -598,18 +598,25 @@ pub fn extract_text_uinodes(
     }
 }
 
+/// The vertex for a Ui components
 #[repr(C)]
 #[derive(Copy, Clone, Pod, Zeroable)]
 pub struct UiVertex {
+    /// Position of the vertex, stored in a buffer as x, y, z coordinates accordingly
     pub position: [f32; 3],
+    /// UV coordinates
     pub uv: [f32; 2],
+    /// Color of the vertex
     pub color: [f32; 4],
+    /// Usage of the texture by this vertex
     pub mode: u32,
 }
 
 #[derive(Resource)]
 pub struct UiMeta {
+    // Buffer with Ui vertices
     pub vertices: BufferVec<UiVertex>,
+    // Bind group for the view projection matrix
     pub view_bind_group: Option<BindGroup>,
 }
 


### PR DESCRIPTION
# Objective

It would be easier to customize the Bevy UI.
For example, I would like to create a plugin that will create rounded corners for the Bevy UI node.
With publicly available fields it will be easier to achieve.

## Solution

`UiVertex` become public and `UiMeta` fields too.
