### PR TITLE
create the audio output stream on demand

### DIFF
--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -226,6 +226,8 @@ pub(crate) fn cleanup_finished_audio<T: Decodable + Asset>(
 }
 
 /// Run Condition to only play audio if the audio output is available
-pub(crate) fn audio_output_available(audio_output: Res<AudioOutput>) -> bool {
-    audio_output.stream_handle.is_some()
+pub(crate) fn audio_output_available(audio_output: Option<Res<AudioOutput>>) -> bool {
+    audio_output
+        .map(|output| output.stream_handle.is_some())
+        .unwrap_or_default()
 }


### PR DESCRIPTION
# Objective

- Fixes #9798
- Bevy starts an audio output stream even when not needed which can cause error

## Solution

- Start the output stream only when an entity wants to play audio
