### PR TITLE
fix deprecation warning in bench

### DIFF
--- a/benches/benches/bevy_ecs/events/iter.rs
+++ b/benches/benches/bevy_ecs/events/iter.rs
@@ -18,7 +18,7 @@ impl<const SIZE: usize> Benchmark<SIZE> {
 
     pub fn run(&mut self) {
         let mut reader = self.0.get_reader();
-        for evt in reader.iter(&self.0) {
+        for evt in reader.read(&self.0) {
             std::hint::black_box(evt);
         }
     }


### PR DESCRIPTION
# Objective

- Fix deprecation warning when running benches.

## Solution

- iter -> read