### PR TITLE
Add inline(never) to bench systems

### DIFF
--- a/benches/benches/bevy_ecs/iteration/iter_frag.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag.rs
@@ -27,6 +27,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut data in self.1.iter_mut(&mut self.0) {
             data.0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach.rs
@@ -27,6 +27,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut data| {
             data.0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_sparse.rs
@@ -38,6 +38,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut data| {
             data.0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide.rs
@@ -55,6 +55,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut data| {
             data.0 .0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_foreach_wide_sparse.rs
@@ -65,6 +65,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut data| {
             data.0 .0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_sparse.rs
@@ -38,6 +38,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut data in self.1.iter_mut(&mut self.0) {
             data.0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_wide.rs
@@ -55,6 +55,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut data in self.1.iter_mut(&mut self.0) {
             data.0 .0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_frag_wide_sparse.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_frag_wide_sparse.rs
@@ -65,6 +65,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut data in self.1.iter_mut(&mut self.0) {
             data.0 .0 *= 2.0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple.rs
@@ -33,6 +33,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for (velocity, mut position) in self.1.iter_mut(&mut self.0) {
             position.0 += velocity.0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
@@ -33,6 +33,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1
             .for_each_mut(&mut self.0, |(velocity, mut position)| {

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
@@ -35,6 +35,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1
             .for_each_mut(&mut self.0, |(velocity, mut position)| {

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
@@ -55,6 +55,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut item| {
             item.1 .0 += item.0 .0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
@@ -57,6 +57,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.for_each_mut(&mut self.0, |mut item| {
             item.1 .0 += item.0 .0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
@@ -35,6 +35,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for (velocity, mut position) in self.1.iter_mut(&mut self.0) {
             position.0 += velocity.0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple_system.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_system.rs
@@ -41,6 +41,7 @@ impl Benchmark {
         Self(world, Box::new(system))
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         self.1.run((), &mut self.0);
     }

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
@@ -55,6 +55,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut item in self.1.iter_mut(&mut self.0) {
             item.1 .0 += item.0 .0;

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
@@ -57,6 +57,7 @@ impl<'w> Benchmark<'w> {
         Self(world, query)
     }
 
+    #[inline(never)]
     pub fn run(&mut self) {
         for mut item in self.1.iter_mut(&mut self.0) {
             item.1 .0 += item.0 .0;


### PR DESCRIPTION
# Objective

It is difficult to inspect the generated assembly of benchmark systems using a tool such as `cargo-asm`

## Solution

Mark the related functions as `#[inline(never)]`. This way, you can pass the module name as argument to `cargo-asm` to get the generated assembly for the given function.

It may have as side effect to make benchmarks a bit more predictable and useful too. As it prevents inlining where in bevy no inlining could possibly take place.

### Measurements

Following the recommendations in <https://easyperf.net/blog/2019/08/02/Perf-measurement-environment-on-Linux>, I

1. Put my CPU in "AMD ECO" mode, which surprisingly is the equivalent of disabling turboboost, giving more consistent performances
2. Disabled all hyperthreading cores using `echo 0 > /sys/devices/system/cpu/cpu{11,12…}/online`
3. Set the scaling governor to `performance`
4. Manually disabled AMD boost with `echo 0 > /sys/devices/system/cpu/cpufreq/boost`
5. Set the nice level of the criterion benchmark using `cargo bench … & sudo renice -n -5 -p $! ; fg`
6. Not running any other program than the benchmarks (outside of system daemons and the X11 server)

With this setup, running multiple times the same benchmarks on `main` gives me a lot of "regression" and "improvement" messages, which is absurd given that no code changed.

On this branch, there is still some spurious performance change detection, but they are much less frequent.

This only accounts for `iter_simple` and `iter_frag` benchmarks of course.