### PR TITLE
Add Explicit Ordering for `DefaultPlugins` Systems

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -21,3 +21,4 @@ bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0-dev" }
+bevy_ui = { path = "../bevy_ui", version = "0.12.0-dev" }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -738,7 +738,9 @@ impl Plugin for AnimationPlugin {
             .register_type::<AnimationPlayer>()
             .add_systems(
                 PostUpdate,
-                animation_player.before(TransformSystem::TransformPropagate),
+                animation_player
+                    .before(TransformSystem::TransformPropagate)
+                    .before(bevy_ui::UiSystem::Layout),
             );
     }
 }

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -14,6 +14,7 @@ bevy_app = { path = "../bevy_app", version = "0.12.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = ["bevy"] }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -92,9 +92,16 @@ impl AddAudioSource for App {
     {
         self.init_asset::<T>().add_systems(
             PostUpdate,
-            play_queued_audio_system::<T>.in_set(AudioPlaySet),
+            play_queued_audio_system::<T>
+                .in_set(AudioPlaySet)
+                .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
         );
-        self.add_systems(PostUpdate, cleanup_finished_audio::<T>.in_set(AudioPlaySet));
+        self.add_systems(
+            PostUpdate,
+            cleanup_finished_audio::<T>
+                .in_set(AudioPlaySet)
+                .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
+        );
         self
     }
 }

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -16,6 +16,7 @@ bevy_input = { path = "../bevy_input", version = "0.12.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.12.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.12.0-dev" }
 
 # other
 gilrs = "0.10.1"

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -31,7 +31,12 @@ impl Plugin for GilrsPlugin {
                     .init_non_send_resource::<RunningRumbleEffects>()
                     .add_systems(PreStartup, gilrs_event_startup_system)
                     .add_systems(PreUpdate, gilrs_event_system.before(InputSystem))
-                    .add_systems(PostUpdate, play_gilrs_rumble.in_set(RumbleSystem));
+                    .add_systems(
+                        PostUpdate,
+                        play_gilrs_rumble
+                            .in_set(RumbleSystem)
+                            .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
+                    );
             }
             Err(err) => error!("Failed to start Gilrs. {}", err),
         }

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -90,7 +90,8 @@ impl Plugin for GizmoPlugin {
                     draw_aabbs,
                     draw_all_aabbs.run_if(|config: Res<GizmoConfig>| config.aabb.draw_all),
                 )
-                    .after(TransformSystem::TransformPropagate),
+                    .after(TransformSystem::TransformPropagate)
+                    .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
             );
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -23,6 +23,7 @@ bevy_render = { path = "../bevy_render", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.12.0-dev" }
+bevy_winit = { path = "../bevy_winit", version = "0.12.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }
 
 # other

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -195,8 +195,17 @@ impl Plugin for PbrPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    add_clusters.in_set(SimulationLightSystems::AddClusters),
-                    apply_deferred.in_set(SimulationLightSystems::AddClustersFlush),
+                    add_clusters
+                        .in_set(SimulationLightSystems::AddClusters)
+                        .after(bevy_render::view::VisibilitySystems::CalculateBoundsFlush),
+                    apply_deferred
+                        .in_set(SimulationLightSystems::AddClustersFlush)
+                        .after(bevy_render::view::VisibilitySystems::CalculateBounds)
+                        .after(VisibilitySystems::CheckVisibility)
+                        .after(bevy_winit::accessibility::AccessKitSystemSet)
+                        .before(bevy_window::exit_on_all_closed)
+                        .after(TransformSystem::TransformPropagate)
+                        .after(bevy_render::mesh::morph::inherit_weights),
                     assign_lights_to_clusters
                         .in_set(SimulationLightSystems::AssignLightsToClusters)
                         .after(TransformSystem::TransformPropagate)
@@ -204,6 +213,7 @@ impl Plugin for PbrPlugin {
                         .after(CameraUpdateSystem),
                     update_directional_light_cascades
                         .in_set(SimulationLightSystems::UpdateDirectionalLightCascades)
+                        .after(SimulationLightSystems::AddClustersFlush)
                         .after(TransformSystem::TransformPropagate)
                         .after(CameraUpdateSystem),
                     update_directional_light_frusta
@@ -212,6 +222,7 @@ impl Plugin for PbrPlugin {
                         .after(VisibilitySystems::CheckVisibility)
                         .after(TransformSystem::TransformPropagate)
                         .after(SimulationLightSystems::UpdateDirectionalLightCascades)
+                        .after(SimulationLightSystems::AddClustersFlush)
                         // We assume that no entity will be both a directional light and a spot light,
                         // so these systems will run independently of one another.
                         // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -50,6 +50,7 @@ bevy_render_macros = { path = "macros", version = "0.12.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.12.0-dev" }
+bevy_winit = { path = "../bevy_winit", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -42,7 +42,8 @@ impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraPro
                     // We assume that each camera will only have one projection,
                     // so we can ignore ambiguities with all other monomorphizations.
                     // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(CameraUpdateSystem),
+                    .ambiguous_with(CameraUpdateSystem)
+                    .after(crate::view::VisibilitySystems::CalculateBoundsFlush),
             );
     }
 }

--- a/crates/bevy_render/src/mesh/morph.rs
+++ b/crates/bevy_render/src/mesh/morph.rs
@@ -28,7 +28,10 @@ impl Plugin for MorphPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         app.register_type::<MorphWeights>()
             .register_type::<MeshMorphWeights>()
-            .add_systems(PostUpdate, inherit_weights);
+            .add_systems(
+                PostUpdate,
+                inherit_weights.after(crate::view::VisibilitySystems::CalculateBoundsFlush),
+            );
     }
 }
 

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -18,6 +18,7 @@ bevy_app = { path = "../bevy_app", version = "0.12.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = ["bevy"] }
 bevy_render = { path = "../bevy_render", version = "0.12.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", version = "0.12.0-dev" }

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -92,9 +92,12 @@ impl Plugin for TextPlugin {
                         // In practice, they run independently since `bevy_render::camera_update_system`
                         // will only ever observe its own render target, and `update_text2d_layout`
                         // will never modify a pre-existing `Image` asset.
-                        .ambiguous_with(CameraUpdateSystem),
+                        .ambiguous_with(CameraUpdateSystem)
+                        .ambiguous_with(bevy_sprite::calculate_bounds_2d),
                     font_atlas_set::remove_dropped_font_atlas_sets,
-                ),
+                )
+                    .chain()
+                    .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
             );
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -20,6 +20,7 @@ bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.12.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = [
     "bevy",
 ] }
@@ -28,6 +29,7 @@ bevy_sprite = { path = "../bevy_sprite", version = "0.12.0-dev" }
 bevy_text = { path = "../bevy_text", version = "0.12.0-dev", optional = true }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.12.0-dev" }
+bevy_winit = { path = "../bevy_winit", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 
 # other

--- a/crates/bevy_ui/src/accessibility.rs
+++ b/crates/bevy_ui/src/accessibility.rs
@@ -154,7 +154,10 @@ impl Plugin for AccessibilityPlugin {
                 button_changed,
                 image_changed,
                 label_changed,
-            ),
+            )
+                .chain()
+                .after(bevy_winit::accessibility::AccessKitSystemSet)
+                .after(bevy_pbr::SimulationLightSystems::AddClustersFlush),
         );
     }
 }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -16,6 +16,7 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::{DetectChanges, Entity, EventReader, EventWriter},
     query::With,
+    schedule::{IntoSystemConfigs, SystemSet},
     system::{NonSend, NonSendMut, Query, Res, ResMut, Resource},
 };
 use bevy_hierarchy::{Children, Parent};
@@ -161,6 +162,10 @@ fn update_accessibility_nodes(
     }
 }
 
+/// Label for [`AccessibilityPlugin`] systems.
+#[derive(SystemSet, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct AccessKitSystemSet;
+
 /// Implements winit-specific `AccessKit` functionality.
 pub struct AccessibilityPlugin;
 
@@ -176,7 +181,9 @@ impl Plugin for AccessibilityPlugin {
                     window_closed,
                     poll_receivers,
                     update_accessibility_nodes,
-                ),
+                )
+                    .chain()
+                    .in_set(AccessKitSystemSet),
             );
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #9511

## Solution

- Added `before` and `after` statements as required to remove system order ambiguity.

## Notes

This PR is a bit on the rough side of things and probably serves better as a reference point for the kind of work required to properly resolve #9511. A number of system ambiguities were between areas of Bevy that previously didn't need to reference each other. In those instances, I chose to add the crate and resolve the ambiguity directly. A better approach would probably be to add some better sets for sharing between these crates.

Also, I had some troubles on my machine actually diagnosing the original ambiguity errors using the `nondeterministic_system_order` example. I ended up working around this issue by explicitly configuring all the schedules run by `Main` separately:

```rust
// ...
.edit_schedule(Main, |schedule| {
    schedule.set_build_settings(ScheduleBuildSettings {
        ambiguity_detection: LogLevel::Error,
        ..default()
    });
})
.edit_schedule(PreStartup, |schedule| {
    schedule.set_build_settings(ScheduleBuildSettings {
        ambiguity_detection: LogLevel::Error,
        ..default()
    });
})
.edit_schedule(Startup, |schedule| {
    schedule.set_build_settings(ScheduleBuildSettings {
        ambiguity_detection: LogLevel::Error,
        ..default()
    });
})
// ... etc.
```

If this is merged, I do think the CI tests should be updated to include ambiguity detection to prevent regression.