### PR TITLE
don't enable filesystem_watcher when building for WebGPU

### DIFF
--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -71,7 +71,6 @@ fn main() {
             features.push("zstd");
             features.push("vorbis");
             features.push("x11");
-            features.push("filesystem_watcher");
             features.push("bevy_gizmos");
             features.push("android_shared_stdcxx");
             features.push("tonemapping_luts");


### PR DESCRIPTION
# Objective

- There are errors when building for WebGPU, since Assets V2 PR
```
error[E0432]: unresolved import `file_id::get_file_id`
  --> /Users/francoismockers/.cargo/registry/src/index.crates.io-6f17d22bba15001f/notify-debouncer-full-0.2.0/src/cache.rs:6:15
   |
6  | use file_id::{get_file_id, FileId};
   |               ^^^^^^^^^^^ no `get_file_id` in the root
   |
note: found an item that was configured out
  --> /Users/francoismockers/.cargo/registry/src/index.crates.io-6f17d22bba15001f/file-id-0.1.0/src/lib.rs:41:8
   |
41 | pub fn get_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
   |        ^^^^^^^^^^^
   = note: the item is gated behind the `unix` feature
note: found an item that was configured out
  --> /Users/francoismockers/.cargo/registry/src/index.crates.io-6f17d22bba15001f/file-id-0.1.0/src/lib.rs:54:8
   |
54 | pub fn get_file_id(path: impl AsRef<Path>) -> io::Result<FileId> {
   |        ^^^^^^^^^^^
   = note: the item is gated behind the `windows` feature

For more information about this error, try `rustc --explain E0432`.
error: could not compile `notify-debouncer-full` (lib) due to previous error
```

## Solution

- Don't enable feature `filesystem_watcher` in WebGPU as it can't work anyway
