### PR TITLE
Use single threaded executor for archetype benches

### DIFF
--- a/benches/benches/bevy_ecs/components/archetype_updates.rs
+++ b/benches/benches/bevy_ecs/components/archetype_updates.rs
@@ -1,4 +1,9 @@
-use bevy_ecs::{component::Component, schedule::Schedule, world::World};
+use bevy_ecs::{
+    component::Component,
+    prelude::EntityWorldMut,
+    schedule::{ExecutorKind, Schedule},
+    world::World,
+};
 use criterion::{BenchmarkId, Criterion};
 
 #[derive(Component)]
@@ -8,6 +13,7 @@ fn setup(system_count: usize) -> (World, Schedule) {
     let mut world = World::new();
     fn empty() {}
     let mut schedule = Schedule::default();
+    schedule.set_executor_kind(ExecutorKind::SingleThreaded);
     for _ in 0..system_count {
         schedule.add_systems(empty);
     }
@@ -15,58 +21,31 @@ fn setup(system_count: usize) -> (World, Schedule) {
     (world, schedule)
 }
 
+fn insert_if_bit_enabled<const B: u16>(entity: &mut EntityWorldMut, i: u16) {
+    if i & 1 << B != 0 {
+        entity.insert(A::<B>(1.0));
+    }
+}
 /// create `count` entities with distinct archetypes
 fn add_archetypes(world: &mut World, count: u16) {
     for i in 0..count {
         let mut e = world.spawn_empty();
-        if i & 1 << 0 != 0 {
-            e.insert(A::<0>(1.0));
-        }
-        if i & 1 << 1 != 0 {
-            e.insert(A::<1>(1.0));
-        }
-        if i & 1 << 2 != 0 {
-            e.insert(A::<2>(1.0));
-        }
-        if i & 1 << 3 != 0 {
-            e.insert(A::<3>(1.0));
-        }
-        if i & 1 << 4 != 0 {
-            e.insert(A::<4>(1.0));
-        }
-        if i & 1 << 5 != 0 {
-            e.insert(A::<5>(1.0));
-        }
-        if i & 1 << 6 != 0 {
-            e.insert(A::<6>(1.0));
-        }
-        if i & 1 << 7 != 0 {
-            e.insert(A::<7>(1.0));
-        }
-        if i & 1 << 8 != 0 {
-            e.insert(A::<8>(1.0));
-        }
-        if i & 1 << 9 != 0 {
-            e.insert(A::<9>(1.0));
-        }
-        if i & 1 << 10 != 0 {
-            e.insert(A::<10>(1.0));
-        }
-        if i & 1 << 11 != 0 {
-            e.insert(A::<11>(1.0));
-        }
-        if i & 1 << 12 != 0 {
-            e.insert(A::<12>(1.0));
-        }
-        if i & 1 << 13 != 0 {
-            e.insert(A::<13>(1.0));
-        }
-        if i & 1 << 14 != 0 {
-            e.insert(A::<14>(1.0));
-        }
-        if i & 1 << 15 != 0 {
-            e.insert(A::<15>(1.0));
-        }
+        insert_if_bit_enabled::<0>(&mut e, i);
+        insert_if_bit_enabled::<1>(&mut e, i);
+        insert_if_bit_enabled::<2>(&mut e, i);
+        insert_if_bit_enabled::<3>(&mut e, i);
+        insert_if_bit_enabled::<4>(&mut e, i);
+        insert_if_bit_enabled::<5>(&mut e, i);
+        insert_if_bit_enabled::<6>(&mut e, i);
+        insert_if_bit_enabled::<7>(&mut e, i);
+        insert_if_bit_enabled::<8>(&mut e, i);
+        insert_if_bit_enabled::<9>(&mut e, i);
+        insert_if_bit_enabled::<10>(&mut e, i);
+        insert_if_bit_enabled::<11>(&mut e, i);
+        insert_if_bit_enabled::<12>(&mut e, i);
+        insert_if_bit_enabled::<13>(&mut e, i);
+        insert_if_bit_enabled::<14>(&mut e, i);
+        insert_if_bit_enabled::<15>(&mut e, i);
     }
 }
 


### PR DESCRIPTION
# Objective

`no_archetype` benchmark group results were very noisy

## Solution

Use the `SingeThreaded` executor.

On my machine, this makes the `no_archetype` bench group 20 to 30 times faster. Meaning that most of the runtime was accounted by the multithreaded scheduler. ie: the benchmark was not testing system archetype update, but the overhead of multithreaded scheduling.

With this change, the benchmark results are more meaningful.

The add_archetypes function is also simplified.