### PR TITLE
Add mutual exclusion safety info on filter_fetch

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -410,6 +410,9 @@ pub unsafe trait WorldQuery {
     ///
     /// Must always be called _after_ [`WorldQuery::set_table`] or [`WorldQuery::set_archetype`]. `entity` and
     /// `table_row` must be in the range of the current table and archetype.
+    ///
+    /// If this includes any mutable access, then this should never be called
+    /// while the return value of [`WorldQuery::fetch`] for the same entity is live.
     #[allow(unused_variables)]
     #[inline(always)]
     unsafe fn filter_fetch(


### PR DESCRIPTION
# Objective

Currently, in bevy, it's valid to do `Query<&mut Foo, Changed<Foo>>`.

This assumes that `filter_fetch` and `fetch` are mutually exclusive, because of the mutable reference to the tick that `Mut<Foo>` implies and the reference that `Changed<Foo>` implies. However nothing guarantees that.

## Solution

Documenting this assumption as a safety invariant is the least thing.