### PR TITLE
Added 64bit VertexAttributeValues and Conversions

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -67,6 +67,11 @@ macro_rules! impl_from_into {
     };
 }
 
+impl_from!(f64, Float64);
+impl_from!([f64; 2], Float64x2);
+impl_from!([f64; 3], Float64x3);
+impl_from!([f64; 4], Float64x4);
+
 impl_from!(f32, Float32);
 impl_from!([f32; 2], Float32x2);
 impl_from_into!(Vec2, Float32x2);
@@ -124,6 +129,11 @@ macro_rules! impl_try_from_into {
     };
 }
 
+impl_try_from!(f64, Float64);
+impl_try_from!([f64; 2], Float64x2);
+impl_try_from!([f64; 3], Float64x3);
+impl_try_from!([f64; 4], Float64x4);
+
 impl_try_from!(f32, Float32);
 impl_try_from!([f32; 2], Float32x2);
 impl_try_from_into!(Vec2, Float32x2);
@@ -179,6 +189,18 @@ mod tests {
     }
 
     #[test]
+    fn f64() {
+        let buffer = vec![0.0_f64; 10];
+        let values = VertexAttributeValues::from(buffer.clone());
+        let result_into: Vec<f64> = values.clone().try_into().unwrap();
+        let result_from: Vec<f64> = Vec::try_from(values.clone()).unwrap();
+        let error: Result<Vec<u32>, _> = values.try_into();
+        assert_eq!(buffer, result_into);
+        assert_eq!(buffer, result_from);
+        assert!(error.is_err());
+    }
+
+    #[test]
     fn i32() {
         let buffer = vec![0; 10];
         let values = VertexAttributeValues::from(buffer.clone());
@@ -208,6 +230,18 @@ mod tests {
         let values = VertexAttributeValues::from(buffer.clone());
         let result_into: Vec<[f32; 2]> = values.clone().try_into().unwrap();
         let result_from: Vec<[f32; 2]> = Vec::try_from(values.clone()).unwrap();
+        let error: Result<Vec<u32>, _> = values.try_into();
+        assert_eq!(buffer, result_into);
+        assert_eq!(buffer, result_from);
+        assert!(error.is_err());
+    }
+
+    #[test]
+    fn f64_2() {
+        let buffer = vec![[0.0_f64; 2]; 10];
+        let values = VertexAttributeValues::from(buffer.clone());
+        let result_into: Vec<[f64; 2]> = values.clone().try_into().unwrap();
+        let result_from: Vec<[f64; 2]> = Vec::try_from(values.clone()).unwrap();
         let error: Result<Vec<u32>, _> = values.try_into();
         assert_eq!(buffer, result_into);
         assert_eq!(buffer, result_from);
@@ -283,6 +317,18 @@ mod tests {
         let values = VertexAttributeValues::from(buffer.clone());
         let result_into: Vec<[f32; 3]> = values.clone().try_into().unwrap();
         let result_from: Vec<[f32; 3]> = Vec::try_from(values.clone()).unwrap();
+        let error: Result<Vec<u32>, _> = values.try_into();
+        assert_eq!(buffer, result_into);
+        assert_eq!(buffer, result_from);
+        assert!(error.is_err());
+    }
+
+    #[test]
+    fn f64_3() {
+        let buffer = vec![[0.0_f64; 3]; 10];
+        let values = VertexAttributeValues::from(buffer.clone());
+        let result_into: Vec<[f64; 3]> = values.clone().try_into().unwrap();
+        let result_from: Vec<[f64; 3]> = Vec::try_from(values.clone()).unwrap();
         let error: Result<Vec<u32>, _> = values.try_into();
         assert_eq!(buffer, result_into);
         assert_eq!(buffer, result_from);
@@ -366,11 +412,23 @@ mod tests {
     }
 
     #[test]
-    fn f32_4() {
+    fn f32_4() { 
         let buffer = vec![[0.0; 4]; 10];
         let values = VertexAttributeValues::from(buffer.clone());
         let result_into: Vec<[f32; 4]> = values.clone().try_into().unwrap();
         let result_from: Vec<[f32; 4]> = Vec::try_from(values.clone()).unwrap();
+        let error: Result<Vec<u32>, _> = values.try_into();
+        assert_eq!(buffer, result_into);
+        assert_eq!(buffer, result_from);
+        assert!(error.is_err());
+    }
+
+    #[test]
+    fn f64_4() {
+        let buffer = vec![[0.0_f64; 4]; 10];
+        let values = VertexAttributeValues::from(buffer.clone());
+        let result_into: Vec<[f64; 4]> = values.clone().try_into().unwrap();
+        let result_from: Vec<[f64; 4]> = Vec::try_from(values.clone()).unwrap();
         let error: Result<Vec<u32>, _> = values.try_into();
         assert_eq!(buffer, result_into);
         assert_eq!(buffer, result_from);

--- a/crates/bevy_render/src/mesh/mesh/conversions.rs
+++ b/crates/bevy_render/src/mesh/mesh/conversions.rs
@@ -412,7 +412,7 @@ mod tests {
     }
 
     #[test]
-    fn f32_4() { 
+    fn f32_4() {
         let buffer = vec![[0.0; 4]; 10];
         let values = VertexAttributeValues::from(buffer.clone());
         let result_into: Vec<[f32; 4]> = values.clone().try_into().unwrap();

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -686,8 +686,8 @@ impl VertexFormatSize for wgpu::VertexFormat {
 ///
 /// Be aware that the [`Float64`](VertexAttributeValues::Float64),
 /// [`Float64x2`](VertexAttributeValues::Float64x2), [`Float64x3`](VertexAttributeValues::Float64x3) and
-/// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with Caution, because they might cause
-/// Performance Problems due to [f64](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE)
+/// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with caution, because they might cause
+/// performance problems due to [f64](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE)
 /// slower than [f32](std::primitive::f32) on GPUs.
 #[derive(Clone, Debug, EnumVariantMeta)]
 pub enum VertexAttributeValues {

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -686,9 +686,10 @@ impl VertexFormatSize for wgpu::VertexFormat {
 ///
 /// Be aware that the [`Float64`](VertexAttributeValues::Float64),
 /// [`Float64x2`](VertexAttributeValues::Float64x2), [`Float64x3`](VertexAttributeValues::Float64x3) and
-/// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with caution, because they might cause
-/// performance problems due to [f64](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE)
-/// slower than [f32](std::primitive::f32) on GPUs.
+/// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with caution, because they might not
+/// be available on your platform and/or hardware. If they are available, they might cause performance
+/// problems due to [`f64`](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE)
+/// slower than [`f32`](std::primitive::f32) on GPUs. The availability can be tested with [`WgpuFeatures::VERTEX_ATTRIBUTE_64BIT`](crate::render_resource::WgpuFeatures).
 #[derive(Clone, Debug, EnumVariantMeta)]
 pub enum VertexAttributeValues {
     Float32(Vec<f32>),

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -683,7 +683,7 @@ impl VertexFormatSize for wgpu::VertexFormat {
 
 /// Contains an array where each entry describes a property of a single vertex.
 /// Matches the [`VertexFormats`](VertexFormat).
-/// 
+///
 /// Be aware that the [`Float64`](VertexAttributeValues::Float64),
 /// [`Float64x2`](VertexAttributeValues::Float64x2), [`Float64x3`](VertexAttributeValues::Float64x3) and
 /// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with Caution, because they might cause
@@ -1149,9 +1149,9 @@ mod tests {
 
     #[test]
     fn test_64_bit_format() {
-        pub const TEST_UV: MeshVertexAttribute = 
+        pub const TEST_UV: MeshVertexAttribute =
             MeshVertexAttribute::new("TEST_UV", 2000, VertexFormat::Float64x2);
-        
+
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.insert_attribute(TEST_UV, vec![[0.0f64, 0.0f64]]);
     }

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -682,12 +682,12 @@ impl VertexFormatSize for wgpu::VertexFormat {
 }
 
 /// Contains an array where each entry describes a property of a single vertex.
-/// Matches the [`VertexFormats`](VertexFormat). 
+/// Matches the [`VertexFormats`](VertexFormat).
 /// 
 /// Be aware that the [`Float64`](VertexAttributeValues::Float64),
-/// [`Float64x2`](VertexAttributeValues::Float64x2), [`Float64x3`](VertexAttributeValues::Float64x3) and 
+/// [`Float64x2`](VertexAttributeValues::Float64x2), [`Float64x3`](VertexAttributeValues::Float64x3) and
 /// [`Float64x4`](VertexAttributeValues::Float64x4) need to be used with Caution, because they might cause
-/// Performance Problems due to [f64](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE) 
+/// Performance Problems due to [f64](std::primitive::f64) being between [considerably](https://groups.google.com/g/amgcl/c/Bz_X2B0UBWE)
 /// slower than [f32](std::primitive::f32) on GPUs.
 #[derive(Clone, Debug, EnumVariantMeta)]
 pub enum VertexAttributeValues {
@@ -1149,7 +1149,8 @@ mod tests {
 
     #[test]
     fn test_64_bit_format() {
-        pub const TEST_UV: MeshVertexAttribute = MeshVertexAttribute::new("TEST_UV", 2000, VertexFormat::Float64x2);
+        pub const TEST_UV: MeshVertexAttribute = 
+            MeshVertexAttribute::new("TEST_UV", 2000, VertexFormat::Float64x2);
         
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.insert_attribute(TEST_UV, vec![[0.0f64, 0.0f64]]);

--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -107,9 +107,9 @@ impl From<Box> for Mesh {
             ([sp.max_x, sp.min_y, sp.min_z], [0., -1.0, 0.], [0., 1.0]),
         ];
 
-        let positions: Vec<_> = vertices.iter().map(|(p, _, _)| *p).collect();
-        let normals: Vec<_> = vertices.iter().map(|(_, n, _)| *n).collect();
-        let uvs: Vec<_> = vertices.iter().map(|(_, _, uv)| *uv).collect();
+        let positions: Vec<[f32; 3]> = vertices.iter().map(|(p, _, _)| *p).collect();
+        let normals: Vec<[f32; 3]> = vertices.iter().map(|(_, n, _)| *n).collect();
+        let uvs: Vec<[f32; 2]> = vertices.iter().map(|(_, _, uv)| *uv).collect();
 
         let indices = Indices::U32(vec![
             0, 1, 2, 2, 3, 0, // front
@@ -169,9 +169,9 @@ impl From<Quad> for Mesh {
 
         let indices = Indices::U32(vec![0, 2, 1, 0, 3, 2]);
 
-        let positions: Vec<_> = vertices.iter().map(|(p, _, _)| *p).collect();
-        let normals: Vec<_> = vertices.iter().map(|(_, n, _)| *n).collect();
-        let uvs: Vec<_> = vertices.iter().map(|(_, _, uv)| *uv).collect();
+        let positions: Vec<[f32; 3]> = vertices.iter().map(|(p, _, _)| *p).collect();
+        let normals: Vec<[f32; 3]> = vertices.iter().map(|(_, n, _)| *n).collect();
+        let uvs: Vec<[f32; 2]> = vertices.iter().map(|(_, _, uv)| *uv).collect();
 
         let mut mesh = Mesh::new(PrimitiveTopology::TriangleList);
         mesh.set_indices(Some(indices));

--- a/crates/bevy_render/src/mesh/shape/regular_polygon.rs
+++ b/crates/bevy_render/src/mesh/shape/regular_polygon.rs
@@ -34,9 +34,9 @@ impl From<RegularPolygon> for Mesh {
 
         debug_assert!(sides > 2, "RegularPolygon requires at least 3 sides.");
 
-        let mut positions = Vec::with_capacity(sides);
-        let mut normals = Vec::with_capacity(sides);
-        let mut uvs = Vec::with_capacity(sides);
+        let mut positions: Vec<[f32; 3]> = Vec::with_capacity(sides);
+        let mut normals: Vec<[f32; 3]> = Vec::with_capacity(sides);
+        let mut uvs: Vec<[f32; 2]> = Vec::with_capacity(sides);
 
         let step = std::f32::consts::TAU / sides as f32;
         for i in 0..sides {


### PR DESCRIPTION
# Objective

The Goal is to add the missing f64 VertexAttributeValues Types, that exist in wgpu, but were not present in bevy.

## Solution

Extended the VertexAttributeValues enum with the Float64, Float64x2, Float64x3 and Float64x4 Variants,
added some Tests for these new Types and also checked, if the new Vertex Attributes can be added into a Mesh.
Also Added a performance Note, for those who want to explore this area further.

---

## Changelog

* Added VertexAttributeValues::Float64 enum variant
* Added VertexAttributeValues::Float64x2 enum variant
* Added VertexAttributeValues::Float64x3 enum variant
* Added VertexAttributeValues::Float64x4 enum variant
* Added Appropriate Conversion Methods for Arrays of f64
* Added Tests for checking, if adding f64 Array is possible into a mesh
* Added Tests to cover f64 conversions

## Migration Guide

- Matches on the enum VertexAttributeValues will break, fixable by just adding the new variants in the match.
- if using `mesh.insert_attribute(...)` make sure, the inbound Vec is of the correct floating point type. It sometimes can happen, if not restricted by type anywhere, that a f64 type might be used automatically. The error message of not doing that will contain something along the lines of (analog also other variants):

> Failed to insert attribute. Invalid attribute format for Vertex_Uv. Given format is Float64x2 but expected Float32x2
