### PR TITLE
Fix ambiguities in transform example

### DIFF
--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -31,7 +31,8 @@ fn main() {
                 move_cube,
                 rotate_cube,
                 scale_down_sphere_proportional_to_cube_travel_distance,
-            ),
+            )
+                .chain(),
         )
         .run();
 }


### PR DESCRIPTION
# Objective

Fix these

```
 -- rotate_cube and move_cube
    conflict on: ["bevy_transform::components::transform::Transform", "transform::CubeState"]
 -- rotate_cube and scale_down_sphere_proportional_to_cube_travel_distance
    conflict on: ["bevy_transform::components::transform::Transform", "transform::CubeState"]
 -- move_cube and scale_down_sphere_proportional_to_cube_travel_distance
    conflict on: ["bevy_transform::components::transform::Transform", "transform::CubeState"]
```

The three systems in this example depend on the results of the others. This leads to minor but detectable differences in output between runs by automated screenshot diffing depending on the order of the schedule.

We don't necessarily need to be able to do this for **every** example, but I think this is a case where fixing it is easy / maybe the right thing to do anyway.

## Solution

Chain the three systems