### PR TITLE
Use a seeded rng for custom_skinned_mesh example

### DIFF
--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -11,7 +11,7 @@ use bevy::{
         Indices, PrimitiveTopology, VertexAttributeValues,
     },
 };
-use rand::Rng;
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn main() {
     App::new()
@@ -116,13 +116,16 @@ fn setup(
     ])));
 
     let mesh = meshes.add(mesh);
+
+    let mut rng = StdRng::seed_from_u64(42);
+
     for i in -5..5 {
         // Create joint entities
         let joint_0 = commands
             .spawn(TransformBundle::from(Transform::from_xyz(
                 i as f32 * 1.5,
                 0.0,
-                0.0,
+                i as f32 * 0.1,
             )))
             .id();
         let joint_1 = commands
@@ -141,9 +144,9 @@ fn setup(
                 mesh: mesh.clone(),
                 material: materials.add(
                     Color::rgb(
-                        rand::thread_rng().gen_range(0.0..1.0),
-                        rand::thread_rng().gen_range(0.0..1.0),
-                        rand::thread_rng().gen_range(0.0..1.0),
+                        rng.gen_range(0.0..1.0),
+                        rng.gen_range(0.0..1.0),
+                        rng.gen_range(0.0..1.0),
                     )
                     .into(),
                 ),


### PR DESCRIPTION
# Objective

Make the output of this example repeatable so it can be utilized by automated screenshot diffing.

## Solution

- Use a seeded RNG for the random colors
- Offset the meshes slightly in z so they don't intersect each other at the extents of their animations.