### PR TITLE
Use a single line for of large binding lists

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -4,10 +4,8 @@
 #import bevy_core_pipeline::tonemapping tone_mapping
 #import bevy_pbr::pbr_functions as fns
 
-@group(1) @binding(0)
-var my_array_texture: texture_2d_array<f32>;
-@group(1) @binding(1)
-var my_array_texture_sampler: sampler;
+@group(1) @binding(0) var my_array_texture: texture_2d_array<f32>;
+@group(1) @binding(1) var my_array_texture_sampler: sampler;
 
 @fragment
 fn fragment(

--- a/assets/shaders/cubemap_unlit.wgsl
+++ b/assets/shaders/cubemap_unlit.wgsl
@@ -1,15 +1,12 @@
 #import bevy_pbr::mesh_vertex_output MeshVertexOutput
 
 #ifdef CUBEMAP_ARRAY
-@group(1) @binding(0)
-var base_color_texture: texture_cube_array<f32>;
+@group(1) @binding(0) var base_color_texture: texture_cube_array<f32>;
 #else
-@group(1) @binding(0)
-var base_color_texture: texture_cube<f32>;
+@group(1) @binding(0) var base_color_texture: texture_cube<f32>;
 #endif
 
-@group(1) @binding(1)
-var base_color_sampler: sampler;
+@group(1) @binding(1) var base_color_sampler: sampler;
 
 @fragment
 fn fragment(

--- a/assets/shaders/custom_material.wgsl
+++ b/assets/shaders/custom_material.wgsl
@@ -4,12 +4,9 @@ struct CustomMaterial {
     color: vec4<f32>,
 };
 
-@group(1) @binding(0)
-var<uniform> material: CustomMaterial;
-@group(1) @binding(1)
-var base_color_texture: texture_2d<f32>;
-@group(1) @binding(2)
-var base_color_sampler: sampler;
+@group(1) @binding(0) var<uniform> material: CustomMaterial;
+@group(1) @binding(1) var base_color_texture: texture_2d<f32>;
+@group(1) @binding(2) var base_color_sampler: sampler;
 
 @fragment
 fn fragment(

--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -2,10 +2,8 @@
 #import bevy_pbr::mesh_vertex_output  MeshVertexOutput
 #import bevy_pbr::utils               coords_to_viewport_uv
 
-@group(1) @binding(0)
-var texture: texture_2d<f32>;
-@group(1) @binding(1)
-var texture_sampler: sampler;
+@group(1) @binding(0) var texture: texture_2d<f32>;
+@group(1) @binding(1) var texture_sampler: sampler;
 
 @fragment
 fn fragment(

--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -4,8 +4,7 @@
 struct CustomMaterial {
     color: vec4<f32>,
 };
-@group(1) @binding(0)
-var<uniform> material: CustomMaterial;
+@group(1) @binding(0) var<uniform> material: CustomMaterial;
 
 struct Vertex {
     @builtin(instance_index) instance_index: u32,

--- a/assets/shaders/fallback_image_test.wgsl
+++ b/assets/shaders/fallback_image_test.wgsl
@@ -2,35 +2,23 @@
 #import bevy_pbr::mesh_bindings
 #import bevy_pbr::mesh_vertex_output MeshVertexOutput
 
-@group(1) @binding(0)
-var test_texture_1d: texture_1d<f32>;
-@group(1) @binding(1)
-var test_texture_1d_sampler: sampler;
+@group(1) @binding(0) var test_texture_1d: texture_1d<f32>;
+@group(1) @binding(1) var test_texture_1d_sampler: sampler;
 
-@group(1) @binding(2)
-var test_texture_2d: texture_2d<f32>;
-@group(1) @binding(3)
-var test_texture_2d_sampler: sampler;
+@group(1) @binding(2) var test_texture_2d: texture_2d<f32>;
+@group(1) @binding(3) var test_texture_2d_sampler: sampler;
 
-@group(1) @binding(4)
-var test_texture_2d_array: texture_2d_array<f32>;
-@group(1) @binding(5)
-var test_texture_2d_array_sampler: sampler;
+@group(1) @binding(4) var test_texture_2d_array: texture_2d_array<f32>;
+@group(1) @binding(5) var test_texture_2d_array_sampler: sampler;
 
-@group(1) @binding(6)
-var test_texture_cube: texture_cube<f32>;
-@group(1) @binding(7)
-var test_texture_cube_sampler: sampler;
+@group(1) @binding(6) var test_texture_cube: texture_cube<f32>;
+@group(1) @binding(7) var test_texture_cube_sampler: sampler;
 
-@group(1) @binding(8)
-var test_texture_cube_array: texture_cube_array<f32>;
-@group(1) @binding(9)
-var test_texture_cube_array_sampler: sampler;
+@group(1) @binding(8) var test_texture_cube_array: texture_cube_array<f32>;
+@group(1) @binding(9) var test_texture_cube_array_sampler: sampler;
 
-@group(1) @binding(10)
-var test_texture_3d: texture_3d<f32>;
-@group(1) @binding(11)
-var test_texture_3d_sampler: sampler;
+@group(1) @binding(10) var test_texture_3d: texture_3d<f32>;
+@group(1) @binding(11) var test_texture_3d_sampler: sampler;
 
 @fragment
 fn fragment(in: MeshVertexOutput) {}

--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,5 +1,4 @@
-@group(0) @binding(0)
-var texture: texture_storage_2d<rgba8unorm, read_write>;
+@group(0) @binding(0) var texture: texture_storage_2d<rgba8unorm, read_write>;
 
 fn hash(value: u32) -> u32 {
     var state = value;

--- a/assets/shaders/line_material.wgsl
+++ b/assets/shaders/line_material.wgsl
@@ -4,8 +4,7 @@ struct LineMaterial {
     color: vec4<f32>,
 };
 
-@group(1) @binding(0)
-var<uniform> material: LineMaterial;
+@group(1) @binding(0) var<uniform> material: LineMaterial;
 
 @fragment
 fn fragment(

--- a/assets/shaders/post_processing.wgsl
+++ b/assets/shaders/post_processing.wgsl
@@ -22,10 +22,8 @@
 // You don't need to worry about this too much since bevy will compute the correct UVs for you.
 #import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
 
-@group(0) @binding(0)
-var screen_texture: texture_2d<f32>;
-@group(0) @binding(1)
-var texture_sampler: sampler;
+@group(0) @binding(0) var screen_texture: texture_2d<f32>;
+@group(0) @binding(1) var texture_sampler: sampler;
 struct PostProcessSettings {
     intensity: f32,
 #ifdef SIXTEEN_BYTE_ALIGNMENT
@@ -33,8 +31,7 @@ struct PostProcessSettings {
     _webgl2_padding: vec3<f32>
 #endif
 }
-@group(0) @binding(2)
-var<uniform> settings: PostProcessSettings;
+@group(0) @binding(2) var<uniform> settings: PostProcessSettings;
 
 @fragment
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {

--- a/assets/shaders/shader_defs.wgsl
+++ b/assets/shaders/shader_defs.wgsl
@@ -4,8 +4,7 @@ struct CustomMaterial {
     color: vec4<f32>,
 };
 
-@group(1) @binding(0)
-var<uniform> material: CustomMaterial;
+@group(1) @binding(0) var<uniform> material: CustomMaterial;
 
 @fragment
 fn fragment(

--- a/assets/shaders/show_prepass.wgsl
+++ b/assets/shaders/show_prepass.wgsl
@@ -10,8 +10,7 @@ struct ShowPrepassSettings {
     padding_1: u32,
     padding_2: u32,
 }
-@group(1) @binding(0)
-var<uniform> settings: ShowPrepassSettings;
+@group(1) @binding(0) var<uniform> settings: ShowPrepassSettings;
 
 @fragment
 fn fragment(

--- a/assets/shaders/texture_binding_array.wgsl
+++ b/assets/shaders/texture_binding_array.wgsl
@@ -1,9 +1,7 @@
 #import bevy_pbr::mesh_vertex_output MeshVertexOutput
 
-@group(1) @binding(0)
-var textures: binding_array<texture_2d<f32>>;
-@group(1) @binding(1)
-var nearest_sampler: sampler;
+@group(1) @binding(0) var textures: binding_array<texture_2d<f32>>;
+@group(1) @binding(1) var nearest_sampler: sampler;
 // We can also have array of samplers
 // var samplers: binding_array<sampler>;
 

--- a/crates/bevy_core_pipeline/src/blit/blit.wgsl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wgsl
@@ -1,9 +1,7 @@
 #import bevy_core_pipeline::fullscreen_vertex_shader  FullscreenVertexOutput
 
-@group(0) @binding(0)
-var in_texture: texture_2d<f32>;
-@group(0) @binding(1)
-var in_sampler: sampler;
+@group(0) @binding(0) var in_texture: texture_2d<f32>;
+@group(0) @binding(1) var in_sampler: sampler;
 
 @fragment
 fn fs_main(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {

--- a/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
+++ b/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
@@ -14,13 +14,10 @@ struct BloomUniforms {
     aspect: f32,
 };
 
-@group(0) @binding(0)
-var input_texture: texture_2d<f32>;
-@group(0) @binding(1)
-var s: sampler;
+@group(0) @binding(0) var input_texture: texture_2d<f32>;
+@group(0) @binding(1) var s: sampler;
 
-@group(0) @binding(2)
-var<uniform> uniforms: BloomUniforms;
+@group(0) @binding(2) var<uniform> uniforms: BloomUniforms;
 
 #ifdef FIRST_DOWNSAMPLE
 // https://catlikecoding.com/unity/tutorials/advanced-rendering/bloom/#3.4

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
@@ -23,12 +23,9 @@ struct CASUniforms {
     sharpness: f32,
 };
 
-@group(0) @binding(0)
-var screenTexture: texture_2d<f32>;
-@group(0) @binding(1)
-var samp: sampler;
-@group(0) @binding(2)
-var<uniform> uniforms: CASUniforms;
+@group(0) @binding(0) var screenTexture: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
+@group(0) @binding(2) var<uniform> uniforms: CASUniforms;
 
 // This is set at the limit of providing unnatural results for sharpening.
 const FSR_RCAS_LIMIT = 0.1875;

--- a/crates/bevy_core_pipeline/src/fxaa/fxaa.wgsl
+++ b/crates/bevy_core_pipeline/src/fxaa/fxaa.wgsl
@@ -8,10 +8,8 @@
 
 #import bevy_core_pipeline::fullscreen_vertex_shader  FullscreenVertexOutput
 
-@group(0) @binding(0)
-var screenTexture: texture_2d<f32>;
-@group(0) @binding(1)
-var samp: sampler;
+@group(0) @binding(0) var screenTexture: texture_2d<f32>;
+@group(0) @binding(1) var samp: sampler;
 
 // Trims the algorithm from processing darks.
 #ifdef EDGE_THRESH_MIN_LOW

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -1,11 +1,8 @@
 #import bevy_render::view View
 
-@group(0) @binding(0)
-var skybox: texture_cube<f32>;
-@group(0) @binding(1)
-var skybox_sampler: sampler;
-@group(0) @binding(2)
-var<uniform> view: View;
+@group(0) @binding(0) var skybox: texture_cube<f32>;
+@group(0) @binding(1) var skybox_sampler: sampler;
+@group(0) @binding(2) var<uniform> view: View;
 
 struct VertexOutput {
     @builtin(position) clip_position: vec4<f32>,

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
@@ -4,17 +4,12 @@
 #import bevy_render::view  View
 #import bevy_core_pipeline::tonemapping  tone_mapping, powsafe, screen_space_dither
 
-@group(0) @binding(0)
-var<uniform> view: View;
+@group(0) @binding(0) var<uniform> view: View;
 
-@group(0) @binding(1)
-var hdr_texture: texture_2d<f32>;
-@group(0) @binding(2)
-var hdr_sampler: sampler;
-@group(0) @binding(3)
-var dt_lut_texture: texture_3d<f32>;
-@group(0) @binding(4)
-var dt_lut_sampler: sampler;
+@group(0) @binding(1) var hdr_texture: texture_2d<f32>;
+@group(0) @binding(2) var hdr_sampler: sampler;
+@group(0) @binding(3) var dt_lut_texture: texture_3d<f32>;
+@group(0) @binding(4) var dt_lut_sampler: sampler;
 
 #import bevy_core_pipeline::tonemapping
 

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
@@ -4,15 +4,11 @@
 
 // hack !! not sure what to do with this
 #ifdef TONEMAPPING_PASS
-    @group(0) @binding(3)
-    var dt_lut_texture: texture_3d<f32>;
-    @group(0) @binding(4)
-    var dt_lut_sampler: sampler;
+    @group(0) @binding(3) var dt_lut_texture: texture_3d<f32>;
+    @group(0) @binding(4) var dt_lut_sampler: sampler;
 #else
-    @group(0) @binding(15)
-    var dt_lut_texture: texture_3d<f32>;
-    @group(0) @binding(16)
-    var dt_lut_sampler: sampler;
+    @group(0) @binding(15) var dt_lut_texture: texture_3d<f32>;
+    @group(0) @binding(16) var dt_lut_sampler: sampler;
 #endif
 
 fn sample_current_lut(p: vec3<f32>) -> vec3<f32> {

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -1,8 +1,7 @@
 // TODO use common view binding
 #import bevy_render::view View
 
-@group(0) @binding(0)
-var<uniform> view: View;
+@group(0) @binding(0) var<uniform> view: View;
 
 
 struct LineGizmoUniform {
@@ -14,8 +13,7 @@ struct LineGizmoUniform {
 #endif
 }
 
-@group(1) @binding(0)
-var<uniform> line_gizmo: LineGizmoUniform;
+@group(1) @binding(0) var<uniform> line_gizmo: LineGizmoUniform;
 
 struct VertexInput {
     @location(0) position_a: vec3<f32>,

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -95,12 +95,9 @@ use std::marker::PhantomData;
 /// In WGSL shaders, the material's binding would look like this:
 ///
 /// ```wgsl
-/// @group(1) @binding(0)
-/// var<uniform> color: vec4<f32>;
-/// @group(1) @binding(1)
-/// var color_texture: texture_2d<f32>;
-/// @group(1) @binding(2)
-/// var color_sampler: sampler;
+/// @group(1) @binding(0) var<uniform> color: vec4<f32>;
+/// @group(1) @binding(1) var color_texture: texture_2d<f32>;
+/// @group(1) @binding(2) var color_sampler: sampler;
 /// ```
 pub trait Material: Asset + AsBindGroup + Clone + Sized {
     /// Returns this material's vertex shader. If [`ShaderRef::Default`] is returned, the default mesh vertex shader

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -3,16 +3,12 @@
 #import bevy_render::globals Globals
 #import bevy_pbr::mesh_types
 
-@group(0) @binding(0)
-var<uniform> view: View;
-@group(0) @binding(1)
-var<uniform> globals: Globals;
+@group(0) @binding(0) var<uniform> view: View;
+@group(0) @binding(1) var<uniform> globals: Globals;
 
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(2)
-var<uniform> previous_view_proj: mat4x4<f32>;
+@group(0) @binding(2) var<uniform> previous_view_proj: mat4x4<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 // Material bindings will be in @group(1)
-
 #import bevy_pbr::mesh_bindings   mesh

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -445,11 +445,9 @@ pub struct MeshPipeline {
     /// Use code like this in custom shaders:
     /// ```wgsl
     /// ##ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-    /// @group(2) @binding(0)
-    /// var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+    /// @group(2) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
     /// ##else
-    /// @group(2) @binding(0)
-    /// var<storage> mesh: array<Mesh>;
+    /// @group(2) @binding(0) var<storage> mesh: array<Mesh>;
     /// ##endif // PER_OBJECT_BUFFER_BATCH_SIZE
     /// ```
     pub per_object_buffer_batch_size: Option<u32>,

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -5,21 +5,17 @@
 #ifdef MESH_BINDGROUP_1
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(1) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+@group(1) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(1) @binding(0)
-var<storage> mesh: array<Mesh>;
+@group(1) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
 
 #else // MESH_BINDGROUP_1
 
 #ifdef PER_OBJECT_BUFFER_BATCH_SIZE
-@group(2) @binding(0)
-var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+@group(2) @binding(0) var<uniform> mesh: array<Mesh, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
 #else
-@group(2) @binding(0)
-var<storage> mesh: array<Mesh>;
+@group(2) @binding(0) var<storage> mesh: array<Mesh>;
 #endif // PER_OBJECT_BUFFER_BATCH_SIZE
 
 #endif // MESH_BINDGROUP_1

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -4,77 +4,49 @@
 #import bevy_render::view  View
 #import bevy_render::globals  Globals
 
-@group(0) @binding(0)
-var<uniform> view: View;
-@group(0) @binding(1)
-var<uniform> lights: types::Lights;
+@group(0) @binding(0) var<uniform> view: View;
+@group(0) @binding(1) var<uniform> lights: types::Lights;
 #ifdef NO_ARRAY_TEXTURES_SUPPORT
-@group(0) @binding(2)
-var point_shadow_textures: texture_depth_cube;
+@group(0) @binding(2) var point_shadow_textures: texture_depth_cube;
 #else
-@group(0) @binding(2)
-var point_shadow_textures: texture_depth_cube_array;
+@group(0) @binding(2) var point_shadow_textures: texture_depth_cube_array;
 #endif
-@group(0) @binding(3)
-var point_shadow_textures_sampler: sampler_comparison;
+@group(0) @binding(3) var point_shadow_textures_sampler: sampler_comparison;
 #ifdef NO_ARRAY_TEXTURES_SUPPORT
-@group(0) @binding(4)
-var directional_shadow_textures: texture_depth_2d;
+@group(0) @binding(4) var directional_shadow_textures: texture_depth_2d;
 #else
-@group(0) @binding(4)
-var directional_shadow_textures: texture_depth_2d_array;
+@group(0) @binding(4) var directional_shadow_textures: texture_depth_2d_array;
 #endif
-@group(0) @binding(5)
-var directional_shadow_textures_sampler: sampler_comparison;
+@group(0) @binding(5) var directional_shadow_textures_sampler: sampler_comparison;
 
 #if AVAILABLE_STORAGE_BUFFER_BINDINGS >= 3
-@group(0) @binding(6)
-var<storage> point_lights: types::PointLights;
-@group(0) @binding(7)
-var<storage> cluster_light_index_lists: types::ClusterLightIndexLists;
-@group(0) @binding(8)
-var<storage> cluster_offsets_and_counts: types::ClusterOffsetsAndCounts;
+@group(0) @binding(6) var<storage> point_lights: types::PointLights;
+@group(0) @binding(7) var<storage> cluster_light_index_lists: types::ClusterLightIndexLists;
+@group(0) @binding(8) var<storage> cluster_offsets_and_counts: types::ClusterOffsetsAndCounts;
 #else
-@group(0) @binding(6)
-var<uniform> point_lights: types::PointLights;
-@group(0) @binding(7)
-var<uniform> cluster_light_index_lists: types::ClusterLightIndexLists;
-@group(0) @binding(8)
-var<uniform> cluster_offsets_and_counts: types::ClusterOffsetsAndCounts;
+@group(0) @binding(6) var<uniform> point_lights: types::PointLights;
+@group(0) @binding(7) var<uniform> cluster_light_index_lists: types::ClusterLightIndexLists;
+@group(0) @binding(8) var<uniform> cluster_offsets_and_counts: types::ClusterOffsetsAndCounts;
 #endif
 
-@group(0) @binding(9)
-var<uniform> globals: Globals;
-@group(0) @binding(10)
-var<uniform> fog: types::Fog;
+@group(0) @binding(9) var<uniform> globals: Globals;
+@group(0) @binding(10) var<uniform> fog: types::Fog;
 
-@group(0) @binding(11)
-var screen_space_ambient_occlusion_texture: texture_2d<f32>;
+@group(0) @binding(11) var screen_space_ambient_occlusion_texture: texture_2d<f32>;
 
-@group(0) @binding(12)
-var environment_map_diffuse: texture_cube<f32>;
-@group(0) @binding(13)
-var environment_map_specular: texture_cube<f32>;
-@group(0) @binding(14)
-var environment_map_sampler: sampler;
+@group(0) @binding(12) var environment_map_diffuse: texture_cube<f32>;
+@group(0) @binding(13) var environment_map_specular: texture_cube<f32>;
+@group(0) @binding(14) var environment_map_sampler: sampler;
 
-@group(0) @binding(15)
-var dt_lut_texture: texture_3d<f32>;
-@group(0) @binding(16)
-var dt_lut_sampler: sampler;
+@group(0) @binding(15) var dt_lut_texture: texture_3d<f32>;
+@group(0) @binding(16) var dt_lut_sampler: sampler;
 
 #ifdef MULTISAMPLED
-@group(0) @binding(17)
-var depth_prepass_texture: texture_depth_multisampled_2d;
-@group(0) @binding(18)
-var normal_prepass_texture: texture_multisampled_2d<f32>;
-@group(0) @binding(19)
-var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(17) var depth_prepass_texture: texture_depth_multisampled_2d;
+@group(0) @binding(18) var normal_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(19) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
 #else
-@group(0) @binding(17)
-var depth_prepass_texture: texture_depth_2d;
-@group(0) @binding(18)
-var normal_prepass_texture: texture_2d<f32>;
-@group(0) @binding(19)
-var motion_vector_prepass_texture: texture_2d<f32>;
+@group(0) @binding(17) var depth_prepass_texture: texture_depth_2d;
+@group(0) @binding(18) var normal_prepass_texture: texture_2d<f32>;
+@group(0) @binding(19) var motion_vector_prepass_texture: texture_2d<f32>;
 #endif

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -13,17 +13,13 @@
 
 #ifdef MESH_BINDGROUP_1
 
-@group(1) @binding(2)
-var<uniform> morph_weights: MorphWeights;
-@group(1) @binding(3)
-var morph_targets: texture_3d<f32>;
+@group(1) @binding(2) var<uniform> morph_weights: MorphWeights;
+@group(1) @binding(3) var morph_targets: texture_3d<f32>;
 
 #else
 
-@group(2) @binding(2)
-var<uniform> morph_weights: MorphWeights;
-@group(2) @binding(3)
-var morph_targets: texture_3d<f32>;
+@group(2) @binding(2) var<uniform> morph_weights: MorphWeights;
+@group(2) @binding(3) var morph_targets: texture_3d<f32>;
 
 #endif
 

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -2,29 +2,16 @@
 
 #import bevy_pbr::pbr_types  StandardMaterial
 
-@group(1) @binding(0)
-var<uniform> material: StandardMaterial;
-@group(1) @binding(1)
-var base_color_texture: texture_2d<f32>;
-@group(1) @binding(2)
-var base_color_sampler: sampler;
-@group(1) @binding(3)
-var emissive_texture: texture_2d<f32>;
-@group(1) @binding(4)
-var emissive_sampler: sampler;
-@group(1) @binding(5)
-var metallic_roughness_texture: texture_2d<f32>;
-@group(1) @binding(6)
-var metallic_roughness_sampler: sampler;
-@group(1) @binding(7)
-var occlusion_texture: texture_2d<f32>;
-@group(1) @binding(8)
-var occlusion_sampler: sampler;
-@group(1) @binding(9)
-var normal_map_texture: texture_2d<f32>;
-@group(1) @binding(10)
-var normal_map_sampler: sampler;
-@group(1) @binding(11)
-var depth_map_texture: texture_2d<f32>;
-@group(1) @binding(12)
-var depth_map_sampler: sampler;
+@group(1) @binding(0) var<uniform> material: StandardMaterial;
+@group(1) @binding(1) var base_color_texture: texture_2d<f32>;
+@group(1) @binding(2) var base_color_sampler: sampler;
+@group(1) @binding(3) var emissive_texture: texture_2d<f32>;
+@group(1) @binding(4) var emissive_sampler: sampler;
+@group(1) @binding(5) var metallic_roughness_texture: texture_2d<f32>;
+@group(1) @binding(6) var metallic_roughness_sampler: sampler;
+@group(1) @binding(7) var occlusion_texture: texture_2d<f32>;
+@group(1) @binding(8) var occlusion_sampler: sampler;
+@group(1) @binding(9) var normal_map_texture: texture_2d<f32>;
+@group(1) @binding(10) var normal_map_sampler: sampler;
+@group(1) @binding(11) var depth_map_texture: texture_2d<f32>;
+@group(1) @binding(12) var depth_map_sampler: sampler;

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -5,15 +5,9 @@
 #ifdef SKINNED
 
 #ifdef MESH_BINDGROUP_1
-
-    @group(1) @binding(1)
-    var<uniform> joint_matrices: SkinnedMesh;
-
+    @group(1) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
 #else 
-
-    @group(2) @binding(1)
-    var<uniform> joint_matrices: SkinnedMesh;
-
+    @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
 #endif
 
 

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -92,14 +92,10 @@ impl Deref for BindGroup {
 /// In WGSL shaders, the binding would look like this:
 ///
 /// ```wgsl
-/// @group(1) @binding(0)
-/// var<uniform> color: vec4<f32>;
-/// @group(1) @binding(1)
-/// var color_texture: texture_2d<f32>;
-/// @group(1) @binding(2)
-/// var color_sampler: sampler;
-/// @group(1) @binding(3)
-/// var<storage> values: array<f32>;
+/// @group(1) @binding(0) var<uniform> color: vec4<f32>;
+/// @group(1) @binding(1) var color_texture: texture_2d<f32>;
+/// @group(1) @binding(2) var color_sampler: sampler;
+/// @group(1) @binding(3) var<storage> values: array<f32>;
 /// ```
 /// Note that the "group" index is determined by the usage context. It is not defined in [`AsBindGroup`]. For example, in Bevy material bind groups
 /// are generally bound to group 1.
@@ -194,8 +190,7 @@ impl Deref for BindGroup {
 ///     roughness: f32,
 /// };
 ///
-/// @group(1) @binding(0)
-/// var<uniform> material: CoolMaterial;
+/// @group(1) @binding(0) var<uniform> material: CoolMaterial;
 /// ```
 ///
 /// Some less common scenarios will require "struct-level" attributes. These are the currently supported struct-level attributes:

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -13,12 +13,9 @@ struct ColorMaterial {
 };
 const COLOR_MATERIAL_FLAGS_TEXTURE_BIT: u32 = 1u;
 
-@group(1) @binding(0)
-var<uniform> material: ColorMaterial;
-@group(1) @binding(1)
-var texture: texture_2d<f32>;
-@group(1) @binding(2)
-var texture_sampler: sampler;
+@group(1) @binding(0) var<uniform> material: ColorMaterial;
+@group(1) @binding(1) var texture: texture_2d<f32>;
+@group(1) @binding(2) var texture_sampler: sampler;
 
 @fragment
 fn fragment(

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -100,12 +100,9 @@ use crate::{
 ///     color: vec4<f32>,
 /// }
 ///
-/// @group(1) @binding(0)
-/// var<uniform> material: CustomMaterial;
-/// @group(1) @binding(1)
-/// var color_texture: texture_2d<f32>;
-/// @group(1) @binding(2)
-/// var color_sampler: sampler;
+/// @group(1) @binding(0) var<uniform> material: CustomMaterial;
+/// @group(1) @binding(1) var color_texture: texture_2d<f32>;
+/// @group(1) @binding(2) var color_sampler: sampler;
 /// ```
 pub trait Material2d: AsBindGroup + Asset + Clone + Sized {
     /// Returns this material's vertex shader. If [`ShaderRef::Default`] is returned, the default mesh vertex shader

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
@@ -2,5 +2,4 @@
 
 #import bevy_sprite::mesh2d_types
 
-@group(2) @binding(0)
-var<uniform> mesh: bevy_sprite::mesh2d_types::Mesh2d;
+@group(2) @binding(0) var<uniform> mesh: bevy_sprite::mesh2d_types::Mesh2d;

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -3,8 +3,6 @@
 #import bevy_render::view  View
 #import bevy_render::globals  Globals
 
-@group(0) @binding(0)
-var<uniform> view: View;
+@group(0) @binding(0) var<uniform> view: View;
 
-@group(0) @binding(1)
-var<uniform> globals: Globals;
+@group(0) @binding(1) var<uniform> globals: Globals;

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -5,8 +5,7 @@
 #import bevy_render::maths affine_to_square
 #import bevy_render::view  View
 
-@group(0) @binding(0)
-var<uniform> view: View;
+@group(0) @binding(0) var<uniform> view: View;
 
 struct VertexInput {
     @builtin(vertex_index) index: u32,
@@ -47,10 +46,8 @@ fn vertex(in: VertexInput) -> VertexOutput {
     return out;
 }
 
-@group(1) @binding(0)
-var sprite_texture: texture_2d<f32>;
-@group(1) @binding(1)
-var sprite_sampler: sampler;
+@group(1) @binding(0) var sprite_texture: texture_2d<f32>;
+@group(1) @binding(1) var sprite_sampler: sampler;
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -2,8 +2,7 @@
 
 const TEXTURED_QUAD: u32 = 0u;
 
-@group(0) @binding(0)
-var<uniform> view: View;
+@group(0) @binding(0) var<uniform> view: View;
 
 struct VertexOutput {
     @location(0) uv: vec2<f32>,

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -27,10 +27,8 @@ fn vertex(
     return out;
 }
 
-@group(1) @binding(0)
-var sprite_texture: texture_2d<f32>;
-@group(1) @binding(1)
-var sprite_sampler: sampler;
+@group(1) @binding(0) var sprite_texture: texture_2d<f32>;
+@group(1) @binding(1) var sprite_sampler: sampler;
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -215,8 +215,7 @@ const COLORED_MESH2D_SHADER: &str = r"
 #import bevy_sprite::mesh2d_types as MeshTypes
 #import bevy_sprite::mesh2d_functions as MeshFunctions
 
-@group(1) @binding(0)
-var<uniform> mesh: MeshTypes::Mesh2d;
+@group(1) @binding(0) var<uniform> mesh: MeshTypes::Mesh2d;
 
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {


### PR DESCRIPTION
# Objective

- When adding/removing bindings in large binding lists, git would generate very difficult-to-read diffs

## Solution

- Move the `@group(X) @binding(Y)` into the same line as the binding type declaration
