### PR TITLE
Cleanup `visibility` module

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -490,26 +490,21 @@ mod test {
 
     use bevy_hierarchy::BuildWorldChildren;
 
+    fn visibility_bundle(visibility: Visibility) -> VisibilityBundle {
+        VisibilityBundle {
+            visibility,
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn visibility_propagation() {
         let mut app = App::new();
         app.add_systems(Update, visibility_propagate_system);
 
-        let root1 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
+        let root1 = app.world.spawn(visibility_bundle(Visibility::Hidden)).id();
         let root1_child1 = app.world.spawn(VisibilityBundle::default()).id();
-        let root1_child2 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
+        let root1_child2 = app.world.spawn(visibility_bundle(Visibility::Hidden)).id();
         let root1_child1_grandchild1 = app.world.spawn(VisibilityBundle::default()).id();
         let root1_child2_grandchild1 = app.world.spawn(VisibilityBundle::default()).id();
 
@@ -525,13 +520,7 @@ mod test {
 
         let root2 = app.world.spawn(VisibilityBundle::default()).id();
         let root2_child1 = app.world.spawn(VisibilityBundle::default()).id();
-        let root2_child2 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
+        let root2_child2 = app.world.spawn(visibility_bundle(Visibility::Hidden)).id();
         let root2_child1_grandchild1 = app.world.spawn(VisibilityBundle::default()).id();
         let root2_child2_grandchild1 = app.world.spawn(VisibilityBundle::default()).id();
 
@@ -599,59 +588,19 @@ mod test {
 
     #[test]
     fn visibility_propagation_unconditional_visible() {
+        use Visibility::{Hidden, Inherited, Visible};
+
         let mut app = App::new();
         app.add_systems(Update, visibility_propagate_system);
 
-        let root1 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Visible,
-                ..Default::default()
-            })
-            .id();
-        let root1_child1 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Inherited,
-                ..Default::default()
-            })
-            .id();
-        let root1_child2 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
-        let root1_child1_grandchild1 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Visible,
-                ..Default::default()
-            })
-            .id();
-        let root1_child2_grandchild1 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Visible,
-                ..Default::default()
-            })
-            .id();
+        let root1 = app.world.spawn(visibility_bundle(Visible)).id();
+        let root1_child1 = app.world.spawn(visibility_bundle(Inherited)).id();
+        let root1_child2 = app.world.spawn(visibility_bundle(Hidden)).id();
+        let root1_child1_grandchild1 = app.world.spawn(visibility_bundle(Visible)).id();
+        let root1_child2_grandchild1 = app.world.spawn(visibility_bundle(Visible)).id();
 
-        let root2 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Inherited,
-                ..Default::default()
-            })
-            .id();
-        let root3 = app
-            .world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
+        let root2 = app.world.spawn(visibility_bundle(Inherited)).id();
+        let root3 = app.world.spawn(visibility_bundle(Hidden)).id();
 
         app.world
             .entity_mut(root1)
@@ -709,12 +658,7 @@ mod test {
         let id2 = world.spawn(VisibilityBundle::default()).id();
         world.entity_mut(id1).push_children(&[id2]);
 
-        let id3 = world
-            .spawn(VisibilityBundle {
-                visibility: Visibility::Hidden,
-                ..Default::default()
-            })
-            .id();
+        let id3 = world.spawn(visibility_bundle(Visibility::Hidden)).id();
         world.entity_mut(id2).push_children(&[id3]);
 
         let id4 = world.spawn(VisibilityBundle::default()).id();

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -431,7 +431,7 @@ pub fn check_visibility(
             }
 
             // If we have an aabb and transform, do frustum culling
-            if no_frustum_culling {
+            if !no_frustum_culling {
                 let model = transform.affine();
                 let model_sphere = Sphere {
                     center: model.transform_point3a(model_aabb.center),


### PR DESCRIPTION
# Objective

- `check_visibility` system in `bevy_render` had an `Option<&NoFrustumCulling>` that could be replaced by `Has`, which is theoretically faster and semantically more correct.
- It also had some awkward indenting due to very large closure argument lists.
- Some of the tests could be written more concisely

## Solution

Use `Has`, move the tuple destructuring in a `let` binding, create a function for the tests.

## Note to reviewers

Enable the "no white space diff" in the diff viewer to have a more meaningful diff in the `check_visibility` system.
In the "Files changed" view, click on the little cog right of the "Jump to" text, on the row where the "Review changes" button is. then enable the "Hide whitespace" checkbox and click reload.  

---

## Migration Guide

- The `check_visibility` system's `Option<&NoFrustumCulling>` parameter has been replaced by  `Has<NoFrustumCulling>`, if you were calling it manually, you should change the type to match it