### PR TITLE
Fix clippy lint in single_threaded_task_pool

### DIFF
--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -19,7 +19,7 @@ pub struct ThreadExecutor<'a>(PhantomData<&'a ()>);
 impl<'a> ThreadExecutor<'a> {
     /// Creates a new `ThreadExecutor`
     pub fn new() -> Self {
-        Self(PhantomData::default())
+        Self::default()
     }
 }
 


### PR DESCRIPTION
# Objective

`single_threaded_task_pool` emitted a warning:

```
warning: use of `default` to create a unit struct
  --> crates/bevy_tasks/src/single_threaded_task_pool.rs:22:25
   |
22 |         Self(PhantomData::default())
   |                         ^^^^^^^^^^^ help: remove this call to `default`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#default_constructed_unit_structs
   = note: `#[warn(clippy::default_constructed_unit_structs)]` on by default
```

## Solution

fix the lint