### PR TITLE
Allow for manual instantiation of an ImageLoader

### DIFF
--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// `CompressedImageFormats::from_features(render_device.features())`
 /// and it is a bitfield of length 4.
 ///
-/// If in doubt, use CompressedImageFormats::NONE to only load uncompressed images.
+/// If in doubt, use `CompressedImageFormats::NONE` to only load uncompressed images.
 ///
 #[derive(Clone)]
 pub struct ImageLoader {

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 /// Loader for images that can be read by the `image` crate.
 #[derive(Clone)]
 pub struct ImageLoader {
-    supported_compressed_formats: CompressedImageFormats,
+    pub supported_compressed_formats: CompressedImageFormats,
 }
 
 pub(crate) const IMG_FILE_EXTENSIONS: &[&str] = &[

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -17,8 +17,10 @@ use serde::{Deserialize, Serialize};
 /// compressed image formats this loader can handle.
 ///
 /// Typically, information about `supported_compressed_formats` is provided by
-/// CompressedImageFormats::from_features(render_device.features())
+/// `CompressedImageFormats::from_features(render_device.features())`
 /// and it is a bitfield of length 4.
+///
+/// If in doubt, use CompressedImageFormats::NONE to only load uncompressed images.
 ///
 #[derive(Clone)]
 pub struct ImageLoader {

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -12,6 +12,13 @@ use super::CompressedImageFormats;
 use serde::{Deserialize, Serialize};
 
 /// Loader for images that can be read by the `image` crate.
+///
+/// It contains a public variable `supported_compressed_formats` which specifies the
+/// compressed image formats this loader can handle.
+///
+/// Typically, information about `supported_compressed_formats` is provided by
+/// world.get_resource::<RenderDevice>() and it is a bitfield of length 4.
+///
 #[derive(Clone)]
 pub struct ImageLoader {
     pub supported_compressed_formats: CompressedImageFormats,

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 /// compressed image formats this loader can handle.
 ///
 /// Typically, information about `supported_compressed_formats` is provided by
-/// CompressedImageFormats::from_features(render_device.features()) 
+/// CompressedImageFormats::from_features(render_device.features())
 /// and it is a bitfield of length 4.
 ///
 #[derive(Clone)]

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -17,7 +17,8 @@ use serde::{Deserialize, Serialize};
 /// compressed image formats this loader can handle.
 ///
 /// Typically, information about `supported_compressed_formats` is provided by
-/// world.get_resource::<RenderDevice>() and it is a bitfield of length 4.
+/// CompressedImageFormats::from_features(render_device.features()) 
+/// and it is a bitfield of length 4.
 ///
 #[derive(Clone)]
 pub struct ImageLoader {


### PR DESCRIPTION
# Objective

I am trying to create a custom loader that loads an Image out of a Zip file and i realized that while i can manually instantiate a bevy GLTF loader, i cannot manually instantiate a bevy Image Loader due to the parameter on it being private.  Therefore i need a change like this to allow me to continue.  

## Solution

I suggest that we make this parameter public.   I can see that typically the constructor tries to read the RenderDevice resource to figure out which formats are valid but I think making it public will be nice for power users who can estimate/figure this out on their own and who want to load images anywhere in their bevy app, such as inside of a custom loader like i am doing.   

---

## Changelog
 

## Migration Guide
 not a breaking change.  