### PR TITLE
Add `unsafe_op_in_unsafe_fn` to Clippy CI & Crates

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use std::ops::Deref;
 use std::time::Duration;

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -2,6 +2,7 @@
 
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod app;
 mod main_schedule;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
 pub mod io;
 pub mod meta;
 pub mod processor;

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -88,7 +88,7 @@ impl ReflectAsset {
         handle: UntypedHandle,
     ) -> Option<&'w mut dyn Reflect> {
         // SAFETY: requirements are deferred to the caller
-        (self.get_unchecked_mut)(world, handle)
+        unsafe { (self.get_unchecked_mut)(world, handle) }
     }
 
     /// Equivalent of [`Assets::add`]

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,5 +1,6 @@
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 //! This crate provides core functionality for Bevy Engine.
 
 mod name;

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod blit;
 pub mod bloom;

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 extern crate proc_macro;
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod diagnostic;
 mod entity_count_diagnostics_plugin;

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
 #![allow(clippy::single_component_path_imports)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! Forces dynamic linking of Bevy.
 //!

--- a/crates/bevy_dynamic_plugin/src/lib.rs
+++ b/crates/bevy_dynamic_plugin/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod loader;
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -121,7 +121,7 @@ impl BundleComponentStatus for AddBundle {
     #[inline]
     unsafe fn get_status(&self, index: usize) -> ComponentStatus {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        *self.bundle_status.get_unchecked(index)
+        unsafe { *self.bundle_status.get_unchecked(index) }
     }
 }
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -417,11 +417,14 @@ impl<'a> Ticks<'a> {
         last_run: Tick,
         this_run: Tick,
     ) -> Self {
-        Self {
-            added: cells.added.deref(),
-            changed: cells.changed.deref(),
-            last_run,
-            this_run,
+        // SAFETY: It is the caller's responsibility to uphold the invariants of `deref`
+        unsafe {
+            Self {
+                added: cells.added.deref(),
+                changed: cells.changed.deref(),
+                last_run,
+                this_run,
+            }
         }
     }
 }
@@ -442,11 +445,14 @@ impl<'a> TicksMut<'a> {
         last_run: Tick,
         this_run: Tick,
     ) -> Self {
-        Self {
-            added: cells.added.deref_mut(),
-            changed: cells.changed.deref_mut(),
-            last_run,
-            this_run,
+        // SAFETY: It is the caller's responsibility to uphold the invariants of `deref_mut`
+        unsafe {
+            Self {
+                added: cells.added.deref_mut(),
+                changed: cells.changed.deref_mut(),
+                last_run,
+                this_run,
+            }
         }
     }
 }
@@ -847,9 +853,12 @@ impl<'a> MutUntyped<'a> {
     /// # Safety
     /// - `T` must be the erased pointee type for this [`MutUntyped`].
     pub unsafe fn with_type<T>(self) -> Mut<'a, T> {
-        Mut {
-            value: self.value.deref_mut(),
-            ticks: self.ticks,
+        // SAFETY: It is the responsibility of the caller to uphold the invariants of `deref_mut`
+        unsafe {
+            Mut {
+                value: self.value.deref_mut(),
+                ticks: self.ticks,
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -349,9 +349,11 @@ impl std::fmt::Debug for ComponentDescriptor {
 }
 
 impl ComponentDescriptor {
-    // SAFETY: The pointer points to a valid value of type `T` and it is safe to drop this value.
     unsafe fn drop_ptr<T>(x: OwningPtr<'_>) {
-        x.drop_as::<T>();
+        // SAFETY: The pointer points to a valid value of type `T` and it is safe to drop this value.
+        unsafe {
+            x.drop_as::<T>();
+        }
     }
 
     /// Create a new `ComponentDescriptor` for the type `T`.
@@ -536,7 +538,8 @@ impl Components {
     #[inline]
     pub unsafe fn get_info_unchecked(&self, id: ComponentId) -> &ComponentInfo {
         debug_assert!(id.index() < self.components.len());
-        self.components.get_unchecked(id.0)
+        // SAFETY: It is the caller's responsibility to ensure that `id` is a valid `ComponentId`
+        unsafe { self.components.get_unchecked(id.0) }
     }
 
     /// Type-erased equivalent of [`Components::component_id()`].
@@ -759,9 +762,12 @@ impl<'a> TickCells<'a> {
     /// All cells contained within must uphold the safety invariants of [`UnsafeCellDeref::read`].
     #[inline]
     pub(crate) unsafe fn read(&self) -> ComponentTicks {
-        ComponentTicks {
-            added: self.added.read(),
-            changed: self.changed.read(),
+        // SAFETY: It is the caller's responsibility to uphold the invariants of `read`
+        unsafe {
+            ComponentTicks {
+                added: self.added.read(),
+                changed: self.changed.read(),
+            }
         }
     }
 }

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -620,7 +620,7 @@ impl Entities {
     #[inline]
     pub(crate) unsafe fn set(&mut self, index: u32, location: EntityLocation) {
         // SAFETY: Caller guarantees that `index` a valid entity index
-        self.meta.get_unchecked_mut(index as usize).location = location;
+        unsafe { self.meta.get_unchecked_mut(index as usize) }.location = location;
     }
 
     /// Increments the `generation` of a freed [`Entity`]. The next entity ID allocated with this
@@ -736,9 +736,11 @@ impl Entities {
         let free_cursor = self.free_cursor.get_mut();
         *free_cursor = 0;
         self.meta.reserve(count);
-        // the EntityMeta struct only contains integers, and it is valid to have all bytes set to u8::MAX
-        self.meta.as_mut_ptr().write_bytes(u8::MAX, count);
-        self.meta.set_len(count);
+        // SAFETY: The EntityMeta struct only contains integers, and it is valid to have all bytes set to u8::MAX
+        unsafe {
+            self.meta.as_mut_ptr().write_bytes(u8::MAX, count);
+            self.meta.set_len(count);
+        }
 
         self.len = count as u32;
     }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
 
 #[cfg(target_pointer_width = "16")]

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -177,7 +177,7 @@ impl ReflectComponent {
         entity: UnsafeEntityCell<'a>,
     ) -> Option<Mut<'a, dyn Reflect>> {
         // SAFETY: safety requirements deferred to caller
-        (self.0.reflect_unchecked_mut)(entity)
+        unsafe { (self.0.reflect_unchecked_mut)(entity) }
     }
 
     /// Gets the value of this [`Component`] type from entity from `source_world` and [applies](Self::apply()) it to the value of this [`Component`] type in entity in `destination_world`.

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -116,7 +116,7 @@ impl ReflectResource {
         world: UnsafeWorldCell<'w>,
     ) -> Option<Mut<'w, dyn Reflect>> {
         // SAFETY: caller promises to uphold uniqueness guarantees
-        (self.0.reflect_unchecked_mut)(world)
+        unsafe { (self.0.reflect_unchecked_mut)(world) }
     }
 
     /// Gets the value of this [`Resource`] type from `source_world` and [applies](Self::apply()) it to the value of this [`Resource`] type in `destination_world`.

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -274,6 +274,8 @@ unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
         world: UnsafeWorldCell<'w>,
         _change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        world.world_metadata().removed_components()
+        // SAFETY: no component value access, removed component events can be read in parallel and are
+        // never mutably borrowed during system execution
+        unsafe { world.world_metadata() }.removed_components()
     }
 }

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -333,7 +333,7 @@ impl MultiThreadedExecutor {
             // SAFETY: `can_run` returned true, which means that:
             // - It must have called `update_archetype_component_access` for each run condition.
             // - There can be no systems running whose accesses would conflict with any conditions.
-            if !self.should_run(system_index, system, conditions, world_cell) {
+            if !unsafe { self.should_run(system_index, system, conditions, world_cell) } {
                 self.skip_system_and_signal_dependents(system_index);
                 continue;
             }
@@ -450,8 +450,9 @@ impl MultiThreadedExecutor {
             // - The caller ensures that `world` has permission to read any data
             //   required by the conditions.
             // - `update_archetype_component_access` has been called for each run condition.
-            let set_conditions_met =
-                evaluate_and_fold_conditions(&mut conditions.set_conditions[set_idx], world);
+            let set_conditions_met = unsafe {
+                evaluate_and_fold_conditions(&mut conditions.set_conditions[set_idx], world)
+            };
 
             if !set_conditions_met {
                 self.skipped_systems
@@ -467,8 +468,9 @@ impl MultiThreadedExecutor {
         // - The caller ensures that `world` has permission to read any data
         //   required by the conditions.
         // - `update_archetype_component_access` has been called for each run condition.
-        let system_conditions_met =
-            evaluate_and_fold_conditions(&mut conditions.system_conditions[system_index], world);
+        let system_conditions_met = unsafe {
+            evaluate_and_fold_conditions(&mut conditions.system_conditions[system_index], world)
+        };
 
         if !system_conditions_met {
             self.skipped_systems.insert(system_index);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -172,11 +172,17 @@ impl ComponentSparseSet {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index as usize]);
-            self.dense
-                .replace(TableRow::new(dense_index as usize), value, change_tick);
+            // SAFETY: It is the caller's responsibility to uphold the invariants of `replace`
+            unsafe {
+                self.dense
+                    .replace(TableRow::new(dense_index as usize), value, change_tick);
+            }
         } else {
             let dense_index = self.dense.len();
-            self.dense.push(value, ComponentTicks::new(change_tick));
+            // SAFETY: It is the caller's responsibility to uphold the invariants of `push`
+            unsafe {
+                self.dense.push(value, ComponentTicks::new(change_tick));
+            }
             self.sparse.insert(entity.index(), dense_index as u32);
             #[cfg(debug_assertions)]
             assert_eq!(self.entities.len(), dense_index);

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -107,8 +107,9 @@ where
     #[inline]
     unsafe fn run_unsafe(&mut self, input: Self::In, world: UnsafeWorldCell) -> Self::Out {
         // SAFETY: `system.run_unsafe` has the same invariants as `self.run_unsafe`.
-        self.func
-            .adapt(input, |input| self.system.run_unsafe(input, world))
+        self.func.adapt(input, |input| unsafe {
+            self.system.run_unsafe(input, world)
+        })
     }
 
     #[inline]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -658,8 +658,10 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         // SAFETY:
         // - `self.world` has permission to access the required components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
-        self.state
-            .iter_unchecked_manual(self.world, self.last_run, self.this_run)
+        unsafe {
+            self.state
+                .iter_unchecked_manual(self.world, self.last_run, self.this_run)
+        }
     }
 
     /// Iterates over all possible combinations of `K` query items without repetition.
@@ -679,8 +681,10 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         // SAFETY:
         // - `self.world` has permission to access the required components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
-        self.state
-            .iter_combinations_unchecked_manual(self.world, self.last_run, self.this_run)
+        unsafe {
+            self.state
+                .iter_combinations_unchecked_manual(self.world, self.last_run, self.this_run)
+        }
     }
 
     /// Returns an [`Iterator`] over the query items generated from an [`Entity`] list.
@@ -704,8 +708,14 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         // SAFETY:
         // - `self.world` has permission to access the required components.
         // - The caller ensures that this operation will not result in any aliased mutable accesses.
-        self.state
-            .iter_many_unchecked_manual(entities, self.world, self.last_run, self.this_run)
+        unsafe {
+            self.state.iter_many_unchecked_manual(
+                entities,
+                self.world,
+                self.last_run,
+                self.this_run,
+            )
+        }
     }
 
     /// Runs `f` on each read-only query item.
@@ -1064,8 +1074,10 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     pub unsafe fn get_unchecked(&self, entity: Entity) -> Result<Q::Item<'_>, QueryEntityError> {
         // SEMI-SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
-        self.state
-            .get_unchecked_manual(self.world, entity, self.last_run, self.this_run)
+        unsafe {
+            self.state
+                .get_unchecked_manual(self.world, entity, self.last_run, self.this_run)
+        }
     }
 
     /// Returns a shared reference to the component `T` of the given [`Entity`].

--- a/crates/bevy_ecs_compile_fail_tests/src/lib.rs
+++ b/crates/bevy_ecs_compile_fail_tests/src/lib.rs
@@ -1,3 +1,4 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 // Nothing here, check out the integration tests

--- a/crates/bevy_encase_derive/src/lib.rs
+++ b/crates/bevy_encase_derive/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use bevy_macro_utils::BevyManifest;
 use encase_derive_impl::{implement, syn};

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod converter;
 mod gilrs_system;

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! This crate adds an immediate mode drawing api to Bevy for visual debugging.
 //!

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 //! `bevy_hierarchy` can be used to define hierarchies of entities.
 //!
 //! Most commonly, these hierarchies are used for inheriting `Transform` values

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! Input functionality for the [Bevy game engine](https://bevyengine.org/).
 //!

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 //! This module is separated into its own crate to enable simple dynamic linking for Bevy, and should not be used directly
 
 /// `use bevy::prelude::*;` to import common components, bundles, and plugins.

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 //! This crate provides logging functions and configuration for [Bevy](https://bevyengine.org)
 //! apps, and automatically configures platform specific log handlers (i.e. WASM or Android).
 //!

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 extern crate proc_macro;
 

--- a/crates/bevy_macros_compile_fail_tests/src/lib.rs
+++ b/crates/bevy_macros_compile_fail_tests/src/lib.rs
@@ -1,1 +1,2 @@
 // Nothing here, check out the integration tests
+#![forbid(unsafe_op_in_unsafe_fn)]

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -6,6 +6,7 @@
 
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod affine3;
 pub mod cubic_splines;

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -230,110 +230,113 @@ pub unsafe fn genTangSpace<I: Geometry>(geometry: &mut I, fAngularThreshold: f32
     let mut piTriListIn = vec![0i32; 3 * iNrTrianglesIn];
     let mut pTriInfos = vec![STriInfo::zero(); iNrTrianglesIn];
 
-    iNrTSPaces = GenerateInitialVerticesIndexList(
-        &mut pTriInfos,
-        &mut piTriListIn,
-        geometry,
-        iNrTrianglesIn,
-    );
-    GenerateSharedVerticesIndexList(piTriListIn.as_mut_ptr(), geometry, iNrTrianglesIn);
-    iTotTris = iNrTrianglesIn;
-    iDegenTriangles = 0;
-    t = 0;
-    while t < iTotTris as usize {
-        let i0 = piTriListIn[t * 3 + 0];
-        let i1 = piTriListIn[t * 3 + 1];
-        let i2 = piTriListIn[t * 3 + 2];
-        let p0 = get_position(geometry, i0 as usize);
-        let p1 = get_position(geometry, i1 as usize);
-        let p2 = get_position(geometry, i2 as usize);
-        if p0 == p1 || p0 == p2 || p1 == p2 {
-            pTriInfos[t].iFlag |= 1i32;
-            iDegenTriangles += 1
-        }
-        t += 1
-    }
-    iNrTrianglesIn = iTotTris - iDegenTriangles;
-    DegenPrologue(
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_mut_ptr(),
-        iNrTrianglesIn as i32,
-        iTotTris as i32,
-    );
-    InitTriInfo(
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_ptr(),
-        geometry,
-        iNrTrianglesIn,
-    );
-    iNrMaxGroups = iNrTrianglesIn * 3;
-
-    let mut pGroups = vec![SGroup::zero(); iNrMaxGroups];
-    let mut piGroupTrianglesBuffer = vec![0; iNrTrianglesIn * 3];
-
-    iNrActiveGroups = Build4RuleGroups(
-        pTriInfos.as_mut_ptr(),
-        pGroups.as_mut_ptr(),
-        piGroupTrianglesBuffer.as_mut_ptr(),
-        piTriListIn.as_ptr(),
-        iNrTrianglesIn as i32,
-    );
-
-    let mut psTspace = vec![
-        STSpace {
-            vOs: Vec3::new(1.0, 0.0, 0.0),
-            fMagS: 1.0,
-            vOt: Vec3::new(0.0, 1.0, 0.0),
-            fMagT: 1.0,
-            ..STSpace::zero()
-        };
-        iNrTSPaces
-    ];
-
-    bRes = GenerateTSpaces(
-        &mut psTspace,
-        pTriInfos.as_ptr(),
-        pGroups.as_ptr(),
-        iNrActiveGroups,
-        piTriListIn.as_ptr(),
-        fThresCos,
-        geometry,
-    );
-    if !bRes {
-        return false;
-    }
-    DegenEpilogue(
-        psTspace.as_mut_ptr(),
-        pTriInfos.as_mut_ptr(),
-        piTriListIn.as_mut_ptr(),
-        geometry,
-        iNrTrianglesIn as i32,
-        iTotTris as i32,
-    );
-    index = 0;
-    f = 0;
-    while f < iNrFaces {
-        let verts_0 = geometry.num_vertices_of_face(f);
-        if !(verts_0 != 3 && verts_0 != 4) {
-            i = 0;
-            while i < verts_0 {
-                let mut pTSpace: *const STSpace = &mut psTspace[index] as *mut STSpace;
-                let mut tang = Vec3::new((*pTSpace).vOs.x, (*pTSpace).vOs.y, (*pTSpace).vOs.z);
-                let mut bitang = Vec3::new((*pTSpace).vOt.x, (*pTSpace).vOt.y, (*pTSpace).vOt.z);
-                geometry.set_tangent(
-                    tang.into(),
-                    bitang.into(),
-                    (*pTSpace).fMagS,
-                    (*pTSpace).fMagT,
-                    (*pTSpace).bOrient,
-                    f,
-                    i,
-                );
-                index += 1;
-                i += 1
+    unsafe {
+        iNrTSPaces = GenerateInitialVerticesIndexList(
+            &mut pTriInfos,
+            &mut piTriListIn,
+            geometry,
+            iNrTrianglesIn,
+        );
+        GenerateSharedVerticesIndexList(piTriListIn.as_mut_ptr(), geometry, iNrTrianglesIn);
+        iTotTris = iNrTrianglesIn;
+        iDegenTriangles = 0;
+        t = 0;
+        while t < iTotTris as usize {
+            let i0 = piTriListIn[t * 3 + 0];
+            let i1 = piTriListIn[t * 3 + 1];
+            let i2 = piTriListIn[t * 3 + 2];
+            let p0 = get_position(geometry, i0 as usize);
+            let p1 = get_position(geometry, i1 as usize);
+            let p2 = get_position(geometry, i2 as usize);
+            if p0 == p1 || p0 == p2 || p1 == p2 {
+                pTriInfos[t].iFlag |= 1i32;
+                iDegenTriangles += 1
             }
+            t += 1
         }
-        f += 1
+        iNrTrianglesIn = iTotTris - iDegenTriangles;
+        DegenPrologue(
+            pTriInfos.as_mut_ptr(),
+            piTriListIn.as_mut_ptr(),
+            iNrTrianglesIn as i32,
+            iTotTris as i32,
+        );
+        InitTriInfo(
+            pTriInfos.as_mut_ptr(),
+            piTriListIn.as_ptr(),
+            geometry,
+            iNrTrianglesIn,
+        );
+        iNrMaxGroups = iNrTrianglesIn * 3;
+
+        let mut pGroups = vec![SGroup::zero(); iNrMaxGroups];
+        let mut piGroupTrianglesBuffer = vec![0; iNrTrianglesIn * 3];
+
+        iNrActiveGroups = Build4RuleGroups(
+            pTriInfos.as_mut_ptr(),
+            pGroups.as_mut_ptr(),
+            piGroupTrianglesBuffer.as_mut_ptr(),
+            piTriListIn.as_ptr(),
+            iNrTrianglesIn as i32,
+        );
+
+        let mut psTspace = vec![
+            STSpace {
+                vOs: Vec3::new(1.0, 0.0, 0.0),
+                fMagS: 1.0,
+                vOt: Vec3::new(0.0, 1.0, 0.0),
+                fMagT: 1.0,
+                ..STSpace::zero()
+            };
+            iNrTSPaces
+        ];
+
+        bRes = GenerateTSpaces(
+            &mut psTspace,
+            pTriInfos.as_ptr(),
+            pGroups.as_ptr(),
+            iNrActiveGroups,
+            piTriListIn.as_ptr(),
+            fThresCos,
+            geometry,
+        );
+        if !bRes {
+            return false;
+        }
+        DegenEpilogue(
+            psTspace.as_mut_ptr(),
+            pTriInfos.as_mut_ptr(),
+            piTriListIn.as_mut_ptr(),
+            geometry,
+            iNrTrianglesIn as i32,
+            iTotTris as i32,
+        );
+        index = 0;
+        f = 0;
+        while f < iNrFaces {
+            let verts_0 = geometry.num_vertices_of_face(f);
+            if !(verts_0 != 3 && verts_0 != 4) {
+                i = 0;
+                while i < verts_0 {
+                    let mut pTSpace: *const STSpace = &mut psTspace[index] as *mut STSpace;
+                    let mut tang = Vec3::new((*pTSpace).vOs.x, (*pTSpace).vOs.y, (*pTSpace).vOs.z);
+                    let mut bitang =
+                        Vec3::new((*pTSpace).vOt.x, (*pTSpace).vOt.y, (*pTSpace).vOt.z);
+                    geometry.set_tangent(
+                        tang.into(),
+                        bitang.into(),
+                        (*pTSpace).fMagS,
+                        (*pTSpace).fMagT,
+                        (*pTSpace).bOrient,
+                        f,
+                        i,
+                    );
+                    index += 1;
+                    i += 1
+                }
+            }
+            f += 1
+        }
     }
 
     return true;
@@ -349,85 +352,88 @@ unsafe fn DegenEpilogue<I: Geometry>(
     let mut t: i32 = 0i32;
     let mut i: i32 = 0i32;
     t = iNrTrianglesIn;
-    while t < iTotTris {
-        let bSkip: bool = if (*pTriInfos.offset(t as isize)).iFlag & 2i32 != 0i32 {
-            true
-        } else {
-            false
-        };
-        if !bSkip {
-            i = 0i32;
-            while i < 3i32 {
-                let index1: i32 = *piTriListIn.offset((t * 3i32 + i) as isize);
-                let mut bNotFound: bool = true;
-                let mut j: i32 = 0i32;
-                while bNotFound && j < 3i32 * iNrTrianglesIn {
-                    let index2: i32 = *piTriListIn.offset(j as isize);
-                    if index1 == index2 {
-                        bNotFound = false
+    unsafe {
+        while t < iTotTris {
+            let bSkip: bool = if (*pTriInfos.offset(t as isize)).iFlag & 2i32 != 0i32 {
+                true
+            } else {
+                false
+            };
+            if !bSkip {
+                i = 0i32;
+                while i < 3i32 {
+                    let index1: i32 = *piTriListIn.offset((t * 3i32 + i) as isize);
+                    let mut bNotFound: bool = true;
+                    let mut j: i32 = 0i32;
+                    while bNotFound && j < 3i32 * iNrTrianglesIn {
+                        let index2: i32 = *piTriListIn.offset(j as isize);
+                        if index1 == index2 {
+                            bNotFound = false
+                        } else {
+                            j += 1
+                        }
+                    }
+                    if !bNotFound {
+                        let iTri: i32 = j / 3i32;
+                        let iVert: i32 = j % 3i32;
+                        let iSrcVert: i32 =
+                            (*pTriInfos.offset(iTri as isize)).vert_num[iVert as usize] as i32;
+                        let iSrcOffs: i32 = (*pTriInfos.offset(iTri as isize)).iTSpacesOffs;
+                        let iDstVert: i32 =
+                            (*pTriInfos.offset(t as isize)).vert_num[i as usize] as i32;
+                        let iDstOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
+                        *psTspace.offset((iDstOffs + iDstVert) as isize) =
+                            *psTspace.offset((iSrcOffs + iSrcVert) as isize)
+                    }
+                    i += 1
+                }
+            }
+            t += 1
+        }
+        t = 0i32;
+        while t < iNrTrianglesIn {
+            if (*pTriInfos.offset(t as isize)).iFlag & 2i32 != 0i32 {
+                let mut vDstP = Vec3::new(0.0, 0.0, 0.0);
+                let mut iOrgF: i32 = -1i32;
+                let mut i_0: i32 = 0i32;
+                let mut bNotFound_0: bool = false;
+                let mut pV: *mut u8 = (*pTriInfos.offset(t as isize)).vert_num.as_mut_ptr();
+                let mut iFlag: i32 = 1i32 << *pV.offset(0isize) as i32
+                    | 1i32 << *pV.offset(1isize) as i32
+                    | 1i32 << *pV.offset(2isize) as i32;
+                let mut iMissingIndex: i32 = 0i32;
+                if iFlag & 2i32 == 0i32 {
+                    iMissingIndex = 1i32
+                } else if iFlag & 4i32 == 0i32 {
+                    iMissingIndex = 2i32
+                } else if iFlag & 8i32 == 0i32 {
+                    iMissingIndex = 3i32
+                }
+                iOrgF = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
+                vDstP = get_position(
+                    geometry,
+                    face_vert_to_index(iOrgF as usize, iMissingIndex as usize),
+                );
+                bNotFound_0 = true;
+                i_0 = 0i32;
+                while bNotFound_0 && i_0 < 3i32 {
+                    let iVert_0: i32 = *pV.offset(i_0 as isize) as i32;
+                    let vSrcP = get_position(
+                        geometry,
+                        face_vert_to_index(iOrgF as usize, iVert_0 as usize),
+                    );
+                    if vSrcP == vDstP {
+                        let iOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
+                        *psTspace.offset((iOffs + iMissingIndex) as isize) =
+                            *psTspace.offset((iOffs + iVert_0) as isize);
+                        bNotFound_0 = false
                     } else {
-                        j += 1
+                        i_0 += 1
                     }
                 }
-                if !bNotFound {
-                    let iTri: i32 = j / 3i32;
-                    let iVert: i32 = j % 3i32;
-                    let iSrcVert: i32 =
-                        (*pTriInfos.offset(iTri as isize)).vert_num[iVert as usize] as i32;
-                    let iSrcOffs: i32 = (*pTriInfos.offset(iTri as isize)).iTSpacesOffs;
-                    let iDstVert: i32 = (*pTriInfos.offset(t as isize)).vert_num[i as usize] as i32;
-                    let iDstOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
-                    *psTspace.offset((iDstOffs + iDstVert) as isize) =
-                        *psTspace.offset((iSrcOffs + iSrcVert) as isize)
-                }
-                i += 1
             }
+            t += 1
         }
-        t += 1
-    }
-    t = 0i32;
-    while t < iNrTrianglesIn {
-        if (*pTriInfos.offset(t as isize)).iFlag & 2i32 != 0i32 {
-            let mut vDstP = Vec3::new(0.0, 0.0, 0.0);
-            let mut iOrgF: i32 = -1i32;
-            let mut i_0: i32 = 0i32;
-            let mut bNotFound_0: bool = false;
-            let mut pV: *mut u8 = (*pTriInfos.offset(t as isize)).vert_num.as_mut_ptr();
-            let mut iFlag: i32 = 1i32 << *pV.offset(0isize) as i32
-                | 1i32 << *pV.offset(1isize) as i32
-                | 1i32 << *pV.offset(2isize) as i32;
-            let mut iMissingIndex: i32 = 0i32;
-            if iFlag & 2i32 == 0i32 {
-                iMissingIndex = 1i32
-            } else if iFlag & 4i32 == 0i32 {
-                iMissingIndex = 2i32
-            } else if iFlag & 8i32 == 0i32 {
-                iMissingIndex = 3i32
-            }
-            iOrgF = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-            vDstP = get_position(
-                geometry,
-                face_vert_to_index(iOrgF as usize, iMissingIndex as usize),
-            );
-            bNotFound_0 = true;
-            i_0 = 0i32;
-            while bNotFound_0 && i_0 < 3i32 {
-                let iVert_0: i32 = *pV.offset(i_0 as isize) as i32;
-                let vSrcP = get_position(
-                    geometry,
-                    face_vert_to_index(iOrgF as usize, iVert_0 as usize),
-                );
-                if vSrcP == vDstP {
-                    let iOffs: i32 = (*pTriInfos.offset(t as isize)).iTSpacesOffs;
-                    *psTspace.offset((iOffs + iMissingIndex) as isize) =
-                        *psTspace.offset((iOffs + iVert_0) as isize);
-                    bNotFound_0 = false
-                } else {
-                    i_0 += 1
-                }
-            }
-        }
-        t += 1
     }
 }
 
@@ -445,188 +451,194 @@ unsafe fn GenerateTSpaces<I: Geometry>(
     let mut g: i32 = 0i32;
     let mut i: i32 = 0i32;
     g = 0i32;
-    while g < iNrActiveGroups {
-        if iMaxNrFaces < (*pGroups.offset(g as isize)).iNrFaces as usize {
-            iMaxNrFaces = (*pGroups.offset(g as isize)).iNrFaces as usize
+    unsafe {
+        while g < iNrActiveGroups {
+            if iMaxNrFaces < (*pGroups.offset(g as isize)).iNrFaces as usize {
+                iMaxNrFaces = (*pGroups.offset(g as isize)).iNrFaces as usize
+            }
+            g += 1
         }
-        g += 1
-    }
-    if iMaxNrFaces == 0 {
-        return true;
-    }
+        if iMaxNrFaces == 0 {
+            return true;
+        }
 
-    let mut pSubGroupTspace = vec![STSpace::zero(); iMaxNrFaces];
-    let mut pUniSubGroups = vec![SSubGroup::zero(); iMaxNrFaces];
-    let mut pTmpMembers = vec![0i32; iMaxNrFaces];
+        let mut pSubGroupTspace = vec![STSpace::zero(); iMaxNrFaces];
+        let mut pUniSubGroups = vec![SSubGroup::zero(); iMaxNrFaces];
+        let mut pTmpMembers = vec![0i32; iMaxNrFaces];
 
-    iUniqueTspaces = 0;
-    g = 0i32;
-    while g < iNrActiveGroups {
-        let mut pGroup: *const SGroup = &*pGroups.offset(g as isize) as *const SGroup;
-        let mut iUniqueSubGroups = 0;
-        let mut s = 0;
-        i = 0i32;
-        while i < (*pGroup).iNrFaces {
-            let f: i32 = *(*pGroup).pFaceIndices.offset(i as isize);
-            let mut index: i32 = -1i32;
-            let mut iVertIndex: i32 = -1i32;
-            let mut iOF_1: i32 = -1i32;
-            let mut iMembers: usize = 0;
-            let mut j: i32 = 0i32;
-            let mut l: usize = 0;
-            let mut tmp_group: SSubGroup = SSubGroup {
-                iNrFaces: 0,
-                pTriMembers: Vec::new(),
-            };
-            let mut bFound: bool = false;
-            let mut n = Vec3::new(0.0, 0.0, 0.0);
-            let mut vOs = Vec3::new(0.0, 0.0, 0.0);
-            let mut vOt = Vec3::new(0.0, 0.0, 0.0);
-            if (*pTriInfos.offset(f as isize)).AssignedGroup[0usize] == pGroup as *mut SGroup {
-                index = 0i32
-            } else if (*pTriInfos.offset(f as isize)).AssignedGroup[1usize] == pGroup as *mut SGroup
-            {
-                index = 1i32
-            } else if (*pTriInfos.offset(f as isize)).AssignedGroup[2usize] == pGroup as *mut SGroup
-            {
-                index = 2i32
-            }
-            iVertIndex = *piTriListIn.offset((f * 3i32 + index) as isize);
-            n = get_normal(geometry, iVertIndex as usize);
-            let mut vOs = (*pTriInfos.offset(f as isize)).vOs
-                - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
-            let mut vOt = (*pTriInfos.offset(f as isize)).vOt
-                - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
-            if VNotZero(vOs) {
-                vOs = Normalize(vOs)
-            }
-            if VNotZero(vOt) {
-                vOt = Normalize(vOt)
-            }
-            iOF_1 = (*pTriInfos.offset(f as isize)).iOrgFaceNumber;
-            iMembers = 0;
-            j = 0i32;
-            while j < (*pGroup).iNrFaces {
-                let t: i32 = *(*pGroup).pFaceIndices.offset(j as isize);
-                let iOF_2: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-                let mut vOs2 = (*pTriInfos.offset(t as isize)).vOs
-                    - (n.dot((*pTriInfos.offset(t as isize)).vOs) * n);
-                let mut vOt2 = (*pTriInfos.offset(t as isize)).vOt
-                    - (n.dot((*pTriInfos.offset(t as isize)).vOt) * n);
-                if VNotZero(vOs2) {
-                    vOs2 = Normalize(vOs2)
-                }
-                if VNotZero(vOt2) {
-                    vOt2 = Normalize(vOt2)
-                }
-                let bAny: bool = if ((*pTriInfos.offset(f as isize)).iFlag
-                    | (*pTriInfos.offset(t as isize)).iFlag)
-                    & 4i32
-                    != 0i32
-                {
-                    true
-                } else {
-                    false
+        iUniqueTspaces = 0;
+        g = 0i32;
+        while g < iNrActiveGroups {
+            let mut pGroup: *const SGroup = &*pGroups.offset(g as isize) as *const SGroup;
+            let mut iUniqueSubGroups = 0;
+            let mut s = 0;
+            i = 0i32;
+            while i < (*pGroup).iNrFaces {
+                let f: i32 = *(*pGroup).pFaceIndices.offset(i as isize);
+                let mut index: i32 = -1i32;
+                let mut iVertIndex: i32 = -1i32;
+                let mut iOF_1: i32 = -1i32;
+                let mut iMembers: usize = 0;
+                let mut j: i32 = 0i32;
+                let mut l: usize = 0;
+                let mut tmp_group: SSubGroup = SSubGroup {
+                    iNrFaces: 0,
+                    pTriMembers: Vec::new(),
                 };
-                let bSameOrgFace: bool = iOF_1 == iOF_2;
-                let fCosS: f32 = vOs.dot(vOs2);
-                let fCosT: f32 = vOt.dot(vOt2);
-                if bAny || bSameOrgFace || fCosS > fThresCos && fCosT > fThresCos {
-                    let fresh0 = iMembers;
-                    iMembers = iMembers + 1;
-                    pTmpMembers[fresh0] = t
+                let mut bFound: bool = false;
+                let mut n = Vec3::new(0.0, 0.0, 0.0);
+                let mut vOs = Vec3::new(0.0, 0.0, 0.0);
+                let mut vOt = Vec3::new(0.0, 0.0, 0.0);
+                if (*pTriInfos.offset(f as isize)).AssignedGroup[0usize] == pGroup as *mut SGroup {
+                    index = 0i32
+                } else if (*pTriInfos.offset(f as isize)).AssignedGroup[1usize]
+                    == pGroup as *mut SGroup
+                {
+                    index = 1i32
+                } else if (*pTriInfos.offset(f as isize)).AssignedGroup[2usize]
+                    == pGroup as *mut SGroup
+                {
+                    index = 2i32
                 }
-                j += 1
-            }
-            if iMembers > 1 {
-                let mut uSeed: u32 = 39871946i32 as u32;
-                QuickSort(pTmpMembers.as_mut_ptr(), 0i32, (iMembers - 1) as i32, uSeed);
-            }
-            tmp_group.iNrFaces = iMembers as i32;
-            tmp_group.pTriMembers = pTmpMembers.clone();
-            bFound = false;
-            l = 0;
-            while l < iUniqueSubGroups && !bFound {
-                bFound = CompareSubGroups(&mut tmp_group, &mut pUniSubGroups[l]);
+                iVertIndex = *piTriListIn.offset((f * 3i32 + index) as isize);
+                n = get_normal(geometry, iVertIndex as usize);
+                let mut vOs = (*pTriInfos.offset(f as isize)).vOs
+                    - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
+                let mut vOt = (*pTriInfos.offset(f as isize)).vOt
+                    - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
+                if VNotZero(vOs) {
+                    vOs = Normalize(vOs)
+                }
+                if VNotZero(vOt) {
+                    vOt = Normalize(vOt)
+                }
+                iOF_1 = (*pTriInfos.offset(f as isize)).iOrgFaceNumber;
+                iMembers = 0;
+                j = 0i32;
+                while j < (*pGroup).iNrFaces {
+                    let t: i32 = *(*pGroup).pFaceIndices.offset(j as isize);
+                    let iOF_2: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
+                    let mut vOs2 = (*pTriInfos.offset(t as isize)).vOs
+                        - (n.dot((*pTriInfos.offset(t as isize)).vOs) * n);
+                    let mut vOt2 = (*pTriInfos.offset(t as isize)).vOt
+                        - (n.dot((*pTriInfos.offset(t as isize)).vOt) * n);
+                    if VNotZero(vOs2) {
+                        vOs2 = Normalize(vOs2)
+                    }
+                    if VNotZero(vOt2) {
+                        vOt2 = Normalize(vOt2)
+                    }
+                    let bAny: bool = if ((*pTriInfos.offset(f as isize)).iFlag
+                        | (*pTriInfos.offset(t as isize)).iFlag)
+                        & 4i32
+                        != 0i32
+                    {
+                        true
+                    } else {
+                        false
+                    };
+                    let bSameOrgFace: bool = iOF_1 == iOF_2;
+                    let fCosS: f32 = vOs.dot(vOs2);
+                    let fCosT: f32 = vOt.dot(vOt2);
+                    if bAny || bSameOrgFace || fCosS > fThresCos && fCosT > fThresCos {
+                        let fresh0 = iMembers;
+                        iMembers = iMembers + 1;
+                        pTmpMembers[fresh0] = t
+                    }
+                    j += 1
+                }
+                if iMembers > 1 {
+                    let mut uSeed: u32 = 39871946i32 as u32;
+                    QuickSort(pTmpMembers.as_mut_ptr(), 0i32, (iMembers - 1) as i32, uSeed);
+                }
+                tmp_group.iNrFaces = iMembers as i32;
+                tmp_group.pTriMembers = pTmpMembers.clone();
+                bFound = false;
+                l = 0;
+                while l < iUniqueSubGroups && !bFound {
+                    bFound = CompareSubGroups(&mut tmp_group, &mut pUniSubGroups[l]);
+                    if !bFound {
+                        l += 1
+                    }
+                }
                 if !bFound {
-                    l += 1
-                }
-            }
-            if !bFound {
-                pUniSubGroups[iUniqueSubGroups].iNrFaces = iMembers as i32;
-                pUniSubGroups[iUniqueSubGroups].pTriMembers = tmp_group.pTriMembers.clone();
+                    pUniSubGroups[iUniqueSubGroups].iNrFaces = iMembers as i32;
+                    pUniSubGroups[iUniqueSubGroups].pTriMembers = tmp_group.pTriMembers.clone();
 
-                pSubGroupTspace[iUniqueSubGroups] = EvalTspace(
-                    tmp_group.pTriMembers.as_mut_ptr(),
-                    iMembers as i32,
-                    piTriListIn,
-                    pTriInfos,
-                    geometry,
-                    (*pGroup).iVertexRepresentitive,
-                );
-                iUniqueSubGroups += 1
+                    pSubGroupTspace[iUniqueSubGroups] = EvalTspace(
+                        tmp_group.pTriMembers.as_mut_ptr(),
+                        iMembers as i32,
+                        piTriListIn,
+                        pTriInfos,
+                        geometry,
+                        (*pGroup).iVertexRepresentitive,
+                    );
+                    iUniqueSubGroups += 1
+                }
+                let iOffs = (*pTriInfos.offset(f as isize)).iTSpacesOffs as usize;
+                let iVert = (*pTriInfos.offset(f as isize)).vert_num[index as usize] as usize;
+                let mut pTS_out: *mut STSpace = &mut psTspace[iOffs + iVert] as *mut STSpace;
+                if (*pTS_out).iCounter == 1i32 {
+                    *pTS_out = AvgTSpace(pTS_out, &mut pSubGroupTspace[l]);
+                    (*pTS_out).iCounter = 2i32;
+                    (*pTS_out).bOrient = (*pGroup).bOrientPreservering
+                } else {
+                    *pTS_out = pSubGroupTspace[l];
+                    (*pTS_out).iCounter = 1i32;
+                    (*pTS_out).bOrient = (*pGroup).bOrientPreservering
+                }
+                i += 1
             }
-            let iOffs = (*pTriInfos.offset(f as isize)).iTSpacesOffs as usize;
-            let iVert = (*pTriInfos.offset(f as isize)).vert_num[index as usize] as usize;
-            let mut pTS_out: *mut STSpace = &mut psTspace[iOffs + iVert] as *mut STSpace;
-            if (*pTS_out).iCounter == 1i32 {
-                *pTS_out = AvgTSpace(pTS_out, &mut pSubGroupTspace[l]);
-                (*pTS_out).iCounter = 2i32;
-                (*pTS_out).bOrient = (*pGroup).bOrientPreservering
-            } else {
-                *pTS_out = pSubGroupTspace[l];
-                (*pTS_out).iCounter = 1i32;
-                (*pTS_out).bOrient = (*pGroup).bOrientPreservering
-            }
-            i += 1
+            iUniqueTspaces += iUniqueSubGroups;
+            g += 1
         }
-        iUniqueTspaces += iUniqueSubGroups;
-        g += 1
     }
     return true;
 }
 unsafe fn AvgTSpace(mut pTS0: *const STSpace, mut pTS1: *const STSpace) -> STSpace {
-    let mut ts_res: STSpace = STSpace {
-        vOs: Vec3::new(0.0, 0.0, 0.0),
-        fMagS: 0.,
-        vOt: Vec3::new(0.0, 0.0, 0.0),
-        fMagT: 0.,
-        iCounter: 0,
-        bOrient: false,
-    };
-    if (*pTS0).fMagS == (*pTS1).fMagS
-        && (*pTS0).fMagT == (*pTS1).fMagT
-        && (*pTS0).vOs == (*pTS1).vOs
-        && (*pTS0).vOt == (*pTS1).vOt
-    {
-        ts_res.fMagS = (*pTS0).fMagS;
-        ts_res.fMagT = (*pTS0).fMagT;
-        ts_res.vOs = (*pTS0).vOs;
-        ts_res.vOt = (*pTS0).vOt
-    } else {
-        ts_res.fMagS = 0.5f32 * ((*pTS0).fMagS + (*pTS1).fMagS);
-        ts_res.fMagT = 0.5f32 * ((*pTS0).fMagT + (*pTS1).fMagT);
-        ts_res.vOs = (*pTS0).vOs + (*pTS1).vOs;
-        ts_res.vOt = (*pTS0).vOt + (*pTS1).vOt;
-        if VNotZero(ts_res.vOs) {
-            ts_res.vOs = Normalize(ts_res.vOs)
+    unsafe {
+        let mut ts_res: STSpace = STSpace {
+            vOs: Vec3::new(0.0, 0.0, 0.0),
+            fMagS: 0.,
+            vOt: Vec3::new(0.0, 0.0, 0.0),
+            fMagT: 0.,
+            iCounter: 0,
+            bOrient: false,
+        };
+        if (*pTS0).fMagS == (*pTS1).fMagS
+            && (*pTS0).fMagT == (*pTS1).fMagT
+            && (*pTS0).vOs == (*pTS1).vOs
+            && (*pTS0).vOt == (*pTS1).vOt
+        {
+            ts_res.fMagS = (*pTS0).fMagS;
+            ts_res.fMagT = (*pTS0).fMagT;
+            ts_res.vOs = (*pTS0).vOs;
+            ts_res.vOt = (*pTS0).vOt
+        } else {
+            ts_res.fMagS = 0.5f32 * ((*pTS0).fMagS + (*pTS1).fMagS);
+            ts_res.fMagT = 0.5f32 * ((*pTS0).fMagT + (*pTS1).fMagT);
+            ts_res.vOs = (*pTS0).vOs + (*pTS1).vOs;
+            ts_res.vOt = (*pTS0).vOt + (*pTS1).vOt;
+            if VNotZero(ts_res.vOs) {
+                ts_res.vOs = Normalize(ts_res.vOs)
+            }
+            if VNotZero(ts_res.vOt) {
+                ts_res.vOt = Normalize(ts_res.vOt)
+            }
         }
-        if VNotZero(ts_res.vOt) {
-            ts_res.vOt = Normalize(ts_res.vOt)
-        }
+        return ts_res;
     }
-    return ts_res;
 }
 
-unsafe fn Normalize(v: Vec3) -> Vec3 {
+fn Normalize(v: Vec3) -> Vec3 {
     return (1.0 / v.length()) * v;
 }
 
-unsafe fn VNotZero(v: Vec3) -> bool {
+fn VNotZero(v: Vec3) -> bool {
     NotZero(v.x) || NotZero(v.y) || NotZero(v.z)
 }
 
-unsafe fn NotZero(fX: f32) -> bool {
+fn NotZero(fX: f32) -> bool {
     fX.abs() > 1.17549435e-38f32
 }
 
@@ -658,77 +670,81 @@ unsafe fn EvalTspace<I: Geometry>(
     res.fMagT = 0i32 as f32;
     face = 0i32;
     while face < iFaces {
-        let f: i32 = *face_indices.offset(face as isize);
-        if (*pTriInfos.offset(f as isize)).iFlag & 4i32 == 0i32 {
-            let mut n = Vec3::new(0.0, 0.0, 0.0);
-            let mut vOs = Vec3::new(0.0, 0.0, 0.0);
-            let mut vOt = Vec3::new(0.0, 0.0, 0.0);
-            let mut p0 = Vec3::new(0.0, 0.0, 0.0);
-            let mut p1 = Vec3::new(0.0, 0.0, 0.0);
-            let mut p2 = Vec3::new(0.0, 0.0, 0.0);
-            let mut v1 = Vec3::new(0.0, 0.0, 0.0);
-            let mut v2 = Vec3::new(0.0, 0.0, 0.0);
-            let mut fCos: f32 = 0.;
-            let mut fAngle: f32 = 0.;
-            let mut fMagS: f32 = 0.;
-            let mut fMagT: f32 = 0.;
-            let mut i: i32 = -1i32;
-            let mut index: i32 = -1i32;
-            let mut i0: i32 = -1i32;
-            let mut i1: i32 = -1i32;
-            let mut i2: i32 = -1i32;
-            if *piTriListIn.offset((3i32 * f + 0i32) as isize) == iVertexRepresentitive {
-                i = 0i32
-            } else if *piTriListIn.offset((3i32 * f + 1i32) as isize) == iVertexRepresentitive {
-                i = 1i32
-            } else if *piTriListIn.offset((3i32 * f + 2i32) as isize) == iVertexRepresentitive {
-                i = 2i32
-            }
-            index = *piTriListIn.offset((3i32 * f + i) as isize);
-            n = get_normal(geometry, index as usize);
-            let mut vOs = (*pTriInfos.offset(f as isize)).vOs
-                - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
-            let mut vOt = (*pTriInfos.offset(f as isize)).vOt
-                - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
-            if VNotZero(vOs) {
-                vOs = Normalize(vOs)
-            }
-            if VNotZero(vOt) {
-                vOt = Normalize(vOt)
-            }
-            i2 = *piTriListIn.offset((3i32 * f + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
-            i1 = *piTriListIn.offset((3i32 * f + i) as isize);
-            i0 = *piTriListIn.offset((3i32 * f + if i > 0i32 { i - 1i32 } else { 2i32 }) as isize);
-            p0 = get_position(geometry, i0 as usize);
-            p1 = get_position(geometry, i1 as usize);
-            p2 = get_position(geometry, i2 as usize);
-            v1 = p0 - p1;
-            v2 = p2 - p1;
-            let mut v1 = v1 - (n.dot(v1) * n);
-            if VNotZero(v1) {
-                v1 = Normalize(v1)
-            }
-            let mut v2 = v2 - (n.dot(v2) * n);
-            if VNotZero(v2) {
-                v2 = Normalize(v2)
-            }
-            let fCos = v1.dot(v2);
+        unsafe {
+            let f: i32 = *face_indices.offset(face as isize);
+            if (*pTriInfos.offset(f as isize)).iFlag & 4i32 == 0i32 {
+                let mut n = Vec3::new(0.0, 0.0, 0.0);
+                let mut vOs = Vec3::new(0.0, 0.0, 0.0);
+                let mut vOt = Vec3::new(0.0, 0.0, 0.0);
+                let mut p0 = Vec3::new(0.0, 0.0, 0.0);
+                let mut p1 = Vec3::new(0.0, 0.0, 0.0);
+                let mut p2 = Vec3::new(0.0, 0.0, 0.0);
+                let mut v1 = Vec3::new(0.0, 0.0, 0.0);
+                let mut v2 = Vec3::new(0.0, 0.0, 0.0);
+                let mut fCos: f32 = 0.;
+                let mut fAngle: f32 = 0.;
+                let mut fMagS: f32 = 0.;
+                let mut fMagT: f32 = 0.;
+                let mut i: i32 = -1i32;
+                let mut index: i32 = -1i32;
+                let mut i0: i32 = -1i32;
+                let mut i1: i32 = -1i32;
+                let mut i2: i32 = -1i32;
+                if *piTriListIn.offset((3i32 * f + 0i32) as isize) == iVertexRepresentitive {
+                    i = 0i32
+                } else if *piTriListIn.offset((3i32 * f + 1i32) as isize) == iVertexRepresentitive {
+                    i = 1i32
+                } else if *piTriListIn.offset((3i32 * f + 2i32) as isize) == iVertexRepresentitive {
+                    i = 2i32
+                }
+                index = *piTriListIn.offset((3i32 * f + i) as isize);
+                n = get_normal(geometry, index as usize);
+                let mut vOs = (*pTriInfos.offset(f as isize)).vOs
+                    - (n.dot((*pTriInfos.offset(f as isize)).vOs) * n);
+                let mut vOt = (*pTriInfos.offset(f as isize)).vOt
+                    - (n.dot((*pTriInfos.offset(f as isize)).vOt) * n);
+                if VNotZero(vOs) {
+                    vOs = Normalize(vOs)
+                }
+                if VNotZero(vOt) {
+                    vOt = Normalize(vOt)
+                }
+                i2 = *piTriListIn
+                    .offset((3i32 * f + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
+                i1 = *piTriListIn.offset((3i32 * f + i) as isize);
+                i0 = *piTriListIn
+                    .offset((3i32 * f + if i > 0i32 { i - 1i32 } else { 2i32 }) as isize);
+                p0 = get_position(geometry, i0 as usize);
+                p1 = get_position(geometry, i1 as usize);
+                p2 = get_position(geometry, i2 as usize);
+                v1 = p0 - p1;
+                v2 = p2 - p1;
+                let mut v1 = v1 - (n.dot(v1) * n);
+                if VNotZero(v1) {
+                    v1 = Normalize(v1)
+                }
+                let mut v2 = v2 - (n.dot(v2) * n);
+                if VNotZero(v2) {
+                    v2 = Normalize(v2)
+                }
+                let fCos = v1.dot(v2);
 
-            let fCos = if fCos > 1i32 as f32 {
-                1i32 as f32
-            } else if fCos < -1i32 as f32 {
-                -1i32 as f32
-            } else {
-                fCos
-            };
-            fAngle = (fCos as f64).acos() as f32;
-            fMagS = (*pTriInfos.offset(f as isize)).fMagS;
-            fMagT = (*pTriInfos.offset(f as isize)).fMagT;
-            res.vOs = res.vOs + (fAngle * vOs);
-            res.vOt = res.vOt + (fAngle * vOt);
-            res.fMagS += fAngle * fMagS;
-            res.fMagT += fAngle * fMagT;
-            fAngleSum += fAngle
+                let fCos = if fCos > 1i32 as f32 {
+                    1i32 as f32
+                } else if fCos < -1i32 as f32 {
+                    -1i32 as f32
+                } else {
+                    fCos
+                };
+                fAngle = (fCos as f64).acos() as f32;
+                fMagS = (*pTriInfos.offset(f as isize)).fMagS;
+                fMagT = (*pTriInfos.offset(f as isize)).fMagT;
+                res.vOs = res.vOs + (fAngle * vOs);
+                res.vOt = res.vOt + (fAngle * vOt);
+                res.fMagS += fAngle * fMagS;
+                res.fMagT += fAngle * fMagT;
+                fAngleSum += fAngle
+            }
         }
         face += 1
     }
@@ -748,17 +764,19 @@ unsafe fn EvalTspace<I: Geometry>(
 unsafe fn CompareSubGroups(mut pg1: *const SSubGroup, mut pg2: *const SSubGroup) -> bool {
     let mut bStillSame: bool = true;
     let mut i = 0;
-    if (*pg1).iNrFaces != (*pg2).iNrFaces {
-        return false;
-    }
-    while i < (*pg1).iNrFaces as usize && bStillSame {
-        bStillSame = if (*pg1).pTriMembers[i] == (*pg2).pTriMembers[i] {
-            true
-        } else {
-            false
-        };
-        if bStillSame {
-            i += 1
+    unsafe {
+        if (*pg1).iNrFaces != (*pg2).iNrFaces {
+            return false;
+        }
+        while i < (*pg1).iNrFaces as usize && bStillSame {
+            bStillSame = if (*pg1).pTriMembers[i] == (*pg2).pTriMembers[i] {
+                true
+            } else {
+                false
+            };
+            if bStillSame {
+                i += 1
+            }
         }
     }
     return bStillSame;
@@ -781,31 +799,33 @@ unsafe fn QuickSort(mut pSortBuffer: *mut i32, mut iLeft: i32, mut iRight: i32, 
     iR = iRight;
     n = iR - iL + 1i32;
     index = uSeed.wrapping_rem(n as u32) as i32;
-    iMid = *pSortBuffer.offset((index + iL) as isize);
-    loop {
-        while *pSortBuffer.offset(iL as isize) < iMid {
-            iL += 1
+    unsafe {
+        iMid = *pSortBuffer.offset((index + iL) as isize);
+        loop {
+            while *pSortBuffer.offset(iL as isize) < iMid {
+                iL += 1
+            }
+            while *pSortBuffer.offset(iR as isize) > iMid {
+                iR -= 1
+            }
+            if iL <= iR {
+                iTmp = *pSortBuffer.offset(iL as isize);
+                *pSortBuffer.offset(iL as isize) = *pSortBuffer.offset(iR as isize);
+                *pSortBuffer.offset(iR as isize) = iTmp;
+                iL += 1;
+                iR -= 1
+            }
+            if !(iL <= iR) {
+                break;
+            }
         }
-        while *pSortBuffer.offset(iR as isize) > iMid {
-            iR -= 1
+        if iLeft < iR {
+            QuickSort(pSortBuffer, iLeft, iR, uSeed);
         }
-        if iL <= iR {
-            iTmp = *pSortBuffer.offset(iL as isize);
-            *pSortBuffer.offset(iL as isize) = *pSortBuffer.offset(iR as isize);
-            *pSortBuffer.offset(iR as isize) = iTmp;
-            iL += 1;
-            iR -= 1
-        }
-        if !(iL <= iR) {
-            break;
-        }
+        if iL < iRight {
+            QuickSort(pSortBuffer, iL, iRight, uSeed);
+        };
     }
-    if iLeft < iR {
-        QuickSort(pSortBuffer, iLeft, iR, uSeed);
-    }
-    if iL < iRight {
-        QuickSort(pSortBuffer, iL, iRight, uSeed);
-    };
 }
 unsafe fn Build4RuleGroups(
     mut pTriInfos: *mut STriInfo,
@@ -823,64 +843,66 @@ unsafe fn Build4RuleGroups(
     while f < iNrTrianglesIn {
         i = 0i32;
         while i < 3i32 {
-            if (*pTriInfos.offset(f as isize)).iFlag & 4i32 == 0i32
-                && (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize].is_null()
-            {
-                let mut bOrPre: bool = false;
-                let mut neigh_indexL: i32 = 0;
-                let mut neigh_indexR: i32 = 0;
-                let vert_index: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
-                let ref mut fresh2 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
-                *fresh2 = &mut *pGroups.offset(iNrActiveGroups as isize) as *mut SGroup;
-                (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize])
-                    .iVertexRepresentitive = vert_index;
-                (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).bOrientPreservering =
-                    (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32;
-                (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces = 0i32;
-                let ref mut fresh3 =
-                    (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).pFaceIndices;
-                *fresh3 = &mut *piGroupTrianglesBuffer.offset(iOffset as isize) as *mut i32;
-                iNrActiveGroups += 1;
-                AddTriToGroup((*pTriInfos.offset(f as isize)).AssignedGroup[i as usize], f);
-                bOrPre = if (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32 {
-                    true
-                } else {
-                    false
-                };
-                neigh_indexL = (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize];
-                neigh_indexR = (*pTriInfos.offset(f as isize)).FaceNeighbors
-                    [(if i > 0i32 { i - 1i32 } else { 2i32 }) as usize];
-                if neigh_indexL >= 0i32 {
-                    let bAnswer: bool = AssignRecur(
-                        piTriListIn,
-                        pTriInfos,
-                        neigh_indexL,
-                        (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize],
-                    );
-                    let bOrPre2: bool =
-                        if (*pTriInfos.offset(neigh_indexL as isize)).iFlag & 8i32 != 0i32 {
-                            true
-                        } else {
-                            false
-                        };
-                    let bDiff: bool = if bOrPre != bOrPre2 { true } else { false };
+            unsafe {
+                if (*pTriInfos.offset(f as isize)).iFlag & 4i32 == 0i32
+                    && (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize].is_null()
+                {
+                    let mut bOrPre: bool = false;
+                    let mut neigh_indexL: i32 = 0;
+                    let mut neigh_indexR: i32 = 0;
+                    let vert_index: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
+                    let ref mut fresh2 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
+                    *fresh2 = &mut *pGroups.offset(iNrActiveGroups as isize) as *mut SGroup;
+                    (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize])
+                        .iVertexRepresentitive = vert_index;
+                    (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize])
+                        .bOrientPreservering = (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32;
+                    (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces = 0i32;
+                    let ref mut fresh3 =
+                        (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).pFaceIndices;
+                    *fresh3 = &mut *piGroupTrianglesBuffer.offset(iOffset as isize) as *mut i32;
+                    iNrActiveGroups += 1;
+                    AddTriToGroup((*pTriInfos.offset(f as isize)).AssignedGroup[i as usize], f);
+                    bOrPre = if (*pTriInfos.offset(f as isize)).iFlag & 8i32 != 0i32 {
+                        true
+                    } else {
+                        false
+                    };
+                    neigh_indexL = (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize];
+                    neigh_indexR = (*pTriInfos.offset(f as isize)).FaceNeighbors
+                        [(if i > 0i32 { i - 1i32 } else { 2i32 }) as usize];
+                    if neigh_indexL >= 0i32 {
+                        let bAnswer: bool = AssignRecur(
+                            piTriListIn,
+                            pTriInfos,
+                            neigh_indexL,
+                            (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize],
+                        );
+                        let bOrPre2: bool =
+                            if (*pTriInfos.offset(neigh_indexL as isize)).iFlag & 8i32 != 0i32 {
+                                true
+                            } else {
+                                false
+                            };
+                        let bDiff: bool = if bOrPre != bOrPre2 { true } else { false };
+                    }
+                    if neigh_indexR >= 0i32 {
+                        let bAnswer_0: bool = AssignRecur(
+                            piTriListIn,
+                            pTriInfos,
+                            neigh_indexR,
+                            (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize],
+                        );
+                        let bOrPre2_0: bool =
+                            if (*pTriInfos.offset(neigh_indexR as isize)).iFlag & 8i32 != 0i32 {
+                                true
+                            } else {
+                                false
+                            };
+                        let bDiff_0: bool = if bOrPre != bOrPre2_0 { true } else { false };
+                    }
+                    iOffset += (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces
                 }
-                if neigh_indexR >= 0i32 {
-                    let bAnswer_0: bool = AssignRecur(
-                        piTriListIn,
-                        pTriInfos,
-                        neigh_indexR,
-                        (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize],
-                    );
-                    let bOrPre2_0: bool =
-                        if (*pTriInfos.offset(neigh_indexR as isize)).iFlag & 8i32 != 0i32 {
-                            true
-                        } else {
-                            false
-                        };
-                    let bDiff_0: bool = if bOrPre != bOrPre2_0 { true } else { false };
-                }
-                iOffset += (*(*pTriInfos.offset(f as isize)).AssignedGroup[i as usize]).iNrFaces
             }
             i += 1
         }
@@ -896,64 +918,68 @@ unsafe fn AssignRecur(
     iMyTriIndex: i32,
     mut pGroup: *mut SGroup,
 ) -> bool {
-    let mut pMyTriInfo: *mut STriInfo =
-        &mut *psTriInfos.offset(iMyTriIndex as isize) as *mut STriInfo;
-    // track down vertex
-    let iVertRep: i32 = (*pGroup).iVertexRepresentitive;
-    let mut pVerts: *const i32 =
-        &*piTriListIn.offset((3i32 * iMyTriIndex + 0i32) as isize) as *const i32;
-    let mut i: i32 = -1i32;
-    if *pVerts.offset(0isize) == iVertRep {
-        i = 0i32
-    } else if *pVerts.offset(1isize) == iVertRep {
-        i = 1i32
-    } else if *pVerts.offset(2isize) == iVertRep {
-        i = 2i32
-    }
-    if (*pMyTriInfo).AssignedGroup[i as usize] == pGroup {
-        return true;
-    } else {
-        if !(*pMyTriInfo).AssignedGroup[i as usize].is_null() {
-            return false;
+    unsafe {
+        let mut pMyTriInfo: *mut STriInfo =
+            &mut *psTriInfos.offset(iMyTriIndex as isize) as *mut STriInfo;
+        // track down vertex
+        let iVertRep: i32 = (*pGroup).iVertexRepresentitive;
+        let mut pVerts: *const i32 =
+            &*piTriListIn.offset((3i32 * iMyTriIndex + 0i32) as isize) as *const i32;
+        let mut i: i32 = -1i32;
+        if *pVerts.offset(0isize) == iVertRep {
+            i = 0i32
+        } else if *pVerts.offset(1isize) == iVertRep {
+            i = 1i32
+        } else if *pVerts.offset(2isize) == iVertRep {
+            i = 2i32
         }
-    }
-    if (*pMyTriInfo).iFlag & 4i32 != 0i32 {
-        if (*pMyTriInfo).AssignedGroup[0usize].is_null()
-            && (*pMyTriInfo).AssignedGroup[1usize].is_null()
-            && (*pMyTriInfo).AssignedGroup[2usize].is_null()
-        {
-            (*pMyTriInfo).iFlag &= !8i32;
-            (*pMyTriInfo).iFlag |= if (*pGroup).bOrientPreservering {
-                8i32
-            } else {
-                0i32
+        if (*pMyTriInfo).AssignedGroup[i as usize] == pGroup {
+            return true;
+        } else {
+            if !(*pMyTriInfo).AssignedGroup[i as usize].is_null() {
+                return false;
             }
         }
-    }
-    let bOrient: bool = if (*pMyTriInfo).iFlag & 8i32 != 0i32 {
-        true
-    } else {
-        false
-    };
-    if bOrient != (*pGroup).bOrientPreservering {
-        return false;
-    }
-    AddTriToGroup(pGroup, iMyTriIndex);
-    (*pMyTriInfo).AssignedGroup[i as usize] = pGroup;
-    let neigh_indexL: i32 = (*pMyTriInfo).FaceNeighbors[i as usize];
-    let neigh_indexR: i32 =
-        (*pMyTriInfo).FaceNeighbors[(if i > 0i32 { i - 1i32 } else { 2i32 }) as usize];
-    if neigh_indexL >= 0i32 {
-        AssignRecur(piTriListIn, psTriInfos, neigh_indexL, pGroup);
-    }
-    if neigh_indexR >= 0i32 {
-        AssignRecur(piTriListIn, psTriInfos, neigh_indexR, pGroup);
+        if (*pMyTriInfo).iFlag & 4i32 != 0i32 {
+            if (*pMyTriInfo).AssignedGroup[0usize].is_null()
+                && (*pMyTriInfo).AssignedGroup[1usize].is_null()
+                && (*pMyTriInfo).AssignedGroup[2usize].is_null()
+            {
+                (*pMyTriInfo).iFlag &= !8i32;
+                (*pMyTriInfo).iFlag |= if (*pGroup).bOrientPreservering {
+                    8i32
+                } else {
+                    0i32
+                }
+            }
+        }
+        let bOrient: bool = if (*pMyTriInfo).iFlag & 8i32 != 0i32 {
+            true
+        } else {
+            false
+        };
+        if bOrient != (*pGroup).bOrientPreservering {
+            return false;
+        }
+        AddTriToGroup(pGroup, iMyTriIndex);
+        (*pMyTriInfo).AssignedGroup[i as usize] = pGroup;
+        let neigh_indexL: i32 = (*pMyTriInfo).FaceNeighbors[i as usize];
+        let neigh_indexR: i32 =
+            (*pMyTriInfo).FaceNeighbors[(if i > 0i32 { i - 1i32 } else { 2i32 }) as usize];
+        if neigh_indexL >= 0i32 {
+            AssignRecur(piTriListIn, psTriInfos, neigh_indexL, pGroup);
+        }
+        if neigh_indexR >= 0i32 {
+            AssignRecur(piTriListIn, psTriInfos, neigh_indexR, pGroup);
+        }
     }
     return true;
 }
 unsafe fn AddTriToGroup(mut pGroup: *mut SGroup, iTriIndex: i32) {
-    *(*pGroup).pFaceIndices.offset((*pGroup).iNrFaces as isize) = iTriIndex;
-    (*pGroup).iNrFaces += 1;
+    unsafe {
+        *(*pGroup).pFaceIndices.offset((*pGroup).iNrFaces as isize) = iTriIndex;
+        (*pGroup).iNrFaces += 1;
+    }
 }
 unsafe fn InitTriInfo<I: Geometry>(
     mut pTriInfos: *mut STriInfo,
@@ -968,30 +994,36 @@ unsafe fn InitTriInfo<I: Geometry>(
     while f < iNrTrianglesIn {
         i = 0i32;
         while i < 3i32 {
-            (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize] = -1i32;
-            let ref mut fresh4 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
-            *fresh4 = 0 as *mut SGroup;
-            (*pTriInfos.offset(f as isize)).vOs.x = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOs.y = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOs.z = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.x = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.y = 0.0f32;
-            (*pTriInfos.offset(f as isize)).vOt.z = 0.0f32;
-            (*pTriInfos.offset(f as isize)).fMagS = 0i32 as f32;
-            (*pTriInfos.offset(f as isize)).fMagT = 0i32 as f32;
-            (*pTriInfos.offset(f as isize)).iFlag |= 4i32;
+            unsafe {
+                (*pTriInfos.offset(f as isize)).FaceNeighbors[i as usize] = -1i32;
+                let ref mut fresh4 = (*pTriInfos.offset(f as isize)).AssignedGroup[i as usize];
+                *fresh4 = 0 as *mut SGroup;
+                (*pTriInfos.offset(f as isize)).vOs.x = 0.0f32;
+                (*pTriInfos.offset(f as isize)).vOs.y = 0.0f32;
+                (*pTriInfos.offset(f as isize)).vOs.z = 0.0f32;
+                (*pTriInfos.offset(f as isize)).vOt.x = 0.0f32;
+                (*pTriInfos.offset(f as isize)).vOt.y = 0.0f32;
+                (*pTriInfos.offset(f as isize)).vOt.z = 0.0f32;
+                (*pTriInfos.offset(f as isize)).fMagS = 0i32 as f32;
+                (*pTriInfos.offset(f as isize)).fMagT = 0i32 as f32;
+                (*pTriInfos.offset(f as isize)).iFlag |= 4i32;
+            }
             i += 1
         }
         f += 1
     }
     f = 0;
     while f < iNrTrianglesIn {
-        let v1 = get_position(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
-        let v2 = get_position(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
-        let v3 = get_position(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
-        let t1 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 0) as isize) as usize);
-        let t2 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 1) as isize) as usize);
-        let t3 = get_tex_coord(geometry, *piTriListIn.offset((f * 3 + 2) as isize) as usize);
+        let a = unsafe { *piTriListIn.offset((f * 3 + 0) as isize) } as usize;
+        let b = unsafe { *piTriListIn.offset((f * 3 + 1) as isize) } as usize;
+        let c = unsafe { *piTriListIn.offset((f * 3 + 2) as isize) } as usize;
+
+        let v1 = get_position(geometry, a);
+        let v2 = get_position(geometry, b);
+        let v3 = get_position(geometry, c);
+        let t1 = get_tex_coord(geometry, a);
+        let t2 = get_tex_coord(geometry, b);
+        let t3 = get_tex_coord(geometry, c);
         let t21x: f32 = t2.x - t1.x;
         let t21y: f32 = t2.y - t1.y;
         let t31x: f32 = t3.x - t1.x;
@@ -1001,7 +1033,7 @@ unsafe fn InitTriInfo<I: Geometry>(
         let fSignedAreaSTx2: f32 = t21x * t31y - t21y * t31x;
         let mut vOs = (t31y * d1) - (t21y * d2);
         let mut vOt = (-t31x * d1) + (t21x * d2);
-        (*pTriInfos.offset(f as isize)).iFlag |= if fSignedAreaSTx2 > 0i32 as f32 {
+        unsafe { *pTriInfos.offset(f as isize) }.iFlag |= if fSignedAreaSTx2 > 0i32 as f32 {
             8i32
         } else {
             0i32
@@ -1010,66 +1042,77 @@ unsafe fn InitTriInfo<I: Geometry>(
             let fAbsArea: f32 = fSignedAreaSTx2.abs();
             let fLenOs: f32 = vOs.length();
             let fLenOt: f32 = vOt.length();
-            let fS: f32 = if (*pTriInfos.offset(f as isize)).iFlag & 8i32 == 0i32 {
+            let fS: f32 = if unsafe { *pTriInfos.offset(f as isize) }.iFlag & 8i32 == 0i32 {
                 -1.0f32
             } else {
                 1.0f32
             };
-            if NotZero(fLenOs) {
-                (*pTriInfos.offset(f as isize)).vOs = (fS / fLenOs) * vOs
+            unsafe {
+                if NotZero(fLenOs) {
+                    (*pTriInfos.offset(f as isize)).vOs = (fS / fLenOs) * vOs
+                }
             }
-            if NotZero(fLenOt) {
-                (*pTriInfos.offset(f as isize)).vOt = (fS / fLenOt) * vOt
+            unsafe {
+                if NotZero(fLenOt) {
+                    (*pTriInfos.offset(f as isize)).vOt = (fS / fLenOt) * vOt
+                }
             }
-            (*pTriInfos.offset(f as isize)).fMagS = fLenOs / fAbsArea;
-            (*pTriInfos.offset(f as isize)).fMagT = fLenOt / fAbsArea;
-            if NotZero((*pTriInfos.offset(f as isize)).fMagS)
-                && NotZero((*pTriInfos.offset(f as isize)).fMagT)
+            unsafe { *pTriInfos.offset(f as isize) }.fMagS = fLenOs / fAbsArea;
+            unsafe { *pTriInfos.offset(f as isize) }.fMagT = fLenOt / fAbsArea;
+            if unsafe { NotZero((*pTriInfos.offset(f as isize)).fMagS) }
+                && unsafe { NotZero((*pTriInfos.offset(f as isize)).fMagT) }
             {
-                (*pTriInfos.offset(f as isize)).iFlag &= !4i32
+                unsafe { *pTriInfos.offset(f as isize) }.iFlag &= !4i32
             }
         }
         f += 1
     }
     while t < iNrTrianglesIn - 1 {
-        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-        let iFO_b: i32 = (*pTriInfos.offset((t + 1) as isize)).iOrgFaceNumber;
+        let iFO_a: i32 = unsafe { *pTriInfos.offset(t as isize) }.iOrgFaceNumber;
+        let iFO_b: i32 = unsafe { *pTriInfos.offset((t + 1) as isize) }.iOrgFaceNumber;
         if iFO_a == iFO_b {
-            let bIsDeg_a: bool = if (*pTriInfos.offset(t as isize)).iFlag & 1i32 != 0i32 {
+            let bIsDeg_a: bool = if unsafe { *pTriInfos.offset(t as isize) }.iFlag & 1i32 != 0i32 {
                 true
             } else {
                 false
             };
-            let bIsDeg_b: bool = if (*pTriInfos.offset((t + 1) as isize)).iFlag & 1i32 != 0i32 {
-                true
-            } else {
-                false
-            };
+            let bIsDeg_b: bool =
+                if unsafe { *pTriInfos.offset((t + 1) as isize) }.iFlag & 1i32 != 0i32 {
+                    true
+                } else {
+                    false
+                };
             if !(bIsDeg_a || bIsDeg_b) {
-                let bOrientA: bool = if (*pTriInfos.offset(t as isize)).iFlag & 8i32 != 0i32 {
-                    true
-                } else {
-                    false
-                };
-                let bOrientB: bool = if (*pTriInfos.offset((t + 1) as isize)).iFlag & 8i32 != 0i32 {
-                    true
-                } else {
-                    false
-                };
+                let bOrientA: bool =
+                    if unsafe { *pTriInfos.offset(t as isize) }.iFlag & 8i32 != 0i32 {
+                        true
+                    } else {
+                        false
+                    };
+                let bOrientB: bool =
+                    if unsafe { *pTriInfos.offset((t + 1) as isize) }.iFlag & 8i32 != 0i32 {
+                        true
+                    } else {
+                        false
+                    };
                 if bOrientA != bOrientB {
                     let mut bChooseOrientFirstTri: bool = false;
-                    if (*pTriInfos.offset((t + 1) as isize)).iFlag & 4i32 != 0i32 {
+                    if unsafe { *pTriInfos.offset((t + 1) as isize) }.iFlag & 4i32 != 0i32 {
                         bChooseOrientFirstTri = true
-                    } else if CalcTexArea(geometry, piTriListIn.offset((t * 3 + 0) as isize))
-                        >= CalcTexArea(geometry, piTriListIn.offset(((t + 1) * 3 + 0) as isize))
-                    {
+                    } else if unsafe {
+                        CalcTexArea(geometry, piTriListIn.offset((t * 3 + 0) as isize))
+                    } >= unsafe {
+                        CalcTexArea(geometry, piTriListIn.offset(((t + 1) * 3 + 0) as isize))
+                    } {
                         bChooseOrientFirstTri = true
                     }
                     let t0 = if bChooseOrientFirstTri { t } else { t + 1 };
                     let t1_0 = if bChooseOrientFirstTri { t + 1 } else { t };
-                    (*pTriInfos.offset(t1_0 as isize)).iFlag &= !8i32;
-                    (*pTriInfos.offset(t1_0 as isize)).iFlag |=
-                        (*pTriInfos.offset(t0 as isize)).iFlag & 8i32
+                    unsafe {
+                        (*pTriInfos.offset(t1_0 as isize)).iFlag &= !8i32;
+                        (*pTriInfos.offset(t1_0 as isize)).iFlag |=
+                            (*pTriInfos.offset(t0 as isize)).iFlag & 8i32
+                    }
                 }
             }
             t += 2
@@ -1079,12 +1122,14 @@ unsafe fn InitTriInfo<I: Geometry>(
     }
 
     let mut pEdges = vec![SEdge::zero(); iNrTrianglesIn * 3];
-    BuildNeighborsFast(
-        pTriInfos,
-        pEdges.as_mut_ptr(),
-        piTriListIn,
-        iNrTrianglesIn as i32,
-    );
+    unsafe {
+        BuildNeighborsFast(
+            pTriInfos,
+            pEdges.as_mut_ptr(),
+            piTriListIn,
+            iNrTrianglesIn as i32,
+        );
+    }
 }
 
 unsafe fn BuildNeighborsFast(
@@ -1104,97 +1149,115 @@ unsafe fn BuildNeighborsFast(
     while f < iNrTrianglesIn {
         i = 0i32;
         while i < 3i32 {
-            let i0: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
-            let i1: i32 =
-                *piTriListIn.offset((f * 3i32 + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
-            (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.i0 = if i0 < i1 { i0 } else { i1 };
-            (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.i1 = if !(i0 < i1) { i0 } else { i1 };
-            (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.f = f;
+            unsafe {
+                let i0: i32 = *piTriListIn.offset((f * 3i32 + i) as isize);
+                let i1: i32 = *piTriListIn
+                    .offset((f * 3i32 + if i < 2i32 { i + 1i32 } else { 0i32 }) as isize);
+                (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.i0 =
+                    if i0 < i1 { i0 } else { i1 };
+                (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.i1 =
+                    if !(i0 < i1) { i0 } else { i1 };
+                (*pEdges.offset((f * 3i32 + i) as isize)).unnamed.f = f;
+            }
             i += 1
         }
         f += 1
     }
-    QuickSortEdges(pEdges, 0i32, iNrTrianglesIn * 3i32 - 1i32, 0i32, uSeed);
+    unsafe {
+        QuickSortEdges(pEdges, 0i32, iNrTrianglesIn * 3i32 - 1i32, 0i32, uSeed);
+    }
     iEntries = iNrTrianglesIn * 3i32;
     iCurStartIndex = 0i32;
     i = 1i32;
     while i < iEntries {
-        if (*pEdges.offset(iCurStartIndex as isize)).unnamed.i0
-            != (*pEdges.offset(i as isize)).unnamed.i0
+        if unsafe { (*pEdges.offset(iCurStartIndex as isize)).unnamed }.i0
+            != unsafe { (*pEdges.offset(i as isize)).unnamed }.i0
         {
             let iL: i32 = iCurStartIndex;
             let iR: i32 = i - 1i32;
             iCurStartIndex = i;
-            QuickSortEdges(pEdges, iL, iR, 1i32, uSeed);
+            unsafe {
+                QuickSortEdges(pEdges, iL, iR, 1i32, uSeed);
+            }
         }
         i += 1
     }
     iCurStartIndex = 0i32;
     i = 1i32;
     while i < iEntries {
-        if (*pEdges.offset(iCurStartIndex as isize)).unnamed.i0
-            != (*pEdges.offset(i as isize)).unnamed.i0
-            || (*pEdges.offset(iCurStartIndex as isize)).unnamed.i1
-                != (*pEdges.offset(i as isize)).unnamed.i1
+        if unsafe { (*pEdges.offset(iCurStartIndex as isize)).unnamed }.i0
+            != unsafe { (*pEdges.offset(i as isize)).unnamed }.i0
+            || unsafe { (*pEdges.offset(iCurStartIndex as isize)).unnamed }.i1
+                != unsafe { (*pEdges.offset(i as isize)).unnamed }.i1
         {
             let iL_0: i32 = iCurStartIndex;
             let iR_0: i32 = i - 1i32;
             iCurStartIndex = i;
-            QuickSortEdges(pEdges, iL_0, iR_0, 2i32, uSeed);
+            unsafe {
+                QuickSortEdges(pEdges, iL_0, iR_0, 2i32, uSeed);
+            }
         }
         i += 1
     }
     i = 0i32;
     while i < iEntries {
-        let i0_0: i32 = (*pEdges.offset(i as isize)).unnamed.i0;
-        let i1_0: i32 = (*pEdges.offset(i as isize)).unnamed.i1;
-        let f_0: i32 = (*pEdges.offset(i as isize)).unnamed.f;
+        let i0_0: i32 = unsafe { (*pEdges.offset(i as isize)).unnamed }.i0;
+        let i1_0: i32 = unsafe { (*pEdges.offset(i as isize)).unnamed }.i1;
+        let f_0: i32 = unsafe { (*pEdges.offset(i as isize)).unnamed }.f;
         let mut bUnassigned_A: bool = false;
         let mut i0_A: i32 = 0;
         let mut i1_A: i32 = 0;
         let mut edgenum_A: i32 = 0;
         let mut edgenum_B: i32 = 0i32;
-        GetEdge(
-            &mut i0_A,
-            &mut i1_A,
-            &mut edgenum_A,
-            &*piTriListIn.offset((f_0 * 3i32) as isize),
-            i0_0,
-            i1_0,
-        );
-        bUnassigned_A =
-            if (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] == -1i32 {
-                true
-            } else {
-                false
-            };
+        unsafe {
+            GetEdge(
+                &mut i0_A,
+                &mut i1_A,
+                &mut edgenum_A,
+                &*piTriListIn.offset((f_0 * 3i32) as isize),
+                i0_0,
+                i1_0,
+            );
+        }
+        bUnassigned_A = if unsafe { *pTriInfos.offset(f_0 as isize) }.FaceNeighbors
+            [edgenum_A as usize]
+            == -1i32
+        {
+            true
+        } else {
+            false
+        };
         if bUnassigned_A {
             let mut j: i32 = i + 1i32;
             let mut t: i32 = 0;
             let mut bNotFound: bool = true;
             while j < iEntries
-                && i0_0 == (*pEdges.offset(j as isize)).unnamed.i0
-                && i1_0 == (*pEdges.offset(j as isize)).unnamed.i1
+                && i0_0 == unsafe { (*pEdges.offset(j as isize)).unnamed }.i0
+                && i1_0 == unsafe { (*pEdges.offset(j as isize)).unnamed }.i1
                 && bNotFound
             {
                 let mut bUnassigned_B: bool = false;
                 let mut i0_B: i32 = 0;
                 let mut i1_B: i32 = 0;
-                t = (*pEdges.offset(j as isize)).unnamed.f;
-                GetEdge(
-                    &mut i1_B,
-                    &mut i0_B,
-                    &mut edgenum_B,
-                    &*piTriListIn.offset((t * 3i32) as isize),
-                    (*pEdges.offset(j as isize)).unnamed.i0,
-                    (*pEdges.offset(j as isize)).unnamed.i1,
-                );
-                bUnassigned_B =
-                    if (*pTriInfos.offset(t as isize)).FaceNeighbors[edgenum_B as usize] == -1i32 {
-                        true
-                    } else {
-                        false
-                    };
+                t = unsafe { (*pEdges.offset(j as isize)).unnamed }.f;
+                unsafe {
+                    GetEdge(
+                        &mut i1_B,
+                        &mut i0_B,
+                        &mut edgenum_B,
+                        &*piTriListIn.offset((t * 3i32) as isize),
+                        (*pEdges.offset(j as isize)).unnamed.i0,
+                        (*pEdges.offset(j as isize)).unnamed.i1,
+                    );
+                }
+                bUnassigned_B = if unsafe { *pTriInfos.offset(t as isize) }.FaceNeighbors
+                    [edgenum_B as usize]
+                    == -1i32
+                {
+                    true
+                } else {
+                    false
+                };
                 if i0_A == i0_B && i1_A == i1_B && bUnassigned_B {
                     bNotFound = false
                 } else {
@@ -1202,9 +1265,11 @@ unsafe fn BuildNeighborsFast(
                 }
             }
             if !bNotFound {
-                let mut t_0: i32 = (*pEdges.offset(j as isize)).unnamed.f;
-                (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] = t_0;
-                (*pTriInfos.offset(t_0 as isize)).FaceNeighbors[edgenum_B as usize] = f_0
+                unsafe {
+                    let mut t_0: i32 = (*pEdges.offset(j as isize)).unnamed.f;
+                    (*pTriInfos.offset(f_0 as isize)).FaceNeighbors[edgenum_A as usize] = t_0;
+                    (*pTriInfos.offset(t_0 as isize)).FaceNeighbors[edgenum_B as usize] = f_0
+                }
             }
         }
         i += 1
@@ -1218,22 +1283,24 @@ unsafe fn GetEdge(
     i0_in: i32,
     i1_in: i32,
 ) {
-    *edgenum_out = -1i32;
-    if *indices.offset(0isize) == i0_in || *indices.offset(0isize) == i1_in {
-        if *indices.offset(1isize) == i0_in || *indices.offset(1isize) == i1_in {
-            *edgenum_out.offset(0isize) = 0i32;
-            *i0_out.offset(0isize) = *indices.offset(0isize);
-            *i1_out.offset(0isize) = *indices.offset(1isize)
+    unsafe {
+        *edgenum_out = -1i32;
+        if *indices.offset(0isize) == i0_in || *indices.offset(0isize) == i1_in {
+            if *indices.offset(1isize) == i0_in || *indices.offset(1isize) == i1_in {
+                *edgenum_out.offset(0isize) = 0i32;
+                *i0_out.offset(0isize) = *indices.offset(0isize);
+                *i1_out.offset(0isize) = *indices.offset(1isize)
+            } else {
+                *edgenum_out.offset(0isize) = 2i32;
+                *i0_out.offset(0isize) = *indices.offset(2isize);
+                *i1_out.offset(0isize) = *indices.offset(0isize)
+            }
         } else {
-            *edgenum_out.offset(0isize) = 2i32;
-            *i0_out.offset(0isize) = *indices.offset(2isize);
-            *i1_out.offset(0isize) = *indices.offset(0isize)
-        }
-    } else {
-        *edgenum_out.offset(0isize) = 1i32;
-        *i0_out.offset(0isize) = *indices.offset(1isize);
-        *i1_out.offset(0isize) = *indices.offset(2isize)
-    };
+            *edgenum_out.offset(0isize) = 1i32;
+            *i0_out.offset(0isize) = *indices.offset(1isize);
+            *i1_out.offset(0isize) = *indices.offset(2isize)
+        };
+    }
 }
 // ///////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
@@ -1259,12 +1326,14 @@ unsafe fn QuickSortEdges(
         return;
     } else {
         if iElems == 2i32 {
-            if (*pSortBuffer.offset(iLeft as isize)).array[channel as usize]
-                > (*pSortBuffer.offset(iRight as isize)).array[channel as usize]
-            {
-                sTmp = *pSortBuffer.offset(iLeft as isize);
-                *pSortBuffer.offset(iLeft as isize) = *pSortBuffer.offset(iRight as isize);
-                *pSortBuffer.offset(iRight as isize) = sTmp
+            unsafe {
+                if (*pSortBuffer.offset(iLeft as isize)).array[channel as usize]
+                    > (*pSortBuffer.offset(iRight as isize)).array[channel as usize]
+                {
+                    sTmp = *pSortBuffer.offset(iLeft as isize);
+                    *pSortBuffer.offset(iLeft as isize) = *pSortBuffer.offset(iRight as isize);
+                    *pSortBuffer.offset(iRight as isize) = sTmp
+                }
             }
             return;
         }
@@ -1280,18 +1349,20 @@ unsafe fn QuickSortEdges(
     iR = iRight;
     n = iR - iL + 1i32;
     index = uSeed.wrapping_rem(n as u32) as i32;
-    iMid = (*pSortBuffer.offset((index + iL) as isize)).array[channel as usize];
+    iMid = unsafe { (*pSortBuffer.offset((index + iL) as isize)).array[channel as usize] };
     loop {
-        while (*pSortBuffer.offset(iL as isize)).array[channel as usize] < iMid {
+        while unsafe { (*pSortBuffer.offset(iL as isize)).array[channel as usize] } < iMid {
             iL += 1
         }
-        while (*pSortBuffer.offset(iR as isize)).array[channel as usize] > iMid {
+        while unsafe { (*pSortBuffer.offset(iR as isize)).array[channel as usize] } > iMid {
             iR -= 1
         }
         if iL <= iR {
-            sTmp = *pSortBuffer.offset(iL as isize);
-            *pSortBuffer.offset(iL as isize) = *pSortBuffer.offset(iR as isize);
-            *pSortBuffer.offset(iR as isize) = sTmp;
+            unsafe {
+                sTmp = *pSortBuffer.offset(iL as isize);
+                *pSortBuffer.offset(iL as isize) = *pSortBuffer.offset(iR as isize);
+                *pSortBuffer.offset(iR as isize) = sTmp;
+            }
             iL += 1;
             iR -= 1
         }
@@ -1300,18 +1371,22 @@ unsafe fn QuickSortEdges(
         }
     }
     if iLeft < iR {
-        QuickSortEdges(pSortBuffer, iLeft, iR, channel, uSeed);
+        unsafe {
+            QuickSortEdges(pSortBuffer, iLeft, iR, channel, uSeed);
+        }
     }
     if iL < iRight {
-        QuickSortEdges(pSortBuffer, iL, iRight, channel, uSeed);
+        unsafe {
+            QuickSortEdges(pSortBuffer, iL, iRight, channel, uSeed);
+        }
     };
 }
 
 // returns the texture area times 2
 unsafe fn CalcTexArea<I: Geometry>(geometry: &mut I, mut indices: *const i32) -> f32 {
-    let t1 = get_tex_coord(geometry, *indices.offset(0isize) as usize);
-    let t2 = get_tex_coord(geometry, *indices.offset(1isize) as usize);
-    let t3 = get_tex_coord(geometry, *indices.offset(2isize) as usize);
+    let t1 = get_tex_coord(geometry, unsafe { *indices.offset(0isize) } as usize);
+    let t2 = get_tex_coord(geometry, unsafe { *indices.offset(1isize) } as usize);
+    let t3 = get_tex_coord(geometry, unsafe { *indices.offset(2isize) } as usize);
     let t21x: f32 = t2.x - t1.x;
     let t21y: f32 = t2.y - t1.y;
     let t31x: f32 = t3.x - t1.x;
@@ -1336,22 +1411,25 @@ unsafe fn DegenPrologue(
     // locate quads with only one good triangle
     let mut t: i32 = 0i32;
     while t < iTotTris - 1i32 {
-        let iFO_a: i32 = (*pTriInfos.offset(t as isize)).iOrgFaceNumber;
-        let iFO_b: i32 = (*pTriInfos.offset((t + 1i32) as isize)).iOrgFaceNumber;
+        let iFO_a: i32 = unsafe { *pTriInfos.offset(t as isize) }.iOrgFaceNumber;
+        let iFO_b: i32 = unsafe { *pTriInfos.offset((t + 1i32) as isize) }.iOrgFaceNumber;
         if iFO_a == iFO_b {
-            let bIsDeg_a: bool = if (*pTriInfos.offset(t as isize)).iFlag & 1i32 != 0i32 {
+            let bIsDeg_a: bool = if unsafe { *pTriInfos.offset(t as isize) }.iFlag & 1i32 != 0i32 {
                 true
             } else {
                 false
             };
-            let bIsDeg_b: bool = if (*pTriInfos.offset((t + 1i32) as isize)).iFlag & 1i32 != 0i32 {
-                true
-            } else {
-                false
-            };
+            let bIsDeg_b: bool =
+                if unsafe { *pTriInfos.offset((t + 1i32) as isize) }.iFlag & 1i32 != 0i32 {
+                    true
+                } else {
+                    false
+                };
             if bIsDeg_a ^ bIsDeg_b != false {
-                (*pTriInfos.offset(t as isize)).iFlag |= 2i32;
-                (*pTriInfos.offset((t + 1i32) as isize)).iFlag |= 2i32
+                unsafe {
+                    (*pTriInfos.offset(t as isize)).iFlag |= 2i32;
+                    (*pTriInfos.offset((t + 1i32) as isize)).iFlag |= 2i32
+                }
             }
             t += 2i32
         } else {
@@ -1362,7 +1440,7 @@ unsafe fn DegenPrologue(
     t = 0i32;
     bStillFindingGoodOnes = true;
     while t < iNrTrianglesIn && bStillFindingGoodOnes {
-        let bIsGood: bool = if (*pTriInfos.offset(t as isize)).iFlag & 1i32 == 0i32 {
+        let bIsGood: bool = if unsafe { *pTriInfos.offset(t as isize) }.iFlag & 1i32 == 0i32 {
             true
         } else {
             false
@@ -1377,7 +1455,8 @@ unsafe fn DegenPrologue(
             let mut bJustADegenerate: bool = true;
             while bJustADegenerate && iNextGoodTriangleSearchIndex < iTotTris {
                 let bIsGood_0: bool =
-                    if (*pTriInfos.offset(iNextGoodTriangleSearchIndex as isize)).iFlag & 1i32
+                    if unsafe { *pTriInfos.offset(iNextGoodTriangleSearchIndex as isize) }.iFlag
+                        & 1i32
                         == 0i32
                     {
                         true
@@ -1397,15 +1476,19 @@ unsafe fn DegenPrologue(
                 let mut i: i32 = 0i32;
                 i = 0i32;
                 while i < 3i32 {
-                    let index: i32 = *piTriList_out.offset((t0 * 3i32 + i) as isize);
-                    *piTriList_out.offset((t0 * 3i32 + i) as isize) =
-                        *piTriList_out.offset((t1 * 3i32 + i) as isize);
-                    *piTriList_out.offset((t1 * 3i32 + i) as isize) = index;
+                    unsafe {
+                        let index: i32 = *piTriList_out.offset((t0 * 3i32 + i) as isize);
+                        *piTriList_out.offset((t0 * 3i32 + i) as isize) =
+                            *piTriList_out.offset((t1 * 3i32 + i) as isize);
+                        *piTriList_out.offset((t1 * 3i32 + i) as isize) = index;
+                    }
                     i += 1
                 }
-                let tri_info: STriInfo = *pTriInfos.offset(t0 as isize);
-                *pTriInfos.offset(t0 as isize) = *pTriInfos.offset(t1 as isize);
-                *pTriInfos.offset(t1 as isize) = tri_info
+                unsafe {
+                    let tri_info: STriInfo = *pTriInfos.offset(t0 as isize);
+                    *pTriInfos.offset(t0 as isize) = *pTriInfos.offset(t1 as isize);
+                    *pTriInfos.offset(t1 as isize) = tri_info
+                }
             } else {
                 bStillFindingGoodOnes = false
             }
@@ -1432,7 +1515,7 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
     let mut fMax: f32 = 0.;
     i = 1;
     while i < iNrTrianglesIn * 3 {
-        let index: i32 = *piTriList_in_and_out.offset(i as isize);
+        let index: i32 = unsafe { *piTriList_in_and_out.offset(i as isize) };
         let vP = get_position(geometry, index as usize);
         if vMin.x > vP.x {
             vMin.x = vP.x
@@ -1472,7 +1555,7 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
 
     i = 0;
     while i < iNrTrianglesIn * 3 {
-        let index_0: i32 = *piTriList_in_and_out.offset(i as isize);
+        let index_0: i32 = unsafe { *piTriList_in_and_out.offset(i as isize) };
         let vP_0 = get_position(geometry, index_0 as usize);
         let fVal: f32 = if iChannel == 0i32 {
             vP_0.x
@@ -1481,7 +1564,7 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
         } else {
             vP_0.z
         };
-        let iCell = FindGridCell(fMin, fMax, fVal);
+        let iCell = unsafe { FindGridCell(fMin, fMax, fVal) };
         piHashCount[iCell] += 1;
         i += 1
     }
@@ -1493,7 +1576,7 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
     }
     i = 0;
     while i < iNrTrianglesIn * 3 {
-        let index_1: i32 = *piTriList_in_and_out.offset(i as isize);
+        let index_1: i32 = unsafe { *piTriList_in_and_out.offset(i as isize) };
         let vP_1 = get_position(geometry, index_1 as usize);
         let fVal_0: f32 = if iChannel == 0i32 {
             vP_1.x
@@ -1502,7 +1585,7 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
         } else {
             vP_1.z
         };
-        let iCell_0 = FindGridCell(fMin, fMax, fVal_0);
+        let iCell_0 = unsafe { FindGridCell(fMin, fMax, fVal_0) };
         piHashTable[(piHashOffsets[iCell_0] + piHashCount2[iCell_0]) as usize] = i as i32;
         piHashCount2[iCell_0] += 1;
         i += 1
@@ -1523,29 +1606,32 @@ unsafe fn GenerateSharedVerticesIndexList<I: Geometry>(
     k = 0;
     while k < g_iCells {
         // extract table of cell k and amount of entries in it
-        let pTable_0 = piHashTable.as_mut_ptr().offset(piHashOffsets[k] as isize);
+        let pTable_0 = unsafe { piHashTable.as_mut_ptr().offset(piHashOffsets[k] as isize) };
         let iEntries = piHashCount[k] as usize;
         if !(iEntries < 2) {
             e = 0;
             while e < iEntries {
-                let mut i_0: i32 = *pTable_0.offset(e as isize);
-                let vP_2 = get_position(
-                    geometry,
-                    *piTriList_in_and_out.offset(i_0 as isize) as usize,
-                );
+                let mut i_0: i32 = unsafe { *pTable_0.offset(e as isize) };
+                let vP_2 =
+                    get_position(
+                        geometry,
+                        unsafe { *piTriList_in_and_out.offset(i_0 as isize) } as usize,
+                    );
                 pTmpVert[e].vert[0usize] = vP_2.x;
                 pTmpVert[e].vert[1usize] = vP_2.y;
                 pTmpVert[e].vert[2usize] = vP_2.z;
                 pTmpVert[e].index = i_0;
                 e += 1
             }
-            MergeVertsFast(
-                piTriList_in_and_out,
-                pTmpVert.as_mut_ptr(),
-                geometry,
-                0i32,
-                (iEntries - 1) as i32,
-            );
+            unsafe {
+                MergeVertsFast(
+                    piTriList_in_and_out,
+                    pTmpVert.as_mut_ptr(),
+                    geometry,
+                    0i32,
+                    (iEntries - 1) as i32,
+                );
+            }
         }
         k += 1
     }
@@ -1570,7 +1656,7 @@ unsafe fn MergeVertsFast<I: Geometry>(
     let mut fSep: f32 = 0i32 as f32;
     c = 0i32;
     while c < 3i32 {
-        fvMin[c as usize] = (*pTmpVert.offset(iL_in as isize)).vert[c as usize];
+        fvMin[c as usize] = unsafe { *pTmpVert.offset(iL_in as isize) }.vert[c as usize];
         fvMax[c as usize] = fvMin[c as usize];
         c += 1
     }
@@ -1578,10 +1664,10 @@ unsafe fn MergeVertsFast<I: Geometry>(
     while l <= iR_in {
         c = 0i32;
         while c < 3i32 {
-            if fvMin[c as usize] > (*pTmpVert.offset(l as isize)).vert[c as usize] {
-                fvMin[c as usize] = (*pTmpVert.offset(l as isize)).vert[c as usize]
-            } else if fvMax[c as usize] < (*pTmpVert.offset(l as isize)).vert[c as usize] {
-                fvMax[c as usize] = (*pTmpVert.offset(l as isize)).vert[c as usize]
+            if fvMin[c as usize] > unsafe { *pTmpVert.offset(l as isize) }.vert[c as usize] {
+                fvMin[c as usize] = unsafe { *pTmpVert.offset(l as isize) }.vert[c as usize]
+            } else if fvMax[c as usize] < unsafe { *pTmpVert.offset(l as isize) }.vert[c as usize] {
+                fvMax[c as usize] = unsafe { *pTmpVert.offset(l as isize) }.vert[c as usize]
             }
             c += 1
         }
@@ -1600,8 +1686,8 @@ unsafe fn MergeVertsFast<I: Geometry>(
     if fSep >= fvMax[channel as usize] || fSep <= fvMin[channel as usize] {
         l = iL_in;
         while l <= iR_in {
-            let mut i: i32 = (*pTmpVert.offset(l as isize)).index;
-            let index: i32 = *piTriList_in_and_out.offset(i as isize);
+            let mut i: i32 = unsafe { *pTmpVert.offset(l as isize) }.index;
+            let index: i32 = unsafe { *piTriList_in_and_out.offset(i as isize) };
             let vP = get_position(geometry, index as usize);
             let vN = get_normal(geometry, index as usize);
             let vT = get_tex_coord(geometry, index as usize);
@@ -1609,8 +1695,8 @@ unsafe fn MergeVertsFast<I: Geometry>(
             let mut l2: i32 = iL_in;
             let mut i2rec: i32 = -1i32;
             while l2 < l && bNotFound {
-                let i2: i32 = (*pTmpVert.offset(l2 as isize)).index;
-                let index2: i32 = *piTriList_in_and_out.offset(i2 as isize);
+                let i2: i32 = unsafe { *pTmpVert.offset(l2 as isize) }.index;
+                let index2: i32 = unsafe { *piTriList_in_and_out.offset(i2 as isize) };
                 let vP2 = get_position(geometry, index2 as usize);
                 let vN2 = get_normal(geometry, index2 as usize);
                 let vT2 = get_tex_coord(geometry, index2 as usize);
@@ -1631,8 +1717,10 @@ unsafe fn MergeVertsFast<I: Geometry>(
                 }
             }
             if !bNotFound {
-                *piTriList_in_and_out.offset(i as isize) =
-                    *piTriList_in_and_out.offset(i2rec as isize)
+                unsafe {
+                    *piTriList_in_and_out.offset(i as isize) =
+                        *piTriList_in_and_out.offset(i2rec as isize)
+                }
             }
             l += 1
         }
@@ -1643,28 +1731,32 @@ unsafe fn MergeVertsFast<I: Geometry>(
             let mut bReadyLeftSwap: bool = false;
             let mut bReadyRightSwap: bool = false;
             while !bReadyLeftSwap && iL < iR {
-                bReadyLeftSwap = !((*pTmpVert.offset(iL as isize)).vert[channel as usize] < fSep);
+                bReadyLeftSwap =
+                    !(unsafe { *pTmpVert.offset(iL as isize) }.vert[channel as usize] < fSep);
                 if !bReadyLeftSwap {
                     iL += 1
                 }
             }
             while !bReadyRightSwap && iL < iR {
-                bReadyRightSwap = (*pTmpVert.offset(iR as isize)).vert[channel as usize] < fSep;
+                bReadyRightSwap =
+                    unsafe { *pTmpVert.offset(iR as isize) }.vert[channel as usize] < fSep;
                 if !bReadyRightSwap {
                     iR -= 1
                 }
             }
             if bReadyLeftSwap && bReadyRightSwap {
-                let sTmp: STmpVert = *pTmpVert.offset(iL as isize);
-                *pTmpVert.offset(iL as isize) = *pTmpVert.offset(iR as isize);
-                *pTmpVert.offset(iR as isize) = sTmp;
+                unsafe {
+                    let sTmp: STmpVert = *pTmpVert.offset(iL as isize);
+                    *pTmpVert.offset(iL as isize) = *pTmpVert.offset(iR as isize);
+                    *pTmpVert.offset(iR as isize) = sTmp;
+                }
                 iL += 1;
                 iR -= 1
             }
         }
         if iL == iR {
             let bReadyRightSwap_0: bool =
-                (*pTmpVert.offset(iR as isize)).vert[channel as usize] < fSep;
+                unsafe { *pTmpVert.offset(iR as isize) }.vert[channel as usize] < fSep;
             if bReadyRightSwap_0 {
                 iL += 1
             } else {
@@ -1672,10 +1764,14 @@ unsafe fn MergeVertsFast<I: Geometry>(
             }
         }
         if iL_in < iR {
-            MergeVertsFast(piTriList_in_and_out, pTmpVert, geometry, iL_in, iR);
+            unsafe {
+                MergeVertsFast(piTriList_in_and_out, pTmpVert, geometry, iL_in, iR);
+            }
         }
         if iL < iR_in {
-            MergeVertsFast(piTriList_in_and_out, pTmpVert, geometry, iL, iR_in);
+            unsafe {
+                MergeVertsFast(piTriList_in_and_out, pTmpVert, geometry, iL, iR_in);
+            }
         }
     };
 }

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::all)]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use glam::{Vec2, Vec3};
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod wireframe;
 

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -2,6 +2,7 @@
 #![no_std]
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 use core::fmt::{self, Formatter, Pointer};
 use core::{

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -465,6 +465,7 @@
 //! [`bevy_reflect_derive/documentation`]: bevy_reflect_derive
 //! [derive `Reflect`]: derive@crate::Reflect
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod array;
 mod fields;

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -545,7 +545,8 @@ impl ReflectFromPtr {
     /// `val` must be a pointer to value of the type that the [`ReflectFromPtr`] was constructed for.
     /// This can be verified by checking that the type id returned by [`ReflectFromPtr::type_id`] is the expected one.
     pub unsafe fn as_reflect<'a>(&self, val: Ptr<'a>) -> &'a dyn Reflect {
-        (self.from_ptr)(val)
+        // SAFETY: the caller must uphold the safety contract for `from_ptr`.
+        unsafe { (self.from_ptr)(val) }
     }
 
     /// Convert `PtrMut` into `&mut dyn Reflect`.
@@ -555,7 +556,8 @@ impl ReflectFromPtr {
     /// `val` must be a pointer to a value of the type that the [`ReflectFromPtr`] was constructed for
     /// This can be verified by checking that the type id returned by [`ReflectFromPtr::type_id`] is the expected one.
     pub unsafe fn as_reflect_mut<'a>(&self, val: PtrMut<'a>) -> &'a mut dyn Reflect {
-        (self.from_ptr_mut)(val)
+        // SAFETY: the caller must uphold the safety contract for `from_ptr_mut`.
+        unsafe { (self.from_ptr_mut)(val) }
     }
     /// Get a function pointer to turn a `Ptr` into `&dyn Reflect` for
     /// the type this [`ReflectFromPtr`] was constructed for.

--- a/crates/bevy_reflect_compile_fail_tests/src/lib.rs
+++ b/crates/bevy_reflect_compile_fail_tests/src/lib.rs
@@ -1,1 +1,3 @@
 // Nothing here, check out the integration tests
+
+#![forbid(unsafe_op_in_unsafe_fn)]

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -83,12 +83,14 @@ where
         // SAFETY:
         // - The caller ensures that `world` is the same one that `init_state` was called with.
         // - The caller ensures that no other `SystemParam`s will conflict with the accesses we have registered.
-        let main_world = Res::<MainWorld>::get_param(
-            &mut state.main_world_state,
-            system_meta,
-            world,
-            change_tick,
-        );
+        let main_world = unsafe {
+            Res::<MainWorld>::get_param(
+                &mut state.main_world_state,
+                system_meta,
+                world,
+                change_tick,
+            )
+        };
         let item = state.state.get(main_world.into_inner());
         Extract { item }
     }

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_render cannot compile for a 16-bit platform.");

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod bundle;
 mod dynamic_scene;

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod bundle;
 mod dynamic_texture_atlas_builder;

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 #![allow(clippy::type_complexity)]
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod slice;
 pub use slice::{ParallelSlice, ParallelSliceMut};

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 mod error;
 mod font;

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 /// Common run conditions
 pub mod common_conditions;

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -2,6 +2,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::undocumented_unsafe_blocks)]
 #![doc = include_str!("../README.md")]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 pub mod commands;
 /// The basic components of the transform crate

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! This crate contains Bevy's UI system, which can be used to create UI for both 2D and 3D games
 //! # Basic usage

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
 #![warn(clippy::undocumented_unsafe_blocks)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 #[allow(missing_docs)]
 pub mod prelude {

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::type_complexity)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 #[warn(missing_docs)]
 mod cursor;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(clippy::type_complexity)]
 #![warn(missing_docs)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 //! `bevy_winit` provides utilities to handle window creation and the eventloop through [`winit`]
 //!
 //! Most commonly, the [`WinitPlugin`] is used as part of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::single_component_path_imports)]
+#![forbid(unsafe_op_in_unsafe_fn)]
 
 //! [![](https://bevyengine.org/assets/bevy_logo_docs.svg)](https://bevyengine.org)
 //!

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,13 +17,14 @@ bitflags! {
     }
 }
 
-const CLIPPY_FLAGS: [&str; 7] = [
+const CLIPPY_FLAGS: [&str; 8] = [
     "-Aclippy::type_complexity",
     "-Wclippy::doc_markdown",
     "-Wclippy::redundant_else",
     "-Wclippy::match_same_arms",
     "-Wclippy::semicolon_if_nothing_returned",
     "-Wclippy::map_flatten",
+    "-Wunsafe_op_in_unsafe_fn",
     "-Dwarnings",
 ];
 


### PR DESCRIPTION
# Objective

- Fixes #9848

## Solution

- Added `unsafe_op_in_unsafe_fn` to the lint options for CI `clippy` task.
- Added `#![forbid(unsafe_op_in_unsafe_fn)]` to all crates that did not already forbid `unsafe`
- Placed `unsafe { ... }` statements around specific uses of `unsafe` where lint raised warnings.

## Notes

* My safety comments are fairly generic due to the shear volume required. I would encourage people to submit change suggestions to better comments where they may have a better understanding of the specific unsafe function contract.
* I've neglected the `generated.rs` file in `bevy_mikktspace`, as something like #9050 will resolve that issue on its own.