### PR TITLE
Fix a typo in `DirectionalLightBundle`

### DIFF
--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -123,7 +123,7 @@ pub struct DirectionalLightBundle {
     /// Enables or disables the light
     pub visibility: Visibility,
     /// Inherited visibility of an entity.
-    pub visible_in_hieararchy: InheritedVisibility,
+    pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
 }


### PR DESCRIPTION
# Objective

Fix a typo introduced by #9497. While drafting the PR, the type was originally called `VisibleInHierarchy` before I renamed it to `InheritedVisibility`, but this field got left behind due to a typo.
