### PR TITLE
resolve conflicts by insertion order

### DIFF
--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -707,7 +707,7 @@ mod tests {
             let mut schedule = Schedule::default();
 
             schedule.set_build_settings(ScheduleBuildSettings {
-                ambiguity_detection: LogLevel::Error,
+                ambiguity_detection: AmbiguityDetection::Error,
                 ..Default::default()
             });
 

--- a/examples/ecs/nondeterministic_system_order.rs
+++ b/examples/ecs/nondeterministic_system_order.rs
@@ -13,7 +13,7 @@
 //! This example demonstrates how you might detect and resolve (or silence) these ambiguities.
 
 use bevy::{
-    ecs::schedule::{LogLevel, ScheduleBuildSettings},
+    ecs::schedule::{AmbiguityDetection, ScheduleBuildSettings},
     prelude::*,
 };
 
@@ -22,7 +22,7 @@ fn main() {
         // We can modify the reporting strategy for system execution order ambiguities on a per-schedule basis
         .edit_schedule(Main, |schedule| {
             schedule.set_build_settings(ScheduleBuildSettings {
-                ambiguity_detection: LogLevel::Warn,
+                ambiguity_detection: AmbiguityDetection::Warn,
                 ..default()
             });
         })


### PR DESCRIPTION
> Opening this as draft as I'd prefer to merge #9822 first and this is likely to have conflicts with that pr. Also might add write-before-read resolution in this pr rather than a follow up pr. I haven't decided which is better yet.

# Objective

- Make a stable order of system execution when there are ambiguities. Ambiguities lead to hard to diagnose behavior as the symptoms only occur randomly per run of the app. 

## Solution

- Depend on system insertion order to resolve ambiguities. The `NodeId` was already being generated when inserting new systems.
- Make a new enum `AmbiguityDetection` that has a `Resolve` variant added. Otherwise has the same variants as `LogLevel`.
- Make `Resolve` the default instead of `Ignore`. Having the random behavior was hard for users to understand. Now if they have an incorrect ambiguity it will always be present. 
- Bugs with ambiguity will now manifest in a new way. Say a user reorders their plugins. This could now introduce new behavior even the user didn't change anything else with their app. Users should be taught to turn on ambiguity detection in these situations. I think this is better than the status quo, but not ideal.

---

## Changelog

- resolve ambiguities in system execution with insertion order

## Migration Guide

- `ScheduleBuildSetings::ambiguity_detection` now takes a `AmbiguityDetection` that has an extra variant `Resolve` over `LogLevel`.
- The default ambiguity detection level was changed from `Ignore` to `Resolve`. If you want the previous behavior you'll need to use `schedule.set_build_settings` to change it back.

## Future Work

I'd like to also add in resolving by placing writes before reads, but this is more work as this information is not currently available in the reported conflicts, so this will require more extensive changes. This feature should also help a bit with the confusing bugs by reordering plugins mentioned above.

There will be systems that can't be resolved by write-before-read ordering. They could be writing the same component or one will write one component while the other reads that component, but writes another. In these cases we can fall back to system insertion order, but we provide the options to error or warn in these situations.