### PR TITLE
Add as_slice to parent

### DIFF
--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -30,7 +30,7 @@ impl Parent {
     /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.
     ///
     /// [`Children`]: super::children::Children
-    pub fn get_slice(&self) -> &[Entity] {
+    pub fn as_slice(&self) -> &[Entity] {
         std::slice::from_ref(&self.0)
     }
 }

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -26,8 +26,10 @@ impl Parent {
 
     /// Get parent as a slice.
     ///
-    /// This is useful for making APIs that require a type or homogenous storage
+    /// Useful for making APIs that require a type or homogenous storage
     /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.
+    ///
+    /// [`Children`]: super::children::Children
     pub fn get_slice(&self) -> &[Entity] {
         std::slice::from_ref(&self.0)
     }

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -24,7 +24,7 @@ impl Parent {
         self.0
     }
 
-    /// Get parent as a slice.
+    /// Gets the parent [`Entity`] as a slice of length 1.
     ///
     /// Useful for making APIs that require a type or homogenous storage
     /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -24,7 +24,9 @@ impl Parent {
         self.0
     }
 
-    /// Get parent as a slice. Useful for making APIs that require a type or homogenous storage
+    /// Get parent as a slice.
+    ///
+    /// This is useful for making APIs that require a type or homogenous storage
     /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.
     pub fn get_slice(&self) -> &[Entity] {
         std::slice::from_ref(&self.0)

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -23,6 +23,12 @@ impl Parent {
     pub fn get(&self) -> Entity {
         self.0
     }
+
+    /// Get parent as a slice. Useful for making APIs that require a type or homogenous storage
+    /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.
+    pub fn get_slice(&self) -> &[Entity] {
+        std::slice::from_ref(&self.0)
+    }
 }
 
 // TODO: We need to impl either FromWorld or Default so Parent can be registered as Reflect.


### PR DESCRIPTION
# Objective
- Make it possible to write APIs that require a type or homogenous storage for both `Children` & `Parent` that is agnostic to edge direction.

## Solution
- Add a way to get the `Entity` from `Parent` as a slice.