### PR TITLE
Revert "Update defaults for OrthographicProjection (#9537)"

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -197,8 +197,6 @@ pub enum ScalingMode {
 ///
 /// Note that the scale of the projection and the apparent size of objects are inversely proportional.
 /// As the size of the projection increases, the size of objects decreases.
-///
-/// Note also that the view frustum is centered at the origin.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct OrthographicProjection {
@@ -206,7 +204,7 @@ pub struct OrthographicProjection {
     ///
     /// Objects closer than this will not be rendered.
     ///
-    /// Defaults to `-1000.0`
+    /// Defaults to `0.0`
     pub near: f32,
     /// The distance of the far clipping plane in world units.
     ///
@@ -317,7 +315,7 @@ impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
             scale: 1.0,
-            near: -1000.0,
+            near: 0.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize(1.0),


### PR DESCRIPTION
# Objective

- Fixes #9876

## Solution

- Reverted commit `5012a0fd57748ab6f146776368b4cf988bba1eaa` to restore the previous default values for `OrthographicProjection`.

---

## Migration Guide

- Migration guide steps from #9537 should be removed for next release.
