### PR TITLE
Rename `num_font_atlases`  to `len`.

### DIFF
--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -153,7 +153,8 @@ impl FontAtlasSet {
             })
     }
 
-    pub fn num_font_atlases(&self) -> usize {
+    /// Returns the number of font atlases in this set
+    pub fn len(&self) -> usize {
         self.font_atlases.len()
     }
 }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -158,7 +158,7 @@ impl FontAtlasSet {
         self.font_atlases.len()
     }
 
-    /// Returns `true` if the font atlas set contains no elements.
+    /// Returns `true` if the font atlas set contains no elements
     pub fn is_empty(&self) -> bool {
         self.font_atlases.is_empty()
     }

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -157,4 +157,9 @@ impl FontAtlasSet {
     pub fn len(&self) -> usize {
         self.font_atlases.len()
     }
+
+    /// Returns `true` if the font atlas set contains no elements.
+    pub fn is_empty(&self) -> bool {
+        self.font_atlases.is_empty()
+    }
 }

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -114,7 +114,7 @@ impl GlyphBrush {
 
                 if !text_settings.allow_dynamic_font_size
                     && !font_atlas_warning.warned
-                    && font_atlas_set.num_font_atlases() > text_settings.max_font_atlases.get()
+                    && font_atlas_set.len() > text_settings.max_font_atlases.get()
                 {
                     warn!("warning[B0005]: Number of font atlases has exceeded the maximum of {}. Performance and memory usage may suffer.", text_settings.max_font_atlases.get());
                     font_atlas_warning.warned = true;


### PR DESCRIPTION
# Objective

Rename the `num_font_atlases` method of `FontAtlasSet` to `len`.

All the function does is return the number of entries in its hashmap and the unnatural naming only makes it harder to discover.

---

## Changelog

* Renamed the `num_font_atlases` method of `FontAtlasSet` to `len`.

## Migration Guide

The `num_font_atlases` method of `FontAtlasSet` has been renamed to `len`.