### PR TITLE
Remove dependecies from bevy_tasks' README

### DIFF
--- a/crates/bevy_tasks/README.md
+++ b/crates/bevy_tasks/README.md
@@ -31,19 +31,3 @@ The determining factor for what kind of work should go in each pool is latency r
 [bevy]: https://bevyengine.org
 [rayon]: https://github.com/rayon-rs/rayon
 [async-executor]: https://github.com/stjepang/async-executor
-
-## Dependencies
-
-A very small dependency list is a key feature of this module
-
-```text
-├── async-executor
-│   ├── async-task
-│   ├── concurrent-queue
-│   │   └── cache-padded
-│   └── fastrand
-├── num_cpus
-│   └── libc
-├── parking
-└── futures-lite
-```


### PR DESCRIPTION
# Objective
Noticed that bevy_tasks' README mentions its dependency tree, which is very outdated at this point.

## Solution
Remove it.