### PR TITLE
Add default for UntypedHandle

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -362,6 +362,12 @@ impl Hash for UntypedHandle {
     }
 }
 
+impl Default for UntypedHandle {
+    fn default() -> Self {
+        Self::Weak(UntypedAssetId::default())
+    }
+}
+
 impl std::fmt::Debug for UntypedHandle {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -224,6 +224,15 @@ pub enum UntypedAssetId {
     Uuid { type_id: TypeId, uuid: Uuid },
 }
 
+impl Default for UntypedAssetId {
+    fn default() -> Self {
+        Self::Uuid {
+            type_id: TypeId::of::<()>(),
+            uuid: AssetId::<()>::DEFAULT_UUID,
+        }
+    }
+}
+
 impl UntypedAssetId {
     /// Converts this to a "typed" [`AssetId`] without checking the stored type to see if it matches the target `A` [`Asset`] type.
     /// This should only be called if you are _absolutely certain_ the asset type matches the stored type. And even then, you should


### PR DESCRIPTION
# Objective

Fixes #9773 

## Solution

I reused `DEFAULT_UUID` from `AssetId` and  made the default untyped handle typed as an empty tuple since this type was already defined as an Asset and seemed appropriate.
