### PR TITLE
Ignore ambiguous components or resources

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -855,7 +855,7 @@ impl App {
         self
     }
 
-    /// When doing [ambiguity checking](bevy_ecs::scheduling::ScheduleBuildSettings) this
+    /// When doing [ambiguity checking](bevy_ecs::schedule::ScheduleBuildSettings) this
     /// ignores systems that are ambiguious on [`Component`] T.
     ///
     /// This settings only applies to the main world. To apply this to other worlds call the
@@ -893,7 +893,7 @@ impl App {
         self
     }
 
-    /// When doing [ambiguity checking](bevy_ecs::scheduling::ScheduleBuildSettings) this
+    /// When doing [ambiguity checking](bevy_ecs::schedule::ScheduleBuildSettings) this
     /// ignores systems that are ambiguious on [`Resource`] T.
     ///
     /// This settings only applies to the main world. To apply this to other worlds call the

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -910,7 +910,7 @@ impl App {
     /// #[derive(Resource)]
     /// struct R;
     ///
-    /// // these systems are ambiguous on A
+    /// // these systems are ambiguous on R
     /// fn system_1(_: ResMut<R>) {}
     /// fn system_2(_: Res<R>) {}
     ///

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -854,6 +854,83 @@ impl App {
             .configure_schedules(schedule_build_settings);
         self
     }
+
+    /// When doing [ambiguity checking](bevy_ecs::scheduling::ScheduleBuildSettings) this
+    /// ignores systems that are ambiguious on [`Component`] T.
+    ///
+    /// This settings only applies to the main world. To apply this to other worlds call the
+    /// [corresponding method](World::allow_ambiguous_component) on World
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::{LogLevel, ScheduleBuildSettings};
+    /// # use bevy_utils::default;
+    ///
+    /// #[derive(Component)]
+    /// struct A;
+    ///
+    /// // these systems are ambiguous on A
+    /// fn system_1(_: Query<&mut A>) {}
+    /// fn system_2(_: Query<&A>) {}
+    ///
+    /// let mut app = App::new();
+    /// app.configure_schedules(ScheduleBuildSettings {
+    ///   ambiguity_detection: LogLevel::Error,
+    ///   ..default()
+    /// });
+    ///
+    /// app.add_systems(Update, ( system_1, system_2 ));
+    /// app.allow_ambiguous_component::<A>();
+    ///
+    /// // running the app does not error.
+    /// app.update();
+    /// ```
+    pub fn allow_ambiguous_component<T: Component>(&mut self) -> &mut Self {
+        self.world.allow_ambiguous_component::<T>();
+        self
+    }
+
+    /// When doing [ambiguity checking](bevy_ecs::scheduling::ScheduleBuildSettings) this
+    /// ignores systems that are ambiguious on [`Resource`] T.
+    ///
+    /// This settings only applies to the main world. To apply this to other worlds call the
+    /// [corresponding method](World::allow_ambiguous_resource) on World
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// # use bevy_app::prelude::*;
+    /// # use bevy_ecs::prelude::*;
+    /// # use bevy_ecs::schedule::{LogLevel, ScheduleBuildSettings};
+    /// # use bevy_utils::default;
+    ///
+    /// #[derive(Resource)]
+    /// struct R;
+    ///
+    /// // these systems are ambiguous on A
+    /// fn system_1(_: ResMut<R>) {}
+    /// fn system_2(_: Res<R>) {}
+    ///
+    /// let mut app = App::new();
+    /// app.configure_schedules(ScheduleBuildSettings {
+    ///   ambiguity_detection: LogLevel::Error,
+    ///   ..default()
+    /// });
+    /// app.insert_resource(R);
+    ///
+    /// app.add_systems(Update, ( system_1, system_2 ));
+    /// app.allow_ambiguous_resource::<R>();
+    ///
+    /// // running the app does not error.
+    /// app.update();
+    /// ```
+    pub fn allow_ambiguous_resource<T: Resource>(&mut self) -> &mut Self {
+        self.world.allow_ambiguous_resource::<T>();
+        self
+    }
 }
 
 fn run_once(mut app: App) {

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -261,6 +261,9 @@ pub trait AssetApp {
     /// * Registering the [`Asset`] in the [`AssetServer`]
     /// * Initializing the [`AssetEvent`] resource for the [`Asset`]
     /// * Adding other relevant systems and resources for the [`Asset`]
+    /// * Ignoring schedule ambiguities in [`Assets`] resource. Any time a system takes
+    /// mutable access to this resource this causes a conflict, but they rarely actually
+    /// modify the same underlying asset.
     fn init_asset<A: Asset>(&mut self) -> &mut Self;
     /// Registers the asset type `T` using `[App::register]`,
     /// and adds [`ReflectAsset`] type data to `T` and [`ReflectHandle`] type data to [`Handle<T>`] in the type registry.
@@ -301,6 +304,7 @@ impl AssetApp for App {
                 ));
         }
         self.insert_resource(assets)
+            .allow_ambiguous_resource::<Assets<A>>()
             .add_event::<AssetEvent<A>>()
             .register_type::<Handle<A>>()
             .register_type::<AssetId<A>>()

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -718,6 +718,8 @@ mod tests {
     }
 
     mod system_ambiguity {
+        use std::collections::BTreeSet;
+
         use super::*;
         // Required to make the derive macro behave
         use crate as bevy_ecs;
@@ -1010,7 +1012,7 @@ mod tests {
             let _ = schedule.graph_mut().build_schedule(
                 world.components(),
                 &TestSchedule.dyn_clone(),
-                &[],
+                &BTreeSet::new(),
             );
 
             let ambiguities: Vec<_> = schedule
@@ -1059,7 +1061,7 @@ mod tests {
             let _ = schedule.graph_mut().build_schedule(
                 world.components(),
                 &TestSchedule.dyn_clone(),
-                &[],
+                &BTreeSet::new(),
             );
 
             let ambiguities: Vec<_> = schedule

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -1010,7 +1010,7 @@ mod tests {
             let _ = schedule.graph_mut().build_schedule(
                 world.components(),
                 &TestSchedule.dyn_clone(),
-                &Vec::new(),
+                &[],
             );
 
             let ambiguities: Vec<_> = schedule
@@ -1055,12 +1055,11 @@ mod tests {
             schedule.add_systems((resmut_system, resmut_system).run_if(|| true));
 
             let mut world = World::new();
-
             schedule.graph_mut().initialize(&mut world);
             let _ = schedule.graph_mut().build_schedule(
                 world.components(),
                 &TestSchedule.dyn_clone(),
-                &Vec::new(),
+                &[],
             );
 
             let ambiguities: Vec<_> = schedule
@@ -1091,26 +1090,6 @@ mod tests {
             assert!(schedule.graph().conflicting_systems().is_empty());
 
             // check components
-            world.allow_ambiguous_component::<A>();
-            schedule.add_systems((write_component_system, read_component_system));
-            schedule.initialize(&mut world).unwrap();
-            assert!(schedule.graph().conflicting_systems().is_empty());
-        }
-
-        #[test]
-        fn ignore_before_add() {
-            let mut world = World::new();
-            world.allow_ambiguous_resource::<R>();
-            world.insert_resource(R);
-            let mut schedule = Schedule::new(TestSchedule);
-
-            //check resource
-            schedule.add_systems((resmut_system, res_system));
-            schedule.initialize(&mut world).unwrap();
-            assert!(schedule.graph().conflicting_systems().is_empty());
-
-            // check components
-            world.init_component::<A>();
             world.allow_ambiguous_component::<A>();
             schedule.add_systems((write_component_system, read_component_system));
             schedule.initialize(&mut world).unwrap();

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeSet,
     fmt::{Debug, Write},
     result::Result,
 };
@@ -880,7 +881,7 @@ impl ScheduleGraph {
         &mut self,
         components: &Components,
         schedule_label: &BoxedScheduleLabel,
-        ignored_ambiguities: &[ComponentId],
+        ignored_ambiguities: &BTreeSet<ComponentId>,
     ) -> Result<SystemSchedule, ScheduleBuildError> {
         // check hierarchy for cycles
         self.hierarchy.topsort =
@@ -1053,7 +1054,7 @@ impl ScheduleGraph {
         &self,
         flat_results_disconnected: &Vec<(NodeId, NodeId)>,
         ambiguous_with_flattened: &GraphMap<NodeId, (), Undirected>,
-        ignored_ambiguities: &[ComponentId],
+        ignored_ambiguities: &BTreeSet<ComponentId>,
     ) -> Vec<(NodeId, NodeId, Vec<ComponentId>)> {
         let mut conflicting_systems = Vec::new();
         for &(a, b) in flat_results_disconnected {
@@ -1192,7 +1193,7 @@ impl ScheduleGraph {
         &mut self,
         schedule: &mut SystemSchedule,
         components: &Components,
-        ignored_ambiguities: &[ComponentId],
+        ignored_ambiguities: &BTreeSet<ComponentId>,
         schedule_label: &BoxedScheduleLabel,
     ) -> Result<(), ScheduleBuildError> {
         if !self.uninit.is_empty() {
@@ -1734,17 +1735,17 @@ impl ScheduleBuildSettings {
 
 /// list of [`ComponentId`]'s to ignore when reporting ambiguity conflicts between systems
 #[derive(Resource, Default, Clone, Debug)]
-pub struct IgnoredSchedulingAmbiguities(Vec<ComponentId>);
+pub struct IgnoredSchedulingAmbiguities(BTreeSet<ComponentId>);
 
 impl IgnoredSchedulingAmbiguities {
     /// Ignore ambiguities between systems in [`Component`] T.
     pub fn allow_ambiguous_component<T: Component>(&mut self, world: &mut World) {
-        self.0.push(world.init_component::<T>());
+        self.0.insert(world.init_component::<T>());
     }
 
     /// Ignore ambiguities between systems in [`Resource`] T.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self, world: &mut World) {
-        self.0.push(world.components.init_resource::<T>());
+        self.0.insert(world.components.init_resource::<T>());
     }
 }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1733,17 +1733,17 @@ impl ScheduleBuildSettings {
     }
 }
 
-/// list of [`ComponentId`]'s to ignore when reporting ambiguity conflicts between systems
+/// List of [`ComponentId`]s to ignore when reporting system order ambiguity conflicts
 #[derive(Resource, Default, Clone, Debug)]
 pub struct IgnoredSchedulingAmbiguities(BTreeSet<ComponentId>);
 
 impl IgnoredSchedulingAmbiguities {
-    /// Ignore ambiguities between systems in [`Component`] T.
+    /// Ignore system order ambiguities caused by conflicts on [`Component`]s of type `T`.
     pub fn allow_ambiguous_component<T: Component>(&mut self, world: &mut World) {
         self.0.insert(world.init_component::<T>());
     }
 
-    /// Ignore ambiguities between systems in [`Resource`] T.
+    /// Ignore system order ambiguities caused by conflicts on [`Resource`]s of type `T`.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self, world: &mut World) {
         self.0.insert(world.components.init_resource::<T>());
     }
@@ -1758,7 +1758,9 @@ impl IgnoredSchedulingAmbiguities {
     /// May panic or retrieve incorrect names if [`Components`] is not from the same
     /// world
     pub fn print_names(&self, components: &Components) {
-        let mut message = "Ambiguities of the following types are ignored:\n".to_string();
+        let mut message =
+            "System order ambiguities caused by conflicts on the following types are ignored:\n"
+                .to_string();
         for id in self.iter() {
             writeln!(message, "{}", components.get_name(*id).unwrap()).unwrap();
         }

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{btree_set::Iter, BTreeSet},
+    collections::BTreeSet,
     fmt::{Debug, Write},
     result::Result,
 };
@@ -1749,7 +1749,7 @@ impl IgnoredSchedulingAmbiguities {
     }
 
     /// Iterate through the [`ComponentId`]'s that will be ignored.
-    pub fn iter(&self) -> Iter<'_, ComponentId> {
+    pub fn iter(&self) -> impl Iterator<Item = &ComponentId> + '_ {
         self.0.iter()
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -263,14 +263,14 @@ impl Schedule {
     pub fn initialize(&mut self, world: &mut World) -> Result<(), ScheduleBuildError> {
         if self.graph.changed {
             self.graph.initialize(world);
-            let ignore_ambiguities = world
-                .get_resource::<IgnoreSchedulingAmbiguities>()
+            let ignored_ambiguities = world
+                .get_resource::<IgnoredSchedulingAmbiguities>()
                 .cloned()
                 .unwrap_or_default();
             self.graph.update_schedule(
                 &mut self.executable,
                 world.components(),
-                &ignore_ambiguities.0,
+                &ignored_ambiguities.0,
                 &self.name,
             )?;
             self.graph.changed = false;
@@ -1733,10 +1733,10 @@ impl ScheduleBuildSettings {
 }
 
 /// list of [`ComponentId`]'s to ignore when reporting ambiguity conflicts between systems
-#[derive(Resource, Default, Clone)]
-pub struct IgnoreSchedulingAmbiguities(Vec<ComponentId>);
+#[derive(Resource, Default, Clone, Debug)]
+pub struct IgnoredSchedulingAmbiguities(Vec<ComponentId>);
 
-impl IgnoreSchedulingAmbiguities {
+impl IgnoredSchedulingAmbiguities {
     /// Ignore ambiguities between systems in [`Component`] T.
     pub fn allow_ambiguous_component<T: Component>(&mut self, world: &mut World) {
         self.0.push(world.init_component::<T>());

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1,12 +1,12 @@
 use std::{
-    collections::BTreeSet,
+    collections::{btree_set::Iter, BTreeSet},
     fmt::{Debug, Write},
     result::Result,
 };
 
-use bevy_utils::default;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
+use bevy_utils::{default, tracing::info};
 use bevy_utils::{
     petgraph::{algo::TarjanScc, prelude::*},
     thiserror::Error,
@@ -1746,6 +1746,24 @@ impl IgnoredSchedulingAmbiguities {
     /// Ignore ambiguities between systems in [`Resource`] T.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self, world: &mut World) {
         self.0.insert(world.components.init_resource::<T>());
+    }
+
+    /// Iterate through the [`ComponentId`]'s that will be ignored.
+    pub fn iter(&self) -> Iter<'_, ComponentId> {
+        self.0.iter()
+    }
+
+    /// Prints the names of the components and resources with [`info`]
+    ///
+    /// May panic or retrieve incorrect names if [`Components`] is not from the same
+    /// world
+    pub fn print_names(&self, components: &Components) {
+        let mut message = "Ambiguities of the following types are ignored:\n".to_string();
+        for id in self.iter() {
+            writeln!(message, "{}", components.get_name(*id).unwrap()).unwrap();
+        }
+
+        info!("{}", message);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     event::{Event, Events},
     query::{DebugCheckedUnwrap, QueryEntityError, QueryState, ReadOnlyWorldQuery, WorldQuery},
     removal_detection::RemovedComponentEvents,
-    schedule::{Schedule, ScheduleLabel, Schedules},
+    schedule::{IgnoreSchedulingAmbiguities, Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
     world::error::TryRunScheduleError,
@@ -2086,6 +2086,22 @@ impl World {
     /// If the requested schedule does not exist.
     pub fn run_schedule(&mut self, label: impl AsRef<dyn ScheduleLabel>) {
         self.schedule_scope(label, |world, sched| sched.run(world));
+    }
+
+    pub fn allow_ambiguous_component<T: Component>(&mut self) {
+        let mut ignore_ambiguities = self
+            .remove_resource::<IgnoreSchedulingAmbiguities>()
+            .unwrap_or_default();
+        ignore_ambiguities.allow_ambiguous_component::<T>(self);
+        self.insert_resource(ignore_ambiguities);
+    }
+
+    pub fn allow_ambiguous_resource<T: Resource>(&mut self) {
+        let mut ignore_ambiguities = self
+            .remove_resource::<IgnoreSchedulingAmbiguities>()
+            .unwrap_or_default();
+        ignore_ambiguities.allow_ambiguous_resource::<T>(self);
+        self.insert_resource(ignore_ambiguities);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     event::{Event, Events},
     query::{DebugCheckedUnwrap, QueryEntityError, QueryState, ReadOnlyWorldQuery, WorldQuery},
     removal_detection::RemovedComponentEvents,
-    schedule::{IgnoreSchedulingAmbiguities, Schedule, ScheduleLabel, Schedules},
+    schedule::{IgnoredSchedulingAmbiguities, Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
     world::error::TryRunScheduleError,
@@ -2090,20 +2090,20 @@ impl World {
 
     /// Ignore ambiguities between systems in [`Component`] T.
     pub fn allow_ambiguous_component<T: Component>(&mut self) {
-        let mut ignore_ambiguities = self
-            .remove_resource::<IgnoreSchedulingAmbiguities>()
+        let mut ignored_ambiguities = self
+            .remove_resource::<IgnoredSchedulingAmbiguities>()
             .unwrap_or_default();
-        ignore_ambiguities.allow_ambiguous_component::<T>(self);
-        self.insert_resource(ignore_ambiguities);
+        ignored_ambiguities.allow_ambiguous_component::<T>(self);
+        self.insert_resource(ignored_ambiguities);
     }
 
     /// Ignore ambiguities between systems in [`Resource`] T.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self) {
-        let mut ignore_ambiguities = self
-            .remove_resource::<IgnoreSchedulingAmbiguities>()
+        let mut ignored_ambiguities = self
+            .remove_resource::<IgnoredSchedulingAmbiguities>()
             .unwrap_or_default();
-        ignore_ambiguities.allow_ambiguous_resource::<T>(self);
-        self.insert_resource(ignore_ambiguities);
+        ignored_ambiguities.allow_ambiguous_resource::<T>(self);
+        self.insert_resource(ignored_ambiguities);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2088,7 +2088,7 @@ impl World {
         self.schedule_scope(label, |world, sched| sched.run(world));
     }
 
-    /// Ignore ambiguities between systems in [`Component`] T.
+    /// Ignore system order ambiguities caused by conflicts on [`Component`]s of type `T`.
     pub fn allow_ambiguous_component<T: Component>(&mut self) {
         let mut ignored_ambiguities = self
             .remove_resource::<IgnoredSchedulingAmbiguities>()
@@ -2097,7 +2097,7 @@ impl World {
         self.insert_resource(ignored_ambiguities);
     }
 
-    /// Ignore ambiguities between systems in [`Resource`] T.
+    /// Ignore system order ambiguities caused by conflicts on [`Resource`]s of type `T`.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self) {
         let mut ignored_ambiguities = self
             .remove_resource::<IgnoredSchedulingAmbiguities>()

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     event::{Event, Events},
     query::{DebugCheckedUnwrap, QueryEntityError, QueryState, ReadOnlyWorldQuery, WorldQuery},
     removal_detection::RemovedComponentEvents,
-    schedule::{IgnoredSchedulingAmbiguities, Schedule, ScheduleLabel, Schedules},
+    schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
     system::Resource,
     world::error::TryRunScheduleError,
@@ -2090,20 +2090,16 @@ impl World {
 
     /// Ignore system order ambiguities caused by conflicts on [`Component`]s of type `T`.
     pub fn allow_ambiguous_component<T: Component>(&mut self) {
-        let mut ignored_ambiguities = self
-            .remove_resource::<IgnoredSchedulingAmbiguities>()
-            .unwrap_or_default();
-        ignored_ambiguities.allow_ambiguous_component::<T>(self);
-        self.insert_resource(ignored_ambiguities);
+        let mut schedules = self.remove_resource::<Schedules>().unwrap_or_default();
+        schedules.allow_ambiguous_component::<T>(self);
+        self.insert_resource(schedules);
     }
 
     /// Ignore system order ambiguities caused by conflicts on [`Resource`]s of type `T`.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self) {
-        let mut ignored_ambiguities = self
-            .remove_resource::<IgnoredSchedulingAmbiguities>()
-            .unwrap_or_default();
-        ignored_ambiguities.allow_ambiguous_resource::<T>(self);
-        self.insert_resource(ignored_ambiguities);
+        let mut schedules = self.remove_resource::<Schedules>().unwrap_or_default();
+        schedules.allow_ambiguous_resource::<T>(self);
+        self.insert_resource(schedules);
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2088,6 +2088,7 @@ impl World {
         self.schedule_scope(label, |world, sched| sched.run(world));
     }
 
+    /// Ignore ambiguities between systems in [`Component`] T.
     pub fn allow_ambiguous_component<T: Component>(&mut self) {
         let mut ignore_ambiguities = self
             .remove_resource::<IgnoreSchedulingAmbiguities>()
@@ -2096,6 +2097,7 @@ impl World {
         self.insert_resource(ignore_ambiguities);
     }
 
+    /// Ignore ambiguities between systems in [`Resource`] T.
     pub fn allow_ambiguous_resource<T: Resource>(&mut self) {
         let mut ignore_ambiguities = self
             .remove_resource::<IgnoreSchedulingAmbiguities>()


### PR DESCRIPTION
# Objective

- Fixes #9884
- Add API for ignoring ambiguities on certain resource or components.

## Solution

- Add a `IgnoreSchedulingAmbiguitiy` resource to the world which holds the `ComponentIds` to be ignored
- Filter out ambiguities with those component id's.

## Changelog

- add `allow_ambiguous_component` and `allow_ambiguous_resource` apis for ignoring ambiguities
