### PR TITLE
Move skin code to a separate module

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -1,5 +1,6 @@
 //! Bind group layout related definitions for the mesh pipeline.
 
+use bevy_math::Mat4;
 use bevy_render::{
     mesh::morph::MAX_MORPH_WEIGHTS,
     render_resource::{
@@ -9,13 +10,17 @@ use bevy_render::{
     renderer::RenderDevice,
 };
 
+use crate::render::skin::MAX_JOINTS;
+
 const MORPH_WEIGHT_SIZE: usize = std::mem::size_of::<f32>();
 pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 
+const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
+pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
+
 /// Individual layout entries.
 mod layout_entry {
-    use super::MORPH_BUFFER_SIZE;
-    use crate::render::mesh::JOINT_BUFFER_SIZE;
+    use super::{JOINT_BUFFER_SIZE, MORPH_BUFFER_SIZE};
     use crate::MeshUniform;
     use bevy_render::{
         render_resource::{
@@ -66,8 +71,7 @@ mod layout_entry {
 /// Individual [`BindGroupEntry`](bevy_render::render_resource::BindGroupEntry)
 /// for bind groups.
 mod entry {
-    use super::MORPH_BUFFER_SIZE;
-    use crate::render::mesh::JOINT_BUFFER_SIZE;
+    use super::{JOINT_BUFFER_SIZE, MORPH_BUFFER_SIZE};
     use bevy_render::render_resource::{
         BindGroupEntry, BindingResource, Buffer, BufferBinding, BufferSize, TextureView,
     };

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -3,8 +3,10 @@ mod light;
 pub(crate) mod mesh;
 mod mesh_bindings;
 mod morph;
+mod skin;
 
 pub use fog::*;
 pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
+pub use skin::{extract_skins, prepare_skins, SkinIndex, SkinUniform, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -69,6 +69,8 @@ fn add_to_alignment<T: Pod + Default>(buffer: &mut BufferVec<T>) {
     buffer.extend(iter::repeat_with(T::default).take(ts_to_add));
 }
 
+// Notes on implementation: see comment on top of the extract_skins system in skin module.
+// This works similarly, but for `f32` instead of `Mat4`
 pub fn extract_morphs(
     mut commands: Commands,
     mut previous_len: Local<usize>,

--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -28,16 +28,16 @@ impl Default for MorphUniform {
 }
 
 pub fn prepare_morphs(
-    device: Res<RenderDevice>,
-    queue: Res<RenderQueue>,
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
     mut uniform: ResMut<MorphUniform>,
 ) {
     if uniform.buffer.is_empty() {
         return;
     }
-    let buffer = &mut uniform.buffer;
-    buffer.reserve(buffer.len(), &device);
-    buffer.write_buffer(&device, &queue);
+    let len = uniform.buffer.len();
+    uniform.buffer.reserve(len, &render_device);
+    uniform.buffer.write_buffer(&render_device, &render_queue);
 }
 
 const fn can_align(step: usize, target: usize) -> bool {

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -97,6 +97,8 @@ pub fn extract_skins(
         while buffer.len() % 4 != 0 {
             buffer.push(Mat4::ZERO);
         }
+        // NOTE: The skinned joints uniform buffer has to be bound at a dynamic offset per
+        // entity and so cannot currently be batched.
         values.push((entity, (SkinIndex::new(start), NoAutomaticBatching)));
     }
 

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -1,0 +1,110 @@
+use bevy_asset::Assets;
+use bevy_ecs::prelude::*;
+use bevy_math::Mat4;
+use bevy_render::{
+    batching::NoAutomaticBatching,
+    mesh::skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
+    render_resource::{BufferUsages, BufferVec},
+    renderer::{RenderDevice, RenderQueue},
+    view::ViewVisibility,
+    Extract,
+};
+use bevy_transform::prelude::GlobalTransform;
+
+/// Maximum number of joints supported for skinned meshes.
+pub const MAX_JOINTS: usize = 256;
+
+#[derive(Component)]
+pub struct SkinIndex {
+    pub index: u32,
+}
+impl SkinIndex {
+    /// Index to be in address space based on [`SkinnedMeshUniform`] size.
+    const fn new(start: usize) -> Self {
+        SkinIndex {
+            index: (start * std::mem::size_of::<Mat4>()) as u32,
+        }
+    }
+}
+
+#[derive(Resource)]
+pub struct SkinUniform {
+    pub buffer: BufferVec<Mat4>,
+}
+impl Default for SkinUniform {
+    fn default() -> Self {
+        Self {
+            buffer: BufferVec::new(BufferUsages::UNIFORM),
+        }
+    }
+}
+
+pub fn prepare_skins(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut uniform: ResMut<SkinUniform>,
+) {
+    if uniform.buffer.is_empty() {
+        return;
+    }
+
+    let len = uniform.buffer.len();
+    uniform.buffer.reserve(len, &render_device);
+    uniform.buffer.write_buffer(&render_device, &render_queue);
+}
+
+pub fn extract_skins(
+    mut commands: Commands,
+    mut previous_len: Local<usize>,
+    mut uniform: ResMut<SkinUniform>,
+    query: Extract<Query<(Entity, &ViewVisibility, &SkinnedMesh)>>,
+    inverse_bindposes: Extract<Res<Assets<SkinnedMeshInverseBindposes>>>,
+    joints: Extract<Query<&GlobalTransform>>,
+) {
+    uniform.buffer.clear();
+
+    let mut values = Vec::with_capacity(*previous_len);
+    let mut last_start = 0;
+
+    for (entity, view_visibility, skin) in &query {
+        if !view_visibility.get() {
+            continue;
+        }
+        // PERF: This can be expensive, can we move this to prepare?
+        let buffer = &mut uniform.buffer;
+        let Some(inverse_bindposes) = inverse_bindposes.get(&skin.inverse_bindposes) else {
+            continue;
+        };
+        let start = buffer.len();
+
+        let target = start + skin.joints.len().min(MAX_JOINTS);
+        buffer.extend(
+            joints
+                .iter_many(&skin.joints)
+                .zip(inverse_bindposes.iter())
+                .take(MAX_JOINTS)
+                .map(|(joint, bindpose)| joint.affine() * *bindpose),
+        );
+        // iter_many will skip any failed fetches. This will cause it to assign the wrong bones,
+        // so just bail by truncating to the start.
+        if buffer.len() != target {
+            buffer.truncate(start);
+            continue;
+        }
+        last_start = last_start.max(start);
+
+        // Pad to 256 byte alignment
+        while buffer.len() % 4 != 0 {
+            buffer.push(Mat4::ZERO);
+        }
+        values.push((entity, (SkinIndex::new(start), NoAutomaticBatching)));
+    }
+
+    // Pad out the buffer to ensure that there's enough space for bindings
+    while uniform.buffer.len() - last_start < MAX_JOINTS {
+        uniform.buffer.push(Mat4::ZERO);
+    }
+
+    *previous_len = values.len();
+    commands.insert_or_spawn_batch(values);
+}

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -19,7 +19,7 @@ pub struct SkinIndex {
     pub index: u32,
 }
 impl SkinIndex {
-    /// Index to be in address space based on [`SkinnedMeshUniform`] size.
+    /// Index to be in address space based on [`SkinUniform`] size.
     const fn new(start: usize) -> Self {
         SkinIndex {
             index: (start * std::mem::size_of::<Mat4>()) as u32,

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -53,6 +53,7 @@ pub fn prepare_skins(
     uniform.buffer.write_buffer(&render_device, &render_queue);
 }
 
+// PERF: This can be expensive, can we move this to prepare?
 pub fn extract_skins(
     mut commands: Commands,
     mut previous_len: Local<usize>,
@@ -70,7 +71,6 @@ pub fn extract_skins(
         if !view_visibility.get() {
             continue;
         }
-        // PERF: This can be expensive, can we move this to prepare?
         let buffer = &mut uniform.buffer;
         let Some(inverse_bindposes) = inverse_bindposes.get(&skin.inverse_bindposes) else {
             continue;


### PR DESCRIPTION
# Objective

mesh.rs is infamously large. We could split off unrelated code.

## Solution

Morph targets are very similar to skinning and have their own module. We move skinned meshes to an independent module like morph targets and give the systems similar names.

### Open questions

Should the skinning systems and structs stay public?

---

## Migration Guide

Renamed skinning systems, resources and components:

- extract_skinned_meshes -> extract_skins
- prepare_skinned_meshes -> prepare_skins
- SkinnedMeshUniform -> SkinUniform
- SkinnedMeshJoints -> SkinIndex
