### PR TITLE
Add link to `Text2dBundle` in `TextBundle` docs.

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -159,6 +159,9 @@ pub struct AtlasImageBundle {
 
 #[cfg(feature = "bevy_text")]
 /// A UI node that is text
+///
+/// The positioning of this node is controlled by the UI layout system. If you need manual control,
+/// use [`Text2dBundle.`](`bevy_text::Text2dBundle`)
 #[derive(Bundle, Debug)]
 pub struct TextBundle {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -161,7 +161,7 @@ pub struct AtlasImageBundle {
 /// A UI node that is text
 ///
 /// The positioning of this node is controlled by the UI layout system. If you need manual control,
-/// use [`Text2dBundle.`](`bevy_text::Text2dBundle`)
+/// use [`Text2dBundle`](bevy_text::Text2dBundle).
 #[derive(Bundle, Debug)]
 pub struct TextBundle {
     /// Describes the logical size of the node


### PR DESCRIPTION
# Objective

Some beginners spend time trying to manually set the position of a `TextBundle`, without realizing that `Text2dBundle` exists.

## Solution

Mention `Text2dBundle` in the documentation of `TextBundle`.
