### PR TITLE
Add motion vectors support for animated meshes

### DIFF
--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -134,8 +134,6 @@ pub struct TemporalAntiAliasBundle {
 ///
 /// [Currently](https://github.com/bevyengine/bevy/issues/8423) cannot be used with [`bevy_render::camera::OrthographicProjection`].
 ///
-/// Currently does not support skinned meshes and morph targets.
-/// There will probably be ghosting artifacts if used with them.
 /// Does not work well with alpha-blended meshes as it requires depth writing to determine motion.
 ///
 /// It is very important that correct motion vectors are written for everything on screen.

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -369,7 +369,7 @@ type DrawMaterial<M> = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
     SetMaterialBindGroup<M, 1>,
-    SetMeshBindGroup<2>,
+    SetMeshBindGroup<2, false>,
     DrawMesh,
 );
 

--- a/crates/bevy_pbr/src/render/double_buffer.rs
+++ b/crates/bevy_pbr/src/render/double_buffer.rs
@@ -1,0 +1,62 @@
+use std::mem;
+
+use bevy_ecs::prelude::Entity;
+use bevy_render::render_resource::{BufferUsages, BufferVec};
+use bevy_utils::EntityHashMap;
+use bytemuck::Pod;
+
+/// A double buffer of `T`.
+///
+/// Use [`DoubleBuffer::swap`] to swap buffer,
+/// access the current buffer with [`DoubleBuffer::current`],
+/// and the previous one with [`DoubleBuffer::previous`].
+#[derive(Default)]
+pub struct DoubleBuffer<T> {
+    pub previous: T,
+    pub current: T,
+}
+
+impl<T> DoubleBuffer<T> {
+    pub fn swap(&mut self, swap_buffer: bool) {
+        if swap_buffer {
+            mem::swap(&mut self.current, &mut self.previous);
+        }
+    }
+}
+
+pub type DoubleBufferVec<T> = DoubleBuffer<BufferVec<T>>;
+
+impl<T: Pod> DoubleBufferVec<T> {
+    pub const fn new(buffer_usage: BufferUsages) -> Self {
+        DoubleBufferVec {
+            previous: BufferVec::new(buffer_usage),
+            current: BufferVec::new(buffer_usage),
+        }
+    }
+
+    pub fn clear(&mut self, swap_buffer: bool) {
+        self.swap(swap_buffer);
+        self.current.clear();
+    }
+}
+
+pub type DoubleEntityMap<T> = DoubleBuffer<EntityHashMap<Entity, T>>;
+
+impl<T> DoubleEntityMap<T> {
+    pub fn clear(&mut self, swap_buffer: bool) {
+        self.swap(swap_buffer);
+        self.current.clear();
+    }
+
+    pub fn insert(&mut self, entity: Entity, value: T) {
+        self.current.insert(entity, value);
+    }
+
+    pub fn missing_previous(&self, entity: &Entity) -> bool {
+        let current = self.current.contains_key(entity);
+        let previous = self.previous.contains_key(entity);
+        // Either it's already missing (therefore there is no "previous" to miss)
+        // or it's not missing and there is no "previous", so we miss previous.
+        current && !previous
+    }
+}

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -1,9 +1,17 @@
 //! Bind group layout related definitions for the mesh pipeline.
+use std::{array, fmt};
 
+use bevy_asset::AssetId;
+use bevy_ecs::prelude::Resource;
 use bevy_math::Mat4;
-use bevy_render::{mesh::morph::MAX_MORPH_WEIGHTS, render_resource::*, renderer::RenderDevice};
+use bevy_render::mesh::{morph::MAX_MORPH_WEIGHTS, Mesh};
+use bevy_render::{render_resource::*, renderer::RenderDevice};
+use bevy_utils::HashMap;
+use bitflags::bitflags;
+use smallvec::SmallVec;
 
 use crate::render::skin::MAX_JOINTS;
+use crate::MeshUniform;
 
 const MORPH_WEIGHT_SIZE: usize = std::mem::size_of::<f32>();
 pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
@@ -11,219 +19,328 @@ pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
 
-/// Individual layout entries.
-mod layout_entry {
-    use super::{JOINT_BUFFER_SIZE, MORPH_BUFFER_SIZE};
-    use crate::MeshUniform;
-    use bevy_render::{
-        render_resource::{
-            BindGroupLayoutEntry, BindingType, BufferBindingType, BufferSize, GpuArrayBuffer,
-            ShaderStages, TextureSampleType, TextureViewDimension,
-        },
-        renderer::RenderDevice,
-    };
+// --- Individual layout entries and individual bind group entries ---
 
-    fn buffer(binding: u32, size: u64, visibility: ShaderStages) -> BindGroupLayoutEntry {
-        BindGroupLayoutEntry {
-            binding,
-            visibility,
-            count: None,
-            ty: BindingType::Buffer {
-                ty: BufferBindingType::Uniform,
-                has_dynamic_offset: true,
-                min_binding_size: BufferSize::new(size),
-            },
-        }
-    }
-    pub(super) fn model(render_device: &RenderDevice, binding: u32) -> BindGroupLayoutEntry {
-        GpuArrayBuffer::<MeshUniform>::binding_layout(
-            binding,
-            ShaderStages::VERTEX_FRAGMENT,
-            render_device,
-        )
-    }
-    pub(super) fn skinning(binding: u32) -> BindGroupLayoutEntry {
-        buffer(binding, JOINT_BUFFER_SIZE as u64, ShaderStages::VERTEX)
-    }
-    pub(super) fn weights(binding: u32) -> BindGroupLayoutEntry {
-        buffer(binding, MORPH_BUFFER_SIZE as u64, ShaderStages::VERTEX)
-    }
-    pub(super) fn targets(binding: u32) -> BindGroupLayoutEntry {
-        BindGroupLayoutEntry {
-            binding,
-            visibility: ShaderStages::VERTEX,
-            ty: BindingType::Texture {
-                view_dimension: TextureViewDimension::D3,
-                sample_type: TextureSampleType::Float { filterable: false },
-                multisampled: false,
-            },
-            count: None,
-        }
+fn buffer_layout(binding: u32, size: u64, visibility: ShaderStages) -> BindGroupLayoutEntry {
+    BindGroupLayoutEntry {
+        binding,
+        visibility,
+        count: None,
+        ty: BindingType::Buffer {
+            ty: BufferBindingType::Uniform,
+            has_dynamic_offset: true,
+            min_binding_size: BufferSize::new(size),
+        },
     }
 }
-/// Individual [`BindGroupEntry`]
-/// for bind groups.
-mod entry {
-    use super::{JOINT_BUFFER_SIZE, MORPH_BUFFER_SIZE};
-    use bevy_render::render_resource::{
-        BindGroupEntry, BindingResource, Buffer, BufferBinding, BufferSize, TextureView,
-    };
+fn buffer_entry(binding: u32, size: u64, buffer: &Buffer) -> BindGroupEntry {
+    BindGroupEntry {
+        binding,
+        resource: BindingResource::Buffer(BufferBinding {
+            buffer,
+            offset: 0,
+            size: Some(BufferSize::new(size).unwrap()),
+        }),
+    }
+}
 
-    fn entry(binding: u32, size: u64, buffer: &Buffer) -> BindGroupEntry {
-        BindGroupEntry {
-            binding,
-            resource: BindingResource::Buffer(BufferBinding {
-                buffer,
-                offset: 0,
-                size: Some(BufferSize::new(size).unwrap()),
-            }),
+fn model_layout(render_device: &RenderDevice, binding: u32) -> BindGroupLayoutEntry {
+    GpuArrayBuffer::<MeshUniform>::binding_layout(
+        binding,
+        ShaderStages::VERTEX_FRAGMENT,
+        render_device,
+    )
+}
+fn model_entry(binding: u32, resource: BindingResource) -> BindGroupEntry {
+    BindGroupEntry { binding, resource }
+}
+
+fn skinning_layout(binding: u32) -> BindGroupLayoutEntry {
+    buffer_layout(binding, JOINT_BUFFER_SIZE as u64, ShaderStages::VERTEX)
+}
+fn skinning_entry(binding: u32, buffer: &Buffer) -> BindGroupEntry {
+    buffer_entry(binding, JOINT_BUFFER_SIZE as u64, buffer)
+}
+
+fn weights_layout(binding: u32) -> BindGroupLayoutEntry {
+    buffer_layout(binding, MORPH_BUFFER_SIZE as u64, ShaderStages::VERTEX)
+}
+fn weights_entry(binding: u32, buffer: &Buffer) -> BindGroupEntry {
+    buffer_entry(binding, MORPH_BUFFER_SIZE as u64, buffer)
+}
+
+fn targets_layout(binding: u32) -> BindGroupLayoutEntry {
+    BindGroupLayoutEntry {
+        binding,
+        visibility: ShaderStages::VERTEX,
+        ty: BindingType::Texture {
+            view_dimension: TextureViewDimension::D3,
+            sample_type: TextureSampleType::Float { filterable: false },
+            multisampled: false,
+        },
+        count: None,
+    }
+}
+fn targets_entry(binding: u32, texture: &TextureView) -> BindGroupEntry {
+    BindGroupEntry {
+        binding,
+        resource: BindingResource::TextureView(texture),
+    }
+}
+
+/// Create a layout for a specific [`ActiveVariant`] by combining the layouts of
+/// all the active shader features.
+fn variant_layout(active_variant: ActiveVariant, device: &RenderDevice) -> BindGroupLayout {
+    let skin = active_variant.contains(ActiveVariant::SKIN);
+    let morph = active_variant.contains(ActiveVariant::MORPH);
+    let motion_vectors = active_variant.contains(ActiveVariant::MOTION_VECTORS);
+
+    let mut layout_entries = SmallVec::<[BindGroupLayoutEntry; 6]>::new();
+
+    layout_entries.push(model_layout(device, 0));
+
+    if skin {
+        layout_entries.push(skinning_layout(1));
+    }
+    if morph {
+        layout_entries.extend([weights_layout(2), targets_layout(3)]);
+    }
+    if skin && motion_vectors {
+        layout_entries.push(skinning_layout(4));
+    }
+    if morph && motion_vectors {
+        layout_entries.push(weights_layout(5));
+    }
+
+    device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+        entries: &layout_entries,
+        label: Some(&*format!("{active_variant}_layout")),
+    })
+}
+
+/// Create [`BindGroup`]s and add them to a [`MeshBindGroups`].
+///
+/// Use [`MeshBindGroups::bind_group_builder`] to get a [`MeshBindGroupBuilder`],
+/// and use [`MeshBindGroupBuilder::add_variant`] to add new bind group variants.
+pub struct MeshBindGroupBuilder<'a> {
+    layouts: &'a MeshLayouts,
+    device: &'a RenderDevice,
+    model: BindingResource<'a>,
+    pub bind_groups: &'a mut MeshBindGroups,
+}
+impl<'a> MeshBindGroupBuilder<'a> {
+    /// Create a [`BindGroup`] with the provided active features, and add it to [`Self::bind_groups`].
+    ///
+    /// Each parameter to `add_variant` is a shader feature. When the parameter
+    /// is `None`, it means that the shader feature is disabled.
+    pub fn add_variant(
+        &mut self,
+        skin: Option<&Buffer>,
+        morph: Option<(AssetId<Mesh>, &Buffer, &TextureView)>,
+        previous_skin: Option<&Buffer>,
+        previous_weights: Option<&Buffer>,
+    ) {
+        let mut bind_group_entries = SmallVec::<[BindGroupEntry; 6]>::new();
+
+        bind_group_entries.push(model_entry(0, self.model.clone()));
+
+        if let Some(skin) = skin {
+            bind_group_entries.push(skinning_entry(1, skin));
+        }
+        if let Some((_, weights, targets)) = morph {
+            bind_group_entries.extend([weights_entry(2, weights), targets_entry(3, targets)]);
+        }
+        if let Some(skin) = previous_skin {
+            bind_group_entries.push(skinning_entry(4, skin));
+        }
+        if let Some(weights) = previous_weights {
+            bind_group_entries.push(weights_entry(5, weights));
+        }
+
+        let skin = skin.is_some();
+        let motion_vectors = previous_skin.is_some() || previous_weights.is_some();
+        let active_variant = ActiveVariant::new(skin, morph.is_some(), motion_vectors);
+
+        let bind_group = self.device.create_bind_group(
+            Some(&*format!("{active_variant}_bind_group")),
+            self.layouts.get_variant(active_variant),
+            &bind_group_entries,
+        );
+        self.bind_groups
+            .insert(skin, morph.map(|m| m.0), motion_vectors, bind_group);
+    }
+}
+
+/// The [`BindGroup`]s for individual existing mesh shader variants.
+///
+/// Morph targets allow several different bind groups, because individual mesh
+/// may have a different [`TextureView`] that represents the morph target's pose
+/// vertex attribute values.
+///
+/// Non-morph target bind groups are optional. We don't know at compile time
+/// whether motion vectors or skinned meshes will be used.
+#[derive(Default, Resource)]
+pub struct MeshBindGroups {
+    shared: HashMap<ActiveVariant, BindGroup>,
+    distinct: HashMap<(AssetId<Mesh>, ActiveVariant), BindGroup>,
+}
+
+impl MeshBindGroups {
+    pub fn new() -> Self {
+        MeshBindGroups::default()
+    }
+    /// Get a specific [`BindGroup`] that was previously added.
+    pub fn get(
+        &self,
+        skin: bool,
+        morph_id: Option<AssetId<Mesh>>,
+        motion_vectors: bool,
+    ) -> Option<&BindGroup> {
+        let variant = ActiveVariant::new(skin, morph_id.is_some(), motion_vectors);
+        if let Some(id) = morph_id {
+            self.distinct.get(&(id, variant))
+        } else {
+            self.shared.get(&variant)
         }
     }
-    pub(super) fn model(binding: u32, resource: BindingResource) -> BindGroupEntry {
-        BindGroupEntry { binding, resource }
+    fn insert(
+        &mut self,
+        skin: bool,
+        morph_id: Option<AssetId<Mesh>>,
+        motion_vectors: bool,
+        bind_group: BindGroup,
+    ) {
+        let variant = ActiveVariant::new(skin, morph_id.is_some(), motion_vectors);
+
+        if let Some(id) = morph_id {
+            self.distinct.insert((id, variant), bind_group);
+        } else {
+            self.shared.insert(variant, bind_group);
+        }
     }
-    pub(super) fn skinning(binding: u32, buffer: &Buffer) -> BindGroupEntry {
-        entry(binding, JOINT_BUFFER_SIZE as u64, buffer)
+    pub fn clear(&mut self) {
+        self.shared.clear();
+        self.distinct.clear();
     }
-    pub(super) fn weights(binding: u32, buffer: &Buffer) -> BindGroupEntry {
-        entry(binding, MORPH_BUFFER_SIZE as u64, buffer)
-    }
-    pub(super) fn targets(binding: u32, texture: &TextureView) -> BindGroupEntry {
-        BindGroupEntry {
-            binding,
-            resource: BindingResource::TextureView(texture),
+    /// Clears `self` and returns a [`MeshBindGroupBuilder`].
+    pub fn bind_group_builder<'a>(
+        &'a mut self,
+        device: &'a RenderDevice,
+        model: BindingResource<'a>,
+        layouts: &'a MeshLayouts,
+    ) -> MeshBindGroupBuilder<'a> {
+        self.clear();
+
+        MeshBindGroupBuilder {
+            layouts,
+            device,
+            model,
+            bind_groups: self,
         }
     }
 }
 
 /// All possible [`BindGroupLayout`]s in bevy's default mesh shader (`mesh.wgsl`).
 #[derive(Clone)]
-pub struct MeshLayouts {
-    /// The mesh model uniform (transform) and nothing else.
-    pub model_only: BindGroupLayout,
-
-    /// Also includes the uniform for skinning
-    pub skinned: BindGroupLayout,
-
-    /// Also includes the uniform and [`MorphAttributes`] for morph targets.
-    ///
-    /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
-    pub morphed: BindGroupLayout,
-
-    /// Also includes both uniforms for skinning and morph targets, also the
-    /// morph target [`MorphAttributes`] binding.
-    ///
-    /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
-    pub morphed_skinned: BindGroupLayout,
-}
+pub struct MeshLayouts([BindGroupLayout; ActiveVariant::COUNT]);
 
 impl MeshLayouts {
     /// Prepare the layouts used by the default bevy [`Mesh`].
     ///
     /// [`Mesh`]: bevy_render::prelude::Mesh
-    pub fn new(render_device: &RenderDevice) -> Self {
-        MeshLayouts {
-            model_only: Self::model_only_layout(render_device),
-            skinned: Self::skinned_layout(render_device),
-            morphed: Self::morphed_layout(render_device),
-            morphed_skinned: Self::morphed_skinned_layout(render_device),
+    pub fn new(device: &RenderDevice) -> Self {
+        let layout = |bits| variant_layout(ActiveVariant::from_bits_truncate(bits), device);
+        MeshLayouts(array::from_fn(layout))
+    }
+    // TODO: Passing 3 bools is pretty bad
+    pub fn get(&self, skin: bool, morph: bool, motion_vectors: bool) -> &BindGroupLayout {
+        let variant = ActiveVariant::new(skin, morph, motion_vectors);
+        self.get_variant(variant)
+    }
+    fn get_variant(&self, active_variant: ActiveVariant) -> &BindGroupLayout {
+        &self.0[active_variant.bits()]
+    }
+}
+
+bitflags! {
+    /// The set of active features for a given mesh shader instance.
+    ///
+    /// Individual meshes may have different features. For example,
+    /// one mesh may have morph targets, another skinning.
+    ///
+    /// Each of those features enable different shader code and bind groups through
+    /// the naga C-like pre-processor (`#ifdef FOO`).
+    ///
+    /// As a result, different meshes may use different variants of the shader and need
+    /// different bind group layouts.
+    #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    struct ActiveVariant: usize {
+        /// Whether this mesh uses skeletal skinning.
+        ///
+        /// It is true whenever the mesh being rendered has both `Mesh::ATTRIBUTE_JOINT_INDEX`
+        /// and `Mesh::ATTRIBUTE_JOINT_WEIGHT` vertex attributes.
+        const SKIN = 1 << 0;
+
+        /// Whether this mesh uses morph targets.
+        ///
+        /// This is determined by the `MeshPipelineKey::MORPH_TARGETS` pipeline key
+        /// flag.
+        ///
+        /// This pipeline key flag is set whenever the mesh being rendered has the
+        /// `morph_targets` field set to `Some`.
+        const MORPH = 1 << 1;
+
+        /// Whether this mesh is being rendered with motion vectors.
+        ///
+        /// This is determined by the `MeshPipelineKey::MOTION_VECTOR_PREPASS` pipeline key
+        /// flag.
+        ///
+        /// This pipeline key flag is set whenever the view rendering the mesh has the
+        /// `MotionVectorPrepass` component, **and** the mesh, if it has morph targets
+        /// or skinning, was rendered last frame.
+        ///
+        /// Note that the same mesh can be rendered by different views, some of them
+        /// with or without motion vectors.
+        const MOTION_VECTORS =  1 << 2;
+
+        // NOTE: ADDING A NEW VARIANT
+        // You'll have to add handling for the new variants in the various places
+        // in this file:
+        // - fmt::Display for ActiveVariant
+        // - ActiveVariant::new
+        // - MeshBindGroupBuilder::add_variant
+        // - variant_layout
+        // - setup_morph_and_skinning_defs in render/mesh.rs
+        // - RenderCommand<P> for SetMeshBindGroup in render/mesh.rs
+    }
+}
+impl ActiveVariant {
+    const COUNT: usize = Self::all().bits() + 1;
+
+    fn new(skin: bool, morph: bool, mut motion_vectors: bool) -> Self {
+        let if_enabled = |flag, value| if flag { value } else { Self::empty() };
+
+        // Meshes with and without motion vectors, but also without skins/morphs
+        // share the same bind group.
+        if !skin && !morph {
+            motion_vectors = false;
         }
+        if_enabled(skin, Self::SKIN)
+            | if_enabled(morph, Self::MORPH)
+            | if_enabled(motion_vectors, Self::MOTION_VECTORS)
     }
-
-    // ---------- create individual BindGroupLayouts ----------
-
-    fn model_only_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[layout_entry::model(render_device, 0)],
-            label: Some("mesh_layout"),
-        })
-    }
-    fn skinned_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::skinning(1),
-            ],
-            label: Some("skinned_mesh_layout"),
-        })
-    }
-    fn morphed_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::weights(2),
-                layout_entry::targets(3),
-            ],
-            label: Some("morphed_mesh_layout"),
-        })
-    }
-    fn morphed_skinned_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::skinning(1),
-                layout_entry::weights(2),
-                layout_entry::targets(3),
-            ],
-            label: Some("morphed_skinned_mesh_layout"),
-        })
-    }
-
-    // ---------- BindGroup methods ----------
-
-    pub fn model_only(&self, render_device: &RenderDevice, model: &BindingResource) -> BindGroup {
-        render_device.create_bind_group(
-            "model_only_mesh_bind_group",
-            &self.model_only,
-            &[entry::model(0, model.clone())],
-        )
-    }
-    pub fn skinned(
-        &self,
-        render_device: &RenderDevice,
-        model: &BindingResource,
-        skin: &Buffer,
-    ) -> BindGroup {
-        render_device.create_bind_group(
-            "skinned_mesh_bind_group",
-            &self.skinned,
-            &[entry::model(0, model.clone()), entry::skinning(1, skin)],
-        )
-    }
-    pub fn morphed(
-        &self,
-        render_device: &RenderDevice,
-        model: &BindingResource,
-        weights: &Buffer,
-        targets: &TextureView,
-    ) -> BindGroup {
-        render_device.create_bind_group(
-            "morphed_mesh_bind_group",
-            &self.morphed,
-            &[
-                entry::model(0, model.clone()),
-                entry::weights(2, weights),
-                entry::targets(3, targets),
-            ],
-        )
-    }
-    pub fn morphed_skinned(
-        &self,
-        render_device: &RenderDevice,
-        model: &BindingResource,
-        skin: &Buffer,
-        weights: &Buffer,
-        targets: &TextureView,
-    ) -> BindGroup {
-        render_device.create_bind_group(
-            "morphed_skinned_mesh_bind_group",
-            &self.morphed_skinned,
-            &[
-                entry::model(0, model.clone()),
-                entry::skinning(1, skin),
-                entry::weights(2, weights),
-                entry::targets(3, targets),
-            ],
-        )
+}
+impl fmt::Display for ActiveVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.contains(Self::SKIN) {
+            f.write_str("skinned_")?;
+        }
+        if self.contains(Self::MORPH) {
+            f.write_str("morphed_")?;
+        }
+        if self.contains(Self::MOTION_VECTORS) {
+            f.write_str("motion_vectors_")?;
+        }
+        f.write_str("mesh")
     }
 }

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -173,12 +173,17 @@ impl<'a> MeshBindGroupBuilder<'a> {
 
 /// The [`BindGroup`]s for individual existing mesh shader variants.
 ///
-/// Morph targets allow several different bind groups, because individual mesh
-/// may have a different [`TextureView`] that represents the morph target's pose
-/// vertex attribute values.
+/// To add bind groups to it, you would first create a `MeshBindGroupBuilder`
+/// using `MeshBindGroups::bind_group_builder`. Then, call `add_variant` for
+/// each `BindGroup` that will be needed for rendering.
 ///
-/// Non-morph target bind groups are optional. We don't know at compile time
-/// whether motion vectors or skinned meshes will be used.
+/// `MeshBindGroups` has two `HashMap`, one `shared` that contains bind groups that
+/// can be shared between different entities with the same set of `ActiveVariant`.
+///
+/// The other `HashMap` is `distinct`, which contain bind groups that are unique per-mesh.
+/// This is currently only relevant for meshes with morph targets. (Morph targets have
+/// a texture binding, therefore need to bind to a different individual texture for each
+/// individual mesh).
 #[derive(Default, Resource)]
 pub struct MeshBindGroups {
     shared: HashMap<ActiveVariant, BindGroup>,

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -1,3 +1,4 @@
+mod double_buffer;
 mod fog;
 mod light;
 pub(crate) mod mesh;
@@ -11,4 +12,5 @@ pub use light::*;
 pub use mesh::*;
 pub use mesh_bindings::MeshLayouts;
 pub use mesh_view_bindings::*;
-pub use skin::{extract_skins, prepare_skins, SkinIndex, SkinUniform, MAX_JOINTS};
+pub use morph::{MorphIndex, MorphIndices};
+pub use skin::{extract_skins, prepare_skins, SkinIndex, SkinIndices, SkinUniform, MAX_JOINTS};

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -9,11 +9,17 @@
 @group(1) @binding(2) var<uniform> morph_weights: MorphWeights;
 @group(1) @binding(3) var morph_targets: texture_3d<f32>;
 
+#ifdef MOTION_VECTOR_PREPASS
+@group(1) @binding(5) var<uniform> previous_morph_weights: MorphWeights;
+#endif
 #else
 
 @group(2) @binding(2) var<uniform> morph_weights: MorphWeights;
 @group(2) @binding(3) var morph_targets: texture_3d<f32>;
 
+#ifdef MOTION_VECTOR_PREPASS
+@group(2) @binding(5) var<uniform> previous_morph_weights: MorphWeights;
+#endif
 #endif
 
 
@@ -53,5 +59,12 @@ fn morph(vertex_index: u32, component_offset: u32, weight_index: u32) -> vec3<f3
         morph_pixel(vertex_index, component_offset + 2u, weight_index),
     );
 }
+
+#ifdef MOTION_VECTOR_PREPASS
+fn previous_weight_at(weight_index: u32) -> f32 {
+    let i = weight_index;
+    return previous_morph_weights.weights[i / 4u][i % 4u];
+}
+#endif
 
 #endif // MORPH_TARGETS

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -6,8 +6,14 @@
 
 #ifdef MESH_BINDGROUP_1
     @group(1) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
+    #ifdef MOTION_VECTOR_PREPASS
+    @group(1) @binding(4) var<uniform> previous_joint_matrices: SkinnedMesh;
+    #endif // MOTION_VECTOR_PREPASS
 #else 
     @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
+    #ifdef MOTION_VECTOR_PREPASS
+    @group(2) @binding(4) var<uniform> previous_joint_matrices: SkinnedMesh;
+    #endif // MOTION_VECTOR_PREPASS
 #endif
 
 
@@ -48,4 +54,15 @@ fn skin_normals(
     );
 }
 
+#ifdef MOTION_VECTOR_PREPASS
+fn previous_skin_model(
+    indexes: vec4<u32>,
+    weights: vec4<f32>,
+) -> mat4x4<f32> {
+    return weights.x * previous_joint_matrices.data[indexes.x]
+        + weights.y * previous_joint_matrices.data[indexes.y]
+        + weights.z * previous_joint_matrices.data[indexes.z]
+        + weights.w * previous_joint_matrices.data[indexes.w];
+}
+#endif // MOTION_VECTOR_PREPASS
 #endif

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -237,7 +237,7 @@ impl SpecializedMeshPipeline for CustomPipeline {
 type DrawCustom = (
     SetItemPipeline,
     SetMeshViewBindGroup<0>,
-    SetMeshBindGroup<1>,
+    SetMeshBindGroup<1, false>,
     DrawMeshInstanced,
 );
 


### PR DESCRIPTION
# Objective

- Add motion vector support for meshes animated with morph targets or skinned meshes
- Addresses points (1) and (2) of #8423

https://github.com/bevyengine/bevy/assets/26321040/5fb794b6-7095-41d4-91ed-c20e24fd15b9

## Solution

- Add `DoubleBufferVec`, a thin wrapper around two `BufferVec`
- Replace the `BufferVec` used in `SkinUniform` and `MorphUniform` by the double buffer.
- When `buffer.clear()` instead of clearing the current buffer, swap the buffers and then clear the 2-frames-behind buffer
- Also double buffer the skinning and morphing index maps, use the last frame's index to index into the previous buffer.
- If this is the first frame a mesh with skin or morph is rendered, do not render it with motion vectors.
  - This requires splitting the concept of "view that supports motion vectors" and "mesh that support motion vectors".
  - Now, `MeshPipelineKey::MOTION_VECTOR_PREPASS` indicates that the mesh supports motion vectors
  - For "view" motion vectors, we add an additional key: `MeshPipelineKey::VIEW_MOTION_VECTOR_PREPASS`. It is technically meaningless outside of the prepass pipeline, but it avoids widening the key, and therefore slow down processing.

The other changes are the shader code for handling the previous values (which is _mostly_ copy/pasting, sadly); And some attempt at copping with the combinatorial explosion of shader variants in `mesh_bindings.rs`. (we have the following variables: with/out morph targets, with/out skinning with/out motion vectors)

## Note to reviewers

### `mesh_bindings.rs`

Following is a description of the `mesh_bindings.rs` file.

#### Entry definition

We first define each individual bind group (layout) entries as functions that accept a binding index and an additional parameter for the binding resource when relevant, and return the layout/bind group entry.

Those are the `FOOBAR_layout` and `FOOBAR_entry` functions.

#### Combination functions

Then we have `variant_layout` and `MeshBindGroupBuilder::add_variant`.

Those take a `ActiveVariant`[^1] (or build one), create an empty buffer (`SmallVec`) and progressively add the entries based on what flag is active in the `ActiveVariant`. Then we create the `BindGroupLayout` or `BindGroup` (respectively) with all the gathered entries.

#### `MeshBindGroups`

`MeshBindGroups` is a collection of `BindGroup`s.

To add bind groups to it, you would first create a `MeshBindGroupBuilder` using `MeshBindGroups::bind_group_builder`. Then, call `add_variant` for each `BindGroup` that will be needed for rendering.

`MeshBindGroups` has two `HashMap`, one `shared` that contains bind groups that can be shared between different entities with the same set of shader features (`ActiveVariant` elements).

The other `HashMap` is `distinct`, which contain bind groups that are unique per-mesh. This is currently only relevant for meshes with morph targets. (Morph targets have a texture binding, therefore need to bind to a different individual texture for each individual mesh).

The idea of two hashmaps, one for shared and another for distinct bind groups is taken from #10235.

In bevy, `prepare_mesh_bind_group` is where variants are added to `MeshBindGroups`.

#### `MeshLayouts`

`MeshLayouts` is to layout what `MeshBindGroups` is to bind groups. Here, however, since there is exactly one layout per **set of shader feature**, we can pre-compute every possible layouts. This is what occurs in `MeshLayouts::new`, which is called in the `FromWorld` impl of `MeshPipeline`. Then, we can just get an existing layout by using `MeshLayouts::get`, in `setup_morph_and_skinning_defs`; And `MeshLayouts::get_variant` in `add_variant` (to get the corresponding layout for the bind group).

This approach is a shameless clone of the #10156 approach. Unlike with `MeshBindGroups`, we don't even need to enumerate every features. By using `array::from_fn::<ActiveVariant::COUNT>`, we automatically get an enumeration of all possible (and more) shader feature **combinations**.

#### `ActiveVariant`

A downside of the `bitflags` crate is that it conflates carelessly **a set of** FOO and FOO, it makes it harder to talk about the bitflag struct.

An `ActiveVariant` is a **set** of *shader features*, a feature may be (1) skinning, (2) morph targets, (3) motion vectors, (N) more in the future.

Since a shader is composed of 0-to-N features, a single `ActiveVariant` represents a single instance of a shader.

###  `MeshPipelineKey::VIEW_MOTION_VECTOR_PREPASS`

There are two problems with a double buffer approach:

1. The first frame, only the `current` buffer is filled, there is no such thing as the `previous` buffer page
2. The buffer is shared across all meshes, this means that adding/removing a mesh makes indexing the `previous` buffer with the current frame's indices is bogus.

To solve (1) we need to disable motion vectors, not for the whole view, but for individual meshes. Meshes which skinning or morphing shader are enabled, but didn't exist last frame (their `previous` buffer page is empty) can't have a `previous` buffer, therefore shouldn't have the binding for the previous buffer set.

This is where we introduce `MeshPipelineKey::VIEW_MOTION_VECTOR_PREPASS`. It is a distinct value than `MeshPipelineKey::MOTION_VECTOR_PREPASS`. The view still has access to the motion vector buffer, but the mesh/instance doesn't have a `previous` buffer to compute the motion vector with. So we need to have two different key flags to handle this.

To solve (2), we make the double buffer generic over the buffer, and we allow to use it for `EntityHashMap`, now we can keep around the indices for the previous frame as well as the buffer.

Note that we add special logic so that when motion vectors aren't used, we don't double buffer anything, so that no one pays the cost (memory cost, as it has no runtime cost) of the double-buffer when not needing it.

### Tricky bits

The code changes outside of `mesh_bindings.rs` sure seem small (even `double_buffer.rs` is 62 lines). But it was actually extremely complex to get right. Bind groups that depend on runtime values such as "does the double buffer have a 'previous' page?" Are really tricky to get right. `MeshPipelineKey` is more or less a "cache" for the world state, but this cache is set in several places. I often got the infamous wgpu error, and had no way to tell where my errors where. I had to patiently add printlns a bit everywhere, glare at the logs and try to think what explained them, compound that with how many rendering functionalities I had to rebase through, it was very difficult.

Merging this PR will probably move the burden of handling this to more people, and we should prioritize making that kind of bugs impossible in the future.

[^1]: `ActiveVariant` is a "set of shader features", see relevant section

#### Testing

I used this modified version of `shader_prepass.rs` to test the change set: <https://gist.github.com/nicopap/bf97174f1496df4854909d672eb2cc0f>. Note that it is still missing a morph target + skinned mesh (I tested a morph+skin model locally and seemed to work).

I tried to compare how this affects ghosting with TAA, but I failed to reproduce ghosting artifacts on main. The motion vectors do look correct though.

### Future work

- #8423 mentions using a double buffer for the mesh uniform, it seems possible to re-use the one we define here.

---

## Migration guide

- `SetMeshBindGroup` now requires an additional boolean const parameter, set it to `false` to keep the old behavior, `true` if you want it to handle motion vectors.
- `MeshBindGroups`'s `reset` method is now `clear`.
- `MeshLayouts` has been revamped. To get bind groups from the layouts, use `MeshBindGroups::bind_group_builder`, or access manually the layouts.


## Changelog

- Add motion vectors support for animated meshes. Meaning: TAA now works with animations!
