### PR TITLE
Add non-default `devcontainer.json` specification

### DIFF
--- a/.devcontainer/codespaces/devcontainer.json
+++ b/.devcontainer/codespaces/devcontainer.json
@@ -1,0 +1,35 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Codespaces (8-core recommended)",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1",
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+		"ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+			"packages": "libasound2-dev,libudev-dev"
+		}
+	}
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}


### PR DESCRIPTION
# Objective

- I develop Bevy exclusively in GitHub Codespaces, never using a local machine for anything
- It would be nice to get a properly configured VM automatically that can compile all of Bevy
- However, adding a devault `devcontainer.json` will cause VS Code to automatically use it for local development as well, which complicates the experience for those developers as Bevy is usually compiled natively and requires access to GPU etc.
- Objective is to add a configuration that makes GitHub Codespaces development easier without making the experience for local development worse

## Solution

Add a `devcontainer.json` configuration file in a subdirectory of the `.devcontainer` directory.

According to GitHub documentation, this should not modify the default configuration: https://docs.github.com/en/codespaces/setting-up-your-project-for-codespaces/adding-a-dev-container-configuration/introduction-to-dev-containers#default-configuration-selection-during-codespace-creation

However, this definitely needs testing from some local VS Code developers to ensure that there are no extra prompts just by adding this file.