### PR TITLE
Use single threaded executor in benchmarks and tests

### DIFF
--- a/benches/benches/bevy_ecs/components/archetype_updates.rs
+++ b/benches/benches/bevy_ecs/components/archetype_updates.rs
@@ -1,9 +1,4 @@
-use bevy_ecs::{
-    component::Component,
-    prelude::EntityWorldMut,
-    schedule::{ExecutorKind, Schedule},
-    world::World,
-};
+use bevy_ecs::{component::Component, prelude::EntityWorldMut, schedule::Schedule, world::World};
 use criterion::{BenchmarkId, Criterion};
 
 #[derive(Component)]

--- a/benches/benches/bevy_ecs/components/archetype_updates.rs
+++ b/benches/benches/bevy_ecs/components/archetype_updates.rs
@@ -12,8 +12,7 @@ struct A<const N: u16>(f32);
 fn setup(system_count: usize) -> (World, Schedule) {
     let mut world = World::new();
     fn empty() {}
-    let mut schedule = Schedule::default();
-    schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+    let mut schedule = Schedule::single_threaded();
     for _ in 0..system_count {
         schedule.add_systems(empty);
     }

--- a/benches/benches/bevy_ecs/empty_archetypes.rs
+++ b/benches/benches/bevy_ecs/empty_archetypes.rs
@@ -77,7 +77,7 @@ fn par_for_each(
 
 fn setup(parallel: bool, setup: impl FnOnce(&mut Schedule)) -> (World, Schedule) {
     let mut world = World::new();
-    let mut schedule = Schedule::default();
+    let mut schedule = Schedule::single_threaded();
     if parallel {
         world.insert_resource(ComputeTaskPool(TaskPool::default()));
     }

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -18,7 +18,7 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(yes));
@@ -41,7 +41,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(no));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(no));
@@ -71,7 +71,7 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         query.single().0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes_with_query));
         for _ in 0..amount {
             schedule.add_systems(
@@ -100,7 +100,7 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         res.0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         schedule.add_systems(empty.run_if(yes_with_resource));
         for _ in 0..amount {
             schedule.add_systems(

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -18,7 +18,7 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(empty.run_if(yes));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(yes));
@@ -41,7 +41,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(empty.run_if(no));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(no));
@@ -71,7 +71,7 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         query.single().0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(empty.run_if(yes_with_query));
         for _ in 0..amount {
             schedule.add_systems(
@@ -100,7 +100,7 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         res.0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(empty.run_if(yes_with_resource));
         for _ in 0..amount {
             schedule.add_systems(

--- a/benches/benches/bevy_ecs/scheduling/run_condition.rs
+++ b/benches/benches/bevy_ecs/scheduling/run_condition.rs
@@ -18,7 +18,7 @@ pub fn run_condition_yes(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         schedule.add_systems(empty.run_if(yes));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(yes));
@@ -41,7 +41,7 @@ pub fn run_condition_no(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         schedule.add_systems(empty.run_if(no));
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty).distributive_run_if(no));
@@ -71,7 +71,7 @@ pub fn run_condition_yes_with_query(criterion: &mut Criterion) {
         query.single().0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         schedule.add_systems(empty.run_if(yes_with_query));
         for _ in 0..amount {
             schedule.add_systems(
@@ -100,7 +100,7 @@ pub fn run_condition_yes_with_resource(criterion: &mut Criterion) {
         res.0
     }
     for amount in 0..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         schedule.add_systems(empty.run_if(yes_with_resource));
         for _ in 0..amount {
             schedule.add_systems(

--- a/benches/benches/bevy_ecs/scheduling/running_systems.rs
+++ b/benches/benches/bevy_ecs/scheduling/running_systems.rs
@@ -21,7 +21,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..5 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         for _ in 0..amount {
             schedule.add_systems(empty);
         }
@@ -33,7 +33,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
         });
     }
     for amount in 1..21 {
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty));
         }
@@ -73,7 +73,7 @@ pub fn busy_systems(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), D(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
             schedule.add_systems((ab, cd, ce));
             for _ in 0..system_amount {
                 schedule.add_systems((ab, cd, ce));
@@ -124,7 +124,7 @@ pub fn contrived(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (C(0.0), D(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
             schedule.add_systems((s_0, s_1, s_2));
             for _ in 0..system_amount {
                 schedule.add_systems((s_0, s_1, s_2));

--- a/benches/benches/bevy_ecs/scheduling/running_systems.rs
+++ b/benches/benches/bevy_ecs/scheduling/running_systems.rs
@@ -21,7 +21,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..5 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         for _ in 0..amount {
             schedule.add_systems(empty);
         }
@@ -33,7 +33,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
         });
     }
     for amount in 1..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty));
         }
@@ -73,7 +73,7 @@ pub fn busy_systems(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), D(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::multi_threaded();
             schedule.add_systems((ab, cd, ce));
             for _ in 0..system_amount {
                 schedule.add_systems((ab, cd, ce));
@@ -124,7 +124,7 @@ pub fn contrived(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (C(0.0), D(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::multi_threaded();
             schedule.add_systems((s_0, s_1, s_2));
             for _ in 0..system_amount {
                 schedule.add_systems((s_0, s_1, s_2));

--- a/benches/benches/bevy_ecs/scheduling/running_systems.rs
+++ b/benches/benches/bevy_ecs/scheduling/running_systems.rs
@@ -21,7 +21,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(3));
     fn empty() {}
     for amount in 0..5 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         for _ in 0..amount {
             schedule.add_systems(empty);
         }
@@ -33,7 +33,7 @@ pub fn empty_systems(criterion: &mut Criterion) {
         });
     }
     for amount in 1..21 {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         for _ in 0..amount {
             schedule.add_systems((empty, empty, empty, empty, empty));
         }
@@ -73,7 +73,7 @@ pub fn busy_systems(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), D(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((ab, cd, ce));
             for _ in 0..system_amount {
                 schedule.add_systems((ab, cd, ce));
@@ -124,7 +124,7 @@ pub fn contrived(criterion: &mut Criterion) {
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (A(0.0), B(0.0))));
         world.spawn_batch((0..ENTITY_BUNCH).map(|_| (C(0.0), D(0.0))));
         for system_amount in 0..5 {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((s_0, s_1, s_2));
             for _ in 0..system_amount {
                 schedule.add_systems((s_0, s_1, s_2));

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -46,7 +46,7 @@ pub fn schedule(c: &mut Criterion) {
 
         world.spawn_batch((0..10000).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
 
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default();
         schedule.add_systems((ab, cd, ce));
         schedule.run(&mut world);
 

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -46,7 +46,7 @@ pub fn schedule(c: &mut Criterion) {
 
         world.spawn_batch((0..10000).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::multi_threaded();
         schedule.add_systems((ab, cd, ce));
         schedule.run(&mut world);
 

--- a/benches/benches/bevy_ecs/scheduling/schedule.rs
+++ b/benches/benches/bevy_ecs/scheduling/schedule.rs
@@ -46,7 +46,7 @@ pub fn schedule(c: &mut Criterion) {
 
         world.spawn_batch((0..10000).map(|_| (A(0.0), B(0.0), C(0.0), E(0.0))));
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((ab, cd, ce));
         schedule.run(&mut world);
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -150,7 +150,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// # score_changed.initialize(&mut world);
     /// # score_changed.run((), &mut world);
     /// #
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::single_threaded();
     /// # schedule.add_systems(reset_score);
     /// #
     /// # // first time `reset_score` runs, the score is changed.
@@ -218,7 +218,7 @@ pub trait DetectChangesMut: DetectChanges {
     /// # score_changed_event.initialize(&mut world);
     /// # score_changed_event.run((), &mut world);
     /// #
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::single_threaded();
     /// # schedule.add_systems(reset_score);
     /// #
     /// # // first time `reset_score` runs, the score is changed.

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1052,7 +1052,7 @@ mod tests {
         world.send_event(TestEvent { i: 3 });
         world.send_event(TestEvent { i: 4 });
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(|mut events: EventReader<TestEvent>| {
             let mut iter = events.read();
 

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -791,7 +791,7 @@ mod tests {
             }
         }
 
-        let mut schedule = Schedule::single_threaded();
+        let mut schedule = Schedule::default(); // Uses MultiThreaded executor
         schedule.add_systems((propagate_system, modify_system).chain());
         schedule.run(&mut world);
         world.clear_trackers();

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -791,7 +791,7 @@ mod tests {
             }
         }
 
-        let mut schedule = Schedule::default(); // Uses MultiThreaded executor
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((propagate_system, modify_system).chain());
         schedule.run(&mut world);
         world.clear_trackers();

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -791,7 +791,7 @@ mod tests {
             }
         }
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((propagate_system, modify_system).chain());
         schedule.run(&mut world);
         world.clear_trackers();

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -1084,7 +1084,7 @@ mod tests {
     fn run_condition() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         // Run every other cycle
         schedule.add_systems(increment_counter.run_if(every_other_time));
@@ -1111,7 +1111,7 @@ mod tests {
     fn run_condition_combinators() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         // Always run
         schedule.add_systems(increment_counter.run_if(every_other_time.or_else(|| true)));
@@ -1128,7 +1128,7 @@ mod tests {
     fn multiple_run_conditions() {
         let mut world = World::new();
         world.init_resource::<Counter>();
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         // Run every other cycle
         schedule.add_systems(increment_counter.run_if(every_other_time).run_if(|| true));
@@ -1146,7 +1146,7 @@ mod tests {
         let mut world = World::new();
         world.init_resource::<Counter>();
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         // This should never run, if multiple run conditions worked
         // like an OR condition then it would always run
@@ -1180,7 +1180,7 @@ mod tests {
     // Ensure distributive_run_if compiles with the common conditions.
     #[test]
     fn distributive_run_if_compiles() {
-        Schedule::default().add_systems(
+        Schedule::single_threaded().add_systems(
             (test_system, test_system)
                 .distributive_run_if(run_once())
                 .distributive_run_if(resource_exists::<State<TestState>>())

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -26,7 +26,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 ///
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
-/// # let mut schedule = Schedule::default();
+/// # let mut schedule = Schedule::single_threaded();
 /// schedule.add_systems(my_system.run_if(every_other_time()));
 /// # let mut world = World::new();
 /// # world.insert_resource(DidRun(false));
@@ -46,7 +46,7 @@ pub type BoxedCondition<In = ()> = Box<dyn ReadOnlySystem<In = In, Out = bool>>;
 /// }
 ///
 /// # fn always_true() -> bool { true }
-/// # let mut app = Schedule::default();
+/// # let mut app = Schedule::single_threaded();
 /// # #[derive(Resource)] struct DidRun(bool);
 /// # fn my_system(mut did_run: ResMut<DidRun>) { did_run.0 = true; }
 /// app.add_systems(my_system.run_if(always_true.pipe(identity())));
@@ -69,7 +69,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// #[derive(Resource, PartialEq)]
     /// struct R(u32);
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # fn my_system() {}
     /// app.add_systems(
@@ -86,7 +86,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, PartialEq)]
     /// # struct R(u32);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # fn my_system() {}
     /// app.add_systems(
@@ -123,7 +123,7 @@ pub trait Condition<Marker, In = ()>: sealed::Condition<Marker, In> {
     /// #[derive(Resource, PartialEq)]
     /// struct B(u32);
     ///
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # #[derive(Resource)] struct C(bool);
     /// # fn my_system(mut c: ResMut<C>) { c.0 = true; }
@@ -197,7 +197,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -238,7 +238,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists` will only return true if the given resource exists in the world
@@ -277,7 +277,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -315,7 +315,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default, PartialEq)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_equals` will only return true
@@ -358,7 +358,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_added` will only return true if the
@@ -408,7 +408,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -462,7 +462,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// app.add_systems(
     ///     // `resource_exists_and_changed` will only return true if the
@@ -523,7 +523,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -593,7 +593,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -648,7 +648,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -695,7 +695,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -747,7 +747,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -813,7 +813,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// #[derive(States, Clone, Copy, Default, Eq, PartialEq, Hash, Debug)]
@@ -863,7 +863,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// # world.init_resource::<Events<MyEvent>>();
@@ -907,7 +907,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(
@@ -954,7 +954,7 @@ pub mod common_conditions {
     /// # use bevy_ecs::prelude::*;
     /// # #[derive(Resource, Default)]
     /// # struct Counter(u8);
-    /// # let mut app = Schedule::default();
+    /// # let mut app = Schedule::single_threaded();
     /// # let mut world = World::new();
     /// # world.init_resource::<Counter>();
     /// app.add_systems(

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -243,7 +243,7 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::single_threaded();
     /// # fn a() {}
     /// # fn b() {}
     /// # fn condition() -> bool { true }
@@ -276,7 +276,7 @@ where
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::single_threaded();
     /// # fn a() {}
     /// # fn b() {}
     /// # fn condition() -> bool { true }

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -73,7 +73,7 @@ mod tests {
         #[test]
         fn run_system() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -86,7 +86,7 @@ mod tests {
         #[test]
         fn run_exclusive_system() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -103,7 +103,7 @@ mod tests {
             use std::sync::{Arc, Barrier};
 
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             let thread_count = ComputeTaskPool::init(TaskPool::default).thread_num();
 
             let barrier = Arc::new(Barrier::new(thread_count));
@@ -125,7 +125,7 @@ mod tests {
         #[test]
         fn order_systems() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -163,7 +163,7 @@ mod tests {
         #[test]
         fn order_exclusive_systems() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -180,7 +180,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -201,7 +201,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order_nested() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<SystemOrder>();
 
@@ -251,7 +251,7 @@ mod tests {
         #[test]
         fn system_with_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<RunConditionBool>();
             world.init_resource::<SystemOrder>();
@@ -271,7 +271,7 @@ mod tests {
         #[test]
         fn systems_with_distributive_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.insert_resource(RunConditionBool(true));
             world.init_resource::<SystemOrder>();
@@ -297,7 +297,7 @@ mod tests {
         #[test]
         fn run_exclusive_system_with_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<RunConditionBool>();
             world.init_resource::<SystemOrder>();
@@ -317,7 +317,7 @@ mod tests {
         #[test]
         fn multiple_conditions_on_system() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<Counter>();
 
@@ -335,7 +335,7 @@ mod tests {
         #[test]
         fn multiple_conditions_on_system_sets() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<Counter>();
 
@@ -355,7 +355,7 @@ mod tests {
         #[test]
         fn systems_nested_in_system_sets() {
             let mut world = World::default();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             world.init_resource::<Counter>();
 
@@ -381,7 +381,7 @@ mod tests {
             world.init_resource::<Counter>();
             world.init_resource::<RunConditionBool>();
             world.init_resource::<Bool2>();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.add_systems(
                 counting_system
@@ -429,7 +429,7 @@ mod tests {
             world.init_resource::<Counter>();
             world.init_resource::<RunConditionBool>();
             world.init_resource::<Bool2>();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.configure_sets(
                 TestSet::A
@@ -479,7 +479,7 @@ mod tests {
             world.init_resource::<Counter>();
             world.init_resource::<RunConditionBool>();
             world.init_resource::<Bool2>();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule
                 .configure_sets(TestSet::A.run_if(|res1: Res<RunConditionBool>| res1.is_changed()));
@@ -528,14 +528,14 @@ mod tests {
         #[test]
         #[should_panic]
         fn dependency_loop() {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.configure_sets(TestSet::X.after(TestSet::X));
         }
 
         #[test]
         fn dependency_cycle() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.configure_sets(TestSet::A.after(TestSet::B));
             schedule.configure_sets(TestSet::B.after(TestSet::A));
@@ -550,7 +550,7 @@ mod tests {
             fn bar() {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.add_systems((foo.after(bar), bar.after(foo)));
             let result = schedule.initialize(&mut world);
@@ -563,14 +563,14 @@ mod tests {
         #[test]
         #[should_panic]
         fn hierarchy_loop() {
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.configure_sets(TestSet::X.in_set(TestSet::X));
         }
 
         #[test]
         fn hierarchy_cycle() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.configure_sets(TestSet::A.in_set(TestSet::B));
             schedule.configure_sets(TestSet::B.in_set(TestSet::A));
@@ -586,7 +586,7 @@ mod tests {
             fn bar() {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             // Schedule `bar` to run after `foo`.
             schedule.add_systems((foo, bar.after(foo)));
@@ -607,7 +607,7 @@ mod tests {
             ));
 
             // same goes for `ambiguous_with`
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems(foo);
             schedule.add_systems(bar.ambiguous_with(foo));
             let result = schedule.initialize(&mut world);
@@ -624,14 +624,14 @@ mod tests {
         #[should_panic]
         fn configure_system_type_set() {
             fn foo() {}
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.configure_sets(foo.into_system_set());
         }
 
         #[test]
         fn hierarchy_redundancy() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.set_build_settings(ScheduleBuildSettings {
                 hierarchy_detection: LogLevel::Error,
@@ -658,7 +658,7 @@ mod tests {
         #[test]
         fn cross_dependency() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             // Add `B` and give it both kinds of relationships with `A`.
             schedule.configure_sets(TestSet::B.in_set(TestSet::A));
@@ -673,7 +673,7 @@ mod tests {
         #[test]
         fn sets_have_order_but_intersect() {
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             fn foo() {}
 
@@ -704,7 +704,7 @@ mod tests {
             fn res_mut(_x: ResMut<X>) {}
 
             let mut world = World::new();
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
 
             schedule.set_build_settings(ScheduleBuildSettings {
                 ambiguity_detection: LogLevel::Error,
@@ -760,7 +760,7 @@ mod tests {
             world.spawn(A);
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule
                 // nonsendmut system deliberately conflicts with resmut system
                 .add_systems((resmut_system, write_component_system, event_writer_system));
@@ -777,7 +777,7 @@ mod tests {
             world.spawn(A);
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 empty_system,
                 empty_system,
@@ -805,7 +805,7 @@ mod tests {
             world.spawn(A);
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 resmut_system,
                 write_component_system,
@@ -823,7 +823,7 @@ mod tests {
             let mut world = World::new();
             world.insert_resource(R);
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((resmut_system, res_system));
 
             let _ = schedule.initialize(&mut world);
@@ -836,7 +836,7 @@ mod tests {
             let mut world = World::new();
             world.insert_resource(R);
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((nonsendmut_system, nonsend_system));
 
             let _ = schedule.initialize(&mut world);
@@ -849,7 +849,7 @@ mod tests {
             let mut world = World::new();
             world.spawn(A);
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((read_component_system, write_component_system));
 
             let _ = schedule.initialize(&mut world);
@@ -863,7 +863,7 @@ mod tests {
             let mut world = World::new();
             world.spawn(A);
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 with_filtered_component_system,
                 without_filtered_component_system,
@@ -879,7 +879,7 @@ mod tests {
             let mut world = World::new();
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 // All of these systems clash
                 event_reader_system,
@@ -899,7 +899,7 @@ mod tests {
             world.spawn(A);
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 // All 3 of these conflict with each other
                 write_world_system,
@@ -918,7 +918,7 @@ mod tests {
             let mut world = World::new();
             world.init_resource::<Events<E>>();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 event_reader_system.before(event_writer_system),
                 event_writer_system,
@@ -935,7 +935,7 @@ mod tests {
             let mut world = World::new();
             world.insert_resource(R);
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 resmut_system.ambiguous_with_all(),
                 res_system,
@@ -955,7 +955,7 @@ mod tests {
             #[derive(SystemSet, Hash, PartialEq, Eq, Debug, Clone)]
             struct IgnoreMe;
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 resmut_system.ambiguous_with(IgnoreMe),
                 res_system.in_set(IgnoreMe),
@@ -971,7 +971,7 @@ mod tests {
         fn ambiguous_with_system() {
             let mut world = World::new();
 
-            let mut schedule = Schedule::default();
+            let mut schedule = Schedule::single_threaded();
             schedule.add_systems((
                 write_component_system.ambiguous_with(read_component_system),
                 read_component_system,

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -103,7 +103,7 @@ mod tests {
             use std::sync::{Arc, Barrier};
 
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default(); // Uses MultiThreaded executor
             let thread_count = ComputeTaskPool::init(TaskPool::default).thread_num();
 
             let barrier = Arc::new(Barrier::new(thread_count));

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -73,7 +73,7 @@ mod tests {
         #[test]
         fn run_system() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -86,7 +86,7 @@ mod tests {
         #[test]
         fn run_exclusive_system() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -125,7 +125,7 @@ mod tests {
         #[test]
         fn order_systems() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -163,7 +163,7 @@ mod tests {
         #[test]
         fn order_exclusive_systems() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -180,7 +180,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order() {
             let mut world = World::new();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -201,7 +201,7 @@ mod tests {
         #[test]
         fn add_systems_correct_order_nested() {
             let mut world = World::new();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<SystemOrder>();
 
@@ -251,7 +251,7 @@ mod tests {
         #[test]
         fn system_with_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<RunConditionBool>();
             world.init_resource::<SystemOrder>();
@@ -271,7 +271,7 @@ mod tests {
         #[test]
         fn systems_with_distributive_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.insert_resource(RunConditionBool(true));
             world.init_resource::<SystemOrder>();
@@ -297,7 +297,7 @@ mod tests {
         #[test]
         fn run_exclusive_system_with_condition() {
             let mut world = World::default();
-            let mut schedule = Schedule::single_threaded();
+            let mut schedule = Schedule::default();
 
             world.init_resource::<RunConditionBool>();
             world.init_resource::<SystemOrder>();

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -103,7 +103,7 @@ mod tests {
             use std::sync::{Arc, Barrier};
 
             let mut world = World::default();
-            let mut schedule = Schedule::default(); // Uses MultiThreaded executor
+            let mut schedule = Schedule::multi_threaded();
             let thread_count = ComputeTaskPool::init(TaskPool::default).thread_num();
 
             let barrier = Arc::new(Barrier::new(thread_count));

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -190,6 +190,18 @@ impl Schedule {
         }
     }
 
+    /// Constructs an empty `Schedule` with the [`SingleThreaded`] executor.
+    /// Only use in situations where you don't care about the [`ScheduleLabel`].
+    /// Inserting a default schedule into the world risks overwriting another
+    /// schedule. For most situations you should use [`Schedule::new`].
+    ///
+    /// [`SingleThreaded`]: ExecutorKind::SingleThreaded
+    pub fn single_threaded() -> Self {
+        let mut schedule = Self::default();
+        schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        schedule
+    }
+
     /// Add a collection of systems to the schedule.
     pub fn add_systems<M>(&mut self, systems: impl IntoSystemConfigs<M>) -> &mut Self {
         self.graph.process_configs(systems.into_configs(), false);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -147,7 +147,7 @@ fn make_executor(kind: ExecutorKind) -> Box<dyn SystemExecutor> {
 ///    
 /// fn main() {
 ///     let mut world = World::new();
-///     let mut schedule = Schedule::default();
+///     let mut schedule = Schedule::single_threaded();
 ///     schedule.add_systems((
 ///         system_two,
 ///         system_one.before(system_two),

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -214,7 +214,7 @@ impl Schedule {
     /// [`MultiThreaded`]: ExecutorKind::MultiThreaded
     pub fn multi_threaded() -> Self {
         let mut schedule = Self::default();
-        schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        schedule.set_executor_kind(ExecutorKind::MultiThreaded);
         schedule
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -206,6 +206,18 @@ impl Schedule {
         schedule
     }
 
+    /// Constructs an empty `Schedule` with the [`MultiThreaded`] executor.
+    /// Only use in situations where you don't care about the [`ScheduleLabel`].
+    /// Inserting a default schedule into the world risks overwriting another
+    /// schedule. For most situations you should use [`Schedule::new`].
+    ///
+    /// [`MultiThreaded`]: ExecutorKind::MultiThreaded
+    pub fn multi_threaded() -> Self {
+        let mut schedule = Self::default();
+        schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        schedule
+    }
+
     /// Add a collection of systems to the schedule.
     pub fn add_systems<M>(&mut self, systems: impl IntoSystemConfigs<M>) -> &mut Self {
         self.graph.process_configs(systems.into_configs(), false);

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -173,6 +173,10 @@ impl Default for Schedule {
     /// you don't care about the [`ScheduleLabel`]. Inserting a default schedule
     /// into the world risks overwriting another schedule. For most situations
     /// you should use [`Schedule::new`].
+    ///
+    /// # Note
+    /// In benchmarks/tests is recommended to use [`Schedule::single_threaded`]
+    /// instead, for lower overhead
     fn default() -> Self {
         Self::new(DefaultSchedule)
     }
@@ -1737,7 +1741,7 @@ mod tests {
         struct Set;
 
         let mut world = World::new();
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         schedule.configure_sets(Set.run_if(|| false));
         schedule.add_systems(

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -50,7 +50,7 @@ use super::{ReadOnlySystem, System};
 /// # let mut world = World::new();
 /// # world.init_resource::<RanFlag>();
 /// #
-/// # let mut app = Schedule::default();
+/// # let mut app = Schedule::single_threaded();
 /// app.add_systems(my_system.run_if(Xor::new(
 ///     IntoSystem::into_system(resource_equals(A(1))),
 ///     IntoSystem::into_system(resource_equals(B(1))),

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -603,9 +603,9 @@ impl<'w, 's> Commands<'w, 's> {
 /// # let mut world = World::new();
 /// # world.init_resource::<Counter>();
 /// #
-/// # let mut setup_schedule = Schedule::default();
+/// # let mut setup_schedule = Schedule::single_threaded();
 /// # setup_schedule.add_systems(setup);
-/// # let mut assert_schedule = Schedule::default();
+/// # let mut assert_schedule = Schedule::single_threaded();
 /// # assert_schedule.add_systems(assert_names);
 /// #
 /// # setup_schedule.run(&mut world);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -595,7 +595,7 @@ mod tests {
     }
 
     fn run_system<Marker, S: IntoSystem<(), (), Marker>>(world: &mut World, system: S) {
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems(system);
         schedule.run(world);
     }
@@ -772,7 +772,7 @@ mod tests {
         world.insert_resource(Added(0));
         world.insert_resource(Changed(0));
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
 
         schedule.add_systems((incr_e_on_flip, apply_deferred, World::clear_trackers).chain());
 
@@ -1920,7 +1920,7 @@ mod tests {
 
         world.insert_resource(A);
         world.insert_resource(C(0));
-        let mut sched = Schedule::default();
+        let mut sched = Schedule::single_threaded();
         sched.add_systems(
             (
                 (|mut res: ResMut<C>| {

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -172,7 +172,7 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// # let mut schedule = Schedule::default();
+    /// # let mut schedule = Schedule::single_threaded();
     /// // Ignores the output of a system that may fail.
     /// schedule.add_systems(my_system.map(std::mem::drop));
     /// # let mut world = World::new();
@@ -363,7 +363,7 @@ pub mod adapter {
     /// use bevy_ecs::prelude::*;
     ///
     /// // Building a new schedule/app...
-    /// # let mut sched = Schedule::default();
+    /// # let mut sched = Schedule::single_threaded();
     /// sched.add_systems(
     ///         // Prints system warning if system returns an error.
     ///         warning_pipe_system.pipe(system_adapter::warn)
@@ -429,7 +429,7 @@ pub mod adapter {
     /// struct Monster;
     ///
     /// // Building a new schedule/app...
-    /// # let mut sched = Schedule::default(); sched
+    /// # let mut sched = Schedule::single_threaded(); sched
     ///     .add_systems(
     ///         // If the system fails, just move on and try again next frame.
     ///         fallible_system.pipe(system_adapter::ignore)

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1735,7 +1735,7 @@ mod tests {
         }
 
         let mut world = World::new();
-        let mut schedule = crate::schedule::Schedule::default();
+        let mut schedule = crate::schedule::Schedule::single_threaded();
         schedule.add_systems(non_sync_system);
         schedule.run(&mut world);
     }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -353,7 +353,7 @@ impl_param_set!();
 ///
 /// ```
 /// # let mut world = World::default();
-/// # let mut schedule = Schedule::default();
+/// # let mut schedule = Schedule::single_threaded();
 /// # use bevy_ecs::prelude::*;
 /// #[derive(Resource)]
 /// struct MyResource { value: u32 }

--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -200,7 +200,7 @@ mod test {
         let offset_transform =
             |offset| TransformBundle::from_transform(Transform::from_xyz(offset, offset, offset));
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         let mut command_queue = CommandQueue::default();
@@ -251,7 +251,7 @@ mod test {
         ComputeTaskPool::init(TaskPool::default);
         let mut world = World::default();
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
@@ -289,7 +289,7 @@ mod test {
     fn did_propagate_command_buffer() {
         let mut world = World::default();
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Root entity
@@ -329,7 +329,7 @@ mod test {
         ComputeTaskPool::init(TaskPool::default);
         let mut world = World::default();
 
-        let mut schedule = Schedule::default();
+        let mut schedule = Schedule::single_threaded();
         schedule.add_systems((sync_simple_transforms, propagate_transforms));
 
         // Add parent entities


### PR DESCRIPTION
# Objective
Fixes: #9838
## Solution
Add `single_threaded` constructor for `Schedule` and use it in all benchmarks and tests.