### PR TITLE
skybox.wgsl: Fix precision issues

### DIFF
--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -1,11 +1,37 @@
 #import bevy_render::view View
+#import bevy_pbr::utils coords_to_viewport_uv
 
 @group(0) @binding(0) var skybox: texture_cube<f32>;
 @group(0) @binding(1) var skybox_sampler: sampler;
 @group(0) @binding(2) var<uniform> view: View;
 
+fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32> {
+    // Using world positions of the fragment and camera to calculate a ray direction
+    // break down at large translations. This code only needs to know the ray direction.
+    // The ray direction is along the direction from the camera to the fragment position.
+    // In view space, the camera is at the origin, so the view space ray direction is
+    // along the direction of the fragment position - (0,0,0) which is just the
+    // fragment position.
+    // Use the position on the near clipping plane to avoid -inf world position
+    // because the far plane of an infinite reverse projection is at infinity.
+    let view_position_homogeneous = view.inverse_projection * vec4(
+        coords_to_viewport_uv(position, viewport) * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
+        1.0,
+        1.0,
+    );
+    let view_position = view_position_homogeneous.xyz / view_position_homogeneous.w;
+    let view_ray_direction = normalize(view_position);
+    // Transforming the view space ray direction by the view matrix, transforms the
+    // direction to world space. Note that the w element is set to 0.0, as this is a
+    // vector direction, not a position, That causes the matrix multiplication to ignore
+    // the translations from the view matrix.
+    let ray_direction = (view.view * vec4(view_ray_direction, 0.0)).xyz;
+
+    return normalize(ray_direction);
+}
+
 struct VertexOutput {
-    @builtin(position) clip_position: vec4<f32>,
+    @builtin(position) position: vec4<f32>,
 };
 
 //  3 |  2.
@@ -34,27 +60,8 @@ fn skybox_vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn skybox_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    // Using world positions of the fragment and camera to calculate a ray direction
-    // break down at large translations. This code only needs to know the ray direction.
-    // The ray direction is along the direction from the camera to the fragment position.
-    // In view space, the camera is at the origin, so the view space ray direction is
-    // along the direction of the fragment position - (0,0,0) which is just the
-    // fragment position.
-    // Use the position on the near clipping plane to avoid -inf world position
-    // because the far plane of an infinite reverse projection is at infinity.
-    let view_position_homogeneous = view.inverse_projection * vec4(
-        in.clip_position.xy / view.viewport.zw * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
-        1.0,
-        1.0
-    );
-    let view_position = view_position_homogeneous.xyz / view_position_homogeneous.w;
-    let view_ray_direction = normalize(view_position);
-    // Transforming the view space ray direction by the view matrix, transforms the
-    // direction to world space. Note that the w element is set to 0.0, as this is a
-    // vector direction, not a position, That causes the matrix multiplication to ignore
-    // the translations from the view matrix.
-    let ray_direction = (view.view * vec4(view_ray_direction, 0.0)).xyz;
+    let ray_direction = coords_to_ray_direction(in.position.xy, view.viewport);
 
     // Cube maps are left-handed so we negate the z coordinate.
-    return textureSample(skybox, skybox_sampler, normalize(ray_direction) * vec3(1.0, 1.0, -1.0));
+    return textureSample(skybox, skybox_sampler, ray_direction * vec3(1.0, 1.0, -1.0));
 }

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -19,8 +19,7 @@ fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32
         1.0,
         1.0,
     );
-    let view_position = view_position_homogeneous.xyz / view_position_homogeneous.w;
-    let view_ray_direction = normalize(view_position);
+    let view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
     // Transforming the view space ray direction by the view matrix, transforms the
     // direction to world space. Note that the w element is set to 0.0, as this is a
     // vector direction, not a position, That causes the matrix multiplication to ignore


### PR DESCRIPTION
# Objective

- Fixes #9707 

## Solution

- At large translations (a few thousand units), the precision of calculating the ray direction from the fragment world position and camera world position seems to break down. Sampling the cubemap only needs the ray direction. As such we can use the view space fragment position, normalise it, rotate it to world space, and use that.

---

## Changelog

- Fixed: Jittery skybox at large translations.