### PR TITLE
`as_deref_mut()` method for Mut-like types

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -384,10 +384,10 @@ macro_rules! impl_methods {
 
             /// Allows you access to the dereferenced value of this pointer without immediately
             /// triggering change detection.
-            pub fn as_deref_mut(&mut self)  -> Mut<'_, <$target as Deref>::Target>
+            pub fn as_deref_mut(&mut self) -> Mut<'_, <$target as Deref>::Target>
                 where $target: DerefMut
             {
-                self.reborrow().map_unchanged(|v|v.deref_mut())
+                self.reborrow().map_unchanged(|v| v.deref_mut())
             }
 
         }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -384,13 +384,10 @@ macro_rules! impl_methods {
 
             /// Allows you access to the dereferenced value of this pointer without immediately
             /// triggering change detection.
-            pub fn as_deref_mut(self)  -> Mut<'a, <$target as Deref>::Target>
+            pub fn as_deref_mut(&mut self)  -> Mut<'_, <$target as Deref>::Target>
                 where $target: DerefMut
             {
-                Mut {
-                    value: self.value.deref_mut(),
-                    ticks: self.ticks,
-                }
+                self.reborrow().map_unchanged(|v|v.deref_mut())
             }
 
         }
@@ -1179,7 +1176,7 @@ mod tests {
         // This is required to update world::last_change_tick
         world.clear_trackers();
 
-        let r = world.resource_mut::<R2>();
+        let mut r = world.resource_mut::<R2>();
         assert!(!r.is_changed(), "Resource must begin unchanged.");
 
         let mut r = r.as_deref_mut();

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -175,75 +175,6 @@ pub trait DetectChangesMut: DetectChanges {
         }
     }
 
-    /// Similar to [`set_if_neq`](DetectChangesMut::set_if_neq), but for when the inner type
-    /// implements [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html).
-    ///
-    /// Dereferences the inner value, then overwrites this smart pointer with the given value, if and only if `**self != value`.
-    /// Returns `true` if the value was overwritten, and returns `false` if it was not.
-    ///
-    /// This is useful to ensure change detection is only triggered when the underlying value
-    /// changes, instead of every time it is mutably accessed.
-    ///
-    /// If you need the previous value, use [`replace_if_neq`](DetectChangesMut::replace_if_neq).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use bevy_ecs::{prelude::*, schedule::common_conditions::resource_changed};
-    /// # use std::ops::{Deref, DerefMut};
-    /// #[derive(Resource, PartialEq, Eq)]
-    /// pub struct Score(u32);
-    ///
-    /// // These can be derived using bevy macros
-    /// impl Deref for Score {
-    ///     type Target = u32;
-    ///     fn deref(&self) -> &Self::Target {
-    ///         &self.0
-    ///     }
-    /// }
-    /// impl DerefMut for Score {
-    ///     fn deref_mut(&mut self) -> &mut Self::Target {
-    ///         &mut self.0
-    ///     }
-    /// }
-    ///
-    /// fn reset_score(mut score: ResMut<Score>) {
-    ///     // Set the score to zero, unless it is already zero.
-    ///     score.set_deref_if_neq(0);
-    /// }
-    ///
-    /// # let mut world = World::new();
-    /// # world.insert_resource(Score(1));
-    /// # let mut score_changed = IntoSystem::into_system(resource_changed::<Score>());
-    /// # score_changed.initialize(&mut world);
-    /// # score_changed.run((), &mut world);
-    /// #
-    /// # let mut schedule = Schedule::default();
-    /// # schedule.add_systems(reset_score);
-    /// #
-    /// # // first time `reset_score` runs, the score is changed.
-    /// # schedule.run(&mut world);
-    /// # assert!(score_changed.run((), &mut world));
-    /// # // second time `reset_score` runs, the score is not changed.
-    /// # schedule.run(&mut world);
-    /// # assert!(!score_changed.run((), &mut world));
-    /// ```
-    #[inline]
-    fn set_deref_if_neq(&mut self, value: <Self::Inner as Deref>::Target) -> bool
-    where
-        Self::Inner: DerefMut,
-        <Self::Inner as Deref>::Target: Sized + PartialEq,
-    {
-        let old = self.bypass_change_detection();
-        if **old != value {
-            **old = value;
-            self.set_changed();
-            true
-        } else {
-            false
-        }
-    }
-
     /// Overwrites this smart pointer with the given value, if and only if `*self != value`,
     /// returning the previous value if this occurs.
     ///
@@ -450,6 +381,18 @@ macro_rules! impl_methods {
                     ticks: self.ticks,
                 }
             }
+
+            /// Allows you access to the dereferenced value of this pointer without immediately
+            /// triggering change detection.
+            pub fn as_deref_mut(self)  -> Mut<'a, <$target as Deref>::Target>
+                where $target: DerefMut
+            {
+                Mut {
+                    value: self.value.deref_mut(),
+                    ticks: self.ticks,
+                }
+            }
+
         }
     };
 }
@@ -1001,13 +944,13 @@ mod tests {
 
     impl Deref for R2 {
         type Target = u8;
-        fn deref(&self) -> &Self::Target {
+        fn deref(&self) -> &u8 {
             &self.0
         }
     }
 
     impl DerefMut for R2 {
-        fn deref_mut(&mut self) -> &mut Self::Target {
+        fn deref_mut(&mut self) -> &mut u8 {
             &mut self.0
         }
     }
@@ -1227,7 +1170,7 @@ mod tests {
     }
 
     #[test]
-    fn set_deref_if_neq() {
+    fn as_deref_mut() {
         let mut world = World::new();
 
         world.insert_resource(R2(0));
@@ -1236,16 +1179,16 @@ mod tests {
         // This is required to update world::last_change_tick
         world.clear_trackers();
 
-        let mut r = world.resource_mut::<R2>();
+        let r = world.resource_mut::<R2>();
         assert!(!r.is_changed(), "Resource must begin unchanged.");
 
-        r.set_deref_if_neq(0);
+        let mut r = r.as_deref_mut();
         assert!(
             !r.is_changed(),
-            "Resource must not be changed after setting to the same value."
+            "Dereferencing should not mark the item as changed yet"
         );
 
-        r.set_deref_if_neq(3);
+        r.set_if_neq(3);
         assert!(
             r.is_changed(),
             "Resource must be changed after setting to a different value."

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -175,7 +175,6 @@ pub trait DetectChangesMut: DetectChanges {
         }
     }
 
-    /// NOCOMMIT fix comment
     /// Similar to [`set_if_neq`](DetectChangesMut::set_if_neq), but for when the inner type
     /// implements [`DerefMut`](https://doc.rust-lang.org/std/ops/trait.DerefMut.html).
     ///


### PR DESCRIPTION
# Objective

Add a new method so you can do `set_if_neq` with dereferencing components: `as_deref_mut()`!

## Solution

Added an as_deref_mut method so that we can use `set_if_neq()` without having to wrap up types for derefencable components 