### PR TITLE
Split OrthographicProjection::default into 2d & 3d

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -35,11 +35,7 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        let projection = OrthographicProjection {
-            far: 1000.,
-            near: -1000.,
-            ..Default::default()
-        };
+        let projection = OrthographicProjection::default_2d();
         let transform = Transform::default();
         let view_projection =
             projection.get_projection_matrix() * transform.compute_matrix().inverse();
@@ -76,7 +72,7 @@ impl Camera2dBundle {
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
             far,
-            ..Default::default()
+            ..OrthographicProjection::default_2d()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
         let view_projection =

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -774,7 +774,7 @@ fn load_node(
                     far: orthographic.zfar(),
                     scaling_mode: ScalingMode::FixedHorizontal(1.0),
                     scale: xmag,
-                    ..Default::default()
+                    ..OrthographicProjection::default_3d()
                 };
 
                 Projection::Orthographic(orthographic_projection)

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -198,7 +198,7 @@ pub enum ScalingMode {
 /// Note that the scale of the projection and the apparent size of objects are inversely proportional.
 /// As the size of the projection increases, the size of objects decreases.
 #[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default)]
+#[reflect(Component)]
 pub struct OrthographicProjection {
     /// The distance of the near clipping plane in world units.
     ///
@@ -311,8 +311,25 @@ impl CameraProjection for OrthographicProjection {
     }
 }
 
-impl Default for OrthographicProjection {
-    fn default() -> Self {
+impl FromWorld for OrthographicProjection {
+    fn from_world(_world: &mut World) -> Self {
+        OrthographicProjection::default_3d()
+    }
+}
+
+impl OrthographicProjection {
+    pub fn default_2d() -> Self {
+        OrthographicProjection {
+            scale: 1.0,
+            near: -1000.0,
+            far: 1000.0,
+            viewport_origin: Vec2::new(0.5, 0.5),
+            scaling_mode: ScalingMode::WindowSize(1.0),
+            area: Rect::new(-1.0, -1.0, 1.0, 1.0),
+        }
+    }
+
+    pub fn default_3d() -> Self {
         OrthographicProjection {
             scale: 1.0,
             near: 0.0,

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -20,7 +20,7 @@ fn setup(
         projection: OrthographicProjection {
             scale: 3.0,
             scaling_mode: ScalingMode::FixedVertical(2.0),
-            ..default()
+            ..OrthographicProjection::default_3d()
         }
         .into(),
         transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -132,7 +132,7 @@ fn setup(
             transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
             projection: OrthographicProjection {
                 scale: 0.01,
-                ..default()
+                ..OrthographicProjection::default_3d()
             }
             .into(),
             ..default()

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -91,7 +91,7 @@ fn setup(
             projection: OrthographicProjection {
                 scale: 20.0,
                 scaling_mode: ScalingMode::FixedHorizontal(1.0),
-                ..default()
+                ..OrthographicProjection::default_3d()
             }
             .into(),
             ..default()


### PR DESCRIPTION
# Objective

The default value for `near` in `OrthographicProjection` should be different for 2d & 3d.

For 2d using `near = -1000` allows bevy users to build up scenes using background `z = 0`, and foreground elements `z > 0` similar to css. However in 3d `near = -1000` results in objects behind the camera being rendered.  Using `near = 0` works for 3d, but forces 2d users to assign `z <= 0` for rendered elements, putting the background at some arbitrary negative value.

There is no common value for `near` that doesn't result in a footgun or usability issue for either 2d or 3d, so they should have separate values.

There was discussion about other options in the discord [0], but splitting `default()` into `default_2d()` and `default_3d()` seemed like the lowest cost approach.

Related/past work #9138, #9214, #9310, #9537 (thanks to @Selene-Amanita for the list)

[0]: https://discord.com/channels/691052431525675048/1154114310042292325

## Solution

This commit splits `OrthographicProjection::default` into `default_2d` and `default_3d`.

---

## Changelog

- `OrthographicProjection::default()` removed
- `OrthographicProjection::default_3d()` added
- `OrthographicProjection::default_2d()` added
- `impl FromWorld for OrthographicProjection` added; calls `default_3d()`
   - necessary for `#[derive(Reflect)]` when `impl Default` removed

## Migration Guide

- In initialization of `OrthographicProjection` change `..default()` to `..OrthographicProjection::default_2d()` or `..OrthographicProjection::default_3d()`

Example:
```diff
--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -20,7 +20,7 @@ fn setup(
         projection: OrthographicProjection {
             scale: 3.0,
             scaling_mode: ScalingMode::FixedVertical(2.0),
-            ..default()
+            ..OrthographicProjection::default_3d()
         }
         .into(),
         transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
```
