### PR TITLE
implement Reflect for Box<T>

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1,5 +1,8 @@
 use crate::std_traits::ReflectDefault;
-use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwned};
+use crate::{
+    self as bevy_reflect, DynamicTupleStruct, ReflectFromPtr, ReflectFromReflect, ReflectOwned,
+    TupleStruct, TupleStructFieldIter, TupleStructInfo,
+};
 use crate::{
     impl_type_path, map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum,
     DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
@@ -791,6 +794,201 @@ impl_array_get_type_registration! {
     10 11 12 13 14 15 16 17 18 19
     20 21 22 23 24 25 26 27 28 29
     30 31 32
+}
+
+impl<T: FromReflect + TypePath> TupleStruct for Box<T> {
+    fn field(&self, index: usize) -> Option<&dyn Reflect> {
+        if index == 0 {
+            Some(self.as_ref())
+        } else {
+            None
+        }
+    }
+
+    fn field_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        if index == 0 {
+            Some(self.as_mut())
+        } else {
+            None
+        }
+    }
+
+    fn field_len(&self) -> usize {
+        1
+    }
+
+    fn iter_fields(&self) -> bevy_reflect::TupleStructFieldIter {
+        TupleStructFieldIter {
+            tuple_struct: self,
+            index: 0,
+        }
+    }
+
+    fn clone_dynamic(&self) -> DynamicTupleStruct {
+        let mut dyn_tuple_struct = DynamicTupleStruct::default();
+        dyn_tuple_struct.set_represented_type(self.get_represented_type_info());
+        dyn_tuple_struct.insert_boxed(self.as_ref().clone_value());
+        dyn_tuple_struct
+    }
+}
+
+impl<T: FromReflect + TypePath> GetTypeRegistration for Box<T> {
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration
+    }
+}
+
+impl<T: FromReflect + TypePath> FromReflect for Box<T> {
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        if let Some(value) = reflect.downcast_ref::<Self>() {
+            return Some(Box::new(T::from_reflect(value.as_ref().as_reflect())?));
+        } else if let Some(value) = reflect.downcast_ref::<T>() {
+            return Some(Box::new(T::from_reflect(value.as_reflect())?));
+        } else if let Some(value) = reflect.downcast_ref::<DynamicTupleStruct>() {
+            if value
+                .get_represented_type_info()
+                .map(|t| t.type_id() == Self::type_info().type_id())
+                .unwrap_or_default()
+            {
+                return Some(Box::new(T::from_reflect(value.field(0).unwrap())?));
+            }
+        }
+
+        None
+    }
+}
+
+impl<T: FromReflect + TypePath> TypePath for Box<T> {
+    fn type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| format!("std::boxed::Box::<{}>", Self::type_path()))
+    }
+
+    fn short_type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| format!("Box<{}>", Self::short_type_path()))
+    }
+
+    fn type_ident() -> Option<&'static str> {
+        Some("Box")
+    }
+
+    fn crate_name() -> Option<&'static str> {
+        Some("std")
+    }
+
+    fn module_path() -> Option<&'static str> {
+        Some("std::boxed")
+    }
+}
+
+impl<T: FromReflect + TypePath> Reflect for Box<T> {
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_inner(&self) -> Option<&dyn Reflect> {
+        Some(self.as_ref().as_reflect())
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        let value = value.as_any();
+        let value = if let Some(value) = value.downcast_ref::<Self>() {
+            value.as_ref()
+        } else if let Some(value) = value.downcast_ref::<T>() {
+            value
+        } else {
+            panic!("Value is not a {}.", std::any::type_name::<Self>());
+        };
+
+        self.as_mut().apply(value);
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        if value.is::<T>() {
+            *self = value.downcast()?;
+        } else if let Ok(value) = value.take() {
+            *self = value;
+        }
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::TupleStruct(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::TupleStruct(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::TupleStruct(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+
+    fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
+        Some(<Self as Typed>::type_info())
+    }
+
+    fn reflect_hash(&self) -> Option<u64> {
+        self.as_ref().reflect_hash()
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        let value = value.as_inner().unwrap_or(value);
+        self.as_ref().reflect_partial_eq(value)
+    }
+
+    fn debug(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Box(")?;
+        self.as_ref().debug(f)?;
+        write!(f, ")")
+    }
+
+    fn serializable(&self) -> Option<bevy_reflect::serde::Serializable> {
+        self.as_ref().serializable()
+    }
+}
+
+impl<T: FromReflect + TypePath> Typed for Box<T> {
+    fn type_info() -> &'static TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+        CELL.get_or_insert::<Self, _>(|| {
+            TypeInfo::TupleStruct(TupleStructInfo::new::<Self>(
+                "Box",
+                &[UnnamedField::new::<T>(0)],
+            ))
+        })
+    }
 }
 
 impl<T: FromReflect + TypePath> GetTypeRegistration for Option<T> {

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -93,6 +93,12 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// [`TypeRegistry::get_type_info`]: crate::TypeRegistry::get_type_info
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo>;
 
+    /// Returns the internal boxed value when the value itself is wrapped in a [`Box`].
+    /// If the value is not a [`Box`], returns None.
+    fn as_inner(&self) -> Option<&dyn Reflect> {
+        None
+    }
+
     /// Returns the value as a [`Box<dyn Any>`][std::any::Any].
     fn into_any(self: Box<Self>) -> Box<dyn Any>;
 


### PR DESCRIPTION
# Objective

- This should allow deriving Reflect values when values are wrapped in `Box`
- This precedes #6098 , which is held for quite a long time.

## Solution

For most methods, we are able to use inner wrapped reflect value directly through `self.as_ref()` and rely on that when the semantic seems to be valid.
However there are several design choices that I made by my own and may need more discussion.
My preference is to minimize the changes so hopefully I don't introduce too many bugs in this PR.
So:

1. I decided to make `Box` not a `Value` but a `TupleStruct`. Internally within Rust std, the `Box` is a tuple struct as well but over both the contained value and the allocator. I was saving the allocator part unless it is really needed in the future. In the previous PR (namely #6098 ), it introduces a new kind called `Wrapper`, my guess is that, the reason it introduces this new kind is to allow  access to the internal value contained in the Box but not be confused with the real other kind like `TupleStruct`. I'm solving this with the next choice, so I'm presuming it is OK to stay `TupleStruct` for Box.
2. A new method `fn as_inner(&self) -> Option<&dyn Reflect>` is introduced within `Reflect` trait and returns `None` by default for all non-boxed type. This distinguishes `Box` type with all other normal `TupleStruct` types. By this way, we know if a type is a `Box`-ed or not. The drawback is that, the complexity of the `Reflect` is increased.

This should not be the only way of implementing `Reflect` for `Box<T>`.
We might need a bit discussion on this to make sure if these design choices are reasonable enough.
Also, if I'm wrong about the `Wrapper` type in #6098 , there's still things that I ignored, I'm happy to rethink my design.

(As a side note, I'm not sure if this is OK to re-implement a proposed PR. If I'm wrong about this, please tell me what is the better way of doing this, I'm OK to change.)

---

## Changelog

- Added `Reflect` trait implementation for `Box<T>` when T implements `FromReflect` and `TypePath` trait.
