### PR TITLE
Fix the doc warning attribute and document remaining items for `bevy_window`

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -313,7 +313,7 @@ pub struct WindowMoved {
     pub position: IVec2,
 }
 
-/// An event sent when system changed window theme.
+/// An event sent when the system theme changes for a window.
 ///
 /// This event is only sent when the window is relying on the system theme to control its appearance.
 /// i.e. It is only sent when [`Window::window_theme`](crate::window::Window::window_theme) is `None` and the system theme changes.
@@ -325,6 +325,8 @@ pub struct WindowMoved {
     reflect(Serialize, Deserialize)
 )]
 pub struct WindowThemeChanged {
+    /// Window for which the system theme has changed.
     pub window: Entity,
+    /// The new system theme.
     pub theme: WindowTheme,
 }

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,6 +1,12 @@
 #![allow(clippy::type_complexity)]
+#![warn(missing_docs)]
+//! `bevy_window` provides a platform-agnostic interface for windowing in Bevy.
+//!
+//! This crate contains types for window management and events,
+//! used by windowing implementors such as `bevy_winit`.
+//! The [`WindowPlugin`] sets up some global window-related parameters and
+//! is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
 
-#[warn(missing_docs)]
 mod cursor;
 mod event;
 mod raw_handle;
@@ -14,6 +20,7 @@ pub use event::*;
 pub use system::*;
 pub use window::*;
 
+#[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{

--- a/crates/bevy_window/src/raw_handle.rs
+++ b/crates/bevy_window/src/raw_handle.rs
@@ -10,7 +10,9 @@ use raw_window_handle::{
 /// thread-safe.
 #[derive(Debug, Clone, Component)]
 pub struct RawHandleWrapper {
+    /// Raw handle to a window.
     pub window_handle: RawWindowHandle,
+    /// Raw handle to the display server.
     pub display_handle: RawDisplayHandle,
 }
 
@@ -23,14 +25,6 @@ impl RawHandleWrapper {
     /// operations off of the main thread. The caller must ensure the [`RawHandleWrapper`] is only used in valid contexts.
     pub unsafe fn get_handle(&self) -> ThreadLockedRawWindowHandleWrapper {
         ThreadLockedRawWindowHandleWrapper(self.clone())
-    }
-
-    pub fn get_display_handle(&self) -> RawDisplayHandle {
-        self.display_handle
-    }
-
-    pub fn get_window_handle(&self) -> RawWindowHandle {
-        self.window_handle
     }
 }
 
@@ -59,7 +53,7 @@ pub struct ThreadLockedRawWindowHandleWrapper(RawHandleWrapper);
 // and so exposing a safe method to get a [`RawWindowHandle`] directly would be UB.
 unsafe impl HasRawWindowHandle for ThreadLockedRawWindowHandleWrapper {
     fn raw_window_handle(&self) -> RawWindowHandle {
-        self.0.get_window_handle()
+        self.0.window_handle
     }
 }
 
@@ -71,6 +65,6 @@ unsafe impl HasRawWindowHandle for ThreadLockedRawWindowHandleWrapper {
 // and so exposing a safe method to get a [`RawDisplayHandle`] directly would be UB.
 unsafe impl HasRawDisplayHandle for ThreadLockedRawWindowHandleWrapper {
     fn raw_display_handle(&self) -> RawDisplayHandle {
-        self.0.get_display_handle()
+        self.0.display_handle
     }
 }


### PR DESCRIPTION
# Objective

Complete the documentation for `bevy_window`.

## Solution

The `warn(missing_doc)` attribute was only applying to the `cursor` module as it was declared as an inner attribute. I switched it to an outer attribute and documented the remaining items.