### PR TITLE
docs: Use intradoc links for method references.

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -88,9 +88,9 @@ pub trait Command: Send + 'static {
 ///
 /// # Implementing
 ///
-/// Each built-in command is implemented as a separate method, e.g. [`spawn`](#method.spawn).
+/// Each built-in command is implemented as a separate method, e.g. [`Commands::spawn`].
 /// In addition to the pre-defined command methods, you can add commands with any arbitrary
-/// behavior using [`Commands::add`](#method.add), which accepts any type implementing [`Command`].
+/// behavior using [`Commands::add`], which accepts any type implementing [`Command`].
 ///
 /// Since closures and other functions implement this trait automatically, this allows one-shot,
 /// anonymous custom commands.


### PR DESCRIPTION
# Objective

- Use intradoc links to let the compiler verify correctness.

## Solution

- Use intradoc links.
