### PR TITLE
ignore time channel error

### DIFF
--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -88,9 +88,16 @@ pub fn render_system(world: &mut World) {
 
     // update the time and send it to the app world
     let time_sender = world.resource::<TimeSender>();
-    time_sender.0.try_send(Instant::now()).expect(
-        "The TimeSender channel should always be empty during render. You might need to add the bevy::core::time_system to your app.",
-    );
+    if let Err(error) = time_sender.0.try_send(Instant::now()) {
+        match error {
+            bevy_time::TrySendError::Full(_) => {
+                panic!("The TimeSender channel should always be empty during render. You might need to add the bevy::core::time_system to your app.",);
+            }
+            bevy_time::TrySendError::Disconnected(_) => {
+                // ignore disconnected errors, the main world probably just got dropped during shutdown
+            }
+        }
+    }
 }
 
 /// This queue is used to enqueue tasks for the GPU to execute asynchronously.

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -17,6 +17,7 @@ pub use timer::*;
 
 use bevy_ecs::system::{Res, ResMut};
 use bevy_utils::{tracing::warn, Duration, Instant};
+pub use crossbeam_channel::TrySendError;
 use crossbeam_channel::{Receiver, Sender};
 
 pub mod prelude {


### PR DESCRIPTION
# Objective

- sometimes when bevy shuts down on certain machines the render thread tries to send the time after the main world has been dropped.
- fixes an error mentioned in a reply in https://github.com/bevyengine/bevy/issues/9543

---

## Changelog

- ignore disconnected errors from the time channel.