### PR TITLE
Simple sub states - MVP

### DIFF
--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -732,8 +732,12 @@ pub mod common_conditions {
     /// app.run(&mut world);
     /// assert_eq!(world.resource::<Counter>().0, 0);
     /// ```
-    pub fn in_state<S: States>(state: S) -> impl FnMut(Res<State<S>>) -> bool + Clone {
-        move |current_state: Res<State<S>>| *current_state == state
+    pub fn in_state<S: States>(state: S) -> impl FnMut(Option<Res<State<S>>>) -> bool + Clone {
+        move |current_state: Option<Res<State<S>>>| {
+            current_state
+                .map(|current_state| *current_state == state)
+                .unwrap_or(false)
+        }
     }
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`


### PR DESCRIPTION
# Objective

This PR provides a very simple, initial implementation of Sub States, separated from the additional concerns provided by #9957.

## Solution

- make `in_state`,  `run_enter_schedule` and `apply_state_transition` rely on optional resources, allowing for the states to not exist
- add `initialize_state_and_enter` & `remove_state_from_world` systems to activate and de-activate sub states when entering/exiting the parent state
- add `add_sub_state<S: States, Parent: States>(condition: Parent)` function to app, to allow for adding sub-states to the application.
