### PR TITLE
Revert "macOS Sonoma (14.0) / Xcode 15.0 — Compatibility Fixes + Docs…

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -28,13 +28,15 @@ bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 
 # other
-winit = { version = "0.28", default-features = false }
+winit = { version = "0.28.7", default-features = false }
 accesskit_winit = { version = "0.14", default-features = false }
 approx = { version = "0.5", default-features = false }
 raw-window-handle = "0.5"
 
 [target.'cfg(target_os = "android")'.dependencies]
-winit = { version = "0.28", default-features = false, features = ["android-native-activity"] }
+winit = { version = "0.28.7", default-features = false, features = [
+    "android-native-activity",
+] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -441,14 +441,6 @@ pub fn winit_runner(mut app: App) {
 
                 match event {
                     WindowEvent::Resized(size) => {
-                        // TODO: Remove this once we upgrade winit to a version with the fix
-                        #[cfg(target_os = "macos")]
-                        if size.width == u32::MAX || size.height == u32::MAX {
-                            // HACK to fix a bug on Macos 14
-                            // https://github.com/rust-windowing/winit/issues/2876
-                            return;
-                        }
-
                         window
                             .resolution
                             .set_physical_resolution(size.width, size.height);


### PR DESCRIPTION
… (#9905)"

This reverts commit 20ed3e0e765405ee334a44ce3c49c72bd29ab753.

Issue was already fixed:
https://github.com/rust-windowing/winit/pull/3118
