### PR TITLE
Add READMEs to all crates and clarify they are part of Bevy

### DIFF
--- a/crates/bevy_a11y/README.md
+++ b/crates/bevy_a11y/README.md
@@ -1,5 +1,5 @@
 # Bevy A11Y
 
-[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_a11y/README.md
+++ b/crates/bevy_a11y/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy A11Y
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy A11Y is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_a11y/README.md
+++ b/crates/bevy_a11y/README.md
@@ -1,5 +1,5 @@
 # Bevy A11Y
 
-Bevy A11Y is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_a11y/README.md
+++ b/crates/bevy_a11y/README.md
@@ -1,5 +1,5 @@
 # Bevy A11Y
 
-[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy A11Y](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_a11y) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_a11y/README.md
+++ b/crates/bevy_a11y/README.md
@@ -1,5 +1,5 @@
 # Bevy A11Y
 
-[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy A11Y](https://github.com/bevyengine/bevy/tree/main/crates/bevy_a11y)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_animation/README.md
+++ b/crates/bevy_animation/README.md
@@ -1,5 +1,5 @@
 # Bevy Animation
 
-[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_animation/README.md
+++ b/crates/bevy_animation/README.md
@@ -1,5 +1,5 @@
 # Bevy Animation
 
-Bevy Animation is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_animation/README.md
+++ b/crates/bevy_animation/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Animation
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Animation is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_animation/README.md
+++ b/crates/bevy_animation/README.md
@@ -1,5 +1,5 @@
 # Bevy Animation
 
-[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_animation/README.md
+++ b/crates/bevy_animation/README.md
@@ -1,5 +1,5 @@
 # Bevy Animation
 
-[Bevy Animation](https://github.com/bevyengine/bevy/tree/main/crates/bevy_animation)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Animation](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_animation) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_app/README.md
+++ b/crates/bevy_app/README.md
@@ -1,5 +1,5 @@
 # Bevy App
 
-Bevy App is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy App](https://github.com/bevyengine/bevy/tree/main/crates/bevy_app) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_app/README.md
+++ b/crates/bevy_app/README.md
@@ -1,5 +1,0 @@
-# Bevy App
-
-[Bevy App](https://github.com/bevyengine/bevy/tree/main/crates/bevy_app) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
-
-This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_app/README.md
+++ b/crates/bevy_app/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy App
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy App is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_asset/README.md
+++ b/crates/bevy_asset/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset
 
-Bevy Asset is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/README.md
+++ b/crates/bevy_asset/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Asset
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Asset is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_asset/README.md
+++ b/crates/bevy_asset/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset
 
-[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/README.md
+++ b/crates/bevy_asset/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset
 
-[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_asset) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/README.md
+++ b/crates/bevy_asset/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset
 
-[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/macros/README.md
+++ b/crates/bevy_asset/macros/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Asset Macros
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Asset Macros is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_asset/macros/README.md
+++ b/crates/bevy_asset/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset Macros
 
-[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/macros/README.md
+++ b/crates/bevy_asset/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset Macros
 
-[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/macros/README.md
+++ b/crates/bevy_asset/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset Macros
 
-[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_asset/macros) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_asset/macros/README.md
+++ b/crates/bevy_asset/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Asset Macros
 
-Bevy Asset Macros is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Asset Macros)](https://github.com/bevyengine/bevy/tree/main/crates/bevy_asset/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_audio/README.md
+++ b/crates/bevy_audio/README.md
@@ -1,5 +1,5 @@
 # Bevy Audio
 
-[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_audio/README.md
+++ b/crates/bevy_audio/README.md
@@ -1,5 +1,5 @@
 # Bevy Audio
 
-[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Audio](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_audio) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_audio/README.md
+++ b/crates/bevy_audio/README.md
@@ -1,5 +1,5 @@
 # Bevy Audio
 
-Bevy Audio is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_audio/README.md
+++ b/crates/bevy_audio/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Audio
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Audio is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_audio/README.md
+++ b/crates/bevy_audio/README.md
@@ -1,5 +1,5 @@
 # Bevy Audio
 
-[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Audio](https://github.com/bevyengine/bevy/tree/main/crates/bevy_audio) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core/README.md
+++ b/crates/bevy_core/README.md
@@ -1,5 +1,5 @@
 # Bevy Core
 
-[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core/README.md
+++ b/crates/bevy_core/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Core
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Core is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_core/README.md
+++ b/crates/bevy_core/README.md
@@ -1,5 +1,5 @@
 # Bevy Core
 
-Bevy Core is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core/README.md
+++ b/crates/bevy_core/README.md
@@ -1,5 +1,5 @@
 # Bevy Core
 
-[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core/README.md
+++ b/crates/bevy_core/README.md
@@ -1,5 +1,5 @@
 # Bevy Core
 
-[Bevy Core](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_core) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core_pipeline/README.md
+++ b/crates/bevy_core_pipeline/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Core Pipeline
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Core Pipeline is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_core_pipeline/README.md
+++ b/crates/bevy_core_pipeline/README.md
@@ -1,5 +1,5 @@
 # Bevy Core Pipeline
 
-[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core_pipeline/README.md
+++ b/crates/bevy_core_pipeline/README.md
@@ -1,5 +1,5 @@
 # Bevy Core Pipeline
 
-[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core_pipeline/README.md
+++ b/crates/bevy_core_pipeline/README.md
@@ -1,5 +1,5 @@
 # Bevy Core Pipeline
 
-Bevy Core Pipeline is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_core_pipeline/README.md
+++ b/crates/bevy_core_pipeline/README.md
@@ -1,5 +1,5 @@
 # Bevy Core Pipeline
 
-[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/main/crates/bevy_core_pipeline)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Core Pipeline](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_core_pipeline) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_derive/README.md
+++ b/crates/bevy_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Derive
 
-[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_derive/README.md
+++ b/crates/bevy_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Derive
 
-[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Derive](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_derive) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_derive/README.md
+++ b/crates/bevy_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Derive
 
-[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_derive/README.md
+++ b/crates/bevy_derive/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Derive
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Derive is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_derive/README.md
+++ b/crates/bevy_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Derive
 
-Bevy Derive is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_diagnostic/README.md
+++ b/crates/bevy_diagnostic/README.md
@@ -1,5 +1,5 @@
 # Bevy Diagnostic
 
-[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_diagnostic) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_diagnostic/README.md
+++ b/crates/bevy_diagnostic/README.md
@@ -1,5 +1,5 @@
 # Bevy Diagnostic
 
-[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_diagnostic/README.md
+++ b/crates/bevy_diagnostic/README.md
@@ -1,5 +1,5 @@
 # Bevy Diagnostic
 
-Bevy Diagnostic is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_diagnostic/README.md
+++ b/crates/bevy_diagnostic/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Diagnostic
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Diagnostic is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_diagnostic/README.md
+++ b/crates/bevy_diagnostic/README.md
@@ -1,5 +1,5 @@
 # Bevy Diagnostic
 
-[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Diagnostic](https://github.com/bevyengine/bevy/tree/main/crates/bevy_diagnostic) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dylib/README.md
+++ b/crates/bevy_dylib/README.md
@@ -1,5 +1,5 @@
 # Bevy DyLib
 
-Bevy DyLib is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dylib/README.md
+++ b/crates/bevy_dylib/README.md
@@ -1,5 +1,5 @@
 # Bevy DyLib
 
-[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dylib/README.md
+++ b/crates/bevy_dylib/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy DyLib
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy DyLib is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_dylib/README.md
+++ b/crates/bevy_dylib/README.md
@@ -1,5 +1,5 @@
 # Bevy DyLib
 
-[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dylib/README.md
+++ b/crates/bevy_dylib/README.md
@@ -1,5 +1,5 @@
 # Bevy DyLib
 
-[Bevy DyLib](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dylib)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy DyLib](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_dylib) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dynamic_plugin/README.md
+++ b/crates/bevy_dynamic_plugin/README.md
@@ -1,5 +1,5 @@
 # Bevy Dynamic Plugin
 
-[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_dynamic_plugin) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dynamic_plugin/README.md
+++ b/crates/bevy_dynamic_plugin/README.md
@@ -1,5 +1,5 @@
 # Bevy Dynamic Plugin
 
-[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dynamic_plugin/README.md
+++ b/crates/bevy_dynamic_plugin/README.md
@@ -1,5 +1,5 @@
 # Bevy Dynamic Plugin
 
-[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_dynamic_plugin/README.md
+++ b/crates/bevy_dynamic_plugin/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Dynamic Plugin
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Dynamic Plugin is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_dynamic_plugin/README.md
+++ b/crates/bevy_dynamic_plugin/README.md
@@ -1,5 +1,5 @@
 # Bevy Dynamic Plugin
 
-Bevy Dynamic Plugin is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Dynamic Plugin](https://github.com/bevyengine/bevy/tree/main/crates/bevy_dynamic_plugin) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ecs/macros/README.md
+++ b/crates/bevy_ecs/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy ECS Macros
 
-[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ecs/macros/README.md
+++ b/crates/bevy_ecs/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy ECS Macros
 
-[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ecs/macros/README.md
+++ b/crates/bevy_ecs/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy ECS Macros
 
-Bevy ECS Macros is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ecs/macros/README.md
+++ b/crates/bevy_ecs/macros/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy ECS Macros
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy ECS Macros is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_ecs/macros/README.md
+++ b/crates/bevy_ecs/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy ECS Macros
 
-[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ecs/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Ecs Macros](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_ecs/macros) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_encase_derive/README.md
+++ b/crates/bevy_encase_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Encase Derive
 
-[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_encase_derive) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_encase_derive/README.md
+++ b/crates/bevy_encase_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Encase Derive
 
-Bevy Encase Derive is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_encase_derive/README.md
+++ b/crates/bevy_encase_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Encase Derive
 
-[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_encase_derive/README.md
+++ b/crates/bevy_encase_derive/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Encase Derive
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Encase Derive is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_encase_derive/README.md
+++ b/crates/bevy_encase_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Encase Derive
 
-[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Encase Derive](https://github.com/bevyengine/bevy/tree/main/crates/bevy_encase_derive)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gilrs/README.md
+++ b/crates/bevy_gilrs/README.md
@@ -1,5 +1,5 @@
 # Bevy GilRs
 
-[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GilRs](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_gilrs) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gilrs/README.md
+++ b/crates/bevy_gilrs/README.md
@@ -1,5 +1,5 @@
 # Bevy GilRs
 
-Bevy GilRs is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gilrs/README.md
+++ b/crates/bevy_gilrs/README.md
@@ -1,5 +1,5 @@
 # Bevy GilRs
 
-[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gilrs/README.md
+++ b/crates/bevy_gilrs/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy GilRs
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy GilRs is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_gilrs/README.md
+++ b/crates/bevy_gilrs/README.md
@@ -1,5 +1,5 @@
 # Bevy GilRs
 
-[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GilRs](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gilrs) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gizmos/README.md
+++ b/crates/bevy_gizmos/README.md
@@ -1,5 +1,5 @@
 # Bevy Gizmos
 
-[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_gizmos) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gizmos/README.md
+++ b/crates/bevy_gizmos/README.md
@@ -1,5 +1,5 @@
 # Bevy Gizmos
 
-Bevy Gizmos is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gizmos/README.md
+++ b/crates/bevy_gizmos/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Gizmos
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Gizmos is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_gizmos/README.md
+++ b/crates/bevy_gizmos/README.md
@@ -1,5 +1,5 @@
 # Bevy Gizmos
 
-[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gizmos/README.md
+++ b/crates/bevy_gizmos/README.md
@@ -1,5 +1,5 @@
 # Bevy Gizmos
 
-[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Gizmos](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gizmos) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gltf/README.md
+++ b/crates/bevy_gltf/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy GLTF
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy GLTF is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_gltf/README.md
+++ b/crates/bevy_gltf/README.md
@@ -1,5 +1,5 @@
 # Bevy GLTF
 
-[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gltf/README.md
+++ b/crates/bevy_gltf/README.md
@@ -1,5 +1,5 @@
 # Bevy GLTF
 
-[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GLTF](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_gltf) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gltf/README.md
+++ b/crates/bevy_gltf/README.md
@@ -1,5 +1,5 @@
 # Bevy GLTF
 
-Bevy GLTF is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_gltf/README.md
+++ b/crates/bevy_gltf/README.md
@@ -1,5 +1,5 @@
 # Bevy GLTF
 
-[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy GLTF](https://github.com/bevyengine/bevy/tree/main/crates/bevy_gltf) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_hierarchy/README.md
+++ b/crates/bevy_hierarchy/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Hierarchy
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Hierarchy is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_hierarchy/README.md
+++ b/crates/bevy_hierarchy/README.md
@@ -1,5 +1,5 @@
 # Bevy Hierarchy
 
-[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_hierarchy/README.md
+++ b/crates/bevy_hierarchy/README.md
@@ -1,5 +1,5 @@
 # Bevy Hierarchy
 
-[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_hierarchy) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_hierarchy/README.md
+++ b/crates/bevy_hierarchy/README.md
@@ -1,5 +1,5 @@
 # Bevy Hierarchy
 
-[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_hierarchy/README.md
+++ b/crates/bevy_hierarchy/README.md
@@ -1,5 +1,5 @@
 # Bevy Hierarchy
 
-Bevy Hierarchy is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Hierarchy](https://github.com/bevyengine/bevy/tree/main/crates/bevy_hierarchy) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_input/README.md
+++ b/crates/bevy_input/README.md
@@ -1,5 +1,5 @@
 # Bevy Input
 
-[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_input/README.md
+++ b/crates/bevy_input/README.md
@@ -1,5 +1,5 @@
 # Bevy Input
 
-[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_input/README.md
+++ b/crates/bevy_input/README.md
@@ -1,5 +1,5 @@
 # Bevy Input
 
-[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Input](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_input) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_input/README.md
+++ b/crates/bevy_input/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Input
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Input is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_input/README.md
+++ b/crates/bevy_input/README.md
@@ -1,5 +1,5 @@
 # Bevy Input
 
-Bevy Input is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Input](https://github.com/bevyengine/bevy/tree/main/crates/bevy_input) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_internal/README.md
+++ b/crates/bevy_internal/README.md
@@ -1,5 +1,5 @@
 # Bevy Internal
 
-[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_internal/README.md
+++ b/crates/bevy_internal/README.md
@@ -1,5 +1,5 @@
 # Bevy Internal
 
-[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Internal](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_internal) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_internal/README.md
+++ b/crates/bevy_internal/README.md
@@ -1,5 +1,5 @@
 # Bevy Internal
 
-[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_internal/README.md
+++ b/crates/bevy_internal/README.md
@@ -1,5 +1,5 @@
 # Bevy Internal
 
-Bevy Internal is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Internal](https://github.com/bevyengine/bevy/tree/main/crates/bevy_internal) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_internal/README.md
+++ b/crates/bevy_internal/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Internal
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Internal is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_log/README.md
+++ b/crates/bevy_log/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Log
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Log is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_log/README.md
+++ b/crates/bevy_log/README.md
@@ -1,5 +1,5 @@
 # Bevy Log
 
-[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Log](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_log) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_log/README.md
+++ b/crates/bevy_log/README.md
@@ -1,5 +1,5 @@
 # Bevy Log
 
-[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_log/README.md
+++ b/crates/bevy_log/README.md
@@ -1,5 +1,5 @@
 # Bevy Log
 
-[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_log/README.md
+++ b/crates/bevy_log/README.md
@@ -1,5 +1,5 @@
 # Bevy Log
 
-Bevy Log is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Log](https://github.com/bevyengine/bevy/tree/main/crates/bevy_log) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_macro_utils/README.md
+++ b/crates/bevy_macro_utils/README.md
@@ -1,5 +1,5 @@
 # Bevy Macro Utils
 
-[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_macro_utils/README.md
+++ b/crates/bevy_macro_utils/README.md
@@ -1,5 +1,5 @@
 # Bevy Macro Utils
 
-Bevy Macro Utils is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_macro_utils/README.md
+++ b/crates/bevy_macro_utils/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Macro Utils
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Macro Utils is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_macro_utils/README.md
+++ b/crates/bevy_macro_utils/README.md
@@ -1,5 +1,5 @@
 # Bevy Macro Utils
 
-[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_macro_utils) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_macro_utils/README.md
+++ b/crates/bevy_macro_utils/README.md
@@ -1,5 +1,5 @@
 # Bevy Macro Utils
 
-[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Macro Utils](https://github.com/bevyengine/bevy/tree/main/crates/bevy_macro_utils)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_math/README.md
+++ b/crates/bevy_math/README.md
@@ -1,5 +1,5 @@
 # Bevy Math
 
-[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_math/README.md
+++ b/crates/bevy_math/README.md
@@ -1,5 +1,5 @@
 # Bevy Math
 
-Bevy Math is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_math/README.md
+++ b/crates/bevy_math/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Math
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Math is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_math/README.md
+++ b/crates/bevy_math/README.md
@@ -1,5 +1,5 @@
 # Bevy Math
 
-[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_math/README.md
+++ b/crates/bevy_math/README.md
@@ -1,5 +1,5 @@
 # Bevy Math
 
-[Bevy Math](https://github.com/bevyengine/bevy/tree/main/crates/bevy_math)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Math](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_math) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_mikktspace/README.md
+++ b/crates/bevy_mikktspace/README.md
@@ -1,6 +1,6 @@
 # bevy_mikktspace
 
-This is a fork of [https://github.com/gltf-rs/mikktspace](https://github.com/gltf-rs/mikktspace), which in turn is a port of the Mikkelsen Tangent Space Algorithm reference implementation to Rust. It has been forked for use in the bevy game engine to be able to update maths crate dependencies in lock-step with bevy releases. It is vendored in the bevy repository itself as [crates/bevy_mikktspace](https://github.com/bevyengine/bevy/tree/main/crates/bevy_mikktspace).
+This is a fork of [https://github.com/gltf-rs/mikktspace](https://github.com/gltf-rs/mikktspace), which in turn is a port of the Mikkelsen Tangent Space Algorithm reference implementation to Rust. It has been forked for use in the bevy game engine to be able to update maths crate dependencies in lock-step with bevy releases. It is vendored in the bevy repository itself as [crates/bevy_mikktspace](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_mikktspace).
 
 Port of the [Mikkelsen Tangent Space Algorithm](https://en.blender.org/index.php/Dev:Shading/Tangent_Space_Normal_Maps) reference implementation.
 

--- a/crates/bevy_pbr/README.md
+++ b/crates/bevy_pbr/README.md
@@ -1,5 +1,5 @@
 # Bevy PBR
 
-Bevy PBR is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_pbr/README.md
+++ b/crates/bevy_pbr/README.md
@@ -1,5 +1,5 @@
 # Bevy PBR
 
-[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_pbr/README.md
+++ b/crates/bevy_pbr/README.md
@@ -1,5 +1,5 @@
 # Bevy PBR
 
-[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_pbr/README.md
+++ b/crates/bevy_pbr/README.md
@@ -1,5 +1,5 @@
 # Bevy PBR
 
-[Bevy PBR](https://github.com/bevyengine/bevy/tree/main/crates/bevy_pbr)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy PBR](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_pbr) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_pbr/README.md
+++ b/crates/bevy_pbr/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy PBR
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy PBR is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_reflect/bevy_reflect_derive/README.md
+++ b/crates/bevy_reflect/bevy_reflect_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Reflect Derive
 
-Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_reflect/bevy_reflect_derive/README.md
+++ b/crates/bevy_reflect/bevy_reflect_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Reflect Derive
 
-Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+Bevy Reflect Derive  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_reflect/bevy_reflect_derive/README.md
+++ b/crates/bevy_reflect/bevy_reflect_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Reflect Derive
 
-Bevy Reflect Derive  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+Bevy Reflect Derive is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_reflect/bevy_reflect_derive/README.md
+++ b/crates/bevy_reflect/bevy_reflect_derive/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Reflect Derive
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_reflect/bevy_reflect_derive/README.md
+++ b/crates/bevy_reflect/bevy_reflect_derive/README.md
@@ -1,5 +1,5 @@
 # Bevy Reflect Derive
 
-Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Reflect Derive is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/README.md
+++ b/crates/bevy_render/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Render
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Render is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_render/README.md
+++ b/crates/bevy_render/README.md
@@ -1,5 +1,5 @@
 # Bevy Render
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/README.md
+++ b/crates/bevy_render/README.md
@@ -1,5 +1,5 @@
 # Bevy Render
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/README.md
+++ b/crates/bevy_render/README.md
@@ -1,5 +1,5 @@
 # Bevy Render
 
-Bevy Render is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/README.md
+++ b/crates/bevy_render/README.md
@@ -1,5 +1,5 @@
 # Bevy Render
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_render) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/macros/README.md
+++ b/crates/bevy_render/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Render Macros
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_render/macros) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/macros/README.md
+++ b/crates/bevy_render/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Render Macros
 
-Bevy Render Macros is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/macros/README.md
+++ b/crates/bevy_render/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Render Macros
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_render/macros/README.md
+++ b/crates/bevy_render/macros/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Render Macros
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Render Macros is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_render/macros/README.md
+++ b/crates/bevy_render/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Render Macros
 
-[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Render](https://github.com/bevyengine/bevy/tree/main/crates/bevy_render/macros) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_scene/README.md
+++ b/crates/bevy_scene/README.md
@@ -1,5 +1,5 @@
 # Bevy Scene
 
-Bevy Scene is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_scene/README.md
+++ b/crates/bevy_scene/README.md
@@ -1,5 +1,5 @@
 # Bevy Scene
 
-[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_scene/README.md
+++ b/crates/bevy_scene/README.md
@@ -1,5 +1,5 @@
 # Bevy Scene
 
-[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Scene](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_scene) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_scene/README.md
+++ b/crates/bevy_scene/README.md
@@ -1,5 +1,5 @@
 # Bevy Scene
 
-[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Scene](https://github.com/bevyengine/bevy/tree/main/crates/bevy_scene) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_scene/README.md
+++ b/crates/bevy_scene/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Scene
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Scene is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_sprite/README.md
+++ b/crates/bevy_sprite/README.md
@@ -1,5 +1,5 @@
 # Bevy Sprite
 
-[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_sprite/README.md
+++ b/crates/bevy_sprite/README.md
@@ -1,5 +1,5 @@
 # Bevy Sprite
 
-[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_sprite/README.md
+++ b/crates/bevy_sprite/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Sprite
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Sprite is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_sprite/README.md
+++ b/crates/bevy_sprite/README.md
@@ -1,5 +1,5 @@
 # Bevy Sprite
 
-[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Sprite](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_sprite) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_sprite/README.md
+++ b/crates/bevy_sprite/README.md
@@ -1,5 +1,5 @@
 # Bevy Sprite
 
-Bevy Sprite is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Sprite](https://github.com/bevyengine/bevy/tree/main/crates/bevy_sprite) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_text/README.md
+++ b/crates/bevy_text/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Text
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Text is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_text/README.md
+++ b/crates/bevy_text/README.md
@@ -1,5 +1,5 @@
 # Bevy Text
 
-[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_text/README.md
+++ b/crates/bevy_text/README.md
@@ -1,5 +1,5 @@
 # Bevy Text
 
-[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text) is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_text/README.md
+++ b/crates/bevy_text/README.md
@@ -1,5 +1,5 @@
 # Bevy Text
 
-[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text)  is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Text](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_text) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_text/README.md
+++ b/crates/bevy_text/README.md
@@ -1,5 +1,5 @@
 # Bevy Text
 
-Bevy Text is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Text](https://github.com/bevyengine/bevy/tree/main/crates/bevy_text) is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -1,5 +1,7 @@
 # Bevy Time
 
-The built-in timekeeping plugin for the [Bevy Engine](https://bevyengine.org/).
+The built-in timekeeping plugin for the Bevy game engine.
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -1,5 +1,5 @@
 # Bevy Time
 
-Bevy Time is a component of the [Bevy Engine](https://bevyengine.org/).
+The built-in timekeeping plugin for the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -2,6 +2,6 @@
 
 The built-in timekeeping plugin for the Bevy game engine.
 
-[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Time](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_time) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -2,6 +2,6 @@
 
 The built-in timekeeping plugin for the Bevy game engine.
 
-[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -2,6 +2,6 @@
 
 The built-in timekeeping plugin for the Bevy game engine.
 
-[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Time](https://github.com/bevyengine/bevy/tree/main/crates/bevy_time)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_time/README.md
+++ b/crates/bevy_time/README.md
@@ -1,3 +1,5 @@
 # Bevy Time
 
-The built-in timekeeping plugin for the Bevy game engine.
+Bevy Time is a component of the [Bevy Engine](https://bevyengine.org/).
+
+It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,7 +1,7 @@
 # Bevy Transform
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.
 
 This crate is largely a 1:1 port from [legion_transform](https://github.com/AThilenius/legion_transform) (ecs: legion, math: nalgebra) to bevy (ecs: bevy_ecs, math: glam).

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,6 +1,6 @@
 # Bevy Transform
 
-[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Transform](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_transform) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.
 

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,6 +1,6 @@
 # Bevy Transform
 
-[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.
 

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -1,6 +1,6 @@
 # Bevy Transform
 
-[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Transform](https://github.com/bevyengine/bevy/tree/main/crates/bevy_transform)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.
 

--- a/crates/bevy_transform/README.md
+++ b/crates/bevy_transform/README.md
@@ -3,3 +3,5 @@
 Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+
+This crate is largely a 1:1 port from [legion_transform](https://github.com/AThilenius/legion_transform) (ecs: legion, math: nalgebra) to bevy (ecs: bevy_ecs, math: glam).

--- a/crates/bevy_ui/README.md
+++ b/crates/bevy_ui/README.md
@@ -1,5 +1,5 @@
 # Bevy UI
 
-[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ui/README.md
+++ b/crates/bevy_ui/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy UI
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy UI is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_ui/README.md
+++ b/crates/bevy_ui/README.md
@@ -1,5 +1,5 @@
 # Bevy UI
 
-Bevy UI is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ui/README.md
+++ b/crates/bevy_ui/README.md
@@ -1,5 +1,5 @@
 # Bevy UI
 
-[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_ui/README.md
+++ b/crates/bevy_ui/README.md
@@ -1,5 +1,5 @@
 # Bevy UI
 
-[Bevy UI](https://github.com/bevyengine/bevy/tree/main/crates/bevy_ui)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy UI](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_ui) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_utils/README.md
+++ b/crates/bevy_utils/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Utils
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Utils is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_utils/README.md
+++ b/crates/bevy_utils/README.md
@@ -1,5 +1,0 @@
-# Bevy Utils
-
-Bevy Utils is a component of the [Bevy Engine](https://bevyengine.org/).
-
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_utils/macros/README.md
+++ b/crates/bevy_utils/macros/README.md
@@ -1,0 +1,5 @@
+# Bevy Utils Proc Macros
+
+Bevy Utils Proc Macros is a component of the [Bevy Engine](https://bevyengine.org/).
+
+It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_utils/macros/README.md
+++ b/crates/bevy_utils/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Utils Proc Macros
 
-[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_utils/macros/README.md
+++ b/crates/bevy_utils/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Utils Proc Macros
 
-[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_utils/macros/README.md
+++ b/crates/bevy_utils/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Utils Proc Macros
 
-[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_utils/macros) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_utils/macros/README.md
+++ b/crates/bevy_utils/macros/README.md
@@ -1,5 +1,5 @@
 # Bevy Utils Proc Macros
 
-Bevy Utils Proc Macros is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Utils Proc Macros](https://github.com/bevyengine/bevy/tree/main/crates/bevy_utils/macros)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,5 +1,5 @@
 # Bevy Window
 
-[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Window](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_window) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,5 +1,5 @@
 # Bevy Window
 
-Bevy Window is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Window
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Window is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,5 +1,5 @@
 # Bevy Window
 
-[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_window/README.md
+++ b/crates/bevy_window/README.md
@@ -1,5 +1,5 @@
 # Bevy Window
 
-[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Window](https://github.com/bevyengine/bevy/tree/main/crates/bevy_window)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,5 +1,5 @@
-# Bevy Transform
+# Bevy Winit
 
-Bevy Transform is a component of the [Bevy Engine](https://bevyengine.org/).
+Bevy Winit is a component of the [Bevy Engine](https://bevyengine.org/).
 
 It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,5 +1,5 @@
 # Bevy Winit
 
-Bevy Winit is a component of the [Bevy Engine](https://bevyengine.org/).
+[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
-It is not intended for independent use, use it only as a part of [Bevy](https://crates.io/crates/bevy).
+This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,5 +1,5 @@
 # Bevy Winit
 
-[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,5 +1,5 @@
 # Bevy Winit
 
-[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)  is a component of the [Bevy Engine](https://bevyengine.org/). You can revise the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)  is a component of the [Bevy Engine](https://bevyengine.org/). You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.

--- a/crates/bevy_winit/README.md
+++ b/crates/bevy_winit/README.md
@@ -1,5 +1,5 @@
 # Bevy Winit
 
-[Bevy Winit](https://github.com/bevyengine/bevy/tree/main/crates/bevy_winit)   is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/main/crates).
+[Bevy Winit](https://github.com/bevyengine/bevy/tree/latest/crates/bevy_winit) is a component of the [Bevy](https://crates.io/crates/bevy) crate. You can review the list of official crates [here](https://github.com/bevyengine/bevy/tree/latest/crates).
 
 This crate is intended to be used as a part of [Bevy](https://crates.io/crates/bevy) and not independently. However, feel free to use it if it fits your needs.


### PR DESCRIPTION

# Objective

The majority of the Bevy crates don't have a README.md.

![Screenshot 2023-10-01 at 20 19 33](https://github.com/bevyengine/bevy/assets/104745335/4da20f3e-48bf-489f-93c3-c910ef94c38c)

I want to add a README so that when search for a crate on crates.io, it reports that:

- The crate is a component of the BevyEngine.
- The crate is not intended for independent use.
