### PR TITLE
Fixed: Use VertexOuput instead of FragmentInput in prepass.wgsl 

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -142,24 +142,6 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 }
 
 #ifdef PREPASS_FRAGMENT
-struct FragmentInput {
-#ifdef VERTEX_UVS
-    @location(0) uv: vec2<f32>,
-#endif // VERTEX_UVS
-
-#ifdef NORMAL_PREPASS
-    @location(1) world_normal: vec3<f32>,
-#endif // NORMAL_PREPASS
-
-#ifdef MOTION_VECTOR_PREPASS
-    @location(3) world_position: vec4<f32>,
-    @location(4) previous_world_position: vec4<f32>,
-#endif // MOTION_VECTOR_PREPASS
-
-#ifdef DEPTH_CLAMP_ORTHO
-    @location(5) clip_position_unclamped: vec4<f32>,
-#endif // DEPTH_CLAMP_ORTHO
-}
 
 struct FragmentOutput {
 #ifdef NORMAL_PREPASS
@@ -176,7 +158,7 @@ struct FragmentOutput {
 }
 
 @fragment
-fn fragment(in: FragmentInput) -> FragmentOutput {
+fn fragment(in: VertexOutput) -> FragmentOutput {
     var out: FragmentOutput;
 
 #ifdef NORMAL_PREPASS

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -32,8 +32,8 @@ struct Vertex {
 #endif // MORPH_TARGETS
 }
 
-struct VertexOutput {
-    @builtin(position) clip_position: vec4<f32>,
+struct PrepassMeshVertexOutput {
+    @builtin(position) position: vec4<f32>,
 
 #ifdef VERTEX_UVS
     @location(0) uv: vec2<f32>,
@@ -78,8 +78,8 @@ fn morph_vertex(vertex_in: Vertex) -> Vertex {
 #endif
 
 @vertex
-fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
-    var out: VertexOutput;
+fn vertex(vertex_no_morph: Vertex) -> PrepassMeshVertexOutput {
+    var out: PrepassMeshVertexOutput;
 
 #ifdef MORPH_TARGETS
     var vertex = morph_vertex(vertex_no_morph);
@@ -95,10 +95,10 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var model = bevy_pbr::mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
 #endif // SKINNED
 
-    out.clip_position = bevy_pbr::mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
+    out.position = bevy_pbr::mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
 #ifdef DEPTH_CLAMP_ORTHO
-    out.clip_position_unclamped = out.clip_position;
-    out.clip_position.z = min(out.clip_position.z, 1.0);
+    out.clip_position_unclamped = out.position;
+    out.position.z = min(out.position.z, 1.0);
 #endif // DEPTH_CLAMP_ORTHO
 
 #ifdef VERTEX_UVS
@@ -142,7 +142,6 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 }
 
 #ifdef PREPASS_FRAGMENT
-
 struct FragmentOutput {
 #ifdef NORMAL_PREPASS
     @location(0) normal: vec4<f32>,
@@ -158,7 +157,7 @@ struct FragmentOutput {
 }
 
 @fragment
-fn fragment(in: VertexOutput) -> FragmentOutput {
+fn fragment(in: PrepassMeshVertexOutput) -> FragmentOutput {
     var out: FragmentOutput;
 
 #ifdef NORMAL_PREPASS


### PR DESCRIPTION
Fix Inconsistency between `VertexOutput` and `FragmentInput` in `prepass.wgsl`

# Objective
Fixes #9402 - 
Encountered this bug:
```
2023-08-09T20:52:12.883651Z ERROR wgpu::backend::direct: Handling wgpu errors as fatal by default
thread 'Compute Task Pool (1)' panicked at /home/jlewis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.16.3/src/backend/direct.rs:3019:5:
wgpu error: Validation Error

Caused by:
    In Device::create_render_pipeline
      note: label = `prepass_pipeline`
    Error matching ShaderStages(FRAGMENT) shader requirements against the pipeline
    Location[2] is provided by the previous stage output but is not consumed as input by this stage.


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::render_resource::pipeline_cache::PipelineCache::process_pipeline_queue_system`!
thread 'Compute Task Pool (0)' panicked at /home/jlewis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bevy_render-0.11.0/src/pipelined_rendering.rs:135:45:
called `Result::unwrap()` on an `Err` value: RecvError
```
The reason was that the `FragmentInput` in the `prepass.wgsl` was missing `@location(2)` which is the `VERTEX_TANGENTS`.

## Solution
- Remove `FragmentInput` in `prepass.wgsl` use `VertexOutput` instead
- Rename `VertexOutput` to `PrepassMeshVertexOutput`
- Rename `clip_position` to `position` in `PrepassMeshVertexOutput`

