### PR TITLE
Allow Bevy to start from non-main threads on supported platforms

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -64,7 +64,7 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_winit")]
         {
-            group = group.add(bevy_winit::WinitPlugin);
+            group = group.add(bevy_winit::WinitPlugin::default());
         }
 
         #[cfg(feature = "bevy_render")]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -83,7 +83,7 @@ pub struct WinitPlugin {
     /// Only works on Linux (X11/Wayland) and Windows.
     /// This field is ignored on other platforms.
     ///
-    /// [`winit with_any_thread`]: https://docs.rs/winit/latest/winit/event_loop/struct.EventLoopBuilder.html#method.with_any_thread
+    /// [`winit with_any_thread`]: winit::event_loop::EventLoopBuilder::with_any_thread
     pub run_on_any_thread: bool,
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -72,7 +72,20 @@ pub static ANDROID_APP: std::sync::OnceLock<AndroidApp> = std::sync::OnceLock::n
 /// replace the existing [`App`] runner with one that constructs an [event loop](EventLoop) to
 /// receive window and input events from the OS.
 #[derive(Default)]
-pub struct WinitPlugin;
+pub struct WinitPlugin {
+    /// Allows the window (and the event loop) to be created on any thread
+    /// instead of only the main thread.
+    ///
+    /// See [`winit with_any_thread`].
+    ///
+    /// # Supported platforms
+    ///
+    /// Only works on Linux (X11/Wayland) and Windows.
+    /// This field is ignored on other platforms.
+    ///
+    /// [`winit with_any_thread`]: https://docs.rs/winit/latest/winit/event_loop/struct.EventLoopBuilder.html#method.with_any_thread
+    pub run_on_any_thread: bool,
+}
 
 impl Plugin for WinitPlugin {
     fn build(&self, app: &mut App) {
@@ -90,20 +103,20 @@ impl Plugin for WinitPlugin {
                 // A use case for this is to allow external applications to spawn a thread
                 // which runs a Bevy app without requiring the Bevy app to need to reside on
                 // the main thread, which can be problematic.
-                event_loop_builder.with_any_thread(true);
+                event_loop_builder.with_any_thread(self.run_on_any_thread);
             }
 
             #[cfg(feature = "wayland")]
             {
                 use winit::platform::wayland::EventLoopBuilderExtWayland;
-                event_loop_builder.with_any_thread(true);
+                event_loop_builder.with_any_thread(self.run_on_any_thread);
             }
         }
 
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::EventLoopBuilderExtWindows;
-            event_loop_builder.with_any_thread(true);
+            event_loop_builder.with_any_thread(self.run_on_any_thread);
         }
 
         #[cfg(target_os = "android")]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -78,21 +78,26 @@ impl Plugin for WinitPlugin {
     fn build(&self, app: &mut App) {
         let mut event_loop_builder = EventLoopBuilder::<()>::with_user_event();
 
-        #[cfg(feature = "x11")]
+        // This is needed because the X11 feature
+        // might be enabled for macos too.
+        #[cfg(target_os = "linux")]
         {
-            use winit::platform::x11::EventLoopBuilderExtX11;
+            #[cfg(feature = "x11")]
+            {
+                use winit::platform::x11::EventLoopBuilderExtX11;
 
-            // This allows a Bevy app to be started and ran outside of the main thread.
-            // A use case for this is to allow external applications to spawn a thread
-            // which runs a Bevy app without requiring the Bevy app to need to reside on
-            // the main thread, which can be problematic.
-            event_loop_builder.with_any_thread(true);
-        }
+                // This allows a Bevy app to be started and ran outside of the main thread.
+                // A use case for this is to allow external applications to spawn a thread
+                // which runs a Bevy app without requiring the Bevy app to need to reside on
+                // the main thread, which can be problematic.
+                event_loop_builder.with_any_thread(true);
+            }
 
-        #[cfg(feature = "wayland")]
-        {
-            use winit::platform::wayland::EventLoopBuilderExtWayland;
-            event_loop_builder.with_any_thread(true);
+            #[cfg(feature = "wayland")]
+            {
+                use winit::platform::wayland::EventLoopBuilderExtWayland;
+                event_loop_builder.with_any_thread(true);
+            }
         }
 
         #[cfg(target_os = "android")]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -78,8 +78,8 @@ impl Plugin for WinitPlugin {
     fn build(&self, app: &mut App) {
         let mut event_loop_builder = EventLoopBuilder::<()>::with_user_event();
 
-        // This is needed because the X11 feature
-        // might be enabled for macos too.
+        // This is needed because the features checked in the inner
+        // block might be enabled on other platforms than linux.
         #[cfg(target_os = "linux")]
         {
             #[cfg(feature = "x11")]

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -76,14 +76,12 @@ pub struct WinitPlugin {
     /// Allows the window (and the event loop) to be created on any thread
     /// instead of only the main thread.
     ///
-    /// See [`winit with_any_thread`].
+    /// See [`EventLoopBuilder::build`] for more information on this.
     ///
     /// # Supported platforms
     ///
     /// Only works on Linux (X11/Wayland) and Windows.
     /// This field is ignored on other platforms.
-    ///
-    /// [`winit with_any_thread`]: winit::event_loop::EventLoopBuilder::with_any_thread
     pub run_on_any_thread: bool,
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -100,6 +100,12 @@ impl Plugin for WinitPlugin {
             }
         }
 
+        #[cfg(target_os = "windows")]
+        {
+            use winit::platform::windows::EventLoopBuilderExtWindows;
+            event_loop_builder.with_any_thread(true);
+        }
+
         #[cfg(target_os = "android")]
         {
             use winit::platform::android::EventLoopBuilderExtAndroid;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -77,6 +77,24 @@ pub struct WinitPlugin;
 impl Plugin for WinitPlugin {
     fn build(&self, app: &mut App) {
         let mut event_loop_builder = EventLoopBuilder::<()>::with_user_event();
+
+        #[cfg(feature = "x11")]
+        {
+            use winit::platform::x11::EventLoopBuilderExtX11;
+
+            // This allows a Bevy app to be started and ran outside of the main thread.
+            // A use case for this is to allow external applications to spawn a thread
+            // which runs a Bevy app without requiring the Bevy app to need to reside on
+            // the main thread, which can be problematic.
+            event_loop_builder.with_any_thread(true);
+        }
+
+        #[cfg(feature = "wayland")]
+        {
+            use winit::platform::wayland::EventLoopBuilderExtWayland;
+            event_loop_builder.with_any_thread(true);
+        }
+
         #[cfg(target_os = "android")]
         {
             use winit::platform::android::EventLoopBuilderExtAndroid;


### PR DESCRIPTION
# Objective

Allow Bevy apps to run without requiring to start from the main thread.
This allows other projects and applications to do things like spawning a normal or scoped
thread and run Bevy applications there.

The current behaviour if you try this is a panic.

## Solution

Allow this by default on platforms winit supports this behaviour on (x11, Wayland, Windows).

---

## Changelog

### Added

- Added the ability to start Bevy apps outside of the main thread on x11, Wayland, Windows