### PR TITLE
Updates for rust 1.73

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -334,7 +334,7 @@ impl App {
     /// initial state.
     ///
     /// If you would like to control how other systems run based on the current state,
-    /// you can emulate this behavior using the [`in_state`] [`Condition`](bevy_ecs::schedule::Condition).
+    /// you can emulate this behavior using the [`in_state`] [`Condition`].
     ///
     /// Note that you can also apply state transitions at other points in the schedule
     /// by adding the [`apply_state_transition`] system manually.

--- a/crates/bevy_app/src/plugin.rs
+++ b/crates/bevy_app/src/plugin.rs
@@ -51,7 +51,7 @@ pub trait Plugin: Downcast + Any + Send + Sync {
         std::any::type_name::<Self>()
     }
 
-    /// If the plugin can be meaningfully instantiated several times in an [`App`](crate::App),
+    /// If the plugin can be meaningfully instantiated several times in an [`App`],
     /// override this method to return `false`.
     fn is_unique(&self) -> bool {
         true

--- a/crates/bevy_audio/src/audio_output.rs
+++ b/crates/bevy_audio/src/audio_output.rs
@@ -13,7 +13,7 @@ use crate::AudioSink;
 ///
 /// ## Note
 ///
-/// Initializing this resource will leak [`rodio::OutputStream`](rodio::OutputStream)
+/// Initializing this resource will leak [`rodio::OutputStream`]
 /// using [`std::mem::forget`].
 /// This is done to avoid storing this in the struct (and making this `!Send`)
 /// while preventing it from dropping (to avoid halting of audio).

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -535,7 +535,7 @@ impl_debug!(Res<'w, T>, Resource);
 ///
 /// See the [`Resource`] documentation for usage.
 ///
-/// If you need a shared borrow, use [`Res`](crate::system::Res) instead.
+/// If you need a shared borrow, use [`Res`] instead.
 ///
 /// # Panics
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -266,7 +266,7 @@ impl ComponentInfo {
 }
 
 /// A value which uniquely identifies the type of a [`Component`] within a
-/// [`World`](crate::world::World).
+/// [`World`].
 ///
 /// Each time a new `Component` type is registered within a `World` using
 /// [`World::init_component`](crate::world::World::init_component) or

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -616,10 +616,10 @@ impl_tick_filter!(
 
 /// A marker trait to indicate that the filter works at an archetype level.
 ///
-/// This is needed to implement [`ExactSizeIterator`](std::iter::ExactSizeIterator) for
+/// This is needed to implement [`ExactSizeIterator`] for
 /// [`QueryIter`](crate::query::QueryIter) that contains archetype-level filters.
 ///
-/// The trait must only be implement for filters where its corresponding [`WorldQuery::IS_ARCHETYPAL`](crate::query::WorldQuery::IS_ARCHETYPAL)
+/// The trait must only be implement for filters where its corresponding [`WorldQuery::IS_ARCHETYPAL`]
 /// is [`prim@true`]. As such, only the [`With`] and [`Without`] filters can implement the trait.
 /// [Tuples](prim@tuple) and [`Or`] filters are automatically implemented with the trait only if its containing types
 /// also implement the same trait.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -274,7 +274,7 @@ impl Schedule {
 
     /// Set whether the schedule applies deferred system buffers on final time or not. This is a catch-all
     /// in case a system uses commands but was not explicitly ordered before an instance of
-    /// [`apply_deferred`](crate::prelude::apply_deferred). By default this
+    /// [`apply_deferred`]. By default this
     /// setting is true, but may be disabled if needed.
     pub fn set_apply_final_deferred(&mut self, apply_final_deferred: bool) -> &mut Self {
         self.executor.set_apply_final_deferred(apply_final_deferred);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! System functions can have parameters, through which one can query and mutate Bevy ECS state.
 //! Only types that implement [`SystemParam`] can be used, automatically fetching data from
-//! the [`World`](crate::world::World).
+//! the [`World`].
 //!
 //! System functions often look like this:
 //!

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -383,7 +383,7 @@ impl World {
         }
     }
 
-    /// Returns the components of an [`Entity`](crate::entity::Entity) through [`ComponentInfo`](crate::component::ComponentInfo).
+    /// Returns the components of an [`Entity`] through [`ComponentInfo`].
     #[inline]
     pub fn inspect_entity(&self, entity: Entity) -> Vec<&ComponentInfo> {
         let entity_location = self
@@ -1766,7 +1766,7 @@ impl World {
     /// Iterates all component change ticks and clamps any older than [`MAX_CHANGE_AGE`](crate::change_detection::MAX_CHANGE_AGE).
     /// This prevents overflow and thus prevents false positives.
     ///
-    /// **Note:** Does nothing if the [`World`] counter has not been incremented at least [`CHECK_TICK_THRESHOLD`](crate::change_detection::CHECK_TICK_THRESHOLD)
+    /// **Note:** Does nothing if the [`World`] counter has not been incremented at least [`CHECK_TICK_THRESHOLD`]
     /// times since the previous pass.
     // TODO: benchmark and optimize
     pub fn check_change_ticks(&mut self) {

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -26,14 +26,14 @@ use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
 /// In rust, having a `&mut World` means that there are absolutely no other references to the safe world alive at the same time,
 /// without exceptions. Not even unsafe code can change this.
 ///
-/// But there are situations where careful shared mutable access through a type is possible and safe. For this, rust provides the [`UnsafeCell`](std::cell::UnsafeCell)
+/// But there are situations where careful shared mutable access through a type is possible and safe. For this, rust provides the [`UnsafeCell`]
 /// escape hatch, which allows you to get a `*mut T` from a `&UnsafeCell<T>` and around which safe abstractions can be built.
 ///
 /// Access to resources and components can be done uniquely using [`World::resource_mut`] and [`World::entity_mut`], and shared using [`World::resource`] and [`World::entity`].
 /// These methods use lifetimes to check at compile time that no aliasing rules are being broken.
 ///
 /// This alone is not enough to implement bevy systems where multiple systems can access *disjoint* parts of the world concurrently. For this, bevy stores all values of
-/// resources and components (and [`ComponentTicks`](crate::component::ComponentTicks)) in [`UnsafeCell`](std::cell::UnsafeCell)s, and carefully validates disjoint access patterns using
+/// resources and components (and [`ComponentTicks`]) in [`UnsafeCell`]s, and carefully validates disjoint access patterns using
 /// APIs like [`System::component_access`](crate::system::System::component_access).
 ///
 /// A system then can be executed using [`System::run_unsafe`](crate::system::System::run_unsafe) with a `&World` and use methods with interior mutability to access resource values.
@@ -909,7 +909,7 @@ impl<'w> UnsafeWorldCell<'w> {
     }
 }
 
-/// Get an untyped pointer to a particular [`Component`](crate::component::Component) on a particular [`Entity`] in the provided [`World`](crate::world::World).
+/// Get an untyped pointer to a particular [`Component`] on a particular [`Entity`] in the provided [`World`].
 ///
 /// # Safety
 /// - `location` must refer to an archetype that contains `entity`
@@ -937,7 +937,7 @@ unsafe fn get_component(
     }
 }
 
-/// Get an untyped pointer to a particular [`Component`](crate::component::Component) and its [`ComponentTicks`]
+/// Get an untyped pointer to a particular [`Component`] and its [`ComponentTicks`]
 ///
 /// # Safety
 /// - `location` must refer to an archetype that contains `entity`

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -336,19 +336,19 @@ impl<'w> WorldCell<'w> {
         }
     }
 
-    /// Sends an [`Event`](crate::event::Event).
+    /// Sends an [`Event`].
     #[inline]
     pub fn send_event<E: Event>(&self, event: E) {
         self.send_event_batch(std::iter::once(event));
     }
 
-    /// Sends the default value of the [`Event`](crate::event::Event) of type `E`.
+    /// Sends the default value of the [`Event`] of type `E`.
     #[inline]
     pub fn send_event_default<E: Event + Default>(&self) {
         self.send_event_batch(std::iter::once(E::default()));
     }
 
-    /// Sends a batch of [`Event`](crate::event::Event)s from an iterator.
+    /// Sends a batch of [`Event`]s from an iterator.
     #[inline]
     pub fn send_event_batch<E: Event>(&self, events: impl Iterator<Item = E>) {
         match self.get_resource_mut::<Events<E>>() {

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/entity_ref_mut_lifetime_safety.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as im
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:17:26
    |
 16 |         let gotten: &A = e_mut.get::<A>().unwrap();
-   |                          ---------------- immutable borrow occurs here
+   |                          ----- immutable borrow occurs here
 17 |         let gotten2: A = e_mut.take::<A>().unwrap();
    |                          ^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 18 |         assert_eq!(gotten, &gotten2); // oops UB
@@ -12,9 +12,9 @@ error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:25:30
    |
 24 |         let mut gotten: Mut<A> = e_mut.get_mut::<A>().unwrap();
-   |                                  -------------------- first mutable borrow occurs here
+   |                                  ----- first mutable borrow occurs here
 25 |         let mut gotten2: A = e_mut.take::<A>().unwrap();
-   |                              ^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |                              ^^^^^ second mutable borrow occurs here
 26 |         assert_eq!(&mut *gotten, &mut gotten2); // oops UB
    |                          ------ first borrow later used here
 
@@ -25,7 +25,7 @@ error[E0505]: cannot move out of `e_mut` because it is borrowed
    |         --------- binding `e_mut` declared here
 ...
 32 |         let gotten: &A = e_mut.get::<A>().unwrap();
-   |                          ---------------- borrow of `e_mut` occurs here
+   |                          ----- borrow of `e_mut` occurs here
 33 |         e_mut.despawn();
    |         ^^^^^ move out of `e_mut` occurs here
 34 |         assert_eq!(gotten, &A(Box::new(14_usize))); // oops UB
@@ -35,7 +35,7 @@ error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as im
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:42:34
    |
 41 |         let gotten: &A = e_mut.get::<A>().unwrap();
-   |                          ---------------- immutable borrow occurs here
+   |                          ----- immutable borrow occurs here
 42 |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
    |                                  ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 43 |         assert_eq!(gotten, &*gotten_mut); // oops UB
@@ -45,9 +45,9 @@ error[E0502]: cannot borrow `e_mut` as immutable because it is also borrowed as 
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:48:26
    |
 47 |         let gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
-   |                                  -------------------- mutable borrow occurs here
+   |                                  ----- mutable borrow occurs here
 48 |         let gotten: &A = e_mut.get::<A>().unwrap();
-   |                          ^^^^^^^^^^^^^^^^ immutable borrow occurs here
+   |                          ^^^^^ immutable borrow occurs here
 49 |         assert_eq!(gotten, &*gotten_mut); // oops UB
    |                              ---------- mutable borrow later used here
 
@@ -55,7 +55,7 @@ error[E0502]: cannot borrow `e_mut` as mutable because it is also borrowed as im
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:54:9
    |
 53 |         let gotten: &A = e_mut.get::<A>().unwrap();
-   |                          ---------------- immutable borrow occurs here
+   |                          ----- immutable borrow occurs here
 54 |         e_mut.insert::<B>(B);
    |         ^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 55 |         assert_eq!(gotten, &A(Box::new(16_usize))); // oops UB
@@ -65,8 +65,8 @@ error[E0499]: cannot borrow `e_mut` as mutable more than once at a time
   --> tests/ui/entity_ref_mut_lifetime_safety.rs:61:9
    |
 60 |         let mut gotten_mut: Mut<A> = e_mut.get_mut::<A>().unwrap();
-   |                                      -------------------- first mutable borrow occurs here
+   |                                      ----- first mutable borrow occurs here
 61 |         e_mut.insert::<B>(B);
-   |         ^^^^^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |         ^^^^^ second mutable borrow occurs here
 62 |         assert_eq!(&mut *gotten_mut, &mut A(Box::new(16_usize))); // oops UB
    |                          ---------- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_lifetime_safety.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:17:39
    |
 16 |             let data: &Foo = query.get(e).unwrap();
-   |                              ------------ immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 17 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 18 |             assert_eq!(data, &mut *data2); // oops UB
@@ -12,9 +12,9 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:23:30
    |
 22 |             let mut data2: Mut<Foo> = query.get_mut(e).unwrap();
-   |                                       ---------------- mutable borrow occurs here
+   |                                       ----- mutable borrow occurs here
 23 |             let data: &Foo = query.get(e).unwrap();
-   |                              ^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 24 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
@@ -22,7 +22,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:29:39
    |
 28 |             let data: &Foo = query.get_component::<Foo>(e).unwrap();
-   |                              ----------------------------- immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 29 |             let mut data2: Mut<Foo> = query.get_component_mut(e).unwrap();
    |                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 30 |             assert_eq!(data, &mut *data2); // oops UB
@@ -32,9 +32,9 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:35:30
    |
 34 |             let mut data2: Mut<Foo> = query.get_component_mut(e).unwrap();
-   |                                       -------------------------- mutable borrow occurs here
+   |                                       ----- mutable borrow occurs here
 35 |             let data: &Foo = query.get_component::<Foo>(e).unwrap();
-   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 36 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
@@ -42,7 +42,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:41:39
    |
 40 |             let data: &Foo = query.single();
-   |                              -------------- immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 41 |             let mut data2: Mut<Foo> = query.single_mut();
    |                                       ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 42 |             assert_eq!(data, &mut *data2); // oops UB
@@ -52,9 +52,9 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:47:30
    |
 46 |             let mut data2: Mut<Foo> = query.single_mut();
-   |                                       ------------------ mutable borrow occurs here
+   |                                       ----- mutable borrow occurs here
 47 |             let data: &Foo = query.single();
-   |                              ^^^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 48 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
@@ -62,7 +62,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:53:39
    |
 52 |             let data: &Foo = query.get_single().unwrap();
-   |                              ------------------ immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 53 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
    |                                       ^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 54 |             assert_eq!(data, &mut *data2); // oops UB
@@ -72,9 +72,9 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:59:30
    |
 58 |             let mut data2: Mut<Foo> = query.get_single_mut().unwrap();
-   |                                       ---------------------- mutable borrow occurs here
+   |                                       ----- mutable borrow occurs here
 59 |             let data: &Foo = query.get_single().unwrap();
-   |                              ^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 60 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
@@ -82,7 +82,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:65:39
    |
 64 |             let data: &Foo = query.iter().next().unwrap();
-   |                              ------------ immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 65 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
    |                                       ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 66 |             assert_eq!(data, &mut *data2); // oops UB
@@ -92,9 +92,9 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:71:30
    |
 70 |             let mut data2: Mut<Foo> = query.iter_mut().next().unwrap();
-   |                                       ---------------- mutable borrow occurs here
+   |                                       ----- mutable borrow occurs here
 71 |             let data: &Foo = query.iter().next().unwrap();
-   |                              ^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 72 |             assert_eq!(data, &mut *data2); // oops UB
    |                                    ----- mutable borrow later used here
 
@@ -102,7 +102,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_lifetime_safety.rs:79:13
    |
 78 |             query.for_each(|data| opt_data = Some(data));
-   |             -------------------------------------------- immutable borrow occurs here
+   |             ----- immutable borrow occurs here
 79 |             query.for_each_mut(|data| opt_data_2 = Some(data));
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ mutable borrow occurs here
 80 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
@@ -112,8 +112,8 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_lifetime_safety.rs:87:13
    |
 86 |             query.for_each_mut(|data| opt_data_2 = Some(data));
-   |             -------------------------------------------------- mutable borrow occurs here
+   |             ----- mutable borrow occurs here
 87 |             query.for_each(|data| opt_data = Some(data));
-   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+   |             ^^^^^ immutable borrow occurs here
 88 |             assert_eq!(opt_data.unwrap(), &mut *opt_data_2.unwrap()); // oops UB
    |                                                 ---------- mutable borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_to_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_to_readonly.stderr
@@ -7,7 +7,7 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   |              mutable borrow occurs here
   |              mutable borrow later used here
 9 |         for _ in query.to_readonly().iter() {}
-  |                  ^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+  |                  ^^^^^ immutable borrow occurs here
 
 error[E0502]: cannot borrow `query` as mutable because it is also borrowed as immutable
   --> tests/ui/query_to_readonly.rs:14:18
@@ -24,10 +24,10 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/query_to_readonly.rs:39:30
    |
 36 |         let mut mut_foo = query.single_mut();
-   |                           ------------------ mutable borrow occurs here
+   |                           ----- mutable borrow occurs here
 ...
 39 |         let readonly_query = query.to_readonly();
-   |                              ^^^^^^^^^^^^^^^^^^^ immutable borrow occurs here
+   |                              ^^^^^ immutable borrow occurs here
 ...
 43 |         *mut_foo = Foo;
    |          ------- mutable borrow later used here
@@ -36,7 +36,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/query_to_readonly.rs:55:27
    |
 51 |         let readonly_query = query.to_readonly();
-   |                              ------------------- immutable borrow occurs here
+   |                              ----- immutable borrow occurs here
 ...
 55 |         let mut mut_foo = query.single_mut();
    |                           ^^^^^^^^^^^^^^^^^^ mutable borrow occurs here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_lifetime_safety.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_get_lifetime_safety.rs:8:14
    |
 7  |     let a1 = query.get_mut(e).unwrap();
-   |              ---------------- first mutable borrow occurs here
+   |              ----- first mutable borrow occurs here
 8  |     let a2 = query.get_mut(e).unwrap();
-   |              ^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^ second mutable borrow occurs here
 9  |     // this should fail to compile
 10 |     println!("{} {}", a1.0, a2.0);
    |                       -- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_many_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_many_lifetime_safety.stderr
@@ -2,7 +2,7 @@ error[E0502]: cannot borrow `query` as mutable because it is also borrowed as im
   --> tests/ui/system_query_get_many_lifetime_safety.rs:8:14
    |
 7  |     let a1 = query.get_many([e, e]).unwrap();
-   |              ---------------------- immutable borrow occurs here
+   |              ----- immutable borrow occurs here
 8  |     let a2 = query.get_mut(e).unwrap();
    |              ^^^^^^^^^^^^^^^^ mutable borrow occurs here
 9  |     // this should fail to compile

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_many_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_get_many_mut_lifetime_safety.stderr
@@ -2,9 +2,9 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_get_many_mut_lifetime_safety.rs:8:14
    |
 7  |     let a1 = query.get_many_mut([e, e]).unwrap();
-   |              -------------------------- first mutable borrow occurs here
+   |              ----- first mutable borrow occurs here
 8  |     let a2 = query.get_mut(e).unwrap();
-   |              ^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^ second mutable borrow occurs here
 9  |     // this should fail to compile
 10 |     println!("{} {}", a1[0].0, a2.0);
    |                       ----- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `query` as mutable more than once at a time
   --> tests/ui/system_query_iter_lifetime_safety.rs:10:21
    |
 7  |     let mut iter = query.iter_mut();
-   |                    ---------------- first mutable borrow occurs here
+   |                    ----- first mutable borrow occurs here
 ...
 10 |     let mut iter2 = query.iter_mut();
-   |                     ^^^^^^^^^^^^^^^^ second mutable borrow occurs here
+   |                     ^^^^^ second mutable borrow occurs here
 ...
 14 |     println!("{}", a.0);
    |                    --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_iter_many_mut_lifetime_safety.stderr
@@ -2,7 +2,7 @@ error[E0499]: cannot borrow `iter` as mutable more than once at a time
   --> tests/ui/system_query_iter_many_mut_lifetime_safety.rs:9:25
    |
 9  |     while let Some(a) = iter.fetch_next() {
-   |                         ^^^^^^^^^^^^^^^^^ `iter` was mutably borrowed here in the previous iteration of the loop
+   |                         ^^^^ `iter` was mutably borrowed here in the previous iteration of the loop
 10 |         // this should fail to compile
 11 |         results.push(a);
-   |         --------------- first borrow used here, in later iteration of loop
+   |         ------- first borrow used here, in later iteration of loop

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_get_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_get_lifetime_safety.rs:10:14
    |
 7  |     let mut q2 = queries.p0();
-   |                  ------------ first mutable borrow occurs here
+   |                  ------- first mutable borrow occurs here
 ...
 10 |     let q1 = queries.p1();
-   |              ^^^^^^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^^^ second mutable borrow occurs here
 ...
 14 |     b.0 = a.0
    |     - first borrow later used here
@@ -14,10 +14,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_get_lifetime_safety.rs:21:18
    |
 18 |     let q1 = queries.p1();
-   |              ------------ first mutable borrow occurs here
+   |              ------- first mutable borrow occurs here
 ...
 21 |     let mut q2 = queries.p0();
-   |                  ^^^^^^^^^^^^ second mutable borrow occurs here
+   |                  ^^^^^^^ second mutable borrow occurs here
 ...
 25 |     b.0 = a.0
    |           --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_iter_lifetime_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_query_set_iter_lifetime_safety.stderr
@@ -2,10 +2,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_iter_lifetime_safety.rs:11:14
    |
 7  |     let mut q2 = queries.p0();
-   |                  ------------ first mutable borrow occurs here
+   |                  ------- first mutable borrow occurs here
 ...
 11 |     let q1 = queries.p1();
-   |              ^^^^^^^^^^^^ second mutable borrow occurs here
+   |              ^^^^^^^ second mutable borrow occurs here
 ...
 16 |     b.0 = a.0
    |     - first borrow later used here
@@ -14,10 +14,10 @@ error[E0499]: cannot borrow `queries` as mutable more than once at a time
   --> tests/ui/system_query_set_iter_lifetime_safety.rs:24:18
    |
 20 |     let q1 = queries.p1();
-   |              ------------ first mutable borrow occurs here
+   |              ------- first mutable borrow occurs here
 ...
 24 |     let mut q2 = queries.p0();
-   |                  ^^^^^^^^^^^^ second mutable borrow occurs here
+   |                  ^^^^^^^ second mutable borrow occurs here
 ...
 29 |     b.0 = a.0;
    |           --- first borrow later used here

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_state_iter_mut_overlap_safety.stderr
@@ -2,10 +2,10 @@ error[E0502]: cannot borrow `query` as immutable because it is also borrowed as 
   --> tests/ui/system_state_iter_mut_overlap_safety.rs:18:13
    |
 15 |         let mut_vec = query.iter_mut().collect::<Vec<bevy_ecs::prelude::Mut<A>>>();
-   |                       ---------------- mutable borrow occurs here
+   |                       ----- mutable borrow occurs here
 ...
 18 |             query.iter().collect::<Vec<&A>>(),
-   |             ^^^^^^^^^^^^ immutable borrow occurs here
+   |             ^^^^^ immutable borrow occurs here
 ...
 23 |             mut_vec.iter().map(|m| **m).collect::<Vec<A>>(),
-   |             -------------- mutable borrow later used here
+   |             ------- mutable borrow later used here

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -1,4 +1,4 @@
-//! A module for the [`Gizmos`](crate::gizmos::Gizmos) [`SystemParam`](bevy_ecs::system::SystemParam).
+//! A module for the [`Gizmos`] [`SystemParam`].
 
 use std::{f32::consts::TAU, iter};
 
@@ -23,7 +23,7 @@ pub(crate) struct GizmoStorage {
     pub strip_colors: Vec<ColorItem>,
 }
 
-/// A [`SystemParam`](bevy_ecs::system::SystemParam) for drawing gizmos.
+/// A [`SystemParam`] for drawing gizmos.
 ///
 /// They are drawn in immediate mode, which means they will be rendered only for
 /// the frames in which they are spawned.

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -14,7 +14,7 @@
 //! # bevy_ecs::system::assert_is_system(system);
 //! ```
 //!
-//! See the documentation on [`Gizmos`](crate::gizmos::Gizmos) for more examples.
+//! See the documentation on [`Gizmos`] for more examples.
 
 pub mod gizmos;
 

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -24,7 +24,7 @@ use bevy_ecs::schedule::State;
 ///
 /// In case multiple systems are checking for [`Input::just_pressed`] or [`Input::just_released`]
 /// but only one should react, for example in the case of triggering
-/// [`State`](bevy_ecs::schedule::State) change, you should consider clearing the input state, either by:
+/// [`State`] change, you should consider clearing the input state, either by:
 ///
 /// * Using [`Input::clear_just_pressed`] or [`Input::clear_just_released`] instead.
 /// * Calling [`Input::clear`] or [`Input::reset`] immediately after the state change.

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -19,7 +19,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// ## Usage
 ///
-/// The event is consumed inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system)
+/// The event is consumed inside of the [`keyboard_input_system`]
 /// to update the [`Input<KeyCode>`](crate::Input<KeyCode>) resource.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
@@ -70,16 +70,16 @@ pub fn keyboard_input_system(
     }
 }
 
-/// The key code of a [`KeyboardInput`](crate::keyboard::KeyboardInput).
+/// The key code of a [`KeyboardInput`].
 ///
 /// ## Usage
 ///
-/// It is used as the generic `T` value of an [`Input`](crate::Input) to create a `Res<Input<KeyCode>>`.
-/// The resource values are mapped to the current layout of the keyboard and correlate to an [`ScanCode`](ScanCode).
+/// It is used as the generic `T` value of an [`Input`] to create a `Res<Input<KeyCode>>`.
+/// The resource values are mapped to the current layout of the keyboard and correlate to an [`ScanCode`].
 ///
 /// ## Updating
 ///
-/// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
+/// The resource is updated inside of the [`keyboard_input_system`].
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
 #[reflect(Debug, Hash, PartialEq)]
 #[cfg_attr(
@@ -443,16 +443,16 @@ pub enum KeyCode {
     Cut,
 }
 
-/// The scan code of a [`KeyboardInput`](crate::keyboard::KeyboardInput).
+/// The scan code of a [`KeyboardInput`].
 ///
 /// ## Usage
 ///
-/// It is used as the generic `<T>` value of an [`Input`](crate::Input) to create a `Res<Input<ScanCode>>`.
-/// The resource values are mapped to the physical location of a key on the keyboard and correlate to an [`KeyCode`](KeyCode)
+/// It is used as the generic `<T>` value of an [`Input`] to create a `Res<Input<ScanCode>>`.
+/// The resource values are mapped to the physical location of a key on the keyboard and correlate to an [`KeyCode`]
 ///
 /// ## Updating
 ///
-/// The resource is updated inside of the [`keyboard_input_system`](crate::keyboard::keyboard_input_system).
+/// The resource is updated inside of the [`keyboard_input_system`].
 #[derive(Debug, Hash, Ord, PartialOrd, PartialEq, Eq, Clone, Copy, Reflect)]
 #[reflect(Debug, Hash, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -19,7 +19,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// ## Usage
 ///
-/// The event is read inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system)
+/// The event is read inside of the [`mouse_button_input_system`]
 /// to update the [`Input<MouseButton>`](crate::Input<MouseButton>) resource.
 #[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
@@ -41,12 +41,12 @@ pub struct MouseButtonInput {
 ///
 /// ## Usage
 ///
-/// It is used as the generic `T` value of an [`Input`](crate::Input) to create a `bevy`
+/// It is used as the generic `T` value of an [`Input`] to create a `bevy`
 /// resource.
 ///
 /// ## Updating
 ///
-/// The resource is updated inside of the [`mouse_button_input_system`](crate::mouse::mouse_button_input_system).
+/// The resource is updated inside of the [`mouse_button_input_system`].
 #[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 #[reflect(Debug, Hash, PartialEq)]
 #[cfg_attr(
@@ -88,7 +88,7 @@ pub struct MouseMotion {
 
 /// The scroll unit.
 ///
-/// Describes how a value of a [`MouseWheel`](crate::mouse::MouseWheel) event has to be interpreted.
+/// Describes how a value of a [`MouseWheel`] event has to be interpreted.
 ///
 /// The value of the event can either be interpreted as the amount of lines or the amount of pixels
 /// to scroll.
@@ -102,12 +102,12 @@ pub struct MouseMotion {
 pub enum MouseScrollUnit {
     /// The line scroll unit.
     ///
-    /// The delta of the associated [`MouseWheel`](crate::mouse::MouseWheel) event corresponds
+    /// The delta of the associated [`MouseWheel`] event corresponds
     /// to the amount of lines or rows to scroll.
     Line,
     /// The pixel scroll unit.
     ///
-    /// The delta of the associated [`MouseWheel`](crate::mouse::MouseWheel) event corresponds
+    /// The delta of the associated [`MouseWheel`] event corresponds
     /// to the amount of pixels to scroll.
     Pixel,
 }

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -53,7 +53,7 @@ pub struct TouchInput {
     pub id: u64,
 }
 
-/// A force description of a [`Touch`](crate::touch::Touch) input.
+/// A force description of a [`Touch`] input.
 #[derive(Debug, Clone, Copy, PartialEq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
@@ -92,7 +92,7 @@ pub enum ForceTouch {
     Normalized(f64),
 }
 
-/// A phase of a [`TouchInput`](crate::touch::TouchInput).
+/// A phase of a [`TouchInput`].
 ///
 /// ## Usage
 ///
@@ -223,7 +223,7 @@ impl From<&TouchInput> for Touch {
 ///
 /// ## Updating
 ///
-/// The resource is updated inside of the [`touch_screen_input_system`](crate::touch::touch_screen_input_system).
+/// The resource is updated inside of the [`touch_screen_input_system`].
 #[derive(Debug, Clone, Default, Resource)]
 pub struct Touches {
     /// A collection of every [`Touch`] that is currently being pressed.

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,9 +6,6 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -18,9 +15,6 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-  |
-  | pub trait DerefMut: Deref {
-  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -6,6 +6,9 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
@@ -15,6 +18,9 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
+  |
+  | pub trait DerefMut: Deref {
+  |                     ^^^^^ required by this bound in `DerefMut`
 
 error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:3:10

--- a/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/derive_data.rs
@@ -422,7 +422,7 @@ impl<'a> ReflectStruct<'a> {
 
     /// Access the data about which fields should be ignored during serialization.
     ///
-    /// The returned bitset is a collection of indices obtained from the [`members_to_serialization_denylist`](crate::utility::members_to_serialization_denylist) function.
+    /// The returned bitset is a collection of indices obtained from the [`members_to_serialization_denylist`] function.
     #[allow(dead_code)]
     pub fn serialization_denylist(&self) -> &BitSet<u32> {
         &self.serialization_denylist

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -404,7 +404,7 @@ impl CameraRenderGraph {
     }
 }
 
-/// The "target" that a [`Camera`] will render to. For example, this could be a [`Window`](bevy_window::Window)
+/// The "target" that a [`Camera`] will render to. For example, this could be a [`Window`]
 /// swapchain or an [`Image`].
 #[derive(Debug, Clone, Reflect)]
 pub enum RenderTarget {

--- a/crates/bevy_render/src/extract_component.rs
+++ b/crates/bevy_render/src/extract_component.rs
@@ -33,7 +33,7 @@ impl<C: Component> DynamicUniformIndex<C> {
 /// Describes how a component gets extracted for rendering.
 ///
 /// Therefore the component is transferred from the "app world" into the "render world"
-/// in the [`ExtractSchedule`](crate::ExtractSchedule) step.
+/// in the [`ExtractSchedule`] step.
 pub trait ExtractComponent: Component {
     /// ECS [`WorldQuery`] to fetch the components to extract.
     type Query: WorldQuery + ReadOnlyWorldQuery;
@@ -68,7 +68,7 @@ pub trait ExtractComponent: Component {
 /// For referencing the newly created uniforms a [`DynamicUniformIndex`] is inserted
 /// for every processed entity.
 ///
-/// Therefore it sets up the [`RenderSet::Prepare`](crate::RenderSet::Prepare) step
+/// Therefore it sets up the [`RenderSet::Prepare`] step
 /// for the specified [`ExtractComponent`].
 pub struct UniformComponentPlugin<C>(PhantomData<fn() -> C>);
 
@@ -157,7 +157,7 @@ fn prepare_uniform_components<C: Component>(
 
 /// This plugin extracts the components into the "render world".
 ///
-/// Therefore it sets up the [`ExtractSchedule`](crate::ExtractSchedule) step
+/// Therefore it sets up the [`ExtractSchedule`] step
 /// for the specified [`ExtractComponent`].
 pub struct ExtractComponentPlugin<C, F = ()> {
     only_extract_visible: bool,

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -9,7 +9,7 @@ use crate::{Extract, ExtractSchedule, RenderApp};
 /// Describes how a resource gets extracted for rendering.
 ///
 /// Therefore the resource is transferred from the "main world" into the "render world"
-/// in the [`ExtractSchedule`](crate::ExtractSchedule) step.
+/// in the [`ExtractSchedule`] step.
 pub trait ExtractResource: Resource {
     type Source: Resource;
 
@@ -19,7 +19,7 @@ pub trait ExtractResource: Resource {
 
 /// This plugin extracts the resources into the "render world".
 ///
-/// Therefore it sets up the[`ExtractSchedule`](crate::ExtractSchedule) step
+/// Therefore it sets up the[`ExtractSchedule`] step
 /// for the specified [`Resource`].
 pub struct ExtractResourcePlugin<R: ExtractResource>(PhantomData<R>);
 

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -235,7 +235,7 @@ pub const INSTANCE_INDEX_SHADER_HANDLE: Handle<Shader> =
 pub const MATHS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10665356303104593376);
 
 impl Plugin for RenderPlugin {
-    /// Initializes the renderer, sets up the [`RenderSet`](RenderSet) and creates the rendering sub-app.
+    /// Initializes the renderer, sets up the [`RenderSet`] and creates the rendering sub-app.
     fn build(&self, app: &mut App) {
         app.init_asset::<Shader>()
             .init_asset_loader::<ShaderLoader>();

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -15,12 +15,12 @@ pub enum PrepareAssetError<E: Send + Sync + 'static> {
 
 /// Describes how an asset gets extracted and prepared for rendering.
 ///
-/// In the [`ExtractSchedule`](crate::ExtractSchedule) step the asset is transferred
+/// In the [`ExtractSchedule`] step the asset is transferred
 /// from the "main world" into the "render world".
 /// Therefore it is converted into a [`RenderAsset::ExtractedAsset`], which may be the same type
 /// as the render asset itself.
 ///
-/// After that in the [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) step the extracted asset
+/// After that in the [`RenderSet::PrepareAssets`] step the extracted asset
 /// is transformed into its GPU-representation of type [`RenderAsset::PreparedAsset`].
 pub trait RenderAsset: Asset {
     /// The representation of the asset in the "render world".
@@ -43,8 +43,8 @@ pub trait RenderAsset: Asset {
 /// This plugin extracts the changed assets from the "app world" into the "render world"
 /// and prepares them for the GPU. They can then be accessed from the [`RenderAssets`] resource.
 ///
-/// Therefore it sets up the [`ExtractSchedule`](crate::ExtractSchedule) and
-/// [`RenderSet::PrepareAssets`](crate::RenderSet::PrepareAssets) steps for the specified [`RenderAsset`].
+/// Therefore it sets up the [`ExtractSchedule`] and
+/// [`RenderSet::PrepareAssets`] steps for the specified [`RenderAsset`].
 ///
 /// The `AFTER` generic parameter can be used to specify that `A::prepare_asset` should not be run until
 /// `prepare_assets::<AFTER>` has completed. This allows the `prepare_asset` function to depend on another

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -123,7 +123,7 @@ impl Deref for BindGroup {
 /// | `visibility(...)`     | `all`, `none`, or a list-combination of `vertex`, `fragment`, `compute` | `vertex`, `fragment` |
 ///
 /// * `sampler(BINDING_INDEX, arguments)`
-///     * This field's [`Handle<Image>`](bevy_asset::Handle) will be used to look up the matching [`Sampler`](crate::render_resource::Sampler) GPU
+///     * This field's [`Handle<Image>`](bevy_asset::Handle) will be used to look up the matching [`Sampler`] GPU
 ///     resource, which will be bound as a sampler in shaders. The field will be assumed to implement [`Into<Option<Handle<Image>>>`]. In practice,
 ///     most fields should be a [`Handle<Image>`](bevy_asset::Handle) or [`Option<Handle<Image>>`]. If the value of an [`Option<Handle<Image>>`] is
 ///     [`None`], the [`FallbackImage`] resource will be used instead. This attribute can be used in conjunction with a `texture` binding attribute

--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -16,7 +16,7 @@ use wgpu::BufferUsages;
 /// so this helper type is a good choice for them.
 ///
 /// The contained data is stored in system RAM. Calling [`reserve`](crate::render_resource::BufferVec::reserve)
-/// allocates VRAM from the [`RenderDevice`](crate::renderer::RenderDevice).
+/// allocates VRAM from the [`RenderDevice`].
 /// [`write_buffer`](crate::render_resource::BufferVec::write_buffer) queues copying of the data
 /// from system RAM to VRAM.
 ///
@@ -26,7 +26,7 @@ use wgpu::BufferUsages;
 /// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
 /// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
 /// * [`GpuArrayBuffer`](crate::render_resource::GpuArrayBuffer)
-/// * [`BufferVec`](crate::render_resource::BufferVec)
+/// * [`BufferVec`]
 /// * [`Texture`](crate::render_resource::Texture)
 pub struct BufferVec<T: Pod> {
     values: Vec<T>,
@@ -95,16 +95,16 @@ impl<T: Pod> BufferVec<T> {
         self.label.as_deref()
     }
 
-    /// Creates a [`Buffer`](crate::render_resource::Buffer) on the [`RenderDevice`](crate::renderer::RenderDevice) with size
+    /// Creates a [`Buffer`] on the [`RenderDevice`] with size
     /// at least `std::mem::size_of::<T>() * capacity`, unless a such a buffer already exists.
     ///
-    /// If a [`Buffer`](crate::render_resource::Buffer) exists, but is too small, references to it will be discarded,
-    /// and a new [`Buffer`](crate::render_resource::Buffer) will be created. Any previously created [`Buffer`](crate::render_resource::Buffer)s
-    /// that are no longer referenced will be deleted by the [`RenderDevice`](crate::renderer::RenderDevice)
+    /// If a [`Buffer`] exists, but is too small, references to it will be discarded,
+    /// and a new [`Buffer`] will be created. Any previously created [`Buffer`]s
+    /// that are no longer referenced will be deleted by the [`RenderDevice`]
     /// once it is done using them (typically 1-2 frames).
     ///
-    /// In addition to any [`BufferUsages`](crate::render_resource::BufferUsages) provided when
-    /// the `BufferVec` was created, the buffer on the [`RenderDevice`](crate::renderer::RenderDevice)
+    /// In addition to any [`BufferUsages`] provided when
+    /// the `BufferVec` was created, the buffer on the [`RenderDevice`]
     /// is marked as [`BufferUsages::COPY_DST`](crate::render_resource::BufferUsages).
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
         if capacity > self.capacity || self.label_changed {
@@ -120,8 +120,8 @@ impl<T: Pod> BufferVec<T> {
         }
     }
 
-    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
-    /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`]
+    /// and the provided [`RenderQueue`].
     ///
     /// Before queuing the write, a [`reserve`](crate::render_resource::BufferVec::reserve) operation
     /// is executed.

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -20,7 +20,7 @@ impl<T: ShaderType + ShaderSize + WriteInto + Clone> GpuArrayBufferable for T {}
 /// array of T that fits within a uniform buffer binding (within reasonable limits).
 ///
 /// Other options for storing GPU-accessible data are:
-/// * [`StorageBuffer`](crate::render_resource::StorageBuffer)
+/// * [`StorageBuffer`]
 /// * [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
 /// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
 /// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -22,7 +22,7 @@ use wgpu::{util::BufferInitDescriptor, BindingResource, BufferBinding, BufferUsa
 /// is automatically enforced by this structure.
 ///
 /// Other options for storing GPU-accessible data are:
-/// * [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
+/// * [`DynamicStorageBuffer`]
 /// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
 /// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
 /// * [`GpuArrayBuffer`](crate::render_resource::GpuArrayBuffer)
@@ -114,8 +114,8 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
         self.changed = true;
     }
 
-    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
-    /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`]
+    /// and the provided [`RenderQueue`].
     ///
     /// If there is no GPU-side buffer allocated to hold the data currently stored, or if a GPU-side buffer previously
     /// allocated does not have enough capacity, a new GPU-side buffer is created.
@@ -152,7 +152,7 @@ impl<T: ShaderType + WriteInto> StorageBuffer<T> {
 /// will additionally be aligned to meet dynamic offset alignment requirements.
 ///
 /// Other options for storing GPU-accessible data are:
-/// * [`StorageBuffer`](crate::render_resource::StorageBuffer)
+/// * [`StorageBuffer`]
 /// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
 /// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
 /// * [`GpuArrayBuffer`](crate::render_resource::GpuArrayBuffer)

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -27,7 +27,7 @@ use wgpu::{
 /// Other options for storing GPU-accessible data are:
 /// * [`StorageBuffer`](crate::render_resource::StorageBuffer)
 /// * [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
-/// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
+/// * [`DynamicUniformBuffer`]
 /// * [`GpuArrayBuffer`](crate::render_resource::GpuArrayBuffer)
 /// * [`BufferVec`](crate::render_resource::BufferVec)
 /// * [`Texture`](crate::render_resource::Texture)
@@ -118,8 +118,8 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
         self.changed = true;
     }
 
-    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
-    /// and the provided [`RenderQueue`](crate::renderer::RenderQueue), if a GPU-side backing buffer already exists.
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`]
+    /// and the provided [`RenderQueue`], if a GPU-side backing buffer already exists.
     ///
     /// If a GPU-side buffer does not already exist for this data, such a buffer is initialized with currently
     /// available data.
@@ -153,8 +153,8 @@ impl<T: ShaderType + WriteInto> UniformBuffer<T> {
 /// Other options for storing GPU-accessible data are:
 /// * [`StorageBuffer`](crate::render_resource::StorageBuffer)
 /// * [`DynamicStorageBuffer`](crate::render_resource::DynamicStorageBuffer)
-/// * [`UniformBuffer`](crate::render_resource::UniformBuffer)
-/// * [`DynamicUniformBuffer`](crate::render_resource::DynamicUniformBuffer)
+/// * [`UniformBuffer`]
+/// * [`DynamicUniformBuffer`]
 /// * [`GpuArrayBuffer`](crate::render_resource::GpuArrayBuffer)
 /// * [`BufferVec`](crate::render_resource::BufferVec)
 /// * [`Texture`](crate::render_resource::Texture)
@@ -249,7 +249,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
     ///
     /// `max_count` *must* be greater than or equal to the number of elements that are to be written to the buffer, or
     /// the writer will panic while writing.  Dropping the writer will schedule the buffer write into the provided
-    /// [`RenderQueue`](crate::renderer::RenderQueue).
+    /// [`RenderQueue`].
     ///
     /// If there is no GPU-side buffer allocated to hold the data currently stored, or if a GPU-side buffer previously
     /// allocated does not have enough capacity to hold `max_count` elements, a new GPU-side buffer is created.
@@ -304,8 +304,8 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         }
     }
 
-    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`](crate::renderer::RenderDevice)
-    /// and the provided [`RenderQueue`](crate::renderer::RenderQueue).
+    /// Queues writing of data from system RAM to VRAM using the [`RenderDevice`]
+    /// and the provided [`RenderQueue`].
     ///
     /// If there is no GPU-side buffer allocated to hold the data currently stored, or if a GPU-side buffer previously
     /// allocated does not have enough capacity, a new GPU-side buffer is created.

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -19,7 +19,7 @@ pub enum WgpuSettingsPriority {
 }
 
 /// Provides configuration for renderer initialization. Use [`RenderDevice::features`](crate::renderer::RenderDevice::features),
-/// [`RenderDevice::limits`](crate::renderer::RenderDevice::limits), and the [`RenderAdapterInfo`](crate::renderer::RenderAdapterInfo)
+/// [`RenderDevice::limits`](crate::renderer::RenderDevice::limits), and the [`RenderAdapterInfo`]
 /// resource to get runtime information about the actual adapter, backend, features, and limits.
 /// NOTE: [`Backends::DX12`](Backends::DX12), [`Backends::METAL`](Backends::METAL), and
 /// [`Backends::VULKAN`](Backends::VULKAN) are enabled by default for non-web and the best choice

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -129,7 +129,7 @@ impl ViewVisibility {
 }
 
 /// A [`Bundle`] of the [`Visibility`], [`InheritedVisibility`], and [`ViewVisibility`]
-/// [`Component`](bevy_ecs::component::Component)s, which describe the visibility of an entity.
+/// [`Component`]s, which describe the visibility of an entity.
 ///
 /// * To show or hide an entity, you should set its [`Visibility`].
 /// * To get the inherited visibility of an entity, you should get its [`InheritedVisibility`].

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -22,7 +22,7 @@ pub struct TextPipeline {
     map_font_id: HashMap<AssetId<Font>, FontId>,
 }
 
-/// Render information for a corresponding [`Text`](crate::Text) component.
+/// Render information for a corresponding [`Text`] component.
 ///
 ///  Contains scaled glyphs and their size. Generated via [`TextPipeline::queue_text`].
 #[derive(Component, Clone, Default, Debug, Reflect)]

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -27,7 +27,7 @@ use prelude::{GlobalTransform, Transform};
 use systems::{propagate_transforms, sync_simple_transforms};
 
 /// A [`Bundle`] of the [`Transform`] and [`GlobalTransform`]
-/// [`Component`](bevy_ecs::component::Component)s, which describe the position of an entity.
+/// [`Component`]s, which describe the position of an entity.
 ///
 /// * To place or move an entity, you should set its [`Transform`].
 /// * To get the global transform of an entity, you should get its [`GlobalTransform`].
@@ -44,7 +44,7 @@ use systems::{propagate_transforms, sync_simple_transforms};
 /// [`GlobalTransform`] is updated from [`Transform`] by systems in the system set
 /// [`TransformPropagate`](crate::TransformSystem::TransformPropagate).
 ///
-/// This system runs during [`PostUpdate`](bevy_app::PostUpdate). If you
+/// This system runs during [`PostUpdate`]. If you
 /// update the [`Transform`] of an entity in this schedule or after, you will notice a 1 frame lag
 /// before the [`GlobalTransform`] is updated.
 #[derive(Bundle, Clone, Copy, Debug, Default)]
@@ -65,7 +65,7 @@ impl TransformBundle {
     /// Creates a new [`TransformBundle`] from a [`Transform`].
     ///
     /// This initializes [`GlobalTransform`] as identity, to be updated later by the
-    /// [`PostUpdate`](bevy_app::PostUpdate) schedule.
+    /// [`PostUpdate`] schedule.
     #[inline]
     pub const fn from_transform(transform: Transform) -> Self {
         TransformBundle {
@@ -84,7 +84,7 @@ impl From<Transform> for TransformBundle {
 /// Set enum for the systems relating to transform propagation
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum TransformSystem {
-    /// Propagates changes in transform to children's [`GlobalTransform`](crate::components::GlobalTransform)
+    /// Propagates changes in transform to children's [`GlobalTransform`]
     TransformPropagate,
 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! Most commonly, the [`WinitPlugin`] is used as part of
 //! [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
-//! The app's [runner](bevy_app::App::runner) is set by `WinitPlugin` and handles the `winit` [`EventLoop`](winit::event_loop::EventLoop).
+//! The app's [runner](bevy_app::App::runner) is set by `WinitPlugin` and handles the `winit` [`EventLoop`].
 //! See `winit_runner` for details.
 
 pub mod accessibility;


### PR DESCRIPTION
# Objective

- Updates for rust 1.73

## Solution

- new doc check for `redundant_explicit_links`
- updated to text for compile fail tests

---

## Changelog

- updates for rust 1.73