### PR TITLE
Convert queries to a more general form

### DIFF
--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -352,6 +352,12 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                     }
                 }
 
+                fn new_state(components: &#path::component::Components) -> #state_struct_name #user_ty_generics {
+                    #state_struct_name {
+                        #(#named_field_idents: <#field_types>::new_state(components),)*
+                    }
+                }
+
                 fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {
                     true #(&& <#field_types>::matches_component_set(&state.#named_field_idents, _set_contains_id))*
                 }

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -289,8 +289,6 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
 
                 const IS_ARCHETYPAL: bool = true #(&& <#field_types>::IS_ARCHETYPAL)*;
 
-                const IS_EXACT: bool = true #(&& <#field_types>::IS_EXACT)*;
-
                 /// SAFETY: we call `set_archetype` for each member that implements `Fetch`
                 #[inline]
                 unsafe fn set_archetype<'__w>(
@@ -349,7 +347,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                 }
 
                 fn optional_access(
-                    state: &Self::State, 
+                    state: &Self::State,
                     _access: &mut #path::query::Access<#path::component::ComponentId>,
                     parent_is_optional: bool,
                 ) {

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -360,9 +360,9 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                fn new_state(components: &#path::component::Components) -> Option<#state_struct_name #user_ty_generics> {
+                fn get_state(components: &#path::component::Components) -> Option<#state_struct_name #user_ty_generics> {
                     Some(#state_struct_name {
-                        #(#named_field_idents: <#field_types>::new_state(components)?,)*
+                        #(#named_field_idents: <#field_types>::get_state(components)?,)*
                     })
                 }
 

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -288,7 +288,7 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                 const IS_DENSE: bool = true #(&& <#field_types>::IS_DENSE)*;
 
                 const IS_ARCHETYPAL: bool = true #(&& <#field_types>::IS_ARCHETYPAL)*;
-                
+
                 const IS_EXACT: bool = true #(&& <#field_types>::IS_EXACT)*;
 
                 /// SAFETY: we call `set_archetype` for each member that implements `Fetch`
@@ -346,6 +346,14 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                     #(
                         <#field_types>::update_archetype_component_access(&state.#named_field_idents, _archetype, _access);
                     )*
+                }
+
+                fn optional_access(
+                    state: &Self::State, 
+                    _access: &mut #path::query::Access<#path::component::ComponentId>,
+                    parent_is_optional: bool,
+                ) {
+                    #( <#field_types>::optional_access(&state.#named_field_idents, _access, parent_is_optional); )*
                 }
 
                 fn init_state(world: &mut #path::world::World) -> #state_struct_name #user_ty_generics {

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -288,6 +288,8 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                 const IS_DENSE: bool = true #(&& <#field_types>::IS_DENSE)*;
 
                 const IS_ARCHETYPAL: bool = true #(&& <#field_types>::IS_ARCHETYPAL)*;
+                
+                const IS_EXACT: bool = true #(&& <#field_types>::IS_EXACT)*;
 
                 /// SAFETY: we call `set_archetype` for each member that implements `Fetch`
                 #[inline]

--- a/crates/bevy_ecs/macros/src/fetch.rs
+++ b/crates/bevy_ecs/macros/src/fetch.rs
@@ -352,10 +352,10 @@ pub fn derive_world_query_impl(input: TokenStream) -> TokenStream {
                     }
                 }
 
-                fn new_state(components: &#path::component::Components) -> #state_struct_name #user_ty_generics {
-                    #state_struct_name {
-                        #(#named_field_idents: <#field_types>::new_state(components),)*
-                    }
+                fn new_state(components: &#path::component::Components) -> Option<#state_struct_name #user_ty_generics> {
+                    Some(#state_struct_name {
+                        #(#named_field_idents: <#field_types>::new_state(components)?,)*
+                    })
                 }
 
                 fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -270,7 +270,7 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.ones().map(T::get_sparse_set_index)
     }
 
-    /// checks if the difference of `self` with `other` is empty
+    /// Returns true if the difference of `self` with `other` is empty
     pub fn read_and_writes_difference_is_empty(&self, other: &Access<T>) -> bool {
         if self.reads_all || self.writes_all {
             return other.reads_all || other.writes_all;
@@ -279,11 +279,6 @@ impl<T: SparseSetIndex> Access<T> {
             .difference(&other.reads_and_writes)
             .count()
             == 0
-    }
-
-    /// checks if there is any access set
-    pub fn has_access(&self) -> bool {
-        self.writes_all || self.reads_all || !self.reads_and_writes.is_clear()
     }
 }
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -270,6 +270,7 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.ones().map(T::get_sparse_set_index)
     }
 
+    /// checks if the difference of `self` with `other` is empty
     pub fn read_and_writes_difference_is_empty(&self, other: &Access<T>) -> bool {
         if self.reads_all || self.writes_all {
             return other.reads_all || other.writes_all;
@@ -280,6 +281,7 @@ impl<T: SparseSetIndex> Access<T> {
             == 0
     }
 
+    /// checks if there is any access set
     pub fn has_access(&self) -> bool {
         self.writes_all || self.reads_all || !self.reads_and_writes.is_clear()
     }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -269,6 +269,11 @@ impl<T: SparseSetIndex> Access<T> {
     pub fn writes(&self) -> impl Iterator<Item = T> + '_ {
         self.writes.ones().map(T::get_sparse_set_index)
     }
+
+    /// 
+    pub fn difference_is_empty(&self, other: &Access<T>) -> bool {
+        self.reads_and_writes.difference(&other.reads_and_writes).count() == 0
+    }
 }
 
 /// An [`Access`] that has been filtered to include and exclude certain combinations of elements.
@@ -400,7 +405,7 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
         })
     }
 
-    ///  access is compatible with other access. This does not take into account the filtered access.
+    /// `other` contains all the same access as `self`.  This does not take into account the filtered access.
     pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
         self.access.is_subset(&other.access)
     }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -271,7 +271,10 @@ impl<T: SparseSetIndex> Access<T> {
     }
 
     pub fn difference_is_empty(&self, other: &Access<T>) -> bool {
-        self.reads_and_writes.difference(&other.reads_and_writes).count() == 0
+        self.reads_and_writes
+            .difference(&other.reads_and_writes)
+            .count()
+            == 0
     }
 
     pub fn takes_no_access(&self) -> bool {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -270,9 +270,12 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.ones().map(T::get_sparse_set_index)
     }
 
-    /// 
     pub fn difference_is_empty(&self, other: &Access<T>) -> bool {
         self.reads_and_writes.difference(&other.reads_and_writes).count() == 0
+    }
+
+    pub fn takes_no_access(&self) -> bool {
+        self.reads_and_writes.is_empty()
     }
 }
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -224,7 +224,7 @@ impl<T: SparseSetIndex> Access<T> {
         reads.is_subset(&other.reads_and_writes) && self.writes.is_subset(&other.writes)
     }
 
-    /// modifies self with the intersection with `other`
+    /// Modify `self` with the intersection with `other`
     pub fn intersect(&mut self, other: &Access<T>) {
         if self.writes_all {
             if other.writes_all {
@@ -317,7 +317,7 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.ones().map(T::get_sparse_set_index)
     }
 
-    /// Returns true if the difference of `self` with `other` is empty
+    /// Returns `true` if the difference of `self` with `other` is empty
     pub fn read_and_writes_difference_is_empty(&self, other: &Access<T>) -> bool {
         if self.reads_all || self.writes_all {
             return other.reads_all || other.writes_all;
@@ -458,12 +458,12 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
         })
     }
 
-    /// `other` contains all the same access as `self`.  This does not take into account the filtered access.
+    /// `other` contains all the same access as `self`.  This does not take into account the `filter_sets`.
     pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
         self.access.is_subset(&other.access)
     }
 
-    /// returns true if optional access has not changed
+    /// Returns `true` if optional access has not changed.
     pub fn is_optional_compatible(
         &self,
         mut original_optional: Access<T>,

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1,750 +1,753 @@
-    use crate::storage::SparseSetIndex;
-    use bevy_utils::HashSet;
-    use core::fmt;
+use crate::storage::SparseSetIndex;
+use bevy_utils::HashSet;
+use core::fmt;
+use fixedbitset::FixedBitSet;
+use std::marker::PhantomData;
+
+/// A wrapper struct to make Debug representations of [`FixedBitSet`] easier
+/// to read, when used to store [`SparseSetIndex`].
+///
+/// Instead of the raw integer representation of the `FixedBitSet`, the list of
+/// `T` valid for [`SparseSetIndex`] is shown.
+///
+/// Normal `FixedBitSet` `Debug` output:
+/// ```text
+/// read_and_writes: FixedBitSet { data: [ 160 ], length: 8 }
+/// ```
+///
+/// Which, unless you are a computer, doesn't help much understand what's in
+/// the set. With `FormattedBitSet`, we convert the present set entries into
+/// what they stand for, it is much clearer what is going on:
+/// ```text
+/// read_and_writes: [ ComponentId(5), ComponentId(7) ]
+/// ```
+struct FormattedBitSet<'a, T: SparseSetIndex> {
+    bit_set: &'a FixedBitSet,
+    _marker: PhantomData<T>,
+}
+
+impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
+    fn new(bit_set: &'a FixedBitSet) -> Self {
+        Self {
+            bit_set,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, T: SparseSetIndex + fmt::Debug> fmt::Debug for FormattedBitSet<'a, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list()
+            .entries(self.bit_set.ones().map(T::get_sparse_set_index))
+            .finish()
+    }
+}
+
+/// Tracks read and write access to specific elements in a collection.
+///
+/// Used internally to ensure soundness during system initialization and execution.
+/// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Access<T: SparseSetIndex> {
+    /// All accessed elements.
+    reads_and_writes: FixedBitSet,
+    /// The exclusively-accessed elements.
+    writes: FixedBitSet,
+    /// Is `true` if this has access to all elements in the collection.
+    /// This field is a performance optimization for `&World` (also harder to mess up for soundness).
+    reads_all: bool,
+    /// Is `true` if this has mutable access to all elements in the collection.
+    /// If this is true, then `reads_all` must also be true.
+    writes_all: bool,
+    marker: PhantomData<T>,
+}
+
+impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Access")
+            .field(
+                "read_and_writes",
+                &FormattedBitSet::<T>::new(&self.reads_and_writes),
+            )
+            .field("writes", &FormattedBitSet::<T>::new(&self.writes))
+            .field("reads_all", &self.reads_all)
+            .field("writes_all", &self.writes_all)
+            .finish()
+    }
+}
+
+impl<T: SparseSetIndex> Default for Access<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: SparseSetIndex> Access<T> {
+    /// Creates an empty [`Access`] collection.
+    pub const fn new() -> Self {
+        Self {
+            reads_all: false,
+            writes_all: false,
+            reads_and_writes: FixedBitSet::new(),
+            writes: FixedBitSet::new(),
+            marker: PhantomData,
+        }
+    }
+
+    /// Increases the set capacity to the specified amount.
+    ///
+    /// Does nothing if `capacity` is less than or equal to the current value.
+    pub fn grow(&mut self, capacity: usize) {
+        self.reads_and_writes.grow(capacity);
+        self.writes.grow(capacity);
+    }
+
+    /// Adds access to the element given by `index`.
+    pub fn add_read(&mut self, index: T) {
+        self.reads_and_writes.grow(index.sparse_set_index() + 1);
+        self.reads_and_writes.insert(index.sparse_set_index());
+    }
+
+    /// Adds exclusive access to the element given by `index`.
+    pub fn add_write(&mut self, index: T) {
+        self.reads_and_writes.grow(index.sparse_set_index() + 1);
+        self.reads_and_writes.insert(index.sparse_set_index());
+        self.writes.grow(index.sparse_set_index() + 1);
+        self.writes.insert(index.sparse_set_index());
+    }
+
+    /// Returns `true` if this can access the element given by `index`.
+    pub fn has_read(&self, index: T) -> bool {
+        self.reads_all || self.reads_and_writes.contains(index.sparse_set_index())
+    }
+
+    /// Returns `true` if this can access anything.
+    pub fn has_any_read(&self) -> bool {
+        self.reads_all || !self.reads_and_writes.is_clear()
+    }
+
+    /// Returns `true` if this can exclusively access the element given by `index`.
+    pub fn has_write(&self, index: T) -> bool {
+        self.writes_all || self.writes.contains(index.sparse_set_index())
+    }
+
+    /// Returns `true` if this accesses anything mutably.
+    pub fn has_any_write(&self) -> bool {
+        self.writes_all || !self.writes.is_clear()
+    }
+
+    /// Sets this as having access to all indexed elements (i.e. `&World`).
+    pub fn read_all(&mut self) {
+        self.reads_all = true;
+    }
+
+    /// Sets this as having mutable access to all indexed elements (i.e. `EntityMut`).
+    pub fn write_all(&mut self) {
+        self.reads_all = true;
+        self.writes_all = true;
+    }
+
+    /// Returns `true` if this has access to all indexed elements (i.e. `&World`).
+    pub fn has_read_all(&self) -> bool {
+        self.reads_all
+    }
+
+    /// Returns `true` if this has write access to all indexed elements (i.e. `EntityMut`).
+    pub fn has_write_all(&self) -> bool {
+        self.writes_all
+    }
+
+    /// Removes all accesses.
+    pub fn clear(&mut self) {
+        self.reads_all = false;
+        self.writes_all = false;
+        self.reads_and_writes.clear();
+        self.writes.clear();
+    }
+
+    /// Adds all access from `other`.
+    pub fn extend(&mut self, other: &Access<T>) {
+        self.reads_all = self.reads_all || other.reads_all;
+        self.writes_all = self.writes_all || other.writes_all;
+        self.reads_and_writes.union_with(&other.reads_and_writes);
+        self.writes.union_with(&other.writes);
+    }
+
+    /// Returns `true` if the access and `other` can be active at the same time.
+    ///
+    /// [`Access`] instances are incompatible if one can write
+    /// an element that the other can read or write.
+    pub fn is_compatible(&self, other: &Access<T>) -> bool {
+        if self.writes_all {
+            return !other.has_any_read();
+        }
+
+        if other.writes_all {
+            return !self.has_any_read();
+        }
+
+        if self.reads_all {
+            return !other.has_any_write();
+        }
+
+        if other.reads_all {
+            return !self.has_any_write();
+        }
+
+        self.writes.is_disjoint(&other.reads_and_writes)
+            && other.writes.is_disjoint(&self.reads_and_writes)
+    }
+
+    /// [`Access`] is subset of `other` access.
+    pub fn is_subset(&self, other: &Access<T>) -> bool {
+        if self.writes_all {
+            return other.writes_all;
+        }
+
+        if other.writes_all {
+            return true;
+        }
+
+        if self.reads_all {
+            return other.reads_all || other.writes_all;
+        }
+
+        if other.reads_all {
+            return self.has_any_write();
+        }
+
+        let reads = self
+            .reads_and_writes
+            .difference(&self.writes)
+            .collect::<FixedBitSet>();
+
+        reads.is_subset(&other.reads_and_writes) && self.writes.is_subset(&other.writes)
+    }
+
+    /// Returns a vector of elements that the access and `other` cannot access at the same time.
+    pub fn get_conflicts(&self, other: &Access<T>) -> Vec<T> {
+        let mut conflicts = FixedBitSet::default();
+        if self.reads_all {
+            // QUESTION: How to handle `other.writes_all`?
+            conflicts.extend(other.writes.ones());
+        }
+
+        if other.reads_all {
+            // QUESTION: How to handle `self.writes_all`.
+            conflicts.extend(self.writes.ones());
+        }
+
+        if self.writes_all {
+            conflicts.extend(other.reads_and_writes.ones());
+        }
+
+        if other.writes_all {
+            conflicts.extend(self.reads_and_writes.ones());
+        }
+
+        conflicts.extend(self.writes.intersection(&other.reads_and_writes));
+        conflicts.extend(self.reads_and_writes.intersection(&other.writes));
+        conflicts
+            .ones()
+            .map(SparseSetIndex::get_sparse_set_index)
+            .collect()
+    }
+
+    /// Returns the indices of the elements this has access to.
+    pub fn reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
+        self.reads_and_writes.ones().map(T::get_sparse_set_index)
+    }
+
+    /// Returns the indices of the elements this has non-exclusive access to.
+    pub fn reads(&self) -> impl Iterator<Item = T> + '_ {
+        self.reads_and_writes
+            .difference(&self.writes)
+            .map(T::get_sparse_set_index)
+    }
+
+    /// Returns the indices of the elements this has exclusive access to.
+    pub fn writes(&self) -> impl Iterator<Item = T> + '_ {
+        self.writes.ones().map(T::get_sparse_set_index)
+    }
+}
+
+/// An [`Access`] that has been filtered to include and exclude certain combinations of elements.
+///
+/// Used internally to statically check if queries are disjoint.
+///
+/// Subtle: a `read` or `write` in `access` should not be considered to imply a
+/// `with` access.
+///
+/// For example consider `Query<Option<&T>>` this only has a `read` of `T` as doing
+/// otherwise would allow for queries to be considered disjoint when they shouldn't:
+/// - `Query<(&mut T, Option<&U>)>` read/write `T`, read `U`, with `U`
+/// - `Query<&mut T, Without<U>>` read/write `T`, without `U`
+/// from this we could reasonably conclude that the queries are disjoint but they aren't.
+///
+/// In order to solve this the actual access that `Query<(&mut T, Option<&U>)>` has
+/// is read/write `T`, read `U`. It must still have a read `U` access otherwise the following
+/// queries would be incorrectly considered disjoint:
+/// - `Query<&mut T>`  read/write `T`
+/// - `Query<Option<&T>>` accesses nothing
+///
+/// See comments the [`WorldQuery`](super::WorldQuery) impls of [`AnyOf`](super::AnyOf)/`Option`/[`Or`](super::Or) for more information.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FilteredAccess<T: SparseSetIndex> {
+    access: Access<T>,
+    // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
+    // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
+    filter_sets: Vec<AccessFilters<T>>,
+}
+
+impl<T: SparseSetIndex> Default for FilteredAccess<T> {
+    fn default() -> Self {
+        Self {
+            access: Access::default(),
+            filter_sets: vec![AccessFilters::default()],
+        }
+    }
+}
+
+impl<T: SparseSetIndex> From<FilteredAccess<T>> for FilteredAccessSet<T> {
+    fn from(filtered_access: FilteredAccess<T>) -> Self {
+        let mut base = FilteredAccessSet::<T>::default();
+        base.add(filtered_access);
+        base
+    }
+}
+
+impl<T: SparseSetIndex> FilteredAccess<T> {
+    /// Returns a reference to the underlying unfiltered access.
+    #[inline]
+    pub fn access(&self) -> &Access<T> {
+        &self.access
+    }
+
+    /// Returns a mutable reference to the underlying unfiltered access.
+    #[inline]
+    pub fn access_mut(&mut self) -> &mut Access<T> {
+        &mut self.access
+    }
+
+    /// Adds access to the element given by `index`.
+    pub fn add_read(&mut self, index: T) {
+        self.access.add_read(index.clone());
+        self.and_with(index);
+    }
+
+    /// Adds exclusive access to the element given by `index`.
+    pub fn add_write(&mut self, index: T) {
+        self.access.add_write(index.clone());
+        self.and_with(index);
+    }
+
+    /// Adds a `With` filter: corresponds to a conjunction (AND) operation.
+    ///
+    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+    /// Adding `AND With<C>` via this method transforms it into the equivalent of  `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
+    pub fn and_with(&mut self, index: T) {
+        let index = index.sparse_set_index();
+        for filter in &mut self.filter_sets {
+            filter.with.grow(index + 1);
+            filter.with.insert(index);
+        }
+    }
+
+    /// Adds a `Without` filter: corresponds to a conjunction (AND) operation.
+    ///
+    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+    /// Adding `AND Without<C>` via this method transforms it into the equivalent of  `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
+    pub fn and_without(&mut self, index: T) {
+        let index = index.sparse_set_index();
+        for filter in &mut self.filter_sets {
+            filter.without.grow(index + 1);
+            filter.without.insert(index);
+        }
+    }
+
+    /// Appends an array of filters: corresponds to a disjunction (OR) operation.
+    ///
+    /// As the underlying array of filters represents a disjunction,
+    /// where each element (`AccessFilters`) represents a conjunction,
+    /// we can simply append to the array.
+    pub fn append_or(&mut self, other: &FilteredAccess<T>) {
+        self.filter_sets.append(&mut other.filter_sets.clone());
+    }
+
+    /// Adds all of the accesses from `other` to `self`.
+    pub fn extend_access(&mut self, other: &FilteredAccess<T>) {
+        self.access.extend(&other.access);
+    }
+
+    /// Returns `true` if this and `other` can be active at the same time.
+    pub fn is_compatible(&self, other: &FilteredAccess<T>) -> bool {
+        if self.access.is_compatible(&other.access) {
+            return true;
+        }
+
+        // If the access instances are incompatible, we want to check that whether filters can
+        // guarantee that queries are disjoint.
+        // Since the `filter_sets` array represents a Disjunctive Normal Form formula ("ORs of ANDs"),
+        // we need to make sure that each filter set (ANDs) rule out every filter set from the `other` instance.
+        //
+        // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,
+        // but `Query<&mut C, Or<(Without<A>, Without<B>)>>` isn't compatible with `Query<&mut C, Or<(With<A>, With<B>)>>`.
+        self.filter_sets.iter().all(|filter| {
+            other
+                .filter_sets
+                .iter()
+                .all(|other_filter| filter.is_ruled_out_by(other_filter))
+        })
+    }
+
+    ///  access is compatible with other access. This does not take into account the filtered access.
+    pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
+        self.access.is_subset(&other.access)
+    }
+
+    /// Returns a vector of elements that this and `other` cannot access at the same time.
+    pub fn get_conflicts(&self, other: &FilteredAccess<T>) -> Vec<T> {
+        if !self.is_compatible(other) {
+            // filters are disjoint, so we can just look at the unfiltered intersection
+            return self.access.get_conflicts(&other.access);
+        }
+        Vec::new()
+    }
+
+    /// Adds all access and filters from `other`.
+    ///
+    /// Corresponds to a conjunction operation (AND) for filters.
+    ///
+    /// Extending `Or<(With<A>, Without<B>)>` with `Or<(With<C>, Without<D>)>` will result in
+    /// `Or<((With<A>, With<C>), (With<A>, Without<D>), (Without<B>, With<C>), (Without<B>, Without<D>))>`.
+    pub fn extend(&mut self, other: &FilteredAccess<T>) {
+        self.access.extend(&other.access);
+
+        // We can avoid allocating a new array of bitsets if `other` contains just a single set of filters:
+        // in this case we can short-circuit by performing an in-place union for each bitset.
+        if other.filter_sets.len() == 1 {
+            for filter in &mut self.filter_sets {
+                filter.with.union_with(&other.filter_sets[0].with);
+                filter.without.union_with(&other.filter_sets[0].without);
+            }
+            return;
+        }
+
+        let mut new_filters = Vec::with_capacity(self.filter_sets.len() * other.filter_sets.len());
+        for filter in &self.filter_sets {
+            for other_filter in &other.filter_sets {
+                let mut new_filter = filter.clone();
+                new_filter.with.union_with(&other_filter.with);
+                new_filter.without.union_with(&other_filter.without);
+                new_filters.push(new_filter);
+            }
+        }
+        self.filter_sets = new_filters;
+    }
+
+    /// Sets the underlying unfiltered access as having access to all indexed elements.
+    pub fn read_all(&mut self) {
+        self.access.read_all();
+    }
+
+    /// Sets the underlying unfiltered access as having mutable access to all indexed elements.
+    pub fn write_all(&mut self) {
+        self.access.write_all();
+    }
+}
+
+#[derive(Clone, Eq, PartialEq)]
+struct AccessFilters<T> {
+    with: FixedBitSet,
+    without: FixedBitSet,
+    _index_type: PhantomData<T>,
+}
+
+impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for AccessFilters<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AccessFilters")
+            .field("with", &FormattedBitSet::<T>::new(&self.with))
+            .field("without", &FormattedBitSet::<T>::new(&self.without))
+            .finish()
+    }
+}
+
+impl<T: SparseSetIndex> Default for AccessFilters<T> {
+    fn default() -> Self {
+        Self {
+            with: FixedBitSet::default(),
+            without: FixedBitSet::default(),
+            _index_type: PhantomData,
+        }
+    }
+}
+
+impl<T: SparseSetIndex> AccessFilters<T> {
+    fn is_ruled_out_by(&self, other: &Self) -> bool {
+        // Although not technically complete, we don't consider the case when `AccessFilters`'s
+        // `without` bitset contradicts its own `with` bitset (e.g. `(With<A>, Without<A>)`).
+        // Such query would be considered compatible with any other query, but as it's almost
+        // always an error, we ignore this case instead of treating such query as compatible
+        // with others.
+        !self.with.is_disjoint(&other.without) || !self.without.is_disjoint(&other.with)
+    }
+}
+
+/// A collection of [`FilteredAccess`] instances.
+///
+/// Used internally to statically check if systems have conflicting access.
+///
+/// It stores multiple sets of accesses.
+/// - A "combined" set, which is the access of all filters in this set combined.
+/// - The set of access of each individual filters in this set.
+#[derive(Debug, Clone)]
+pub struct FilteredAccessSet<T: SparseSetIndex> {
+    combined_access: Access<T>,
+    filtered_accesses: Vec<FilteredAccess<T>>,
+}
+
+impl<T: SparseSetIndex> FilteredAccessSet<T> {
+    /// Returns a reference to the unfiltered access of the entire set.
+    #[inline]
+    pub fn combined_access(&self) -> &Access<T> {
+        &self.combined_access
+    }
+
+    /// Returns `true` if this and `other` can be active at the same time.
+    ///
+    /// Access conflict resolution happen in two steps:
+    /// 1. A "coarse" check, if there is no mutual unfiltered conflict between
+    ///    `self` and `other`, we already know that the two access sets are
+    ///    compatible.
+    /// 2. A "fine grained" check, it kicks in when the "coarse" check fails.
+    ///    the two access sets might still be compatible if some of the accesses
+    ///    are restricted with the [`With`](super::With) or [`Without`](super::Without) filters so that access is
+    ///    mutually exclusive. The fine grained phase iterates over all filters in
+    ///    the `self` set and compares it to all the filters in the `other` set,
+    ///    making sure they are all mutually compatible.
+    pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
+        if self.combined_access.is_compatible(other.combined_access()) {
+            return true;
+        }
+        for filtered in &self.filtered_accesses {
+            for other_filtered in &other.filtered_accesses {
+                if !filtered.is_compatible(other_filtered) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Returns a vector of elements that this set and `other` cannot access at the same time.
+    pub fn get_conflicts(&self, other: &FilteredAccessSet<T>) -> Vec<T> {
+        // if the unfiltered access is incompatible, must check each pair
+        let mut conflicts = HashSet::new();
+        if !self.combined_access.is_compatible(other.combined_access()) {
+            for filtered in &self.filtered_accesses {
+                for other_filtered in &other.filtered_accesses {
+                    conflicts.extend(filtered.get_conflicts(other_filtered).into_iter());
+                }
+            }
+        }
+        conflicts.into_iter().collect()
+    }
+
+    /// Returns a vector of elements that this set and `other` cannot access at the same time.
+    pub fn get_conflicts_single(&self, filtered_access: &FilteredAccess<T>) -> Vec<T> {
+        // if the unfiltered access is incompatible, must check each pair
+        let mut conflicts = HashSet::new();
+        if !self.combined_access.is_compatible(filtered_access.access()) {
+            for filtered in &self.filtered_accesses {
+                conflicts.extend(filtered.get_conflicts(filtered_access).into_iter());
+            }
+        }
+        conflicts.into_iter().collect()
+    }
+
+    /// Adds the filtered access to the set.
+    pub fn add(&mut self, filtered_access: FilteredAccess<T>) {
+        self.combined_access.extend(&filtered_access.access);
+        self.filtered_accesses.push(filtered_access);
+    }
+
+    /// Adds a read access without filters to the set.
+    pub(crate) fn add_unfiltered_read(&mut self, index: T) {
+        let mut filter = FilteredAccess::default();
+        filter.add_read(index);
+        self.add(filter);
+    }
+
+    /// Adds a write access without filters to the set.
+    pub(crate) fn add_unfiltered_write(&mut self, index: T) {
+        let mut filter = FilteredAccess::default();
+        filter.add_write(index);
+        self.add(filter);
+    }
+
+    /// Adds all of the accesses from the passed set to `self`.
+    pub fn extend(&mut self, filtered_access_set: FilteredAccessSet<T>) {
+        self.combined_access
+            .extend(&filtered_access_set.combined_access);
+        self.filtered_accesses
+            .extend(filtered_access_set.filtered_accesses);
+    }
+
+    /// Removes all accesses stored in this set.
+    pub fn clear(&mut self) {
+        self.combined_access.clear();
+        self.filtered_accesses.clear();
+    }
+}
+
+impl<T: SparseSetIndex> Default for FilteredAccessSet<T> {
+    fn default() -> Self {
+        Self {
+            combined_access: Default::default(),
+            filtered_accesses: Vec::new(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::query::access::AccessFilters;
+    use crate::query::{Access, FilteredAccess, FilteredAccessSet};
     use fixedbitset::FixedBitSet;
     use std::marker::PhantomData;
 
-    /// A wrapper struct to make Debug representations of [`FixedBitSet`] easier
-    /// to read, when used to store [`SparseSetIndex`].
-    ///
-    /// Instead of the raw integer representation of the `FixedBitSet`, the list of
-    /// `T` valid for [`SparseSetIndex`] is shown.
-    ///
-    /// Normal `FixedBitSet` `Debug` output:
-    /// ```text
-    /// read_and_writes: FixedBitSet { data: [ 160 ], length: 8 }
-    /// ```
-    ///
-    /// Which, unless you are a computer, doesn't help much understand what's in
-    /// the set. With `FormattedBitSet`, we convert the present set entries into
-    /// what they stand for, it is much clearer what is going on:
-    /// ```text
-    /// read_and_writes: [ ComponentId(5), ComponentId(7) ]
-    /// ```
-    struct FormattedBitSet<'a, T: SparseSetIndex> {
-        bit_set: &'a FixedBitSet,
-        _marker: PhantomData<T>,
+    #[test]
+    fn read_all_access_conflicts() {
+        // read_all / single write
+        let mut access_a = Access::<usize>::default();
+        access_a.grow(10);
+        access_a.add_write(0);
+
+        let mut access_b = Access::<usize>::default();
+        access_b.read_all();
+
+        assert!(!access_b.is_compatible(&access_a));
+
+        // read_all / read_all
+        let mut access_a = Access::<usize>::default();
+        access_a.grow(10);
+        access_a.read_all();
+
+        let mut access_b = Access::<usize>::default();
+        access_b.read_all();
+
+        assert!(access_b.is_compatible(&access_a));
     }
 
-    impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
-        fn new(bit_set: &'a FixedBitSet) -> Self {
-            Self {
-                bit_set,
-                _marker: PhantomData,
-            }
-        }
+    #[test]
+    fn access_get_conflicts() {
+        let mut access_a = Access::<usize>::default();
+        access_a.add_read(0);
+        access_a.add_read(1);
+
+        let mut access_b = Access::<usize>::default();
+        access_b.add_read(0);
+        access_b.add_write(1);
+
+        assert_eq!(access_a.get_conflicts(&access_b), vec![1]);
+
+        let mut access_c = Access::<usize>::default();
+        access_c.add_write(0);
+        access_c.add_write(1);
+
+        assert_eq!(access_a.get_conflicts(&access_c), vec![0, 1]);
+        assert_eq!(access_b.get_conflicts(&access_c), vec![0, 1]);
+
+        let mut access_d = Access::<usize>::default();
+        access_d.add_read(0);
+
+        assert_eq!(access_d.get_conflicts(&access_a), vec![]);
+        assert_eq!(access_d.get_conflicts(&access_b), vec![]);
+        assert_eq!(access_d.get_conflicts(&access_c), vec![0]);
     }
 
-    impl<'a, T: SparseSetIndex + fmt::Debug> fmt::Debug for FormattedBitSet<'a, T> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_list()
-                .entries(self.bit_set.ones().map(T::get_sparse_set_index))
-                .finish()
-        }
+    #[test]
+    fn filtered_combined_access() {
+        let mut access_a = FilteredAccessSet::<usize>::default();
+        access_a.add_unfiltered_read(1);
+
+        let mut filter_b = FilteredAccess::<usize>::default();
+        filter_b.add_write(1);
+
+        let conflicts = access_a.get_conflicts_single(&filter_b);
+        assert_eq!(
+            &conflicts,
+            &[1_usize],
+            "access_a: {access_a:?}, filter_b: {filter_b:?}"
+        );
     }
 
-    /// Tracks read and write access to specific elements in a collection.
-    ///
-    /// Used internally to ensure soundness during system initialization and execution.
-    /// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
-    #[derive(Clone, Eq, PartialEq)]
-    pub struct Access<T: SparseSetIndex> {
-        /// All accessed elements.
-        reads_and_writes: FixedBitSet,
-        /// The exclusively-accessed elements.
-        writes: FixedBitSet,
-        /// Is `true` if this has access to all elements in the collection.
-        /// This field is a performance optimization for `&World` (also harder to mess up for soundness).
-        reads_all: bool,
-        /// Is `true` if this has mutable access to all elements in the collection.
-        /// If this is true, then `reads_all` must also be true.
-        writes_all: bool,
-        marker: PhantomData<T>,
+    #[test]
+    fn filtered_access_extend() {
+        let mut access_a = FilteredAccess::<usize>::default();
+        access_a.add_read(0);
+        access_a.add_read(1);
+        access_a.and_with(2);
+
+        let mut access_b = FilteredAccess::<usize>::default();
+        access_b.add_read(0);
+        access_b.add_write(3);
+        access_b.and_without(4);
+
+        access_a.extend(&access_b);
+
+        let mut expected = FilteredAccess::<usize>::default();
+        expected.add_read(0);
+        expected.add_read(1);
+        expected.and_with(2);
+        expected.add_write(3);
+        expected.and_without(4);
+
+        assert!(access_a.eq(&expected));
     }
 
-    impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("Access")
-                .field(
-                    "read_and_writes",
-                    &FormattedBitSet::<T>::new(&self.reads_and_writes),
-                )
-                .field("writes", &FormattedBitSet::<T>::new(&self.writes))
-                .field("reads_all", &self.reads_all)
-                .field("writes_all", &self.writes_all)
-                .finish()
-        }
-    }
+    #[test]
+    fn filtered_access_extend_or() {
+        let mut access_a = FilteredAccess::<usize>::default();
+        // Exclusive access to `(&mut A, &mut B)`.
+        access_a.add_write(0);
+        access_a.add_write(1);
 
-    impl<T: SparseSetIndex> Default for Access<T> {
-        fn default() -> Self {
-            Self::new()
-        }
-    }
+        // Filter by `With<C>`.
+        let mut access_b = FilteredAccess::<usize>::default();
+        access_b.and_with(2);
 
-    impl<T: SparseSetIndex> Access<T> {
-        /// Creates an empty [`Access`] collection.
-        pub const fn new() -> Self {
-            Self {
-                reads_all: false,
-                writes_all: false,
-                reads_and_writes: FixedBitSet::new(),
-                writes: FixedBitSet::new(),
-                marker: PhantomData,
-            }
-        }
+        // Filter by `(With<D>, Without<E>)`.
+        let mut access_c = FilteredAccess::<usize>::default();
+        access_c.and_with(3);
+        access_c.and_without(4);
 
-        /// Increases the set capacity to the specified amount.
-        ///
-        /// Does nothing if `capacity` is less than or equal to the current value.
-        pub fn grow(&mut self, capacity: usize) {
-            self.reads_and_writes.grow(capacity);
-            self.writes.grow(capacity);
-        }
+        // Turns `access_b` into `Or<(With<C>, (With<D>, Without<D>))>`.
+        access_b.append_or(&access_c);
+        // Applies the filters to the initial query, which corresponds to the FilteredAccess'
+        // representation of `Query<(&mut A, &mut B), Or<(With<C>, (With<D>, Without<E>))>>`.
+        access_a.extend(&access_b);
 
-        /// Adds access to the element given by `index`.
-        pub fn add_read(&mut self, index: T) {
-            self.reads_and_writes.grow(index.sparse_set_index() + 1);
-            self.reads_and_writes.insert(index.sparse_set_index());
-        }
-
-        /// Adds exclusive access to the element given by `index`.
-        pub fn add_write(&mut self, index: T) {
-            self.reads_and_writes.grow(index.sparse_set_index() + 1);
-            self.reads_and_writes.insert(index.sparse_set_index());
-            self.writes.grow(index.sparse_set_index() + 1);
-            self.writes.insert(index.sparse_set_index());
-        }
-
-        /// Returns `true` if this can access the element given by `index`.
-        pub fn has_read(&self, index: T) -> bool {
-            self.reads_all || self.reads_and_writes.contains(index.sparse_set_index())
-        }
-
-        /// Returns `true` if this can access anything.
-        pub fn has_any_read(&self) -> bool {
-            self.reads_all || !self.reads_and_writes.is_clear()
-        }
-
-        /// Returns `true` if this can exclusively access the element given by `index`.
-        pub fn has_write(&self, index: T) -> bool {
-            self.writes_all || self.writes.contains(index.sparse_set_index())
-        }
-
-        /// Returns `true` if this accesses anything mutably.
-        pub fn has_any_write(&self) -> bool {
-            self.writes_all || !self.writes.is_clear()
-        }
-
-        /// Sets this as having access to all indexed elements (i.e. `&World`).
-        pub fn read_all(&mut self) {
-            self.reads_all = true;
-        }
-
-        /// Sets this as having mutable access to all indexed elements (i.e. `EntityMut`).
-        pub fn write_all(&mut self) {
-            self.reads_all = true;
-            self.writes_all = true;
-        }
-
-        /// Returns `true` if this has access to all indexed elements (i.e. `&World`).
-        pub fn has_read_all(&self) -> bool {
-            self.reads_all
-        }
-
-        /// Returns `true` if this has write access to all indexed elements (i.e. `EntityMut`).
-        pub fn has_write_all(&self) -> bool {
-            self.writes_all
-        }
-
-        /// Removes all accesses.
-        pub fn clear(&mut self) {
-            self.reads_all = false;
-            self.writes_all = false;
-            self.reads_and_writes.clear();
-            self.writes.clear();
-        }
-
-        /// Adds all access from `other`.
-        pub fn extend(&mut self, other: &Access<T>) {
-            self.reads_all = self.reads_all || other.reads_all;
-            self.writes_all = self.writes_all || other.writes_all;
-            self.reads_and_writes.union_with(&other.reads_and_writes);
-            self.writes.union_with(&other.writes);
-        }
-
-        /// Returns `true` if the access and `other` can be active at the same time.
-        ///
-        /// [`Access`] instances are incompatible if one can write
-        /// an element that the other can read or write.
-        pub fn is_compatible(&self, other: &Access<T>) -> bool {
-            if self.writes_all {
-                return !other.has_any_read();
-            }
-
-            if other.writes_all {
-                return !self.has_any_read();
-            }
-
-            if self.reads_all {
-                return !other.has_any_write();
-            }
-
-            if other.reads_all {
-                return !self.has_any_write();
-            }
-
-            self.writes.is_disjoint(&other.reads_and_writes)
-                && other.writes.is_disjoint(&self.reads_and_writes)
-        }
-
-        /// [`Access`] is subset of `other` access.
-        pub fn is_subset(&self, other: &Access<T>) -> bool {
-            if self.writes_all {
-                return other.writes_all;
-            }
-
-            if other.writes_all {
-                return true;
-            }
-
-            if self.reads_all {
-                return other.reads_all || other.writes_all;
-            }
-
-            if other.reads_all {
-                return self.has_any_write();
-            }
-
-            let reads = self.reads_and_writes.difference(&self.writes).collect::<FixedBitSet>();
-
-            reads.is_subset(&other.reads_and_writes) && self.writes.is_subset(&other.writes)
-        }
-
-        /// Returns a vector of elements that the access and `other` cannot access at the same time.
-        pub fn get_conflicts(&self, other: &Access<T>) -> Vec<T> {
-            let mut conflicts = FixedBitSet::default();
-            if self.reads_all {
-                // QUESTION: How to handle `other.writes_all`?
-                conflicts.extend(other.writes.ones());
-            }
-
-            if other.reads_all {
-                // QUESTION: How to handle `self.writes_all`.
-                conflicts.extend(self.writes.ones());
-            }
-
-            if self.writes_all {
-                conflicts.extend(other.reads_and_writes.ones());
-            }
-
-            if other.writes_all {
-                conflicts.extend(self.reads_and_writes.ones());
-            }
-
-            conflicts.extend(self.writes.intersection(&other.reads_and_writes));
-            conflicts.extend(self.reads_and_writes.intersection(&other.writes));
-            conflicts
-                .ones()
-                .map(SparseSetIndex::get_sparse_set_index)
-                .collect()
-        }
-
-        /// Returns the indices of the elements this has access to.
-        pub fn reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
-            self.reads_and_writes.ones().map(T::get_sparse_set_index)
-        }
-
-        /// Returns the indices of the elements this has non-exclusive access to.
-        pub fn reads(&self) -> impl Iterator<Item = T> + '_ {
-            self.reads_and_writes
-                .difference(&self.writes)
-                .map(T::get_sparse_set_index)
-        }
-
-        /// Returns the indices of the elements this has exclusive access to.
-        pub fn writes(&self) -> impl Iterator<Item = T> + '_ {
-            self.writes.ones().map(T::get_sparse_set_index)
-        }
-    }
-
-    /// An [`Access`] that has been filtered to include and exclude certain combinations of elements.
-    ///
-    /// Used internally to statically check if queries are disjoint.
-    ///
-    /// Subtle: a `read` or `write` in `access` should not be considered to imply a
-    /// `with` access.
-    ///
-    /// For example consider `Query<Option<&T>>` this only has a `read` of `T` as doing
-    /// otherwise would allow for queries to be considered disjoint when they shouldn't:
-    /// - `Query<(&mut T, Option<&U>)>` read/write `T`, read `U`, with `U`
-    /// - `Query<&mut T, Without<U>>` read/write `T`, without `U`
-    /// from this we could reasonably conclude that the queries are disjoint but they aren't.
-    ///
-    /// In order to solve this the actual access that `Query<(&mut T, Option<&U>)>` has
-    /// is read/write `T`, read `U`. It must still have a read `U` access otherwise the following
-    /// queries would be incorrectly considered disjoint:
-    /// - `Query<&mut T>`  read/write `T`
-    /// - `Query<Option<&T>>` accesses nothing
-    ///
-    /// See comments the [`WorldQuery`](super::WorldQuery) impls of [`AnyOf`](super::AnyOf)/`Option`/[`Or`](super::Or) for more information.
-    #[derive(Debug, Clone, Eq, PartialEq)]
-    pub struct FilteredAccess<T: SparseSetIndex> {
-        access: Access<T>,
-        // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
-        // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
-        filter_sets: Vec<AccessFilters<T>>,
-    }
-
-    impl<T: SparseSetIndex> Default for FilteredAccess<T> {
-        fn default() -> Self {
-            Self {
-                access: Access::default(),
-                filter_sets: vec![AccessFilters::default()],
-            }
-        }
-    }
-
-    impl<T: SparseSetIndex> From<FilteredAccess<T>> for FilteredAccessSet<T> {
-        fn from(filtered_access: FilteredAccess<T>) -> Self {
-            let mut base = FilteredAccessSet::<T>::default();
-            base.add(filtered_access);
-            base
-        }
-    }
-
-    impl<T: SparseSetIndex> FilteredAccess<T> {
-        /// Returns a reference to the underlying unfiltered access.
-        #[inline]
-        pub fn access(&self) -> &Access<T> {
-            &self.access
-        }
-
-        /// Returns a mutable reference to the underlying unfiltered access.
-        #[inline]
-        pub fn access_mut(&mut self) -> &mut Access<T> {
-            &mut self.access
-        }
-
-        /// Adds access to the element given by `index`.
-        pub fn add_read(&mut self, index: T) {
-            self.access.add_read(index.clone());
-            self.and_with(index);
-        }
-
-        /// Adds exclusive access to the element given by `index`.
-        pub fn add_write(&mut self, index: T) {
-            self.access.add_write(index.clone());
-            self.and_with(index);
-        }
-
-        /// Adds a `With` filter: corresponds to a conjunction (AND) operation.
-        ///
-        /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
-        /// Adding `AND With<C>` via this method transforms it into the equivalent of  `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
-        pub fn and_with(&mut self, index: T) {
-            let index = index.sparse_set_index();
-            for filter in &mut self.filter_sets {
-                filter.with.grow(index + 1);
-                filter.with.insert(index);
-            }
-        }
-
-        /// Adds a `Without` filter: corresponds to a conjunction (AND) operation.
-        ///
-        /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
-        /// Adding `AND Without<C>` via this method transforms it into the equivalent of  `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
-        pub fn and_without(&mut self, index: T) {
-            let index = index.sparse_set_index();
-            for filter in &mut self.filter_sets {
-                filter.without.grow(index + 1);
-                filter.without.insert(index);
-            }
-        }
-
-        /// Appends an array of filters: corresponds to a disjunction (OR) operation.
-        ///
-        /// As the underlying array of filters represents a disjunction,
-        /// where each element (`AccessFilters`) represents a conjunction,
-        /// we can simply append to the array.
-        pub fn append_or(&mut self, other: &FilteredAccess<T>) {
-            self.filter_sets.append(&mut other.filter_sets.clone());
-        }
-
-        /// Adds all of the accesses from `other` to `self`.
-        pub fn extend_access(&mut self, other: &FilteredAccess<T>) {
-            self.access.extend(&other.access);
-        }
-
-        /// Returns `true` if this and `other` can be active at the same time.
-        pub fn is_compatible(&self, other: &FilteredAccess<T>) -> bool {
-            if self.access.is_compatible(&other.access) {
-                return true;
-            }
-
-            // If the access instances are incompatible, we want to check that whether filters can
-            // guarantee that queries are disjoint.
-            // Since the `filter_sets` array represents a Disjunctive Normal Form formula ("ORs of ANDs"),
-            // we need to make sure that each filter set (ANDs) rule out every filter set from the `other` instance.
-            //
-            // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,
-            // but `Query<&mut C, Or<(Without<A>, Without<B>)>>` isn't compatible with `Query<&mut C, Or<(With<A>, With<B>)>>`.
-            self.filter_sets.iter().all(|filter| {
-                other
-                    .filter_sets
-                    .iter()
-                    .all(|other_filter| filter.is_ruled_out_by(other_filter))
-            })
-        }
-
-        ///  access is compatible with other access. This does not take into account the filtered access.
-        pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
-            self.access.is_subset(&other.access)
-        }
-
-        /// Returns a vector of elements that this and `other` cannot access at the same time.
-        pub fn get_conflicts(&self, other: &FilteredAccess<T>) -> Vec<T> {
-            if !self.is_compatible(other) {
-                // filters are disjoint, so we can just look at the unfiltered intersection
-                return self.access.get_conflicts(&other.access);
-            }
-            Vec::new()
-        }
-
-        /// Adds all access and filters from `other`.
-        ///
-        /// Corresponds to a conjunction operation (AND) for filters.
-        ///
-        /// Extending `Or<(With<A>, Without<B>)>` with `Or<(With<C>, Without<D>)>` will result in
-        /// `Or<((With<A>, With<C>), (With<A>, Without<D>), (Without<B>, With<C>), (Without<B>, Without<D>))>`.
-        pub fn extend(&mut self, other: &FilteredAccess<T>) {
-            self.access.extend(&other.access);
-
-            // We can avoid allocating a new array of bitsets if `other` contains just a single set of filters:
-            // in this case we can short-circuit by performing an in-place union for each bitset.
-            if other.filter_sets.len() == 1 {
-                for filter in &mut self.filter_sets {
-                    filter.with.union_with(&other.filter_sets[0].with);
-                    filter.without.union_with(&other.filter_sets[0].without);
-                }
-                return;
-            }
-
-            let mut new_filters = Vec::with_capacity(self.filter_sets.len() * other.filter_sets.len());
-            for filter in &self.filter_sets {
-                for other_filter in &other.filter_sets {
-                    let mut new_filter = filter.clone();
-                    new_filter.with.union_with(&other_filter.with);
-                    new_filter.without.union_with(&other_filter.without);
-                    new_filters.push(new_filter);
-                }
-            }
-            self.filter_sets = new_filters;
-        }
-
-        /// Sets the underlying unfiltered access as having access to all indexed elements.
-        pub fn read_all(&mut self) {
-            self.access.read_all();
-        }
-
-        /// Sets the underlying unfiltered access as having mutable access to all indexed elements.
-        pub fn write_all(&mut self) {
-            self.access.write_all();
-        }
-    }
-
-    #[derive(Clone, Eq, PartialEq)]
-    struct AccessFilters<T> {
-        with: FixedBitSet,
-        without: FixedBitSet,
-        _index_type: PhantomData<T>,
-    }
-
-    impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for AccessFilters<T> {
-        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-            f.debug_struct("AccessFilters")
-                .field("with", &FormattedBitSet::<T>::new(&self.with))
-                .field("without", &FormattedBitSet::<T>::new(&self.without))
-                .finish()
-        }
-    }
-
-    impl<T: SparseSetIndex> Default for AccessFilters<T> {
-        fn default() -> Self {
-            Self {
-                with: FixedBitSet::default(),
+        // Construct the expected `FilteredAccess` struct.
+        // The intention here is to test that exclusive access implied by `add_write`
+        // forms correct normalized access structs when extended with `Or` filters.
+        let mut expected = FilteredAccess::<usize>::default();
+        expected.add_write(0);
+        expected.add_write(1);
+        // The resulted access is expected to represent `Or<((With<A>, With<B>, With<C>), (With<A>, With<B>, With<D>, Without<E>))>`.
+        expected.filter_sets = vec![
+            AccessFilters {
+                with: FixedBitSet::with_capacity_and_blocks(3, [0b111]),
                 without: FixedBitSet::default(),
                 _index_type: PhantomData,
-            }
-        }
+            },
+            AccessFilters {
+                with: FixedBitSet::with_capacity_and_blocks(4, [0b1011]),
+                without: FixedBitSet::with_capacity_and_blocks(5, [0b10000]),
+                _index_type: PhantomData,
+            },
+        ];
+
+        assert_eq!(access_a, expected);
     }
-
-    impl<T: SparseSetIndex> AccessFilters<T> {
-        fn is_ruled_out_by(&self, other: &Self) -> bool {
-            // Although not technically complete, we don't consider the case when `AccessFilters`'s
-            // `without` bitset contradicts its own `with` bitset (e.g. `(With<A>, Without<A>)`).
-            // Such query would be considered compatible with any other query, but as it's almost
-            // always an error, we ignore this case instead of treating such query as compatible
-            // with others.
-            !self.with.is_disjoint(&other.without) || !self.without.is_disjoint(&other.with)
-        }
-    }
-
-    /// A collection of [`FilteredAccess`] instances.
-    ///
-    /// Used internally to statically check if systems have conflicting access.
-    ///
-    /// It stores multiple sets of accesses.
-    /// - A "combined" set, which is the access of all filters in this set combined.
-    /// - The set of access of each individual filters in this set.
-    #[derive(Debug, Clone)]
-    pub struct FilteredAccessSet<T: SparseSetIndex> {
-        combined_access: Access<T>,
-        filtered_accesses: Vec<FilteredAccess<T>>,
-    }
-
-    impl<T: SparseSetIndex> FilteredAccessSet<T> {
-        /// Returns a reference to the unfiltered access of the entire set.
-        #[inline]
-        pub fn combined_access(&self) -> &Access<T> {
-            &self.combined_access
-        }
-
-        /// Returns `true` if this and `other` can be active at the same time.
-        ///
-        /// Access conflict resolution happen in two steps:
-        /// 1. A "coarse" check, if there is no mutual unfiltered conflict between
-        ///    `self` and `other`, we already know that the two access sets are
-        ///    compatible.
-        /// 2. A "fine grained" check, it kicks in when the "coarse" check fails.
-        ///    the two access sets might still be compatible if some of the accesses
-        ///    are restricted with the [`With`](super::With) or [`Without`](super::Without) filters so that access is
-        ///    mutually exclusive. The fine grained phase iterates over all filters in
-        ///    the `self` set and compares it to all the filters in the `other` set,
-        ///    making sure they are all mutually compatible.
-        pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
-            if self.combined_access.is_compatible(other.combined_access()) {
-                return true;
-            }
-            for filtered in &self.filtered_accesses {
-                for other_filtered in &other.filtered_accesses {
-                    if !filtered.is_compatible(other_filtered) {
-                        return false;
-                    }
-                }
-            }
-            true
-        }
-
-        /// Returns a vector of elements that this set and `other` cannot access at the same time.
-        pub fn get_conflicts(&self, other: &FilteredAccessSet<T>) -> Vec<T> {
-            // if the unfiltered access is incompatible, must check each pair
-            let mut conflicts = HashSet::new();
-            if !self.combined_access.is_compatible(other.combined_access()) {
-                for filtered in &self.filtered_accesses {
-                    for other_filtered in &other.filtered_accesses {
-                        conflicts.extend(filtered.get_conflicts(other_filtered).into_iter());
-                    }
-                }
-            }
-            conflicts.into_iter().collect()
-        }
-
-        /// Returns a vector of elements that this set and `other` cannot access at the same time.
-        pub fn get_conflicts_single(&self, filtered_access: &FilteredAccess<T>) -> Vec<T> {
-            // if the unfiltered access is incompatible, must check each pair
-            let mut conflicts = HashSet::new();
-            if !self.combined_access.is_compatible(filtered_access.access()) {
-                for filtered in &self.filtered_accesses {
-                    conflicts.extend(filtered.get_conflicts(filtered_access).into_iter());
-                }
-            }
-            conflicts.into_iter().collect()
-        }
-
-        /// Adds the filtered access to the set.
-        pub fn add(&mut self, filtered_access: FilteredAccess<T>) {
-            self.combined_access.extend(&filtered_access.access);
-            self.filtered_accesses.push(filtered_access);
-        }
-
-        /// Adds a read access without filters to the set.
-        pub(crate) fn add_unfiltered_read(&mut self, index: T) {
-            let mut filter = FilteredAccess::default();
-            filter.add_read(index);
-            self.add(filter);
-        }
-
-        /// Adds a write access without filters to the set.
-        pub(crate) fn add_unfiltered_write(&mut self, index: T) {
-            let mut filter = FilteredAccess::default();
-            filter.add_write(index);
-            self.add(filter);
-        }
-
-        /// Adds all of the accesses from the passed set to `self`.
-        pub fn extend(&mut self, filtered_access_set: FilteredAccessSet<T>) {
-            self.combined_access
-                .extend(&filtered_access_set.combined_access);
-            self.filtered_accesses
-                .extend(filtered_access_set.filtered_accesses);
-        }
-
-        /// Removes all accesses stored in this set.
-        pub fn clear(&mut self) {
-            self.combined_access.clear();
-            self.filtered_accesses.clear();
-        }
-    }
-
-    impl<T: SparseSetIndex> Default for FilteredAccessSet<T> {
-        fn default() -> Self {
-            Self {
-                combined_access: Default::default(),
-                filtered_accesses: Vec::new(),
-            }
-        }
-    }
-
-    #[cfg(test)]
-    mod tests {
-        use crate::query::access::AccessFilters;
-        use crate::query::{Access, FilteredAccess, FilteredAccessSet};
-        use fixedbitset::FixedBitSet;
-        use std::marker::PhantomData;
-
-        #[test]
-        fn read_all_access_conflicts() {
-            // read_all / single write
-            let mut access_a = Access::<usize>::default();
-            access_a.grow(10);
-            access_a.add_write(0);
-
-            let mut access_b = Access::<usize>::default();
-            access_b.read_all();
-
-            assert!(!access_b.is_compatible(&access_a));
-
-            // read_all / read_all
-            let mut access_a = Access::<usize>::default();
-            access_a.grow(10);
-            access_a.read_all();
-
-            let mut access_b = Access::<usize>::default();
-            access_b.read_all();
-
-            assert!(access_b.is_compatible(&access_a));
-        }
-
-        #[test]
-        fn access_get_conflicts() {
-            let mut access_a = Access::<usize>::default();
-            access_a.add_read(0);
-            access_a.add_read(1);
-
-            let mut access_b = Access::<usize>::default();
-            access_b.add_read(0);
-            access_b.add_write(1);
-
-            assert_eq!(access_a.get_conflicts(&access_b), vec![1]);
-
-            let mut access_c = Access::<usize>::default();
-            access_c.add_write(0);
-            access_c.add_write(1);
-
-            assert_eq!(access_a.get_conflicts(&access_c), vec![0, 1]);
-            assert_eq!(access_b.get_conflicts(&access_c), vec![0, 1]);
-
-            let mut access_d = Access::<usize>::default();
-            access_d.add_read(0);
-
-            assert_eq!(access_d.get_conflicts(&access_a), vec![]);
-            assert_eq!(access_d.get_conflicts(&access_b), vec![]);
-            assert_eq!(access_d.get_conflicts(&access_c), vec![0]);
-        }
-
-        #[test]
-        fn filtered_combined_access() {
-            let mut access_a = FilteredAccessSet::<usize>::default();
-            access_a.add_unfiltered_read(1);
-
-            let mut filter_b = FilteredAccess::<usize>::default();
-            filter_b.add_write(1);
-
-            let conflicts = access_a.get_conflicts_single(&filter_b);
-            assert_eq!(
-                &conflicts,
-                &[1_usize],
-                "access_a: {access_a:?}, filter_b: {filter_b:?}"
-            );
-        }
-
-        #[test]
-        fn filtered_access_extend() {
-            let mut access_a = FilteredAccess::<usize>::default();
-            access_a.add_read(0);
-            access_a.add_read(1);
-            access_a.and_with(2);
-
-            let mut access_b = FilteredAccess::<usize>::default();
-            access_b.add_read(0);
-            access_b.add_write(3);
-            access_b.and_without(4);
-
-            access_a.extend(&access_b);
-
-            let mut expected = FilteredAccess::<usize>::default();
-            expected.add_read(0);
-            expected.add_read(1);
-            expected.and_with(2);
-            expected.add_write(3);
-            expected.and_without(4);
-
-            assert!(access_a.eq(&expected));
-        }
-
-        #[test]
-        fn filtered_access_extend_or() {
-            let mut access_a = FilteredAccess::<usize>::default();
-            // Exclusive access to `(&mut A, &mut B)`.
-            access_a.add_write(0);
-            access_a.add_write(1);
-
-            // Filter by `With<C>`.
-            let mut access_b = FilteredAccess::<usize>::default();
-            access_b.and_with(2);
-
-            // Filter by `(With<D>, Without<E>)`.
-            let mut access_c = FilteredAccess::<usize>::default();
-            access_c.and_with(3);
-            access_c.and_without(4);
-
-            // Turns `access_b` into `Or<(With<C>, (With<D>, Without<D>))>`.
-            access_b.append_or(&access_c);
-            // Applies the filters to the initial query, which corresponds to the FilteredAccess'
-            // representation of `Query<(&mut A, &mut B), Or<(With<C>, (With<D>, Without<E>))>>`.
-            access_a.extend(&access_b);
-
-            // Construct the expected `FilteredAccess` struct.
-            // The intention here is to test that exclusive access implied by `add_write`
-            // forms correct normalized access structs when extended with `Or` filters.
-            let mut expected = FilteredAccess::<usize>::default();
-            expected.add_write(0);
-            expected.add_write(1);
-            // The resulted access is expected to represent `Or<((With<A>, With<B>, With<C>), (With<A>, With<B>, With<D>, Without<E>))>`.
-            expected.filter_sets = vec![
-                AccessFilters {
-                    with: FixedBitSet::with_capacity_and_blocks(3, [0b111]),
-                    without: FixedBitSet::default(),
-                    _index_type: PhantomData,
-                },
-                AccessFilters {
-                    with: FixedBitSet::with_capacity_and_blocks(4, [0b1011]),
-                    without: FixedBitSet::with_capacity_and_blocks(5, [0b10000]),
-                    _index_type: PhantomData,
-                },
-            ];
-
-            assert_eq!(access_a, expected);
-        }
-    }
+}

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -1,722 +1,750 @@
-use crate::storage::SparseSetIndex;
-use bevy_utils::HashSet;
-use core::fmt;
-use fixedbitset::FixedBitSet;
-use std::marker::PhantomData;
-
-/// A wrapper struct to make Debug representations of [`FixedBitSet`] easier
-/// to read, when used to store [`SparseSetIndex`].
-///
-/// Instead of the raw integer representation of the `FixedBitSet`, the list of
-/// `T` valid for [`SparseSetIndex`] is shown.
-///
-/// Normal `FixedBitSet` `Debug` output:
-/// ```text
-/// read_and_writes: FixedBitSet { data: [ 160 ], length: 8 }
-/// ```
-///
-/// Which, unless you are a computer, doesn't help much understand what's in
-/// the set. With `FormattedBitSet`, we convert the present set entries into
-/// what they stand for, it is much clearer what is going on:
-/// ```text
-/// read_and_writes: [ ComponentId(5), ComponentId(7) ]
-/// ```
-struct FormattedBitSet<'a, T: SparseSetIndex> {
-    bit_set: &'a FixedBitSet,
-    _marker: PhantomData<T>,
-}
-
-impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
-    fn new(bit_set: &'a FixedBitSet) -> Self {
-        Self {
-            bit_set,
-            _marker: PhantomData,
-        }
-    }
-}
-
-impl<'a, T: SparseSetIndex + fmt::Debug> fmt::Debug for FormattedBitSet<'a, T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_list()
-            .entries(self.bit_set.ones().map(T::get_sparse_set_index))
-            .finish()
-    }
-}
-
-/// Tracks read and write access to specific elements in a collection.
-///
-/// Used internally to ensure soundness during system initialization and execution.
-/// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
-#[derive(Clone, Eq, PartialEq)]
-pub struct Access<T: SparseSetIndex> {
-    /// All accessed elements.
-    reads_and_writes: FixedBitSet,
-    /// The exclusively-accessed elements.
-    writes: FixedBitSet,
-    /// Is `true` if this has access to all elements in the collection.
-    /// This field is a performance optimization for `&World` (also harder to mess up for soundness).
-    reads_all: bool,
-    /// Is `true` if this has mutable access to all elements in the collection.
-    /// If this is true, then `reads_all` must also be true.
-    writes_all: bool,
-    marker: PhantomData<T>,
-}
-
-impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Access")
-            .field(
-                "read_and_writes",
-                &FormattedBitSet::<T>::new(&self.reads_and_writes),
-            )
-            .field("writes", &FormattedBitSet::<T>::new(&self.writes))
-            .field("reads_all", &self.reads_all)
-            .field("writes_all", &self.writes_all)
-            .finish()
-    }
-}
-
-impl<T: SparseSetIndex> Default for Access<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<T: SparseSetIndex> Access<T> {
-    /// Creates an empty [`Access`] collection.
-    pub const fn new() -> Self {
-        Self {
-            reads_all: false,
-            writes_all: false,
-            reads_and_writes: FixedBitSet::new(),
-            writes: FixedBitSet::new(),
-            marker: PhantomData,
-        }
-    }
-
-    /// Increases the set capacity to the specified amount.
-    ///
-    /// Does nothing if `capacity` is less than or equal to the current value.
-    pub fn grow(&mut self, capacity: usize) {
-        self.reads_and_writes.grow(capacity);
-        self.writes.grow(capacity);
-    }
-
-    /// Adds access to the element given by `index`.
-    pub fn add_read(&mut self, index: T) {
-        self.reads_and_writes.grow(index.sparse_set_index() + 1);
-        self.reads_and_writes.insert(index.sparse_set_index());
-    }
-
-    /// Adds exclusive access to the element given by `index`.
-    pub fn add_write(&mut self, index: T) {
-        self.reads_and_writes.grow(index.sparse_set_index() + 1);
-        self.reads_and_writes.insert(index.sparse_set_index());
-        self.writes.grow(index.sparse_set_index() + 1);
-        self.writes.insert(index.sparse_set_index());
-    }
-
-    /// Returns `true` if this can access the element given by `index`.
-    pub fn has_read(&self, index: T) -> bool {
-        self.reads_all || self.reads_and_writes.contains(index.sparse_set_index())
-    }
-
-    /// Returns `true` if this can access anything.
-    pub fn has_any_read(&self) -> bool {
-        self.reads_all || !self.reads_and_writes.is_clear()
-    }
-
-    /// Returns `true` if this can exclusively access the element given by `index`.
-    pub fn has_write(&self, index: T) -> bool {
-        self.writes_all || self.writes.contains(index.sparse_set_index())
-    }
-
-    /// Returns `true` if this accesses anything mutably.
-    pub fn has_any_write(&self) -> bool {
-        self.writes_all || !self.writes.is_clear()
-    }
-
-    /// Sets this as having access to all indexed elements (i.e. `&World`).
-    pub fn read_all(&mut self) {
-        self.reads_all = true;
-    }
-
-    /// Sets this as having mutable access to all indexed elements (i.e. `EntityMut`).
-    pub fn write_all(&mut self) {
-        self.reads_all = true;
-        self.writes_all = true;
-    }
-
-    /// Returns `true` if this has access to all indexed elements (i.e. `&World`).
-    pub fn has_read_all(&self) -> bool {
-        self.reads_all
-    }
-
-    /// Returns `true` if this has write access to all indexed elements (i.e. `EntityMut`).
-    pub fn has_write_all(&self) -> bool {
-        self.writes_all
-    }
-
-    /// Removes all accesses.
-    pub fn clear(&mut self) {
-        self.reads_all = false;
-        self.writes_all = false;
-        self.reads_and_writes.clear();
-        self.writes.clear();
-    }
-
-    /// Adds all access from `other`.
-    pub fn extend(&mut self, other: &Access<T>) {
-        self.reads_all = self.reads_all || other.reads_all;
-        self.writes_all = self.writes_all || other.writes_all;
-        self.reads_and_writes.union_with(&other.reads_and_writes);
-        self.writes.union_with(&other.writes);
-    }
-
-    /// Returns `true` if the access and `other` can be active at the same time.
-    ///
-    /// [`Access`] instances are incompatible if one can write
-    /// an element that the other can read or write.
-    pub fn is_compatible(&self, other: &Access<T>) -> bool {
-        if self.writes_all {
-            return !other.has_any_read();
-        }
-
-        if other.writes_all {
-            return !self.has_any_read();
-        }
-
-        if self.reads_all {
-            return !other.has_any_write();
-        }
-
-        if other.reads_all {
-            return !self.has_any_write();
-        }
-
-        self.writes.is_disjoint(&other.reads_and_writes)
-            && other.writes.is_disjoint(&self.reads_and_writes)
-    }
-
-    /// Returns a vector of elements that the access and `other` cannot access at the same time.
-    pub fn get_conflicts(&self, other: &Access<T>) -> Vec<T> {
-        let mut conflicts = FixedBitSet::default();
-        if self.reads_all {
-            // QUESTION: How to handle `other.writes_all`?
-            conflicts.extend(other.writes.ones());
-        }
-
-        if other.reads_all {
-            // QUESTION: How to handle `self.writes_all`.
-            conflicts.extend(self.writes.ones());
-        }
-
-        if self.writes_all {
-            conflicts.extend(other.reads_and_writes.ones());
-        }
-
-        if other.writes_all {
-            conflicts.extend(self.reads_and_writes.ones());
-        }
-
-        conflicts.extend(self.writes.intersection(&other.reads_and_writes));
-        conflicts.extend(self.reads_and_writes.intersection(&other.writes));
-        conflicts
-            .ones()
-            .map(SparseSetIndex::get_sparse_set_index)
-            .collect()
-    }
-
-    /// Returns the indices of the elements this has access to.
-    pub fn reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
-        self.reads_and_writes.ones().map(T::get_sparse_set_index)
-    }
-
-    /// Returns the indices of the elements this has non-exclusive access to.
-    pub fn reads(&self) -> impl Iterator<Item = T> + '_ {
-        self.reads_and_writes
-            .difference(&self.writes)
-            .map(T::get_sparse_set_index)
-    }
-
-    /// Returns the indices of the elements this has exclusive access to.
-    pub fn writes(&self) -> impl Iterator<Item = T> + '_ {
-        self.writes.ones().map(T::get_sparse_set_index)
-    }
-}
-
-/// An [`Access`] that has been filtered to include and exclude certain combinations of elements.
-///
-/// Used internally to statically check if queries are disjoint.
-///
-/// Subtle: a `read` or `write` in `access` should not be considered to imply a
-/// `with` access.
-///
-/// For example consider `Query<Option<&T>>` this only has a `read` of `T` as doing
-/// otherwise would allow for queries to be considered disjoint when they shouldn't:
-/// - `Query<(&mut T, Option<&U>)>` read/write `T`, read `U`, with `U`
-/// - `Query<&mut T, Without<U>>` read/write `T`, without `U`
-/// from this we could reasonably conclude that the queries are disjoint but they aren't.
-///
-/// In order to solve this the actual access that `Query<(&mut T, Option<&U>)>` has
-/// is read/write `T`, read `U`. It must still have a read `U` access otherwise the following
-/// queries would be incorrectly considered disjoint:
-/// - `Query<&mut T>`  read/write `T`
-/// - `Query<Option<&T>>` accesses nothing
-///
-/// See comments the [`WorldQuery`](super::WorldQuery) impls of [`AnyOf`](super::AnyOf)/`Option`/[`Or`](super::Or) for more information.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FilteredAccess<T: SparseSetIndex> {
-    access: Access<T>,
-    // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
-    // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
-    filter_sets: Vec<AccessFilters<T>>,
-}
-
-impl<T: SparseSetIndex> Default for FilteredAccess<T> {
-    fn default() -> Self {
-        Self {
-            access: Access::default(),
-            filter_sets: vec![AccessFilters::default()],
-        }
-    }
-}
-
-impl<T: SparseSetIndex> From<FilteredAccess<T>> for FilteredAccessSet<T> {
-    fn from(filtered_access: FilteredAccess<T>) -> Self {
-        let mut base = FilteredAccessSet::<T>::default();
-        base.add(filtered_access);
-        base
-    }
-}
-
-impl<T: SparseSetIndex> FilteredAccess<T> {
-    /// Returns a reference to the underlying unfiltered access.
-    #[inline]
-    pub fn access(&self) -> &Access<T> {
-        &self.access
-    }
-
-    /// Returns a mutable reference to the underlying unfiltered access.
-    #[inline]
-    pub fn access_mut(&mut self) -> &mut Access<T> {
-        &mut self.access
-    }
-
-    /// Adds access to the element given by `index`.
-    pub fn add_read(&mut self, index: T) {
-        self.access.add_read(index.clone());
-        self.and_with(index);
-    }
-
-    /// Adds exclusive access to the element given by `index`.
-    pub fn add_write(&mut self, index: T) {
-        self.access.add_write(index.clone());
-        self.and_with(index);
-    }
-
-    /// Adds a `With` filter: corresponds to a conjunction (AND) operation.
-    ///
-    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
-    /// Adding `AND With<C>` via this method transforms it into the equivalent of  `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
-    pub fn and_with(&mut self, index: T) {
-        let index = index.sparse_set_index();
-        for filter in &mut self.filter_sets {
-            filter.with.grow(index + 1);
-            filter.with.insert(index);
-        }
-    }
-
-    /// Adds a `Without` filter: corresponds to a conjunction (AND) operation.
-    ///
-    /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
-    /// Adding `AND Without<C>` via this method transforms it into the equivalent of  `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
-    pub fn and_without(&mut self, index: T) {
-        let index = index.sparse_set_index();
-        for filter in &mut self.filter_sets {
-            filter.without.grow(index + 1);
-            filter.without.insert(index);
-        }
-    }
-
-    /// Appends an array of filters: corresponds to a disjunction (OR) operation.
-    ///
-    /// As the underlying array of filters represents a disjunction,
-    /// where each element (`AccessFilters`) represents a conjunction,
-    /// we can simply append to the array.
-    pub fn append_or(&mut self, other: &FilteredAccess<T>) {
-        self.filter_sets.append(&mut other.filter_sets.clone());
-    }
-
-    /// Adds all of the accesses from `other` to `self`.
-    pub fn extend_access(&mut self, other: &FilteredAccess<T>) {
-        self.access.extend(&other.access);
-    }
-
-    /// Returns `true` if this and `other` can be active at the same time.
-    pub fn is_compatible(&self, other: &FilteredAccess<T>) -> bool {
-        if self.access.is_compatible(&other.access) {
-            return true;
-        }
-
-        // If the access instances are incompatible, we want to check that whether filters can
-        // guarantee that queries are disjoint.
-        // Since the `filter_sets` array represents a Disjunctive Normal Form formula ("ORs of ANDs"),
-        // we need to make sure that each filter set (ANDs) rule out every filter set from the `other` instance.
-        //
-        // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,
-        // but `Query<&mut C, Or<(Without<A>, Without<B>)>>` isn't compatible with `Query<&mut C, Or<(With<A>, With<B>)>>`.
-        self.filter_sets.iter().all(|filter| {
-            other
-                .filter_sets
-                .iter()
-                .all(|other_filter| filter.is_ruled_out_by(other_filter))
-        })
-    }
-
-    /// Returns a vector of elements that this and `other` cannot access at the same time.
-    pub fn get_conflicts(&self, other: &FilteredAccess<T>) -> Vec<T> {
-        if !self.is_compatible(other) {
-            // filters are disjoint, so we can just look at the unfiltered intersection
-            return self.access.get_conflicts(&other.access);
-        }
-        Vec::new()
-    }
-
-    /// Adds all access and filters from `other`.
-    ///
-    /// Corresponds to a conjunction operation (AND) for filters.
-    ///
-    /// Extending `Or<(With<A>, Without<B>)>` with `Or<(With<C>, Without<D>)>` will result in
-    /// `Or<((With<A>, With<C>), (With<A>, Without<D>), (Without<B>, With<C>), (Without<B>, Without<D>))>`.
-    pub fn extend(&mut self, other: &FilteredAccess<T>) {
-        self.access.extend(&other.access);
-
-        // We can avoid allocating a new array of bitsets if `other` contains just a single set of filters:
-        // in this case we can short-circuit by performing an in-place union for each bitset.
-        if other.filter_sets.len() == 1 {
-            for filter in &mut self.filter_sets {
-                filter.with.union_with(&other.filter_sets[0].with);
-                filter.without.union_with(&other.filter_sets[0].without);
-            }
-            return;
-        }
-
-        let mut new_filters = Vec::with_capacity(self.filter_sets.len() * other.filter_sets.len());
-        for filter in &self.filter_sets {
-            for other_filter in &other.filter_sets {
-                let mut new_filter = filter.clone();
-                new_filter.with.union_with(&other_filter.with);
-                new_filter.without.union_with(&other_filter.without);
-                new_filters.push(new_filter);
-            }
-        }
-        self.filter_sets = new_filters;
-    }
-
-    /// Sets the underlying unfiltered access as having access to all indexed elements.
-    pub fn read_all(&mut self) {
-        self.access.read_all();
-    }
-
-    /// Sets the underlying unfiltered access as having mutable access to all indexed elements.
-    pub fn write_all(&mut self) {
-        self.access.write_all();
-    }
-}
-
-#[derive(Clone, Eq, PartialEq)]
-struct AccessFilters<T> {
-    with: FixedBitSet,
-    without: FixedBitSet,
-    _index_type: PhantomData<T>,
-}
-
-impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for AccessFilters<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AccessFilters")
-            .field("with", &FormattedBitSet::<T>::new(&self.with))
-            .field("without", &FormattedBitSet::<T>::new(&self.without))
-            .finish()
-    }
-}
-
-impl<T: SparseSetIndex> Default for AccessFilters<T> {
-    fn default() -> Self {
-        Self {
-            with: FixedBitSet::default(),
-            without: FixedBitSet::default(),
-            _index_type: PhantomData,
-        }
-    }
-}
-
-impl<T: SparseSetIndex> AccessFilters<T> {
-    fn is_ruled_out_by(&self, other: &Self) -> bool {
-        // Although not technically complete, we don't consider the case when `AccessFilters`'s
-        // `without` bitset contradicts its own `with` bitset (e.g. `(With<A>, Without<A>)`).
-        // Such query would be considered compatible with any other query, but as it's almost
-        // always an error, we ignore this case instead of treating such query as compatible
-        // with others.
-        !self.with.is_disjoint(&other.without) || !self.without.is_disjoint(&other.with)
-    }
-}
-
-/// A collection of [`FilteredAccess`] instances.
-///
-/// Used internally to statically check if systems have conflicting access.
-///
-/// It stores multiple sets of accesses.
-/// - A "combined" set, which is the access of all filters in this set combined.
-/// - The set of access of each individual filters in this set.
-#[derive(Debug, Clone)]
-pub struct FilteredAccessSet<T: SparseSetIndex> {
-    combined_access: Access<T>,
-    filtered_accesses: Vec<FilteredAccess<T>>,
-}
-
-impl<T: SparseSetIndex> FilteredAccessSet<T> {
-    /// Returns a reference to the unfiltered access of the entire set.
-    #[inline]
-    pub fn combined_access(&self) -> &Access<T> {
-        &self.combined_access
-    }
-
-    /// Returns `true` if this and `other` can be active at the same time.
-    ///
-    /// Access conflict resolution happen in two steps:
-    /// 1. A "coarse" check, if there is no mutual unfiltered conflict between
-    ///    `self` and `other`, we already know that the two access sets are
-    ///    compatible.
-    /// 2. A "fine grained" check, it kicks in when the "coarse" check fails.
-    ///    the two access sets might still be compatible if some of the accesses
-    ///    are restricted with the [`With`](super::With) or [`Without`](super::Without) filters so that access is
-    ///    mutually exclusive. The fine grained phase iterates over all filters in
-    ///    the `self` set and compares it to all the filters in the `other` set,
-    ///    making sure they are all mutually compatible.
-    pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
-        if self.combined_access.is_compatible(other.combined_access()) {
-            return true;
-        }
-        for filtered in &self.filtered_accesses {
-            for other_filtered in &other.filtered_accesses {
-                if !filtered.is_compatible(other_filtered) {
-                    return false;
-                }
-            }
-        }
-        true
-    }
-
-    /// Returns a vector of elements that this set and `other` cannot access at the same time.
-    pub fn get_conflicts(&self, other: &FilteredAccessSet<T>) -> Vec<T> {
-        // if the unfiltered access is incompatible, must check each pair
-        let mut conflicts = HashSet::new();
-        if !self.combined_access.is_compatible(other.combined_access()) {
-            for filtered in &self.filtered_accesses {
-                for other_filtered in &other.filtered_accesses {
-                    conflicts.extend(filtered.get_conflicts(other_filtered).into_iter());
-                }
-            }
-        }
-        conflicts.into_iter().collect()
-    }
-
-    /// Returns a vector of elements that this set and `other` cannot access at the same time.
-    pub fn get_conflicts_single(&self, filtered_access: &FilteredAccess<T>) -> Vec<T> {
-        // if the unfiltered access is incompatible, must check each pair
-        let mut conflicts = HashSet::new();
-        if !self.combined_access.is_compatible(filtered_access.access()) {
-            for filtered in &self.filtered_accesses {
-                conflicts.extend(filtered.get_conflicts(filtered_access).into_iter());
-            }
-        }
-        conflicts.into_iter().collect()
-    }
-
-    /// Adds the filtered access to the set.
-    pub fn add(&mut self, filtered_access: FilteredAccess<T>) {
-        self.combined_access.extend(&filtered_access.access);
-        self.filtered_accesses.push(filtered_access);
-    }
-
-    /// Adds a read access without filters to the set.
-    pub(crate) fn add_unfiltered_read(&mut self, index: T) {
-        let mut filter = FilteredAccess::default();
-        filter.add_read(index);
-        self.add(filter);
-    }
-
-    /// Adds a write access without filters to the set.
-    pub(crate) fn add_unfiltered_write(&mut self, index: T) {
-        let mut filter = FilteredAccess::default();
-        filter.add_write(index);
-        self.add(filter);
-    }
-
-    /// Adds all of the accesses from the passed set to `self`.
-    pub fn extend(&mut self, filtered_access_set: FilteredAccessSet<T>) {
-        self.combined_access
-            .extend(&filtered_access_set.combined_access);
-        self.filtered_accesses
-            .extend(filtered_access_set.filtered_accesses);
-    }
-
-    /// Removes all accesses stored in this set.
-    pub fn clear(&mut self) {
-        self.combined_access.clear();
-        self.filtered_accesses.clear();
-    }
-}
-
-impl<T: SparseSetIndex> Default for FilteredAccessSet<T> {
-    fn default() -> Self {
-        Self {
-            combined_access: Default::default(),
-            filtered_accesses: Vec::new(),
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::query::access::AccessFilters;
-    use crate::query::{Access, FilteredAccess, FilteredAccessSet};
+    use crate::storage::SparseSetIndex;
+    use bevy_utils::HashSet;
+    use core::fmt;
     use fixedbitset::FixedBitSet;
     use std::marker::PhantomData;
 
-    #[test]
-    fn read_all_access_conflicts() {
-        // read_all / single write
-        let mut access_a = Access::<usize>::default();
-        access_a.grow(10);
-        access_a.add_write(0);
-
-        let mut access_b = Access::<usize>::default();
-        access_b.read_all();
-
-        assert!(!access_b.is_compatible(&access_a));
-
-        // read_all / read_all
-        let mut access_a = Access::<usize>::default();
-        access_a.grow(10);
-        access_a.read_all();
-
-        let mut access_b = Access::<usize>::default();
-        access_b.read_all();
-
-        assert!(access_b.is_compatible(&access_a));
+    /// A wrapper struct to make Debug representations of [`FixedBitSet`] easier
+    /// to read, when used to store [`SparseSetIndex`].
+    ///
+    /// Instead of the raw integer representation of the `FixedBitSet`, the list of
+    /// `T` valid for [`SparseSetIndex`] is shown.
+    ///
+    /// Normal `FixedBitSet` `Debug` output:
+    /// ```text
+    /// read_and_writes: FixedBitSet { data: [ 160 ], length: 8 }
+    /// ```
+    ///
+    /// Which, unless you are a computer, doesn't help much understand what's in
+    /// the set. With `FormattedBitSet`, we convert the present set entries into
+    /// what they stand for, it is much clearer what is going on:
+    /// ```text
+    /// read_and_writes: [ ComponentId(5), ComponentId(7) ]
+    /// ```
+    struct FormattedBitSet<'a, T: SparseSetIndex> {
+        bit_set: &'a FixedBitSet,
+        _marker: PhantomData<T>,
     }
 
-    #[test]
-    fn access_get_conflicts() {
-        let mut access_a = Access::<usize>::default();
-        access_a.add_read(0);
-        access_a.add_read(1);
-
-        let mut access_b = Access::<usize>::default();
-        access_b.add_read(0);
-        access_b.add_write(1);
-
-        assert_eq!(access_a.get_conflicts(&access_b), vec![1]);
-
-        let mut access_c = Access::<usize>::default();
-        access_c.add_write(0);
-        access_c.add_write(1);
-
-        assert_eq!(access_a.get_conflicts(&access_c), vec![0, 1]);
-        assert_eq!(access_b.get_conflicts(&access_c), vec![0, 1]);
-
-        let mut access_d = Access::<usize>::default();
-        access_d.add_read(0);
-
-        assert_eq!(access_d.get_conflicts(&access_a), vec![]);
-        assert_eq!(access_d.get_conflicts(&access_b), vec![]);
-        assert_eq!(access_d.get_conflicts(&access_c), vec![0]);
+    impl<'a, T: SparseSetIndex> FormattedBitSet<'a, T> {
+        fn new(bit_set: &'a FixedBitSet) -> Self {
+            Self {
+                bit_set,
+                _marker: PhantomData,
+            }
+        }
     }
 
-    #[test]
-    fn filtered_combined_access() {
-        let mut access_a = FilteredAccessSet::<usize>::default();
-        access_a.add_unfiltered_read(1);
-
-        let mut filter_b = FilteredAccess::<usize>::default();
-        filter_b.add_write(1);
-
-        let conflicts = access_a.get_conflicts_single(&filter_b);
-        assert_eq!(
-            &conflicts,
-            &[1_usize],
-            "access_a: {access_a:?}, filter_b: {filter_b:?}"
-        );
+    impl<'a, T: SparseSetIndex + fmt::Debug> fmt::Debug for FormattedBitSet<'a, T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_list()
+                .entries(self.bit_set.ones().map(T::get_sparse_set_index))
+                .finish()
+        }
     }
 
-    #[test]
-    fn filtered_access_extend() {
-        let mut access_a = FilteredAccess::<usize>::default();
-        access_a.add_read(0);
-        access_a.add_read(1);
-        access_a.and_with(2);
-
-        let mut access_b = FilteredAccess::<usize>::default();
-        access_b.add_read(0);
-        access_b.add_write(3);
-        access_b.and_without(4);
-
-        access_a.extend(&access_b);
-
-        let mut expected = FilteredAccess::<usize>::default();
-        expected.add_read(0);
-        expected.add_read(1);
-        expected.and_with(2);
-        expected.add_write(3);
-        expected.and_without(4);
-
-        assert!(access_a.eq(&expected));
+    /// Tracks read and write access to specific elements in a collection.
+    ///
+    /// Used internally to ensure soundness during system initialization and execution.
+    /// See the [`is_compatible`](Access::is_compatible) and [`get_conflicts`](Access::get_conflicts) functions.
+    #[derive(Clone, Eq, PartialEq)]
+    pub struct Access<T: SparseSetIndex> {
+        /// All accessed elements.
+        reads_and_writes: FixedBitSet,
+        /// The exclusively-accessed elements.
+        writes: FixedBitSet,
+        /// Is `true` if this has access to all elements in the collection.
+        /// This field is a performance optimization for `&World` (also harder to mess up for soundness).
+        reads_all: bool,
+        /// Is `true` if this has mutable access to all elements in the collection.
+        /// If this is true, then `reads_all` must also be true.
+        writes_all: bool,
+        marker: PhantomData<T>,
     }
 
-    #[test]
-    fn filtered_access_extend_or() {
-        let mut access_a = FilteredAccess::<usize>::default();
-        // Exclusive access to `(&mut A, &mut B)`.
-        access_a.add_write(0);
-        access_a.add_write(1);
+    impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for Access<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("Access")
+                .field(
+                    "read_and_writes",
+                    &FormattedBitSet::<T>::new(&self.reads_and_writes),
+                )
+                .field("writes", &FormattedBitSet::<T>::new(&self.writes))
+                .field("reads_all", &self.reads_all)
+                .field("writes_all", &self.writes_all)
+                .finish()
+        }
+    }
 
-        // Filter by `With<C>`.
-        let mut access_b = FilteredAccess::<usize>::default();
-        access_b.and_with(2);
+    impl<T: SparseSetIndex> Default for Access<T> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
 
-        // Filter by `(With<D>, Without<E>)`.
-        let mut access_c = FilteredAccess::<usize>::default();
-        access_c.and_with(3);
-        access_c.and_without(4);
+    impl<T: SparseSetIndex> Access<T> {
+        /// Creates an empty [`Access`] collection.
+        pub const fn new() -> Self {
+            Self {
+                reads_all: false,
+                writes_all: false,
+                reads_and_writes: FixedBitSet::new(),
+                writes: FixedBitSet::new(),
+                marker: PhantomData,
+            }
+        }
 
-        // Turns `access_b` into `Or<(With<C>, (With<D>, Without<D>))>`.
-        access_b.append_or(&access_c);
-        // Applies the filters to the initial query, which corresponds to the FilteredAccess'
-        // representation of `Query<(&mut A, &mut B), Or<(With<C>, (With<D>, Without<E>))>>`.
-        access_a.extend(&access_b);
+        /// Increases the set capacity to the specified amount.
+        ///
+        /// Does nothing if `capacity` is less than or equal to the current value.
+        pub fn grow(&mut self, capacity: usize) {
+            self.reads_and_writes.grow(capacity);
+            self.writes.grow(capacity);
+        }
 
-        // Construct the expected `FilteredAccess` struct.
-        // The intention here is to test that exclusive access implied by `add_write`
-        // forms correct normalized access structs when extended with `Or` filters.
-        let mut expected = FilteredAccess::<usize>::default();
-        expected.add_write(0);
-        expected.add_write(1);
-        // The resulted access is expected to represent `Or<((With<A>, With<B>, With<C>), (With<A>, With<B>, With<D>, Without<E>))>`.
-        expected.filter_sets = vec![
-            AccessFilters {
-                with: FixedBitSet::with_capacity_and_blocks(3, [0b111]),
+        /// Adds access to the element given by `index`.
+        pub fn add_read(&mut self, index: T) {
+            self.reads_and_writes.grow(index.sparse_set_index() + 1);
+            self.reads_and_writes.insert(index.sparse_set_index());
+        }
+
+        /// Adds exclusive access to the element given by `index`.
+        pub fn add_write(&mut self, index: T) {
+            self.reads_and_writes.grow(index.sparse_set_index() + 1);
+            self.reads_and_writes.insert(index.sparse_set_index());
+            self.writes.grow(index.sparse_set_index() + 1);
+            self.writes.insert(index.sparse_set_index());
+        }
+
+        /// Returns `true` if this can access the element given by `index`.
+        pub fn has_read(&self, index: T) -> bool {
+            self.reads_all || self.reads_and_writes.contains(index.sparse_set_index())
+        }
+
+        /// Returns `true` if this can access anything.
+        pub fn has_any_read(&self) -> bool {
+            self.reads_all || !self.reads_and_writes.is_clear()
+        }
+
+        /// Returns `true` if this can exclusively access the element given by `index`.
+        pub fn has_write(&self, index: T) -> bool {
+            self.writes_all || self.writes.contains(index.sparse_set_index())
+        }
+
+        /// Returns `true` if this accesses anything mutably.
+        pub fn has_any_write(&self) -> bool {
+            self.writes_all || !self.writes.is_clear()
+        }
+
+        /// Sets this as having access to all indexed elements (i.e. `&World`).
+        pub fn read_all(&mut self) {
+            self.reads_all = true;
+        }
+
+        /// Sets this as having mutable access to all indexed elements (i.e. `EntityMut`).
+        pub fn write_all(&mut self) {
+            self.reads_all = true;
+            self.writes_all = true;
+        }
+
+        /// Returns `true` if this has access to all indexed elements (i.e. `&World`).
+        pub fn has_read_all(&self) -> bool {
+            self.reads_all
+        }
+
+        /// Returns `true` if this has write access to all indexed elements (i.e. `EntityMut`).
+        pub fn has_write_all(&self) -> bool {
+            self.writes_all
+        }
+
+        /// Removes all accesses.
+        pub fn clear(&mut self) {
+            self.reads_all = false;
+            self.writes_all = false;
+            self.reads_and_writes.clear();
+            self.writes.clear();
+        }
+
+        /// Adds all access from `other`.
+        pub fn extend(&mut self, other: &Access<T>) {
+            self.reads_all = self.reads_all || other.reads_all;
+            self.writes_all = self.writes_all || other.writes_all;
+            self.reads_and_writes.union_with(&other.reads_and_writes);
+            self.writes.union_with(&other.writes);
+        }
+
+        /// Returns `true` if the access and `other` can be active at the same time.
+        ///
+        /// [`Access`] instances are incompatible if one can write
+        /// an element that the other can read or write.
+        pub fn is_compatible(&self, other: &Access<T>) -> bool {
+            if self.writes_all {
+                return !other.has_any_read();
+            }
+
+            if other.writes_all {
+                return !self.has_any_read();
+            }
+
+            if self.reads_all {
+                return !other.has_any_write();
+            }
+
+            if other.reads_all {
+                return !self.has_any_write();
+            }
+
+            self.writes.is_disjoint(&other.reads_and_writes)
+                && other.writes.is_disjoint(&self.reads_and_writes)
+        }
+
+        /// [`Access`] is subset of `other` access.
+        pub fn is_subset(&self, other: &Access<T>) -> bool {
+            if self.writes_all {
+                return other.writes_all;
+            }
+
+            if other.writes_all {
+                return true;
+            }
+
+            if self.reads_all {
+                return other.reads_all || other.writes_all;
+            }
+
+            if other.reads_all {
+                return self.has_any_write();
+            }
+
+            let reads = self.reads_and_writes.difference(&self.writes).collect::<FixedBitSet>();
+
+            reads.is_subset(&other.reads_and_writes) && self.writes.is_subset(&other.writes)
+        }
+
+        /// Returns a vector of elements that the access and `other` cannot access at the same time.
+        pub fn get_conflicts(&self, other: &Access<T>) -> Vec<T> {
+            let mut conflicts = FixedBitSet::default();
+            if self.reads_all {
+                // QUESTION: How to handle `other.writes_all`?
+                conflicts.extend(other.writes.ones());
+            }
+
+            if other.reads_all {
+                // QUESTION: How to handle `self.writes_all`.
+                conflicts.extend(self.writes.ones());
+            }
+
+            if self.writes_all {
+                conflicts.extend(other.reads_and_writes.ones());
+            }
+
+            if other.writes_all {
+                conflicts.extend(self.reads_and_writes.ones());
+            }
+
+            conflicts.extend(self.writes.intersection(&other.reads_and_writes));
+            conflicts.extend(self.reads_and_writes.intersection(&other.writes));
+            conflicts
+                .ones()
+                .map(SparseSetIndex::get_sparse_set_index)
+                .collect()
+        }
+
+        /// Returns the indices of the elements this has access to.
+        pub fn reads_and_writes(&self) -> impl Iterator<Item = T> + '_ {
+            self.reads_and_writes.ones().map(T::get_sparse_set_index)
+        }
+
+        /// Returns the indices of the elements this has non-exclusive access to.
+        pub fn reads(&self) -> impl Iterator<Item = T> + '_ {
+            self.reads_and_writes
+                .difference(&self.writes)
+                .map(T::get_sparse_set_index)
+        }
+
+        /// Returns the indices of the elements this has exclusive access to.
+        pub fn writes(&self) -> impl Iterator<Item = T> + '_ {
+            self.writes.ones().map(T::get_sparse_set_index)
+        }
+    }
+
+    /// An [`Access`] that has been filtered to include and exclude certain combinations of elements.
+    ///
+    /// Used internally to statically check if queries are disjoint.
+    ///
+    /// Subtle: a `read` or `write` in `access` should not be considered to imply a
+    /// `with` access.
+    ///
+    /// For example consider `Query<Option<&T>>` this only has a `read` of `T` as doing
+    /// otherwise would allow for queries to be considered disjoint when they shouldn't:
+    /// - `Query<(&mut T, Option<&U>)>` read/write `T`, read `U`, with `U`
+    /// - `Query<&mut T, Without<U>>` read/write `T`, without `U`
+    /// from this we could reasonably conclude that the queries are disjoint but they aren't.
+    ///
+    /// In order to solve this the actual access that `Query<(&mut T, Option<&U>)>` has
+    /// is read/write `T`, read `U`. It must still have a read `U` access otherwise the following
+    /// queries would be incorrectly considered disjoint:
+    /// - `Query<&mut T>`  read/write `T`
+    /// - `Query<Option<&T>>` accesses nothing
+    ///
+    /// See comments the [`WorldQuery`](super::WorldQuery) impls of [`AnyOf`](super::AnyOf)/`Option`/[`Or`](super::Or) for more information.
+    #[derive(Debug, Clone, Eq, PartialEq)]
+    pub struct FilteredAccess<T: SparseSetIndex> {
+        access: Access<T>,
+        // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
+        // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
+        filter_sets: Vec<AccessFilters<T>>,
+    }
+
+    impl<T: SparseSetIndex> Default for FilteredAccess<T> {
+        fn default() -> Self {
+            Self {
+                access: Access::default(),
+                filter_sets: vec![AccessFilters::default()],
+            }
+        }
+    }
+
+    impl<T: SparseSetIndex> From<FilteredAccess<T>> for FilteredAccessSet<T> {
+        fn from(filtered_access: FilteredAccess<T>) -> Self {
+            let mut base = FilteredAccessSet::<T>::default();
+            base.add(filtered_access);
+            base
+        }
+    }
+
+    impl<T: SparseSetIndex> FilteredAccess<T> {
+        /// Returns a reference to the underlying unfiltered access.
+        #[inline]
+        pub fn access(&self) -> &Access<T> {
+            &self.access
+        }
+
+        /// Returns a mutable reference to the underlying unfiltered access.
+        #[inline]
+        pub fn access_mut(&mut self) -> &mut Access<T> {
+            &mut self.access
+        }
+
+        /// Adds access to the element given by `index`.
+        pub fn add_read(&mut self, index: T) {
+            self.access.add_read(index.clone());
+            self.and_with(index);
+        }
+
+        /// Adds exclusive access to the element given by `index`.
+        pub fn add_write(&mut self, index: T) {
+            self.access.add_write(index.clone());
+            self.and_with(index);
+        }
+
+        /// Adds a `With` filter: corresponds to a conjunction (AND) operation.
+        ///
+        /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+        /// Adding `AND With<C>` via this method transforms it into the equivalent of  `Or<((With<A>, With<C>), (With<B>, With<C>))>`.
+        pub fn and_with(&mut self, index: T) {
+            let index = index.sparse_set_index();
+            for filter in &mut self.filter_sets {
+                filter.with.grow(index + 1);
+                filter.with.insert(index);
+            }
+        }
+
+        /// Adds a `Without` filter: corresponds to a conjunction (AND) operation.
+        ///
+        /// Suppose we begin with `Or<(With<A>, With<B>)>`, which is represented by an array of two `AccessFilter` instances.
+        /// Adding `AND Without<C>` via this method transforms it into the equivalent of  `Or<((With<A>, Without<C>), (With<B>, Without<C>))>`.
+        pub fn and_without(&mut self, index: T) {
+            let index = index.sparse_set_index();
+            for filter in &mut self.filter_sets {
+                filter.without.grow(index + 1);
+                filter.without.insert(index);
+            }
+        }
+
+        /// Appends an array of filters: corresponds to a disjunction (OR) operation.
+        ///
+        /// As the underlying array of filters represents a disjunction,
+        /// where each element (`AccessFilters`) represents a conjunction,
+        /// we can simply append to the array.
+        pub fn append_or(&mut self, other: &FilteredAccess<T>) {
+            self.filter_sets.append(&mut other.filter_sets.clone());
+        }
+
+        /// Adds all of the accesses from `other` to `self`.
+        pub fn extend_access(&mut self, other: &FilteredAccess<T>) {
+            self.access.extend(&other.access);
+        }
+
+        /// Returns `true` if this and `other` can be active at the same time.
+        pub fn is_compatible(&self, other: &FilteredAccess<T>) -> bool {
+            if self.access.is_compatible(&other.access) {
+                return true;
+            }
+
+            // If the access instances are incompatible, we want to check that whether filters can
+            // guarantee that queries are disjoint.
+            // Since the `filter_sets` array represents a Disjunctive Normal Form formula ("ORs of ANDs"),
+            // we need to make sure that each filter set (ANDs) rule out every filter set from the `other` instance.
+            //
+            // For example, `Query<&mut C, Or<(With<A>, Without<B>)>>` is compatible `Query<&mut C, (With<B>, Without<A>)>`,
+            // but `Query<&mut C, Or<(Without<A>, Without<B>)>>` isn't compatible with `Query<&mut C, Or<(With<A>, With<B>)>>`.
+            self.filter_sets.iter().all(|filter| {
+                other
+                    .filter_sets
+                    .iter()
+                    .all(|other_filter| filter.is_ruled_out_by(other_filter))
+            })
+        }
+
+        ///  access is compatible with other access. This does not take into account the filtered access.
+        pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
+            self.access.is_subset(&other.access)
+        }
+
+        /// Returns a vector of elements that this and `other` cannot access at the same time.
+        pub fn get_conflicts(&self, other: &FilteredAccess<T>) -> Vec<T> {
+            if !self.is_compatible(other) {
+                // filters are disjoint, so we can just look at the unfiltered intersection
+                return self.access.get_conflicts(&other.access);
+            }
+            Vec::new()
+        }
+
+        /// Adds all access and filters from `other`.
+        ///
+        /// Corresponds to a conjunction operation (AND) for filters.
+        ///
+        /// Extending `Or<(With<A>, Without<B>)>` with `Or<(With<C>, Without<D>)>` will result in
+        /// `Or<((With<A>, With<C>), (With<A>, Without<D>), (Without<B>, With<C>), (Without<B>, Without<D>))>`.
+        pub fn extend(&mut self, other: &FilteredAccess<T>) {
+            self.access.extend(&other.access);
+
+            // We can avoid allocating a new array of bitsets if `other` contains just a single set of filters:
+            // in this case we can short-circuit by performing an in-place union for each bitset.
+            if other.filter_sets.len() == 1 {
+                for filter in &mut self.filter_sets {
+                    filter.with.union_with(&other.filter_sets[0].with);
+                    filter.without.union_with(&other.filter_sets[0].without);
+                }
+                return;
+            }
+
+            let mut new_filters = Vec::with_capacity(self.filter_sets.len() * other.filter_sets.len());
+            for filter in &self.filter_sets {
+                for other_filter in &other.filter_sets {
+                    let mut new_filter = filter.clone();
+                    new_filter.with.union_with(&other_filter.with);
+                    new_filter.without.union_with(&other_filter.without);
+                    new_filters.push(new_filter);
+                }
+            }
+            self.filter_sets = new_filters;
+        }
+
+        /// Sets the underlying unfiltered access as having access to all indexed elements.
+        pub fn read_all(&mut self) {
+            self.access.read_all();
+        }
+
+        /// Sets the underlying unfiltered access as having mutable access to all indexed elements.
+        pub fn write_all(&mut self) {
+            self.access.write_all();
+        }
+    }
+
+    #[derive(Clone, Eq, PartialEq)]
+    struct AccessFilters<T> {
+        with: FixedBitSet,
+        without: FixedBitSet,
+        _index_type: PhantomData<T>,
+    }
+
+    impl<T: SparseSetIndex + fmt::Debug> fmt::Debug for AccessFilters<T> {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("AccessFilters")
+                .field("with", &FormattedBitSet::<T>::new(&self.with))
+                .field("without", &FormattedBitSet::<T>::new(&self.without))
+                .finish()
+        }
+    }
+
+    impl<T: SparseSetIndex> Default for AccessFilters<T> {
+        fn default() -> Self {
+            Self {
+                with: FixedBitSet::default(),
                 without: FixedBitSet::default(),
                 _index_type: PhantomData,
-            },
-            AccessFilters {
-                with: FixedBitSet::with_capacity_and_blocks(4, [0b1011]),
-                without: FixedBitSet::with_capacity_and_blocks(5, [0b10000]),
-                _index_type: PhantomData,
-            },
-        ];
-
-        assert_eq!(access_a, expected);
+            }
+        }
     }
-}
+
+    impl<T: SparseSetIndex> AccessFilters<T> {
+        fn is_ruled_out_by(&self, other: &Self) -> bool {
+            // Although not technically complete, we don't consider the case when `AccessFilters`'s
+            // `without` bitset contradicts its own `with` bitset (e.g. `(With<A>, Without<A>)`).
+            // Such query would be considered compatible with any other query, but as it's almost
+            // always an error, we ignore this case instead of treating such query as compatible
+            // with others.
+            !self.with.is_disjoint(&other.without) || !self.without.is_disjoint(&other.with)
+        }
+    }
+
+    /// A collection of [`FilteredAccess`] instances.
+    ///
+    /// Used internally to statically check if systems have conflicting access.
+    ///
+    /// It stores multiple sets of accesses.
+    /// - A "combined" set, which is the access of all filters in this set combined.
+    /// - The set of access of each individual filters in this set.
+    #[derive(Debug, Clone)]
+    pub struct FilteredAccessSet<T: SparseSetIndex> {
+        combined_access: Access<T>,
+        filtered_accesses: Vec<FilteredAccess<T>>,
+    }
+
+    impl<T: SparseSetIndex> FilteredAccessSet<T> {
+        /// Returns a reference to the unfiltered access of the entire set.
+        #[inline]
+        pub fn combined_access(&self) -> &Access<T> {
+            &self.combined_access
+        }
+
+        /// Returns `true` if this and `other` can be active at the same time.
+        ///
+        /// Access conflict resolution happen in two steps:
+        /// 1. A "coarse" check, if there is no mutual unfiltered conflict between
+        ///    `self` and `other`, we already know that the two access sets are
+        ///    compatible.
+        /// 2. A "fine grained" check, it kicks in when the "coarse" check fails.
+        ///    the two access sets might still be compatible if some of the accesses
+        ///    are restricted with the [`With`](super::With) or [`Without`](super::Without) filters so that access is
+        ///    mutually exclusive. The fine grained phase iterates over all filters in
+        ///    the `self` set and compares it to all the filters in the `other` set,
+        ///    making sure they are all mutually compatible.
+        pub fn is_compatible(&self, other: &FilteredAccessSet<T>) -> bool {
+            if self.combined_access.is_compatible(other.combined_access()) {
+                return true;
+            }
+            for filtered in &self.filtered_accesses {
+                for other_filtered in &other.filtered_accesses {
+                    if !filtered.is_compatible(other_filtered) {
+                        return false;
+                    }
+                }
+            }
+            true
+        }
+
+        /// Returns a vector of elements that this set and `other` cannot access at the same time.
+        pub fn get_conflicts(&self, other: &FilteredAccessSet<T>) -> Vec<T> {
+            // if the unfiltered access is incompatible, must check each pair
+            let mut conflicts = HashSet::new();
+            if !self.combined_access.is_compatible(other.combined_access()) {
+                for filtered in &self.filtered_accesses {
+                    for other_filtered in &other.filtered_accesses {
+                        conflicts.extend(filtered.get_conflicts(other_filtered).into_iter());
+                    }
+                }
+            }
+            conflicts.into_iter().collect()
+        }
+
+        /// Returns a vector of elements that this set and `other` cannot access at the same time.
+        pub fn get_conflicts_single(&self, filtered_access: &FilteredAccess<T>) -> Vec<T> {
+            // if the unfiltered access is incompatible, must check each pair
+            let mut conflicts = HashSet::new();
+            if !self.combined_access.is_compatible(filtered_access.access()) {
+                for filtered in &self.filtered_accesses {
+                    conflicts.extend(filtered.get_conflicts(filtered_access).into_iter());
+                }
+            }
+            conflicts.into_iter().collect()
+        }
+
+        /// Adds the filtered access to the set.
+        pub fn add(&mut self, filtered_access: FilteredAccess<T>) {
+            self.combined_access.extend(&filtered_access.access);
+            self.filtered_accesses.push(filtered_access);
+        }
+
+        /// Adds a read access without filters to the set.
+        pub(crate) fn add_unfiltered_read(&mut self, index: T) {
+            let mut filter = FilteredAccess::default();
+            filter.add_read(index);
+            self.add(filter);
+        }
+
+        /// Adds a write access without filters to the set.
+        pub(crate) fn add_unfiltered_write(&mut self, index: T) {
+            let mut filter = FilteredAccess::default();
+            filter.add_write(index);
+            self.add(filter);
+        }
+
+        /// Adds all of the accesses from the passed set to `self`.
+        pub fn extend(&mut self, filtered_access_set: FilteredAccessSet<T>) {
+            self.combined_access
+                .extend(&filtered_access_set.combined_access);
+            self.filtered_accesses
+                .extend(filtered_access_set.filtered_accesses);
+        }
+
+        /// Removes all accesses stored in this set.
+        pub fn clear(&mut self) {
+            self.combined_access.clear();
+            self.filtered_accesses.clear();
+        }
+    }
+
+    impl<T: SparseSetIndex> Default for FilteredAccessSet<T> {
+        fn default() -> Self {
+            Self {
+                combined_access: Default::default(),
+                filtered_accesses: Vec::new(),
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use crate::query::access::AccessFilters;
+        use crate::query::{Access, FilteredAccess, FilteredAccessSet};
+        use fixedbitset::FixedBitSet;
+        use std::marker::PhantomData;
+
+        #[test]
+        fn read_all_access_conflicts() {
+            // read_all / single write
+            let mut access_a = Access::<usize>::default();
+            access_a.grow(10);
+            access_a.add_write(0);
+
+            let mut access_b = Access::<usize>::default();
+            access_b.read_all();
+
+            assert!(!access_b.is_compatible(&access_a));
+
+            // read_all / read_all
+            let mut access_a = Access::<usize>::default();
+            access_a.grow(10);
+            access_a.read_all();
+
+            let mut access_b = Access::<usize>::default();
+            access_b.read_all();
+
+            assert!(access_b.is_compatible(&access_a));
+        }
+
+        #[test]
+        fn access_get_conflicts() {
+            let mut access_a = Access::<usize>::default();
+            access_a.add_read(0);
+            access_a.add_read(1);
+
+            let mut access_b = Access::<usize>::default();
+            access_b.add_read(0);
+            access_b.add_write(1);
+
+            assert_eq!(access_a.get_conflicts(&access_b), vec![1]);
+
+            let mut access_c = Access::<usize>::default();
+            access_c.add_write(0);
+            access_c.add_write(1);
+
+            assert_eq!(access_a.get_conflicts(&access_c), vec![0, 1]);
+            assert_eq!(access_b.get_conflicts(&access_c), vec![0, 1]);
+
+            let mut access_d = Access::<usize>::default();
+            access_d.add_read(0);
+
+            assert_eq!(access_d.get_conflicts(&access_a), vec![]);
+            assert_eq!(access_d.get_conflicts(&access_b), vec![]);
+            assert_eq!(access_d.get_conflicts(&access_c), vec![0]);
+        }
+
+        #[test]
+        fn filtered_combined_access() {
+            let mut access_a = FilteredAccessSet::<usize>::default();
+            access_a.add_unfiltered_read(1);
+
+            let mut filter_b = FilteredAccess::<usize>::default();
+            filter_b.add_write(1);
+
+            let conflicts = access_a.get_conflicts_single(&filter_b);
+            assert_eq!(
+                &conflicts,
+                &[1_usize],
+                "access_a: {access_a:?}, filter_b: {filter_b:?}"
+            );
+        }
+
+        #[test]
+        fn filtered_access_extend() {
+            let mut access_a = FilteredAccess::<usize>::default();
+            access_a.add_read(0);
+            access_a.add_read(1);
+            access_a.and_with(2);
+
+            let mut access_b = FilteredAccess::<usize>::default();
+            access_b.add_read(0);
+            access_b.add_write(3);
+            access_b.and_without(4);
+
+            access_a.extend(&access_b);
+
+            let mut expected = FilteredAccess::<usize>::default();
+            expected.add_read(0);
+            expected.add_read(1);
+            expected.and_with(2);
+            expected.add_write(3);
+            expected.and_without(4);
+
+            assert!(access_a.eq(&expected));
+        }
+
+        #[test]
+        fn filtered_access_extend_or() {
+            let mut access_a = FilteredAccess::<usize>::default();
+            // Exclusive access to `(&mut A, &mut B)`.
+            access_a.add_write(0);
+            access_a.add_write(1);
+
+            // Filter by `With<C>`.
+            let mut access_b = FilteredAccess::<usize>::default();
+            access_b.and_with(2);
+
+            // Filter by `(With<D>, Without<E>)`.
+            let mut access_c = FilteredAccess::<usize>::default();
+            access_c.and_with(3);
+            access_c.and_without(4);
+
+            // Turns `access_b` into `Or<(With<C>, (With<D>, Without<D>))>`.
+            access_b.append_or(&access_c);
+            // Applies the filters to the initial query, which corresponds to the FilteredAccess'
+            // representation of `Query<(&mut A, &mut B), Or<(With<C>, (With<D>, Without<E>))>>`.
+            access_a.extend(&access_b);
+
+            // Construct the expected `FilteredAccess` struct.
+            // The intention here is to test that exclusive access implied by `add_write`
+            // forms correct normalized access structs when extended with `Or` filters.
+            let mut expected = FilteredAccess::<usize>::default();
+            expected.add_write(0);
+            expected.add_write(1);
+            // The resulted access is expected to represent `Or<((With<A>, With<B>, With<C>), (With<A>, With<B>, With<D>, Without<E>))>`.
+            expected.filter_sets = vec![
+                AccessFilters {
+                    with: FixedBitSet::with_capacity_and_blocks(3, [0b111]),
+                    without: FixedBitSet::default(),
+                    _index_type: PhantomData,
+                },
+                AccessFilters {
+                    with: FixedBitSet::with_capacity_and_blocks(4, [0b1011]),
+                    without: FixedBitSet::with_capacity_and_blocks(5, [0b10000]),
+                    _index_type: PhantomData,
+                },
+            ];
+
+            assert_eq!(access_a, expected);
+        }
+    }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -213,7 +213,7 @@ impl<T: SparseSetIndex> Access<T> {
         }
 
         if other.reads_all {
-            return self.has_any_write();
+            return !self.has_any_write();
         }
 
         let reads = self
@@ -270,15 +270,18 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.ones().map(T::get_sparse_set_index)
     }
 
-    pub fn difference_is_empty(&self, other: &Access<T>) -> bool {
+    pub fn read_and_writes_difference_is_empty(&self, other: &Access<T>) -> bool {
+        if self.reads_all || self.writes_all {
+            return other.reads_all || other.writes_all;
+        }
         self.reads_and_writes
             .difference(&other.reads_and_writes)
             .count()
             == 0
     }
 
-    pub fn takes_no_access(&self) -> bool {
-        self.reads_and_writes.is_empty()
+    pub fn has_access(&self) -> bool {
+        self.writes_all || self.reads_all || !self.reads_and_writes.is_clear()
     }
 }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -437,9 +437,8 @@ pub unsafe trait WorldQuery {
         access: &mut Access<ArchetypeComponentId>,
     );
 
-    /// Adds component access for when [`WorldQuery`] is not an exact match.
-    /// i.e. Option<&T> where the matched archetypes don't necessarily contain
-    /// the data the [`WorldQuery`] takes access to in [`Self::update_component_access`]
+    /// Adds component access to `access` for when [`WorldQuery`] is not an exact match.
+    /// i.e. With `Option<&T>` the matched archetypes do not necessarily contain a `T`.
     fn optional_access(
         state: &Self::State,
         access: &mut Access<ComponentId>,
@@ -449,8 +448,9 @@ pub unsafe trait WorldQuery {
     /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
     fn init_state(world: &mut World) -> Self::State;
 
-    /// Creates a [`State`](WorldQuery::State) for this [`WorldQuery`] type. This should return
-    /// the same value as [`init_state`](Self::init_state).
+    /// Creates a [`State`](WorldQuery::State) for this [`WorldQuery`] type. When successful, this returns
+    /// the same value as [`init_state`](Self::init_state). When the state cannot be created, this return `None`.
+    /// This might happen if we try to get the state for a component has not been registered in the [`World`].
     fn get_state(components: &Components) -> Option<Self::State>;
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
@@ -1854,7 +1854,6 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     const IS_DENSE: bool = true;
     // `PhantomData` matches every entity in each archetype.
     const IS_ARCHETYPAL: bool = true;
-    // `PhantomData` does not access any data, so it is exact.
 
     unsafe fn set_archetype<'w>(
         _fetch: &mut Self::Fetch<'w>,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1,7 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
     change_detection::{Ticks, TicksMut},
-    component::{Component, ComponentId, ComponentStorage, StorageType, Tick, Components},
+    component::{Component, ComponentId, ComponentStorage, Components, StorageType, Tick},
     entity::Entity,
     query::{Access, DebugCheckedUnwrap, FilteredAccess},
     storage::{ComponentSparseSet, Table, TableRow},
@@ -1406,7 +1406,7 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
     fn init_state(world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
-    
+
     fn new_state(components: &Components) -> ComponentId {
         components.component_id::<T>().unwrap()
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -620,11 +620,10 @@ unsafe impl WorldQuery for EntityRef<'_> {
     fn optional_access(
         _state: &Self::State,
         access: &mut Access<ComponentId>,
-        parent_is_optional: bool,
+        _parent_is_optional: bool,
     ) {
-        if parent_is_optional {
-            access.read_all()
-        }
+        // it's ambiguous what data an entity ref can get
+        access.read_all()
     }
 
     fn init_state(_world: &mut World) {}
@@ -714,11 +713,11 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     fn optional_access(
         _state: &Self::State,
         access: &mut Access<ComponentId>,
-        parent_is_optional: bool,
+        _parent_is_optional: bool,
     ) {
-        if parent_is_optional {
-            access.write_all();
-        }
+        // Entity Ref may or may not have data for a component T
+        access.write_all();
+        
     }
 
     fn init_state(_world: &mut World) {}

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -451,7 +451,7 @@ pub unsafe trait WorldQuery {
 
     /// Creates a [`State`](WorldQuery::State) for this [`WorldQuery`] type. This should return
     /// the same value as [`init_state`](Self::init_state).
-    fn new_state(components: &Components) -> Option<Self::State>;
+    fn get_state(components: &Components) -> Option<Self::State>;
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     fn matches_component_set(
@@ -535,7 +535,7 @@ unsafe impl WorldQuery for Entity {
 
     fn init_state(_world: &mut World) {}
 
-    fn new_state(_components: &Components) -> Option<()> {
+    fn get_state(_components: &Components) -> Option<()> {
         Some(())
     }
 
@@ -628,7 +628,7 @@ unsafe impl WorldQuery for EntityRef<'_> {
 
     fn init_state(_world: &mut World) {}
 
-    fn new_state(_components: &Components) -> Option<()> {
+    fn get_state(_components: &Components) -> Option<()> {
         Some(())
     }
 
@@ -721,7 +721,7 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
 
     fn init_state(_world: &mut World) {}
 
-    fn new_state(_components: &Components) -> Option<()> {
+    fn get_state(_components: &Components) -> Option<()> {
         Some(())
     }
 
@@ -875,7 +875,7 @@ unsafe impl<T: Component> WorldQuery for &T {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<ComponentId> {
+    fn get_state(components: &Components) -> Option<ComponentId> {
         components.component_id::<T>()
     }
 
@@ -1050,7 +1050,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<ComponentId> {
+    fn get_state(components: &Components) -> Option<ComponentId> {
         components.component_id::<T>()
     }
 
@@ -1225,7 +1225,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<ComponentId> {
+    fn get_state(components: &Components) -> Option<ComponentId> {
         components.component_id::<T>()
     }
 
@@ -1349,8 +1349,8 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
         T::init_state(world)
     }
 
-    fn new_state(components: &Components) -> Option<T::State> {
-        T::new_state(components)
+    fn get_state(components: &Components) -> Option<T::State> {
+        T::get_state(components)
     }
 
     fn matches_component_set(
@@ -1495,7 +1495,7 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<ComponentId> {
+    fn get_state(components: &Components) -> Option<ComponentId> {
         components.component_id::<T>()
     }
 
@@ -1600,8 +1600,8 @@ macro_rules! impl_tuple_fetch {
                 ($($name::init_state(_world),)*)
             }
 
-            fn new_state(_components: &Components) -> Option<Self::State> {
-                Some(($($name::new_state(_components)?,)*))
+            fn get_state(_components: &Components) -> Option<Self::State> {
+                Some(($($name::get_state(_components)?,)*))
             }
 
             fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -1732,8 +1732,8 @@ macro_rules! impl_anytuple_fetch {
                 ($($name::init_state(_world),)*)
             }
 
-            fn new_state(_components: &Components) -> Option<Self::State> {
-                Some(($($name::new_state(_components)?,)*))
+            fn get_state(_components: &Components) -> Option<Self::State> {
+                Some(($($name::get_state(_components)?,)*))
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -1817,8 +1817,8 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
         Q::init_state(world)
     }
 
-    fn new_state(components: &Components) -> Option<Self::State> {
-        Q::new_state(components)
+    fn get_state(components: &Components) -> Option<Self::State> {
+        Q::get_state(components)
     }
 
     fn matches_component_set(
@@ -1892,7 +1892,7 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
 
     fn init_state(_world: &mut World) -> Self::State {}
 
-    fn new_state(_components: &Components) -> Option<Self::State> {
+    fn get_state(_components: &Components) -> Option<Self::State> {
         Some(())
     }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -439,7 +439,7 @@ pub unsafe trait WorldQuery {
 
     /// Adds component access for when [`WorldQuery`] is not an exact match.
     /// i.e. Option<&T> where the matched archetypes don't necessarily contain
-    /// the data the WorldQuery takes access to in [`update_component_access`]
+    /// the data the WorldQuery takes access to in [`Self::update_component_access`]
     fn optional_access(
         state: &Self::State,
         access: &mut Access<ComponentId>,
@@ -717,7 +717,6 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     ) {
         // Entity Ref may or may not have data for a component T
         access.write_all();
-        
     }
 
     fn init_state(_world: &mut World) {}

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -360,10 +360,6 @@ pub unsafe trait WorldQuery {
     /// many elements are being iterated (such as `Iterator::collect()`).
     const IS_ARCHETYPAL: bool;
 
-    /// Returns true if (and only if) every archetype returned has data for the underlying types.
-    /// i.e. [`Self::State`] = Option<&T> would return false, but &T would return true.
-    const IS_EXACT: bool;
-
     /// Adjusts internal state to account for the next [`Archetype`]. This will always be called on
     /// archetypes that match this [`WorldQuery`].
     ///
@@ -491,8 +487,6 @@ unsafe impl WorldQuery for Entity {
 
     const IS_ARCHETYPAL: bool = true;
 
-    const IS_EXACT: bool = true;
-
     unsafe fn init_fetch<'w>(
         _world: UnsafeWorldCell<'w>,
         _state: &Self::State,
@@ -570,8 +564,6 @@ unsafe impl WorldQuery for EntityRef<'_> {
     const IS_DENSE: bool = true;
 
     const IS_ARCHETYPAL: bool = true;
-
-    const IS_EXACT: bool = true;
 
     unsafe fn init_fetch<'w>(
         world: UnsafeWorldCell<'w>,
@@ -666,8 +658,6 @@ unsafe impl<'a> WorldQuery for EntityMut<'a> {
     const IS_DENSE: bool = true;
 
     const IS_ARCHETYPAL: bool = true;
-
-    const IS_EXACT: bool = true;
 
     unsafe fn init_fetch<'w>(
         world: UnsafeWorldCell<'w>,
@@ -779,8 +769,6 @@ unsafe impl<T: Component> WorldQuery for &T {
     };
 
     const IS_ARCHETYPAL: bool = true;
-
-    const IS_EXACT: bool = true;
 
     #[inline]
     unsafe fn init_fetch<'w>(
@@ -945,8 +933,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     };
 
     const IS_ARCHETYPAL: bool = true;
-
-    const IS_EXACT: bool = true;
 
     #[inline]
     unsafe fn init_fetch<'w>(
@@ -1123,8 +1109,6 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
 
     const IS_ARCHETYPAL: bool = true;
 
-    const IS_EXACT: bool = true;
-
     #[inline]
     unsafe fn init_fetch<'w>(
         world: UnsafeWorldCell<'w>,
@@ -1284,8 +1268,6 @@ unsafe impl<T: WorldQuery> WorldQuery for Option<T> {
     const IS_DENSE: bool = T::IS_DENSE;
 
     const IS_ARCHETYPAL: bool = T::IS_ARCHETYPAL;
-
-    const IS_EXACT: bool = false;
 
     #[inline]
     unsafe fn init_fetch<'w>(
@@ -1459,8 +1441,6 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
 
     const IS_ARCHETYPAL: bool = true;
 
-    const IS_EXACT: bool = false;
-
     #[inline]
     unsafe fn init_fetch<'w>(
         _world: UnsafeWorldCell<'w>,
@@ -1561,8 +1541,6 @@ macro_rules! impl_tuple_fetch {
             const IS_DENSE: bool = true $(&& $name::IS_DENSE)*;
 
             const IS_ARCHETYPAL: bool = true $(&& $name::IS_ARCHETYPAL)*;
-
-            const IS_EXACT: bool = true $(&& $name::IS_EXACT)*;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -1675,8 +1653,6 @@ macro_rules! impl_anytuple_fetch {
             const IS_DENSE: bool = true $(&& $name::IS_DENSE)*;
 
             const IS_ARCHETYPAL: bool = true $(&& $name::IS_ARCHETYPAL)*;
-
-            const IS_EXACT: bool = false;
 
             #[inline]
             unsafe fn set_archetype<'w>(
@@ -1794,8 +1770,6 @@ unsafe impl<Q: WorldQuery> WorldQuery for NopWorldQuery<Q> {
 
     const IS_ARCHETYPAL: bool = true;
 
-    const IS_EXACT: bool = Q::IS_EXACT;
-
     #[inline(always)]
     unsafe fn init_fetch(
         _world: UnsafeWorldCell,
@@ -1883,7 +1857,6 @@ unsafe impl<T: ?Sized> WorldQuery for PhantomData<T> {
     // `PhantomData` matches every entity in each archetype.
     const IS_ARCHETYPAL: bool = true;
     // `PhantomData` does not access any data, so it is exact.
-    const IS_EXACT: bool = true;
 
     unsafe fn set_archetype<'w>(
         _fetch: &mut Self::Fetch<'w>,

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -439,7 +439,7 @@ pub unsafe trait WorldQuery {
 
     /// Adds component access for when [`WorldQuery`] is not an exact match.
     /// i.e. Option<&T> where the matched archetypes don't necessarily contain
-    /// the data the WorldQuery takes access to in [`Self::update_component_access`]
+    /// the data the [`WorldQuery`] takes access to in [`Self::update_component_access`]
     fn optional_access(
         state: &Self::State,
         access: &mut Access<ComponentId>,
@@ -623,7 +623,7 @@ unsafe impl WorldQuery for EntityRef<'_> {
         _parent_is_optional: bool,
     ) {
         // it's ambiguous what data an entity ref can get
-        access.read_all()
+        access.read_all();
     }
 
     fn init_state(_world: &mut World) {}

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -112,7 +112,7 @@ unsafe impl<T: Component> WorldQuery for With<T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<Self::State> {
+    fn get_state(components: &Components) -> Option<Self::State> {
         components.component_id::<T>()
     }
 
@@ -225,7 +225,7 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Option<Self::State> {
+    fn get_state(components: &Components) -> Option<Self::State> {
         components.component_id::<T>()
     }
 
@@ -398,8 +398,8 @@ macro_rules! impl_query_filter_tuple {
                 ($($filter::init_state(world),)*)
             }
 
-            fn new_state(components: &Components) -> Option<Self::State> {
-                Some(($($filter::new_state(components)?,)*))
+            fn get_state(components: &Components) -> Option<Self::State> {
+                Some(($($filter::get_state(components)?,)*))
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -575,7 +575,7 @@ macro_rules! impl_tick_filter {
                 world.init_component::<T>()
             }
 
-            fn new_state(components: &Components) -> Option<ComponentId> {
+            fn get_state(components: &Components) -> Option<ComponentId> {
                 components.component_id::<T>()
             }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -68,8 +68,6 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     const IS_ARCHETYPAL: bool = true;
 
-    const IS_EXACT: bool = false;
-
     #[inline]
     unsafe fn set_table(_fetch: &mut (), _state: &ComponentId, _table: &Table) {}
 
@@ -181,8 +179,6 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     };
 
     const IS_ARCHETYPAL: bool = true;
-
-    const IS_EXACT: bool = false;
 
     #[inline]
     unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _table: &Table) {}
@@ -310,8 +306,6 @@ macro_rules! impl_query_filter_tuple {
             const IS_DENSE: bool = true $(&& $filter::IS_DENSE)*;
 
             const IS_ARCHETYPAL: bool = true $(&& $filter::IS_ARCHETYPAL)*;
-
-            const IS_EXACT: bool = false;
 
             #[inline]
             unsafe fn init_fetch<'w>(world: UnsafeWorldCell<'w>, state: &Self::State, last_run: Tick, this_run: Tick) -> Self::Fetch<'w> {
@@ -483,8 +477,6 @@ macro_rules! impl_tick_filter {
             };
 
             const IS_ARCHETYPAL:  bool = false;
-
-            const IS_EXACT: bool = true;
 
             #[inline]
             unsafe fn set_table<'w>(

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -103,6 +103,13 @@ unsafe impl<T: Component> WorldQuery for With<T> {
     ) {
     }
 
+    fn optional_access(
+        _state: &Self::State,
+        _access: &mut Access<ComponentId>,
+        _parent_is_optional: bool,
+    ) {
+    }
+
     fn init_state(world: &mut World) -> ComponentId {
         world.init_component::<T>()
     }
@@ -207,6 +214,14 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
         _state: &ComponentId,
         _archetype: &Archetype,
         _access: &mut Access<ArchetypeComponentId>,
+    ) {
+    }
+
+    #[inline]
+    fn optional_access(
+        _state: &Self::State,
+        _access: &mut Access<ComponentId>,
+        _parent_is_optional: bool,
     ) {
     }
 
@@ -380,6 +395,11 @@ macro_rules! impl_query_filter_tuple {
                 $($filter::update_archetype_component_access($filter, archetype, access);)*
             }
 
+            fn optional_access(state: &Self::State, access: &mut Access<ComponentId>, parent_is_optional: bool) {
+                let ($($filter,)*) = state;
+                $($filter::optional_access($filter, access, true);)*
+            }
+
             fn init_state(world: &mut World) -> Self::State {
                 ($($filter::init_state(world),)*)
             }
@@ -546,6 +566,16 @@ macro_rules! impl_tick_filter {
             ) {
                 if let Some(archetype_component_id) = archetype.get_archetype_component_id(id) {
                     access.add_read(archetype_component_id);
+                }
+            }
+
+            fn optional_access(
+                &id: &ComponentId,
+                access: &mut Access<ComponentId>,
+                parent_is_optional: bool,
+            ) {
+                if parent_is_optional {
+                    access.add_read(id);
                 }
             }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -105,8 +105,8 @@ unsafe impl<T: Component> WorldQuery for With<T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Self::State {
-        components.component_id::<T>().unwrap()
+    fn new_state(components: &Components) -> Option<Self::State> {
+        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -210,8 +210,8 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
         world.init_component::<T>()
     }
 
-    fn new_state(components: &Components) -> Self::State {
-        components.component_id::<T>().unwrap()
+    fn new_state(components: &Components) -> Option<Self::State> {
+        components.component_id::<T>()
     }
 
     fn matches_component_set(
@@ -378,8 +378,8 @@ macro_rules! impl_query_filter_tuple {
                 ($($filter::init_state(world),)*)
             }
 
-            fn new_state(components: &Components) -> Self::State {
-                ($($filter::new_state(components),)*)
+            fn new_state(components: &Components) -> Option<Self::State> {
+                Some(($($filter::new_state(components)?,)*))
             }
 
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
@@ -545,8 +545,8 @@ macro_rules! impl_tick_filter {
                 world.init_component::<T>()
             }
 
-            fn new_state(components: &Components) -> ComponentId {
-                components.component_id::<T>().unwrap()
+            fn new_state(components: &Components) -> Option<ComponentId> {
+                components.component_id::<T>()
             }
 
             fn matches_component_set(&id: &ComponentId, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
-    component::{Component, ComponentId, ComponentStorage, StorageType, Tick},
+    component::{Component, ComponentId, ComponentStorage, StorageType, Tick, Components},
     entity::Entity,
     query::{Access, DebugCheckedUnwrap, FilteredAccess, WorldQuery},
     storage::{Column, ComponentSparseSet, Table, TableRow},
@@ -105,6 +105,10 @@ unsafe impl<T: Component> WorldQuery for With<T> {
         world.init_component::<T>()
     }
 
+    fn new_state(components: &Components) -> Self::State {
+        components.component_id::<T>().unwrap()
+    }
+
     fn matches_component_set(
         &id: &ComponentId,
         set_contains_id: &impl Fn(ComponentId) -> bool,
@@ -204,6 +208,10 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
 
     fn init_state(world: &mut World) -> ComponentId {
         world.init_component::<T>()
+    }
+
+    fn new_state(components: &Components) -> Self::State {
+        components.component_id::<T>().unwrap()
     }
 
     fn matches_component_set(
@@ -370,6 +378,10 @@ macro_rules! impl_query_filter_tuple {
                 ($($filter::init_state(world),)*)
             }
 
+            fn new_state(components: &Components) -> Self::State {
+                ($($filter::new_state(components),)*)
+            }
+
             fn matches_component_set(_state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
                 let ($($filter,)*) = _state;
                 false $(|| $filter::matches_component_set($filter, _set_contains_id))*
@@ -531,6 +543,10 @@ macro_rules! impl_tick_filter {
 
             fn init_state(world: &mut World) -> ComponentId {
                 world.init_component::<T>()
+            }
+
+            fn new_state(components: &Components) -> ComponentId {
+                components.component_id::<T>().unwrap()
             }
 
             fn matches_component_set(&id: &ComponentId, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId},
-    component::{Component, ComponentId, ComponentStorage, StorageType, Tick, Components},
+    component::{Component, ComponentId, ComponentStorage, Components, StorageType, Tick},
     entity::Entity,
     query::{Access, DebugCheckedUnwrap, FilteredAccess, WorldQuery},
     storage::{Column, ComponentSparseSet, Table, TableRow},

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -68,6 +68,8 @@ unsafe impl<T: Component> WorldQuery for With<T> {
 
     const IS_ARCHETYPAL: bool = true;
 
+    const IS_EXACT: bool = false;
+
     #[inline]
     unsafe fn set_table(_fetch: &mut (), _state: &ComponentId, _table: &Table) {}
 
@@ -172,6 +174,8 @@ unsafe impl<T: Component> WorldQuery for Without<T> {
     };
 
     const IS_ARCHETYPAL: bool = true;
+
+    const IS_EXACT: bool = false;
 
     #[inline]
     unsafe fn set_table(_fetch: &mut (), _state: &Self::State, _table: &Table) {}
@@ -291,6 +295,8 @@ macro_rules! impl_query_filter_tuple {
             const IS_DENSE: bool = true $(&& $filter::IS_DENSE)*;
 
             const IS_ARCHETYPAL: bool = true $(&& $filter::IS_ARCHETYPAL)*;
+
+            const IS_EXACT: bool = false;
 
             #[inline]
             unsafe fn init_fetch<'w>(world: UnsafeWorldCell<'w>, state: &Self::State, last_run: Tick, this_run: Tick) -> Self::Fetch<'w> {
@@ -457,6 +463,8 @@ macro_rules! impl_tick_filter {
             };
 
             const IS_ARCHETYPAL:  bool = false;
+
+            const IS_EXACT: bool = true;
 
             #[inline]
             unsafe fn set_table<'w>(

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -801,38 +801,4 @@ mod tests {
         let values = world.query::<&B>().iter(&world).collect::<Vec<&B>>();
         assert_eq!(values, vec![&B(2)]);
     }
-
-    #[test]
-    fn restrict_fetch() {
-        use bevy_ecs::prelude::*;
-        use bevy_ecs::system::QueryLens;
-        #[derive(Component)]
-        struct A(usize);
-
-        #[derive(Component)]
-        struct B(usize);
-
-        let mut world = World::new();
-
-        world.spawn((A(10), B(5)));
-
-        fn function_that_uses_a_query(lens: &QueryLens<&mut A>) {
-            let mut q = lens.query();
-            q.single_mut().0 = 15;
-            assert_eq!(q.single().0, 15);
-        }
-
-        fn system_1(mut query: Query<&mut A>) {
-            function_that_uses_a_query(&query.into_query_lens());
-        }
-
-        fn system_2(mut query: Query<(&mut A, &B)>) {
-            let lens = query.restrict_fetch::<&mut A>();
-            function_that_uses_a_query(&lens);
-        }
-
-        let mut schedule = Schedule::default();
-        schedule.add_systems((system_1, system_2));
-        schedule.run(&mut world);
-    }
 }

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -801,4 +801,29 @@ mod tests {
         let values = world.query::<&B>().iter(&world).collect::<Vec<&B>>();
         assert_eq!(values, vec![&B(2)]);
     }
+
+    #[test]
+    fn generalize() {
+        let mut world = World::new();
+
+        world.spawn((A(10), B(5)));
+
+        fn function_that_takes_a_query(query: &Query<&A>) {
+            assert_eq!(query.single().0, 10);
+        }
+
+        fn system_1(query: Query<&A>) {
+            function_that_takes_a_query(&query);
+        }
+
+        fn system_2(query: Query<(&A, &B)>) {
+            let gen_q = query.generalize::<&A>();
+            let q = gen_q.query();
+            function_that_takes_a_query(&q);
+        }
+
+        let mut schedule = Schedule::default();
+        schedule.add_systems((system_1, system_2));
+        schedule.run(&mut world);
+    }
 }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -146,12 +146,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         if !Q::IS_ARCHETYPAL || !F::IS_ARCHETYPAL || !NewQ::IS_ARCHETYPAL {
             panic!("generalizing is not allow with queries that use `Changed` or `Added`");
         }
-        // SAFETY: we are using unsafe world to access &Components which should always be safe
-        let fetch_state = unsafe { NewQ::new_state(world.world().components()) };
+        let fetch_state = NewQ::new_state(world.components());
         #[allow(clippy::let_unit_value)]
         // the archetypal filters have already been applied, so we don't need them.
-        // SAFETY: we are using unsafe world to access &Components which should always be safe
-        let filter_state = unsafe { <()>::new_state(world.world().components()) };
+        let filter_state = <()>::new_state(world.components());
 
         let mut component_access = FilteredAccess::default();
         NewQ::update_component_access(&fetch_state, &mut component_access);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -174,14 +174,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         }
 
         // if we have optional parameters, make sure we don't go from a broader query to a more narrow one
-        let mut original_optional_access = Access::default();
-        Q::optional_access(&self.fetch_state, &mut original_optional_access, false);
-        if original_optional_access.has_any_read() {
-            let mut new_optional_access = Access::default();
-            NewQ::optional_access(&fetch_state, &mut new_optional_access, false);
-            if !original_optional_access.read_and_writes_difference_is_empty(&new_optional_access) {
-                panic!("`transmute` does not allow going from a broader query to a more narrow one. i.e. from Option<&T> -> &T");
-            }
+        let mut original_optional = Access::default();
+        Q::optional_access(&self.fetch_state, &mut original_optional, false);
+        let mut new_optional = Access::default();
+        NewQ::optional_access(&fetch_state, &mut new_optional, false);
+        if !component_access.is_optional_compatible(original_optional, &new_optional) {
+            panic!("`transmute` does not allow going from a broader query to a more narrow one. i.e. from Option<&T> -> &T");
         }
 
         QueryState {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -153,12 +153,12 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         if !Q::IS_ARCHETYPAL || !F::IS_ARCHETYPAL || !NewQ::IS_ARCHETYPAL {
             panic!("`restrict_fetch` is not allowed with queries that use `Changed` or `Added`");
         }
-        let fetch_state = NewQ::new_state(components).expect(
+        let fetch_state = NewQ::get_state(components).expect(
             "Could not create fetch_state. Please initialize any components needed before trying to `transmute`",
         );
         #[allow(clippy::let_unit_value)]
         // the archetypal filters have already been applied, so we don't need them.
-        let filter_state = <()>::new_state(components).expect(
+        let filter_state = <()>::get_state(components).expect(
             "Could not create filter_state. Please initialize any components needed before trying to `transmute`",
         );
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -182,7 +182,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
             par_iter_span: bevy_utils::tracing::info_span!(
                 "par_for_each",
                 query = std::any::type_name::<NewQ>(),
-                filter = std::any::type_name::<NewF>(),
+                filter = std::any::type_name::<()>(),
             ),
         }
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1640,7 +1640,6 @@ mod tests {
             assert_eq!(a.0, 22);
         }
 
-
         #[test]
         fn can_transmute_empty_tuple() {
             let mut world = World::new();
@@ -1683,7 +1682,6 @@ mod tests {
             let _ = q.restrict_fetch::<EntityRef>(world.components());
         }
 
-        
         #[test]
         #[should_panic(expected = "access is not compatible with new query type")]
         fn cannot_transmute_to_include_data_not_in_original_query() {
@@ -1697,7 +1695,9 @@ mod tests {
         }
 
         #[test]
-        #[should_panic(expected = "`restrict_fetch` is not allowed with queries that use `Changed` or `Added`")]
+        #[should_panic(
+            expected = "`restrict_fetch` is not allowed with queries that use `Changed` or `Added`"
+        )]
         fn cannot_transmute_non_archtypal_queries() {
             let mut world = World::new();
             world.spawn(A(22));
@@ -1717,7 +1717,9 @@ mod tests {
         }
 
         #[test]
-        #[should_panic(expected = "`tranmute` does not allow going from a broader query to a more narrow one.")]
+        #[should_panic(
+            expected = "`tranmute` does not allow going from a broader query to a more narrow one."
+        )]
         fn cannot_transmute_option_to_immut() {
             let mut world = World::new();
             world.spawn(C(22));
@@ -1742,7 +1744,7 @@ mod tests {
         #[should_panic(expected = "access is not compatible with new query type")]
         fn cannot_transmute_entity_ref_with_or_filter() {
             let mut world = World::new();
-            
+
             let q = world.query_filtered::<EntityRef, Or<(With<A>, With<B>)>>();
             let _ = q.restrict_fetch::<&A>(world.components());
         }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -145,6 +145,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// You should not call [`update_archetypes`](Self::update_archetypes) on the returned [`QueryState`] as the result will be unpredictable.
     /// You might end up with a mix of archetypes that only matched the original query + archetypes that only match
     /// the new [`QueryState`]. Most of the safe methods on [`QueryState`] call [`QueryState::update_archetypes`] internally.
+    #[track_caller]
     pub(crate) fn transmute_fetch<NewQ: WorldQuery>(
         &self,
         components: &Components,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -138,12 +138,13 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         state
     }
 
-    /// This is used to transform a [`Query`] into a more generic [`Query`]. This can be useful for passsing to another function that
-    /// might take the more generalize query. See [`Query::restrict_fetch`] for more details.
+    /// This is used to transform a [`Query`](crate::system::Query) into a more generic [`Query`](crate::system::Query).
+    /// This can be useful for passsing to another function tha might take the more generalize query.
+    /// See [`Query::restrict_fetch`](crate::system::Query::restrict_fetch) for more details.
     ///
-    /// You should not call `update_archetypes` on the returned QueryState as the result will be unpredictable.
+    /// You should not call `update_archetypes` on the returned [`QueryState`] as the result will be unpredictable.
     /// You might end up with a mix of archetypes that only matched the original query + archetypes that only match
-    /// the new [`QueryState`]. Most of the safe methods on [`QueryState`] call [`update_archetypes`] internally.
+    /// the new [`QueryState`]. Most of the safe methods on [`QueryState`] call [`QueryState::update_archetypes`] internally.
     pub(crate) fn restrict_fetch<NewQ: WorldQuery>(
         &self,
         components: &Components,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -146,10 +146,10 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         if !Q::IS_ARCHETYPAL || !F::IS_ARCHETYPAL || !NewQ::IS_ARCHETYPAL {
             panic!("generalizing is not allow with queries that use `Changed` or `Added`");
         }
-        let fetch_state = NewQ::new_state(world.components());
+        let fetch_state = NewQ::new_state(world.components()).unwrap();
         #[allow(clippy::let_unit_value)]
         // the archetypal filters have already been applied, so we don't need them.
-        let filter_state = <()>::new_state(world.components());
+        let filter_state = <()>::new_state(world.components()).unwrap();
 
         let mut component_access = FilteredAccess::default();
         NewQ::update_component_access(&fetch_state, &mut component_access);

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -138,7 +138,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         state
     }
 
-    /// Transform a query into a more generic query. If the original query state did
+    /// Transform a [`QueryState`] into a more generic [`QueryState`]. If the original query state did
     /// not have the same access this will panic.
     /// Probably should not call update archetype generation on this query state as the results will
     /// be very unpredictable as new archetypes could be added that don't match old query

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -176,7 +176,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         // if we have optional parameters, make sure we don't go from a broader query to a more narrow one
         let mut original_optional_access = Access::default();
         Q::optional_access(&self.fetch_state, &mut original_optional_access, false);
-        if original_optional_access.has_access() {
+        if original_optional_access.has_any_read() {
             let mut new_optional_access = Access::default();
             NewQ::optional_access(&fetch_state, &mut new_optional_access, false);
             if !original_optional_access.read_and_writes_difference_is_empty(&new_optional_access) {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -142,10 +142,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
     /// not have the same access this will panic.
     /// Probably should not call update archetype generation on this query state as the results will
     /// be very unpredictable as new archetypes could be added that don't match old query
-    pub fn generalize<NewQ: WorldQuery>(
-        self,
-        world: UnsafeWorldCell,
-    ) -> QueryState<NewQ, ()> {
+    pub fn generalize<NewQ: WorldQuery>(&self, world: UnsafeWorldCell) -> QueryState<NewQ, ()> {
         if !Q::IS_ARCHETYPAL || !F::IS_ARCHETYPAL || !NewQ::IS_ARCHETYPAL {
             panic!("generalizing is not allow with queries that use `Changed` or `Added`");
         }
@@ -173,8 +170,8 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         QueryState {
             world_id: self.world_id,
             archetype_generation: self.archetype_generation,
-            matched_table_ids: self.matched_table_ids,
-            matched_archetype_ids: self.matched_archetype_ids,
+            matched_table_ids: self.matched_table_ids.clone(),
+            matched_archetype_ids: self.matched_archetype_ids.clone(),
             fetch_state,
             filter_state,
             component_access,

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -138,13 +138,14 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
         state
     }
 
-    /// This is used to transform a [`Query`](crate::system::Query) into a more generic [`Query`](crate::system::Query).
-    /// This can be useful for passsing to another function tha might take the more generalize query.
+    /// Use this to transform a [`QueryState`] into a more generic [`QueryState`].
+    /// This can be useful for passing to another function that might take the more general form.
     /// See [`Query::transmute_fetch`](crate::system::Query::transmute_fetch) for more details.
     ///
     /// You should not call [`update_archetypes`](Self::update_archetypes) on the returned [`QueryState`] as the result will be unpredictable.
     /// You might end up with a mix of archetypes that only matched the original query + archetypes that only match
-    /// the new [`QueryState`]. Most of the safe methods on [`QueryState`] call [`QueryState::update_archetypes`] internally.
+    /// the new [`QueryState`]. Most of the safe methods on [`QueryState`] call [`QueryState::update_archetypes`] internally, so this
+    /// best used through a [`Query`](crate::system::Query).
     #[track_caller]
     pub(crate) fn transmute_fetch<NewQ: WorldQuery>(
         &self,
@@ -157,7 +158,7 @@ impl<Q: WorldQuery, F: ReadOnlyWorldQuery> QueryState<Q, F> {
             "Could not create fetch_state. Please initialize any components needed before trying to `transmute`",
         );
         #[allow(clippy::let_unit_value)]
-        // the archetypal filters have already been applied, so we don't need them.
+        // the archetypal filters have already been applied, so we discard them to make the query type more general.
         let filter_state = <()>::get_state(components).expect(
             "Could not create filter_state. Please initialize any components needed before trying to `transmute`",
         );

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1680,12 +1680,13 @@ mod tests {
         }
 
         #[test]
-        fn can_generalize_option() {
+        fn can_generalize_with_option() {
             let mut world = World::new();
             world.spawn((A(22), B));
 
             let query_state = world.query::<(Option<&A>, &B)>();
             let _ = query_state.transmute_fetch::<Option<&A>>(world.components());
+            let _ = query_state.transmute_fetch::<&B>(world.components());
         }
 
         #[test]

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -442,7 +442,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// # schedule.run(&mut world);
     /// ```
     pub fn restrict_fetch<NewQ: WorldQuery>(&mut self) -> QueryLens<'_, NewQ> {
-        let new_state = self.state.generalize(self.world);
+        let new_state = self.state.restrict_fetch(self.world);
 
         QueryLens {
             state: new_state,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -452,7 +452,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
         }
     }
 
-    /// helper method to get a QueryLens with the same fetch as the existing query
+    /// helper method to get a [`QueryLens`] with the same fetch as the existing query
     pub fn into_query_lens(&mut self) -> QueryLens<'_, Q> {
         self.restrict_fetch()
     }

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -442,7 +442,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// # schedule.run(&mut world);
     /// ```
     pub fn restrict_fetch<NewQ: WorldQuery>(&mut self) -> QueryLens<'_, NewQ> {
-        let new_state = self.state.restrict_fetch(self.world);
+        let new_state = self.state.restrict_fetch(self.world.components());
 
         QueryLens {
             state: new_state,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -320,11 +320,11 @@ use std::{any::TypeId, borrow::Borrow};
 /// [`single_mut`]: Self::single_mut
 /// [`SparseSet`]: crate::storage::SparseSet
 /// [System parameter]: crate::system::SystemParam
-/// [`With`]: crate::query::With
 /// [`Table`]: crate::storage::Table
+/// [`With`]: crate::query::With
 /// [`Without`]: crate::query::Without
-// SAFETY: Must have access to the components registered in `state`.
 pub struct Query<'world, 'state, Q: WorldQuery, F: ReadOnlyWorldQuery = ()> {
+    // SAFETY: Must have access to the components registered in `state`.
     world: UnsafeWorldCell<'world>,
     state: &'state QueryState<Q, F>,
     last_run: Tick,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -433,7 +433,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// }
     ///
     /// fn system_2(mut query: Query<(&mut A, &B)>) {
-    ///     let mut lens = query.restrict_fetch::<&A>();
+    ///     let mut lens = query.transmute_fetch::<&A>();
     ///     function_that_uses_a_query_lens(&mut lens);
     /// }
     ///
@@ -441,8 +441,8 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// # schedule.add_systems((system_1, system_2));
     /// # schedule.run(&mut world);
     /// ```
-    pub fn restrict_fetch<NewQ: WorldQuery>(&mut self) -> QueryLens<'_, NewQ> {
-        let new_state = self.state.restrict_fetch(self.world.components());
+    pub fn transmute_fetch<NewQ: WorldQuery>(&mut self) -> QueryLens<'_, NewQ> {
+        let new_state = self.state.transmute_fetch(self.world.components());
 
         QueryLens {
             state: new_state,
@@ -454,7 +454,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
 
     /// helper method to get a [`QueryLens`] with the same fetch as the existing query
     pub fn into_query_lens(&mut self) -> QueryLens<'_, Q> {
-        self.restrict_fetch()
+        self.transmute_fetch()
     }
 
     /// Returns an [`Iterator`] over the read-only query items.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -441,6 +441,7 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// # schedule.add_systems((system_1, system_2));
     /// # schedule.run(&mut world);
     /// ```
+    #[track_caller]
     pub fn transmute_fetch<NewQ: WorldQuery>(&mut self) -> QueryLens<'_, NewQ> {
         let new_state = self.state.transmute_fetch(self.world.components());
 

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -424,17 +424,17 @@ impl<'w, 's, Q: WorldQuery, F: ReadOnlyWorldQuery> Query<'w, 's, Q, F> {
     /// #
     /// # world.spawn((A(10), B(5)));
     ///
-    /// fn function_that_uses_a_query(lens: &QueryLens<&A>) {
+    /// fn function_that_uses_a_query_lens(lens: &mut QueryLens<&A>) {
     ///     assert_eq!(lens.query().single().0, 10);
     /// }
     ///
-    /// fn system_1(query: Query<&A>) {
-    ///     function_that_uses_a_query(&query.into_query_lens());
+    /// fn system_1(mut query: Query<&A>) {
+    ///     function_that_uses_a_query_lens(&mut query.into_query_lens());
     /// }
     ///
-    /// fn system_2(query: Query<(&mut A, &B)>) {
-    ///     let lens = query.restrict_fetch::<&A>();
-    ///     function_that_uses_a_query(&lens);
+    /// fn system_2(mut query: Query<(&mut A, &B)>) {
+    ///     let mut lens = query.restrict_fetch::<&A>();
+    ///     function_that_uses_a_query_lens(&mut lens);
     /// }
     ///
     /// # let mut schedule = Schedule::default();
@@ -1586,8 +1586,8 @@ pub struct QueryLens<'world, NewQ: WorldQuery> {
 }
 
 impl<'world, NewQ: WorldQuery> QueryLens<'world, NewQ> {
-    /// get the query associated with Generalized Query
-    pub fn query(&self) -> Query<'world, '_, NewQ, ()> {
+    /// Get the [`Query`] associated with the [`QueryLens`]
+    pub fn query(&mut self) -> Query<'world, '_, NewQ, ()> {
         Query {
             world: self.world,
             state: &self.state,

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_transmute_safety.rs
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_transmute_safety.rs
@@ -1,0 +1,39 @@
+use bevy_ecs::prelude::*;
+use bevy_ecs::system::SystemState;
+
+#[derive(Component, Eq, PartialEq, Debug)]
+struct Foo(u32);
+
+#[derive(Component)]
+struct Bar;
+
+fn main() {
+    let mut world = World::default();
+    world.spawn(Foo(10));
+
+    let mut system_state = SystemState::<Query<(&mut Foo, &Bar)>>::new(&mut world);
+    let mut query = system_state.get_mut(&mut world);
+
+    {
+        let mut lens1 = query.transmute_fetch::<&mut Foo>();
+        let mut lens2 = query.transmute_fetch::<&mut Foo>();
+
+        let mut query1 = lens1.query();
+        let mut query2 = lens2.query();
+
+        let f1 = query1.single_mut();
+        let f2 = query2.single_mut(); // oops 2 mutable references to same Foo
+        assert_eq!(*f1, *f2);
+    }
+
+    {
+        let mut lens = query.transmute_fetch::<&mut Foo>();
+
+        let mut query1 = lens.query();
+        let mut query2 = lens.query();
+
+        let f1 = query1.single_mut();
+        let f2 = query2.single_mut(); // oops 2 mutable references to same Foo
+        assert_eq!(*f1, *f2);
+    }
+}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_transmute_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_transmute_safety.stderr
@@ -1,0 +1,21 @@
+error[E0499]: cannot borrow `query` as mutable more than once at a time
+  --> tests/ui/query_transmute_safety.rs:19:25
+   |
+18 |         let mut lens1 = query.transmute_fetch::<&mut Foo>();
+   |                         ----- first mutable borrow occurs here
+19 |         let mut lens2 = query.transmute_fetch::<&mut Foo>();
+   |                         ^^^^^ second mutable borrow occurs here
+20 |
+21 |         let mut query1 = lens1.query();
+   |                          ----- first borrow later used here
+
+error[E0499]: cannot borrow `lens` as mutable more than once at a time
+  --> tests/ui/query_transmute_safety.rs:33:26
+   |
+32 |         let mut query1 = lens.query();
+   |                          ---- first mutable borrow occurs here
+33 |         let mut query2 = lens.query();
+   |                          ^^^^ second mutable borrow occurs here
+34 |
+35 |         let f1 = query1.single_mut();
+   |                  ------ first borrow later used here


### PR DESCRIPTION
# Objective

- Allow transforming a query into a more generalized form, but matches the same data. i.e. turn a `Query<(&A, &B)>` into a `Query<&A>`. This allows passing the narrower query into a function that takes the more general query.

## Solution

- Create a `transmute_fetch` method that transforms an existing `QueryState` into a new one by creating new `filter_state` and `fetch_state`, but keeping the matched archetypes and other info.
- Don't allow going from a fetch that gets optional data to one that is more narrow. i.e. Option<&T> or EntityMut into &T.
- Add a `transmute` method on `Query` that returns QueryLens that stores the new fetch_state and filter_state.
- Don't allow generalize to be run with non archetypal filters. This could maybe be relaxed in the future, but removing a Changed filter or switching from Changed to Added felt very footgunny. As you would naively expect this not to match new data, but it actually could. As a byproduct, this ends up disallowing Change and Added in the fetch.
- Remove any filters from the type. As these are all archetypal, and archetypes have already been filtered. This allows the generalized query to be used in more places.

```rust
fn function_that_takes_a_query(query: &Query<&A>) {
    assert_eq!(query.single().0, 10);
}

fn system_1(query: Query<&A>) {
    function_that_takes_a_query(&query);
}

fn system_2(query: Query<(&A, &B)>) {
    let query_lens = query.transmute_fetch::<&A>();
    let q = query_lens.query();
    function_that_takes_a_query(&q);
}
```
---

## Changelog

- add a transmute_fetch method to transform queries to a similar types.

## Future Work

- add a transmute_fetch_and_filter that would allow Changed and Added filters
- similar approach could be used to join to queries and take the intersection of their matched archetypes.

## To Do

- [ ] consider adding transmute_fetch_and_filter in this PR