### PR TITLE
Add frustum gizmo

### DIFF
--- a/crates/bevy_gizmos/src/frustum.rs
+++ b/crates/bevy_gizmos/src/frustum.rs
@@ -1,0 +1,213 @@
+//! Module for the drawing of [`Frustum`]s.
+
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_asset::{Assets, Handle};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{Changed, Or, With, Without},
+    reflect::ReflectComponent,
+    removal_detection::RemovedComponents,
+    schedule::IntoSystemConfigs,
+    system::{Commands, Query, Res, ResMut},
+};
+use bevy_math::Vec3;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect, ReflectFromReflect};
+use bevy_render::{
+    color::Color,
+    primitives::{Frustum, HalfSpace},
+    view::VisibilitySystems,
+};
+
+use crate::{color_from_entity, GizmoConfig, LineGizmo};
+
+/// Plugin for the drawing of [`Frustum`]s.
+pub struct FrustumGizmoPlugin;
+
+impl Plugin for FrustumGizmoPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(
+            PostUpdate,
+            (
+                frustum_gizmos,
+                all_frustum_gizmos.run_if(|config: Res<GizmoConfig>| config.frustum.draw_all),
+                remove_frustum_gizmos.run_if(|config: Res<GizmoConfig>| !config.frustum.draw_all),
+            )
+                .after(VisibilitySystems::UpdateOrthographicFrusta)
+                .after(VisibilitySystems::UpdatePerspectiveFrusta)
+                .after(VisibilitySystems::UpdateProjectionFrusta),
+        );
+    }
+}
+
+/// Configuration for drawing the [`Frustum`] component on entities.
+#[derive(Clone, Default)]
+pub struct FrustumGizmoConfig {
+    /// Draws all frustums in the scene when set to `true`.
+    ///
+    /// To draw a specific entity's frustum, you can add the [`FrustumGizmo`] component.
+    ///
+    /// Defaults to `false`.
+    pub draw_all: bool,
+    /// The default color for frustum gizmos.
+    ///
+    /// A random color is chosen per frustum if `None`.
+    ///
+    /// Defaults to `None`.
+    pub default_color: Option<Color>,
+}
+
+/// Add this [`Component`] to an entity to draw its [`Frustum`] component.
+#[derive(Component, Reflect, Default, Debug)]
+#[reflect(Component, FromReflect, Default)]
+pub struct FrustumGizmo {
+    /// The color of the frustum.
+    ///
+    /// The default color from the [`GizmoConfig`] resource is used if `None`,
+    pub color: Option<Color>,
+}
+
+fn frustum_gizmos(
+    query: Query<
+        (Entity, &Frustum, &FrustumGizmo, Option<&Handle<LineGizmo>>),
+        Or<(Changed<Frustum>, Changed<FrustumGizmo>)>,
+    >,
+    config: Res<GizmoConfig>,
+    mut commands: Commands,
+    mut lines: ResMut<Assets<LineGizmo>>,
+    mut removed: RemovedComponents<FrustumGizmo>,
+) {
+    for entity in removed.read() {
+        if !query.contains(entity) {
+            commands.entity(entity).remove::<Handle<LineGizmo>>();
+        }
+    }
+
+    for (entity, frustum, gizmo, line_handle) in &query {
+        let color = gizmo
+            .color
+            .or(config.aabb.default_color)
+            .unwrap_or_else(|| color_from_entity(entity));
+
+        frustum_inner(
+            &mut commands,
+            &mut lines,
+            entity,
+            frustum,
+            line_handle,
+            color,
+        );
+    }
+}
+
+fn all_frustum_gizmos(
+    query: Query<
+        (Entity, &Frustum, Option<&Handle<LineGizmo>>),
+        (Without<FrustumGizmo>, Changed<Frustum>),
+    >,
+    config: Res<GizmoConfig>,
+    mut commands: Commands,
+    mut lines: ResMut<Assets<LineGizmo>>,
+) {
+    for (entity, frustum, line_handle) in &query {
+        let color = config
+            .aabb
+            .default_color
+            .unwrap_or_else(|| color_from_entity(entity));
+
+        frustum_inner(
+            &mut commands,
+            &mut lines,
+            entity,
+            frustum,
+            line_handle,
+            color,
+        );
+    }
+}
+
+fn frustum_inner(
+    commands: &mut Commands,
+    lines: &mut ResMut<Assets<LineGizmo>>,
+    entity: Entity,
+    frustum: &Frustum,
+    line_handle: Option<&Handle<LineGizmo>>,
+    color: Color,
+) {
+    let Some(positions) = calculate_frustum_positions(frustum) else {
+        return;
+    };
+
+    let line = LineGizmo {
+        colors: std::iter::repeat(color.as_linear_rgba_f32())
+            .take(positions.len())
+            .collect(),
+        positions,
+        strip: true,
+    };
+
+    if let Some(handle) = line_handle {
+        lines.insert(handle, line);
+    } else {
+        commands.entity(entity).insert(lines.add(line));
+    }
+}
+
+fn remove_frustum_gizmos(
+    query: Query<Entity, (With<Handle<LineGizmo>>, Without<FrustumGizmo>)>,
+    mut commands: Commands,
+) {
+    for entity in &query {
+        commands.entity(entity).remove::<Handle<LineGizmo>>();
+    }
+}
+
+fn calculate_frustum_positions(frustum: &Frustum) -> Option<Vec<[f32; 3]>> {
+    let [left, right, top, bottom, near, far] = frustum.half_spaces;
+
+    // Near
+    let tln = intersect_halfspaces(top, left, near)?;
+    let trn = intersect_halfspaces(top, right, near)?;
+    let brn = intersect_halfspaces(bottom, right, near)?;
+    let bln = intersect_halfspaces(bottom, left, near)?;
+    // Far
+    let tlf = intersect_halfspaces(top, left, far)?;
+    let trf = intersect_halfspaces(top, right, far)?;
+    let brf = intersect_halfspaces(bottom, right, far)?;
+    let blf = intersect_halfspaces(bottom, left, far)?;
+
+    #[rustfmt::skip]
+    let positions = [
+        tln, trn, brn, bln, tln, // Near
+        tlf, trf, brf, blf, tlf, // Far
+        Vec3::NAN, trn, trf, // Near to far
+        Vec3::NAN, brn, brf,
+        Vec3::NAN, bln, blf,
+    ];
+
+    Some(positions.into_iter().map(|v| v.to_array()).collect())
+}
+
+/// Returns the intersection position if the three halfspaces all intersect at a single point.
+fn intersect_halfspaces(a: HalfSpace, b: HalfSpace, c: HalfSpace) -> Option<Vec3> {
+    let an = a.normal();
+    let bn = b.normal();
+    let cn = c.normal();
+
+    let x = Vec3::new(an.x, bn.x, cn.x);
+    let y = Vec3::new(an.y, bn.y, cn.y);
+    let z = Vec3::new(an.z, bn.z, cn.z);
+
+    let d = -Vec3::new(a.d(), b.d(), c.d());
+
+    let u = y.cross(z);
+    let v = x.cross(d);
+
+    let denom = x.dot(u);
+
+    if denom.abs() < f32::EPSILON {
+        return None;
+    }
+
+    Some(Vec3::new(d.dot(u), z.dot(v), -y.dot(v)) / denom)
+}

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! See the documentation on [`Gizmos`] for more examples.
 
+pub mod frustum;
 pub mod gizmos;
 
 #[cfg(feature = "bevy_sprite")]
@@ -26,7 +27,11 @@ mod pipeline_3d;
 /// The `bevy_gizmos` prelude.
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{gizmos::Gizmos, AabbGizmo, AabbGizmoConfig, GizmoConfig};
+    pub use crate::{
+        frustum::{FrustumGizmo, FrustumGizmoConfig},
+        gizmos::Gizmos,
+        AabbGizmo, AabbGizmoConfig, GizmoConfig,
+    };
 }
 
 use bevy_app::{Last, Plugin, PostUpdate};
@@ -68,6 +73,8 @@ use bevy_transform::{
 use gizmos::{GizmoStorage, Gizmos};
 use std::mem;
 
+use crate::frustum::{FrustumGizmoConfig, FrustumGizmoPlugin};
+
 const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
 
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
@@ -77,21 +84,24 @@ impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 
-        app.add_plugins(UniformComponentPlugin::<LineGizmoUniform>::default())
-            .init_asset::<LineGizmo>()
-            .add_plugins(RenderAssetPlugin::<LineGizmo>::default())
-            .init_resource::<LineGizmoHandles>()
-            .init_resource::<GizmoConfig>()
-            .init_resource::<GizmoStorage>()
-            .add_systems(Last, update_gizmo_meshes)
-            .add_systems(
-                PostUpdate,
-                (
-                    draw_aabbs,
-                    draw_all_aabbs.run_if(|config: Res<GizmoConfig>| config.aabb.draw_all),
-                )
-                    .after(TransformSystem::TransformPropagate),
-            );
+        app.add_plugins((
+            FrustumGizmoPlugin,
+            UniformComponentPlugin::<LineGizmoUniform>::default(),
+            RenderAssetPlugin::<LineGizmo>::default(),
+        ))
+        .init_asset::<LineGizmo>()
+        .init_resource::<LineGizmoHandles>()
+        .init_resource::<GizmoConfig>()
+        .init_resource::<GizmoStorage>()
+        .add_systems(Last, update_gizmo_meshes)
+        .add_systems(
+            PostUpdate,
+            (
+                draw_aabbs,
+                draw_all_aabbs.run_if(|config: Res<GizmoConfig>| config.aabb.draw_all),
+            )
+                .after(TransformSystem::TransformPropagate),
+        );
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
@@ -166,6 +176,8 @@ pub struct GizmoConfig {
     pub depth_bias: f32,
     /// Configuration for the [`AabbGizmo`].
     pub aabb: AabbGizmoConfig,
+    /// Configuration for the [`FrustumGizmo`].
+    pub frustum: FrustumGizmoConfig,
     /// Describes which rendering layers gizmos will be rendered to.
     ///
     /// Gizmos will only be rendered to cameras with intersecting layers.
@@ -180,6 +192,7 @@ impl Default for GizmoConfig {
             line_perspective: false,
             depth_bias: 0.,
             aabb: Default::default(),
+            frustum: Default::default(),
             render_layers: Default::default(),
         }
     }
@@ -317,6 +330,7 @@ fn extract_gizmo_data(
     mut commands: Commands,
     handles: Extract<Res<LineGizmoHandles>>,
     config: Extract<Res<GizmoConfig>>,
+    linegizmo_query: Extract<Query<(Entity, &Handle<LineGizmo>)>>,
 ) {
     if config.is_changed() {
         commands.insert_resource(config.clone());
@@ -328,6 +342,18 @@ fn extract_gizmo_data(
 
     for handle in [&handles.list, &handles.strip].into_iter().flatten() {
         commands.spawn((
+            LineGizmoUniform {
+                line_width: config.line_width,
+                depth_bias: config.depth_bias,
+                #[cfg(feature = "webgl")]
+                _padding: Default::default(),
+            },
+            handle.clone_weak(),
+        ));
+    }
+
+    for (entity, handle) in &linegizmo_query {
+        commands.get_or_spawn(entity).insert((
             LineGizmoUniform {
                 line_width: config.line_width,
                 depth_bias: config.depth_bias,

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -156,6 +156,7 @@ fn queue_line_gizmos_3d(
     line_gizmos: Query<(Entity, &Handle<LineGizmo>)>,
     line_gizmo_assets: Res<RenderAssets<LineGizmo>>,
     mut views: Query<(
+        Entity,
         &ExtractedView,
         &mut RenderPhase<Transparent3d>,
         Option<&RenderLayers>,
@@ -163,7 +164,7 @@ fn queue_line_gizmos_3d(
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo3d>().unwrap();
 
-    for (view, mut transparent_phase, render_layers) in &mut views {
+    for (view_entity, view, mut transparent_phase, render_layers) in &mut views {
         let render_layers = render_layers.copied().unwrap_or_default();
         if !config.render_layers.intersects(&render_layers) {
             continue;
@@ -173,6 +174,12 @@ fn queue_line_gizmos_3d(
             | MeshPipelineKey::from_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
+            // The frustum gizmo adds a linegizmo to the same entity.
+            // We can use that here to prevent views from rendering their own frustum.
+            if entity == view_entity {
+                continue;
+            }
+
             let Some(line_gizmo) = line_gizmo_assets.get(handle) else {
                 continue;
             };

--- a/examples/tools/scene_viewer/scene_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/scene_viewer_plugin.rs
@@ -7,10 +7,7 @@
 // type aliases tends to obfuscate code while offering no improvement in code cleanliness.
 #![allow(clippy::type_complexity)]
 
-use bevy::{
-    asset::LoadState, gltf::Gltf, input::common_conditions::input_just_pressed, prelude::*,
-    scene::InstanceId,
-};
+use bevy::{asset::LoadState, gltf::Gltf, prelude::*, scene::InstanceId};
 
 use std::f32::consts::*;
 use std::fmt;
@@ -43,6 +40,8 @@ const INSTRUCTIONS: &str = r#"
 Scene Controls:
     L           - animate light direction
     U           - toggle shadows
+    B           - toggle bounding boxes
+    F           - toggle camera frustums
     C           - cycle through the camera controller and any cameras loaded from the scene
 
     compile with "--features animation" for animation controls.
@@ -54,6 +53,7 @@ Scene Controls:
     L           - animate light direction
     U           - toggle shadows
     B           - toggle bounding boxes
+    F           - toggle camera frustums
     C           - cycle through the camera controller and any cameras loaded from the scene
 
     Space       - Play/Pause animation
@@ -72,19 +72,18 @@ impl Plugin for SceneViewerPlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<CameraTracker>()
             .add_systems(PreUpdate, scene_load_check)
-            .add_systems(
-                Update,
-                (
-                    update_lights,
-                    camera_tracker,
-                    toggle_bounding_boxes.run_if(input_just_pressed(KeyCode::B)),
-                ),
-            );
+            .add_systems(Update, (update_lights, camera_tracker, toggle_gizmos));
     }
 }
 
-fn toggle_bounding_boxes(mut config: ResMut<GizmoConfig>) {
-    config.aabb.draw_all ^= true;
+fn toggle_gizmos(keyboard_input: Res<Input<KeyCode>>, mut config: ResMut<GizmoConfig>) {
+    if keyboard_input.just_pressed(KeyCode::B) {
+        config.aabb.draw_all ^= true;
+    }
+
+    if keyboard_input.just_pressed(KeyCode::F) {
+        config.frustum.draw_all ^= true;
+    }
 }
 
 fn scene_load_check(


### PR DESCRIPTION
Adds the `FrustumGizmo` which works in a similar fashion to the previously added `AabbGizmo`.

Preventing cameras from drawing their own frustums made this a lot messier but this is now technically the first retained gizmo q:

## Changelog
TODO
