### PR TITLE
Support raw access without lifetimes to UntypedMut

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -471,7 +471,9 @@ impl<'a> Ticks<'a> {
     }
 }
 
+// SAFETY: The implementation of `Ticks` matches one which contains lifetimes.
 unsafe impl Send for Ticks<'_> {}
+// SAFETY: The implementation of `Ticks` matches one which contains lifetimes.
 unsafe impl Sync for Ticks<'_> {}
 
 #[derive(Debug, Clone, Copy)]
@@ -568,7 +570,9 @@ impl<'a> TicksMut<'a> {
     }
 }
 
+// SAFETY: The implementation of `TicksMut` matches one which contains lifetimes.
 unsafe impl Send for TicksMut<'_> {}
+// SAFETY: The implementation of `TicksMut` matches one which contains lifetimes.
 unsafe impl Sync for TicksMut<'_> {}
 
 impl<'a> From<TicksMut<'a>> for Ticks<'a> {
@@ -1149,8 +1153,8 @@ mod tests {
 
         let mut query = world.query::<Ref<C>>();
         for tracker in query.iter(&world) {
-            let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added).get();
-            let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed).get();
+            let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added()).get();
+            let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed()).get();
             assert!(ticks_since_insert > MAX_CHANGE_AGE);
             assert!(ticks_since_change > MAX_CHANGE_AGE);
         }
@@ -1159,8 +1163,8 @@ mod tests {
         world.check_change_ticks();
 
         for tracker in query.iter(&world) {
-            let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added).get();
-            let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed).get();
+            let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added()).get();
+            let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed()).get();
             assert!(ticks_since_insert == MAX_CHANGE_AGE);
             assert!(ticks_since_change == MAX_CHANGE_AGE);
         }
@@ -1185,10 +1189,10 @@ mod tests {
         };
 
         let into_mut: Mut<R> = res_mut.into();
-        assert_eq!(1, into_mut.ticks.added.get());
-        assert_eq!(2, into_mut.ticks.changed.get());
-        assert_eq!(3, into_mut.ticks.last_run.get());
-        assert_eq!(4, into_mut.ticks.this_run.get());
+        assert_eq!(1, into_mut.ticks.added().get());
+        assert_eq!(2, into_mut.ticks.changed().get());
+        assert_eq!(3, into_mut.ticks.last_run().get());
+        assert_eq!(4, into_mut.ticks.this_run().get());
     }
 
     #[test]
@@ -1230,10 +1234,10 @@ mod tests {
         };
 
         let into_mut: Mut<R> = non_send_mut.into();
-        assert_eq!(1, into_mut.ticks.added.get());
-        assert_eq!(2, into_mut.ticks.changed.get());
-        assert_eq!(3, into_mut.ticks.last_run.get());
-        assert_eq!(4, into_mut.ticks.this_run.get());
+        assert_eq!(1, into_mut.ticks.added().get());
+        assert_eq!(2, into_mut.ticks.changed().get());
+        assert_eq!(3, into_mut.ticks.last_run().get());
+        assert_eq!(4, into_mut.ticks.this_run().get());
     }
 
     #[test]

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -928,12 +928,12 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                     fetch.table_data.debug_checked_unwrap();
                 Ref {
                     value: table_components.get(table_row.index()).deref(),
-                    ticks: Ticks {
-                        added: added_ticks.get(table_row.index()).deref(),
-                        changed: changed_ticks.get(table_row.index()).deref(),
-                        this_run: fetch.this_run,
-                        last_run: fetch.last_run,
-                    },
+                    ticks: Ticks::new(
+                        added_ticks.get(table_row.index()).deref(),
+                        changed_ticks.get(table_row.index()).deref(),
+                        fetch.this_run,
+                        fetch.last_run,
+                    ),
                 }
             }
             StorageType::SparseSet => {
@@ -1089,12 +1089,12 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                     fetch.table_data.debug_checked_unwrap();
                 Mut {
                     value: table_components.get(table_row.index()).deref_mut(),
-                    ticks: TicksMut {
-                        added: added_ticks.get(table_row.index()).deref_mut(),
-                        changed: changed_ticks.get(table_row.index()).deref_mut(),
-                        this_run: fetch.this_run,
-                        last_run: fetch.last_run,
-                    },
+                    ticks: TicksMut::new(
+                        added_ticks.get(table_row.index()).deref_mut(),
+                        changed_ticks.get(table_row.index()).deref_mut(),
+                        fetch.this_run,
+                        fetch.last_run,
+                    ),
                 }
             }
             StorageType::SparseSet => {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -931,8 +931,8 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                     ticks: Ticks::new(
                         added_ticks.get(table_row.index()).deref(),
                         changed_ticks.get(table_row.index()).deref(),
-                        fetch.this_run,
                         fetch.last_run,
+                        fetch.this_run,
                     ),
                 }
             }
@@ -1092,8 +1092,8 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                     ticks: TicksMut::new(
                         added_ticks.get(table_row.index()).deref_mut(),
                         changed_ticks.get(table_row.index()).deref_mut(),
-                        fetch.this_run,
                         fetch.last_run,
+                        fetch.this_run,
                     ),
                 }
             }

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1561,12 +1561,12 @@ impl World {
         let mut value = unsafe { ptr.read::<R>() };
         let value_mut = Mut {
             value: &mut value,
-            ticks: TicksMut {
-                added: &mut ticks.added,
-                changed: &mut ticks.changed,
-                last_run: last_change_tick,
-                this_run: change_tick,
-            },
+            ticks: TicksMut::new(
+                &mut ticks.added,
+                &mut ticks.changed,
+                last_change_tick,
+                change_tick,
+            ),
         };
         let result = f(self, value_mut);
         assert!(!self.contains_resource::<R>(),

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -242,6 +242,12 @@ impl<'a, A: IsAligned> PtrMut<'a, A> {
         self.0.as_ptr()
     }
 
+    /// Gets the underlying non+null pointer, erasing the associated lifetime.
+    #[doc(hidden)]
+    pub fn as_nonnull_ptr(&self) -> NonNull<u8> {
+        self.0
+    }
+
     /// Gets a [`PtrMut`] from this with a smaller lifetime.
     #[inline]
     pub fn reborrow(&mut self) -> PtrMut<'_, A> {


### PR DESCRIPTION
# Objective

- Builds out raw access to `UntypedMut` to avoid potentially unsound lifetime casts / transmutes when bevy is used across raw APIs.
- See rune-rs/rune#643

Raw access through a pointer requires us to shed the lifetime associated with `UntypedMut` to later reconstruct it using a pointer cast, and the only valid option is `'static`. I *am genuinely not sure* whether this is sound. My hunch is that it isn't because Rust is open to decide that `Foo<'a>` is laid out differently to `Foo<'static>`, all though in practice I don't think it is. To be super sure though it's better to have a dedicated set of raw APIs which are guaranteed to be sound.

## Solution

* Switch `Ticks` and `TicksMut` to both utilize a layout equivalent interior struct called `TicksRaw` containing pointers instead of references, and ensures that their lifetype parameters are constrained through `PhantomData`.
* `UntypedMut` gets a new sibling type called `UntypedMutRaw` which you can construct through `UntypedMut::into_raw`.
* `UntypedMutRaw` gets an unsafe function called `as_mut` which translates it into an `UntypedMut` with an unbounded lifetime.

If this looks good, I'd be happy to build out raw `Ref` access as well since that is also something I'd need. Thank you!