### PR TITLE
foxes shouldn't march in sync

### DIFF
--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -200,12 +200,12 @@ fn setup(
 fn setup_scene_once_loaded(
     animations: Res<Animations>,
     foxes: Res<Foxes>,
-    mut player: Query<&mut AnimationPlayer>,
+    mut player: Query<(Entity, &mut AnimationPlayer)>,
     mut done: Local<bool>,
 ) {
     if !*done && player.iter().len() == foxes.count {
-        for mut player in &mut player {
-            player.play(animations.0[0].clone_weak()).repeat();
+        for (entity, mut player) in &mut player {
+            player.play(animations.0[0].clone_weak()).repeat().seek_to(entity.index() as f32 / 10.0);
         }
         *done = true;
     }

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -205,7 +205,10 @@ fn setup_scene_once_loaded(
 ) {
     if !*done && player.iter().len() == foxes.count {
         for (entity, mut player) in &mut player {
-            player.play(animations.0[0].clone_weak()).repeat().seek_to(entity.index() as f32 / 10.0);
+            player
+                .play(animations.0[0].clone_weak())
+                .repeat()
+                .seek_to(entity.index() as f32 / 10.0);
         }
         *done = true;
     }


### PR DESCRIPTION
# Objective

- All foxes in `many_foxes` are running in sync
- It's scary
- It can also be a source of optimisation that won't be useful in a general case

## Solution

- Advance the animation of each fox so that they are not synced anymore by default
- Add a cli arg to enable them running in sync
