### PR TITLE
Inserting an asset with a new index causes error

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -530,3 +530,39 @@ pub struct InvalidGenerationError {
     index: AssetIndex,
     current_generation: u32,
 }
+
+#[cfg(test)]
+mod test {
+    use crate::VisitAssetDependencies;
+
+    use super::*;
+    use bevy_reflect::TypePath;
+
+    struct SampleAsset;
+    impl Asset for SampleAsset {}
+    impl TypePath for SampleAsset {
+        fn type_path() -> &'static str {
+            "SampleAsset"
+        }
+
+        fn short_type_path() -> &'static str {
+            "SampleAsset"
+        }
+    }
+    impl VisitAssetDependencies for SampleAsset {
+        fn visit_dependencies(&self, _: &mut impl FnMut(crate::UntypedAssetId)) {}
+    }
+
+    #[test]
+    fn test_asset_insert_when_empty() {
+        let mut assets = Assets::<SampleAsset>::default();
+        let id = AssetId::Index {
+            index: AssetIndex {
+                generation: 0,
+                index: 0,
+            },
+            marker: PhantomData {},
+        };
+        assets.insert(id, SampleAsset {});
+    }
+}


### PR DESCRIPTION
# Objective

`Assets::insert(...)` claims to automatically handle both cases of asset id existing and not existing, but when adding a new asset id by index, it causes an error of `index out of bounds: the len is 0 but the index is 0`.

## Test

A unit test `test_asset_insert_when_empty` is proving the error.

## Solution

- ?
