### PR TITLE
Wait until `FixedUpdate` can see events before dropping them

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{First, Main, MainSchedulePlugin, Plugin, Plugins, StateTransition};
+use crate::{FixedUpdate, Main, MainSchedulePlugin, Plugin, Plugins, StateTransition};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     prelude::*,
@@ -467,7 +467,7 @@ impl App {
     {
         if !self.world.contains_resource::<Events<T>>() {
             self.init_resource::<Events<T>>().add_systems(
-                First,
+                FixedUpdate,
                 bevy_ecs::event::event_update_system::<T>
                     .run_if(bevy_ecs::event::event_update_condition::<T>),
             );

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,4 +1,4 @@
-use crate::{First, FixedUpdate, Main, MainSchedulePlugin, Plugin, Plugins, StateTransition};
+use crate::{First, Main, MainSchedulePlugin, Plugin, Plugins, StateTransition};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     prelude::*,
@@ -190,7 +190,6 @@ impl Default for App {
         app.init_resource::<AppTypeRegistry>();
 
         app.add_plugins(MainSchedulePlugin);
-        app.add_systems(FixedUpdate, bevy_ecs::event::event_queue_update_system);
 
         app.add_event::<AppExit>();
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -1,7 +1,6 @@
 use crate::{First, FixedUpdate, Main, MainSchedulePlugin, Plugin, Plugins, StateTransition};
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
-    event::EventUpdateSignal,
     prelude::*,
     schedule::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
@@ -191,6 +190,8 @@ impl Default for App {
         app.init_resource::<AppTypeRegistry>();
 
         app.add_plugins(MainSchedulePlugin);
+        app.add_systems(FixedUpdate, bevy_ecs::event::event_queue_update_system);
+
         app.add_event::<AppExit>();
 
         #[cfg(feature = "bevy_ci_testing")]
@@ -467,18 +468,11 @@ impl App {
         T: Event,
     {
         if !self.world.contains_resource::<Events<T>>() {
-            self.init_resource::<Events<T>>()
-                .init_resource::<EventUpdateSignal<T>>()
-                .add_systems(
-                    First,
-                    bevy_ecs::event::event_update_system::<T>
-                        .run_if(bevy_ecs::event::event_update_condition::<T>),
-                )
-                .add_systems(
-                    FixedUpdate,
-                    bevy_ecs::event::event_queue_update_system::<T>
-                        .run_if(bevy_ecs::event::event_update_condition::<T>),
-                );
+            self.init_resource::<Events<T>>().add_systems(
+                First,
+                bevy_ecs::event::event_update_system::<T>
+                    .run_if(bevy_ecs::event::event_update_condition::<T>),
+            );
         }
         self
     }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -734,17 +734,11 @@ impl<'a, E: Event> ExactSizeIterator for EventIteratorWithId<'a, E> {
 }
 
 #[doc(hidden)]
-#[derive(Resource)]
-pub struct EventUpdateSignal<T>(bool, PhantomData<T>);
-
-impl<T> Default for EventUpdateSignal<T> {
-    fn default() -> Self {
-        Self(false, PhantomData)
-    }
-}
+#[derive(Resource, Default)]
+pub struct EventUpdateSignal(bool);
 
 /// A system that queues a call to [`Events::update`].
-pub fn event_queue_update_system<T: Event>(signal: Option<ResMut<EventUpdateSignal<T>>>) {
+pub fn event_queue_update_system(signal: Option<ResMut<EventUpdateSignal>>) {
     if let Some(mut s) = signal {
         s.0 = true;
     }
@@ -752,7 +746,7 @@ pub fn event_queue_update_system<T: Event>(signal: Option<ResMut<EventUpdateSign
 
 /// A system that calls [`Events::update`].
 pub fn event_update_system<T: Event>(
-    signal: Option<ResMut<EventUpdateSignal<T>>>,
+    signal: Option<ResMut<EventUpdateSignal>>,
     mut events: ResMut<Events<T>>,
 ) {
     if let Some(mut s) = signal {

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -733,7 +733,7 @@ impl<'a, E: Event> ExactSizeIterator for EventIteratorWithId<'a, E> {
     }
 }
 
-/// A system that calls [`Events::update`] once per frame.
+/// A system that calls [`Events::update`].
 pub fn event_update_system<T: Event>(mut events: ResMut<Events<T>>) {
     events.update();
 }

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -750,6 +750,8 @@ pub fn event_update_system<T: Event>(
     mut events: ResMut<Events<T>>,
 ) {
     if let Some(mut s) = signal {
+        // If we haven't got a signal to update the events, but we *could* get such a signal
+        // return early and update the events later.
         if !std::mem::replace(&mut s.0, false) {
             return;
         }

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -18,7 +18,10 @@ pub use time::*;
 pub use timer::*;
 pub use virt::*;
 
-use bevy_ecs::system::{Res, ResMut};
+use bevy_ecs::{
+    event::EventUpdateSignal,
+    system::{Res, ResMut},
+};
 use bevy_utils::{tracing::warn, Duration, Instant};
 pub use crossbeam_channel::TrySendError;
 use crossbeam_channel::{Receiver, Sender};
@@ -48,6 +51,7 @@ impl Plugin for TimePlugin {
             .init_resource::<Time<Virtual>>()
             .init_resource::<Time<Fixed>>()
             .init_resource::<TimeUpdateStrategy>()
+            .init_resource::<EventUpdateSignal>()
             .register_type::<Time>()
             .register_type::<Time<Real>>()
             .register_type::<Time<Virtual>>()


### PR DESCRIPTION
## Objective
 
Currently, events are dropped after two frames. This cadence wasn't *chosen* for a specific reason, double buffering just lets events persist for at least two frames. Events only need to be dropped at a predictable point so that the event queues don't grow forever (i.e. events should never cause a memory leak). 
 
Events (and especially input events) need to be observable by systems in `FixedUpdate`, but as-is events are dropped before those systems even get a chance to see them.
 
## Solution
 
Instead of unconditionally dropping events in `First`, require `FixedUpdate` to first queue the buffer swap (if the `TimePlugin` has been installed). This way, events are only dropped after a frame that runs `FixedUpdate`.
 
## Future Work

In the same way we have independent copies of `Time` for tracking time in `Main` and `FixedUpdate`, we will need independent copies of `Input` for tracking press/release status correctly in `Main` and `FixedUpdate`.

--
 
Every run of `FixedUpdate` covers a specific timespan. For example, if the fixed timestep `Δt` is 10ms, the first three `FixedUpdate` runs cover `[0ms, 10ms)`, `[10ms, 20ms)`, and `[20ms, 30ms)`.
 
`FixedUpdate` can run many times in one frame. For truly framerate-independent behavior, each `FixedUpdate` should only see the events that occurred in its covered timespan, but what happens right now is the first step in the frame reads all pending events.

Fixing that will require timestamped events.