### PR TITLE
Fix UI borders

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -759,7 +759,10 @@ pub fn queue_uinodes(
                 draw_function,
                 pipeline,
                 entity: *entity,
-                sort_key: FloatOrd(extracted_uinode.stack_index as f32),
+                sort_key: (
+                    FloatOrd(extracted_uinode.stack_index as f32),
+                    entity.index(),
+                ),
                 // batch_range will be calculated in prepare_uinodes
                 batch_range: 0..0,
                 dynamic_offset: None,

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -88,7 +88,7 @@ impl Node for UiPassNode {
 }
 
 pub struct TransparentUi {
-    pub sort_key: FloatOrd,
+    pub sort_key: (FloatOrd, u32),
     pub entity: Entity,
     pub pipeline: CachedRenderPipelineId,
     pub draw_function: DrawFunctionId,
@@ -97,7 +97,7 @@ pub struct TransparentUi {
 }
 
 impl PhaseItem for TransparentUi {
-    type SortKey = FloatOrd;
+    type SortKey = (FloatOrd, u32);
 
     #[inline]
     fn entity(&self) -> Entity {


### PR DESCRIPTION
# Objective

Fixes #10069

## Solution

Extracted UI nodes were previously stored in a `SparseSet` and had a predictable iteration order. UI borders and outlines relied on this. Now they are stored in a HashMap and that is no longer true.

This adds `entity.index()` to the sort key for `TransparentUi` so that the iteration order is predictable and the "border entities" that get spawned during extraction are guaranteed to get drawn after their respective container nodes again.

I **think** that everything still works for overlapping ui nodes etc, because the z value / primary sort is still controlled by the "ui stack."

Text above is just my current understanding. A rendering expert should check this out.

I will do some more testing when I can.