### PR TITLE
Removed `once_cell`

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -29,7 +29,6 @@ bevy_ptr = { path = "../bevy_ptr", version = "0.12.0-dev" }
 erased-serde = "0.3"
 downcast-rs = "1.2"
 thiserror = "1.0"
-once_cell = "1.11"
 serde = "1"
 smallvec = { version = "1.6", features = [
     "serde",

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -2,11 +2,10 @@
 
 use crate::TypeInfo;
 use bevy_utils::{FixedState, StableHashMap};
-use once_cell::race::OnceBox;
 use std::{
     any::{Any, TypeId},
     hash::BuildHasher,
-    sync::{PoisonError, RwLock},
+    sync::{OnceLock, PoisonError, RwLock},
 };
 
 /// A type that can be stored in a ([`Non`])[`GenericTypeCell`].
@@ -89,7 +88,7 @@ mod sealed {
 /// ```
 ///
 /// [`TypePath`]: crate::TypePath
-pub struct NonGenericTypeCell<T: TypedProperty>(OnceBox<T::Stored>);
+pub struct NonGenericTypeCell<T: TypedProperty>(OnceLock<Box<T::Stored>>);
 
 /// See [`NonGenericTypeCell`].
 pub type NonGenericTypeInfoCell = NonGenericTypeCell<TypeInfo>;
@@ -97,7 +96,7 @@ pub type NonGenericTypeInfoCell = NonGenericTypeCell<TypeInfo>;
 impl<T: TypedProperty> NonGenericTypeCell<T> {
     /// Initialize a [`NonGenericTypeCell`] for non-generic types.
     pub const fn new() -> Self {
-        Self(OnceBox::new())
+        Self(OnceLock::new())
     }
 
     /// Returns a reference to the [`TypedProperty`] stored in the cell.

--- a/crates/bevy_reflect/src/utility.rs
+++ b/crates/bevy_reflect/src/utility.rs
@@ -88,7 +88,7 @@ mod sealed {
 /// ```
 ///
 /// [`TypePath`]: crate::TypePath
-pub struct NonGenericTypeCell<T: TypedProperty>(OnceLock<Box<T::Stored>>);
+pub struct NonGenericTypeCell<T: TypedProperty>(OnceLock<T::Stored>);
 
 /// See [`NonGenericTypeCell`].
 pub type NonGenericTypeInfoCell = NonGenericTypeCell<TypeInfo>;
@@ -106,7 +106,7 @@ impl<T: TypedProperty> NonGenericTypeCell<T> {
     where
         F: FnOnce() -> T::Stored,
     {
-        self.0.get_or_init(|| Box::new(f()))
+        self.0.get_or_init(f)
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #8303

## Solution

- Replaced 1 instance of `OnceBox<T>` with `OnceLock<T>` in `NonGenericTypeCell`

## Notes

All changes are in the private side of Bevy, and appear to have no observable change in performance or compilation time. This is purely to reduce the quantity of direct dependencies in Bevy.
