### PR TITLE
Batch skinned meshes

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -228,6 +228,7 @@ pub struct PrepassPipeline<M: Material> {
     pub material_vertex_shader: Option<Handle<Shader>>,
     pub material_fragment_shader: Option<Handle<Shader>>,
     pub material_pipeline: MaterialPipeline<M>,
+    pub skinned_mesh_storage_buffer: bool,
     _marker: PhantomData<M>,
 }
 
@@ -323,6 +324,10 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
             },
             material_layout: M::bind_group_layout(render_device),
             material_pipeline: world.resource::<MaterialPipeline<M>>().clone(),
+            skinned_mesh_storage_buffer: render_device
+                .limits()
+                .max_storage_buffers_per_shader_stage
+                > 0,
             _marker: PhantomData,
         }
     }
@@ -424,6 +429,7 @@ where
             &key.mesh_key,
             &mut shader_defs,
             &mut vertex_attributes,
+            self.skinned_mesh_storage_buffer,
         );
         bind_group_layouts.insert(2, bind_group);
 

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -88,7 +88,8 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    var model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
+    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else // SKINNED
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -64,7 +64,8 @@ fn vertex(vertex_no_morph: Vertex) -> MeshVertexOutput {
 #endif
 
 #ifdef SKINNED
-    var model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
+    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416 .

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -16,7 +16,7 @@ const MORPH_WEIGHT_SIZE: usize = std::mem::size_of::<f32>();
 pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 
 const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
-pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
+pub(crate) const JOINT_BUFFER_SIZE: usize = /* MAX_JOINTS * */ JOINT_SIZE;
 
 /// Individual layout entries.
 mod layout_entry {
@@ -36,8 +36,8 @@ mod layout_entry {
             visibility,
             count: None,
             ty: BindingType::Buffer {
-                ty: BufferBindingType::Uniform,
-                has_dynamic_offset: true,
+                ty: BufferBindingType::Storage { read_only: true },
+                has_dynamic_offset: false,
                 min_binding_size: BufferSize::new(size),
             },
         }

--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -90,7 +90,10 @@ mod entry {
         BindGroupEntry { binding, resource }
     }
     pub(super) fn skinning(binding: u32, buffer: &Buffer) -> BindGroupEntry {
-        entry(binding, JOINT_BUFFER_SIZE as u64, buffer)
+        BindGroupEntry {
+            binding,
+            resource: buffer.as_entire_binding(),
+        }
     }
     pub(super) fn weights(binding: u32, buffer: &Buffer) -> BindGroupEntry {
         entry(binding, MORPH_BUFFER_SIZE as u64, buffer)

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -14,11 +14,12 @@ struct Mesh {
     inverse_transpose_model_b: f32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
+    skin_index: u32,
 };
 
 #ifdef SKINNED
 struct SkinnedMesh {
-    data: array<mat4x4<f32>, 256u>,
+    data: array<mat4x4<f32>>,
 };
 #endif
 

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -19,7 +19,11 @@ struct Mesh {
 
 #ifdef SKINNED
 struct SkinnedMesh {
+#ifdef SKINNED_MESH_STORAGE_BUFFER
     data: array<mat4x4<f32>>,
+#else
+    data: array<mat4x4<f32>, 256u>,
+#endif
 };
 #endif
 

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -5,7 +5,7 @@ use bevy_math::Mat4;
 use bevy_render::{
     batching::NoAutomaticBatching,
     mesh::skinning::{SkinnedMesh, SkinnedMeshInverseBindposes},
-    render_resource::{BufferUsages, BufferVec, StorageBuffer},
+    render_resource::{Buffer, BufferUsages, BufferVec, StorageBuffer},
     renderer::{RenderDevice, RenderQueue},
     view::ViewVisibility,
     Extract,
@@ -17,17 +17,9 @@ use bevy_utils::EntityHashMap;
 pub const MAX_JOINTS: usize = 256;
 
 #[derive(Component)]
-pub struct SkinIndex {
-    pub index: u32,
-}
-
-impl SkinIndex {
-    /// Index to be in address space based on [`SkinUniform`] size.
-    const fn new(start: usize) -> Self {
-        SkinIndex {
-            index: start as u32, /* (start * std::mem::size_of::<Mat4>()) as u32, */
-        }
-    }
+pub enum SkinIndex {
+    Index(u32),
+    DynamicOffset(u32),
 }
 
 #[derive(Default, Resource, Deref, DerefMut)]
@@ -35,14 +27,108 @@ pub struct SkinIndices(EntityHashMap<Entity, SkinIndex>);
 
 // Notes on implementation: see comment on top of the `extract_skins` system.
 #[derive(Resource)]
-pub struct SkinUniform {
-    pub buffer: StorageBuffer<Vec<Mat4>>,
+pub enum SkinUniform {
+    Uniform(BufferVec<Mat4>),
+    Storage(StorageBuffer<Vec<Mat4>>),
 }
 
-impl Default for SkinUniform {
-    fn default() -> Self {
-        Self {
-            buffer: StorageBuffer::<Vec<Mat4>>::default(),
+impl SkinUniform {
+    pub fn new(render_device: &RenderDevice) -> Self {
+        if render_device.limits().max_storage_buffers_per_shader_stage > 0 {
+            Self::Storage(StorageBuffer::<Vec<Mat4>>::default())
+        } else {
+            Self::Uniform(BufferVec::new(BufferUsages::UNIFORM))
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.len(),
+            SkinUniform::Storage(buffer) => buffer.get().len(),
+        }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.is_empty(),
+            SkinUniform::Storage(buffer) => buffer.get().is_empty(),
+        }
+    }
+
+    pub fn clear(&mut self) {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.clear(),
+            SkinUniform::Storage(buffer) => buffer.get_mut().clear(),
+        }
+    }
+
+    pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.write_buffer(device, queue),
+            SkinUniform::Storage(buffer) => buffer.write_buffer(device, queue),
+        }
+    }
+
+    pub fn push(&mut self, value: Mat4) {
+        match self {
+            SkinUniform::Uniform(buffer) => {
+                buffer.push(value);
+            }
+            SkinUniform::Storage(buffer) => buffer.get_mut().push(value),
+        }
+    }
+
+    pub fn extend(&mut self, iter: impl IntoIterator<Item = Mat4>) {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.extend(iter),
+            SkinUniform::Storage(buffer) => buffer.get_mut().extend(iter),
+        }
+    }
+
+    pub fn truncate(&mut self, len: usize) {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.truncate(len),
+            SkinUniform::Storage(buffer) => buffer.get_mut().truncate(len),
+        }
+    }
+
+    pub fn align_to_dynamic_offset(&mut self) {
+        match self {
+            SkinUniform::Uniform(buffer) => {
+                // Pad to 256 byte alignment
+                while buffer.len() % 4 != 0 {
+                    buffer.push(Mat4::ZERO);
+                }
+            }
+            SkinUniform::Storage(_) => {}
+        }
+    }
+
+    pub fn pad_to_len(&mut self, len: usize) {
+        match self {
+            SkinUniform::Uniform(buffer) => {
+                // Pad out the buffer to ensure that there's enough space for the last binding
+                while buffer.len() < len {
+                    buffer.push(Mat4::ZERO);
+                }
+            }
+            SkinUniform::Storage(_) => {}
+        }
+    }
+
+    pub fn buffer(&self) -> Option<&Buffer> {
+        match self {
+            SkinUniform::Uniform(buffer) => buffer.buffer(),
+            SkinUniform::Storage(buffer) => buffer.buffer(),
+        }
+    }
+
+    pub fn index(&self) -> SkinIndex {
+        match self {
+            SkinUniform::Uniform(buffer) => {
+                SkinIndex::DynamicOffset((buffer.len() * std::mem::size_of::<Mat4>()) as u32)
+            }
+            SkinUniform::Storage(buffer) => SkinIndex::Index(buffer.get().len() as u32),
         }
     }
 }
@@ -52,11 +138,11 @@ pub fn prepare_skins(
     render_queue: Res<RenderQueue>,
     mut uniform: ResMut<SkinUniform>,
 ) {
-    if uniform.buffer.get().is_empty() {
+    if uniform.is_empty() {
         return;
     }
 
-    uniform.buffer.write_buffer(&render_device, &render_queue);
+    uniform.write_buffer(&render_device, &render_queue);
 }
 
 // Notes on implementation:
@@ -92,7 +178,7 @@ pub fn extract_skins(
     inverse_bindposes: Extract<Res<Assets<SkinnedMeshInverseBindposes>>>,
     joints: Extract<Query<&GlobalTransform>>,
 ) {
-    uniform.buffer.get_mut().clear();
+    uniform.clear();
     skin_indices.clear();
     let mut last_start = 0;
 
@@ -104,11 +190,11 @@ pub fn extract_skins(
         let Some(inverse_bindposes) = inverse_bindposes.get(&skin.inverse_bindposes) else {
             continue;
         };
-        let buffer = uniform.buffer.get_mut();
-        let start = buffer.len();
+        let start = uniform.len();
+        let skin_index = uniform.index();
 
         let target = start + skin.joints.len().min(MAX_JOINTS);
-        buffer.extend(
+        uniform.extend(
             joints
                 .iter_many(&skin.joints)
                 .zip(inverse_bindposes.iter())
@@ -117,33 +203,33 @@ pub fn extract_skins(
         );
         // iter_many will skip any failed fetches. This will cause it to assign the wrong bones,
         // so just bail by truncating to the start.
-        if buffer.len() != target {
-            buffer.truncate(start);
+        if uniform.len() != target {
+            uniform.truncate(start);
             continue;
         }
         last_start = last_start.max(start);
 
-        // // Pad to 256 byte alignment
-        // while buffer.len() % 4 != 0 {
-        //     buffer.push(Mat4::ZERO);
-        // }
+        uniform.align_to_dynamic_offset();
 
-        skin_indices.insert(entity, SkinIndex::new(start));
+        skin_indices.insert(entity, skin_index);
     }
 
-    // // Pad out the buffer to ensure that there's enough space for bindings
-    // while uniform.buffer.len() - last_start < MAX_JOINTS {
-    //     uniform.buffer.push(Mat4::ZERO);
-    // }
+    uniform.pad_to_len(last_start + MAX_JOINTS);
 }
 
-// // NOTE: The skinned joints uniform buffer has to be bound at a dynamic offset per
-// // entity and so cannot currently be batched.
-// pub fn no_automatic_skin_batching(
-//     mut commands: Commands,
-//     query: Query<Entity, (With<SkinnedMesh>, Without<NoAutomaticBatching>)>,
-// ) {
-//     for entity in &query {
-//         commands.entity(entity).insert(NoAutomaticBatching);
-//     }
-// }
+// NOTE: If skinned joints is a uniform buffer, it has to be bound at a dynamic offset per
+// entity and so cannot currently be batched.
+pub fn no_automatic_skin_batching(
+    mut commands: Commands,
+    render_device: Res<RenderDevice>,
+    query: Query<Entity, (With<SkinnedMesh>, Without<NoAutomaticBatching>)>,
+) {
+    if render_device.limits().max_storage_buffers_per_shader_stage > 0 {
+        // SkinUniform is using a storage buffer so skinned meshes can be batched
+        return;
+    }
+
+    for entity in &query {
+        commands.entity(entity).insert(NoAutomaticBatching);
+    }
+}

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -5,20 +5,21 @@
 #ifdef SKINNED
 
 #ifdef MESH_BINDGROUP_1
-    @group(1) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
-#else 
-    @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
+    @group(1) @binding(1) var<storage> joint_matrices: SkinnedMesh;
+#else
+    @group(2) @binding(1) var<storage> joint_matrices: SkinnedMesh;
 #endif
 
 
 fn skin_model(
+    skin_index: u32,
     indexes: vec4<u32>,
     weights: vec4<f32>,
 ) -> mat4x4<f32> {
-    return weights.x * joint_matrices.data[indexes.x]
-        + weights.y * joint_matrices.data[indexes.y]
-        + weights.z * joint_matrices.data[indexes.z]
-        + weights.w * joint_matrices.data[indexes.w];
+    return weights.x * joint_matrices.data[skin_index + indexes.x]
+        + weights.y * joint_matrices.data[skin_index + indexes.y]
+        + weights.z * joint_matrices.data[skin_index + indexes.z]
+        + weights.w * joint_matrices.data[skin_index + indexes.w];
 }
 
 fn inverse_transpose_3x3m(in: mat3x3<f32>) -> mat3x3<f32> {

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -4,22 +4,36 @@
 
 #ifdef SKINNED
 
+#ifdef SKINNED_MESH_STORAGE_BUFFER
 #ifdef MESH_BINDGROUP_1
     @group(1) @binding(1) var<storage> joint_matrices: SkinnedMesh;
 #else
     @group(2) @binding(1) var<storage> joint_matrices: SkinnedMesh;
 #endif
-
+#else // SKINNED_MESH_STORAGE_BUFFER
+#ifdef MESH_BINDGROUP_1
+    @group(1) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
+#else
+    @group(2) @binding(1) var<uniform> joint_matrices: SkinnedMesh;
+#endif
+#endif // SKINNED_MESH_STORAGE_BUFFER
 
 fn skin_model(
     skin_index: u32,
     indexes: vec4<u32>,
     weights: vec4<f32>,
 ) -> mat4x4<f32> {
+#ifdef SKINNED_MESH_STORAGE_BUFFER
     return weights.x * joint_matrices.data[skin_index + indexes.x]
         + weights.y * joint_matrices.data[skin_index + indexes.y]
         + weights.z * joint_matrices.data[skin_index + indexes.z]
         + weights.w * joint_matrices.data[skin_index + indexes.w];
+#else
+    return weights.x * joint_matrices.data[indexes.x]
+        + weights.y * joint_matrices.data[indexes.y]
+        + weights.z * joint_matrices.data[indexes.z]
+        + weights.w * joint_matrices.data[indexes.w];
+#endif
 }
 
 fn inverse_transpose_3x3m(in: mat3x3<f32>) -> mat3x3<f32> {

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -48,7 +48,8 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    let model = bevy_pbr::skinning::skin_model(vertex.joint_indexes, vertex.joint_weights);
+    let skin_index = mesh[get_instance_index(vertex_no_morph.instance_index)].skin_index;
+    var model = bevy_pbr::skinning::skin_model(skin_index, vertex.joint_indices, vertex.joint_weights);
 #else
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416 .


### PR DESCRIPTION
# Objective

- Make it possible to batch/instance skinned meshes

## Solution

- Skinned meshes were excluded from batching/instancing because each skinned mesh entity has its own joint matrix 'skin uniform' binding of a uniform buffer at a dynamic offset. As such, each entity has to be drawn separately in order to set the dynamic offset for each draw.
- This PR adds support for using a storage buffer for the joint matrices where available.

---

## Changelog

- Enable batching/instancing of skinned meshes