### PR TITLE
Fix text2d view-visibility

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -330,6 +330,7 @@ pub struct ExtractedSprite {
 #[derive(Resource, Default)]
 pub struct ExtractedSprites {
     pub sprites: EntityHashMap<Entity, ExtractedSprite>,
+    pub original_entities: HashMap<Entity, Entity>,
 }
 
 #[derive(Resource, Default)]
@@ -372,6 +373,7 @@ pub fn extract_sprites(
     >,
 ) {
     extracted_sprites.sprites.clear();
+    extracted_sprites.original_entities.clear();
 
     for (entity, view_visibility, sprite, transform, handle) in sprite_query.iter() {
         if !view_visibility.get() {
@@ -550,7 +552,12 @@ pub fn queue_sprites(
             .reserve(extracted_sprites.sprites.len());
 
         for (entity, extracted_sprite) in extracted_sprites.sprites.iter() {
-            if !view_entities.contains(entity.index() as usize) {
+            let orig = extracted_sprites
+                .original_entities
+                .get(entity)
+                .unwrap_or(entity);
+
+            if !view_entities.contains(orig.index() as usize) {
                 continue;
             }
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -552,12 +552,13 @@ pub fn queue_sprites(
             .reserve(extracted_sprites.sprites.len());
 
         for (entity, extracted_sprite) in extracted_sprites.sprites.iter() {
-            let orig = extracted_sprites
-                .original_entities
-                .get(entity)
-                .unwrap_or(entity);
-
-            if !view_entities.contains(orig.index() as usize) {
+            if !view_entities.contains(entity.index() as usize)
+                && !extracted_sprites
+                    .original_entities
+                    .get(entity)
+                    .map(|orig| view_entities.contains(orig.index() as usize))
+                    .unwrap_or(false)
+            {
                 continue;
             }
 

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -85,6 +85,7 @@ pub fn extract_text2d_sprite(
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
     text2d_query: Extract<
         Query<(
+            Entity,
             &ViewVisibility,
             &Text,
             &TextLayoutInfo,
@@ -100,7 +101,9 @@ pub fn extract_text2d_sprite(
         .unwrap_or(1.0);
     let scaling = GlobalTransform::from_scale(Vec2::splat(scale_factor.recip()).extend(1.));
 
-    for (view_visibility, text, text_layout_info, anchor, global_transform) in text2d_query.iter() {
+    for (original_entity, view_visibility, text, text_layout_info, anchor, global_transform) in
+        text2d_query.iter()
+    {
         if !view_visibility.get() {
             continue;
         }
@@ -125,8 +128,9 @@ pub fn extract_text2d_sprite(
             }
             let atlas = texture_atlases.get(&atlas_info.texture_atlas).unwrap();
 
+            let entity = commands.spawn_empty().id();
             extracted_sprites.sprites.insert(
-                commands.spawn_empty().id(),
+                entity,
                 ExtractedSprite {
                     transform: transform * GlobalTransform::from_translation(position.extend(0.)),
                     color,
@@ -138,6 +142,9 @@ pub fn extract_text2d_sprite(
                     anchor: Anchor::Center.as_vec(),
                 },
             );
+            extracted_sprites
+                .original_entities
+                .insert(entity, original_entity);
         }
     }
 }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -140,11 +140,9 @@ pub fn extract_text2d_sprite(
                     flip_x: false,
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
+                    original_entity: Some(original_entity),
                 },
             );
-            extracted_sprites
-                .original_entities
-                .insert(entity, original_entity);
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #9676
Possible alternative to #9708

`Text2dBundles` are not currently drawn because the render-world-only entities for glyphs that are created in `extract_text2d_sprite` are not tracked by the per-view `VisibleEntities`.

## Solution

Add an `Option<Entity>` to `ExtractedSprite` that keeps track of the original entity that caused a "glyph entity" to be created.

Use that in `queue_sprites` if it exists when checking view visibility.

## Benchmarks

Quick benchmarks. Average FPS over 1500 frames.

| bench | before fps | after fps | diff |
|-|-|-|-|
|many_sprites|884.93|879.00|🟡 -0.7%|
|bevymark -- --benchmark --waves 100 --per-wave 1000 --mode sprite|75.99|75.93|🟡 -0.1%|
|bevymark -- --benchmark --waves 50 --per-wave 1000 --mode mesh2d|32.85|32.58|🟡 -0.8%|