### PR TITLE
gamepad viewer: drawn border for the stick zones

### DIFF
--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -25,7 +25,7 @@ const NORMAL_BUTTON_COLOR: Color = Color::rgb(0.2, 0.2, 0.2);
 const ACTIVE_BUTTON_COLOR: Color = Color::PURPLE;
 const LIVE_COLOR: Color = Color::rgb(0.4, 0.4, 0.4);
 const DEAD_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
-const EXTENT_COLOR: Color = Color::rgb(0.3, 0.3, 0.3);
+const EXTENT_COLOR: Color = Color::rgb(0.2, 0.2, 0.2);
 const TEXT_COLOR: Color = Color::WHITE;
 
 #[derive(Component, Deref)]
@@ -289,7 +289,7 @@ fn setup_sticks(
                 // full extent
                 parent.spawn(SpriteBundle {
                     sprite: Sprite {
-                        custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.)),
+                        custom_size: Some(Vec2::splat(STICK_BOUNDS_SIZE * 2.1)),
                         color: EXTENT_COLOR,
                         ..default()
                     },


### PR DESCRIPTION
# Objective

- After #10090, there are no border for stick zones in the gamepad viewer
- Before, they were relying on the live zone being smaller than the extent

## Solution

- Increase the extent size so that it's bigger than the live zone and draws a border
- Also make it darker
