### PR TITLE
Allow optional main resource in ExtractResource

### DIFF
--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -40,24 +40,28 @@ impl<R: ExtractResource> Plugin for ExtractResourcePlugin<R> {
 /// This system extracts the resource of the corresponding [`Resource`] type
 pub fn extract_resource<R: ExtractResource>(
     mut commands: Commands,
-    main_resource: Extract<Res<R::Source>>,
+    main_resource: Extract<Option<Res<R::Source>>>,
     target_resource: Option<ResMut<R>>,
     #[cfg(debug_assertions)] mut has_warned_on_remove: Local<bool>,
 ) {
-    if let Some(mut target_resource) = target_resource {
-        if main_resource.is_changed() {
-            *target_resource = R::extract_resource(&main_resource);
-        }
-    } else {
-        #[cfg(debug_assertions)]
-        if !main_resource.is_added() && !*has_warned_on_remove {
-            *has_warned_on_remove = true;
-            bevy_log::warn!(
-                "Removing resource {} from render world not expected, adding using `Commands`.
+    if main_resource.is_some() {
+        let main_resource = main_resource.as_ref().unwrap();
+
+        if let Some(mut target_resource) = target_resource {
+            if main_resource.is_changed() {
+                *target_resource = R::extract_resource(&main_resource);
+            }
+        } else {
+            #[cfg(debug_assertions)]
+            if !main_resource.is_added() && !*has_warned_on_remove {
+                *has_warned_on_remove = true;
+                bevy_log::warn!(
+                    "Removing resource {} from render world not expected, adding using `Commands`.
                 This may decrease performance",
-                std::any::type_name::<R>()
-            );
+                    std::any::type_name::<R>()
+                );
+            }
+            commands.insert_resource(R::extract_resource(&main_resource));
         }
-        commands.insert_resource(R::extract_resource(&main_resource));
     }
 }


### PR DESCRIPTION
# Objective

From my understanding, although resources are not meant to be created and removed at every frame, they are still meant to be created dynamically during the lifetime of the App.
But because the extract_resource API does not allow optional resources from the main world, it's impossible to use resources in the render phase that was not created before the render sub-app itself. 

## Solution

Because the ECS engine already allows for system parameters to be `Option<Res>`, it just had to be added.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Changed
    - `extract_resource` now takes an optional main world resource

- Fixed
    - `ExtractResourcePlugin` doesn't cause panics anymore if the resource is not already inserted
