### PR TITLE
Change visibility of `bevy::core::update_frame_count` to `pub`

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -154,7 +154,7 @@ impl Plugin for FrameCountPlugin {
     }
 }
 
-fn update_frame_count(mut frame_count: ResMut<FrameCount>) {
+pub fn update_frame_count(mut frame_count: ResMut<FrameCount>) {
     frame_count.0 = frame_count.0.wrapping_add(1);
 }
 

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -154,6 +154,9 @@ impl Plugin for FrameCountPlugin {
     }
 }
 
+/// A system used to increment [`FrameCount`] with wrapping addition.
+///
+/// See [`FrameCount`] for more details.
 pub fn update_frame_count(mut frame_count: ResMut<FrameCount>) {
     frame_count.0 = frame_count.0.wrapping_add(1);
 }


### PR DESCRIPTION
# Objective
Closes #10107

The visibility of `bevy::core::update_frame_count` should be `pub` so it can be used in third-party code like this:

```rust
impl Plugin for MyPlugin {
    fn build(&self, app: &mut App) {
        app.add_systems(Last, use_frame_count.before(bevy::core::update_frame_count));
    }
}
```

## Solution
Make `bevy::core::update_frame_count` public.

---

## Changelog

### Added
- Documentation for `bevy::core::update_frame_count`

### Changed
- Visibility of `bevy::core::update_frame_count` is now `pub`