### PR TITLE
Make loading warning for no file ext more descriptive

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -956,7 +956,7 @@ fn format_missing_asset_ext(exts: &[String]) -> String {
             exts.join(", ")
         )
     } else {
-        " for file with no extension"
+        " for file with no extension".to_string()
     }
 }
 

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -956,7 +956,7 @@ fn format_missing_asset_ext(exts: &[String]) -> String {
             exts.join(", ")
         )
     } else {
-        String::new()
+        " for file with no extension"
     }
 }
 


### PR DESCRIPTION
# Objective

Currently, the asset loader outputs 
```
2023-10-14T15:11:09.328850Z  WARN bevy_asset::asset_server: no `AssetLoader` found
```
when user forgets to add an extension to a file. This is very confusing behaviour, it sounds like there aren't any asset loaders existing.

## Solution

Add an extra message on the end when there are no file extensions.