### PR TITLE
Use chain in breakout example

### DIFF
--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -60,15 +60,19 @@ fn main() {
         .add_systems(
             FixedUpdate,
             (
+                apply_velocity,
+                move_paddle,
                 check_for_collisions,
-                apply_velocity.before(check_for_collisions),
-                move_paddle
-                    .before(check_for_collisions)
-                    .after(apply_velocity),
-                play_collision_sound.after(check_for_collisions),
-            ),
+                play_collision_sound,
+            )
+                // `chain`ing systems together runs them in order
+                .chain(),
         )
-        .add_systems(Update, (update_scoreboard, bevy::window::close_on_esc))
+        .add_systems(
+            Update,
+            // Omitting `chain``, these can run in parallel
+            (update_scoreboard, bevy::window::close_on_esc),
+        )
         .run();
 }
 

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -68,11 +68,7 @@ fn main() {
                 // `chain`ing systems together runs them in order
                 .chain(),
         )
-        .add_systems(
-            Update,
-            // Omitting `chain``, these can run in parallel
-            (update_scoreboard, bevy::window::close_on_esc),
-        )
+        .add_systems(Update, (update_scoreboard, bevy::window::close_on_esc))
         .run();
 }
 


### PR DESCRIPTION
# Objective

- We should encourage of the simpler to reason about chain.

## Solution

- Use it in the breakout example

---

## Changelog

- Switch breakout to use `chain` instead of `before` and `after`