### PR TITLE
Fix missing explicit lifetime name for copy_deferred_lighting_id name

### DIFF
--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -60,7 +60,7 @@ impl Plugin for CopyDeferredLightingIdPlugin {
 #[derive(Default)]
 pub struct CopyDeferredLightingIdNode;
 impl CopyDeferredLightingIdNode {
-    pub const NAME: &str = "copy_deferred_lighting_id";
+    pub const NAME: &'static str = "copy_deferred_lighting_id";
 }
 
 impl ViewNode for CopyDeferredLightingIdNode {


### PR DESCRIPTION
# Objective

On nightly there is a warning on a missing lifetime:

```bash
warning: `&` without an explicit lifetime name cannot be used here
```

The details are in https://github.com/rust-lang/rust/issues/115010, but the bottom line is that in associated constants elided lifetimes are no longer allowed to be implicitly defined.

This fixes the only place where it is missing.

## Solution

- Add explicit `'static` lifetime
