### PR TITLE
Fixed mod.rs in rendering to support Radeon Cards

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -344,7 +344,7 @@ pub fn prepare_windows(
                 .enumerate_adapters(wgpu::Backends::VULKAN)
                 .any(|adapter| {
                     let name = adapter.get_info().name;
-                    name.starts_with("AMD") || name.starts_with("Intel")
+                    name.starts_with("Radeon") || name.starts_with("AMD") || name.starts_with("Intel")
                 })
         };
 

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -344,7 +344,9 @@ pub fn prepare_windows(
                 .enumerate_adapters(wgpu::Backends::VULKAN)
                 .any(|adapter| {
                     let name = adapter.get_info().name;
-                    name.starts_with("Radeon") || name.starts_with("AMD") || name.starts_with("Intel")
+                    name.starts_with("Radeon")
+                        || name.starts_with("AMD")
+                        || name.starts_with("Intel")
                 })
         };
 


### PR DESCRIPTION
# Objective

- Added support for newer AMD Radeon cards in the mod.rs file located at  ``crates/bevy_render/src/view/window/mod.rs``

## Solution

- All I needed to add was ``name.starts_with("Radeon") ||`` to the existing code on line 347 of ``crates/bevy_render/src/view/window/mod.rs``

---

## Changelog

- Changed ``crates/bevy_render/src/view/window/mod.rs``
