### PR TITLE
Better link for prepare_windows docs

### DIFF
--- a/docs/profiling.md
+++ b/docs/profiling.md
@@ -21,7 +21,7 @@ You also need to select a `tracing` backend using one of the following cargo fea
 
 When your app is bottlenecked by the GPU, you may encounter frames that have multiple prepare-set systems all taking an unusually long time to complete, and all finishing at about the same time.
 
-Improvements are planned to resolve this issue, you can find more details in the doc comment for [`prepare_windows`](../crates/bevy_render/src/view/window/mod.rs).
+Improvements are planned to resolve this issue, you can find more details in the docs for [`prepare_windows`](https://docs.rs/bevy/latest/bevy/render/view/fn.prepare_windows.html).
 
 ![prepare_windows span bug](https://github.com/bevyengine/bevy/assets/2771466/15c0819b-0e07-4665-aa1e-579caa24fece)
 


### PR DESCRIPTION
# Objective

While pointing someone to the profiling doc, I saw a source link and thought "hm, I wonder if that link is up-to-date?"

After clicking on it, I realized that it wasn't even attempting to point to the right line -- probably a good idea since that would be super prone to breakage.

However, the system being referenced is pub and the docs are on docs.rs, so we can just link there. This gets the content straight onto the user's screen.

## Solution

Change source link to docs link

## Note

This is slightly awkward in that the profiling docs themselves aren't rendered anywhere and just live in the repo. It does feel more correct to link to in-repo code on the same branch.