### PR TITLE
Fix unlit missing parameters

### DIFF
--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -166,6 +166,8 @@ fn fragment(
         pbr_input.flags = mesh[in.instance_index].flags;
         pbr_input.material.flags = pbr_bindings::material.flags;
         pbr_input.world_position = in.world_position;
+        pbr_input.world_normal = in.world_normal;
+        pbr_input.frag_coord = in.position;
 #endif
     }
 


### PR DESCRIPTION
# Objective

- The refactoring in https://github.com/bevyengine/bevy/pull/10105 missed including the frag_coord and normal in pbr_input.

## Solution

- Add them back
