### PR TITLE
add test on Android 14 / Pixel 8

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -99,6 +99,8 @@ jobs:
             os_version: "12.0"
           - device: "Samsung Galaxy S23"
             os_version: "13.0"
+          - device: "Google Pixel 8"
+            os_version: "14.0"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
# Objective

- Android 14 is now supported by Browserstack and Bevy works on it, so add it 🎉 

## Solution

- Add test in CI on Android 14 / Pixel 8

