### PR TITLE
make deferred_rendering simpler to render for CI

### DIFF
--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -111,8 +111,7 @@ fn setup(
     let cube_h = meshes.add(Mesh::from(shape::Cube { size: 0.1 }));
     let sphere_h = meshes.add(Mesh::from(shape::UVSphere {
         radius: 0.125,
-        sectors: 128,
-        stacks: 128,
+        ..default()
     }));
 
     // Cubes


### PR DESCRIPTION
# Objective

- Example `deferred_rendering` sometimes fail to render in CI
- Make it easier to render

## Solution

- Reduce the complexity of the sphere used
