### PR TITLE
make CI less failing on cargo deny bans

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,7 +30,7 @@ default = "deny"
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
-# Certain crates/versions that will be skipped when doing duplicate detection.
+# Certain crates that we don't want multiple versions of in the dependency tree
 deny = [
     { name = "ahash", deny-multiple-versions = true },
     { name = "android-activity", deny-multiple-versions = true },

--- a/deny.toml
+++ b/deny.toml
@@ -28,33 +28,14 @@ exceptions = [
 default = "deny"
 
 [bans]
-multiple-versions = "deny"
+multiple-versions = "warn"
 wildcards = "deny"
-highlight = "all"
 # Certain crates/versions that will be skipped when doing duplicate detection.
-skip = [
-    { name = "ahash", version = "0.7" },
-    { name = "bitflags", version = "1.3" },
-    { name = "core-foundation-sys", version = "0.6" },
-    { name = "jni", version = "0.19" },
-    { name = "hashbrown", version = "0.12"},
-    { name = "libloading", version = "0.7"},
-    { name = "miniz_oxide", version = "0.6"},
-    { name = "nix", version = "0.24" },
-    { name = "redox_syscall", version = "0.2" },
-    { name = "regex-syntax", version = "0.6"},
-    { name = "syn", version = "1.0"},
-    { name = "windows", version = "0.44"},
-    { name = "windows", version = "0.46"},
-    { name = "windows-sys", version = "0.45" },
-    { name = "windows-targets", version = "0.42"},
-    { name = "windows_aarch64_gnullvm", version = "0.42"},
-    { name = "windows_aarch64_msvc", version = "0.42"},
-    { name = "windows_i686_gnu", version = "0.42"},
-    { name = "windows_i686_msvc", version = "0.42"},
-    { name = "windows_x86_64_gnu", version = "0.42"},
-    { name = "windows_x86_64_gnullvm", version = "0.42"},
-    { name = "windows_x86_64_msvc", version = "0.42"},
+deny = [
+    { name = "ahash", deny-multiple-versions = true },
+    { name = "android-activity", deny-multiple-versions = true },
+    { name = "glam", deny-multiple-versions = true },
+    { name = "raw-window-handle", deny-multiple-versions = true },
 ]
 
 [sources]


### PR DESCRIPTION
# Objective

- Job cargo deny for bans is failing too often to be useful
- Having only one version of all dependencies is not realistic

## Solution

- Only warn on multiple dependencies of a crate
- Deny some specific crates that we know shouldn't be present multiple time
