### PR TITLE
Application lifetime events (suspend audio on Android)

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -332,14 +332,14 @@ pub struct WindowThemeChanged {
 }
 
 /// Application lifetime events
-#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
+#[derive(Event, Debug, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
     feature = "serialize",
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub enum Lifetime {
+pub enum ApplicationLifetime {
     /// The application just started.
     Started,
     /// The application was suspended.

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -330,3 +330,22 @@ pub struct WindowThemeChanged {
     /// The new system theme.
     pub theme: WindowTheme,
 }
+
+/// Application lifetime events
+#[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
+#[reflect(Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub enum Lifetime {
+    /// The application just started.
+    Started,
+    /// The application was suspended.
+    ///
+    /// On Android, applications have one frame to react to this event before being paused in the background.
+    Suspended,
+    /// The application was resumed.
+    Resumed,
+}

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -98,7 +98,8 @@ impl Plugin for WindowPlugin {
             .add_event::<WindowBackendScaleFactorChanged>()
             .add_event::<FileDragAndDrop>()
             .add_event::<WindowMoved>()
-            .add_event::<WindowThemeChanged>();
+            .add_event::<WindowThemeChanged>()
+            .add_event::<Lifetime>();
 
         if let Some(primary_window) = &self.primary_window {
             let initial_focus = app
@@ -141,7 +142,8 @@ impl Plugin for WindowPlugin {
             .register_type::<WindowBackendScaleFactorChanged>()
             .register_type::<FileDragAndDrop>()
             .register_type::<WindowMoved>()
-            .register_type::<WindowThemeChanged>();
+            .register_type::<WindowThemeChanged>()
+            .register_type::<Lifetime>();
 
         // Register window descriptor and related types
         app.register_type::<Window>()

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -99,7 +99,7 @@ impl Plugin for WindowPlugin {
             .add_event::<FileDragAndDrop>()
             .add_event::<WindowMoved>()
             .add_event::<WindowThemeChanged>()
-            .add_event::<Lifetime>();
+            .add_event::<ApplicationLifetime>();
 
         if let Some(primary_window) = &self.primary_window {
             let initial_focus = app
@@ -143,7 +143,7 @@ impl Plugin for WindowPlugin {
             .register_type::<FileDragAndDrop>()
             .register_type::<WindowMoved>()
             .register_type::<WindowThemeChanged>()
-            .register_type::<Lifetime>();
+            .register_type::<ApplicationLifetime>();
 
         // Register window descriptor and related types
         app.register_type::<Window>()

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -732,10 +732,10 @@ pub fn winit_runner(mut app: App) {
                 let (mut event_writers, _, _) = event_writer_system_state.get_mut(&mut app.world);
                 match runner_state.active {
                     ActiveState::NotYetStarted => {
-                        event_writers.lifetime.send(ApplicationLifetime::Started)
+                        event_writers.lifetime.send(ApplicationLifetime::Started);
                     }
                     ActiveState::Suspended => {
-                        event_writers.lifetime.send(ApplicationLifetime::Resumed)
+                        event_writers.lifetime.send(ApplicationLifetime::Resumed);
                     }
                     _ => unreachable!(),
                 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -325,10 +325,8 @@ impl ActiveState {
     #[inline]
     fn should_run(&self) -> bool {
         match self {
-            ActiveState::NotYetStarted => false,
-            ActiveState::Active => true,
-            ActiveState::Suspended => false,
-            ActiveState::WillSuspend => true,
+            ActiveState::NotYetStarted | ActiveState::Suspended => false,
+            ActiveState::Active | ActiveState::WillSuspend => true,
         }
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -734,10 +734,9 @@ pub fn winit_runner(mut app: App) {
                     ActiveState::NotYetStarted => {
                         event_writers.lifetime.send(ApplicationLifetime::Started);
                     }
-                    ActiveState::Suspended => {
+                    _ => {
                         event_writers.lifetime.send(ApplicationLifetime::Resumed);
                     }
-                    _ => unreachable!(),
                 }
                 runner_state.active = ActiveState::Active;
                 #[cfg(target_os = "android")]

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -5,7 +5,7 @@
 use bevy::{
     input::touch::TouchPhase,
     prelude::*,
-    window::{Lifetime, WindowMode},
+    window::{ApplicationLifetime, WindowMode},
 };
 
 // the `bevy_main` proc_macro generates the required boilerplate for iOS and Android
@@ -169,14 +169,14 @@ fn setup_music(asset_server: Res<AssetServer>, mut commands: Commands) {
 // Pause audio when app goes into background and resume when it returns.
 // This is handled by the OS on iOS, but not on Android.
 fn handle_lifetime(
-    mut lifetime_events: EventReader<Lifetime>,
+    mut lifetime_events: EventReader<ApplicationLifetime>,
     music_controller: Query<&AudioSink>,
 ) {
     for event in lifetime_events.read() {
         match event {
-            Lifetime::Suspended => music_controller.single().pause(),
-            Lifetime::Resumed => music_controller.single().play(),
-            Lifetime::Started => (),
+            ApplicationLifetime::Suspended => music_controller.single().pause(),
+            ApplicationLifetime::Resumed => music_controller.single().play(),
+            ApplicationLifetime::Started => (),
         }
     }
 }

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -2,7 +2,11 @@
 // type aliases tends to obfuscate code while offering no improvement in code cleanliness.
 #![allow(clippy::type_complexity)]
 
-use bevy::{input::touch::TouchPhase, prelude::*, window::WindowMode};
+use bevy::{
+    input::touch::TouchPhase,
+    prelude::*,
+    window::{Lifetime, WindowMode},
+};
 
 // the `bevy_main` proc_macro generates the required boilerplate for iOS and Android
 #[bevy_main]
@@ -17,7 +21,7 @@ fn main() {
         ..default()
     }))
     .add_systems(Startup, (setup_scene, setup_music))
-    .add_systems(Update, (touch_camera, button_handler));
+    .add_systems(Update, (touch_camera, button_handler, handle_lifetime));
 
     // MSAA makes some Android devices panic, this is under investigation
     // https://github.com/bevyengine/bevy/issues/8229
@@ -160,4 +164,19 @@ fn setup_music(asset_server: Res<AssetServer>, mut commands: Commands) {
         source: asset_server.load("sounds/Windless Slopes.ogg"),
         settings: PlaybackSettings::LOOP,
     });
+}
+
+// Pause audio when app goes into background and resume when it returns.
+// This is handled by the OS on iOS, but not on Android.
+fn handle_lifetime(
+    mut lifetime_events: EventReader<Lifetime>,
+    music_controller: Query<&AudioSink>,
+) {
+    for event in lifetime_events.read() {
+        match event {
+            Lifetime::Suspended => music_controller.single().pause(),
+            Lifetime::Resumed => music_controller.single().play(),
+            Lifetime::Started => (),
+        }
+    }
 }


### PR DESCRIPTION
# Objective

- Handle pausing audio when Android app is suspended

## Solution

- This is the start of application lifetime events. They are mostly useful on mobile
- Next version of winit should add a few more
- When application is suspended, send an event to notify the application, and run the schedule one last time before actually suspending the app
- Audio is now suspended too 🎉 


https://github.com/bevyengine/bevy/assets/8672791/d74e2e09-ee29-4f40-adf2-36a0c064f94e

