### PR TITLE
check for any prepass phase

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -891,18 +891,26 @@ pub fn queue_prepass_material_meshes<M: Material>(
     render_mesh_instances: Res<RenderMeshInstances>,
     render_materials: Res<RenderMaterials<M>>,
     render_material_instances: Res<RenderMaterialInstances<M>>,
-    mut views: Query<(
-        &ExtractedView,
-        &VisibleEntities,
-        &mut RenderPhase<Opaque3dPrepass>,
-        &mut RenderPhase<AlphaMask3dPrepass>,
-        Option<&mut RenderPhase<Opaque3dDeferred>>,
-        Option<&mut RenderPhase<AlphaMask3dDeferred>>,
-        Option<&DepthPrepass>,
-        Option<&NormalPrepass>,
-        Option<&MotionVectorPrepass>,
-        Option<&DeferredPrepass>,
-    )>,
+    mut views: Query<
+        (
+            &ExtractedView,
+            &VisibleEntities,
+            Option<&mut RenderPhase<Opaque3dPrepass>>,
+            Option<&mut RenderPhase<AlphaMask3dPrepass>>,
+            Option<&mut RenderPhase<Opaque3dDeferred>>,
+            Option<&mut RenderPhase<AlphaMask3dDeferred>>,
+            Option<&DepthPrepass>,
+            Option<&NormalPrepass>,
+            Option<&MotionVectorPrepass>,
+            Option<&DeferredPrepass>,
+        ),
+        Or<(
+            With<RenderPhase<Opaque3dPrepass>>,
+            With<RenderPhase<AlphaMask3dPrepass>>,
+            With<RenderPhase<Opaque3dDeferred>>,
+            With<RenderPhase<AlphaMask3dDeferred>>,
+        )>,
+    >,
 ) where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
@@ -1027,7 +1035,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 dynamic_offset: None,
                             });
                     } else {
-                        opaque_phase.add(Opaque3dPrepass {
+                        opaque_phase.as_mut().unwrap().add(Opaque3dPrepass {
                             entity: *visible_entity,
                             draw_function: opaque_draw_prepass,
                             pipeline_id,
@@ -1051,7 +1059,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 dynamic_offset: None,
                             });
                     } else {
-                        alpha_mask_phase.add(AlphaMask3dPrepass {
+                        alpha_mask_phase.as_mut().unwrap().add(AlphaMask3dPrepass {
                             entity: *visible_entity,
                             draw_function: alpha_mask_draw_prepass,
                             pipeline_id,


### PR DESCRIPTION
# Objective

deferred doesn't currently run unless one of `DepthPrepass`, `ForwardPrepass` or `MotionVectorPrepass` is also present on the camera.

## Solution

modify the `queue_prepass_material_meshes` view query to check for any relevant phase, instead of requiring `Opaque3dPrepass` and `AlphaMask3dPrepass` to be present
