### PR TITLE
array_texture example: use new name of pbr function

### DIFF
--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -46,5 +46,5 @@ fn fragment(
     );
     pbr_input.V = fns::calculate_view(mesh.world_position, pbr_input.is_orthographic);
 
-    return tone_mapping(fns::pbr(pbr_input), view.color_grading);
+    return tone_mapping(fns::apply_pbr_lighting(pbr_input), view.color_grading);
 }


### PR DESCRIPTION
# Objective

- After #7820 example `array_texture` doesn't display anything

## Solution

- Use the new name of the function in the shader
