### PR TITLE
Sprite masks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -416,6 +416,17 @@ category = "2D Rendering"
 wasm = true
 
 [[example]]
+name = "sprite_mask"
+path = "examples/2d/sprite_mask.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.sprite_mask]
+name = "Sprite Mask"
+description = "Partially render sprites based on an intersecting mask"
+category = "2D Rendering"
+wasm = true
+
+[[example]]
 name = "text2d"
 path = "examples/2d/text2d.rs"
 doc-scrape-examples = true

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -17,6 +17,7 @@ bevy_app = { path = "../bevy_app", version = "0.12.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.12.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = [

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite,
+    Mask, Sprite,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -37,6 +37,19 @@ pub struct SpriteSheetBundle {
     pub global_transform: GlobalTransform,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+}
+
+#[derive(Bundle, Clone, Default)]
+pub struct SpriteMaskBundle {
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    pub mask: Mask,
+    /// User indication of whether an entity is visible
+    pub visibility: Visibility,
+    /// Inherited visibility of an entity.
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod bundle;
 mod dynamic_texture_atlas_builder;
+mod mask;
 mod mesh2d;
 mod render;
 mod sprite;
@@ -22,6 +23,7 @@ pub mod prelude {
 
 pub use bundle::*;
 pub use dynamic_texture_atlas_builder::*;
+pub use mask::*;
 pub use mesh2d::*;
 pub use render::*;
 pub use sprite::*;
@@ -64,6 +66,8 @@ impl Plugin for SpritePlugin {
             .register_asset_reflect::<TextureAtlas>()
             .register_type::<Sprite>()
             .register_type::<TextureAtlasSprite>()
+            .register_type::<Mask>()
+            .register_type::<Masked>()
             .register_type::<Anchor>()
             .register_type::<Mesh2dHandle>()
             .add_plugins((Mesh2dRenderPlugin, ColorMaterialPlugin))
@@ -79,6 +83,7 @@ impl Plugin for SpritePlugin {
                 .init_resource::<SpriteMeta>()
                 .init_resource::<ExtractedSprites>()
                 .init_resource::<SpriteAssetEvents>()
+                .init_resource::<MaskUniforms>()
                 .add_render_command::<Transparent2d, DrawSprite>()
                 .add_systems(
                     ExtractSchedule,
@@ -93,6 +98,7 @@ impl Plugin for SpritePlugin {
                         queue_sprites
                             .in_set(RenderSet::Queue)
                             .ambiguous_with(queue_material2d_meshes::<ColorMaterial>),
+                        prepare_mask_uniforms.in_set(RenderSet::PrepareResources),
                         prepare_sprites.in_set(RenderSet::PrepareBindGroups),
                     ),
                 );

--- a/crates/bevy_sprite/src/mask.rs
+++ b/crates/bevy_sprite/src/mask.rs
@@ -1,0 +1,50 @@
+use bevy_asset::Handle;
+use bevy_ecs::{component::Component, entity::Entity, reflect::ReflectComponent, world::FromWorld};
+use bevy_math::{Rect, Vec2};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::texture::Image;
+
+use crate::Anchor;
+
+#[derive(Component, Debug, Default, Clone, Reflect)]
+#[reflect(Component, Default)]
+#[repr(C)]
+pub struct Mask {
+    /// The `Image` used to occlude `Masked` `Sprite`s.
+    /// If the `Image` is not grayscale, the red channel will be used.
+    /// Samples of 0 completely occlude the `Sprite`, samples of 1 have
+    /// no effect on the `Sprite`, and in between reduces the alpha
+    /// proportionally.
+    pub image: Handle<Image>,
+    /// If set, samples from `image` less than `threshold` will be clamped to 0,
+    /// greater will be clamped to 1.
+    pub threshold: Option<f32>,
+
+    /// Flip the mask along the `X` axis
+    pub flip_x: bool,
+    /// Flip the mask along the `Y` axis
+    pub flip_y: bool,
+    /// An optional custom size for the mask that will be used when rendering, instead of the size
+    /// of the mask's image
+    pub custom_size: Option<Vec2>,
+    /// An optional rectangle representing the region of the mask's image to render, instead of
+    /// masking as the full image.
+    pub rect: Option<Rect>,
+    /// [`Anchor`] point of the mask in the world
+    pub anchor: Anchor,
+}
+
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component)]
+#[repr(C)]
+pub struct Masked {
+    pub mask: Entity,
+}
+
+impl FromWorld for Masked {
+    fn from_world(_world: &mut bevy_ecs::world::World) -> Self {
+        Self {
+            mask: Entity::PLACEHOLDER,
+        }
+    }
+}

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -2,7 +2,7 @@ use std::ops::Range;
 
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite, SPRITE_SHADER_HANDLE,
+    Mask, Masked, Sprite, SPRITE_SHADER_HANDLE,
 };
 use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
 use bevy_core_pipeline::{
@@ -41,7 +41,34 @@ use fixedbitset::FixedBitSet;
 pub struct SpritePipeline {
     view_layout: BindGroupLayout,
     material_layout: BindGroupLayout,
+    mask_material_layout: BindGroupLayout,
+    mask_uniform_layout: BindGroupLayout,
     pub dummy_white_gpu_image: GpuImage,
+}
+
+#[derive(Default, Clone, ShaderType)]
+pub struct MaskUniform {
+    threshold: f32,
+    /// WebGL2 structs must be 16 byte aligned.
+    #[cfg(feature = "webgl")]
+    _padding_a: f32,
+    #[cfg(feature = "webgl")]
+    _padding_b: f32,
+    #[cfg(feature = "webgl")]
+    _padding_c: f32,
+}
+
+impl PartialEq for MaskUniform {
+    fn eq(&self, other: &Self) -> bool {
+        FloatOrd(self.threshold) == FloatOrd(other.threshold)
+    }
+}
+
+impl Eq for MaskUniform {}
+
+#[derive(Default, Resource)]
+pub struct MaskUniforms {
+    pub uniforms: DynamicUniformBuffer<MaskUniform>,
 }
 
 impl FromWorld for SpritePipeline {
@@ -88,6 +115,45 @@ impl FromWorld for SpritePipeline {
             ],
             label: Some("sprite_material_layout"),
         });
+
+        let mask_material_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                entries: &[
+                    BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Texture {
+                            multisampled: false,
+                            sample_type: TextureSampleType::Float { filterable: true },
+                            view_dimension: TextureViewDimension::D2,
+                        },
+                        count: None,
+                    },
+                    BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: ShaderStages::FRAGMENT,
+                        ty: BindingType::Sampler(SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                ],
+                label: Some("sprite_mask_material_layout"),
+            });
+
+        let mask_uniform_layout =
+            render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+                entries: &[BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: Some(MaskUniform::min_size()),
+                    },
+                    count: None,
+                }],
+                label: Some("sprite_mask_uniform_layout"),
+            });
+
         let dummy_white_gpu_image = {
             let image = Image::default();
             let texture = render_device.create_texture(&image.texture_descriptor);
@@ -129,6 +195,8 @@ impl FromWorld for SpritePipeline {
         SpritePipeline {
             view_layout,
             material_layout,
+            mask_material_layout,
+            mask_uniform_layout,
             dummy_white_gpu_image,
         }
     }
@@ -155,15 +223,23 @@ bitflags::bitflags! {
         const TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM = 5 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_TONY_MC_MAPFACE    = 6 << Self::TONEMAP_METHOD_SHIFT_BITS;
         const TONEMAP_METHOD_BLENDER_FILMIC     = 7 << Self::TONEMAP_METHOD_SHIFT_BITS;
+        const MASK_RESERVED_BITS                = Self::MASK_MASK_BITS << Self::MASK_SHIFT_BITS;
+        const MASK_ENABLED                      = 1 << Self::MASK_SHIFT_BITS;
+        const MASK_THRESHOLD                    = (1 << 1) << Self::MASK_SHIFT_BITS;
     }
 }
 
 impl SpritePipelineKey {
     const MSAA_MASK_BITS: u32 = 0b111;
     const MSAA_SHIFT_BITS: u32 = 32 - Self::MSAA_MASK_BITS.count_ones();
+
     const TONEMAP_METHOD_MASK_BITS: u32 = 0b111;
     const TONEMAP_METHOD_SHIFT_BITS: u32 =
         Self::MSAA_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones();
+
+    const MASK_MASK_BITS: u32 = 0b11;
+    const MASK_SHIFT_BITS: u32 =
+        Self::TONEMAP_METHOD_SHIFT_BITS - Self::MASK_MASK_BITS.count_ones();
 
     #[inline]
     pub const fn from_msaa_samples(msaa_samples: u32) -> Self {
@@ -201,6 +277,10 @@ impl SpecializedRenderPipeline for SpritePipeline {
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         let mut shader_defs = Vec::new();
+
+        #[cfg(feature = "webgl")]
+        shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
+
         if key.contains(SpritePipelineKey::TONEMAP_IN_SHADER) {
             shader_defs.push("TONEMAP_IN_SHADER".into());
 
@@ -231,46 +311,100 @@ impl SpecializedRenderPipeline for SpritePipeline {
             }
         }
 
+        let use_mask = key.contains(SpritePipelineKey::MASK_ENABLED);
+        let use_mask_threshold = key.contains(SpritePipelineKey::MASK_THRESHOLD);
+
+        if use_mask {
+            shader_defs.push("MASK".into());
+
+            if use_mask_threshold {
+                shader_defs.push("MASK_THRESHOLD".into());
+            }
+        }
+
         let format = match key.contains(SpritePipelineKey::HDR) {
             true => ViewTarget::TEXTURE_FORMAT_HDR,
             false => TextureFormat::bevy_default(),
         };
 
+        let mut vertex_buffer_array_stride = 80;
+        let mut vertex_buffer_attributes = vec![
+            // @location(0) i_model_transpose_col0: vec4<f32>,
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 0,
+                shader_location: 0,
+            },
+            // @location(1) i_model_transpose_col1: vec4<f32>,
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 16,
+                shader_location: 1,
+            },
+            // @location(2) i_model_transpose_col2: vec4<f32>,
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 32,
+                shader_location: 2,
+            },
+            // @location(3) i_color: vec4<f32>,
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 48,
+                shader_location: 3,
+            },
+            // @location(4) i_uv_offset_scale: vec4<f32>,
+            VertexAttribute {
+                format: VertexFormat::Float32x4,
+                offset: 64,
+                shader_location: 4,
+            },
+        ];
+
+        if use_mask {
+            vertex_buffer_array_stride += 64;
+            vertex_buffer_attributes.append(&mut vec![
+                // @location(5) i_mask_model_transpose_col0: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 80,
+                    shader_location: 5,
+                },
+                // @location(6) i_mask_model_transpose_col1: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 96,
+                    shader_location: 6,
+                },
+                // @location(7) i_mask_model_transpose_col2: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 112,
+                    shader_location: 7,
+                },
+                // @location(8) i_mask_uv_offset_scale: vec4<f32>,
+                VertexAttribute {
+                    format: VertexFormat::Float32x4,
+                    offset: 128,
+                    shader_location: 8,
+                },
+            ]);
+        }
+
+        let mut pipeline_layout = vec![self.view_layout.clone(), self.material_layout.clone()];
+
+        if use_mask {
+            pipeline_layout.push(self.mask_material_layout.clone());
+
+            if use_mask_threshold {
+                pipeline_layout.push(self.mask_uniform_layout.clone());
+            }
+        }
+
         let instance_rate_vertex_buffer_layout = VertexBufferLayout {
-            array_stride: 80,
+            array_stride: vertex_buffer_array_stride,
             step_mode: VertexStepMode::Instance,
-            attributes: vec![
-                // @location(0) i_model_transpose_col0: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 0,
-                    shader_location: 0,
-                },
-                // @location(1) i_model_transpose_col1: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 16,
-                    shader_location: 1,
-                },
-                // @location(2) i_model_transpose_col2: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 32,
-                    shader_location: 2,
-                },
-                // @location(3) i_color: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 48,
-                    shader_location: 3,
-                },
-                // @location(4) i_uv_offset_scale: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 64,
-                    shader_location: 4,
-                },
-            ],
+            attributes: vertex_buffer_attributes,
         };
 
         RenderPipelineDescriptor {
@@ -290,7 +424,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
                     write_mask: ColorWrites::ALL,
                 })],
             }),
-            layout: vec![self.view_layout.clone(), self.material_layout.clone()],
+            layout: pipeline_layout,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: None,
@@ -312,6 +446,55 @@ impl SpecializedRenderPipeline for SpritePipeline {
     }
 }
 
+fn calculate_transform(
+    image_size: &Vec2,
+    custom_size: &Option<Vec2>,
+    rect: &Option<Rect>,
+    transform: &GlobalTransform,
+    anchor: &Vec2,
+) -> Affine3A {
+    // By default, the size of the quad is the size of the texture, but `rect` or `custom_size` will overwrite
+    let quad_size = custom_size.unwrap_or_else(|| rect.map(|r| r.size()).unwrap_or(*image_size));
+
+    transform.affine()
+        * Affine3A::from_scale_rotation_translation(
+            quad_size.extend(1.0),
+            Quat::IDENTITY,
+            (quad_size * (-*anchor - Vec2::splat(0.5))).extend(0.0),
+        )
+}
+
+fn calculate_uv_offset_scale(
+    image_size: &Vec2,
+    rect: &Option<Rect>,
+    flip_x: bool,
+    flip_y: bool,
+) -> Vec4 {
+    // If a rect is specified, adjust UVs
+    let mut uv_offset_scale = if let Some(rect) = rect {
+        let rect_size = rect.size();
+        Vec4::new(
+            rect.min.x / image_size.x,
+            rect.max.y / image_size.y,
+            rect_size.x / image_size.x,
+            -rect_size.y / image_size.y,
+        )
+    } else {
+        Vec4::new(0.0, 1.0, 1.0, -1.0)
+    };
+
+    if flip_x {
+        uv_offset_scale.x += uv_offset_scale.z;
+        uv_offset_scale.z *= -1.0;
+    }
+    if flip_y {
+        uv_offset_scale.y += uv_offset_scale.w;
+        uv_offset_scale.w *= -1.0;
+    }
+
+    uv_offset_scale
+}
+
 pub struct ExtractedSprite {
     pub transform: GlobalTransform,
     pub color: Color,
@@ -328,11 +511,81 @@ pub struct ExtractedSprite {
     /// For cases where additional ExtractedSprites are created during extraction, this stores the
     /// entity that caused that creation for use in determining visibility.
     pub original_entity: Option<Entity>,
+
+    pub mask: Option<Entity>,
+}
+
+impl ExtractedSprite {
+    fn calculate_transform(&self, image_size: &Vec2) -> Affine3A {
+        calculate_transform(
+            image_size,
+            &self.custom_size,
+            &self.rect,
+            &self.transform,
+            &self.anchor,
+        )
+    }
+
+    fn calculate_uv_offset_scale(&self, image_size: &Vec2) -> Vec4 {
+        calculate_uv_offset_scale(image_size, &self.rect, self.flip_x, self.flip_y)
+    }
+}
+
+pub struct ExtractedMask {
+    pub transform: GlobalTransform,
+    /// Select an area of the texture
+    pub rect: Option<Rect>,
+    /// Change the on-screen size of the mask
+    pub custom_size: Option<Vec2>,
+    pub flip_x: bool,
+    pub flip_y: bool,
+    pub anchor: Vec2,
+
+    pub image_handle_id: AssetId<Image>,
+    pub threshold: Option<f32>,
+    pub uniform_offset: Option<u32>,
+}
+
+impl ExtractedMask {
+    pub fn sprite_pipeline_key(&self) -> SpritePipelineKey {
+        let threshold_key = match &self.threshold {
+            Some(_) => SpritePipelineKey::MASK_THRESHOLD,
+            None => SpritePipelineKey::NONE,
+        };
+
+        SpritePipelineKey::MASK_ENABLED | threshold_key
+    }
+}
+
+impl ExtractedMask {
+    fn calculate_transform(&self, image_size: &Vec2) -> Affine3A {
+        calculate_transform(
+            image_size,
+            &self.custom_size,
+            &self.rect,
+            &self.transform,
+            &self.anchor,
+        )
+    }
+
+    fn calculate_uv_offset_scale(&self, image_size: &Vec2) -> Vec4 {
+        calculate_uv_offset_scale(image_size, &self.rect, self.flip_x, self.flip_y)
+    }
 }
 
 #[derive(Resource, Default)]
 pub struct ExtractedSprites {
     pub sprites: EntityHashMap<Entity, ExtractedSprite>,
+    pub masks: EntityHashMap<Entity, Option<ExtractedMask>>,
+    pub mask_uniform_count: usize,
+}
+
+impl ExtractedSprites {
+    fn clear(&mut self) {
+        self.sprites.clear();
+        self.masks.clear();
+        self.mask_uniform_count = 0;
+    }
 }
 
 #[derive(Resource, Default)]
@@ -362,6 +615,7 @@ pub fn extract_sprites(
             &Sprite,
             &GlobalTransform,
             &Handle<Image>,
+            Option<&Masked>,
         )>,
     >,
     atlas_query: Extract<
@@ -371,15 +625,57 @@ pub fn extract_sprites(
             &TextureAtlasSprite,
             &GlobalTransform,
             &Handle<TextureAtlas>,
+            Option<&Masked>,
         )>,
     >,
+    mask_query: Extract<Query<(&ViewVisibility, &Mask, &GlobalTransform)>>,
 ) {
-    extracted_sprites.sprites.clear();
+    extracted_sprites.clear();
 
-    for (entity, view_visibility, sprite, transform, handle) in sprite_query.iter() {
+    let extract_mask = |extracted_sprites: &mut ExtractedSprites, masked: Option<&Masked>| {
+        let mask = masked.map(|m| m.mask);
+
+        if let Some(mask) = mask {
+            extracted_sprites.masks.entry(mask).or_insert_with(|| {
+                let extracted_mask = match mask_query.get(mask) {
+                    Ok((view_visibility, mask, transform)) => {
+                        if !view_visibility.get() {
+                            None
+                        } else {
+                            Some(ExtractedMask {
+                                transform: *transform,
+                                rect: mask.rect,
+                                custom_size: mask.custom_size,
+                                flip_x: mask.flip_x,
+                                flip_y: mask.flip_y,
+                                anchor: mask.anchor.as_vec(),
+                                image_handle_id: mask.image.id(),
+                                threshold: mask.threshold,
+                                uniform_offset: None,
+                            })
+                        }
+                    }
+                    // The Masked does not point to an Entity with a Mask.
+                    // Store this failure instead of querying again.
+                    Err(_) => None,
+                };
+
+                extracted_sprites.mask_uniform_count += extracted_mask.is_some() as usize;
+
+                extracted_mask
+            });
+        }
+
+        mask
+    };
+
+    for (entity, view_visibility, sprite, transform, handle, masked) in sprite_query.iter() {
         if !view_visibility.get() {
             continue;
         }
+
+        let mask = extract_mask(&mut extracted_sprites, masked);
+
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
         extracted_sprites.sprites.insert(
             entity,
@@ -394,10 +690,12 @@ pub fn extract_sprites(
                 image_handle_id: handle.id(),
                 anchor: sprite.anchor.as_vec(),
                 original_entity: None,
+
+                mask,
             },
         );
     }
-    for (entity, view_visibility, atlas_sprite, transform, texture_atlas_handle) in
+    for (entity, view_visibility, atlas_sprite, transform, texture_atlas_handle, masked) in
         atlas_query.iter()
     {
         if !view_visibility.get() {
@@ -416,6 +714,9 @@ pub fn extract_sprites(
                         )
                     }),
             );
+
+            let mask = extract_mask(&mut extracted_sprites, masked);
+
             extracted_sprites.sprites.insert(
                 entity,
                 ExtractedSprite {
@@ -430,6 +731,8 @@ pub fn extract_sprites(
                     image_handle_id: texture_atlas.texture.id(),
                     anchor: atlas_sprite.anchor.as_vec(),
                     original_entity: None,
+
+                    mask,
                 },
             );
         }
@@ -461,11 +764,56 @@ impl SpriteInstance {
     }
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Pod, Zeroable)]
+struct MaskedSpriteInstance {
+    pub sprite: SpriteInstance,
+    // Affine 4x3 transposed to 3x4
+    pub i_mask_model_transpose: [Vec4; 3],
+    pub i_mask_uv_offset_scale: [f32; 4],
+}
+
+impl MaskedSpriteInstance {
+    #[inline]
+    fn from(
+        sprite_instance: SpriteInstance,
+        mask_transform: &Affine3A,
+        mask_uv_offset_scale: &Vec4,
+    ) -> Self {
+        let transpose_model_3x3 = mask_transform.matrix3.transpose();
+        Self {
+            sprite: sprite_instance,
+            i_mask_model_transpose: [
+                transpose_model_3x3
+                    .x_axis
+                    .extend(mask_transform.translation.x),
+                transpose_model_3x3
+                    .y_axis
+                    .extend(mask_transform.translation.y),
+                transpose_model_3x3
+                    .z_axis
+                    .extend(mask_transform.translation.z),
+            ],
+            i_mask_uv_offset_scale: mask_uv_offset_scale.to_array(),
+        }
+    }
+}
+
 #[derive(Resource)]
 pub struct SpriteMeta {
     view_bind_group: Option<BindGroup>,
     sprite_index_buffer: BufferVec<u32>,
     sprite_instance_buffer: BufferVec<SpriteInstance>,
+    masked_sprite_instance_buffer: BufferVec<MaskedSpriteInstance>,
+}
+
+impl SpriteMeta {
+    fn clear(&mut self) {
+        self.view_bind_group = None;
+        self.sprite_index_buffer.clear();
+        self.sprite_instance_buffer.clear();
+        self.masked_sprite_instance_buffer.clear();
+    }
 }
 
 impl Default for SpriteMeta {
@@ -474,6 +822,9 @@ impl Default for SpriteMeta {
             view_bind_group: None,
             sprite_index_buffer: BufferVec::<u32>::new(BufferUsages::INDEX),
             sprite_instance_buffer: BufferVec::<SpriteInstance>::new(BufferUsages::VERTEX),
+            masked_sprite_instance_buffer: BufferVec::<MaskedSpriteInstance>::new(
+                BufferUsages::VERTEX,
+            ),
         }
     }
 }
@@ -482,11 +833,20 @@ impl Default for SpriteMeta {
 pub struct SpriteBatch {
     image_handle_id: AssetId<Image>,
     range: Range<u32>,
+    mask: Option<MaskBatch>,
+}
+
+#[derive(PartialEq, Eq, Clone)]
+pub struct MaskBatch {
+    mask_handle_id: AssetId<Image>,
+    uniform_offset: Option<u32>,
 }
 
 #[derive(Resource, Default)]
 pub struct ImageBindGroups {
     values: HashMap<AssetId<Image>, BindGroup>,
+    mask_values: HashMap<AssetId<Image>, BindGroup>,
+    mask_uniforms_value: Option<BindGroup>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -536,17 +896,6 @@ pub fn queue_sprites(
             }
         }
 
-        let pipeline = pipelines.specialize(
-            &pipeline_cache,
-            &sprite_pipeline,
-            view_key | SpritePipelineKey::from_colored(false),
-        );
-        let colored_pipeline = pipelines.specialize(
-            &pipeline_cache,
-            &sprite_pipeline,
-            view_key | SpritePipelineKey::from_colored(true),
-        );
-
         view_entities.clear();
         view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
 
@@ -564,27 +913,69 @@ pub fn queue_sprites(
             // These items will be sorted by depth with other phase items
             let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
 
+            let mut specialize_pipeline = |view_key: SpritePipelineKey| {
+                pipelines.specialize(&pipeline_cache, &sprite_pipeline, view_key)
+            };
+
+            let mask_key = extracted_sprite
+                .mask
+                .map(|m| extracted_sprites.masks.get(&m).map(Option::as_ref))
+                .flatten()
+                .flatten()
+                .map(|em| em.sprite_pipeline_key())
+                .unwrap_or(SpritePipelineKey::NONE);
+
+            let color_key = SpritePipelineKey::from_colored(extracted_sprite.color != Color::WHITE);
+
+            let pipeline = specialize_pipeline(view_key | mask_key | color_key);
+
             // Add the item to the render phase
-            if extracted_sprite.color != Color::WHITE {
-                transparent_phase.add(Transparent2d {
-                    draw_function: draw_sprite_function,
-                    pipeline: colored_pipeline,
-                    entity: *entity,
-                    sort_key,
-                    // batch_range and dynamic_offset will be calculated in prepare_sprites
-                    batch_range: 0..0,
-                    dynamic_offset: None,
-                });
-            } else {
-                transparent_phase.add(Transparent2d {
-                    draw_function: draw_sprite_function,
-                    pipeline,
-                    entity: *entity,
-                    sort_key,
-                    // batch_range and dynamic_offset will be calculated in prepare_sprites
-                    batch_range: 0..0,
-                    dynamic_offset: None,
-                });
+            transparent_phase.add(Transparent2d {
+                draw_function: draw_sprite_function,
+                pipeline,
+                entity: *entity,
+                sort_key,
+                // batch_range and dynamic_offset will be calculated in prepare_sprites
+                batch_range: 0..0,
+                dynamic_offset: None,
+            });
+        }
+    }
+}
+
+pub fn prepare_mask_uniforms(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut mask_uniforms: ResMut<MaskUniforms>,
+    mut extracted_sprites: ResMut<ExtractedSprites>,
+) {
+    if extracted_sprites.mask_uniform_count > 0 {
+        let Some(mut writer) =
+            mask_uniforms
+                .uniforms
+                .get_writer(extracted_sprites.mask_uniform_count, &render_device, &render_queue)
+        else {
+            return;
+        };
+
+        let mut last_uniform = None;
+        let mut last_uniform_offset = 0;
+
+        for mask in extracted_sprites
+            .masks
+            .iter_mut()
+            .filter_map(|(_, mask)| mask.as_mut())
+        {
+            if let Some(threshold) = mask.threshold {
+                let uniform = MaskUniform {
+                    threshold,
+                    ..Default::default()
+                };
+                if last_uniform.as_ref() != Some(&uniform) {
+                    last_uniform_offset = writer.write(&uniform);
+                    last_uniform = Some(uniform);
+                }
+                mask.uniform_offset = Some(last_uniform_offset);
             }
         }
     }
@@ -598,6 +989,7 @@ pub fn prepare_sprites(
     render_queue: Res<RenderQueue>,
     mut sprite_meta: ResMut<SpriteMeta>,
     view_uniforms: Res<ViewUniforms>,
+    mask_uniforms: Res<MaskUniforms>,
     sprite_pipeline: Res<SpritePipeline>,
     mut image_bind_groups: ResMut<ImageBindGroups>,
     gpu_images: Res<RenderAssets<Image>>,
@@ -613,6 +1005,7 @@ pub fn prepare_sprites(
             AssetEvent::LoadedWithDependencies { .. } => {}
             AssetEvent::Modified { id } | AssetEvent::Removed { id } => {
                 image_bind_groups.values.remove(id);
+                image_bind_groups.mask_values.remove(id);
             }
         };
     }
@@ -621,7 +1014,7 @@ pub fn prepare_sprites(
         let mut batches: Vec<(Entity, SpriteBatch)> = Vec::with_capacity(*previous_len);
 
         // Clear the sprite instances
-        sprite_meta.sprite_instance_buffer.clear();
+        sprite_meta.clear();
 
         sprite_meta.view_bind_group = Some(render_device.create_bind_group(&BindGroupDescriptor {
             entries: &[BindGroupEntry {
@@ -632,8 +1025,26 @@ pub fn prepare_sprites(
             layout: &sprite_pipeline.view_layout,
         }));
 
+        if extracted_sprites.mask_uniform_count > 0 {
+            image_bind_groups
+                .mask_uniforms_value
+                .get_or_insert_with(|| {
+                    let uniform_binding = mask_uniforms.uniforms.binding().unwrap();
+
+                    render_device.create_bind_group(&BindGroupDescriptor {
+                        entries: &[BindGroupEntry {
+                            binding: 0,
+                            resource: uniform_binding,
+                        }],
+                        label: Some("sprite_mask_uniform_bind_group"),
+                        layout: &sprite_pipeline.mask_uniform_layout,
+                    })
+                });
+        }
+
         // Index buffer indices
-        let mut index = 0;
+        let mut unmasked_index = 0;
+        let mut masked_index = 0;
 
         let image_bind_groups = &mut *image_bind_groups;
 
@@ -641,6 +1052,11 @@ pub fn prepare_sprites(
             let mut batch_item_index = 0;
             let mut batch_image_size = Vec2::ZERO;
             let mut batch_image_handle = AssetId::invalid();
+
+            let mut batch_mask_image_size = Vec2::ZERO;
+            // The mask potentially controls several uniforms, so batch based on the entity instead of just the image
+            let mut batch_mask_handle = None;
+            let mut batch_mask_uniform_offset = None;
 
             // Iterate through the phase items and detect when successive sprites that can be batched.
             // Spawn an entity with a `SpriteBatch` component for each possible batch.
@@ -656,6 +1072,7 @@ pub fn prepare_sprites(
                 };
 
                 let batch_image_changed = batch_image_handle != extracted_sprite.image_handle_id;
+
                 if batch_image_changed {
                     let Some(gpu_image) = gpu_images.get(extracted_sprite.image_handle_id) else {
                         continue;
@@ -686,63 +1103,100 @@ pub fn prepare_sprites(
                         });
                 }
 
-                // By default, the size of the quad is the size of the texture
-                let mut quad_size = batch_image_size;
+                let extracted_mask = extracted_sprite
+                    .mask
+                    .as_ref()
+                    .map(|e| extracted_sprites.masks.get(e).map(Option::as_ref))
+                    .flatten()
+                    .flatten();
+                let mask_asset = extracted_mask.map(|m| m.image_handle_id);
 
-                // Calculate vertex data for this item
-                let mut uv_offset_scale: Vec4;
+                let batch_mask_changed = batch_mask_handle != mask_asset;
 
-                // If a rect is specified, adjust UVs and the size of the quad
-                if let Some(rect) = extracted_sprite.rect {
-                    let rect_size = rect.size();
-                    uv_offset_scale = Vec4::new(
-                        rect.min.x / batch_image_size.x,
-                        rect.max.y / batch_image_size.y,
-                        rect_size.x / batch_image_size.x,
-                        -rect_size.y / batch_image_size.y,
-                    );
-                    quad_size = rect_size;
-                } else {
-                    uv_offset_scale = Vec4::new(0.0, 1.0, 1.0, -1.0);
+                if batch_mask_changed {
+                    if let (Some(extracted_mask), Some(mask_asset)) = (extracted_mask, mask_asset) {
+                        let Some(gpu_image) = gpu_images.get(extracted_mask.image_handle_id) else {
+                            continue;
+                        };
+
+                        batch_mask_image_size = Vec2::new(gpu_image.size.x, gpu_image.size.y);
+
+                        image_bind_groups
+                            .mask_values
+                            .entry(mask_asset)
+                            .or_insert_with(|| {
+                                render_device.create_bind_group(&BindGroupDescriptor {
+                                    entries: &[
+                                        BindGroupEntry {
+                                            binding: 0,
+                                            resource: BindingResource::TextureView(
+                                                &gpu_image.texture_view,
+                                            ),
+                                        },
+                                        BindGroupEntry {
+                                            binding: 1,
+                                            resource: BindingResource::Sampler(&gpu_image.sampler),
+                                        },
+                                    ],
+                                    label: Some("sprite_mask_material_bind_group"),
+                                    layout: &sprite_pipeline.mask_material_layout,
+                                })
+                            });
+                    }
+
+                    batch_mask_handle = mask_asset;
                 }
 
-                if extracted_sprite.flip_x {
-                    uv_offset_scale.x += uv_offset_scale.z;
-                    uv_offset_scale.z *= -1.0;
-                }
-                if extracted_sprite.flip_y {
-                    uv_offset_scale.y += uv_offset_scale.w;
-                    uv_offset_scale.w *= -1.0;
+                let mask_uniform_offset = extracted_mask.map(|m| m.uniform_offset).flatten();
+                let batch_mask_uniform_changed = batch_mask_uniform_offset != mask_uniform_offset;
+                if batch_mask_uniform_changed {
+                    batch_mask_uniform_offset = mask_uniform_offset;
                 }
 
-                // Override the size if a custom one is specified
-                if let Some(custom_size) = extracted_sprite.custom_size {
-                    quad_size = custom_size;
-                }
-                let transform = extracted_sprite.transform.affine()
-                    * Affine3A::from_scale_rotation_translation(
-                        quad_size.extend(1.0),
-                        Quat::IDENTITY,
-                        (quad_size * (-extracted_sprite.anchor - Vec2::splat(0.5))).extend(0.0),
-                    );
+                let sprite_transform = extracted_sprite.calculate_transform(&batch_image_size);
+
+                let sprite_instance = SpriteInstance::from(
+                    &sprite_transform,
+                    &extracted_sprite.color,
+                    &extracted_sprite.calculate_uv_offset_scale(&batch_image_size),
+                );
 
                 // Store the vertex data and add the item to the render phase
-                sprite_meta
-                    .sprite_instance_buffer
-                    .push(SpriteInstance::from(
-                        &transform,
-                        &extracted_sprite.color,
-                        &uv_offset_scale,
-                    ));
+                let index = if let Some(extracted_mask) = extracted_mask {
+                    let masked_sprite_instance = MaskedSpriteInstance::from(
+                        sprite_instance,
+                        &(extracted_mask
+                            .calculate_transform(&batch_mask_image_size)
+                            .inverse()
+                            * sprite_transform),
+                        &extracted_mask.calculate_uv_offset_scale(&batch_mask_image_size),
+                    );
 
-                if batch_image_changed {
+                    sprite_meta
+                        .masked_sprite_instance_buffer
+                        .push(masked_sprite_instance);
+
+                    &mut masked_index
+                } else {
+                    sprite_meta.sprite_instance_buffer.push(sprite_instance);
+
+                    &mut unmasked_index
+                };
+
+                if batch_image_changed || batch_mask_changed || batch_mask_uniform_changed {
                     batch_item_index = item_index;
+
+                    let mask_batch = extracted_mask.map(|em| MaskBatch {
+                        mask_handle_id: em.image_handle_id,
+                        uniform_offset: em.uniform_offset,
+                    });
 
                     batches.push((
                         item.entity,
                         SpriteBatch {
                             image_handle_id: batch_image_handle,
-                            range: index..index,
+                            range: *index..*index,
+                            mask: mask_batch,
                         },
                     ));
                 }
@@ -751,11 +1205,15 @@ pub fn prepare_sprites(
                     .batch_range_mut()
                     .end += 1;
                 batches.last_mut().unwrap().1.range.end += 1;
-                index += 1;
+                *index += 1;
             }
         }
         sprite_meta
             .sprite_instance_buffer
+            .write_buffer(&render_device, &render_queue);
+
+        sprite_meta
+            .masked_sprite_instance_buffer
             .write_buffer(&render_device, &render_queue);
 
         if sprite_meta.sprite_index_buffer.len() != 6 {
@@ -791,6 +1249,8 @@ pub type DrawSprite = (
     SetItemPipeline,
     SetSpriteViewBindGroup<0>,
     SetSpriteTextureBindGroup<1>,
+    SetSpriteMaskTextureBindGroup<2>,
+    SetSpriteMaskUniformsBindGroup<3>,
     DrawSpriteBatch,
 );
 
@@ -842,6 +1302,65 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
     }
 }
 
+pub struct SetSpriteMaskTextureBindGroup<const I: usize>;
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteMaskTextureBindGroup<I> {
+    type Param = SRes<ImageBindGroups>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<SpriteBatch>;
+
+    fn render<'w>(
+        _item: &P,
+        _view: (),
+        batch: &'_ SpriteBatch,
+        image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let image_bind_groups = image_bind_groups.into_inner();
+
+        if let Some(mask_batch) = &batch.mask {
+            pass.set_bind_group(
+                I,
+                image_bind_groups
+                    .mask_values
+                    .get(&mask_batch.mask_handle_id)
+                    .unwrap(),
+                &[],
+            );
+        }
+
+        RenderCommandResult::Success
+    }
+}
+
+pub struct SetSpriteMaskUniformsBindGroup<const I: usize>;
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteMaskUniformsBindGroup<I> {
+    type Param = SRes<ImageBindGroups>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<SpriteBatch>;
+
+    fn render<'w>(
+        _item: &P,
+        _view: (),
+        batch: &'_ SpriteBatch,
+        image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let image_bind_groups = image_bind_groups.into_inner();
+
+        if let Some(mask_batch) = &batch.mask {
+            if let Some(uniform_offset) = mask_batch.uniform_offset {
+                pass.set_bind_group(
+                    I,
+                    image_bind_groups.mask_uniforms_value.as_ref().unwrap(),
+                    &[uniform_offset],
+                );
+            }
+        }
+
+        RenderCommandResult::Success
+    }
+}
+
 pub struct DrawSpriteBatch;
 impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
     type Param = SRes<SpriteMeta>;
@@ -861,14 +1380,12 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
             0,
             IndexFormat::Uint32,
         );
-        pass.set_vertex_buffer(
-            0,
-            sprite_meta
-                .sprite_instance_buffer
-                .buffer()
-                .unwrap()
-                .slice(..),
-        );
+        let buffer = if batch.mask.is_some() {
+            sprite_meta.masked_sprite_instance_buffer.buffer()
+        } else {
+            sprite_meta.sprite_instance_buffer.buffer()
+        };
+        pass.set_vertex_buffer(0, buffer.unwrap().slice(..));
         pass.draw_indexed(0..6, 0, batch.range.clone());
         RenderCommandResult::Success
     }

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -141,6 +141,7 @@ pub fn extract_text2d_sprite(
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
                     original_entity: Some(original_entity),
+                    mask: None,
                 },
             );
         }

--- a/examples/2d/sprite_mask.rs
+++ b/examples/2d/sprite_mask.rs
@@ -1,0 +1,130 @@
+//! Displays partial rendering of [`Sprite`]s using [`Mask`]s.
+
+use bevy::{
+    asset::AssetId,
+    prelude::*,
+    render::{render_resource::*, texture::ImageSampler},
+    sprite::*,
+    utils::HashMap,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .init_resource::<MaskAddressModes>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, set_mask_address_mode)
+        .add_systems(Update, orbit)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut mask_address_modes: ResMut<MaskAddressModes>,
+    asset_server: Res<AssetServer>,
+) {
+    commands.spawn(Camera2dBundle::default());
+
+    let mask_image = asset_server.load("textures/Game Icons/wrench.png");
+
+    let mask = commands
+        .spawn((
+            SpriteMaskBundle {
+                mask: Mask {
+                    image: mask_image,
+                    custom_size: Some(Vec2::splat(128.0)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            Orbit {
+                center: Vec3::X * -300.0,
+                magnitude: Vec3::new(75.0, 300.0, 0.0),
+            },
+        ))
+        .id();
+
+    commands.spawn((
+        SpriteBundle {
+            texture: asset_server.load("textures/array_texture.png"),
+            transform: Transform::from_translation(Vec3::X * -300.0),
+            ..default()
+        },
+        Masked { mask },
+    ));
+
+    let repeating_mask_image = asset_server.load("branding/icon.png");
+    (*mask_address_modes)
+        .0
+        .insert(repeating_mask_image.id(), AddressMode::Repeat);
+
+    let repeating_mask = commands
+        .spawn(SpriteMaskBundle {
+            mask: Mask {
+                image: repeating_mask_image,
+                ..Default::default()
+            },
+            transform: Transform::from_scale(Vec3::splat(0.5)),
+            ..Default::default()
+        })
+        .id();
+
+    commands.spawn((
+        SpriteBundle {
+            texture: asset_server.load("branding/bevy_logo_dark.png"),
+            ..default()
+        },
+        Masked {
+            mask: repeating_mask,
+        },
+        Orbit {
+            center: Vec3::X * 250.0,
+            magnitude: Vec3::Y * -300.0,
+        },
+    ));
+}
+
+#[derive(Default, Resource)]
+struct MaskAddressModes(HashMap<AssetId<Image>, AddressMode>);
+
+fn set_mask_address_mode(
+    mut events: EventReader<AssetEvent<Image>>,
+    mut images: ResMut<Assets<Image>>,
+    mask_address_modes: Res<MaskAddressModes>,
+) {
+    // Change the `AddressMode` of the `SpriteMask` `Image` sampler once it has loaded
+    for event in events.read() {
+        if let &AssetEvent::LoadedWithDependencies { id } = event {
+            if let Some(&address_mode) = mask_address_modes.0.get(&id) {
+                if let Some(image) = images.get_mut(id) {
+                    image.sampler_descriptor = ImageSampler::Descriptor({
+                        SamplerDescriptor {
+                            address_mode_u: address_mode,
+                            address_mode_v: address_mode,
+                            address_mode_w: address_mode,
+                            ..ImageSampler::linear_descriptor()
+                        }
+                    });
+                }
+            }
+        }
+    }
+}
+
+#[derive(Component)]
+struct Orbit {
+    center: Vec3,
+    magnitude: Vec3,
+}
+
+fn orbit(time: Res<Time>, mut orbits: Query<(&mut Transform, &Orbit)>) {
+    for (mut transform, orbit) in orbits.iter_mut() {
+        transform.translation = orbit.center
+            + orbit.magnitude
+                * Vec3::new(
+                    time.elapsed_seconds().sin(),
+                    time.elapsed_seconds().cos(),
+                    0.0,
+                );
+    }
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -105,6 +105,7 @@ Example | Description
 [Sprite](../examples/2d/sprite.rs) | Renders a sprite
 [Sprite Flipping](../examples/2d/sprite_flipping.rs) | Renders a sprite flipped along an axis
 [Sprite Sheet](../examples/2d/sprite_sheet.rs) | Renders an animated sprite
+[Sprite Mask](../examples/2d/sprite_mask.rs) | Partially render sprites based on an intersecting mask
 [Text 2D](../examples/2d/text2d.rs) | Generates text in 2D
 [Texture Atlas](../examples/2d/texture_atlas.rs) | Generates a texture atlas (sprite sheet) from individual sprites
 [Transparency in 2D](../examples/2d/transparency_2d.rs) | Demonstrates transparency in 2d


### PR DESCRIPTION
# Objective

Adds the ability to mask `Sprite`s with other `Image`s.  
Implements #4210

![masking](https://github.com/bevyengine/bevy/assets/13703944/4eaaaf2f-2e6c-4599-87eb-84194b3bd019)

## Solution

### Usage
- Spawn an `Entity` with `Mask` containing a handle to the `Image`. Most of the other fields work like the ones from `Sprite`.
- Spawn a `SpriteBundle`(s) with `Masked` components taking the `Entity` with the `Mask` component.

A `Mask` will be applied to all rendered `Masked` `Sprite`s pointing to it. A `Sprite` can only be affected by a single `Mask`.

### Pipeline implementation
- Masked sprites add 2 additional specialized pipelines for with and without `threshold` values.
- The mask texture and sampler form uniform group(2), optional uniforms (i.e. just `threshold` currently) form group(3). Adds `SIXTEEN_BYTE_ALIGNMENT` define to align uniforms when targeting WebGL2.
- Masked sprites use an alternative vertex buffer that also includes the mask's affine transformation.
- Sprite batches are now delineated by a change in either the `Sprite` `Image` or `Mask`.

### Shader implementation
- In the vertex shader, for each `Masked` vertex, calculate the effective `Mask` uv coordinates at that point. (If the vertex is not contained within the `Mask` bounds, the UVs will be outside of the 0 to 1 range and use the sampler's `AddressMode`.)
- In the fragment shader, sample the mask texture with these UVs, taking the red value[^1]
- If a threshold value is set, map this value to 0.0 if it is less than the threshold, otherwise 1.0.
- Multiply the fragment output alpha by this value.

[^1]: To allow single-channel grayscale masks

### Design concerns
- Linking `Masked` to `Mask` with just an `Entity` is not great, but I don't know of anything better until kinded entities or relations are available? This also makes spawning a self-masking `Entity` awkward.
- Supporting polygonal masks (discussed in #3357, #5180) in the future would be messy at best with this method.
- Should the names for `Mask` and `Masked` be more specific? To differentiate from potential future UI or polygon-based masking?

### Sampler AddressModes  
Changing the `AddressMode` of the mask's sampler is useful to set masking state outside of the mask bounds, or to create a repeating mask. Currently, setting the sampler can't be be done as a part of `Image` loading, it must be done after loading is complete #6893. The recent asset loading changes could make this easy to allow with `ImageLoaderSettings`, *if* `ImageSampler` were serializable.

Note, `AddressMode::ClampToBorder` is not currently supported by WebGPU (gpuweb/gpuweb#1305), though it can be replicated with `ClampToEdge` and adding a slight border to the mask.

---

## Changelog
- Added the `Mask` and `Masked` components. `Sprite`s with `Masked` components will be masked by the linked `Mask` entity.

## Migration Guide
- Added fields to `ExtractedSprite`, `ExtractedSprites`, `SpritePipeline`, `SpriteMeta`, `SpriteBatch`, and `ImageBindGroups`.

