### PR TITLE
Add an attribute to automatically initialize some Resource types

### DIFF
--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -54,9 +54,8 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
                             meta.span(),
                             "#[resource(auto_init)] may only be specified once per type.",
                         ));
-                    } else {
-                        auto_init = true;
                     }
+                    auto_init = true;
                 }
             }
             Ok(())

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -464,7 +464,7 @@ pub fn derive_event(input: TokenStream) -> TokenStream {
     component::derive_event(input)
 }
 
-#[proc_macro_derive(Resource)]
+#[proc_macro_derive(Resource, attributes(resource))]
 pub fn derive_resource(input: TokenStream) -> TokenStream {
     component::derive_resource(input)
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -372,17 +372,17 @@ impl_param_set!();
 /// # schedule.add_systems((read_resource_system, write_resource_system).chain());
 /// # schedule.run(&mut world);
 /// ```
-/// 
+///
 /// # Attributes
-/// 
+///
 /// If a resource type is annotated with the `#[resource(auto_init)]` attribute,
 /// then the resource will be given a default value (via the [`FromWorld`] trait) when
 /// any system that accesses the resource via [`Res`] or [`ResMut`] is initialized.
 /// This happens the first time the system or its containing schedule is run.
-/// 
+///
 /// This is meant to be used for resources that are expected to always have a value
 /// -- removing auto-initialized resources may lead to unexpectd behavior.
-/// 
+///
 /// ```
 /// # use bevy_ecs::{system::Resource, world::World, schedule::Schedule, change_detection::ResMut};
 /// # let mut world = World::new();
@@ -390,11 +390,11 @@ impl_param_set!();
 /// #[derive(Resource, Default)]
 /// #[resource(auto_init)]
 /// pub struct Score(u32);
-/// 
+///
 /// fn increment_score(mut score: ResMut<Score>) {
 ///     score.0 += 1;
 /// }
-/// 
+///
 /// // It is not necessary to call `init_resource`, as it will be called
 /// // automatically due to the `#[resource(auto_init)]` attribute.
 /// schedule.add_systems(increment_score);


### PR DESCRIPTION
# Objective

Having to call `.init_resource()` for every resource type can be annoying, especially if the resource is defined far from where  its containing plugin is built. Many resource types have a sensible default value and are expected to always be defined. For these types, calling `init_resource()` is not a meaningful operation, and can be done automatically with no loss in code clarity. Having to initialize many resource types can make `Plugin::build` cluttered, and can waste users' mental bandwidth by making them organize the init calls.

## Solution

Add an attribute to the derive macro that causes a resource type to be initialized automatically.

```rust
impl Plugin for MyPlugin {
    fn build(&self, app: &mut App) {
        app.add_systems(Update, show_images);
    }
}

#[derive(Resource, Default)]
#[resource(auto_init)]
struct Images(Vec<Image>);

// The `Images` resource will be given a default value when the system is initialized,
// which happens the first time the system or its containing schedule is run.
fn show_images(images: Res<Images>) {
    // ...
}
```

---

## Changelog

+ Added the `#[resource(auto_init)]` attribute, which makes it unnecessary to call `init_resource()` for a type.
