### PR TITLE
Fix alignment on ios simulator

### DIFF
--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -269,6 +269,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
             // On iOS simulator on silicon macs, metal validation check that the host OS alignment
             // is respected, but the device reports the correct value for iOS, which is smaller.
             // Use the larger value.
+            // See https://github.com/bevyengine/bevy/pull/10178 - remove if it's not needed anymore.
             AlignmentValue::new(256)
         } else {
             AlignmentValue::new(device.limits().min_uniform_buffer_offset_alignment as u64)

--- a/examples/mobile/.cargo/config.toml
+++ b/examples/mobile/.cargo/config.toml
@@ -1,0 +1,5 @@
+# Flag to notify the compiler we're building for the iOS simulator from an Apple silicon mac
+# This needs some workarounds for now
+# See https://github.com/bevyengine/bevy/pull/10178 - remove if it's not needed anymore.
+[target.aarch64-apple-ios-sim]
+rustflags = ["--cfg=ios_simulator"]

--- a/examples/mobile/build_rust_deps.sh
+++ b/examples/mobile/build_rust_deps.sh
@@ -48,7 +48,7 @@ for arch in $ARCHS; do
         # Hardware iOS targets
         cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios
       else
-        # M1 iOS simulator -- currently in Nightly only and requires to build `libstd`
+        # M1 iOS simulator
         RUSTFLAGS=--cfg=ios_simulator cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim 
       fi
   esac

--- a/examples/mobile/build_rust_deps.sh
+++ b/examples/mobile/build_rust_deps.sh
@@ -49,7 +49,7 @@ for arch in $ARCHS; do
         cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios
       else
         # M1 iOS simulator
-        RUSTFLAGS=--cfg=ios_simulator cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim 
+        cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim 
       fi
   esac
 done

--- a/examples/mobile/build_rust_deps.sh
+++ b/examples/mobile/build_rust_deps.sh
@@ -49,7 +49,7 @@ for arch in $ARCHS; do
         cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios
       else
         # M1 iOS simulator -- currently in Nightly only and requires to build `libstd`
-        cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim
+        RUSTFLAGS=--cfg=ios_simulator cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim 
       fi
   esac
 done

--- a/examples/mobile/build_rust_deps.sh
+++ b/examples/mobile/build_rust_deps.sh
@@ -49,7 +49,7 @@ for arch in $ARCHS; do
         cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios
       else
         # M1 iOS simulator
-        cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim 
+        cargo rustc --crate-type staticlib --lib $RELFLAG --target aarch64-apple-ios-sim
       fi
   esac
 done


### PR DESCRIPTION
# Objective

- Fix #10165 
- On iOS simulator on apple silicon Macs, shader validation is going through the host, but device limits are reported for the device. They sometimes differ, and cause the validation to crash on something that should work
```
-[MTLDebugRenderCommandEncoder validateCommonDrawErrors:]:5775: failed assertion `Draw Errors Validation
Fragment Function(fragment_): the offset into the buffer _naga_oil_mod_MJSXM6K7OBRHEOR2NVSXG2C7OZUWK527MJUW4ZDJNZTXG_memberfog that is bound at buffer index 6 must be a multiple of 256 but was set to 448.
```

## Solution

- Add a custom flag when building for the simulator and override the buffer alignment
