### PR TITLE
update shader imports

### DIFF
--- a/assets/shaders/animate_shader.wgsl
+++ b/assets/shaders/animate_shader.wgsl
@@ -1,6 +1,8 @@
 // The time since startup data is in the globals binding which is part of the mesh_view_bindings import
-#import bevy_pbr::mesh_view_bindings globals
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::{
+    mesh_view_bindings::globals,
+    forward_io::VertexOutput,
+}
 
 fn oklab_to_linear_srgb(c: vec3<f32>) -> vec3<f32> {
     let L = c.x;

--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -1,8 +1,10 @@
-#import bevy_pbr::forward_io    VertexOutput
-#import bevy_pbr::mesh_view_bindings    view
-#import bevy_pbr::pbr_types             STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT, PbrInput, pbr_input_new
-#import bevy_core_pipeline::tonemapping tone_mapping
-#import bevy_pbr::pbr_functions as fns
+#import bevy_pbr::{
+    forward_io::VertexOutput,
+    mesh_view_bindings::view,
+    pbr_types::{STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT, PbrInput, pbr_input_new},
+    pbr_functions as fns,
+}
+#import bevy_core_pipeline::tonemapping::tone_mapping
 
 @group(1) @binding(0) var my_array_texture: texture_2d_array<f32>;
 @group(1) @binding(1) var my_array_texture_sampler: sampler;

--- a/assets/shaders/cubemap_unlit.wgsl
+++ b/assets/shaders/cubemap_unlit.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 #ifdef CUBEMAP_ARRAY
 @group(1) @binding(0) var base_color_texture: texture_cube_array<f32>;

--- a/assets/shaders/custom_gltf_2d.wgsl
+++ b/assets/shaders/custom_gltf_2d.wgsl
@@ -1,6 +1,7 @@
-#import bevy_sprite::mesh2d_view_bindings   globals
-#import bevy_sprite::mesh2d_bindings        mesh
-#import bevy_sprite::mesh2d_functions       get_model_matrix, mesh2d_position_local_to_clip
+#import bevy_sprite::{
+    mesh2d_view_bindings::globals,
+    mesh2d_functions::{get_model_matrix, mesh2d_position_local_to_clip},
+}
 
 struct Vertex {
     @builtin(instance_index) instance_index: u32,

--- a/assets/shaders/custom_material.wgsl
+++ b/assets/shaders/custom_material.wgsl
@@ -1,6 +1,6 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 // we can import items from shader modules in the assets folder with a quoted path
-#import "shaders/custom_material_import.wgsl" COLOR_MULTIPLIER
+#import "shaders/custom_material_import.wgsl"::COLOR_MULTIPLIER
 
 struct CustomMaterial {
     color: vec4<f32>,

--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -1,6 +1,8 @@
-#import bevy_pbr::mesh_view_bindings  view
-#import bevy_pbr::forward_io  VertexOutput
-#import bevy_pbr::utils               coords_to_viewport_uv
+#import bevy_pbr::{
+    mesh_view_bindings::view,
+    forward_io::VertexOutput,
+    utils::coords_to_viewport_uv,
+}
 
 @group(1) @binding(0) var texture: texture_2d<f32>;
 @group(1) @binding(1) var texture_sampler: sampler;

--- a/assets/shaders/custom_vertex_attribute.wgsl
+++ b/assets/shaders/custom_vertex_attribute.wgsl
@@ -1,5 +1,4 @@
-#import bevy_pbr::mesh_bindings   mesh
-#import bevy_pbr::mesh_functions  get_model_matrix, mesh_position_local_to_clip
+#import bevy_pbr::mesh_functions::{get_model_matrix, mesh_position_local_to_clip}
 
 struct CustomMaterial {
     color: vec4<f32>,

--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -1,12 +1,18 @@
-#import bevy_pbr::pbr_fragment          pbr_input_from_standard_material
-#import bevy_pbr::pbr_functions         alpha_discard
+#import bevy_pbr::{
+    pbr_fragment::pbr_input_from_standard_material,
+    pbr_functions::alpha_discard,
+}
 
 #ifdef PREPASS_PIPELINE
-#import bevy_pbr::prepass_io            VertexOutput, FragmentOutput
-#import bevy_pbr::pbr_deferred_functions  deferred_output
+#import bevy_pbr::{
+    prepass_io::{VertexOutput, FragmentOutput},
+    pbr_deferred_functions::deferred_output,
+}
 #else
-#import bevy_pbr::forward_io            VertexOutput, FragmentOutput
-#import bevy_pbr::pbr_functions         apply_pbr_lighting, main_pass_post_lighting_processing
+#import bevy_pbr::{
+    forward_io::{VertexOutput, FragmentOutput},
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+}
 #endif
 
 struct MyExtendedMaterial {

--- a/assets/shaders/fallback_image_test.wgsl
+++ b/assets/shaders/fallback_image_test.wgsl
@@ -1,6 +1,4 @@
-#import bevy_pbr::mesh_view_bindings
-#import bevy_pbr::mesh_bindings
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 @group(1) @binding(0) var test_texture_1d: texture_1d<f32>;
 @group(1) @binding(1) var test_texture_1d_sampler: sampler;

--- a/assets/shaders/instancing.wgsl
+++ b/assets/shaders/instancing.wgsl
@@ -1,5 +1,4 @@
-#import bevy_pbr::mesh_functions  get_model_matrix, mesh_position_local_to_clip
-#import bevy_pbr::mesh_bindings   mesh
+#import bevy_pbr::mesh_functions::{get_model_matrix, mesh_position_local_to_clip}
 
 struct Vertex {
     @location(0) position: vec3<f32>,

--- a/assets/shaders/line_material.wgsl
+++ b/assets/shaders/line_material.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 struct LineMaterial {
     color: vec4<f32>,

--- a/assets/shaders/post_processing.wgsl
+++ b/assets/shaders/post_processing.wgsl
@@ -1,7 +1,5 @@
 // This shader computes the chromatic aberration effect
 
-#import bevy_pbr::utils
-
 // Since post processing is a fullscreen effect, we use the fullscreen vertex shader provided by bevy.
 // This will import a vertex shader that renders a single fullscreen triangle.
 //
@@ -20,7 +18,7 @@
 // As you can see, the triangle ends up bigger than the screen.
 //
 // You don't need to worry about this too much since bevy will compute the correct UVs for you.
-#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
 @group(0) @binding(0) var screen_texture: texture_2d<f32>;
 @group(0) @binding(1) var texture_sampler: sampler;

--- a/assets/shaders/shader_defs.wgsl
+++ b/assets/shaders/shader_defs.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 struct CustomMaterial {
     color: vec4<f32>,

--- a/assets/shaders/show_prepass.wgsl
+++ b/assets/shaders/show_prepass.wgsl
@@ -1,7 +1,8 @@
-#import bevy_pbr::mesh_types
-#import bevy_pbr::mesh_view_bindings  globals
-#import bevy_pbr::prepass_utils
-#import bevy_pbr::forward_io  VertexOutput
+#import bevy_pbr::{
+    mesh_view_bindings::globals,
+    prepass_utils,
+    forward_io::VertexOutput,
+}
 
 struct ShowPrepassSettings {
     show_depth: u32,

--- a/assets/shaders/texture_binding_array.wgsl
+++ b/assets/shaders/texture_binding_array.wgsl
@@ -1,4 +1,4 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 
 @group(1) @binding(0) var textures: binding_array<texture_2d<f32>>;
 @group(1) @binding(1) var nearest_sampler: sampler;

--- a/assets/shaders/tonemapping_test_patterns.wgsl
+++ b/assets/shaders/tonemapping_test_patterns.wgsl
@@ -1,10 +1,11 @@
-#import bevy_pbr::mesh_view_bindings
-#import bevy_pbr::mesh_bindings
-#import bevy_pbr::forward_io  VertexOutput
-#import bevy_pbr::utils               PI
+#import bevy_pbr::{
+    mesh_view_bindings,
+    forward_io::VertexOutput,
+    utils::PI,
+}
 
 #ifdef TONEMAP_IN_SHADER
-#import bevy_core_pipeline::tonemapping tone_mapping
+#import bevy_core_pipeline::tonemapping::tone_mapping
 #endif
 
 // Sweep across hues on y axis with value from 0.0 to +15EV across x axis 
@@ -55,7 +56,7 @@ fn fragment(
     }
     var color = vec4(out, 1.0);
 #ifdef TONEMAP_IN_SHADER
-    color = tone_mapping(color, bevy_pbr::mesh_view_bindings::view.color_grading);
+    color = tone_mapping(color, mesh_view_bindings::view.color_grading);
 #endif
     return color;
 }

--- a/crates/bevy_core_pipeline/src/blit/blit.wgsl
+++ b/crates/bevy_core_pipeline/src/blit/blit.wgsl
@@ -1,4 +1,4 @@
-#import bevy_core_pipeline::fullscreen_vertex_shader  FullscreenVertexOutput
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
 @group(0) @binding(0) var in_texture: texture_2d<f32>;
 @group(0) @binding(1) var in_sampler: sampler;

--- a/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
+++ b/crates/bevy_core_pipeline/src/bloom/bloom.wgsl
@@ -6,8 +6,6 @@
 // * [COD] - Next Generation Post Processing in Call of Duty - http://www.iryoku.com/next-generation-post-processing-in-call-of-duty-advanced-warfare
 // * [PBB] - Physically Based Bloom - https://learnopengl.com/Guest-Articles/2022/Phys.-Based-Bloom
 
-#import bevy_core_pipeline::fullscreen_vertex_shader
-
 struct BloomUniforms {
     threshold_precomputations: vec4<f32>,
     viewport: vec4<f32>,

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/robust_contrast_adaptive_sharpening.wgsl
@@ -17,7 +17,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
 struct CASUniforms {
     sharpness: f32,

--- a/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wgsl
+++ b/crates/bevy_core_pipeline/src/deferred/copy_deferred_lighting_id.wgsl
@@ -1,5 +1,4 @@
-#import bevy_pbr::utils
-#import bevy_core_pipeline::fullscreen_vertex_shader FullscreenVertexOutput
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
 @group(0) @binding(0)
 var material_id_texture: texture_2d<u32>;

--- a/crates/bevy_core_pipeline/src/fxaa/fxaa.wgsl
+++ b/crates/bevy_core_pipeline/src/fxaa/fxaa.wgsl
@@ -6,7 +6,7 @@
 //
 // Tweaks by mrDIMAS - https://github.com/FyroxEngine/Fyrox/blob/master/src/renderer/shaders/fxaa_fs.glsl
 
-#import bevy_core_pipeline::fullscreen_vertex_shader  FullscreenVertexOutput
+#import bevy_core_pipeline::fullscreen_vertex_shader::FullscreenVertexOutput
 
 @group(0) @binding(0) var screenTexture: texture_2d<f32>;
 @group(0) @binding(1) var samp: sampler;

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -1,5 +1,5 @@
-#import bevy_render::view View
-#import bevy_pbr::utils coords_to_viewport_uv
+#import bevy_render::view::View
+#import bevy_pbr::utils::coords_to_viewport_uv
 
 @group(0) @binding(0) var skybox: texture_cube<f32>;
 @group(0) @binding(1) var skybox_sampler: sampler;

--- a/crates/bevy_core_pipeline/src/taa/taa.wgsl
+++ b/crates/bevy_core_pipeline/src/taa/taa.wgsl
@@ -10,8 +10,6 @@
 const DEFAULT_HISTORY_BLEND_RATE: f32 = 0.1; // Default blend rate to use when no confidence in history
 const MIN_HISTORY_BLEND_RATE: f32 = 0.015; // Minimum blend rate allowed, to ensure at least some of the current sample is used
 
-#import bevy_core_pipeline::fullscreen_vertex_shader
-
 @group(0) @binding(0) var view_target: texture_2d<f32>;
 @group(0) @binding(1) var history: texture_2d<f32>;
 @group(0) @binding(2) var motion_vectors: texture_2d<f32>;

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping.wgsl
@@ -1,8 +1,10 @@
 #define TONEMAPPING_PASS
 
-#import bevy_core_pipeline::fullscreen_vertex_shader  FullscreenVertexOutput
-#import bevy_render::view  View
-#import bevy_core_pipeline::tonemapping  tone_mapping, powsafe, screen_space_dither
+#import bevy_render::view::View
+#import bevy_core_pipeline::{
+    fullscreen_vertex_shader::FullscreenVertexOutput,
+    tonemapping::{tone_mapping, powsafe, screen_space_dither},
+}
 
 @group(0) @binding(0) var<uniform> view: View;
 
@@ -10,8 +12,6 @@
 @group(0) @binding(2) var hdr_sampler: sampler;
 @group(0) @binding(3) var dt_lut_texture: texture_3d<f32>;
 @group(0) @binding(4) var dt_lut_sampler: sampler;
-
-#import bevy_core_pipeline::tonemapping
 
 @fragment
 fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
@@ -21,7 +21,7 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
 
 #ifdef DEBAND_DITHER
     output_rgb = powsafe(output_rgb.rgb, 1.0 / 2.2);
-    output_rgb = output_rgb + bevy_core_pipeline::tonemapping::screen_space_dither(in.position.xy);
+    output_rgb = output_rgb + screen_space_dither(in.position.xy);
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
     output_rgb = powsafe(output_rgb.rgb, 2.2);

--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_core_pipeline::tonemapping
 
-#import bevy_render::view View, ColorGrading
+#import bevy_render::view::ColorGrading
 
 // hack !! not sure what to do with this
 #ifdef TONEMAPPING_PASS

--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -1,5 +1,5 @@
 // TODO use common view binding
-#import bevy_render::view View
+#import bevy_render::view::View
 
 @group(0) @binding(0) var<uniform> view: View;
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -31,6 +31,6 @@ fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
-naga_oil = "0.9"
+naga_oil = "0.10"
 smallvec = "1.6"
 thread_local = "1.0"

--- a/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
+++ b/crates/bevy_pbr/src/deferred/deferred_lighting.wgsl
@@ -1,15 +1,14 @@
-#import bevy_pbr::prepass_utils
-#import bevy_pbr::pbr_types STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT
-#import bevy_pbr::pbr_functions as pbr_functions
-#import bevy_pbr::pbr_deferred_types as deferred_types
-#import bevy_pbr::pbr_deferred_functions pbr_input_from_deferred_gbuffer, unpack_unorm3x4_plus_unorm_20_
-#import bevy_pbr::mesh_view_types FOG_MODE_OFF
-
-#import bevy_pbr::mesh_view_bindings deferred_prepass_texture, fog, view, screen_space_ambient_occlusion_texture
-#import bevy_core_pipeline::tonemapping screen_space_dither, powsafe, tone_mapping
+#import bevy_pbr::{
+    prepass_utils,
+    pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
+    pbr_functions,
+    pbr_deferred_functions::{pbr_input_from_deferred_gbuffer, unpack_unorm3x4_plus_unorm_20_},
+    mesh_view_bindings::deferred_prepass_texture,
+}
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
-#import bevy_pbr::gtao_utils gtao_multibounce
+#import bevy_pbr::mesh_view_bindings::screen_space_ambient_occlusion_texture
+#import bevy_pbr::gtao_utils::gtao_multibounce
 #endif
 
 struct FullscreenVertexOutput {
@@ -48,10 +47,10 @@ fn fragment(in: FullscreenVertexOutput) -> @location(0) vec4<f32> {
     let deferred_data = textureLoad(deferred_prepass_texture, vec2<i32>(frag_coord.xy), 0);
 
 #ifdef WEBGL2
-    frag_coord.z = deferred_types::unpack_unorm3x4_plus_unorm_20_(deferred_data.b).w;
+    frag_coord.z = unpack_unorm3x4_plus_unorm_20_(deferred_data.b).w;
 #else
 #ifdef DEPTH_PREPASS
-    frag_coord.z = bevy_pbr::prepass_utils::prepass_depth(in.position, 0u);
+    frag_coord.z = prepass_utils::prepass_depth(in.position, 0u);
 #endif
 #endif
 

--- a/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
+++ b/crates/bevy_pbr/src/deferred/pbr_deferred_functions.wgsl
@@ -1,16 +1,17 @@
 #define_import_path bevy_pbr::pbr_deferred_functions
 
-#import bevy_pbr::pbr_types PbrInput, standard_material_new, STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT
-#import bevy_pbr::pbr_deferred_types as deferred_types
-#import bevy_pbr::pbr_functions as pbr_functions
-#import bevy_pbr::rgb9e5 as rgb9e5
-#import bevy_pbr::mesh_view_bindings as view_bindings
-#import bevy_pbr::mesh_view_bindings view
-#import bevy_pbr::utils octahedral_encode, octahedral_decode
-#import bevy_pbr::prepass_io VertexOutput, FragmentOutput
+#import bevy_pbr::{
+    pbr_types::{PbrInput, standard_material_new, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
+    pbr_deferred_types as deferred_types,
+    pbr_functions,
+    rgb9e5,
+    mesh_view_bindings::view,
+    utils::{octahedral_encode, octahedral_decode},
+    prepass_io::{VertexOutput, FragmentOutput},
+}
 
 #ifdef MOTION_VECTOR_PREPASS
-    #import bevy_pbr::pbr_prepass_functions calculate_motion_vector
+    #import bevy_pbr::pbr_prepass_functions::calculate_motion_vector
 #endif
 
 // ---------------------------

--- a/crates/bevy_pbr/src/deferred/pbr_deferred_types.wgsl
+++ b/crates/bevy_pbr/src/deferred/pbr_deferred_types.wgsl
@@ -1,6 +1,9 @@
 #define_import_path bevy_pbr::pbr_deferred_types
-#import bevy_pbr::mesh_types MESH_FLAGS_SHADOW_RECEIVER_BIT 
-#import bevy_pbr::pbr_types STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT
+
+#import bevy_pbr::{
+    mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT,
+    pbr_types::{STANDARD_MATERIAL_FLAGS_FOG_ENABLED_BIT, STANDARD_MATERIAL_FLAGS_UNLIT_BIT},
+}
 
 // Maximum of 8 bits available
 const DEFERRED_FLAGS_UNLIT_BIT: u32                 = 1u;

--- a/crates/bevy_pbr/src/environment_map/environment_map.wgsl
+++ b/crates/bevy_pbr/src/environment_map/environment_map.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::environment_map
 
-#import bevy_pbr::mesh_view_bindings as bindings
+#import bevy_pbr::mesh_view_bindings as bindings;
 
 struct EnvironmentMapLight {
     diffuse: vec3<f32>,

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -1,11 +1,13 @@
-#import bevy_pbr::prepass_bindings
-#import bevy_pbr::mesh_functions
-#import bevy_pbr::prepass_io Vertex, VertexOutput, FragmentOutput
-#import bevy_pbr::skinning
-#import bevy_pbr::morph
-#import bevy_pbr::mesh_bindings mesh
-#import bevy_render::instance_index get_instance_index
-#import bevy_pbr::mesh_view_bindings view, previous_view_proj
+#import bevy_pbr::{
+    prepass_bindings,
+    mesh_functions,
+    prepass_io::{Vertex, VertexOutput, FragmentOutput},
+    skinning,
+    morph,
+    mesh_view_bindings::{view, previous_view_proj},
+}
+
+#import bevy_render::instance_index::get_instance_index
 
 #ifdef DEFERRED_PREPASS
 #import bevy_pbr::rgb9e5
@@ -14,18 +16,18 @@
 #ifdef MORPH_TARGETS
 fn morph_vertex(vertex_in: Vertex) -> Vertex {
     var vertex = vertex_in;
-    let weight_count = bevy_pbr::morph::layer_count();
+    let weight_count = morph::layer_count();
     for (var i: u32 = 0u; i < weight_count; i ++) {
-        let weight = bevy_pbr::morph::weight_at(i);
+        let weight = morph::weight_at(i);
         if weight == 0.0 {
             continue;
         }
-        vertex.position += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::position_offset, i);
+        vertex.position += weight * morph::morph(vertex.index, morph::position_offset, i);
 #ifdef VERTEX_NORMALS
-        vertex.normal += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::normal_offset, i);
+        vertex.normal += weight * morph::morph(vertex.index, morph::normal_offset, i);
 #endif
 #ifdef VERTEX_TANGENTS
-        vertex.tangent += vec4(weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
+        vertex.tangent += vec4(weight * morph::morph(vertex.index, morph::tangent_offset, i), 0.0);
 #endif
     }
     return vertex;
@@ -37,20 +39,20 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
 #ifdef MORPH_TARGETS
-    var vertex = morph_vertex(vertex_no_morph);
+    var vertex = morph::morph_vertex(vertex_no_morph);
 #else
     var vertex = vertex_no_morph;
 #endif
 
 #ifdef SKINNED
-    var model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
+    var model = skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else // SKINNED
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416
-    var model = bevy_pbr::mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
+    var model = mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
 #endif // SKINNED
 
-    out.position = bevy_pbr::mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
+    out.position = mesh_functions::mesh_position_local_to_clip(model, vec4(vertex.position, 1.0));
 #ifdef DEPTH_CLAMP_ORTHO
     out.clip_position_unclamped = out.position;
     out.position.z = min(out.position.z, 1.0);
@@ -62,9 +64,9 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS
 #ifdef SKINNED
-    out.world_normal = bevy_pbr::skinning::skin_normals(model, vertex.normal);
+    out.world_normal = skinning::skin_normals(model, vertex.normal);
 #else // SKINNED
-    out.world_normal = bevy_pbr::mesh_functions::mesh_normal_local_to_world(
+    out.world_normal = mesh_functions::mesh_normal_local_to_world(
         vertex.normal,
         // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
         // See https://github.com/gfx-rs/naga/issues/2416
@@ -73,7 +75,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif // SKINNED
 
 #ifdef VERTEX_TANGENTS
-    out.world_tangent = bevy_pbr::mesh_functions::mesh_tangent_local_to_world(
+    out.world_tangent = mesh_functions::mesh_tangent_local_to_world(
         model,
         vertex.tangent,
         // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
@@ -88,14 +90,14 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef MOTION_VECTOR_PREPASS_OR_DEFERRED_PREPASS
-    out.world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
+    out.world_position = mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
 #endif // MOTION_VECTOR_PREPASS_OR_DEFERRED_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416
-    out.previous_world_position = bevy_pbr::mesh_functions::mesh_position_local_to_world(
-        bevy_pbr::mesh_functions::get_previous_model_matrix(vertex_no_morph.instance_index),
+    out.previous_world_position = mesh_functions::mesh_position_local_to_world(
+        mesh_functions::get_previous_model_matrix(vertex_no_morph.instance_index),
         vec4<f32>(vertex.position, 1.0)
     );
 #endif // MOTION_VECTOR_PREPASS
@@ -125,7 +127,7 @@ fn fragment(in: VertexOutput) -> FragmentOutput {
 #ifdef MOTION_VECTOR_PREPASS
     let clip_position_t = view.unjittered_view_proj * in.world_position;
     let clip_position = clip_position_t.xy / clip_position_t.w;
-    let previous_clip_position_t = bevy_pbr::prepass_bindings::previous_view_proj * in.previous_world_position;
+    let previous_clip_position_t = prepass_bindings::previous_view_proj * in.previous_world_position;
     let previous_clip_position = previous_clip_position_t.xy / previous_clip_position_t.w;
     // These motion vectors are used as offsets to UV positions and are stored
     // in the range -1,1 to allow offsetting from the one corner to the

--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -1,9 +1,7 @@
 #define_import_path bevy_pbr::prepass_bindings
-#import bevy_pbr::mesh_types
 
 #ifdef MOTION_VECTOR_PREPASS
 @group(0) @binding(2) var<uniform> previous_view_proj: mat4x4<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 // Material bindings will be in @group(1)
-#import bevy_pbr::mesh_bindings   mesh

--- a/crates/bevy_pbr/src/render/clustered_forward.wgsl
+++ b/crates/bevy_pbr/src/render/clustered_forward.wgsl
@@ -1,7 +1,9 @@
 #define_import_path bevy_pbr::clustered_forward
 
-#import bevy_pbr::mesh_view_bindings as bindings
-#import bevy_pbr::utils hsv2rgb
+#import bevy_pbr::{
+    mesh_view_bindings as bindings,
+    utils::hsv2rgb,
+}
 
 // NOTE: Keep in sync with bevy_pbr/src/light.rs
 fn view_z_to_z_slice(view_z: f32, is_orthographic: bool) -> u32 {

--- a/crates/bevy_pbr/src/render/fog.wgsl
+++ b/crates/bevy_pbr/src/render/fog.wgsl
@@ -1,7 +1,9 @@
 #define_import_path bevy_pbr::fog
 
-#import bevy_pbr::mesh_view_bindings fog
-#import bevy_pbr::mesh_view_types Fog
+#import bevy_pbr::{
+    mesh_view_bindings::fog,
+    mesh_view_types::Fog,
+}
 
 // Fog formulas adapted from:
 // https://learn.microsoft.com/en-us/windows/win32/direct3d9/fog-formulas

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -1,9 +1,10 @@
-#import bevy_pbr::mesh_functions as mesh_functions
-#import bevy_pbr::skinning
-#import bevy_pbr::morph
-#import bevy_pbr::mesh_bindings       mesh
-#import bevy_pbr::forward_io          Vertex, VertexOutput
-#import bevy_render::instance_index   get_instance_index
+#import bevy_pbr::{
+    mesh_functions,
+    skinning,
+    morph::morph,
+    forward_io::{Vertex, VertexOutput},
+}
+#import bevy_render::instance_index::get_instance_index
 
 #ifdef MORPH_TARGETS
 fn morph_vertex(vertex_in: Vertex) -> Vertex {
@@ -14,12 +15,12 @@ fn morph_vertex(vertex_in: Vertex) -> Vertex {
         if weight == 0.0 {
             continue;
         }
-        vertex.position += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::position_offset, i);
+        vertex.position += weight * morph(vertex.index, bevy_pbr::morph::position_offset, i);
 #ifdef VERTEX_NORMALS
-        vertex.normal += weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::normal_offset, i);
+        vertex.normal += weight * morph(vertex.index, bevy_pbr::morph::normal_offset, i);
 #endif
 #ifdef VERTEX_TANGENTS
-        vertex.tangent += vec4(weight * bevy_pbr::morph::morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
+        vertex.tangent += vec4(weight * morph(vertex.index, bevy_pbr::morph::tangent_offset, i), 0.0);
 #endif
     }
     return vertex;
@@ -37,7 +38,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef SKINNED
-    var model = bevy_pbr::skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
+    var model = skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
     // See https://github.com/gfx-rs/naga/issues/2416 .
@@ -46,7 +47,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 
 #ifdef VERTEX_NORMALS
 #ifdef SKINNED
-    out.world_normal = bevy_pbr::skinning::skin_normals(model, vertex.normal);
+    out.world_normal = skinning::skin_normals(model, vertex.normal);
 #else
     out.world_normal = mesh_functions::mesh_normal_local_to_world(
         vertex.normal,

--- a/crates/bevy_pbr/src/render/mesh_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_bindings.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::mesh_bindings
 
-#import bevy_pbr::mesh_types Mesh
+#import bevy_pbr::mesh_types::Mesh
 
 #ifdef MESH_BINDGROUP_1
 

--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -1,10 +1,14 @@
 #define_import_path bevy_pbr::mesh_functions
 
-#import bevy_pbr::mesh_view_bindings  view
-#import bevy_pbr::mesh_bindings       mesh
-#import bevy_pbr::mesh_types          MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT
-#import bevy_render::instance_index   get_instance_index
-#import bevy_render::maths            affine_to_square, mat2x4_f32_to_mat3x3_unpack
+#import bevy_pbr::{
+    mesh_view_bindings::view,
+    mesh_bindings::mesh,
+    mesh_types::MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT,
+}
+#import bevy_render::{
+    instance_index::get_instance_index,
+    maths::{affine_to_square, mat2x4_f32_to_mat3x3_unpack},
+}
 
 fn get_model_matrix(instance_index: u32) -> mat4x4<f32> {
     return affine_to_square(mesh[get_instance_index(instance_index)].model);

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -1,8 +1,10 @@
 #define_import_path bevy_pbr::mesh_view_bindings
 
 #import bevy_pbr::mesh_view_types as types
-#import bevy_render::view  View
-#import bevy_render::globals  Globals
+#import bevy_render::{
+    view::View,
+    globals::Globals,
+}
 
 @group(0) @binding(0) var<uniform> view: View;
 @group(0) @binding(1) var<uniform> lights: types::Lights;

--- a/crates/bevy_pbr/src/render/mesh_view_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_types.wgsl
@@ -1,8 +1,5 @@
 #define_import_path bevy_pbr::mesh_view_types
 
-#import bevy_render::view
-#import bevy_render::globals
-
 struct PointLight {
     // For point lights: the lower-right 2x2 values of the projection matrix [2][2] [2][3] [3][2] [3][3]
     // For spot lights: the direction (x,z), spot_scale and spot_offset

--- a/crates/bevy_pbr/src/render/morph.wgsl
+++ b/crates/bevy_pbr/src/render/morph.wgsl
@@ -1,15 +1,8 @@
-// If using this WGSL snippet as an #import, the following should be in scope:
-//
-// - the `morph_weights` uniform of type `MorphWeights`
-// - the `morph_targets` 3d texture
-//
-// They are defined in `mesh_types.wgsl` and `mesh_bindings.wgsl`.
-
 #define_import_path bevy_pbr::morph
 
 #ifdef MORPH_TARGETS
 
-#import bevy_pbr::mesh_types MorphWeights
+#import bevy_pbr::mesh_types::MorphWeights;
 
 #ifdef MESH_BINDGROUP_1
 

--- a/crates/bevy_pbr/src/render/parallax_mapping.wgsl
+++ b/crates/bevy_pbr/src/render/parallax_mapping.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::parallax_mapping
 
-#import bevy_pbr::pbr_bindings  depth_map_texture, depth_map_sampler
+#import bevy_pbr::pbr_bindings::{depth_map_texture, depth_map_sampler}
 
 fn sample_depth_map(uv: vec2<f32>) -> f32 {
     // We use `textureSampleLevel` over `textureSample` because the wgpu DX12

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -1,13 +1,19 @@
-#import bevy_pbr::pbr_functions           alpha_discard
-#import bevy_pbr::pbr_fragment            pbr_input_from_standard_material
+#import bevy_pbr::{
+    pbr_functions::alpha_discard,
+    pbr_fragment::pbr_input_from_standard_material,
+}
 
 #ifdef PREPASS_PIPELINE
-#import bevy_pbr::prepass_io              VertexOutput, FragmentOutput
-#import bevy_pbr::pbr_deferred_functions  deferred_output
+#import bevy_pbr::{
+    prepass_io::{VertexOutput, FragmentOutput},
+    pbr_deferred_functions::deferred_output,
+}
 #else
-#import bevy_pbr::forward_io              VertexOutput, FragmentOutput
-#import bevy_pbr::pbr_functions           apply_pbr_lighting, main_pass_post_lighting_processing
-#import bevy_pbr::pbr_types               STANDARD_MATERIAL_FLAGS_UNLIT_BIT
+#import bevy_pbr::{
+    forward_io::{VertexOutput, FragmentOutput},
+    pbr_functions::{apply_pbr_lighting, main_pass_post_lighting_processing},
+    pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT,
+}
 #endif
 
 @fragment

--- a/crates/bevy_pbr/src/render/pbr_ambient.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_ambient.wgsl
@@ -1,7 +1,9 @@
 #define_import_path bevy_pbr::ambient
 
-#import bevy_pbr::lighting  EnvBRDFApprox, F_AB
-#import bevy_pbr::mesh_view_bindings  lights
+#import bevy_pbr::{
+    lighting::{EnvBRDFApprox, F_AB},
+    mesh_view_bindings::lights,
+}
 
 // A precomputed `NdotV` is provided because it is computed regardless,
 // but `world_normal` and the view vector `V` are provided separately for more advanced uses.

--- a/crates/bevy_pbr/src/render/pbr_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_bindings.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::pbr_bindings
 
-#import bevy_pbr::pbr_types  StandardMaterial
+#import bevy_pbr::pbr_types::StandardMaterial
 
 @group(1) @binding(0) var<uniform> material: StandardMaterial;
 @group(1) @binding(1) var base_color_texture: texture_2d<f32>;

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -1,22 +1,24 @@
 #define_import_path bevy_pbr::pbr_fragment
 
-#import bevy_pbr::pbr_functions as pbr_functions
-#import bevy_pbr::pbr_bindings as pbr_bindings
-#import bevy_pbr::pbr_types as pbr_types
-#import bevy_pbr::prepass_utils
-
-#import bevy_pbr::mesh_bindings            mesh
-#import bevy_pbr::mesh_view_bindings       view, screen_space_ambient_occlusion_texture
-#import bevy_pbr::parallax_mapping         parallaxed_uv
+#import bevy_pbr::{
+    pbr_functions,
+    pbr_bindings,
+    pbr_types,
+    prepass_utils,
+    mesh_bindings::mesh,
+    mesh_view_bindings::view,
+    parallax_mapping::parallaxed_uv,
+}
 
 #ifdef SCREEN_SPACE_AMBIENT_OCCLUSION
-#import bevy_pbr::gtao_utils gtao_multibounce
+#import bevy_pbr::mesh_view_bindings::screen_space_ambient_occlusion_texture
+#import bevy_pbr::gtao_utils::gtao_multibounce
 #endif
 
 #ifdef PREPASS_PIPELINE
-#import bevy_pbr::prepass_io VertexOutput
+#import bevy_pbr::prepass_io::VertexOutput
 #else
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
 #endif
 
 // prepare a basic PbrInput from the vertex stage output, mesh binding and view binding
@@ -44,7 +46,7 @@ fn pbr_input_from_vertex_output(
     );
 
 #ifdef LOAD_PREPASS_NORMALS
-    pbr_input.N = bevy_pbr::prepass_utils::prepass_normal(in.position, 0u);
+    pbr_input.N = prepass_utils::prepass_normal(in.position, 0u);
 #else
     pbr_input.N = normalize(pbr_input.world_normal);
 #endif

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -1,24 +1,23 @@
 #define_import_path bevy_pbr::pbr_functions
 
-#ifdef TONEMAP_IN_SHADER
-#import bevy_core_pipeline::tonemapping
-#endif
+#import bevy_pbr::{
+    pbr_types,
+    pbr_bindings,
+    mesh_view_bindings as view_bindings,
+    mesh_view_types,
+    lighting,
+    clustered_forward as clustering,
+    shadows,
+    ambient,
+    mesh_types::MESH_FLAGS_SHADOW_RECEIVER_BIT,
+}
 
-#import bevy_pbr::pbr_types as pbr_types
-#import bevy_pbr::pbr_bindings as pbr_bindings
-#import bevy_pbr::mesh_view_bindings as view_bindings
-#import bevy_pbr::mesh_view_types as mesh_view_types
-#import bevy_pbr::lighting as lighting
-#import bevy_pbr::clustered_forward as clustering
-#import bevy_pbr::shadows as shadows
-#import bevy_pbr::fog
-#import bevy_pbr::ambient as ambient
 #ifdef ENVIRONMENT_MAP
 #import bevy_pbr::environment_map
 #endif
-#import bevy_core_pipeline::tonemapping    screen_space_dither, powsafe, tone_mapping
 
-#import bevy_pbr::mesh_types      MESH_FLAGS_SHADOW_RECEIVER_BIT
+#import bevy_core_pipeline::tonemapping::{screen_space_dither, powsafe, tone_mapping}
+
 
 fn alpha_discard(material: pbr_types::StandardMaterial, output_color: vec4<f32>) -> vec4<f32> {
     var color = output_color;
@@ -224,7 +223,7 @@ fn apply_pbr_lighting(
 
     // Environment map light (indirect)
 #ifdef ENVIRONMENT_MAP
-    let environment_light = bevy_pbr::environment_map::environment_map_light(perceptual_roughness, roughness, diffuse_color, NdotV, f_ab, in.N, R, F0);
+    let environment_light = environment_map::environment_map_light(perceptual_roughness, roughness, diffuse_color, NdotV, f_ab, in.N, R, F0);
     indirect_light += (environment_light.diffuse * occlusion) + environment_light.specular;
 #endif
 

--- a/crates/bevy_pbr/src/render/pbr_lighting.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_lighting.wgsl
@@ -1,8 +1,10 @@
 #define_import_path bevy_pbr::lighting
 
-#import bevy_pbr::utils PI
-#import bevy_pbr::mesh_view_types as view_types
-#import bevy_pbr::mesh_view_bindings as view_bindings
+#import bevy_pbr::{
+    utils::PI,
+    mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
+    mesh_view_bindings as view_bindings,
+}
 
 // From the Filament design doc
 // https://google.github.io/filament/Filament.html#table_symbols
@@ -253,7 +255,7 @@ fn spot_light(
     // reconstruct spot dir from x/z and y-direction flag
     var spot_dir = vec3<f32>((*light).light_custom_data.x, 0.0, (*light).light_custom_data.y);
     spot_dir.y = sqrt(max(0.0, 1.0 - spot_dir.x * spot_dir.x - spot_dir.z * spot_dir.z));
-    if ((*light).flags & view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE) != 0u {
+    if ((*light).flags & POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE) != 0u {
         spot_dir.y = -spot_dir.y;
     }
     let light_to_frag = (*light).position_radius.xyz - world_position.xyz;

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -1,12 +1,11 @@
-#import bevy_pbr::pbr_prepass_functions
-#import bevy_pbr::pbr_bindings
-#import bevy_pbr::pbr_types
-#ifdef NORMAL_PREPASS
-#import bevy_pbr::pbr_functions
-#endif // NORMAL_PREPASS
-
-#import bevy_pbr::prepass_io as prepass_io
-#import bevy_pbr::mesh_view_bindings view
+#import bevy_pbr::{
+    pbr_prepass_functions,
+    pbr_bindings::material,
+    pbr_types,
+    pbr_functions,
+    prepass_io,
+    mesh_view_bindings::view,
+}
  
 #ifdef PREPASS_FRAGMENT
 @fragment
@@ -14,7 +13,7 @@ fn fragment(
     in: prepass_io::VertexOutput,
     @builtin(front_facing) is_front: bool,
 ) -> prepass_io::FragmentOutput {
-    bevy_pbr::pbr_prepass_functions::prepass_alpha_discard(in);
+    pbr_prepass_functions::prepass_alpha_discard(in);
 
     var out: prepass_io::FragmentOutput;
 
@@ -24,15 +23,15 @@ fn fragment(
 
 #ifdef NORMAL_PREPASS
     // NOTE: Unlit bit not set means == 0 is true, so the true case is if lit
-    if (bevy_pbr::pbr_bindings::material.flags & bevy_pbr::pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u {
-        let world_normal = bevy_pbr::pbr_functions::prepare_world_normal(
+    if (material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_UNLIT_BIT) == 0u {
+        let world_normal = pbr_functions::prepare_world_normal(
             in.world_normal,
-            (bevy_pbr::pbr_bindings::material.flags & bevy_pbr::pbr_types::STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT) != 0u,
+            (material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_DOUBLE_SIDED_BIT) != 0u,
             is_front,
         );
 
-        let normal = bevy_pbr::pbr_functions::apply_normal_mapping(
-            bevy_pbr::pbr_bindings::material.flags,
+        let normal = pbr_functions::apply_normal_mapping(
+            material.flags,
             world_normal,
 #ifdef VERTEX_TANGENTS
 #ifdef STANDARDMATERIAL_NORMAL_MAP
@@ -52,7 +51,7 @@ fn fragment(
 #endif // NORMAL_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
-    out.motion_vector = bevy_pbr::pbr_prepass_functions::calculate_motion_vector(in.world_position, in.previous_world_position);
+    out.motion_vector = pbr_prepass_functions::calculate_motion_vector(in.world_position, in.previous_world_position);
 #endif
 
     return out;
@@ -60,6 +59,6 @@ fn fragment(
 #else
 @fragment
 fn fragment(in: prepass_io::VertexOutput) {
-    bevy_pbr::pbr_prepass_functions::prepass_alpha_discard(in);
+    pbr_prepass_functions::prepass_alpha_discard(in);
 }
 #endif // PREPASS_FRAGMENT

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -1,11 +1,12 @@
 #define_import_path bevy_pbr::pbr_prepass_functions
-#import bevy_pbr::prepass_io VertexOutput
-#import bevy_pbr::prepass_bindings previous_view_proj
-#import bevy_pbr::mesh_view_bindings view
 
-#import bevy_pbr::pbr_bindings as pbr_bindings
-#import bevy_pbr::pbr_types as pbr_types
-
+#import bevy_pbr::{
+    prepass_io::VertexOutput,
+    prepass_bindings::previous_view_proj,
+    mesh_view_bindings::view,
+    pbr_bindings,
+    pbr_types,
+}
 
 // Cutoff used for the premultiplied alpha modes BLEND and ADD.
 const PREMULTIPLIED_ALPHA_CUTOFF = 0.05;

--- a/crates/bevy_pbr/src/render/shadow_sampling.wgsl
+++ b/crates/bevy_pbr/src/render/shadow_sampling.wgsl
@@ -1,7 +1,9 @@
 #define_import_path bevy_pbr::shadow_sampling
 
-#import bevy_pbr::mesh_view_bindings as view_bindings
-#import bevy_pbr::utils PI
+#import bevy_pbr::{
+    mesh_view_bindings as view_bindings,
+    utils::PI,
+}
 
 // Do the lookup, using HW 2x2 PCF and comparison
 fn sample_shadow_map_hardware(light_local: vec2<f32>, depth: f32, array_index: i32) -> f32 {

--- a/crates/bevy_pbr/src/render/shadows.wgsl
+++ b/crates/bevy_pbr/src/render/shadows.wgsl
@@ -1,9 +1,11 @@
 #define_import_path bevy_pbr::shadows
 
-#import bevy_pbr::mesh_view_types  POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE
-#import bevy_pbr::mesh_view_bindings as view_bindings
-#import bevy_pbr::utils  hsv2rgb
-#import bevy_pbr::shadow_sampling sample_shadow_map
+#import bevy_pbr::{
+    mesh_view_types::POINT_LIGHT_FLAGS_SPOT_LIGHT_Y_NEGATIVE,
+    mesh_view_bindings as view_bindings,
+    utils::hsv2rgb,
+    shadow_sampling::sample_shadow_map
+}
 
 const flip_z: vec3<f32> = vec3<f32>(1.0, 1.0, -1.0);
 

--- a/crates/bevy_pbr/src/render/skinning.wgsl
+++ b/crates/bevy_pbr/src/render/skinning.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::skinning
 
-#import bevy_pbr::mesh_types  SkinnedMesh
+#import bevy_pbr::mesh_types::SkinnedMesh
 
 #ifdef SKINNED
 

--- a/crates/bevy_pbr/src/render/wireframe.wgsl
+++ b/crates/bevy_pbr/src/render/wireframe.wgsl
@@ -1,4 +1,5 @@
-#import bevy_pbr::forward_io VertexOutput
+#import bevy_pbr::forward_io::VertexOutput
+
 struct WireframeMaterial {
     color: vec4<f32>,
 };

--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -5,10 +5,14 @@
 // Source code heavily based on XeGTAO v1.30 from Intel
 // https://github.com/GameTechDev/XeGTAO/blob/0d177ce06bfa642f64d8af4de1197ad1bcb862d4/Source/Rendering/Shaders/XeGTAO.hlsli
 
-#import bevy_pbr::gtao_utils fast_acos
-#import bevy_pbr::utils PI, HALF_PI
-#import bevy_render::view View
-#import bevy_render::globals Globals
+#import bevy_pbr::{
+    gtao_utils::fast_acos,
+    utils::{PI, HALF_PI},
+}
+#import bevy_render::{
+    view::View,
+    globals::Globals,
+}
 
 @group(0) @binding(0) var preprocessed_depth: texture_2d<f32>;
 @group(0) @binding(1) var normals: texture_2d<f32>;

--- a/crates/bevy_pbr/src/ssao/gtao_utils.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao_utils.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_pbr::gtao_utils
 
-#import bevy_pbr::utils PI, HALF_PI
+#import bevy_pbr::utils::{PI, HALF_PI}
 
 // Approximates single-bounce ambient occlusion to multi-bounce ambient occlusion
 // https://blog.selfshadow.com/publications/s2016-shading-course/activision/s2016_pbs_activision_occlusion.pdf#page=78

--- a/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
+++ b/crates/bevy_pbr/src/ssao/preprocess_depth.wgsl
@@ -5,7 +5,7 @@
 
 // Reference: https://research.nvidia.com/sites/default/files/pubs/2012-06_Scalable-Ambient-Obscurance/McGuire12SAO.pdf, section 2.2
 
-#import bevy_render::view View
+#import bevy_render::view::View
 
 @group(0) @binding(0) var input_depth: texture_depth_2d;
 @group(0) @binding(1) var preprocessed_depth_mip0: texture_storage_2d<r16float, write>;

--- a/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
+++ b/crates/bevy_pbr/src/ssao/spatial_denoise.wgsl
@@ -9,7 +9,7 @@
 // XeGTAO does a 3x3 filter, on two pixels at a time per compute thread, applied twice
 // We do a 3x3 filter, on 1 pixel per compute thread, applied once
 
-#import bevy_render::view View
+#import bevy_render::view::View
 
 @group(0) @binding(0) var ambient_occlusion_noisy: texture_2d<f32>;
 @group(0) @binding(1) var depth_differences: texture_2d<u32>;

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -62,7 +62,7 @@ codespan-reporting = "0.11.0"
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
 wgpu = { version = "0.17.1", features = ["naga", "fragile-send-sync-non-atomic-wasm"] }
 naga = { version = "0.13.0", features = ["wgsl-in"] }
-naga_oil = "0.9"
+naga_oil = "0.10"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -1,6 +1,7 @@
-#import bevy_sprite::mesh2d_types          Mesh2d
-#import bevy_sprite::mesh2d_vertex_output  VertexOutput
-#import bevy_sprite::mesh2d_view_bindings  view
+#import bevy_sprite::{
+    mesh2d_vertex_output::VertexOutput,
+    mesh2d_view_bindings::view,
+}
 
 #ifdef TONEMAP_IN_SHADER
 #import bevy_core_pipeline::tonemapping
@@ -29,7 +30,7 @@ fn fragment(
         output_color = output_color * textureSample(texture, texture_sampler, mesh.uv);
     }
 #ifdef TONEMAP_IN_SHADER
-    output_color = bevy_core_pipeline::tonemapping::tone_mapping(output_color, view.color_grading);
+    output_color = tonemapping::tone_mapping(output_color, view.color_grading);
 #endif
     return output_color;
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -1,7 +1,8 @@
-#import bevy_sprite::mesh2d_functions as mesh_functions
-#import bevy_sprite::mesh2d_bindings       mesh
-#import bevy_sprite::mesh2d_vertex_output  VertexOutput
-#import bevy_sprite::mesh2d_view_bindings  view
+#import bevy_sprite::{
+    mesh2d_functions as mesh_functions,
+    mesh2d_vertex_output::VertexOutput,
+    mesh2d_view_bindings::view,
+}
 
 #ifdef TONEMAP_IN_SHADER
 #import bevy_core_pipeline::tonemapping
@@ -66,7 +67,7 @@ fn fragment(
 #ifdef VERTEX_COLORS
     var color = in.color;
 #ifdef TONEMAP_IN_SHADER
-    color = bevy_core_pipeline::tonemapping::tone_mapping(color, view.color_grading);
+    color = tonemapping::tone_mapping(color, view.color_grading);
 #endif
     return color;
 #else

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_bindings.wgsl
@@ -1,6 +1,6 @@
 #define_import_path bevy_sprite::mesh2d_bindings
 
-#import bevy_sprite::mesh2d_types Mesh2d
+#import bevy_sprite::mesh2d_types::Mesh2d
 
 #ifdef MESH_BINDGROUP_1
 

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_functions.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_functions.wgsl
@@ -1,9 +1,13 @@
 #define_import_path bevy_sprite::mesh2d_functions
 
-#import bevy_sprite::mesh2d_view_bindings  view
-#import bevy_sprite::mesh2d_bindings       mesh
-#import bevy_render::instance_index        get_instance_index
-#import bevy_render::maths                 affine_to_square, mat2x4_f32_to_mat3x3_unpack
+#import bevy_sprite::{
+    mesh2d_view_bindings::view,
+    mesh2d_bindings::mesh,
+}
+#import bevy_render::{
+    instance_index::get_instance_index,
+    maths::{affine_to_square, mat2x4_f32_to_mat3x3_unpack},
+}
 
 fn get_model_matrix(instance_index: u32) -> mat4x4<f32> {
     return affine_to_square(mesh[get_instance_index(instance_index)].model);

--- a/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d_view_bindings.wgsl
@@ -1,7 +1,7 @@
 #define_import_path bevy_sprite::mesh2d_view_bindings
 
-#import bevy_render::view  View
-#import bevy_render::globals  Globals
+#import bevy_render::view::View
+#import bevy_render::globals::Globals
 
 @group(0) @binding(0) var<uniform> view: View;
 

--- a/crates/bevy_sprite/src/render/sprite.wgsl
+++ b/crates/bevy_sprite/src/render/sprite.wgsl
@@ -2,8 +2,10 @@
 #import bevy_core_pipeline::tonemapping
 #endif
 
-#import bevy_render::maths affine_to_square
-#import bevy_render::view  View
+#import bevy_render::{
+    maths::affine_to_square,
+    view::View,
+}
 
 @group(0) @binding(0) var<uniform> view: View;
 
@@ -54,7 +56,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     var color = in.color * textureSample(sprite_texture, sprite_sampler, in.uv);
 
 #ifdef TONEMAP_IN_SHADER
-    color = bevy_core_pipeline::tonemapping::tone_mapping(color, view.color_grading);
+    color = tonemapping::tone_mapping(color, view.color_grading);
 #endif
 
     return color;

--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -1,4 +1,4 @@
-#import bevy_render::view  View
+#import bevy_render::view::View
 
 const TEXTURED_QUAD: u32 = 0u;
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -219,8 +219,7 @@ type DrawColoredMesh2d = (
 // using `include_str!()`, or loaded like any other asset with `asset_server.load()`.
 const COLORED_MESH2D_SHADER: &str = r"
 // Import the standard 2d mesh uniforms and set their bind groups
-#import bevy_sprite::mesh2d_bindings mesh
-#import bevy_sprite::mesh2d_functions as MeshFunctions
+#import bevy_sprite::mesh2d_functions
 
 // The structure of the vertex buffer is as specified in `specialize()`
 struct Vertex {
@@ -241,8 +240,8 @@ struct VertexOutput {
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
     // Project the world position of the mesh into screen position
-    let model = MeshFunctions::get_model_matrix(vertex.instance_index);
-    out.clip_position = MeshFunctions::mesh2d_position_local_to_clip(model, vec4<f32>(vertex.position, 1.0));
+    let model = mesh2d_functions::get_model_matrix(vertex.instance_index);
+    out.clip_position = mesh2d_functions::mesh2d_position_local_to_clip(model, vec4<f32>(vertex.position, 1.0));
     // Unpack the `u32` from the vertex buffer into the `vec4<f32>` used by the fragment shader
     out.color = vec4<f32>((vec4<u32>(vertex.color) >> vec4<u32>(0u, 8u, 16u, 24u)) & vec4<u32>(255u)) / 255.0;
     return out;


### PR DESCRIPTION
# Objective

- bump naga_oil to 0.10
- update shader imports to use rusty syntax

## Migration Guide

naga_oil 0.10 reworks the import mechanism to support more syntax to make it more rusty, and test for item use before importing to determine which imports are modules and which are items, which allows:

- use rust-style imports
```
#import bevy_pbr::{
    pbr_functions::{alpha_discard as discard, apply_pbr_lighting}, 
    mesh_bindings,
}
```

- import partial paths:
```
#import part::of::path
...
path::remainder::function();
```
which will call to `part::of::path::remainder::function`

- use fully qualified paths without importing:
```
// #import bevy_pbr::pbr_functions
bevy_pbr::pbr_functions::pbr()
```
- use imported items without qualifying
```
#import bevy_pbr::pbr_functions::pbr
// for backwards compatibility the old style is still supported:
// #import bevy_pbr::pbr_functions pbr
...
pbr()
```

- allows most imported items to end with `_` and numbers (naga_oil#30). still doesn't allow struct members to end with `_` or numbers but it's progress. 

- the vast majority of existing shader code will work without changes, but will emit "deprecated" warnings for old-style imports. these can be suppressed with the `allow-deprecated` feature.

- partly breaks overrides (as far as i'm aware nobody uses these yet) - now overrides will only be applied if the overriding module is added as an additional import in the arguments to `Composer::make_naga_module` or `Composer::add_composable_module`. this is necessary to support determining whether imports are modules or items.