### PR TITLE
Add note about asset source register order

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -242,6 +242,9 @@ pub trait AssetApp {
     /// Registers the given `processor` in the [`App`]'s [`AssetProcessor`].
     fn register_asset_processor<P: Process>(&mut self, processor: P) -> &mut Self;
     /// Registers the given [`AssetSourceBuilder`] with the given `id`.
+    ///
+    /// Note that asset sources must be registered before adding [`AssetPlugin`] to your application,
+    /// since registered asset sources are built at that point and not after.
     fn register_asset_source(
         &mut self,
         id: impl Into<AssetSourceId<'static>>,


### PR DESCRIPTION
# Objective

I encountered a problem where I had a plugin `FooPlugin` which did

```rust
impl Plugin for FooPlugin {
    fn build(&self, app: &mut App) {
        app
           .register_asset_source(...); // more stuff after
    }
}
```

And when I tried using it, e.g.

```rust
asset_server.load("foo://data/asset.custom");
```

I got an error that `foo` was not recognized as a source.

I found that this is because asset sources must be registered _before_ `AssetPlugin` is added, and I had `FooPlugin` _after_.

## Solution

Add clarifying note about having to register sources before `AssetPlugin` is added.