### PR TITLE
Receiver plane depth bias

### DIFF
--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -97,7 +97,15 @@ fn setup(
         commands.spawn(PbrBundle {
             mesh: sphere_handle.clone(),
             material: white_handle.clone(),
-            transform: Transform::from_xyz(0.0, spawn_height, z_i32 as f32),
+            transform: Transform::from_xyz(
+                0.0,
+                if z_i32 % 4 == 0 {
+                    spawn_height
+                } else {
+                    sphere_radius
+                },
+                z_i32 as f32,
+            ),
             ..default()
         });
     }
@@ -111,67 +119,71 @@ fn setup(
 
     let style = TextStyle {
         font_size: 20.,
-        color: Color::rgb(1.0, 0.0, 0.5),
         ..default()
     };
-    commands.spawn(
-        TextBundle::from_sections([
-            TextSection::new("Controls:\n", style.clone()),
-            TextSection::new("WSAD  - forward/back/strafe left/right\n", style.clone()),
-            TextSection::new("E / Q - up / down\n", style.clone()),
-            TextSection::new("R / Z - reset biases to default / zero\n", style.clone()),
-            TextSection::new(
-                "L     - switch between directional and point lights [",
-                style.clone(),
-            ),
-            TextSection::new("DirectionalLight", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new(
-                "F     - switch directional light filter methods [",
-                style.clone(),
-            ),
-            TextSection::new("Hardware2x2", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new("1/2   - change point light depth bias [", style.clone()),
-            TextSection::new("0.00", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new("3/4   - change point light normal bias [", style.clone()),
-            TextSection::new("0.0", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new("5/6   - change direction light depth bias [", style.clone()),
-            TextSection::new("0.00", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new(
-                "7/8   - change direction light normal bias [",
-                style.clone(),
-            ),
-            TextSection::new("0.0", style.clone()),
-            TextSection::new("]\n", style.clone()),
-            TextSection::new(
-                "left/right/up/down/pgup/pgdown - adjust light position (looking at 0,0,0) [",
-                style.clone(),
-            ),
-            TextSection::new(
-                format!("{:.1},", light_transform.translation.x),
-                style.clone(),
-            ),
-            TextSection::new(
-                format!(" {:.1},", light_transform.translation.y),
-                style.clone(),
-            ),
-            TextSection::new(
-                format!(" {:.1}", light_transform.translation.z),
-                style.clone(),
-            ),
-            TextSection::new("]\n", style.clone()),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(12.0),
-            left: Val::Px(12.0),
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                position_type: PositionType::Absolute,
+                padding: UiRect::all(Val::Px(5.0)),
+                ..default()
+            },
+            z_index: ZIndex::Global(i32::MAX),
+            background_color: Color::BLACK.with_a(0.75).into(),
             ..default()
-        }),
-    );
+        })
+        .with_children(|c| {
+            c.spawn(TextBundle::from_sections([
+                TextSection::new("Controls:\n", style.clone()),
+                TextSection::new("WSAD  - forward/back/strafe left/right\n", style.clone()),
+                TextSection::new("E / Q - up / down\n", style.clone()),
+                TextSection::new("R / Z - reset biases to default / zero\n", style.clone()),
+                TextSection::new(
+                    "L     - switch between directional and point lights [",
+                    style.clone(),
+                ),
+                TextSection::new("DirectionalLight", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new(
+                    "F     - switch directional light filter methods [",
+                    style.clone(),
+                ),
+                TextSection::new("Hardware2x2", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new("1/2   - change point light depth bias [", style.clone()),
+                TextSection::new("0.00", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new("3/4   - change point light normal bias [", style.clone()),
+                TextSection::new("0.0", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new("5/6   - change direction light depth bias [", style.clone()),
+                TextSection::new("0.00", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new(
+                    "7/8   - change direction light normal bias [",
+                    style.clone(),
+                ),
+                TextSection::new("0.0", style.clone()),
+                TextSection::new("]\n", style.clone()),
+                TextSection::new(
+                    "left/right/up/down/pgup/pgdown - adjust light position (looking at 0,0,0) [",
+                    style.clone(),
+                ),
+                TextSection::new(
+                    format!("{:.1},", light_transform.translation.x),
+                    style.clone(),
+                ),
+                TextSection::new(
+                    format!(" {:.1},", light_transform.translation.y),
+                    style.clone(),
+                ),
+                TextSection::new(
+                    format!(" {:.1}", light_transform.translation.z),
+                    style.clone(),
+                ),
+                TextSection::new("]\n", style.clone()),
+            ]));
+        });
 }
 
 fn toggle_light(

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -111,6 +111,7 @@ fn setup(
 
     let style = TextStyle {
         font_size: 20.,
+        color: Color::rgb(1.0, 0.0, 0.5),
         ..default()
     };
     commands.spawn(
@@ -125,7 +126,10 @@ fn setup(
             ),
             TextSection::new("DirectionalLight", style.clone()),
             TextSection::new("]\n", style.clone()),
-            TextSection::new("F     - switch between filter methods [", style.clone()),
+            TextSection::new(
+                "F     - switch directional light filter methods [",
+                style.clone(),
+            ),
             TextSection::new("Hardware2x2", style.clone()),
             TextSection::new("]\n", style.clone()),
             TextSection::new("1/2   - change point light depth bias [", style.clone()),
@@ -269,40 +273,27 @@ fn adjust_point_light_biases(
     for mut light in &mut query {
         if input.just_pressed(KeyCode::Key1) {
             light.shadow_depth_bias -= depth_bias_step_size;
-            example_text.single_mut().sections[11].value =
-                format!("{:.2}", light.shadow_depth_bias);
         }
         if input.just_pressed(KeyCode::Key2) {
             light.shadow_depth_bias += depth_bias_step_size;
-            example_text.single_mut().sections[11].value =
-                format!("{:.2}", light.shadow_depth_bias);
         }
         if input.just_pressed(KeyCode::Key3) {
             light.shadow_normal_bias -= normal_bias_step_size;
-            example_text.single_mut().sections[14].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::Key4) {
             light.shadow_normal_bias += normal_bias_step_size;
-            example_text.single_mut().sections[14].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::R) {
             light.shadow_depth_bias = PointLight::DEFAULT_SHADOW_DEPTH_BIAS;
-            example_text.single_mut().sections[11].value =
-                format!("{:.2}", light.shadow_depth_bias);
             light.shadow_normal_bias = PointLight::DEFAULT_SHADOW_NORMAL_BIAS;
-            example_text.single_mut().sections[14].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::Z) {
             light.shadow_depth_bias = 0.0;
-            example_text.single_mut().sections[11].value =
-                format!("{:.2}", light.shadow_depth_bias);
             light.shadow_normal_bias = 0.0;
-            example_text.single_mut().sections[14].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
+
+        example_text.single_mut().sections[11].value = format!("{:.2}", light.shadow_depth_bias);
+        example_text.single_mut().sections[14].value = format!("{:.1}", light.shadow_normal_bias);
     }
 }
 
@@ -316,40 +307,27 @@ fn adjust_directional_light_biases(
     for mut light in &mut query {
         if input.just_pressed(KeyCode::Key5) {
             light.shadow_depth_bias -= depth_bias_step_size;
-            example_text.single_mut().sections[17].value =
-                format!("{:.2}", light.shadow_depth_bias);
         }
         if input.just_pressed(KeyCode::Key6) {
             light.shadow_depth_bias += depth_bias_step_size;
-            example_text.single_mut().sections[17].value =
-                format!("{:.2}", light.shadow_depth_bias);
         }
         if input.just_pressed(KeyCode::Key7) {
             light.shadow_normal_bias -= normal_bias_step_size;
-            example_text.single_mut().sections[20].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::Key8) {
             light.shadow_normal_bias += normal_bias_step_size;
-            example_text.single_mut().sections[20].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::R) {
             light.shadow_depth_bias = DirectionalLight::DEFAULT_SHADOW_DEPTH_BIAS;
-            example_text.single_mut().sections[17].value =
-                format!("{:.2}", light.shadow_depth_bias);
             light.shadow_normal_bias = DirectionalLight::DEFAULT_SHADOW_NORMAL_BIAS;
-            example_text.single_mut().sections[20].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
         if input.just_pressed(KeyCode::Z) {
             light.shadow_depth_bias = 0.0;
-            example_text.single_mut().sections[17].value =
-                format!("{:.2}", light.shadow_depth_bias);
             light.shadow_normal_bias = 0.0;
-            example_text.single_mut().sections[20].value =
-                format!("{:.1}", light.shadow_normal_bias);
         }
+
+        example_text.single_mut().sections[17].value = format!("{:.2}", light.shadow_depth_bias);
+        example_text.single_mut().sections[20].value = format!("{:.1}", light.shadow_normal_bias);
     }
 }
 


### PR DESCRIPTION
# Objective

- Avoid self-shadowing with larger offsets from the fragment position in light space when doing PCF

## Solution

- The problem is that the same light space depth at the fragment position is used to compare to offset positions in the shadow map when using the new PCF techniques. As these offsets get further away from the centre of the filter kernel, and if the surface is at a steep angle, the biasing of the fragment position is insufficient to account for the difference in depth at the offset position. (The PDF below has diagrams.)
- Use [Receiver Plane Depth Bias](https://web.archive.org/web/20230309054654/http://developer.amd.com/wordpress/media/2012/10/Isidoro-ShadowMapping.pdf) (slides 36-40) but using [TheRealMJP's implementation](https://github.com/TheRealMJP/Shadows/blob/1a6d90c92ea58ccddb0dcd32b035c58b8f7784f4/Shadows/Mesh.hlsl#L102)

## Screenshots

Use the `shadow_biases` example and moving the light to 5,1,4. Use the default biases (press R).

### Before

Hardware 2x2:
<img width="1392" alt="Screenshot 2023-10-19 at 15 57 43" src="https://github.com/bevyengine/bevy/assets/302146/a2e89a42-12cc-4e5d-811a-a2e8192fd4e9">

This looks fine because the sample positions used by hardware 2x2 are close enough to the fragment position.

Castano13 (The Witness):
<img width="1392" alt="Screenshot 2023-10-19 at 15 57 53" src="https://github.com/bevyengine/bevy/assets/302146/e8766720-826a-45f5-8164-dc1a56acd782">

Note the bands of self-shadowing on the right side on the ground plane.

Jimenez14 (Call of Duty: Advanced Warfare):
<img width="1392" alt="Screenshot 2023-10-19 at 15 58 00" src="https://github.com/bevyengine/bevy/assets/302146/578250f3-0323-4a60-bdab-4d9008a1ce2c">

The bands are present here too.

### After

Hardware 2x2:
<img width="1392" alt="Screenshot 2023-10-19 at 18 36 38" src="https://github.com/bevyengine/bevy/assets/302146/5a4c1a9b-8a76-4185-9043-302fc9eaf716">

It is the same, but here for completeness.

Castano13:
<img width="1392" alt="Screenshot 2023-10-19 at 18 36 44" src="https://github.com/bevyengine/bevy/assets/302146/d0b22ff6-1be0-40a6-b8a6-f6bf7ea7e315">

Jimenez14:
<img width="1392" alt="Screenshot 2023-10-19 at 18 36 49" src="https://github.com/bevyengine/bevy/assets/302146/107bb932-b14c-43a6-ab18-4db97b25d7cd">

---

## Changelog

- Fixed: Prevent self-shadowing with directional lights where the receiving mesh plane is at a steep angle to the light by using a Receiver Plane Depth Bias.