### PR TITLE
chore: use ExtractComponent derive macro for EnvironmentMapLight and FogSettings

### DIFF
--- a/crates/bevy_pbr/src/environment_map/mod.rs
+++ b/crates/bevy_pbr/src/environment_map/mod.rs
@@ -46,7 +46,8 @@ impl Plugin for EnvironmentMapPlugin {
 /// The diffuse map uses the Lambertian distribution, and the specular map uses the GGX distribution.
 ///
 /// `KhronosGroup` also has several prefiltered environment maps that can be found [here](https://github.com/KhronosGroup/glTF-Sample-Environments).
-#[derive(Component, Reflect, Clone)]
+#[derive(Component, Reflect, Clone, ExtractComponent)]
+#[extract_component_filter(With<Camera3d>)]
 pub struct EnvironmentMapLight {
     pub diffuse_map: Handle<Image>,
     pub specular_map: Handle<Image>,
@@ -57,16 +58,6 @@ impl EnvironmentMapLight {
     /// have been loaded by the asset server.
     pub fn is_loaded(&self, images: &RenderAssets<Image>) -> bool {
         images.get(&self.diffuse_map).is_some() && images.get(&self.specular_map).is_some()
-    }
-}
-
-impl ExtractComponent for EnvironmentMapLight {
-    type Query = &'static Self;
-    type Filter = With<Camera3d>;
-    type Out = Self;
-
-    fn extract_component(item: bevy_ecs::query::QueryItem<'_, Self::Query>) -> Option<Self::Out> {
-        Some(item.clone())
     }
 }
 

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -1,5 +1,5 @@
 use crate::ReflectComponent;
-use bevy_ecs::{prelude::*, query::QueryItem};
+use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
 use bevy_reflect::Reflect;
 use bevy_render::{color::Color, extract_component::ExtractComponent, prelude::Camera};
@@ -47,7 +47,8 @@ use bevy_render::{color::Color, extract_component::ExtractComponent, prelude::Ca
 ///
 /// Once enabled for a specific camera, the fog effect can also be disabled for individual
 /// [`StandardMaterial`](crate::StandardMaterial) instances via the `fog_enabled` flag.
-#[derive(Debug, Clone, Component, Reflect)]
+#[derive(Debug, Clone, Component, Reflect, ExtractComponent)]
+#[extract_component_filter(With<Camera>)]
 #[reflect(Component)]
 pub struct FogSettings {
     /// The color of the fog effect.
@@ -472,15 +473,5 @@ impl Default for FogSettings {
             directional_light_color: Color::NONE,
             directional_light_exponent: 8.0,
         }
-    }
-}
-
-impl ExtractComponent for FogSettings {
-    type Query = &'static Self;
-    type Filter = With<Camera>;
-    type Out = Self;
-
-    fn extract_component(item: QueryItem<Self::Query>) -> Option<Self::Out> {
-        Some(item.clone())
     }
 }


### PR DESCRIPTION
I've done tiny cleanup when playing with code.

## Solution

[derive macro](https://github.com/bevyengine/bevy/blob/main/crates/bevy_render/macros/src/extract_component.rs) with `extract_component_filter` attribute generate the same code I removed.

## Migration Guide

No migration needed
