### PR TITLE
fix run-once runners

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -333,8 +333,7 @@ impl App {
     }
 
     /// Run [`Plugin::finish`] for each plugin. This is usually called by the event loop once all
-    /// plugins are [`App::ready`], but can be useful for situations where you want to use
-    /// [`App::update`].
+    /// plugins are ready, but can be useful for situations where you want to use [`App::update`].
     pub fn finish(&mut self) {
         // temporarily remove the plugin registry to run each plugin's setup function on app.
         let plugin_registry = std::mem::take(&mut self.plugin_registry);

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -326,11 +326,9 @@ impl App {
                         return PluginsState::Adding;
                     }
                 }
-                return PluginsState::Ready;
+                PluginsState::Ready
             }
-            state => {
-                return state;
-            }
+            state => state,
         }
     }
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -315,7 +315,7 @@ impl App {
         (runner)(app);
     }
 
-    /// Check that [`Plugin::ready`] of all plugins returns true. This is usually called by the
+    /// Check the state of all plugins already added to this app. This is usually called by the
     /// event loop, but can be useful for situations where you want to use [`App::update`]
     #[inline]
     pub fn plugins_state(&self) -> PluginsState {

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -978,14 +978,20 @@ impl App {
 }
 
 fn run_once(mut app: App) {
-    while app.plugins_state() != PluginsState::Ready {
-        #[cfg(not(target_arch = "wasm32"))]
-        bevy_tasks::tick_global_task_pools_on_main_thread();
+    let plugins_state = app.plugins_state();
+    if plugins_state != PluginsState::Cleaned {
+        while app.plugins_state() == PluginsState::Adding {
+            #[cfg(not(target_arch = "wasm32"))]
+            bevy_tasks::tick_global_task_pools_on_main_thread();
+        }
+        app.finish();
+        app.cleanup();
     }
-    app.finish();
-    app.cleanup();
 
-    app.update();
+    // if plugins where cleaned before the runner start, an update already ran
+    if plugins_state != PluginsState::Cleaned {
+        app.update();
+    }
 }
 
 /// An event that indicates the [`App`] should exit. This will fully exit the app process at the

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -1,6 +1,7 @@
 use crate::{
     app::{App, AppExit},
     plugin::Plugin,
+    PluginsState,
 };
 use bevy_ecs::event::{Events, ManualEventReader};
 use bevy_utils::{Duration, Instant};
@@ -71,8 +72,9 @@ impl Plugin for ScheduleRunnerPlugin {
     fn build(&self, app: &mut App) {
         let run_mode = self.run_mode;
         app.set_runner(move |mut app: App| {
-            if !app.ready() {
-                while !app.ready() {
+            let plugins_state = app.plugins_state();
+            if plugins_state != PluginsState::Cleaned {
+                while app.plugins_state() != PluginsState::Ready {
                     #[cfg(not(target_arch = "wasm32"))]
                     bevy_tasks::tick_global_task_pools_on_main_thread();
                 }
@@ -83,7 +85,10 @@ impl Plugin for ScheduleRunnerPlugin {
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match run_mode {
                 RunMode::Once => {
-                    app.update();
+                    // if plugins where cleaned before the runner start, an update already ran
+                    if plugins_state != PluginsState::Cleaned {
+                        app.update();
+                    }
                 }
                 RunMode::Loop { wait } => {
                     let mut tick = move |app: &mut App,

--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -74,7 +74,7 @@ impl Plugin for ScheduleRunnerPlugin {
         app.set_runner(move |mut app: App| {
             let plugins_state = app.plugins_state();
             if plugins_state != PluginsState::Cleaned {
-                while app.plugins_state() != PluginsState::Ready {
+                while app.plugins_state() == PluginsState::Adding {
                     #[cfg(not(target_arch = "wasm32"))]
                     bevy_tasks::tick_global_task_pools_on_main_thread();
                 }


### PR DESCRIPTION
# Objective

- After #9826, there are issues on "run once runners"
- example `without_winit` crashes:
```
2023-10-19T22:06:01.810019Z  INFO bevy_render::renderer: AdapterInfo { name: "llvmpipe (LLVM 15.0.7, 256 bits)", vendor: 65541, device: 0, device_type: Cpu, driver: "llvmpipe", driver_info: "Mesa 23.2.1 - kisak-mesa PPA (LLVM 15.0.7)", backend: Vulkan }
2023-10-19T22:06:02.860331Z  WARN bevy_audio::audio_output: No audio device found.
2023-10-19T22:06:03.215154Z  INFO bevy_diagnostic::system_information_diagnostics_plugin::internal: SystemInfo { os: "Linux 22.04 Ubuntu", kernel: "6.2.0-1014-azure", cpu: "Intel(R) Xeon(R) CPU E5-2673 v3 @ 2.40GHz", core_count: "2", memory: "6.8 GiB" }
thread 'main' panicked at crates/bevy_render/src/pipelined_rendering.rs:91:14:
Unable to get RenderApp. Another plugin may have removed the RenderApp before PipelinedRenderingPlugin
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
- example `headless` runs the app twice with the `run_once` schedule

## Solution

- Expose a more complex state of an app than just "ready"
- Also block adding plugins to an app after it has finished or cleaned up its plugins as that wouldn't work anyway

## Migration Guide

* `app.ready()` has been replaced by `app.plugins_state()` which will return more details on the current state of plugins in the app
