### PR TITLE
remove unused import on android

### DIFF
--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -1,6 +1,5 @@
 use crate::io::{
-    get_meta_path, AssetReader, AssetReaderError, AssetWatcher, EmptyPathStream, PathStream,
-    Reader, VecReader,
+    get_meta_path, AssetReader, AssetReaderError, EmptyPathStream, PathStream, Reader, VecReader,
 };
 use bevy_log::error;
 use bevy_utils::BoxedFuture;


### PR DESCRIPTION
# Objective

- Building for android has a warning
```
warning: unused import: `AssetWatcher`
 --> crates/bevy_asset/src/io/android.rs:2:51
  |
2 |     get_meta_path, AssetReader, AssetReaderError, AssetWatcher, EmptyPathStream, PathStream,
  |                                                   ^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default
```

## Solution

- Remove the import
