### PR TITLE
Log an error when registering an AssetSource after AssetPlugin has been built

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -47,6 +47,7 @@ use bevy_ecs::{
     schedule::{IntoSystemConfigs, IntoSystemSetConfigs, ScheduleLabel, SystemSet},
     world::FromWorld,
 };
+use bevy_log::error;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use std::{any::TypeId, sync::Arc};
 
@@ -349,6 +350,11 @@ impl AssetApp for App {
         id: impl Into<AssetSourceId<'static>>,
         source: AssetSourceBuilder,
     ) -> &mut Self {
+        let id = id.into();
+        if self.world.get_resource::<AssetServer>().is_some() {
+            error!("{} must be registered before DefaultPlugins", id);
+        }
+
         {
             let mut sources = self
                 .world

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -352,7 +352,7 @@ impl AssetApp for App {
     ) -> &mut Self {
         let id = id.into();
         if self.world.get_resource::<AssetServer>().is_some() {
-            error!("{} must be registered before DefaultPlugins", id);
+            error!("{} must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)", id);
         }
 
         {


### PR DESCRIPTION
# Objective

- Provides actionable feedback when users encounter the error in https://github.com/bevyengine/bevy/issues/10162
- Complements https://github.com/bevyengine/bevy/pull/10186

## Solution

- Log an error when registering an AssetSource after the AssetPlugin has been built (via DefaultPlugins). This will let users know that their registration order needs changing

The outputted error message will look like this:
```rust
ERROR bevy_asset::server: 'AssetSourceId::Name(test)' must be registered before `AssetPlugin` (typically added as part of `DefaultPlugins`)
```


