### PR TITLE
re-export `debug_glam_assert` feature 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -232,6 +232,9 @@ accesskit_unix = ["bevy_internal/accesskit_unix"]
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["bevy_internal/glam_assert"]
 
+# Enable assertions in debug builds to check the validity of parameters passed to glam
+debug_glam_assert = ["bevy_internal/debug_glam_assert"]
+
 # Include a default font, containing only ASCII characters, at the cost of a 20kB binary size increase
 default_font = ["bevy_internal/default_font"]
 

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -97,8 +97,12 @@ accesskit_unix = ["bevy_winit/accesskit_unix"]
 bevy_text = ["dep:bevy_text", "bevy_ui?/bevy_text"]
 
 bevy_render = ["dep:bevy_render", "bevy_scene?/bevy_render"]
+
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["bevy_math/glam_assert"]
+
+# Enable assertions in debug builds to check the validity of parameters passed to glam
+debug_glam_assert = ["bevy_math/debug_glam_assert"]
 
 default_font = ["bevy_text?/default_font"]
 

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -18,3 +18,5 @@ serialize = ["dep:serde", "glam/serde"]
 mint = ["glam/mint"]
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["glam/glam-assert"]
+# Enable assertions in debug builds to check the validity of parameters passed to glam
+debug_glam_assert = ["glam/debug-glam-assert"]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -49,6 +49,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_dynamic_plugin|Plugin for dynamic loading (using [libloading](https://crates.io/crates/libloading))|
 |bmp|BMP image format support|
 |dds|DDS compressed texture support|
+|debug_glam_assert|Enable assertions in debug builds to check the validity of parameters passed to glam|
 |detailed_trace|Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in|
 |dynamic_linking|Force dynamic linking, which improves iterative compile times|
 |embedded_watcher|Enables watching in memory asset providers for Bevy Asset hot-reloading|


### PR DESCRIPTION
# Objective

- I want to use the `debug_glam_assert` feature with bevy.

## Solution

- Re-export the feature flag

---

## Changelog

- Re-export `debug_glam_assert` feature flag from glam.
