### PR TITLE
assets: use blake3 instead of md5

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5"
 downcast-rs = "1.2"
 futures-io = "0.3"
 futures-lite = "1.12"
-siphasher = "1.0"
+blake3 = "1.5"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -33,7 +33,7 @@ crossbeam-channel = "0.5"
 downcast-rs = "1.2"
 futures-io = "0.3"
 futures-lite = "1.12"
-md5 = "0.7"
+siphasher = "1.0"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"
 serde = { version = "1", features = ["derive"] }

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -232,7 +232,7 @@ pub(crate) fn get_asset_hash(meta_bytes: &[u8], asset_bytes: &[u8]) -> AssetHash
     let mut hasher = blake3::Hasher::new();
     hasher.update(meta_bytes);
     hasher.update(asset_bytes);
-    hasher.finalize().as_bytes().clone()
+    *hasher.finalize().as_bytes()
 }
 
 /// NOTE: changing the hashing logic here is a _breaking change_ that requires a [`META_FORMAT_VERSION`] bump.
@@ -245,5 +245,5 @@ pub(crate) fn get_full_asset_hash(
     for hash in dependency_hashes {
         hasher.update(&hash);
     }
-    hasher.finalize().as_bytes().clone()
+    *hasher.finalize().as_bytes()
 }


### PR DESCRIPTION
# Objective

- Replace md5 by another hasher, as suggested in https://github.com/bevyengine/bevy/pull/8624#discussion_r1359291028
- md5 is not secure, and is slow. use something more secure and faster

## Solution

- Replace md5 by blake3


Putting this PR in the 0.12 as once it's released, changing the hash algorithm will be a painful breaking change