### PR TITLE
`ParamSet`s containing non-send parameters should also be non-send

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -201,6 +201,10 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
                         #param::init_state(world, &mut #meta);
                         let #param = #param::init_state(world, &mut system_meta.clone());
                     )*
+                    // Make the ParamSet non-send if any of its parameters are non-send.
+                    if false #(|| !#meta.is_send())* {
+                        system_meta.set_non_send();
+                    }
                     #(
                         system_meta
                             .component_access_set

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1739,4 +1739,18 @@ mod tests {
         schedule.add_systems(non_sync_system);
         schedule.run(&mut world);
     }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/10207.
+    #[test]
+    fn param_set_non_send() {
+        fn non_send_param_set(mut p: ParamSet<(NonSend<u8>, NonSendMut<u8>)>) {
+            let _ = p.p0();
+        }
+
+        let mut world = World::new();
+        world.init_non_send_resource::<u8>();
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
+        schedule.run(&mut world);
+    }
 }

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1742,14 +1742,29 @@ mod tests {
 
     // Regression test for https://github.com/bevyengine/bevy/issues/10207.
     #[test]
-    fn param_set_non_send() {
-        fn non_send_param_set(mut p: ParamSet<(NonSend<u8>, NonSendMut<u8>)>) {
+    fn param_set_non_send_first() {
+        fn non_send_param_set(mut p: ParamSet<(NonSend<*mut u8>, ())>) {
             let _ = p.p0();
             let _ = p.p1();
         }
 
         let mut world = World::new();
-        world.init_non_send_resource::<u8>();
+        world.insert_non_send_resource(std::ptr::null_mut::<u8>());
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
+        schedule.run(&mut world);
+    }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/10207.
+    #[test]
+    fn param_set_non_send_second() {
+        fn non_send_param_set(mut p: ParamSet<((), NonSendMut<*mut u8>)>) {
+            let _ = p.p0();
+            let _ = p.p1();
+        }
+
+        let mut world = World::new();
+        world.insert_non_send_resource(std::ptr::null_mut::<u8>());
         let mut schedule = crate::schedule::Schedule::default();
         schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
         schedule.run(&mut world);

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1745,7 +1745,7 @@ mod tests {
     fn param_set_non_send_first() {
         fn non_send_param_set(mut p: ParamSet<(NonSend<*mut u8>, ())>) {
             let _ = p.p0();
-            let _ = p.p1();
+            p.p1();
         }
 
         let mut world = World::new();
@@ -1759,7 +1759,7 @@ mod tests {
     #[test]
     fn param_set_non_send_second() {
         fn non_send_param_set(mut p: ParamSet<((), NonSendMut<*mut u8>)>) {
-            let _ = p.p0();
+            p.p0();
             let _ = p.p1();
         }
 

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1745,6 +1745,7 @@ mod tests {
     fn param_set_non_send() {
         fn non_send_param_set(mut p: ParamSet<(NonSend<u8>, NonSendMut<u8>)>) {
             let _ = p.p0();
+            let _ = p.p1();
         }
 
         let mut world = World::new();


### PR DESCRIPTION
# Objective

Fix #10207

## Solution

Mark a `ParamSet`'s `SystemMeta` as non-send if any of its component parameters are non-send.
