### PR TITLE
Reorder quad vertices to allow natural TriangleStrip order

### DIFF
--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -160,20 +160,17 @@ impl From<Quad> for Mesh {
 
         let (u_left, u_right) = if quad.flip { (1.0, 0.0) } else { (0.0, 1.0) };
         let vertices = [
-            ([-extent_x, -extent_y, 0.0], [0.0, 0.0, 1.0], [u_left, 1.0]),
             ([-extent_x, extent_y, 0.0], [0.0, 0.0, 1.0], [u_left, 0.0]),
+            ([-extent_x, -extent_y, 0.0], [0.0, 0.0, 1.0], [u_left, 1.0]),
             ([extent_x, extent_y, 0.0], [0.0, 0.0, 1.0], [u_right, 0.0]),
             ([extent_x, -extent_y, 0.0], [0.0, 0.0, 1.0], [u_right, 1.0]),
         ];
-
-        let indices = Indices::U32(vec![0, 2, 1, 0, 3, 2]);
 
         let positions: Vec<_> = vertices.iter().map(|(p, _, _)| *p).collect();
         let normals: Vec<_> = vertices.iter().map(|(_, n, _)| *n).collect();
         let uvs: Vec<_> = vertices.iter().map(|(_, _, uv)| *uv).collect();
 
-        Mesh::new(PrimitiveTopology::TriangleList)
-            .with_indices(Some(indices))
+        Mesh::new(PrimitiveTopology::TriangleStrip)
             .with_inserted_attribute(Mesh::ATTRIBUTE_POSITION, positions)
             .with_inserted_attribute(Mesh::ATTRIBUTE_NORMAL, normals)
             .with_inserted_attribute(Mesh::ATTRIBUTE_UV_0, uvs)


### PR DESCRIPTION
# Objective

A quad can be rendered using `TriangleStrip` topology without an index buffer if the vertices are ordered in the natural `TriangleStrip` order.

## Solution

Change the topology from list to strip, re-order the vertices and remove the index buffer.

