### PR TITLE
Implement source into Display for AssetPath

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -67,6 +67,9 @@ impl<'a> Debug for AssetPath<'a> {
 
 impl<'a> Display for AssetPath<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let AssetSourceId::Name(name) = self.source() {
+            write!(f, "{name}://")?;
+        }
         write!(f, "{}", self.path.display())?;
         if let Some(label) = &self.label {
             write!(f, "#{label}")?;


### PR DESCRIPTION
# Objective

When debugging and printing asset paths, I am not 100% if I am in the right source or not

## Solution

Add the output of the source