### PR TITLE
Add convenient methods for Image

### DIFF
--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -40,7 +40,7 @@ impl AssetSaver for CompressedImageSaver {
 
         let mut source_image = compressor_params.source_image_mut(0);
         let size = image.size();
-        source_image.init(&image.data, size.x as u32, size.y as u32, 4);
+        source_image.init(&image.data, size.x, size.y, 4);
 
         let mut compressor = basis_universal::Compressor::new(4);
         // SAFETY: the CompressorParams are "valid" to the best of our knowledge. The basis-universal

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -14,7 +14,7 @@ use crate::{
 use bevy_asset::Asset;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::system::{lifetimeless::SRes, Resource, SystemParamItem};
-use bevy_math::Vec2;
+use bevy_math::{UVec2, Vec2};
 use bevy_reflect::Reflect;
 use serde::{Deserialize, Serialize};
 use std::hash::Hash;
@@ -256,15 +256,32 @@ impl Image {
 
     /// Returns the aspect ratio (height/width) of a 2D image.
     pub fn aspect_2d(&self) -> f32 {
-        self.texture_descriptor.size.height as f32 / self.texture_descriptor.size.width as f32
+        self.height() as f32 / self.width() as f32
     }
 
-    /// Returns the size of a 2D image.
-    pub fn size(&self) -> Vec2 {
+    /// Returns the size of a 2D image as f32.
+    pub fn size_f32(&self) -> Vec2 {
         Vec2::new(
             self.texture_descriptor.size.width as f32,
             self.texture_descriptor.size.height as f32,
         )
+    }
+
+    /// Returns the size of a 2D image.
+    pub fn size(&self) -> UVec2 {
+        UVec2::new(
+            self.texture_descriptor.size.width,
+            self.texture_descriptor.size.height,
+        )
+    }
+
+    /// Returns the size of a 2D image.
+    pub fn width(&self) -> u32 {
+        self.texture_descriptor.size.width
+    }
+
+    pub fn height(&self) -> u32 {
+        self.texture_descriptor.size.height
     }
 
     /// Resizes the image to the new size, by removing information or appending 0 to the `data`.

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -255,33 +255,28 @@ impl Image {
     }
 
     /// Returns the aspect ratio (height/width) of a 2D image.
-    pub fn aspect_2d(&self) -> f32 {
+    pub fn aspect_ratio(&self) -> f32 {
         self.height() as f32 / self.width() as f32
     }
 
-    /// Returns the size of a 2D image as f32.
-    pub fn size_f32(&self) -> Vec2 {
-        Vec2::new(
-            self.texture_descriptor.size.width as f32,
-            self.texture_descriptor.size.height as f32,
-        )
-    }
-
-    /// Returns the size of a 2D image.
-    pub fn size(&self) -> UVec2 {
-        UVec2::new(
-            self.texture_descriptor.size.width,
-            self.texture_descriptor.size.height,
-        )
-    }
-
-    /// Returns the size of a 2D image.
+    /// Returns the width of a 2D image.
     pub fn width(&self) -> u32 {
         self.texture_descriptor.size.width
     }
 
+    /// Returns the height of a 2D image.
     pub fn height(&self) -> u32 {
         self.texture_descriptor.size.height
+    }
+
+    /// Returns the size of a 2D image as f32.
+    pub fn size_f32(&self) -> Vec2 {
+        Vec2::new(self.width() as f32, self.height() as f32)
+    }
+
+    /// Returns the size of a 2D image.
+    pub fn size(&self) -> UVec2 {
+        UVec2::new(self.width(), self.height())
     }
 
     /// Resizes the image to the new size, by removing information or appending 0 to the `data`.

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -650,12 +650,12 @@ mod test {
         );
         assert_eq!(
             Vec2::new(size.width as f32, size.height as f32),
-            image.size()
+            image.size_f32()
         );
     }
     #[test]
     fn image_default_size() {
         let image = Image::default();
-        assert_eq!(Vec2::ONE, image.size());
+        assert_eq!(Vec2::ONE, image.size_f32());
     }
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -138,7 +138,7 @@ pub fn calculate_bounds_2d(
     for (entity, sprite, texture_handle) in &sprites_without_aabb {
         if let Some(size) = sprite
             .custom_size
-            .or_else(|| images.get(texture_handle).map(|image| image.size()))
+            .or_else(|| images.get(texture_handle).map(|image| image.size_f32()))
         {
             let aabb = Aabb {
                 center: (-sprite.anchor.as_vec() * size).extend(0.0).into(),

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -336,7 +336,7 @@ fn update_image_viewer(
                 if let Some(base_color_texture) = mat.base_color_texture.clone() {
                     if image_changed_id == base_color_texture.id() {
                         if let Some(image_changed) = images.get(image_changed_id) {
-                            let size = image_changed.size().normalize_or_zero() * 1.4;
+                            let size = image_changed.size_f32().normalize_or_zero() * 1.4;
                             // Resize Mesh
                             let quad = Mesh::from(shape::Quad::new(size));
                             meshes.insert(mesh_h, quad);


### PR DESCRIPTION
# Objective
To get the width or height of an image you do:
```rust
self.texture_descriptor.size.{width, height}
```
that is quite verbose.
This PR adds some convenient methods for Image to reduce verbosity.

## Changelog
* Add a `width()` method for getting the width of an image.
* Add a `height()` method for getting the height of an image.
* Rename the `size()` method to `size_f32()`.
* Add a `size()` method for getting the size of an image as u32.
* Renamed the `aspect_2d()` method to `aspect_ratio()`.

## Migration Guide
Replace calls to the `Image::size()` method with `size_f32()`.
Replace calls to the `Image::aspect_2d()` method with `aspect_ratio()`.