### PR TITLE
Detect cubemap for dds textures

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -438,6 +438,9 @@ pub enum TextureError {
     TranscodeError(String),
     #[error("format requires transcoding: {0:?}")]
     FormatRequiresTranscodingError(TranscodeFormat),
+    /// Only cubemaps with six faces are supported.
+    #[error("only cubemaps with six faces are supported")]
+    IncompleteCubemap,
 }
 
 /// The type of a raw image buffer.


### PR DESCRIPTION
# Objective

- Closes #10049.
- Detect DDS texture containing a cubemap or a cubemap array.

## Solution

- When loading a dds texture, the header capabilities are checked for the cubemap flag. An error is returned if not all faces are provided.

---

## Changelog

### Added

- Added a new texture error `TextureError::IncompleteCubemap`, used for dds cubemap textures containing less than 6 faces, as that is not supported on modern graphics APIs.

### Fixed

- DDS cubemaps are now loaded as cubemaps instead of 2D textures.

## Migration Guide

If you are matching on a `TextureError`, you will need to add a new branch to handle `TextureError::IncompleteCubemap`.