### PR TITLE
allow DeferredPrepass to work without other prepass markers

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -366,10 +366,10 @@ pub fn extract_camera_prepass_phase(
             (
                 Entity,
                 &Camera,
-                Option<&DepthPrepass>,
-                Option<&NormalPrepass>,
-                Option<&MotionVectorPrepass>,
-                Option<&DeferredPrepass>,
+                Has<DepthPrepass>,
+                Has<NormalPrepass>,
+                Has<MotionVectorPrepass>,
+                Has<DeferredPrepass>,
             ),
             With<Camera3d>,
         >,
@@ -381,33 +381,33 @@ pub fn extract_camera_prepass_phase(
         if camera.is_active {
             let mut entity = commands.get_or_spawn(entity);
 
-            if depth_prepass.is_some()
-                || normal_prepass.is_some()
-                || motion_vector_prepass.is_some()
-            {
+            // deferred requires depth
+            let depth_prepass = depth_prepass || deferred_prepass;
+
+            if depth_prepass || normal_prepass || motion_vector_prepass {
                 entity.insert((
                     RenderPhase::<Opaque3dPrepass>::default(),
                     RenderPhase::<AlphaMask3dPrepass>::default(),
                 ));
             }
 
-            if deferred_prepass.is_some() {
+            if deferred_prepass {
                 entity.insert((
                     RenderPhase::<Opaque3dDeferred>::default(),
                     RenderPhase::<AlphaMask3dDeferred>::default(),
                 ));
             }
 
-            if depth_prepass.is_some() {
+            if depth_prepass {
                 entity.insert(DepthPrepass);
             }
-            if normal_prepass.is_some() {
+            if normal_prepass {
                 entity.insert(NormalPrepass);
             }
-            if motion_vector_prepass.is_some() {
+            if motion_vector_prepass {
                 entity.insert(MotionVectorPrepass);
             }
-            if deferred_prepass.is_some() {
+            if deferred_prepass {
                 entity.insert(DeferredPrepass);
             }
         }

--- a/crates/bevy_core_pipeline/src/prepass/mod.rs
+++ b/crates/bevy_core_pipeline/src/prepass/mod.rs
@@ -55,6 +55,7 @@ pub struct NormalPrepass;
 pub struct MotionVectorPrepass;
 
 /// If added to a [`crate::prelude::Camera3d`] then deferred materials will be rendered to the deferred gbuffer texture and will be available to subsequent passes.
+/// Note the default deferred lighting plugin also requires `DepthPrepass` to work correctly.
 #[derive(Component, Default, Reflect)]
 pub struct DeferredPrepass;
 

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -810,9 +810,6 @@ pub fn queue_prepass_material_meshes<M: Material>(
             view_key |= MeshPipelineKey::MOTION_VECTOR_PREPASS;
         }
 
-        let mut opaque_phase_deferred = opaque_deferred_phase.as_mut();
-        let mut alpha_mask_phase_deferred = alpha_mask_deferred_phase.as_mut();
-
         let rangefinder = view.rangefinder3d();
 
         for visible_entity in &visible_entities.entities {
@@ -879,7 +876,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
             match alpha_mode {
                 AlphaMode::Opaque => {
                     if deferred {
-                        opaque_phase_deferred
+                        opaque_deferred_phase
                             .as_mut()
                             .unwrap()
                             .add(Opaque3dDeferred {
@@ -890,8 +887,8 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 batch_range: 0..1,
                                 dynamic_offset: None,
                             });
-                    } else {
-                        opaque_phase.as_mut().unwrap().add(Opaque3dPrepass {
+                    } else if let Some(opaque_phase) = opaque_phase.as_mut() {
+                        opaque_phase.add(Opaque3dPrepass {
                             entity: *visible_entity,
                             draw_function: opaque_draw_prepass,
                             pipeline_id,
@@ -903,7 +900,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                 }
                 AlphaMode::Mask(_) => {
                     if deferred {
-                        alpha_mask_phase_deferred
+                        alpha_mask_deferred_phase
                             .as_mut()
                             .unwrap()
                             .add(AlphaMask3dDeferred {
@@ -914,8 +911,8 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 batch_range: 0..1,
                                 dynamic_offset: None,
                             });
-                    } else {
-                        alpha_mask_phase.as_mut().unwrap().add(AlphaMask3dPrepass {
+                    } else if let Some(alpha_mask_phase) = alpha_mask_phase.as_mut() {
+                        alpha_mask_phase.add(AlphaMask3dPrepass {
                             entity: *visible_entity,
                             draw_function: alpha_mask_draw_prepass,
                             pipeline_id,


### PR DESCRIPTION
# Objective

fix crash / misbehaviour when `DeferredPrepass` is used without `DepthPrepass`.

- Deferred lighting requires the depth prepass texture to be present, so that the depth texture is available for binding. without it the deferred lighting pass will use 0 for depth of all meshes.
- When `DeferredPrepass` is used without other prepass markers, and with any materials that use `OpaqueRenderMode::Forward`, those entities will try to queue to the `Opaque3dPrepass` render phase, which doesn't exist, causing a crash.

## Solution

- check if the prepass phases exist before queueing
- generate prepass textures if `Opaque3dDeferred` is present
- add a note to the DeferredPrepass marker to note that DepthPrepass is also required by the default deferred lighting pass
- also changed some `With<T>.is_some()`s to `Has<T>`s