### PR TITLE
Replace all usages of texture_descritor.size.* with the helper methods

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -374,7 +374,9 @@ impl FromWorld for MeshPipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(&descriptor),
+                ImageSampler::Descriptor(ref descriptor) => {
+                    render_device.create_sampler(&descriptor)
+                }
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -17,7 +17,7 @@ use bevy_ecs::{
     query::{QueryItem, ROQueryItem},
     system::{lifetimeless::*, SystemParamItem, SystemState},
 };
-use bevy_math::{Affine3, Vec2, Vec4};
+use bevy_math::{Affine3, Vec4};
 use bevy_render::{
     batching::{
         batch_and_prepare_render_phase, write_batched_instance_buffer, GetBatchData,
@@ -374,7 +374,7 @@ impl FromWorld for MeshPipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
+                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(&descriptor),
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
@@ -391,7 +391,7 @@ impl FromWorld for MeshPipeline {
                     bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.size(),
+                image.texture_descriptor.size,
             );
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -375,7 +375,7 @@ impl FromWorld for MeshPipeline {
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
                 ImageSampler::Descriptor(ref descriptor) => {
-                    render_device.create_sampler(&descriptor)
+                    render_device.create_sampler(descriptor)
                 }
             };
 

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -388,10 +388,10 @@ impl FromWorld for MeshPipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(image.texture_descriptor.size.width * format_size as u32),
+                    bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.texture_descriptor.size,
+                image.size(),
             );
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
@@ -400,10 +400,7 @@ impl FromWorld for MeshPipeline {
                 texture_view,
                 texture_format: image.texture_descriptor.format,
                 sampler,
-                size: Vec2::new(
-                    image.texture_descriptor.size.width as f32,
-                    image.texture_descriptor.size.height as f32,
-                ),
+                size: image.size_f32(),
                 mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -509,7 +509,7 @@ impl NormalizedRenderTarget {
                 }),
             NormalizedRenderTarget::Image(image_handle) => {
                 let image = images.get(image_handle)?;
-                let Extent3d { width, height, .. } = image.texture_descriptor.size;
+                let Extent3d { width, height, .. } = image.size();
                 Some(RenderTargetInfo {
                     physical_size: UVec2::new(width, height),
                     scale_factor: 1.0,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -27,7 +27,7 @@ use bevy_window::{
     NormalizedWindowRef, PrimaryWindow, Window, WindowCreated, WindowRef, WindowResized,
 };
 use std::{borrow::Cow, ops::Range};
-use wgpu::{BlendState, Extent3d, LoadOp, TextureFormat};
+use wgpu::{BlendState, LoadOp, TextureFormat};
 
 /// Render viewport configuration for the [`Camera`] component.
 ///
@@ -509,9 +509,8 @@ impl NormalizedRenderTarget {
                 }),
             NormalizedRenderTarget::Image(image_handle) => {
                 let image = images.get(image_handle)?;
-                let Extent3d { width, height, .. } = image.size();
                 Some(RenderTargetInfo {
-                    physical_size: UVec2::new(width, height),
+                    physical_size: image.size(),
                     scale_factor: 1.0,
                 })
             }

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -110,10 +110,7 @@ fn fallback_image_new(
         texture_view,
         texture_format: image.texture_descriptor.format,
         sampler,
-        size: Vec2::new(
-            image.texture_descriptor.size.width as f32,
-            image.texture_descriptor.size.height as f32,
-        ),
+        size: image.size_f32(),
         mip_level_count: image.texture_descriptor.mip_level_count,
     }
 }

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -4,7 +4,6 @@ use bevy_ecs::{
     prelude::{FromWorld, Res, ResMut},
     system::{Resource, SystemParam},
 };
-use bevy_math::Vec2;
 use bevy_utils::HashMap;
 use wgpu::{Extent3d, TextureFormat};
 
@@ -103,7 +102,7 @@ fn fallback_image_new(
     });
     let sampler = match image.sampler_descriptor {
         ImageSampler::Default => (**default_sampler).clone(),
-        ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
+        ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(descriptor),
     };
     GpuImage {
         texture,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -254,11 +254,6 @@ impl Image {
         value
     }
 
-    /// Returns the aspect ratio (height/width) of a 2D image.
-    pub fn aspect_ratio(&self) -> f32 {
-        self.height() as f32 / self.width() as f32
-    }
-
     /// Returns the width of a 2D image.
     pub fn width(&self) -> u32 {
         self.texture_descriptor.size.width
@@ -267,6 +262,11 @@ impl Image {
     /// Returns the height of a 2D image.
     pub fn height(&self) -> u32 {
         self.texture_descriptor.size.height
+    }
+
+    /// Returns the aspect ratio (height/width) of a 2D image.
+    pub fn aspect_ratio(&self) -> f32 {
+        self.height() as f32 / self.width() as f32
     }
 
     /// Returns the size of a 2D image as f32.
@@ -316,11 +316,11 @@ impl Image {
         // Must be a stacked image, and the height must be divisible by layers.
         assert!(self.texture_descriptor.dimension == TextureDimension::D2);
         assert!(self.texture_descriptor.size.depth_or_array_layers == 1);
-        assert_eq!(self.texture_descriptor.size.height % layers, 0);
+        assert_eq!(self.height() % layers, 0);
 
         self.reinterpret_size(Extent3d {
-            width: self.texture_descriptor.size.width,
-            height: self.texture_descriptor.size.height / layers,
+            width: self.width(),
+            height: self.height() / layers,
             depth_or_array_layers: layers,
         });
     }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -255,26 +255,31 @@ impl Image {
     }
 
     /// Returns the width of a 2D image.
+    #[inline]
     pub fn width(&self) -> u32 {
         self.texture_descriptor.size.width
     }
 
     /// Returns the height of a 2D image.
+    #[inline]
     pub fn height(&self) -> u32 {
         self.texture_descriptor.size.height
     }
 
     /// Returns the aspect ratio (height/width) of a 2D image.
+    #[inline]
     pub fn aspect_ratio(&self) -> f32 {
         self.height() as f32 / self.width() as f32
     }
 
     /// Returns the size of a 2D image as f32.
+    #[inline]
     pub fn size_f32(&self) -> Vec2 {
         Vec2::new(self.width() as f32, self.height() as f32)
     }
 
     /// Returns the size of a 2D image.
+    #[inline]
     pub fn size(&self) -> UVec2 {
         UVec2::new(self.width(), self.height())
     }

--- a/crates/bevy_render/src/texture/image_texture_conversion.rs
+++ b/crates/bevy_render/src/texture/image_texture_conversion.rs
@@ -165,38 +165,28 @@ impl Image {
     /// To convert [`Image`] to a different format see: [`Image::convert`].
     pub fn try_into_dynamic(self) -> Result<DynamicImage, IntoDynamicImageError> {
         match self.texture_descriptor.format {
-            TextureFormat::R8Unorm => ImageBuffer::from_raw(
-                self.texture_descriptor.size.width,
-                self.texture_descriptor.size.height,
-                self.data,
-            )
-            .map(DynamicImage::ImageLuma8),
-            TextureFormat::Rg8Unorm => ImageBuffer::from_raw(
-                self.texture_descriptor.size.width,
-                self.texture_descriptor.size.height,
-                self.data,
-            )
-            .map(DynamicImage::ImageLumaA8),
-            TextureFormat::Rgba8UnormSrgb => ImageBuffer::from_raw(
-                self.texture_descriptor.size.width,
-                self.texture_descriptor.size.height,
-                self.data,
-            )
-            .map(DynamicImage::ImageRgba8),
+            TextureFormat::R8Unorm => ImageBuffer::from_raw(self.width(), self.height(), self.data)
+                .map(DynamicImage::ImageLuma8),
+            TextureFormat::Rg8Unorm => {
+                ImageBuffer::from_raw(self.width(), self.height(), self.data)
+                    .map(DynamicImage::ImageLumaA8)
+            }
+            TextureFormat::Rgba8UnormSrgb => {
+                ImageBuffer::from_raw(self.width(), self.height(), self.data)
+                    .map(DynamicImage::ImageRgba8)
+            }
             // This format is commonly used as the format for the swapchain texture
             // This conversion is added here to support screenshots
-            TextureFormat::Bgra8UnormSrgb | TextureFormat::Bgra8Unorm => ImageBuffer::from_raw(
-                self.texture_descriptor.size.width,
-                self.texture_descriptor.size.height,
-                {
+            TextureFormat::Bgra8UnormSrgb | TextureFormat::Bgra8Unorm => {
+                ImageBuffer::from_raw(self.width(), self.height(), {
                     let mut data = self.data;
                     for bgra in data.chunks_exact_mut(4) {
                         bgra.swap(0, 2);
                     }
                     data
-                },
-            )
-            .map(DynamicImage::ImageRgba8),
+                })
+                .map(DynamicImage::ImageRgba8)
+            }
             // Throw and error if conversion isn't supported
             texture_format => return Err(IntoDynamicImageError::UnsupportedFormat(texture_format)),
         }

--- a/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/dynamic_texture_atlas_builder.rs
@@ -36,8 +36,8 @@ impl DynamicTextureAtlasBuilder {
         texture: &Image,
     ) -> Option<usize> {
         let allocation = self.atlas_allocator.allocate(size2(
-            texture.texture_descriptor.size.width as i32 + self.padding,
-            texture.texture_descriptor.size.height as i32 + self.padding,
+            texture.width() as i32 + self.padding,
+            texture.height() as i32 + self.padding,
         ));
         if let Some(allocation) = allocation {
             let atlas_texture = textures.get_mut(&texture_atlas.texture).unwrap();
@@ -59,7 +59,7 @@ impl DynamicTextureAtlasBuilder {
         let mut rect = allocation.rectangle;
         rect.max.x -= self.padding;
         rect.max.y -= self.padding;
-        let atlas_width = atlas_texture.texture_descriptor.size.width as usize;
+        let atlas_width = atlas_texture.width() as usize;
         let rect_width = rect.width() as usize;
         let format_size = atlas_texture.texture_descriptor.format.pixel_size();
 

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -311,10 +311,10 @@ impl FromWorld for Mesh2dPipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(image.texture_descriptor.size.width * format_size as u32),
+                    bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.texture_descriptor.size,
+                image.size(),
             );
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
@@ -323,10 +323,7 @@ impl FromWorld for Mesh2dPipeline {
                 texture_view,
                 texture_format: image.texture_descriptor.format,
                 sampler,
-                size: Vec2::new(
-                    image.texture_descriptor.size.width as f32,
-                    image.texture_descriptor.size.height as f32,
-                ),
+                size: image.size_f32(),
                 mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -297,7 +297,9 @@ impl FromWorld for Mesh2dPipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(descriptor)
+                ImageSampler::Descriptor(ref descriptor) => {
+                    render_device.create_sampler(descriptor)
+                }
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -8,7 +8,7 @@ use bevy_ecs::{
     query::{QueryItem, ROQueryItem},
     system::{lifetimeless::*, SystemParamItem, SystemState},
 };
-use bevy_math::{Affine3, Vec2, Vec4};
+use bevy_math::{Affine3, Vec4};
 use bevy_reflect::Reflect;
 use bevy_render::{
     batching::{
@@ -297,7 +297,7 @@ impl FromWorld for Mesh2dPipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
+                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(descriptor)
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
@@ -314,7 +314,7 @@ impl FromWorld for Mesh2dPipeline {
                     bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.size(),
+                image.texture_descriptor.size,
             );
 
             let texture_view = texture.create_view(&TextureViewDescriptor::default());

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -93,7 +93,7 @@ impl FromWorld for SpritePipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(descriptor) => render_device.create_sampler(&descriptor),
+                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(descriptor)
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();
@@ -110,7 +110,7 @@ impl FromWorld for SpritePipeline {
                     bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.size(),
+                image.texture_descriptor.size,
             );
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
             GpuImage {

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -93,7 +93,9 @@ impl FromWorld for SpritePipeline {
             let texture = render_device.create_texture(&image.texture_descriptor);
             let sampler = match image.sampler_descriptor {
                 ImageSampler::Default => (**default_sampler).clone(),
-                ImageSampler::Descriptor(ref descriptor) => render_device.create_sampler(descriptor)
+                ImageSampler::Descriptor(ref descriptor) => {
+                    render_device.create_sampler(descriptor)
+                }
             };
 
             let format_size = image.texture_descriptor.format.pixel_size();

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -107,10 +107,10 @@ impl FromWorld for SpritePipeline {
                 &image.data,
                 ImageDataLayout {
                     offset: 0,
-                    bytes_per_row: Some(image.texture_descriptor.size.width * format_size as u32),
+                    bytes_per_row: Some(image.width() * format_size as u32),
                     rows_per_image: None,
                 },
-                image.texture_descriptor.size,
+                image.size(),
             );
             let texture_view = texture.create_view(&TextureViewDescriptor::default());
             GpuImage {
@@ -118,10 +118,7 @@ impl FromWorld for SpritePipeline {
                 texture_view,
                 texture_format: image.texture_descriptor.format,
                 sampler,
-                size: Vec2::new(
-                    image.texture_descriptor.size.width as f32,
-                    image.texture_descriptor.size.height as f32,
-                ),
+                size: image.size_f32(),
                 mip_level_count: image.texture_descriptor.mip_level_count,
             }
         };

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -83,7 +83,8 @@ impl TextureAtlasBuilder {
 
     /// Adds a texture to be copied to the texture atlas.
     pub fn add_texture(&mut self, image_id: AssetId<Image>, texture: &Image) {
-        self.textures_to_place.push((image_id, texture.texture_descriptor.size));
+        self.textures_to_place
+            .push((image_id, texture.texture_descriptor.size));
     }
 
     /// Sets the amount of padding in pixels to add between the textures in the texture atlas.

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -83,7 +83,7 @@ impl TextureAtlasBuilder {
 
     /// Adds a texture to be copied to the texture atlas.
     pub fn add_texture(&mut self, image_id: AssetId<Image>, texture: &Image) {
-        self.textures_to_place.push((image_id, texture.size()));
+        self.textures_to_place.push((image_id, texture.texture_descriptor.size));
     }
 
     /// Sets the amount of padding in pixels to add between the textures in the texture atlas.

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -83,8 +83,7 @@ impl TextureAtlasBuilder {
 
     /// Adds a texture to be copied to the texture atlas.
     pub fn add_texture(&mut self, image_id: AssetId<Image>, texture: &Image) {
-        self.textures_to_place
-            .push((image_id, texture.texture_descriptor.size));
+        self.textures_to_place.push((image_id, texture.size()));
     }
 
     /// Sets the amount of padding in pixels to add between the textures in the texture atlas.
@@ -105,7 +104,7 @@ impl TextureAtlasBuilder {
         let rect_height = (packed_location.height() - padding.y) as usize;
         let rect_x = packed_location.x() as usize;
         let rect_y = packed_location.y() as usize;
-        let atlas_width = atlas_texture.texture_descriptor.size.width as usize;
+        let atlas_width = atlas_texture.width() as usize;
         let format_size = atlas_texture.texture_descriptor.format.pixel_size();
 
         for (texture_y, bound_y) in (rect_y..rect_y + rect_height).enumerate() {
@@ -247,10 +246,7 @@ impl TextureAtlasBuilder {
             self.copy_converted_texture(&mut atlas_texture, texture, packed_location);
         }
         Ok(TextureAtlas {
-            size: Vec2::new(
-                atlas_texture.texture_descriptor.size.width as f32,
-                atlas_texture.texture_descriptor.size.height as f32,
-            ),
+            size: atlas_texture.size_f32(),
             texture: textures.add(atlas_texture),
             textures: texture_rects,
             texture_handles: Some(texture_ids),

--- a/crates/bevy_text/src/font_atlas_set.rs
+++ b/crates/bevy_text/src/font_atlas_set.rs
@@ -107,7 +107,7 @@ impl FontAtlasSet {
                 .texture_descriptor
                 .size
                 .height
-                .max(glyph_texture.texture_descriptor.size.width);
+                .max(glyph_texture.width());
             // Pick the higher of 512 or the smallest power of 2 greater than glyph_max_size
             let containing = (1u32 << (32 - glyph_max_size.leading_zeros())).max(512) as f32;
             font_atlases.push(FontAtlas::new(

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -92,10 +92,7 @@ pub fn update_image_content_size_system(
 
     for (mut content_size, image, mut image_size) in &mut query {
         if let Some(texture) = textures.get(&image.texture) {
-            let size = Vec2::new(
-                texture.texture_descriptor.size.width as f32,
-                texture.texture_descriptor.size.height as f32,
-            );
+            let size = texture.size_f32();
             // Update only if size or scale factor has changed to avoid needless layout calculations
             if size != image_size.size
                 || combined_scale_factor != *previous_combined_scale_factor

--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -146,9 +146,7 @@ fn asset_loaded(
         // NOTE: PNGs do not have any metadata that could indicate they contain a cubemap texture,
         // so they appear as one texture. The following code reconfigures the texture as necessary.
         if image.texture_descriptor.array_layer_count() == 1 {
-            image.reinterpret_stacked_2d_as_array(
-                image.texture_descriptor.size.height / image.texture_descriptor.size.width,
-            );
+            image.reinterpret_stacked_2d_as_array(image.height() / image.width());
             image.texture_view_descriptor = Some(TextureViewDescriptor {
                 dimension: Some(TextureViewDimension::Cube),
                 ..default()


### PR DESCRIPTION
# Objective

A follow-up PR for https://github.com/bevyengine/bevy/pull/10221

## Changelog

Replaced usages of texture_descriptor.size with the helper methods of `Image` through the entire engine codebase
