### PR TITLE
Remove unused import warning when default_font feature is disabled

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -26,9 +26,9 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_asset::AssetApp;
 #[cfg(feature = "default_font")]
-use bevy_asset::load_internal_binary_asset;
-use bevy_asset::{AssetApp, Handle};
+use bevy_asset::{load_internal_binary_asset, Handle};
 use bevy_ecs::prelude::*;
 use bevy_render::{camera::CameraUpdateSystem, ExtractSchedule, RenderApp};
 use bevy_sprite::SpriteSystem;


### PR DESCRIPTION
# Objective

- Fixes:

```
warning: unused import: `Handle`
  --> crates/bevy_text/src/lib.rs:31:28
   |
31 | use bevy_asset::{AssetApp, Handle};
   |                            ^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default
```

## Solution

- Moved import to match feature.
