### PR TITLE
Add a `PrepareBatches` render set that runs after `PrepareResources`.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -149,9 +149,9 @@ impl Plugin for MeshRenderPlugin {
                             batch_and_prepare_render_phase::<Opaque3dDeferred, MeshPipeline>,
                             batch_and_prepare_render_phase::<AlphaMask3dDeferred, MeshPipeline>,
                         )
-                            .in_set(RenderSet::PrepareResources),
+                            .in_set(RenderSet::PrepareBatches),
                         write_batched_instance_buffer::<MeshPipeline>
-                            .in_set(RenderSet::PrepareResourcesFlush),
+                            .in_set(RenderSet::PrepareBatchesFlush),
                         prepare_skins.in_set(RenderSet::PrepareResources),
                         prepare_morphs.in_set(RenderSet::PrepareResources),
                         prepare_mesh_bind_group.in_set(RenderSet::PrepareBindGroups),

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -102,8 +102,12 @@ pub enum RenderSet {
     Prepare,
     /// A sub-set within [`Prepare`](RenderSet::Prepare) for initializing buffers, textures and uniforms for use in bind groups.
     PrepareResources,
-    /// The copy of [`apply_deferred`] that runs between [`PrepareResources`](RenderSet::PrepareResources) and ['PrepareBindGroups'](RenderSet::PrepareBindGroups).
+    /// The copy of [`apply_deferred`] that runs between [`PrepareResources`](RenderSet::PrepareResources) and ['PrepareBatches'](RenderSet::PrepareBatches).
     PrepareResourcesFlush,
+    /// A sub-set within [`Prepare`](RenderSet::Prepare) that prepares batches of meshes.
+    PrepareBatches,
+    /// The copy of [`apply_deferred`] that runs between [`PrepareBatches`](RenderSet::PrepareBatches) and ['PrepareBindGroups'](RenderSet::PrepareBindGroups).
+    PrepareBatchesFlush,
     /// A sub-set within [`Prepare`](RenderSet::Prepare) for constructing bind groups, or other data that relies on render resources prepared in [`PrepareResources`](RenderSet::PrepareResources).
     PrepareBindGroups,
     /// The copy of [`apply_deferred`] that runs immediately after [`Prepare`](RenderSet::Prepare).
@@ -137,6 +141,7 @@ impl Render {
         schedule.add_systems((
             apply_deferred.in_set(ManageViewsFlush),
             apply_deferred.in_set(PrepareResourcesFlush),
+            apply_deferred.in_set(PrepareBatchesFlush),
             apply_deferred.in_set(RenderFlush),
             apply_deferred.in_set(PrepareFlush),
             apply_deferred.in_set(CleanupFlush),
@@ -166,7 +171,13 @@ impl Render {
                 .after(prepare_assets::<Mesh>),
         );
         schedule.configure_sets(
-            (PrepareResources, PrepareResourcesFlush, PrepareBindGroups)
+            (
+                PrepareResources,
+                PrepareResourcesFlush,
+                PrepareBatches,
+                PrepareBatchesFlush,
+                PrepareBindGroups,
+            )
                 .chain()
                 .in_set(Prepare),
         );


### PR DESCRIPTION
# Objective

PR #10231 needs to add some logic that runs as part of `PrepareResources` but before batch building, because it creates data that batch building needs (the lightmap index, which is part of the `Mesh` structure).

## Solution

This PR adds a new render set for the batching operations. It was split out of #10231 at reviewer request.