### PR TITLE
Refactor mesh bind groups to be based on a set of flags.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_bindings.rs
@@ -1,13 +1,21 @@
 //! Bind group layout related definitions for the mesh pipeline.
 
+use std::{
+    array,
+    fmt::{self, Display, Formatter},
+};
+
 use bevy_math::Mat4;
 use bevy_render::{
     mesh::morph::MAX_MORPH_WEIGHTS,
     render_resource::{
-        BindGroup, BindGroupLayout, BindGroupLayoutDescriptor, BindingResource, Buffer, TextureView,
+        BindGroup, BindGroupEntry, BindGroupLayout, BindGroupLayoutDescriptor,
+        BindGroupLayoutEntry, BindingResource, Buffer, TextureView,
     },
     renderer::RenderDevice,
 };
+use bitflags::bitflags;
+use smallvec::SmallVec;
 
 use crate::render::skin::MAX_JOINTS;
 
@@ -16,6 +24,16 @@ pub const MORPH_BUFFER_SIZE: usize = MAX_MORPH_WEIGHTS * MORPH_WEIGHT_SIZE;
 
 const JOINT_SIZE: usize = std::mem::size_of::<Mat4>();
 pub(crate) const JOINT_BUFFER_SIZE: usize = MAX_JOINTS * JOINT_SIZE;
+
+bitflags! {
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    pub(crate) struct MeshLayoutKey: u8 {
+        const SKINNED = 1;
+        const MORPHED = 2;
+    }
+}
+
+const MESH_LAYOUT_COUNT: usize = MeshLayoutKey::all().bits() as usize + 1;
 
 /// Individual layout entries.
 mod layout_entry {
@@ -104,132 +122,149 @@ mod entry {
 
 /// All possible [`BindGroupLayout`]s in bevy's default mesh shader (`mesh.wgsl`).
 #[derive(Clone)]
-pub struct MeshLayouts {
-    /// The mesh model uniform (transform) and nothing else.
-    pub model_only: BindGroupLayout,
-
-    /// Also includes the uniform for skinning
-    pub skinned: BindGroupLayout,
-
-    /// Also includes the uniform and [`MorphAttributes`] for morph targets.
-    ///
-    /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
-    pub morphed: BindGroupLayout,
-
-    /// Also includes both uniforms for skinning and morph targets, also the
-    /// morph target [`MorphAttributes`] binding.
-    ///
-    /// [`MorphAttributes`]: bevy_render::mesh::morph::MorphAttributes
-    pub morphed_skinned: BindGroupLayout,
-}
+pub struct MeshLayouts([BindGroupLayout; MESH_LAYOUT_COUNT]);
 
 impl MeshLayouts {
     /// Prepare the layouts used by the default bevy [`Mesh`].
     ///
     /// [`Mesh`]: bevy_render::prelude::Mesh
     pub fn new(render_device: &RenderDevice) -> Self {
-        MeshLayouts {
-            model_only: Self::model_only_layout(render_device),
-            skinned: Self::skinned_layout(render_device),
-            morphed: Self::morphed_layout(render_device),
-            morphed_skinned: Self::morphed_skinned_layout(render_device),
+        MeshLayouts(array::from_fn(|mesh_layout_bitmask| {
+            Self::create_layout(
+                render_device,
+                MeshLayoutKey::from_bits_truncate(mesh_layout_bitmask as u8),
+            )
+        }))
+    }
+
+    /// Creates an individual bind group layout.
+    fn create_layout(
+        render_device: &RenderDevice,
+        mesh_layout_key: MeshLayoutKey,
+    ) -> BindGroupLayout {
+        let mut entries: SmallVec<[BindGroupLayoutEntry; 4]> = SmallVec::new();
+        entries.push(layout_entry::model(render_device, 0));
+
+        if mesh_layout_key.contains(MeshLayoutKey::SKINNED) {
+            entries.push(layout_entry::skinning(1));
+        }
+        if mesh_layout_key.contains(MeshLayoutKey::MORPHED) {
+            entries.push(layout_entry::weights(2));
+            entries.push(layout_entry::targets(3));
+        }
+
+        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            label: Some(&*format!("mesh_bind_group_layout_{}", mesh_layout_key)),
+            entries: &entries,
+        })
+    }
+
+    pub(crate) fn get_layout(&self, key: MeshLayoutKey) -> &BindGroupLayout {
+        &self.0[key.bits() as usize]
+    }
+
+    fn populate_generic_bind_group_entries<'vec, 'entry>(
+        &self,
+        bind_group_entries: &'vec mut SmallVec<[BindGroupEntry<'entry>; 4]>,
+        model: &'entry BindingResource,
+        skin: Option<&'entry Buffer>,
+        key: MeshLayoutKey,
+    ) {
+        bind_group_entries.push(entry::model(0, (*model).clone()));
+
+        if key.contains(MeshLayoutKey::SKINNED) {
+            bind_group_entries.push(entry::skinning(1, skin.unwrap()));
         }
     }
 
-    // ---------- create individual BindGroupLayouts ----------
-
-    fn model_only_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[layout_entry::model(render_device, 0)],
-            label: Some("mesh_layout"),
-        })
-    }
-    fn skinned_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::skinning(1),
-            ],
-            label: Some("skinned_mesh_layout"),
-        })
-    }
-    fn morphed_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::weights(2),
-                layout_entry::targets(3),
-            ],
-            label: Some("morphed_mesh_layout"),
-        })
-    }
-    fn morphed_skinned_layout(render_device: &RenderDevice) -> BindGroupLayout {
-        render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
-            entries: &[
-                layout_entry::model(render_device, 0),
-                layout_entry::skinning(1),
-                layout_entry::weights(2),
-                layout_entry::targets(3),
-            ],
-            label: Some("morphed_skinned_mesh_layout"),
-        })
-    }
-
-    // ---------- BindGroup methods ----------
-
-    pub fn model_only(&self, render_device: &RenderDevice, model: &BindingResource) -> BindGroup {
-        render_device.create_bind_group(
-            "model_only_mesh_bind_group",
-            &self.model_only,
-            &[entry::model(0, model.clone())],
-        )
-    }
-    pub fn skinned(
+    // Creates a bind group that isn't associated with a specific mesh.
+    pub(crate) fn create_generic_bind_group(
         &self,
         render_device: &RenderDevice,
         model: &BindingResource,
-        skin: &Buffer,
+        skin: Option<&Buffer>,
+        key: MeshLayoutKey,
     ) -> BindGroup {
+        debug_assert!(!key.bind_group_is_mesh_specific());
+
+        let mut bind_group_entries: SmallVec<[BindGroupEntry; 4]> = SmallVec::new();
+        self.populate_generic_bind_group_entries(&mut bind_group_entries, model, skin, key);
         render_device.create_bind_group(
-            "skinned_mesh_bind_group",
-            &self.skinned,
-            &[entry::model(0, model.clone()), entry::skinning(1, skin)],
+            Some(&*format!("mesh_bind_group_{}", key)),
+            self.get_layout(key),
+            &bind_group_entries,
         )
     }
-    pub fn morphed(
+
+    // Creates a bind group that needs to be associated with a specific mesh.
+    pub(crate) fn create_mesh_specific_bind_group(
         &self,
         render_device: &RenderDevice,
         model: &BindingResource,
-        weights: &Buffer,
-        targets: &TextureView,
+        skin: Option<&Buffer>,
+        morph: Option<(&Buffer, &TextureView)>,
+        key: MeshLayoutKey,
     ) -> BindGroup {
+        debug_assert!(key.bind_group_is_mesh_specific());
+
+        let mut bind_group_entries: SmallVec<[BindGroupEntry; 4]> = SmallVec::new();
+        self.populate_generic_bind_group_entries(&mut bind_group_entries, model, skin, key);
+
+        if key.contains(MeshLayoutKey::MORPHED) {
+            let (weights, targets) = morph.unwrap();
+            bind_group_entries.push(entry::weights(2, weights));
+            bind_group_entries.push(entry::targets(3, targets));
+        }
+
         render_device.create_bind_group(
-            "morphed_mesh_bind_group",
-            &self.morphed,
-            &[
-                entry::model(0, model.clone()),
-                entry::weights(2, weights),
-                entry::targets(3, targets),
-            ],
+            Some(&*format!("mesh_bind_group_{}", key)),
+            self.get_layout(key),
+            &bind_group_entries,
         )
     }
-    pub fn morphed_skinned(
-        &self,
-        render_device: &RenderDevice,
-        model: &BindingResource,
-        skin: &Buffer,
-        weights: &Buffer,
-        targets: &TextureView,
-    ) -> BindGroup {
-        render_device.create_bind_group(
-            "morphed_skinned_mesh_bind_group",
-            &self.morphed_skinned,
-            &[
-                entry::model(0, model.clone()),
-                entry::skinning(1, skin),
-                entry::weights(2, weights),
-                entry::targets(3, targets),
-            ],
-        )
+}
+
+impl MeshLayoutKey {
+    pub fn bind_group_is_mesh_specific(&self) -> bool {
+        self.intersects(MeshLayoutKey::MORPHED)
+    }
+}
+
+impl Display for MeshLayoutKey {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        let mut first = true;
+        add(
+            formatter,
+            &mut first,
+            *self,
+            MeshLayoutKey::SKINNED,
+            "skinned",
+        )?;
+        add(
+            formatter,
+            &mut first,
+            *self,
+            MeshLayoutKey::MORPHED,
+            "morphed",
+        )?;
+        return Ok(());
+
+        fn add(
+            formatter: &mut Formatter<'_>,
+            first: &mut bool,
+            key: MeshLayoutKey,
+            flag: MeshLayoutKey,
+            name: &str,
+        ) -> fmt::Result {
+            if !key.contains(flag) {
+                return Ok(());
+            }
+            if !*first {
+                formatter.write_str("_")?;
+            }
+            formatter.write_str(name)?;
+            *first = false;
+            Ok(())
+        }
     }
 }


### PR DESCRIPTION
# Objective

Currently, Bevy hardcodes the bind group layouts and bind groups for every combination of mesh features: `model_only`, `skinned`, `morphed`, and `morphed_skinned`. This causes a combinatorial explosion when new mesh features are added, as PR #10231 does for lightmaps.

## Solution

To solve this, PR introduces `MeshLayoutKey`, which is a set of flags that define which mesh features are enabled. All possible combinations of bind group layouts and bind groups are generated generically, so new mesh features can be easily added in the future.

To avoid a runtime combinatorial explosion, the following optimizations have been added:

* Some flags are marked *generic*, which means that bind groups with them only have to be generated once and then can be reused across all meshes.

* `SKINNED` and `MORPHED` bind groups are never generated if the scene doesn't contain any skinned or morphed meshes, respectively.

* `SKINNED` and `MORPHED` bind groups are only generated for meshes that actually have skins or morph targets, respectively.