### PR TITLE
Rename `uv` to `uv_a` and `VERTEX_UVS` to `VERTEX_UVS_A` in shaders.

### DIFF
--- a/assets/shaders/animate_shader.wgsl
+++ b/assets/shaders/animate_shader.wgsl
@@ -32,7 +32,7 @@ fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
     let t_1 = sin(globals.time * speed) * 0.5 + 0.5;
     let t_2 = cos(globals.time * speed);
 
-    let distance_to_center = distance(in.uv, vec2<f32>(0.5)) * 1.4;
+    let distance_to_center = distance(in.uv_a, vec2<f32>(0.5)) * 1.4;
 
     // blending is done in a perceptual color space: https://bottosson.github.io/posts/oklab/
     let red = vec3<f32>(0.627955, 0.224863, 0.125846);

--- a/assets/shaders/array_texture.wgsl
+++ b/assets/shaders/array_texture.wgsl
@@ -20,7 +20,7 @@ fn fragment(
     // the material members
     var pbr_input: PbrInput = pbr_input_new();
 
-    pbr_input.material.base_color = textureSample(my_array_texture, my_array_texture_sampler, mesh.uv, layer);
+    pbr_input.material.base_color = textureSample(my_array_texture, my_array_texture_sampler, mesh.uv_a, layer);
 #ifdef VERTEX_COLORS
     pbr_input.material.base_color = pbr_input.material.base_color * mesh.color;
 #endif
@@ -43,7 +43,7 @@ fn fragment(
         mesh.world_tangent,
 #endif
 #endif
-        mesh.uv,
+        mesh.uv_a,
         view.mip_bias,
     );
     pbr_input.V = fns::calculate_view(mesh.world_position, pbr_input.is_orthographic);

--- a/assets/shaders/custom_material.wgsl
+++ b/assets/shaders/custom_material.wgsl
@@ -14,5 +14,5 @@ struct CustomMaterial {
 fn fragment(
     mesh: VertexOutput,
 ) -> @location(0) vec4<f32> {
-    return material.color * textureSample(base_color_texture, base_color_sampler, mesh.uv) * COLOR_MULTIPLIER;
+    return material.color * textureSample(base_color_texture, base_color_sampler, mesh.uv_a) * COLOR_MULTIPLIER;
 }

--- a/assets/shaders/texture_binding_array.wgsl
+++ b/assets/shaders/texture_binding_array.wgsl
@@ -10,8 +10,8 @@ fn fragment(
     mesh: VertexOutput,
 ) -> @location(0) vec4<f32> {
     // Select the texture to sample from using non-uniform uv coordinates
-    let coords = clamp(vec2<u32>(mesh.uv * 4.0), vec2<u32>(0u), vec2<u32>(3u));
+    let coords = clamp(vec2<u32>(mesh.uv_a * 4.0), vec2<u32>(0u), vec2<u32>(3u));
     let index = coords.y * 4u + coords.x;
-    let inner_uv = fract(mesh.uv * 4.0);
+    let inner_uv = fract(mesh.uv_a * 4.0);
     return textureSample(textures[index], nearest_sampler, inner_uv);
 }

--- a/assets/shaders/tonemapping_test_patterns.wgsl
+++ b/assets/shaders/tonemapping_test_patterns.wgsl
@@ -46,7 +46,7 @@ fn continuous_hue(uv: vec2<f32>) -> vec3<f32> {
 fn fragment(
     in: VertexOutput,
 ) -> @location(0) vec4<f32> {
-    var uv = in.uv;
+    var uv = in.uv_a;
     var out = vec3(0.0);
     if uv.y > 0.5 {
         uv.y = 1.0 - uv.y;

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -428,7 +428,7 @@ where
         }
 
         if layout.contains(Mesh::ATTRIBUTE_UV_0) {
-            shader_defs.push("VERTEX_UVS".into());
+            shader_defs.push("VERTEX_UVS_A".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_UV_0.at_shader_location(1));
         }
 

--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -58,9 +58,9 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.position.z = min(out.position.z, 1.0);
 #endif // DEPTH_CLAMP_ORTHO
 
-#ifdef VERTEX_UVS
-    out.uv = vertex.uv;
-#endif // VERTEX_UVS
+#ifdef VERTEX_UVS_A
+    out.uv_a = vertex.uv_a;
+#endif // VERTEX_UVS_A
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS
 #ifdef SKINNED

--- a/crates/bevy_pbr/src/prepass/prepass_io.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_io.wgsl
@@ -6,8 +6,8 @@ struct Vertex {
     @builtin(instance_index) instance_index: u32,
     @location(0) position: vec3<f32>,
 
-#ifdef VERTEX_UVS
-    @location(1) uv: vec2<f32>,
+#ifdef VERTEX_UVS_A
+    @location(1) uv_a: vec2<f32>,
 #endif
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS
@@ -36,8 +36,8 @@ struct VertexOutput {
     // and `frag coord` when used as a fragment stage input
     @builtin(position) position: vec4<f32>,
 
-#ifdef VERTEX_UVS
-    @location(0) uv: vec2<f32>,
+#ifdef VERTEX_UVS_A
+    @location(0) uv_a: vec2<f32>,
 #endif
 
 #ifdef NORMAL_PREPASS_OR_DEFERRED_PREPASS

--- a/crates/bevy_pbr/src/render/forward_io.wgsl
+++ b/crates/bevy_pbr/src/render/forward_io.wgsl
@@ -8,8 +8,8 @@ struct Vertex {
 #ifdef VERTEX_NORMALS
     @location(1) normal: vec3<f32>,
 #endif
-#ifdef VERTEX_UVS
-    @location(2) uv: vec2<f32>,
+#ifdef VERTEX_UVS_A
+    @location(2) uv_a: vec2<f32>,
 #endif
 // (Alternate UVs are at location 3, but they're currently unused here.)
 #ifdef VERTEX_TANGENTS
@@ -33,8 +33,8 @@ struct VertexOutput {
     @builtin(position) position: vec4<f32>,
     @location(0) world_position: vec4<f32>,
     @location(1) world_normal: vec3<f32>,
-#ifdef VERTEX_UVS
-    @location(2) uv: vec2<f32>,
+#ifdef VERTEX_UVS_A
+    @location(2) uv_a: vec2<f32>,
 #endif
 #ifdef VERTEX_TANGENTS
     @location(3) world_tangent: vec4<f32>,

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -645,12 +645,12 @@ impl SpecializedMeshPipeline for MeshPipeline {
         }
 
         if layout.contains(Mesh::ATTRIBUTE_UV_0) {
-            shader_defs.push("VERTEX_UVS".into());
+            shader_defs.push("VERTEX_UVS_A".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_UV_0.at_shader_location(2));
         }
 
         if layout.contains(Mesh::ATTRIBUTE_UV_1) {
-            shader_defs.push("VERTEX_UVS_1".into());
+            shader_defs.push("VERTEX_UVS_B".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_UV_1.at_shader_location(3));
         }
 

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -63,8 +63,8 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.position = mesh_functions::mesh_position_world_to_clip(out.world_position);
 #endif
 
-#ifdef VERTEX_UVS
-    out.uv = vertex.uv;
+#ifdef VERTEX_UVS_A
+    out.uv_a = vertex.uv_a;
 #endif
 
 #ifdef VERTEX_TANGENTS

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -67,8 +67,8 @@ fn pbr_input_from_standard_material(
     pbr_input.material.base_color *= pbr_bindings::material.base_color;
     pbr_input.material.deferred_lighting_pass_id = pbr_bindings::material.deferred_lighting_pass_id;
 
-#ifdef VERTEX_UVS
-    var uv = in.uv;
+#ifdef VERTEX_UVS_A
+    var uv = in.uv_a;
 
 #ifdef VERTEX_TANGENTS
     if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_DEPTH_MAP_BIT) != 0u) {
@@ -94,7 +94,7 @@ fn pbr_input_from_standard_material(
     if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u) {
         pbr_input.material.base_color *= textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, uv, view.mip_bias);
     }
-#endif // VERTEX_UVS
+#endif // VERTEX_UVS_A
 
     pbr_input.material.flags = pbr_bindings::material.flags;
 
@@ -107,7 +107,7 @@ fn pbr_input_from_standard_material(
         // emissive       
         // TODO use .a for exposure compensation in HDR
         var emissive: vec4<f32> = pbr_bindings::material.emissive;
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_EMISSIVE_TEXTURE_BIT) != 0u) {
             emissive = vec4<f32>(emissive.rgb * textureSampleBias(pbr_bindings::emissive_texture, pbr_bindings::emissive_sampler, uv, view.mip_bias).rgb, 1.0);
         }
@@ -117,7 +117,7 @@ fn pbr_input_from_standard_material(
         // metallic and perceptual roughness
         var metallic: f32 = pbr_bindings::material.metallic;
         var perceptual_roughness: f32 = pbr_bindings::material.perceptual_roughness;
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_METALLIC_ROUGHNESS_TEXTURE_BIT) != 0u) {
             let metallic_roughness = textureSampleBias(pbr_bindings::metallic_roughness_texture, pbr_bindings::metallic_roughness_sampler, uv, view.mip_bias);
             // Sampling from GLTF standard channels for now
@@ -131,7 +131,7 @@ fn pbr_input_from_standard_material(
         // occlusion
         // TODO: Split into diffuse/specular occlusion?
         var occlusion: vec3<f32> = vec3(1.0);
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
         if ((pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_OCCLUSION_TEXTURE_BIT) != 0u) {
             occlusion = vec3(textureSampleBias(pbr_bindings::occlusion_texture, pbr_bindings::occlusion_sampler, uv, view.mip_bias).r);
         }
@@ -153,7 +153,7 @@ fn pbr_input_from_standard_material(
             in.world_tangent,
 #endif
 #endif
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
             uv,
 #endif
             view.mip_bias,

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -66,7 +66,7 @@ fn apply_normal_mapping(
     world_tangent: vec4<f32>,
 #endif
 #endif
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
     uv: vec2<f32>,
 #endif
     mip_bias: f32,
@@ -91,7 +91,7 @@ fn apply_normal_mapping(
 #endif
 
 #ifdef VERTEX_TANGENTS
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
 #ifdef STANDARDMATERIAL_NORMAL_MAP
     // Nt is the tangent-space normal.
     var Nt = textureSampleBias(pbr_bindings::normal_map_texture, pbr_bindings::normal_map_sampler, uv, mip_bias).rgb;

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -38,9 +38,9 @@ fn fragment(
             in.world_tangent,
 #endif // STANDARDMATERIAL_NORMAL_MAP
 #endif // VERTEX_TANGENTS
-#ifdef VERTEX_UVS
-            in.uv,
-#endif // VERTEX_UVS
+#ifdef VERTEX_UVS_A
+            in.uv_a,
+#endif // VERTEX_UVS_A
             view.mip_bias,
         );
 

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -17,11 +17,11 @@ fn prepass_alpha_discard(in: VertexOutput) {
 #ifdef MAY_DISCARD
     var output_color: vec4<f32> = pbr_bindings::material.base_color;
 
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
     if (pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u {
-        output_color = output_color * textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, in.uv, view.mip_bias);
+        output_color = output_color * textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, in.uv_a, view.mip_bias);
     }
-#endif // VERTEX_UVS
+#endif // VERTEX_UVS_A
 
     let alpha_mode = pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
     if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {

--- a/crates/bevy_sprite/src/mesh2d/color_material.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/color_material.wgsl
@@ -27,7 +27,7 @@ fn fragment(
     output_color = output_color * mesh.color;
 #endif
     if ((material.flags & COLOR_MATERIAL_FLAGS_TEXTURE_BIT) != 0u) {
-        output_color = output_color * textureSample(texture, texture_sampler, mesh.uv);
+        output_color = output_color * textureSample(texture, texture_sampler, mesh.uv_a);
     }
 #ifdef TONEMAP_IN_SHADER
     output_color = tonemapping::tone_mapping(output_color, view.color_grading);

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -478,7 +478,7 @@ impl SpecializedMeshPipeline for Mesh2dPipeline {
         }
 
         if layout.contains(Mesh::ATTRIBUTE_UV_0) {
-            shader_defs.push("VERTEX_UVS".into());
+            shader_defs.push("VERTEX_UVS_A".into());
             vertex_attributes.push(Mesh::ATTRIBUTE_UV_0.at_shader_location(2));
         }
 

--- a/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/mesh2d.wgsl
@@ -16,7 +16,7 @@ struct Vertex {
 #ifdef VERTEX_NORMALS
     @location(1) normal: vec3<f32>,
 #endif
-#ifdef VERTEX_UVS
+#ifdef VERTEX_UVS_A
     @location(2) uv: vec2<f32>,
 #endif
 #ifdef VERTEX_TANGENTS
@@ -30,8 +30,8 @@ struct Vertex {
 @vertex
 fn vertex(vertex: Vertex) -> VertexOutput {
     var out: VertexOutput;
-#ifdef VERTEX_UVS
-    out.uv = vertex.uv;
+#ifdef VERTEX_UVS_A
+    out.uv_a = vertex.uv_a;
 #endif
 
 #ifdef VERTEX_POSITIONS


### PR DESCRIPTION
# Objective

We now support two sets of UVs, so `uv` and `VERTEX_UVS` in shaders are now ambiguous.

## Solution

To solve this, we explicitly mark the UV set we're using in the shaders, so as to distinguish it from the second UV set used for lightmaps in PR #10231.

The obvious question is "why use `UV_A` and `UV_B` instead of UV0 and UV1?" The answer is that Naga doesn't currently allow preprocessor definitions that end in numbers. To work around this restriction, I renamed UV0 to `UV_A` and UV1 to `UV_B`.

---

## Changelog

### Changed
* In shaders, the `uv` field is now `uv_a`, and the corresponding define changed from `VERTEX_UVS` to `VERTEX_UVS_A`, for clarity when multiple UV sets are involved.

## Migration Guide

* If you were using the `uv` field of the vertex input or output in a custom shaders, change it to `uv_a`. Likewise, the corresponding define should be changed from `VERTEX_UVS` to `VERTEX_UVS_A`.
