### PR TITLE
Use bitbybit to encode the MeshPipelineKey

### DIFF
--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -31,6 +31,8 @@ bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 
+arbitrary-int = "1.2.6"
+bitbybit = "1.2.2"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 radsort = "0.1"

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -87,7 +87,7 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
             shader_defs.push("PERSPECTIVE".into());
         }
 
-        let format = if key.mesh_key.contains(MeshPipelineKey::HDR) {
+        let format = if key.mesh_key.hdr() {
             ViewTarget::TEXTURE_FORMAT_HDR
         } else {
             TextureFormat::bevy_default()
@@ -168,8 +168,7 @@ fn queue_line_gizmos_3d(
             continue;
         }
 
-        let mesh_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
-            | MeshPipelineKey::from_hdr(view.hdr);
+        let mesh_key = MeshPipelineKey::DEFAULT.with_msaa(*msaa).with_hdr(view.hdr);
 
         for (entity, handle) in &line_gizmos {
             let Some(line_gizmo) = line_gizmo_assets.get(handle) else {

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -26,6 +26,8 @@ bevy_window = { path = "../bevy_window", version = "0.12.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }
 
 # other
+arbitrary-int = "1.2.6"
+bitbybit = "1.2.2"
 bitflags = "2.3"
 fixedbitset = "0.4"
 # direct dependency required for derive macro

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -609,19 +609,20 @@ pub struct NotShadowReceiver;
 /// [Percentage Closer Filtering](https://developer.nvidia.com/gpugems/gpugems/part-ii-lighting-and-shadows/chapter-11-shadow-map-antialiasing).
 ///
 /// Currently does not affect point lights.
-#[derive(Component, ExtractComponent, Reflect, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Component, ExtractComponent, Reflect, PartialEq, Eq, Default)]
 #[reflect(Component, Default)]
+#[bitbybit::bitenum(u2, exhaustive: false)]
 pub enum ShadowFilteringMethod {
     /// Hardware 2x2.
     ///
     /// Fast but poor quality.
-    Hardware2x2,
+    Hardware2x2 = 0,
     /// Method by Ignacio Castaño for The Witness using 9 samples and smart
     /// filtering to achieve the same as a regular 5x5 filter kernel.
     ///
     /// Good quality, good performance.
     #[default]
-    Castano13,
+    Castano13 = 1,
     /// Method by Jorge Jimenez for Call of Duty: Advanced Warfare using 8
     /// samples in spiral pattern, randomly-rotated by interleaved gradient
     /// noise with spatial variation.
@@ -629,7 +630,16 @@ pub enum ShadowFilteringMethod {
     /// Good quality when used with
     /// [`TemporalAntiAliasSettings`](bevy_core_pipeline::experimental::taa::TemporalAntiAliasSettings)
     /// and good performance.
-    Jimenez14,
+    Jimenez14 = 2,
+}
+impl ShadowFilteringMethod {
+    pub const fn define(self) -> &'static str {
+        match self {
+            Self::Hardware2x2 => "SHADOW_FILTER_METHOD_HARDWARE_2X2",
+            Self::Castano13 => "SHADOW_FILTER_METHOD_CASTANO_13",
+            Self::Jimenez14 => "SHADOW_FILTER_METHOD_JIMENEZ_14",
+        }
+    }
 }
 
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -91,16 +91,16 @@ impl From<MeshPipelineKey> for MeshPipelineViewLayoutKey {
         if value.msaa_samples() > 1 {
             result |= MeshPipelineViewLayoutKey::MULTISAMPLED;
         }
-        if value.contains(MeshPipelineKey::DEPTH_PREPASS) {
+        if value.depth_prepass() {
             result |= MeshPipelineViewLayoutKey::DEPTH_PREPASS;
         }
-        if value.contains(MeshPipelineKey::NORMAL_PREPASS) {
+        if value.normal_prepass() {
             result |= MeshPipelineViewLayoutKey::NORMAL_PREPASS;
         }
-        if value.contains(MeshPipelineKey::MOTION_VECTOR_PREPASS) {
+        if value.motion_vector_prepass() {
             result |= MeshPipelineViewLayoutKey::MOTION_VECTOR_PREPASS;
         }
-        if value.contains(MeshPipelineKey::DEFERRED_PREPASS) {
+        if value.deferred_prepass() {
             result |= MeshPipelineViewLayoutKey::DEFERRED_PREPASS;
         }
 

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -57,6 +57,8 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.12.0-dev" }
 image = { version = "0.24", default-features = false }
 
 # misc
+arbitrary-int = "1.2.6"
+bitbybit = "1.2.2"
 codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -18,8 +18,37 @@ use bevy_time::TimeSender;
 use bevy_utils::Instant;
 use std::sync::Arc;
 use wgpu::{
-    Adapter, AdapterInfo, CommandBuffer, CommandEncoder, Instance, Queue, RequestAdapterOptions,
+    Adapter, AdapterInfo, CommandBuffer, CommandEncoder, Instance, PrimitiveTopology, Queue,
+    RequestAdapterOptions,
 };
+
+#[bitbybit::bitenum(u3, exhaustive: false)]
+#[derive(Default)]
+pub enum BevyPrimitiveTopology {
+    PointList = 0,
+    LineList = 1,
+    LineStrip = 2,
+    #[default]
+    TriangleList = 3,
+    TriangleStrip = 4,
+}
+impl From<PrimitiveTopology> for BevyPrimitiveTopology {
+    fn from(value: PrimitiveTopology) -> Self {
+        let value = arbitrary_int::u3::new(value as u8);
+        Self::new_with_raw_value(value).unwrap_or_default()
+    }
+}
+impl From<BevyPrimitiveTopology> for PrimitiveTopology {
+    fn from(value: BevyPrimitiveTopology) -> Self {
+        match value {
+            BevyPrimitiveTopology::PointList => Self::PointList,
+            BevyPrimitiveTopology::LineList => Self::LineList,
+            BevyPrimitiveTopology::LineStrip => Self::LineStrip,
+            BevyPrimitiveTopology::TriangleList => Self::TriangleList,
+            BevyPrimitiveTopology::TriangleStrip => Self::TriangleStrip,
+        }
+    }
+}
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -82,22 +82,41 @@ impl Plugin for ViewPlugin {
 ///     .insert_resource(Msaa::default())
 ///     .run();
 /// ```
-#[derive(
-    Resource, Default, Clone, Copy, ExtractResource, Reflect, PartialEq, PartialOrd, Debug,
-)]
+#[bitbybit::bitenum(u3, exhaustive: true)]
+#[derive(Resource, Default, ExtractResource, Reflect, PartialEq, PartialOrd, Debug)]
 #[reflect(Resource)]
 pub enum Msaa {
-    Off = 1,
-    Sample2 = 2,
+    Off = 0,
+    Sample2 = 1,
     #[default]
-    Sample4 = 4,
-    Sample8 = 8,
+    Sample4 = 2,
+    Sample8 = 3,
+    Sample16 = 4,
+    Sample32 = 5,
+    Sample64 = 6,
+    Sample128 = 7,
 }
 
 impl Msaa {
     #[inline]
     pub fn samples(&self) -> u32 {
-        *self as u32
+        1 << u32::from(self.raw_value())
+    }
+    pub fn from_samples(samples: u32) -> Option<Self> {
+        if samples == 0 {
+            return None;
+        }
+        match samples.ilog2() {
+            0 => Some(Msaa::Off),
+            1 => Some(Msaa::Sample2),
+            2 => Some(Msaa::Sample4),
+            3 => Some(Msaa::Sample8),
+            4 => Some(Msaa::Sample16),
+            5 => Some(Msaa::Sample32),
+            6 => Some(Msaa::Sample64),
+            7 => Some(Msaa::Sample128),
+            _ => None,
+        }
     }
 }
 

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -121,10 +121,9 @@ fn queue_custom(
 ) {
     let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
 
-    let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
-
     for (view, mut transparent_phase) in &mut views {
-        let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
+        let view_key = MeshPipelineKey::DEFAULT.with_msaa(*msaa).with_hdr(view.hdr);
+
         let rangefinder = view.rangefinder3d();
         for entity in &material_meshes {
             let Some(mesh_instance) = render_mesh_instances.get(&entity) else {
@@ -133,7 +132,7 @@ fn queue_custom(
             let Some(mesh) = meshes.get(mesh_instance.mesh_asset_id) else {
                 continue;
             };
-            let key = view_key | MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+            let key = view_key.with_primitive_topology(mesh.primitive_topology.into());
             let pipeline = pipelines
                 .specialize(&pipeline_cache, &custom_pipeline, key, &mesh.layout)
                 .unwrap();


### PR DESCRIPTION
# Objective

`MeshPipelineKey` is a "packed struct". Using `bitflags!` doesn't scale for a packed struct, as the key grows in size, so does the complexity of setting its fields and reading them.

## Solution

There are a few crates on crates.io defining macros to make handling packed struct much easier:

- [`packed_struct`]: A venerable crate used in many different libraries, allow reading structs from packed `&[u8]` and vis-versa
- [`bondrewd`]: An old crate generating "reader" and "writers" so that specific fields can be read individually, avoiding the cost of unpacking other fields
- [`bitbybit`]: A relatively recent crate with not many users, based on [`arbitrary-int`], of the same author.

Why chose `bitbybit`?

- It supports arbitrary backing storage for our packed structs (unlike `packed_struct` and `bondrewd` that takes a `&[u8]`), which is important for performance
- It supports reading subset of fields, similarly to `bondrewd`. The struct generated by the macro is pretty much a `MeshPipelineKey(u32)`, then each method does the bitshifting/masking necessary
- It is [post `1.0`][0ver], and still maintained.

Downsides of `bitbybit`:

- There are some cryptic errors hidden in there if you are not careful about how you convert from an `arbitrary-int` to a rust native type (eg: `u3 -> u8`)

Other crates simply do not fit the bill, so I took the one that enabled me to do what I want. 

[`packed_struct`]: https://lib.rs/crates/packed_struct
[`bondrewd`]: https://lib.rs/crates/bondrewd
[`arbitrary-int`]: https://lib.rs/crates/arbitrary-int
[`ux`]: https://lib.rs/crates/ux
[0ver]: https://0ver.org/
[`bitbybit`]: https://lib.rs/crates/bitbybit

We then replace the `bitflags!` definition for `MeshPipelineKey` by one based on `bitflags`. I'm pretty happy with the result. -160 and only for `MeshPipelineKey` is promising.

## Future work

1. This still doesn't fix my major gripe with the rendering code, which is the decoupling between key, shader defs and conditions for shader defs. (But reducing the amount of code reduces how much thinking one has to do to inspect code)
2. There are other pipeline keys that could do with this improvements, but **I'm refusing to update them** before this PR gets merged. It's going to hit **a lot of merge conflicts** and I don't have the time to resolve all of them. I also need the **greenlight from the community** before moving forward with more changes.

---

## Migration Guide

The `MeshPipelineKey` associated `const`s used to compute specific fields have been removed, please replace their usage by accessors such as `MeshPipelineKey::with_taa` and `MeshPipelineKey.may_discard`. With this change, code using `MeshPipelineKey` is likely to be cleaner and easier to read.