### PR TITLE
fix deferred example fog values

### DIFF
--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -52,7 +52,7 @@ fn setup(
             ..default()
         },
         FogSettings {
-            color: Color::rgba(0.05, 0.05, 0.05, 1.0),
+            color: Color::rgba(0.25, 0.25, 0.25, 1.0),
             falloff: FogFalloff::Linear {
                 start: 1.0,
                 end: 8.0,


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/10248

## Solution

- Update fog color values matching the update to the values for [atmospheric_fog.rs](https://github.com/bevyengine/bevy/pull/10226/files#diff-d43c34c9cf52e7ee72b56f8c4fc99ed86e9a1ec2f83642b839c4e75e1dd24f87) in https://github.com/bevyengine/bevy/pull/10226

After this update:
![image](https://github.com/bevyengine/bevy/assets/33357138/5924f97d-e12b-496e-90fa-160d20b82a2e)
