### PR TITLE
Log a warning when the `tonemapping_luts` feature is disabled but required for the selected tonemapper.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,6 @@ default = [
   "multi-threaded",
   "png",
   "hdr",
-  "ktx2",
-  "zstd",
   "vorbis",
   "x11",
   "bevy_gizmos",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -221,8 +221,8 @@ android_shared_stdcxx = ["bevy_internal/android_shared_stdcxx"]
 # Enable detailed trace event logging. These trace events are expensive even when off, thus they require compile time opt-in
 detailed_trace = ["bevy_internal/detailed_trace"]
 
-# Include tonemapping Look Up Tables KTX2 files
-tonemapping_luts = ["bevy_internal/tonemapping_luts"]
+# Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method on your `Camera2dBundle` or `Camera3dBundle`.
+tonemapping_luts = ["bevy_internal/tonemapping_luts", "ktx2", "zstd"]
 
 # Enable AccessKit on Unix backends (currently only works with experimental screen readers and forks.)
 accesskit_unix = ["bevy_internal/accesskit_unix"]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -24,6 +24,7 @@ bevy_asset = { path = "../bevy_asset", version = "0.12.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.12.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.12.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -15,7 +15,7 @@ keywords = ["bevy"]
 [features]
 trace = []
 webgl = []
-tonemapping_luts = []
+tonemapping_luts = ["bevy_render/ktx2", "bevy_render/zstd"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -195,7 +195,11 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             Tonemapping::AcesFitted => shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into()),
             Tonemapping::AgX => {
                 #[cfg(not(feature = "tonemapping_luts"))]
-                bevy_log::error!("AgX tonemapping requires the `tonemapping_luts` feature.");
+                bevy_log::error!(
+                    "AgX tonemapping requires the `tonemapping_luts` feature.
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
+                    or use a different tonemapping method in your CameraBundle."
+                );
                 shader_defs.push("TONEMAP_METHOD_AGX".into());
             }
             Tonemapping::SomewhatBoringDisplayTransform => {
@@ -204,14 +208,18 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             Tonemapping::TonyMcMapface => {
                 #[cfg(not(feature = "tonemapping_luts"))]
                 bevy_log::error!(
-                    "TonyMcMapFace tonemapping requires the `tonemapping_luts` feature."
+                    "TonyMcMapFace tonemapping requires the `tonemapping_luts` feature.
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
+                    or use a different tonemapping method in your CameraBundle."
                 );
                 shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into())
             }
             Tonemapping::BlenderFilmic => {
                 #[cfg(not(feature = "tonemapping_luts"))]
                 bevy_log::error!(
-                    "BlenderFilmic tonemapping requires the `tonemapping_luts` feature."
+                    "BlenderFilmic tonemapping requires the `tonemapping_luts` feature.
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
+                    or use a different tonemapping method in your CameraBundle."
                 );
                 shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
             }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -197,8 +197,8 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                 #[cfg(not(feature = "tonemapping_luts"))]
                 bevy_log::error!(
                     "AgX tonemapping requires the `tonemapping_luts` feature.
-                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
-                    or use a different tonemapping method in your CameraBundle."
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
+                    or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."
                 );
                 shader_defs.push("TONEMAP_METHOD_AGX".into());
             }
@@ -209,8 +209,8 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                 #[cfg(not(feature = "tonemapping_luts"))]
                 bevy_log::error!(
                     "TonyMcMapFace tonemapping requires the `tonemapping_luts` feature.
-                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
-                    or use a different tonemapping method in your CameraBundle."
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
+                    or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."
                 );
                 shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
             }
@@ -218,8 +218,8 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                 #[cfg(not(feature = "tonemapping_luts"))]
                 bevy_log::error!(
                     "BlenderFilmic tonemapping requires the `tonemapping_luts` feature.
-                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
-                    or use a different tonemapping method in your CameraBundle."
+                    Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
+                    or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."
                 );
                 shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
             }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -185,6 +185,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
         if let DebandDither::Enabled = key.deband_dither {
             shader_defs.push("DEBAND_DITHER".into());
         }
+
         match key.tonemapping {
             Tonemapping::None => shader_defs.push("TONEMAP_METHOD_NONE".into()),
             Tonemapping::Reinhard => shader_defs.push("TONEMAP_METHOD_REINHARD".into()),
@@ -192,12 +193,26 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                 shader_defs.push("TONEMAP_METHOD_REINHARD_LUMINANCE".into());
             }
             Tonemapping::AcesFitted => shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into()),
-            Tonemapping::AgX => shader_defs.push("TONEMAP_METHOD_AGX".into()),
+            Tonemapping::AgX => {
+                #[cfg(not(feature = "tonemapping_luts"))]
+                bevy_log::error!("AgX tonemapping requires the `tonemapping_luts` feature.");
+                shader_defs.push("TONEMAP_METHOD_AGX".into());
+            }
             Tonemapping::SomewhatBoringDisplayTransform => {
                 shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
             }
-            Tonemapping::TonyMcMapface => shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into()),
+            Tonemapping::TonyMcMapface => {
+                #[cfg(not(feature = "tonemapping_luts"))]
+                bevy_log::error!(
+                    "TonyMcMapFace tonemapping requires the `tonemapping_luts` feature."
+                );
+                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into())
+            }
             Tonemapping::BlenderFilmic => {
+                #[cfg(not(feature = "tonemapping_luts"))]
+                bevy_log::error!(
+                    "BlenderFilmic tonemapping requires the `tonemapping_luts` feature."
+                );
                 shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
             }
         }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -212,7 +212,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
                     Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml`,
                     or use a different tonemapping method in your CameraBundle."
                 );
-                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into())
+                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
             }
             Tonemapping::BlenderFilmic => {
                 #[cfg(not(feature = "tonemapping_luts"))]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -32,7 +32,7 @@ The default feature set enables most of the expected features of a game engine, 
 |ktx2|KTX2 compressed texture support|
 |multi-threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
 |png|PNG image format support|
-|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files|
+|tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method on your `Camera2dBundle` or `Camera3dBundle`.|
 |vorbis|OGG/VORBIS audio format support|
 |webgl2|Enable some limitations to be able to use WebGL2. If not enabled, it will default to WebGPU in Wasm. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|
 |x11|X11 display server support|


### PR DESCRIPTION
# Objective

Make it obvious why stuff renders pink when rendering stuff with bevy with `default_features = false` and bevy's default tonemapper (TonyMcMapFace, it requires a LUT which requires the `tonemapping_luts`, `ktx2`, and `zstd` features). 

Not sure if this should be considered as fixing these issues, but in my previous PR (https://github.com/bevyengine/bevy/pull/9073, and old discussions on discord that I only somewhat remember) it seemed like we didn't want to make ktx2 and zstd required features for bevy_core_pipeline.

Related https://github.com/bevyengine/bevy/issues/9179
Related https://github.com/bevyengine/bevy/issues/9098

## Solution

This logs an error when a LUT based tonemapper is used without the `tonemapping_luts` feature enabled, and cleans up the default features a bit (`tonemapping_luts` now includes the `ktx2` and `zstd` features, since it panics without them).

Another solution would be to fall back to a non-lut based tonemapper, but I don't like this solution as then it's not explicitly clear to users why eg. a library example renders differently than a normal bevy app (if the library forgot the `tonemapping_luts` feature).

I did remove the `ktx2` and `zstd` features from the list of default features in Cargo.toml, as I don't believe anything else currently in bevy relies on them (or at least searching through every hit for `ktx2` and `zstd` didn't show anything except loading an environment map in some examples), and they still show up in the `cargo_features` doc as default features.

---

## Changelog

- The `tonemapping_luts` feature now includes both the `ktx2` and `zstd` features to avoid a panic when the `tonemapping_luts` feature was enable without both the `ktx2` and `zstd` feature enabled.
