### PR TITLE
Update to wgpu 0.18

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -189,6 +189,8 @@ impl ViewNode for BloomNode {
                         ops: Operations::default(),
                     })],
                     depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
                 });
             downsampling_first_pass.set_render_pipeline(downsampling_first_pipeline);
             downsampling_first_pass.set_bind_group(
@@ -211,6 +213,8 @@ impl ViewNode for BloomNode {
                         ops: Operations::default(),
                     })],
                     depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
                 });
             downsampling_pass.set_render_pipeline(downsampling_pipeline);
             downsampling_pass.set_bind_group(
@@ -232,10 +236,12 @@ impl ViewNode for BloomNode {
                         resolve_target: None,
                         ops: Operations {
                             load: LoadOp::Load,
-                            store: true,
+                            store: StoreOp::Store,
                         },
                     })],
                     depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
                 });
             upsampling_pass.set_render_pipeline(upsampling_pipeline);
             upsampling_pass.set_bind_group(
@@ -262,10 +268,12 @@ impl ViewNode for BloomNode {
                     color_attachments: &[Some(view_target.get_unsampled_color_attachment(
                         Operations {
                             load: LoadOp::Load,
-                            store: true,
+                            store: StoreOp::Store,
                         },
                     ))],
                     depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
                 });
             upsampling_final_pass.set_render_pipeline(upsampling_final_pipeline);
             upsampling_final_pass.set_bind_group(

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
@@ -101,6 +101,8 @@ impl Node for CASNode {
                 ops: Operations::default(),
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         };
 
         let mut render_pass = render_context

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -7,7 +7,7 @@ use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{Node, NodeRunError, RenderGraphContext},
     render_phase::RenderPhase,
-    render_resource::{LoadOp, Operations, RenderPassDescriptor},
+    render_resource::{LoadOp, Operations, RenderPassDescriptor, StoreOp},
     renderer::RenderContext,
     view::{ExtractedView, ViewTarget},
 };
@@ -66,9 +66,11 @@ impl Node for MainPass2dNode {
                         ClearColorConfig::Custom(color) => LoadOp::Clear(color.into()),
                         ClearColorConfig::None => LoadOp::Load,
                     },
-                    store: true,
+                    store: StoreOp::Store,
                 }))],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
 
             if let Some(viewport) = camera.viewport.as_ref() {
@@ -88,9 +90,11 @@ impl Node for MainPass2dNode {
                 label: Some("reset_viewport_pass_2d"),
                 color_attachments: &[Some(target.get_color_attachment(Operations {
                     load: LoadOp::Load,
-                    store: true,
+                    store: StoreOp::Store,
                 }))],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             };
 
             render_context

--- a/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
@@ -11,6 +11,7 @@ use bevy_render::{
     render_phase::RenderPhase,
     render_resource::{
         LoadOp, Operations, PipelineCache, RenderPassDepthStencilAttachment, RenderPassDescriptor,
+        StoreOp,
     },
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget, ViewUniformOffset},
@@ -82,9 +83,10 @@ impl ViewNode for MainOpaquePass3dNode {
             label: Some("main_opaque_pass_3d"),
             // NOTE: The opaque pass loads the color
             // buffer as well as writing to it.
-            color_attachments: &[Some(
-                target.get_color_attachment(Operations { load, store: true }),
-            )],
+            color_attachments: &[Some(target.get_color_attachment(Operations {
+                load,
+                store: StoreOp::Store,
+            }))],
             depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                 view: &depth.view,
                 // NOTE: The opaque main pass loads the depth buffer and possibly overwrites it
@@ -102,10 +104,12 @@ impl ViewNode for MainOpaquePass3dNode {
                         camera_3d.depth_load_op.clone()
                     }
                     .into(),
-                    store: true,
+                    store: StoreOp::Store,
                 }),
                 stencil_ops: None,
             }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         if let Some(viewport) = camera.viewport.as_ref() {

--- a/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
@@ -6,7 +6,7 @@ use bevy_render::{
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::RenderPhase,
     render_resource::{
-        Extent3d, LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor,
+        Extent3d, LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor, StoreOp,
     },
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},
@@ -47,17 +47,19 @@ impl ViewNode for MainTransmissivePass3dNode {
             // NOTE: The transmissive pass loads the color buffer as well as overwriting it where appropriate.
             color_attachments: &[Some(target.get_color_attachment(Operations {
                 load: LoadOp::Load,
-                store: true,
+                store: StoreOp::Store,
             }))],
             depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                 view: &depth.view,
                 // NOTE: The transmissive main pass loads the depth buffer and possibly overwrites it
                 depth_ops: Some(Operations {
                     load: LoadOp::Load,
-                    store: true,
+                    store: StoreOp::Store,
                 }),
                 stencil_ops: None,
             }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
         };
 
         // Run the transmissive pass, sorted back-to-front

--- a/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
@@ -6,7 +6,8 @@ use bevy_render::{
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::RenderPhase,
     render_resource::{
-        Extent3d, LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor, StoreOp,
+        Extent3d, LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor,
+        StoreOp,
     },
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -4,7 +4,9 @@ use bevy_render::{
     camera::ExtractedCamera,
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_phase::RenderPhase,
-    render_resource::{LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor},
+    render_resource::{
+        LoadOp, Operations, RenderPassDepthStencilAttachment, RenderPassDescriptor, StoreOp,
+    },
     renderer::RenderContext,
     view::{ViewDepthTexture, ViewTarget},
 };
@@ -42,7 +44,7 @@ impl ViewNode for MainTransparentPass3dNode {
                 // NOTE: The transparent pass loads the color buffer as well as overwriting it where appropriate.
                 color_attachments: &[Some(target.get_color_attachment(Operations {
                     load: LoadOp::Load,
-                    store: true,
+                    store: StoreOp::Store,
                 }))],
                 depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                     view: &depth.view,
@@ -54,10 +56,12 @@ impl ViewNode for MainTransparentPass3dNode {
                     // transparent ones.
                     depth_ops: Some(Operations {
                         load: LoadOp::Load,
-                        store: true,
+                        store: StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
 
             if let Some(viewport) = camera.viewport.as_ref() {
@@ -77,9 +81,11 @@ impl ViewNode for MainTransparentPass3dNode {
                 label: Some("reset_viewport_pass_3d"),
                 color_attachments: &[Some(target.get_color_attachment(Operations {
                     load: LoadOp::Load,
-                    store: true,
+                    store: StoreOp::Store,
                 }))],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             };
 
             render_context

--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -104,10 +104,12 @@ impl ViewNode for CopyDeferredLightingIdNode {
                 view: &deferred_lighting_id_depth_texture.texture.default_view,
                 depth_ops: Some(Operations {
                     load: LoadOp::Clear(0.0),
-                    store: true,
+                    store: StoreOp::Store,
                 }),
                 stencil_ops: None,
             }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         render_pass.set_render_pipeline(pipeline);

--- a/crates/bevy_core_pipeline/src/deferred/node.rs
+++ b/crates/bevy_core_pipeline/src/deferred/node.rs
@@ -2,6 +2,7 @@ use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryItem;
 use bevy_render::render_graph::ViewNode;
 
+use bevy_render::render_resource::StoreOp;
 use bevy_render::{
     camera::ExtractedCamera,
     prelude::Color,
@@ -76,7 +77,7 @@ impl ViewNode for DeferredGBufferPrepassNode {
                         } else {
                             LoadOp::Clear(Color::BLACK.into())
                         },
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 }),
         );
@@ -92,7 +93,7 @@ impl ViewNode for DeferredGBufferPrepassNode {
                     } else {
                         LoadOp::Clear(Color::BLACK.into())
                     },
-                    store: true,
+                    store: StoreOp::Store,
                 },
             },
         ));
@@ -122,7 +123,7 @@ impl ViewNode for DeferredGBufferPrepassNode {
                         load: LoadOp::Load,
                         #[cfg(not(all(feature = "webgl", target_arch = "wasm32")))]
                         load: LoadOp::Clear(Default::default()),
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 }),
         );
@@ -136,7 +137,7 @@ impl ViewNode for DeferredGBufferPrepassNode {
                     resolve_target: None,
                     ops: Operations {
                         load: LoadOp::Clear(Default::default()),
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 }),
         );
@@ -165,10 +166,12 @@ impl ViewNode for DeferredGBufferPrepassNode {
                             camera_3d.depth_load_op.clone()
                         }
                         .into(),
-                        store: true,
+                        store: StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
 
             if let Some(viewport) = camera.viewport.as_ref() {

--- a/crates/bevy_core_pipeline/src/fxaa/node.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/node.rs
@@ -79,6 +79,8 @@ impl ViewNode for FxaaNode {
                 ops: Operations::default(),
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         };
 
         let mut render_pass = render_context

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -86,9 +86,11 @@ impl Node for MsaaWritebackNode {
                 // the MSAA resolve step.
                 color_attachments: &[Some(target.get_color_attachment(Operations {
                     load: LoadOp::Clear(Default::default()),
-                    store: true,
+                    store: StoreOp::Store,
                 }))],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             };
 
             let bind_group = render_context.render_device().create_bind_group(

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::prelude::*;
 use bevy_ecs::query::QueryItem;
 use bevy_render::render_graph::ViewNode;
+use bevy_render::render_resource::StoreOp;
 use bevy_render::{
     camera::ExtractedCamera,
     prelude::Color,
@@ -59,7 +60,7 @@ impl ViewNode for PrepassNode {
                     resolve_target: None,
                     ops: Operations {
                         load: LoadOp::Clear(Color::BLACK.into()),
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 }),
             view_prepass_textures
@@ -73,7 +74,7 @@ impl ViewNode for PrepassNode {
                         // Blue channel doesn't matter, but set to 0.0 for possible faster clear
                         // https://gpuopen.com/performance/#clears
                         load: LoadOp::Clear(Color::BLACK.into()),
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 }),
             // Use None in place of Deferred attachments
@@ -95,10 +96,12 @@ impl ViewNode for PrepassNode {
                     view: &view_depth_texture.view,
                     depth_ops: Some(Operations {
                         load: LoadOp::Clear(0.0),
-                        store: true,
+                        store: StoreOp::Store,
                     }),
                     stencil_ops: None,
                 }),
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
             if let Some(viewport) = camera.viewport.as_ref() {
                 render_pass.set_camera_viewport(viewport);

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -229,6 +229,8 @@ impl ViewNode for TemporalAntiAliasNode {
                     }),
                 ],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             });
             taa_pass.set_render_pipeline(taa_pipeline);
             taa_pass.set_bind_group(0, &taa_bind_group, &[]);

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -8,7 +8,7 @@ use bevy_render::{
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_resource::{
         BindGroup, BindGroupEntries, BufferId, LoadOp, Operations, PipelineCache,
-        RenderPassColorAttachment, RenderPassDescriptor, SamplerDescriptor, TextureViewId,
+        RenderPassColorAttachment, RenderPassDescriptor, SamplerDescriptor, StoreOp, TextureViewId,
     },
     renderer::RenderContext,
     texture::Image,
@@ -113,10 +113,12 @@ impl ViewNode for TonemappingNode {
                 resolve_target: None,
                 ops: Operations {
                     load: LoadOp::Clear(Default::default()), // TODO shouldn't need to be cleared
-                    store: true,
+                    store: StoreOp::Store,
                 },
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         };
 
         let mut render_pass = render_context

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -5,7 +5,7 @@ use bevy_render::{
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
     render_resource::{
         BindGroup, BindGroupEntries, LoadOp, Operations, PipelineCache, RenderPassColorAttachment,
-        RenderPassDescriptor, SamplerDescriptor, TextureViewId,
+        RenderPassDescriptor, SamplerDescriptor, StoreOp, TextureViewId,
     },
     renderer::RenderContext,
     view::ViewTarget,
@@ -78,10 +78,12 @@ impl ViewNode for UpscalingNode {
                 resolve_target: None,
                 ops: Operations {
                     load: color_attachment_load_op,
-                    store: true,
+                    store: StoreOp::Store,
                 },
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         };
 
         let mut render_pass = render_context

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -34,7 +34,8 @@ fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
-naga_oil = "0.10"
+# naga_oil = "0.10"
+naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "naga-0.14" }
 smallvec = "1.6"
 thread_local = "1.0"
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -34,8 +34,7 @@ fixedbitset = "0.4"
 # direct dependency required for derive macro
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
-# naga_oil = "0.10"
-naga_oil = { git = "https://github.com/robtfm/naga_oil.git", branch = "naga-0.14" }
+naga_oil = "0.11"
 smallvec = "1.6"
 thread_local = "1.0"
 

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -209,16 +209,18 @@ impl ViewNode for DeferredOpaquePass3dPbrLightingNode {
                     ClearColorConfig::Custom(color) => LoadOp::Clear(color.into()),
                     ClearColorConfig::None => LoadOp::Load,
                 },
-                store: true,
+                store: StoreOp::Store,
             }))],
             depth_stencil_attachment: Some(RenderPassDepthStencilAttachment {
                 view: &deferred_lighting_id_depth_texture.texture.default_view,
                 depth_ops: Some(Operations {
                     load: LoadOp::Load,
-                    store: false,
+                    store: StoreOp::Discard,
                 }),
                 stencil_ops: None,
             }),
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         render_pass.set_render_pipeline(pipeline);

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1765,10 +1765,12 @@ impl Node for ShadowPassNode {
                             view: &view_light.depth_texture_view,
                             depth_ops: Some(Operations {
                                 load: LoadOp::Clear(0.0),
-                                store: true,
+                                store: StoreOp::Store,
                             }),
                             stencil_ops: None,
                         }),
+                        timestamp_writes: None,
+                        occlusion_query_set: None,
                     });
 
                 shadow_phase.render(&mut render_pass, world, view_light_entity);

--- a/crates/bevy_pbr/src/render/utils.wgsl
+++ b/crates/bevy_pbr/src/render/utils.wgsl
@@ -34,7 +34,7 @@ fn coords_to_viewport_uv(position: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> 
 // For encoding normals or unit direction vectors as octahedral coordinates.
 fn octahedral_encode(v: vec3<f32>) -> vec2<f32> {
     var n = v / (abs(v.x) + abs(v.y) + abs(v.z));
-    let octahedral_wrap = (1.0 - abs(n.yx)) * select(vec2(-1.0), vec2(1.0), n.xy > 0.0);
+    let octahedral_wrap = (1.0 - abs(n.yx)) * select(vec2(-1.0), vec2(1.0), n.xy > vec2f(0.0));
     let n_xy = select(octahedral_wrap, n.xy, n.z >= 0.0);
     return n_xy * 0.5 + 0.5;
 }

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -238,6 +238,7 @@ impl ViewNode for SsaoNode {
                     .command_encoder()
                     .begin_compute_pass(&ComputePassDescriptor {
                         label: Some("ssao_preprocess_depth_pass"),
+                        timestamp_writes: None,
                     });
             preprocess_depth_pass.set_pipeline(preprocess_depth_pipeline);
             preprocess_depth_pass.set_bind_group(0, &bind_groups.preprocess_depth_bind_group, &[]);
@@ -259,6 +260,7 @@ impl ViewNode for SsaoNode {
                     .command_encoder()
                     .begin_compute_pass(&ComputePassDescriptor {
                         label: Some("ssao_gtao_pass"),
+                        timestamp_writes: None,
                     });
             gtao_pass.set_pipeline(gtao_pipeline);
             gtao_pass.set_bind_group(0, &bind_groups.gtao_bind_group, &[]);
@@ -280,6 +282,7 @@ impl ViewNode for SsaoNode {
                     .command_encoder()
                     .begin_compute_pass(&ComputePassDescriptor {
                         label: Some("ssao_spatial_denoise_pass"),
+                        timestamp_writes: None,
                     });
             spatial_denoise_pass.set_pipeline(spatial_denoise_pipeline);
             spatial_denoise_pass.set_bind_group(0, &bind_groups.spatial_denoise_bind_group, &[]);

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -62,12 +62,12 @@ image = { version = "0.24", default-features = false }
 codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
-wgpu = { version = "0.17.1", features = [
+wgpu = { version = "0.18", features = [
   "naga",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-naga = { version = "0.13.0", features = ["wgsl-in"] }
-naga_oil = "0.10"
+naga = { version = "0.14.0", features = ["wgsl-in"] }
+naga_oil = "0.11"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,7 +66,7 @@ wgpu = { version = "0.18", features = [
   "naga",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-naga = { version = "0.14.1", features = ["wgsl-in"] }
+naga = { version = "0.14.2", features = ["wgsl-in"] }
 naga_oil = "0.11"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,7 +66,7 @@ wgpu = { version = "0.18", features = [
   "naga",
   "fragile-send-sync-non-atomic-wasm",
 ] }
-naga = { version = "0.14.0", features = ["wgsl-in"] }
+naga = { version = "0.14.1", features = ["wgsl-in"] }
 naga_oil = "0.11"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"

--- a/crates/bevy_render/src/camera/camera_driver_node.rs
+++ b/crates/bevy_render/src/camera/camera_driver_node.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use bevy_ecs::{prelude::QueryState, world::World};
 use bevy_utils::HashSet;
-use wgpu::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor};
+use wgpu::{LoadOp, Operations, RenderPassColorAttachment, RenderPassDescriptor, StoreOp};
 
 pub struct CameraDriverNode {
     cameras: QueryState<&'static ExtractedCamera>,
@@ -77,10 +77,12 @@ impl Node for CameraDriverNode {
                     resolve_target: None,
                     ops: Operations {
                         load: LoadOp::Clear(wgpu::Color::BLACK),
-                        store: true,
+                        store: StoreOp::Store,
                     },
                 })],
                 depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
             };
 
             render_context

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -267,9 +267,7 @@ impl Plugin for RenderPlugin {
                         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
                             backends,
                             dx12_shader_compiler: settings.dx12_shader_compiler.clone(),
-                            // TODO: make this configurable
                             flags: settings.instance_flags,
-                            // TODO: make this configurable
                             gles_minor_version: settings.gles3_minor_version,
                         });
                         // SAFETY: Plugins should be set up on the main thread.

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -268,9 +268,9 @@ impl Plugin for RenderPlugin {
                             backends,
                             dx12_shader_compiler: settings.dx12_shader_compiler.clone(),
                             // TODO: make this configurable
-                            flags: wgpu::InstanceFlags::empty(),
+                            flags: settings.instance_flags,
                             // TODO: make this configurable
-                            gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
+                            gles_minor_version: settings.gles3_minor_version,
                         });
                         // SAFETY: Plugins should be set up on the main thread.
                         let surface = primary_window.map(|wrapper| unsafe {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -267,6 +267,10 @@ impl Plugin for RenderPlugin {
                         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
                             backends,
                             dx12_shader_compiler: settings.dx12_shader_compiler.clone(),
+                            // TODO: make this configurable
+                            flags: wgpu::InstanceFlags::empty(),
+                            // TODO: make this configurable
+                            gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
                         });
                         // SAFETY: Plugins should be set up on the main thread.
                         let surface = primary_window.map(|wrapper| unsafe {

--- a/crates/bevy_render/src/render_resource/mod.rs
+++ b/crates/bevy_render/src/render_resource/mod.rs
@@ -46,7 +46,7 @@ pub use wgpu::{
     PushConstantRange, RenderPassColorAttachment, RenderPassDepthStencilAttachment,
     RenderPassDescriptor, RenderPipelineDescriptor as RawRenderPipelineDescriptor,
     SamplerBindingType, SamplerDescriptor, ShaderModule, ShaderModuleDescriptor, ShaderSource,
-    ShaderStages, StencilFaceState, StencilOperation, StencilState, StorageTextureAccess,
+    ShaderStages, StencilFaceState, StencilOperation, StencilState, StorageTextureAccess, StoreOp,
     TextureAspect, TextureDescriptor, TextureDimension, TextureFormat, TextureSampleType,
     TextureUsages, TextureViewDescriptor, TextureViewDimension, VertexAttribute,
     VertexBufferLayout as RawVertexBufferLayout, VertexFormat, VertexState as RawVertexState,

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -197,6 +197,10 @@ impl ShaderCache {
             }
         }
 
+        // TODO: Check if this is supported, though I'm not sure if bevy works without this feature?
+        // We can't compile for native at least without it.
+        capabilities |= Capabilities::CUBE_ARRAY_TEXTURES;
+
         #[cfg(debug_assertions)]
         let composer = naga_oil::compose::Composer::default();
         #[cfg(not(debug_assertions))]

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -266,6 +266,9 @@ pub async fn initialize_renderer(
             max_bindings_per_bind_group: limits
                 .max_bindings_per_bind_group
                 .min(constrained_limits.max_bindings_per_bind_group),
+            max_non_sampler_bindings: limits
+                .max_non_sampler_bindings
+                .min(constrained_limits.max_non_sampler_bindings),
         };
     }
 

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -4,9 +4,8 @@ use crate::renderer::{
 use std::borrow::Cow;
 
 pub use wgpu::{
-    Backends, Dx12Compiler, Features as WgpuFeatures, Limits as WgpuLimits, PowerPreference,
+    Backends, Dx12Compiler, Features as WgpuFeatures, Gles3MinorVersion, InstanceFlags, Limits as WgpuLimits, PowerPreference,
 };
-use wgpu::{Gles3MinorVersion, InstanceFlags};
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.
 #[derive(Clone)]

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -6,6 +6,7 @@ use std::borrow::Cow;
 pub use wgpu::{
     Backends, Dx12Compiler, Features as WgpuFeatures, Limits as WgpuLimits, PowerPreference,
 };
+use wgpu::{Gles3MinorVersion, InstanceFlags};
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.
 #[derive(Clone)]
@@ -44,6 +45,11 @@ pub struct WgpuSettings {
     pub constrained_limits: Option<WgpuLimits>,
     /// The shader compiler to use for the DX12 backend.
     pub dx12_shader_compiler: Dx12Compiler,
+    /// Allows you to choose which minor version of GLES3 to use (3.0, 3.1, 3.2, or automatic)
+    /// This only applies when using ANGLE and the GL backend.
+    pub gles3_minor_version: Gles3MinorVersion,
+    /// These are for controlling WGPU's debug information to eg. enable validation and shader debug info in release builds.
+    pub instance_flags: InstanceFlags,
 }
 
 impl Default for WgpuSettings {
@@ -82,6 +88,10 @@ impl Default for WgpuSettings {
                 dxc_path: None,
             });
 
+        let gles3_minor_version = wgpu::util::gles_minor_version_from_env().unwrap_or_default();
+
+        let instance_flags = InstanceFlags::default().with_env();
+
         Self {
             device_label: Default::default(),
             backends,
@@ -92,6 +102,8 @@ impl Default for WgpuSettings {
             limits,
             constrained_limits: None,
             dx12_shader_compiler: dx12_compiler,
+            gles3_minor_version,
+            instance_flags,
         }
     }
 }

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -4,7 +4,8 @@ use crate::renderer::{
 use std::borrow::Cow;
 
 pub use wgpu::{
-    Backends, Dx12Compiler, Features as WgpuFeatures, Gles3MinorVersion, InstanceFlags, Limits as WgpuLimits, PowerPreference,
+    Backends, Dx12Compiler, Features as WgpuFeatures, Gles3MinorVersion, InstanceFlags,
+    Limits as WgpuLimits, PowerPreference,
 };
 
 /// Configures the priority used when automatically configuring the features/limits of `wgpu`.

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -290,10 +290,12 @@ pub(crate) fn submit_screenshot_commands(world: &World, encoder: &mut CommandEnc
                         resolve_target: None,
                         ops: wgpu::Operations {
                             load: wgpu::LoadOp::Load,
-                            store: true,
+                            store: wgpu::StoreOp::Store,
                         },
                     })],
                     depth_stencil_attachment: None,
+                    timestamp_writes: None,
+                    occlusion_query_set: None,
                 });
                 pass.set_pipeline(pipeline);
                 pass.set_bind_group(0, &memory.bind_group, &[]);

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
 use bevy_render::{
     render_graph::*,
     render_phase::*,
-    render_resource::{CachedRenderPipelineId, LoadOp, Operations, RenderPassDescriptor},
+    render_resource::{CachedRenderPipelineId, LoadOp, Operations, RenderPassDescriptor, StoreOp},
     renderer::*,
     view::*,
 };
@@ -76,9 +76,11 @@ impl Node for UiPassNode {
             label: Some("ui_pass"),
             color_attachments: &[Some(target.get_unsampled_color_attachment(Operations {
                 load: LoadOp::Load,
-                store: true,
+                store: StoreOp::Store,
             }))],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         transparent_phase.render(&mut render_pass, world, view_entity);

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -198,6 +198,8 @@ impl ViewNode for PostProcessNode {
                 ops: Operations::default(),
             })],
             depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
         });
 
         // This is mostly just wgpu boilerplate for drawing a fullscreen triangle,


### PR DESCRIPTION
# Objective

Keep up to date with wgpu.

## Solution

Update the wgpu version.

Currently blocked on naga_oil updating to naga 0.14 and releasing a new version.

3d scenes (or maybe any scene with lighting?) currently don't render anything due to
```
error: naga_oil bug, please file a report: composer failed to build a valid header: Type [2] '' is invalid
 = Capability Capabilities(CUBE_ARRAY_TEXTURES) is required
 ```

I'm not sure what should be passed in for `wgpu::InstanceFlags`, or if we want to make the gles3minorversion configurable (might be useful for debugging?)

Currently blocked on https://github.com/bevyengine/naga_oil/pull/63, and https://github.com/gfx-rs/wgpu/issues/4569 to be fixed upstream in wgpu first.

## Known issues

Amd+windows+vulkan has issues with texture_binding_arrays (see the image [here](https://github.com/bevyengine/bevy/pull/10266#issuecomment-1819946278)), but that'll be fixed in the next wgpu/naga version, and you can just use dx12 as a workaround for now (Amd+linux mesa+vulkan texture_binding_arrays are fixed though).

---

## Changelog

Updated wgpu to 0.18, naga to 0.14.2, and naga_oil to 0.11.
- Windows desktop GL should now be less painful as it no longer requires Angle.
- You can now toggle shader validation and debug information for debug and release builds using `WgpuSettings.instance_flags` and [InstanceFlags](https://docs.rs/wgpu/0.18.0/wgpu/struct.InstanceFlags.html)

## Migration Guide

- `RenderPassDescriptor` `color_attachments`  (as well as `RenderPassColorAttachment`, and `RenderPassDepthStencilAttachment`) now use `StoreOp::Store` or `StoreOp::Discard` instead of a `boolean` to declare whether or not they should be stored.
- `RenderPassDescriptor` now have `timestamp_writes` and `occlusion_query_set` fields. These can safely be set to `None`.
- `ComputePassDescriptor` now have a `timestamp_writes` field. This can be set to `None` for now.
- See the [wgpu changelog](https://github.com/gfx-rs/wgpu/blob/trunk/CHANGELOG.md#v0180-2023-10-25) for additional details