### PR TITLE
Truncate attribute buffer data rather than attribute buffers

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -420,11 +420,13 @@ impl Mesh {
         let mut attributes_interleaved_buffer = vec![0; vertex_count * vertex_size];
         // bundle into interleaved buffers
         let mut attribute_offset = 0;
-        for attribute_data in self.attributes.values().take(vertex_count) {
+        for attribute_data in self.attributes.values() {
             let attribute_size = attribute_data.attribute.format.get_size() as usize;
             let attributes_bytes = attribute_data.values.get_bytes();
-            for (vertex_index, attribute_bytes) in
-                attributes_bytes.chunks_exact(attribute_size).enumerate()
+            for (vertex_index, attribute_bytes) in attributes_bytes
+                .chunks_exact(attribute_size)
+                .take(vertex_count)
+                .enumerate()
             {
                 let offset = vertex_index * vertex_size + attribute_offset;
                 attributes_interleaved_buffer[offset..offset + attribute_size]


### PR DESCRIPTION
Existing truncation code limits the number of attribute buffers to be less than or equal to the number of vertices.
Instead the number of elements from each attribute buffer should be limited to the length of the shortest buffer as mentioned in the earlier warning.

# Objective

- Fixes #10267 

## Solution

- Moves the `.take()` from the outer loop of attribute buffers, to the inner loop of attribute values. 
---
