### PR TITLE
Fix crash with certain right-aligned text

### DIFF
--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -53,7 +53,16 @@ impl Measure for TextMeasure {
         _available_height: AvailableSpace,
     ) -> Vec2 {
         let x = width.unwrap_or_else(|| match available_width {
-            AvailableSpace::Definite(x) => x.clamp(self.info.min.x, self.info.max.x),
+            AvailableSpace::Definite(x) => {
+                // It is possible for the "min content width" to be larger than
+                // the "max content width" when soft-wrapping right-aligned text
+                // and possibly other situations.
+
+                let min_x = self.info.min.x.min(self.info.max.x);
+                let max_x = self.info.min.x.max(self.info.max.x);
+
+                x.clamp(min_x, max_x)
+            }
             AvailableSpace::MinContent => self.info.min.x,
             AvailableSpace::MaxContent => self.info.max.x,
         });

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -58,10 +58,7 @@ impl Measure for TextMeasure {
                 // the "max content width" when soft-wrapping right-aligned text
                 // and possibly other situations.
 
-                let min_x = self.info.min.x.min(self.info.max.x);
-                let max_x = self.info.min.x.max(self.info.max.x);
-
-                x.clamp(min_x, max_x)
+                x.max(self.info.min.x).min(self.info.max.x)
             }
             AvailableSpace::MinContent => self.info.min.x,
             AvailableSpace::MaxContent => self.info.max.x,


### PR DESCRIPTION
# Objective

Fixes #9395
Alternative to #9415 (See discussion here)

## Solution

Do clamping like [`fit-content`](https://www.w3.org/TR/css-sizing-3/#column-sizing).

## Notes

I am not sure if this is a valid approach. It doesn't seem to cause any obvious issues with our existing examples.