### PR TITLE
Re-export wgpu

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -40,6 +40,8 @@ pub mod prelude {
     };
 }
 
+pub use wgpu;
+
 pub use extract_param::Extract;
 
 use bevy_hierarchy::ValidParentCheckPlugin;


### PR DESCRIPTION
# Objective

Most users don't need direct access to `wgpu::` types beyond the ones exposed in `bevy_render::render_resource` and a couple other places, but users wanting to interact with the render graph typically need more. In addition, we expose wgpu types in several public APIs without exposing those types in Bevy. This means when you want to use these APIs, you have to pull in wgpu as a direct dependency. Since Bevy releases don't always coincide with wgpu releases, it's easy to accidentally pull in a different version than the one Bevy is using. It also means you have to carefully update wgpu version when you update Bevy version.
 
## Solution

- Re-export all `wgpu::` types as `bevy_render::wgpu::`
- All `wgpu` type rexports are unchanged, i.e. `bevy_render::render_resource::AddressMode` still works as well as `bevy_render::wgpu::AddressMode`, so no migration guide necessary

---

## Changelog

- `wgpu` types are now available as `bevy_render::wgpu::XXX`