### PR TITLE
default inherited visibility when parent has invalid components

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -310,13 +310,9 @@ fn visibility_propagate_system(
         let is_visible = match visibility {
             Visibility::Visible => true,
             Visibility::Hidden => false,
-            Visibility::Inherited => match parent {
-                None => true,
-                Some(parent) => visibility_query
-                    .get(parent.get())
-                    .map(|x| x.1.get())
-                    .unwrap_or(true),
-            },
+            Visibility::Inherited => parent
+                .and_then(|p| visibility_query.get(p.get()).ok())
+                .map_or(true, |(_, x)| x.get()),
         };
         let (_, mut inherited_visibility) = visibility_query
             .get_mut(entity)

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -310,6 +310,7 @@ fn visibility_propagate_system(
         let is_visible = match visibility {
             Visibility::Visible => true,
             Visibility::Hidden => false,
+            // fall back to true if no parent is found or parent lacks components
             Visibility::Inherited => parent
                 .and_then(|p| visibility_query.get(p.get()).ok())
                 .map_or(true, |(_, x)| x.get()),

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -312,7 +312,10 @@ fn visibility_propagate_system(
             Visibility::Hidden => false,
             Visibility::Inherited => match parent {
                 None => true,
-                Some(parent) => visibility_query.get(parent.get()).unwrap().1.get(),
+                Some(parent) => visibility_query
+                    .get(parent.get())
+                    .map(|x| x.1.get())
+                    .unwrap_or(true),
             },
         };
         let (_, mut inherited_visibility) = visibility_query
@@ -719,6 +722,24 @@ mod test {
         assert!(!q.get(&world, id2).unwrap().is_changed());
         assert!(!q.get(&world, id3).unwrap().is_changed());
         assert!(!q.get(&world, id4).unwrap().is_changed());
+    }
+
+    #[test]
+    fn visibility_propagation_with_invalid_parent() {
+        let mut world = World::new();
+        let mut schedule = Schedule::default();
+        schedule.add_systems(visibility_propagate_system);
+
+        let parent = world.spawn(()).id();
+        let child = world.spawn(VisibilityBundle::default()).id();
+        world.entity_mut(parent).push_children(&[child]);
+
+        schedule.run(&mut world);
+        world.clear_trackers();
+
+        let child_visible = world.entity(child).get::<InheritedVisibility>().unwrap().0;
+        // defaults to same behavior of parent not found: visible = true
+        assert!(child_visible);
     }
 
     #[test]


### PR DESCRIPTION
# Situation

- In case of parent without visibility components, the visibility inheritance of children creates a panic.

## Solution

- Apply same fallback visibility as parent not found instead of panic.
