### PR TITLE
Fix sampling of diffuse env map texture with non-uniform control flow

### DIFF
--- a/crates/bevy_pbr/src/environment_map/environment_map.wgsl
+++ b/crates/bevy_pbr/src/environment_map/environment_map.wgsl
@@ -22,7 +22,7 @@ fn environment_map_light(
     // Technically we could use textureNumLevels(environment_map_specular) - 1 here, but we use a uniform
     // because textureNumLevels() does not work on WebGL2
     let radiance_level = perceptual_roughness * f32(bindings::lights.environment_map_smallest_specular_mip_level);
-    let irradiance = textureSample(bindings::environment_map_diffuse, bindings::environment_map_sampler, vec3(N.xy, -N.z)).rgb;
+    let irradiance = textureSampleLevel(bindings::environment_map_diffuse, bindings::environment_map_sampler, vec3(N.xy, -N.z), 0.0).rgb;
     let radiance = textureSampleLevel(bindings::environment_map_specular, bindings::environment_map_sampler, vec3(R.xy, -R.z), radiance_level).rgb;
 
     // No real world material has specular values under 0.02, so we use this range as a


### PR DESCRIPTION
# Objective

- `deferred_rendering` and `load_gltf` fail in WebGPU builds due to textureSample() being called on the diffuse environment map texture after non-uniform control flow

## Solution

- The diffuse environment map texture only has one mip, so use `textureSampleLevel(..., 0.0)` to sample that mip and not require UV gradient calculation.