### PR TITLE
Use `clippy::doc_markdown` more.

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,1 @@
-doc-valid-idents = ["sRGB", "NaN", "iOS", "glTF", "GitHub", "WebGL", "WebGPU", "GilRs"]
+doc-valid-idents = ["GilRs", "glTF", "sRGB", "VSync", "WebGL2", "WebGPU", ".."]

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -447,12 +447,11 @@ fn prepare_bloom_bind_groups(
 /// actual highest frequency level).
 ///
 /// Parameters:
-/// * *mip* - the index of the lower frequency pyramid level (0 - max_mip, where 0 indicates highest frequency mip but not the highest frequency image).
-/// * *max_mip* - the index of the lowest frequency pyramid level.
+/// * `mip` - the index of the lower frequency pyramid level (0 - `max_mip`, where 0 indicates highest frequency mip but not the highest frequency image).
+/// * `max_mip` - the index of the lowest frequency pyramid level.
 ///
 /// This function can be visually previewed for all values of *mip* (normalized) with tweakable
 /// [`BloomSettings`] parameters on [Desmos graphing calculator](https://www.desmos.com/calculator/ncc8xbhzzl).
-#[allow(clippy::doc_markdown)]
 fn compute_blend_factor(bloom_settings: &BloomSettings, mip: f32, max_mip: f32) -> f32 {
     let mut lf_boost = (1.0
         - (1.0 - (mip / max_mip)).powf(1.0 / (1.0 - bloom_settings.low_frequency_boost_curvature)))

--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -24,7 +24,6 @@ use bevy_render::{extract_component::ExtractComponent, prelude::Camera};
 /// blurred (lower frequency) images generated from the camera's view.
 /// See <https://starlederer.github.io/bloom/> for a visualization of the parametric curve
 /// used in Bevy as well as a visualization of the curve's respective scattering profile.
-#[allow(clippy::doc_markdown)]
 #[derive(Component, Reflect, Clone)]
 #[reflect(Component, Default)]
 pub struct BloomSettings {

--- a/crates/bevy_mikktspace/src/generated.rs
+++ b/crates/bevy_mikktspace/src/generated.rs
@@ -29,7 +29,6 @@
 
 #![allow(
     clippy::all,
-    clippy::doc_markdown,
     clippy::redundant_else,
     clippy::match_same_arms,
     clippy::semicolon_if_nothing_returned,

--- a/crates/bevy_render/src/render_resource/storage_buffer.rs
+++ b/crates/bevy_render/src/render_resource/storage_buffer.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::doc_markdown)]
-
 use std::marker::PhantomData;
 
 use super::Buffer;

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -88,7 +88,6 @@ impl Default for WinitSettings {
     }
 }
 
-#[allow(clippy::doc_markdown)]
 /// Determines how frequently an [`App`](bevy_app::App) should update.
 ///
 /// **Note:** This setting is independent of VSync. VSync is controlled by a window's


### PR DESCRIPTION
# Objective

- Remove special cases where `clippy::doc_markdown` lint is disabled.

## Solution

- Add default values back into `clippy.toml` by adding `".."` to the list of `doc-valid-idents`.
- Add `"VSync"` and `"WebGL2"` to the list of `doc-valid-idents`.
- Remove all instances where `clippy::doc_markdown` is allowed.
- Fix `max_mip` formatting so that there isn't a warning.
