### PR TITLE
Add dedicated component for specifying draw order in 2D

### DIFF
--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -24,6 +24,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.12.0-dev", features = [
 ] }
 bevy_render = { path = "../bevy_render", version = "0.12.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0-dev" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.12.0-dev" }
 

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite,
+    ComputedSorting, Sorting, Sprite,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -22,6 +22,9 @@ pub struct SpriteBundle {
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
+    /// Controls in what order entities are rendered
+    pub sorting: Sorting,
+    pub computed_sorting: ComputedSorting,
 }
 
 /// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
@@ -40,4 +43,7 @@ pub struct SpriteSheetBundle {
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
+    /// Controls in what order entities are rendered
+    pub sorting: Sorting,
+    pub computed_sorting: ComputedSorting,
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -4,6 +4,7 @@ mod bundle;
 mod dynamic_texture_atlas_builder;
 mod mesh2d;
 mod render;
+mod sorting;
 mod sprite;
 mod texture_atlas;
 mod texture_atlas_builder;
@@ -14,6 +15,7 @@ pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
         bundle::{SpriteBundle, SpriteSheetBundle},
+        sorting::{ComputedSorting, Sorting},
         sprite::Sprite,
         texture_atlas::{TextureAtlas, TextureAtlasSprite},
         ColorMaterial, ColorMesh2dBundle, TextureAtlasBuilder,
@@ -24,6 +26,7 @@ pub use bundle::*;
 pub use dynamic_texture_atlas_builder::*;
 pub use mesh2d::*;
 pub use render::*;
+pub use sorting::*;
 pub use sprite::*;
 pub use texture_atlas::*;
 pub use texture_atlas_builder::*;
@@ -66,7 +69,7 @@ impl Plugin for SpritePlugin {
             .register_type::<TextureAtlasSprite>()
             .register_type::<Anchor>()
             .register_type::<Mesh2dHandle>()
-            .add_plugins((Mesh2dRenderPlugin, ColorMaterialPlugin))
+            .add_plugins((Mesh2dRenderPlugin, ColorMaterialPlugin, SortingPlugin))
             .add_systems(
                 PostUpdate,
                 calculate_bounds_2d.in_set(VisibilitySystems::CalculateBounds),

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -34,8 +34,8 @@ use std::hash::Hash;
 use std::marker::PhantomData;
 
 use crate::{
-    DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey, RenderMesh2dInstances,
-    SetMesh2dBindGroup, SetMesh2dViewBindGroup,
+    ComputedSorting, DrawMesh2d, Mesh2dHandle, Mesh2dPipeline, Mesh2dPipelineKey,
+    RenderMesh2dInstances, SetMesh2dBindGroup, SetMesh2dViewBindGroup, Sorting,
 };
 
 /// Materials are used alongside [`Material2dPlugin`] and [`MaterialMesh2dBundle`]
@@ -439,7 +439,6 @@ pub fn queue_material2d_meshes<M: Material2d>(
 
             mesh_instance.material_bind_group_id = material2d.get_bind_group_id();
 
-            let mesh_z = mesh_instance.transforms.transform.translation.z;
             transparent_phase.add(Transparent2d {
                 entity: *visible_entity,
                 draw_function: draw_transparent_pbr,
@@ -448,7 +447,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                 // lowest sort key and getting closer should increase. As we have
                 // -z in front of the camera, the largest distance is -far with values increasing toward the
                 // camera. As such we can just use mesh_z as the distance
-                sort_key: FloatOrd(mesh_z),
+                sort_key: FloatOrd(mesh_instance.order),
                 // Batching is done in batch_and_prepare_render_phase
                 batch_range: 0..1,
                 dynamic_offset: None,
@@ -633,6 +632,9 @@ pub struct MaterialMesh2dBundle<M: Material2d> {
     pub inherited_visibility: InheritedVisibility,
     // Indication of whether an entity is visible in any view.
     pub view_visibility: ViewVisibility,
+    /// Controls in what order entities are rendered
+    pub sorting: Sorting,
+    pub computed_sorting: ComputedSorting,
 }
 
 impl<M: Material2d> Default for MaterialMesh2dBundle<M> {
@@ -645,6 +647,8 @@ impl<M: Material2d> Default for MaterialMesh2dBundle<M> {
             visibility: Default::default(),
             inherited_visibility: Default::default(),
             view_visibility: Default::default(),
+            sorting: Default::default(),
+            computed_sorting: Default::default(),
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -32,7 +32,7 @@ use bevy_render::{
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::EntityHashMap;
 
-use crate::Material2dBindGroupId;
+use crate::{sorting::ComputedSorting, Material2dBindGroupId};
 
 /// Component for rendering with meshes in the 2d pipeline, usually with a [2d material](crate::Material2d) such as [`ColorMaterial`](crate::ColorMaterial).
 ///
@@ -189,6 +189,7 @@ pub struct RenderMesh2dInstance {
     pub mesh_asset_id: AssetId<Mesh>,
     pub material_bind_group_id: Material2dBindGroupId,
     pub automatic_batching: bool,
+    pub order: f32,
 }
 
 #[derive(Default, Resource, Deref, DerefMut)]
@@ -208,13 +209,14 @@ pub fn extract_mesh2d(
             &GlobalTransform,
             &Mesh2dHandle,
             Has<NoAutomaticBatching>,
+            &ComputedSorting,
         )>,
     >,
 ) {
     render_mesh_instances.clear();
     let mut entities = Vec::with_capacity(*previous_len);
 
-    for (entity, view_visibility, transform, handle, no_automatic_batching) in &query {
+    for (entity, view_visibility, transform, handle, no_automatic_batching, sorting) in &query {
         if !view_visibility.get() {
             continue;
         }
@@ -231,6 +233,7 @@ pub fn extract_mesh2d(
                 mesh_asset_id: handle.0.id(),
                 material_bind_group_id: Material2dBindGroupId::default(),
                 automatic_batching: !no_automatic_batching,
+                order: sorting.order,
             },
         );
     }

--- a/crates/bevy_sprite/src/sorting.rs
+++ b/crates/bevy_sprite/src/sorting.rs
@@ -1,0 +1,188 @@
+use bevy_app::{App, Plugin, PostUpdate};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{Changed, With},
+    schedule::{IntoSystemConfigs, SystemSet},
+    system::Query,
+};
+use bevy_hierarchy::{Children, Parent};
+use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
+
+pub struct SortingPlugin;
+
+impl Plugin for SortingPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(ExtractComponentPlugin::<ComputedSorting>::default())
+            .add_systems(
+                PostUpdate,
+                sorting_propagate_system.in_set(SortingPropagation),
+            );
+    }
+}
+
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+pub struct SortingPropagation;
+
+/// A [`Component`] that controls the sorting of entities for rendering in 2D.
+#[derive(Component, Clone, Debug, PartialEq)]
+pub struct Sorting {
+    /// The order in which this entity will be sorted.
+    ///
+    /// Entities with a higher order render on top of entities with a lower order.
+    ///
+    /// Defaults to `0`.
+    pub order: f32,
+    /// Whether the order is relative to the parent's order.
+    ///
+    /// Defaults to `true`.
+    pub relative: bool,
+}
+
+impl Default for Sorting {
+    fn default() -> Self {
+        Sorting {
+            order: 0.,
+            relative: true,
+        }
+    }
+}
+
+impl Sorting {
+    pub fn from_order(order: f32) -> Self {
+        Sorting {
+            order,
+            ..Default::default()
+        }
+    }
+}
+
+/// The render order computed from the [`Sorting`] component on this entity and it's ancestors.
+#[derive(Component, Default, Clone, Debug, PartialEq, ExtractComponent)]
+pub struct ComputedSorting {
+    /// The order in which this entity is sorted.
+    pub order: f32,
+}
+
+fn sorting_propagate_system(
+    changed: Query<
+        (Entity, &Sorting, Option<&Parent>, Option<&Children>),
+        (With<ComputedSorting>, Changed<Sorting>),
+    >,
+    mut sorting_query: Query<(&Sorting, &mut ComputedSorting)>,
+    children_query: Query<&Children, (With<Sorting>, With<ComputedSorting>)>,
+) {
+    for (entity, sorting, parent, children) in &changed {
+        let order = if sorting.relative {
+            let parent_order = parent
+                .and_then(|parent| sorting_query.get(parent.get()).ok())
+                .map(|(_sorting, computed_sorting)| computed_sorting.order);
+            sorting.order + parent_order.unwrap_or(0.)
+        } else {
+            sorting.order
+        };
+
+        let (_, mut computed_sorting) = sorting_query
+            .get_mut(entity)
+            .expect("With<InheritedSorting> ensures this query will return a value");
+
+        // Only update the sorting if it has changed.
+        // This will prevent the sorting from propagating multiple times in the same frame
+        // if this entity's sorting has been updated recursively by its parent.
+        if computed_sorting.order != order {
+            computed_sorting.order = order;
+
+            // Recursively update the sorting of each child.
+            for &child in children.into_iter().flatten() {
+                propagate_recursive(order, child, &mut sorting_query, &children_query);
+            }
+        }
+    }
+}
+
+fn propagate_recursive(
+    parent_order: f32,
+    entity: Entity,
+    sorting_query: &mut Query<(&Sorting, &mut ComputedSorting)>,
+    children_query: &Query<&Children, (With<Sorting>, With<ComputedSorting>)>,
+) {
+    // Get the sorting components for the current entity.
+    // If the entity does not have the required components, just return early.
+    let Ok((sorting, mut computed_sorting)) = sorting_query.get_mut(entity) else {
+        return;
+    };
+
+    if !sorting.relative {
+        return;
+    };
+
+    let order = sorting.order + parent_order;
+
+    // Only update the sorting if it has changed.
+    if computed_sorting.order == order {
+        return;
+    }
+
+    computed_sorting.order = order;
+
+    // Recursively update the sorting of each child.
+    for &child in children_query.get(entity).ok().into_iter().flatten() {
+        propagate_recursive(order, child, sorting_query, children_query);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_app::App;
+    use bevy_ecs::{entity::Entity, world::World};
+    use bevy_hierarchy::BuildWorldChildren;
+
+    use crate::sorting::{ComputedSorting, Sorting, SortingPlugin};
+
+    #[test]
+    fn propagation() {
+        let mut app = App::new();
+        app.add_plugins(SortingPlugin);
+
+        fn spawn(world: &mut World, order: f32, relative: bool, parent: Option<Entity>) -> Entity {
+            let mut entity = world.spawn((Sorting { order, relative }, ComputedSorting::default()));
+
+            if let Some(parent) = parent {
+                entity.set_parent(parent);
+            }
+            entity.id()
+        }
+
+        let a = spawn(&mut app.world, 1., true, None);
+        let b = spawn(&mut app.world, 1., true, Some(a));
+        let c = spawn(&mut app.world, 2., false, Some(a));
+        let d = spawn(&mut app.world, 2., true, Some(c));
+
+        app.update();
+
+        let mut query = app.world.query::<&ComputedSorting>();
+
+        let result = query
+            .get_many(&app.world, [a, b, c, d])
+            .unwrap()
+            .map(|i| i.order);
+
+        assert_eq!(result, [1., 2., 2., 4.]);
+
+        let mut query = app.world.query::<&mut Sorting>();
+
+        query.get_mut(&mut app.world, a).unwrap().order = -1.;
+        query.get_mut(&mut app.world, c).unwrap().relative = true;
+
+        app.update();
+
+        let mut query = app.world.query::<&ComputedSorting>();
+
+        let result = query
+            .get_many(&app.world, [a, b, c, d])
+            .unwrap()
+            .map(|i| i.order);
+
+        assert_eq!(result, [-1., 0., 1., 3.]);
+    }
+}

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -21,7 +21,9 @@ use bevy_render::{
     view::{InheritedVisibility, ViewVisibility, Visibility},
     Extract,
 };
-use bevy_sprite::{Anchor, ExtractedSprite, ExtractedSprites, TextureAtlas};
+use bevy_sprite::{
+    Anchor, ComputedSorting, ExtractedSprite, ExtractedSprites, Sorting, TextureAtlas,
+};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use bevy_utils::HashSet;
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
@@ -76,6 +78,9 @@ pub struct Text2dBundle {
     pub view_visibility: ViewVisibility,
     /// Contains the size of the text and its glyph's position and scale data. Generated via [`TextPipeline::queue_text`]
     pub text_layout_info: TextLayoutInfo,
+    /// Controls in what order entities are rendered
+    pub sorting: Sorting,
+    pub computed_sorting: ComputedSorting,
 }
 
 pub fn extract_text2d_sprite(
@@ -91,6 +96,7 @@ pub fn extract_text2d_sprite(
             &TextLayoutInfo,
             &Anchor,
             &GlobalTransform,
+            &ComputedSorting,
         )>,
     >,
 ) {
@@ -101,8 +107,15 @@ pub fn extract_text2d_sprite(
         .unwrap_or(1.0);
     let scaling = GlobalTransform::from_scale(Vec2::splat(scale_factor.recip()).extend(1.));
 
-    for (original_entity, view_visibility, text, text_layout_info, anchor, global_transform) in
-        text2d_query.iter()
+    for (
+        original_entity,
+        view_visibility,
+        text,
+        text_layout_info,
+        anchor,
+        global_transform,
+        sorting,
+    ) in text2d_query.iter()
     {
         if !view_visibility.get() {
             continue;
@@ -141,6 +154,7 @@ pub fn extract_text2d_sprite(
                     flip_y: false,
                     anchor: Anchor::Center.as_vec(),
                     original_entity: Some(original_entity),
+                    order: sorting.order,
                 },
             );
         }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -303,12 +303,21 @@ pub fn extract_colored_mesh2d(
     // When extracting, you must use `Extract` to mark the `SystemParam`s
     // which should be taken from the main world.
     query: Extract<
-        Query<(Entity, &ViewVisibility, &GlobalTransform, &Mesh2dHandle), With<ColoredMesh2d>>,
+        Query<
+            (
+                Entity,
+                &ViewVisibility,
+                &GlobalTransform,
+                &Mesh2dHandle,
+                &ComputedSorting,
+            ),
+            With<ColoredMesh2d>,
+        >,
     >,
     mut render_mesh_instances: ResMut<RenderMesh2dInstances>,
 ) {
     let mut values = Vec::with_capacity(*previous_len);
-    for (entity, view_visibility, transform, handle) in &query {
+    for (entity, view_visibility, transform, handle, computed_sorting) in &query {
         if !view_visibility.get() {
             continue;
         }
@@ -326,6 +335,7 @@ pub fn extract_colored_mesh2d(
                 transforms,
                 material_bind_group_id: Material2dBindGroupId::default(),
                 automatic_batching: false,
+                order: computed_sorting.order,
             },
         );
     }

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -14,8 +14,7 @@ const PADDLE_SPEED: f32 = 500.0;
 // How close can the paddle get to the wall
 const PADDLE_PADDING: f32 = 10.0;
 
-// We set the z-value of the ball to 1 so it renders on top in the case of overlapping sprites.
-const BALL_STARTING_POSITION: Vec3 = Vec3::new(0.0, -50.0, 1.0);
+const BALL_STARTING_POSITION: Vec3 = Vec3::new(0.0, -50.0, 0.0);
 const BALL_SIZE: Vec3 = Vec3::new(30.0, 30.0, 0.0);
 const BALL_SPEED: f32 = 400.0;
 const INITIAL_BALL_DIRECTION: Vec2 = Vec2::new(0.5, -0.5);
@@ -210,6 +209,8 @@ fn setup(
             mesh: meshes.add(shape::Circle::default().into()).into(),
             material: materials.add(ColorMaterial::from(BALL_COLOR)),
             transform: Transform::from_translation(BALL_STARTING_POSITION).with_scale(BALL_SIZE),
+            // We set the render order of the ball to 1 so it renders on top in the case of overlapping sprites.
+            sorting: Sorting::from_order(1.),
             ..default()
         },
         Ball,

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -69,7 +69,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<Color
     for y in -half_y..half_y {
         for x in -half_x..half_x {
             let position = Vec2::new(x as f32, y as f32);
-            let translation = (position * tile_size).extend(rng.gen::<f32>());
+            let translation = (position * tile_size).extend(0.);
             let rotation = Quat::from_rotation_z(rng.gen::<f32>());
             let scale = Vec3::splat(rng.gen::<f32>() * 2.0);
 
@@ -89,6 +89,7 @@ fn setup(mut commands: Commands, assets: Res<AssetServer>, color_tint: Res<Color
                     },
                     ..default()
                 },
+                sorting: Sorting::from_order(rng.gen::<f32>()),
                 ..default()
             });
         }


### PR DESCRIPTION
# Objective
Move away from basing draw order on global Z translation in 2D.

## Solution
Add a new `Sorting` component to control the draw order of 2D entities.

This solves the issues of scale on the Z axis and rotation on the X and Y axes affecting the draw order of child entities.

Closes https://github.com/bevyengine/bevy/issues/4149

We could later expand this component with desired features like [sorting groups](https://docs.unity3d.com/2023.3/Documentation/Manual/class-SortingGroup.html) or [y-sort](https://docs.godotengine.org/en/stable/classes/class_canvasitem.html#class-canvasitem-property-y-sort-enabled).

This PR should (probably) be consider together with #8268.

### Benchmark
I've tried to benchmark the following command but I was getting very inconsistent results.
`cargo run --release --example bevymark -- --waves 1 --per-wave 50000 --benchmark`
I now seem to be getting consistent results again that show a large improvement from this PR, but quite frankly I have no idea why that would be, so I don't trust it :v
Probably something to do with my machine/os.

It would be great if someone could run this benchmark on their own machine to verify :)

## Changelog

Added `Sorting` and `ComputedSorting` components.

TODO
* investigate performance
* update examples
* migration guide