### PR TITLE
Fix outdated comment referencing CoreSet

### DIFF
--- a/examples/ecs/apply_deferred.rs
+++ b/examples/ecs/apply_deferred.rs
@@ -2,9 +2,9 @@
 //! to flush commands added by systems that have already run,
 //! but have not had their buffers applied yet.
 //!
-//! This is useful when you don't want to wait until the next flush set
-//! automatically added by Bevy (usually `CoreSet::UpdateFlush`, for systems
-//! added to `CoreSet::Update`) but want to flush commands immediately.
+//! This is useful when you don't want to wait until the next time Bevy
+//! automatically flushes commands (by default, after all systems have run in any
+//! particular schedule) but want to flush commands immediately.
 //!
 //! It is important that systems are ordered correctly with respect to
 //! `apply_deferred`, to avoid surprising non-deterministic system execution order.


### PR DESCRIPTION
# Objective

Fix a comment that is referencing `CoreSet::UpdateFlush` which no longer exists.

## Solution

Delete some words. Write some new words.