### PR TITLE
`normalize` method for `Rect`

### DIFF
--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -315,8 +315,8 @@ impl Rect {
     ///
     /// ```rust
     /// # use bevy_math::{Rect, Vec2};
-    /// let r = Rect::new(2.0, 3.0, 4.0, y: 6.0 };
-    /// let s = Rect::new(0.0, 0.0, 10.0, 10.0 };
+    /// let r = Rect::new(2., 3., 4., 6.);
+    /// let s = Rect::new(0., 0., 10., 10.);
     /// let n = r.normalize(s);
     ///
     /// assert_eq!(n.min.x, 0.2);

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -309,6 +309,29 @@ impl Rect {
         r
     }
 
+    /// Express the coordinates of `self` relative to a normalized [0..1] x [0..1] space defined by `other`.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # use bevy_math::{Rect, Vec2};
+    /// let r = Rect::new(2.0, 3.0, 4.0, y: 6.0 };
+    /// let s = Rect::new(0.0, 0.0, 10.0, 10.0 };
+    /// let n = r.normalize(s);
+    ///
+    /// assert_eq!(n.min.x, 0.2);
+    /// assert_eq!(n.min.y, 0.3);
+    /// assert_eq!(n.max.x, 0.4);
+    /// assert_eq!(n.max.y, 0.6);
+    /// ```
+    pub fn normalize(&self, other: Self) -> Self {
+        let outer_size = other.size();
+        Self {
+            min: (self.min - other.min) / outer_size,
+            max: (self.max - other.min) / outer_size,
+        }
+    }
+
     /// Returns self as [`IRect`] (i32)
     #[inline]
     pub fn as_irect(&self) -> IRect {

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -311,9 +311,9 @@ impl Rect {
 
     /// Express the coordinates of `self` relative to a normalized [0..1] x [0..1] space defined by `other`.
     ///
-    /// # Example
+    /// # Examples
     ///
-    /// ```
+    /// ```rust
     /// # use bevy_math::{Rect, Vec2};
     /// let r = Rect::new(2.0, 3.0, 4.0, y: 6.0 };
     /// let s = Rect::new(0.0, 0.0, 10.0, 10.0 };

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -309,7 +309,8 @@ impl Rect {
         r
     }
 
-    /// Express the coordinates of `self` relative to a normalized [0..1] x [0..1] space defined by `other`.
+    /// Express the coordinates of this rectangle relative to a normalized [0..1] x [0..1] space
+    /// defined by another rectangle.
     ///
     /// # Examples
     ///

--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -309,8 +309,8 @@ impl Rect {
         r
     }
 
-    /// Express the coordinates of this rectangle relative to a normalized [0..1] x [0..1] space
-    /// defined by another rectangle.
+    /// Build a new rectangle from this one with its coordinates expressed
+    /// relative to `other` in a normalized ([0..1] x [0..1]) coordinate system.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
# Objective

`normalize` method that expresses a rectangle relative to a normalized [0..1] x [0..1] space defined by another rectangle.

Useful for UI and texture atlas calculations etc. 
