### PR TITLE
Add frustum to shader View

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -2,6 +2,7 @@ use crate::{
     camera::CameraProjection,
     camera::{ManualTextureViewHandle, ManualTextureViews},
     prelude::Image,
+    primitives::Frustum,
     render_asset::RenderAssets,
     render_resource::TextureView,
     view::{ColorGrading, ExtractedView, ExtractedWindows, RenderLayers, VisibleEntities},
@@ -642,6 +643,7 @@ pub fn extract_cameras(
             &CameraRenderGraph,
             &GlobalTransform,
             &VisibleEntities,
+            &Frustum,
             Option<&ColorGrading>,
             Option<&TemporalJitter>,
             Option<&RenderLayers>,
@@ -657,6 +659,7 @@ pub fn extract_cameras(
         camera_render_graph,
         transform,
         visible_entities,
+        frustum,
         color_grading,
         temporal_jitter,
         render_layers,
@@ -714,6 +717,7 @@ pub fn extract_cameras(
                     color_grading,
                 },
                 visible_entities.clone(),
+                *frustum,
             ));
 
             if let Some(temporal_jitter) = temporal_jitter {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     camera::{ExtractedCamera, ManualTextureViews, MipBias, TemporalJitter},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::{Image, Shader},
-    primitives::Frustum,
+    primitives::{Frustum, HalfSpace},
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
@@ -390,16 +390,7 @@ pub fn prepare_view_uniforms(
         };
 
         let frustum = frustum
-            .map(|frustum| {
-                [
-                    frustum.half_spaces[0].normal_d(),
-                    frustum.half_spaces[1].normal_d(),
-                    frustum.half_spaces[2].normal_d(),
-                    frustum.half_spaces[3].normal_d(),
-                    frustum.half_spaces[4].normal_d(),
-                    frustum.half_spaces[5].normal_d(),
-                ]
-            })
+            .map(|frustum| frustum.half_spaces.map(HalfSpace::normal_d))
             .unwrap_or([Vec4::ZERO; 6]);
 
         let view_uniforms = ViewUniformOffset {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     camera::{ExtractedCamera, ManualTextureViews, MipBias, TemporalJitter},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::{Image, Shader},
-    primitives::{Frustum, HalfSpace},
+    primitives::Frustum,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
@@ -390,7 +390,7 @@ pub fn prepare_view_uniforms(
         };
 
         let frustum = frustum
-            .map(|frustum| frustum.half_spaces.map(HalfSpace::normal_d))
+            .map(|frustum| frustum.half_spaces.map(|h| h.normal_d()))
             .unwrap_or([Vec4::ZERO; 6]);
 
         let view_uniforms = ViewUniformOffset {

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -389,6 +389,7 @@ pub fn prepare_view_uniforms(
                 .unwrap_or_else(|| projection * inverse_view)
         };
 
+        // Map Frustum type to shader array<vec4<f32>, 6>
         let frustum = frustum
             .map(|frustum| frustum.half_spaces.map(|h| h.normal_d()))
             .unwrap_or([Vec4::ZERO; 6]);

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     camera::{ExtractedCamera, ManualTextureViews, MipBias, TemporalJitter},
     extract_resource::{ExtractResource, ExtractResourcePlugin},
     prelude::{Image, Shader},
+    primitives::Frustum,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
     render_resource::{DynamicUniformBuffer, ShaderType, Texture, TextureView},
@@ -168,6 +169,7 @@ pub struct ViewUniform {
     world_position: Vec3,
     // viewport(x_origin, y_origin, width, height)
     viewport: Vec4,
+    frustum: [Vec4; 6],
     color_grading: ColorGrading,
     mip_bias: f32,
 }
@@ -352,6 +354,7 @@ pub fn prepare_view_uniforms(
     views: Query<(
         Entity,
         &ExtractedView,
+        Option<&Frustum>,
         Option<&TemporalJitter>,
         Option<&MipBias>,
     )>,
@@ -365,7 +368,7 @@ pub fn prepare_view_uniforms(
     else {
         return;
     };
-    for (entity, camera, temporal_jitter, mip_bias) in &views {
+    for (entity, camera, frustum, temporal_jitter, mip_bias) in &views {
         let viewport = camera.viewport.as_vec4();
         let unjittered_projection = camera.projection;
         let mut projection = unjittered_projection;
@@ -386,6 +389,19 @@ pub fn prepare_view_uniforms(
                 .unwrap_or_else(|| projection * inverse_view)
         };
 
+        let frustum = frustum
+            .map(|frustum| {
+                [
+                    frustum.half_spaces[0].normal_d(),
+                    frustum.half_spaces[1].normal_d(),
+                    frustum.half_spaces[2].normal_d(),
+                    frustum.half_spaces[3].normal_d(),
+                    frustum.half_spaces[4].normal_d(),
+                    frustum.half_spaces[5].normal_d(),
+                ]
+            })
+            .unwrap_or([Vec4::ZERO; 6]);
+
         let view_uniforms = ViewUniformOffset {
             offset: writer.write(&ViewUniform {
                 view_proj,
@@ -397,6 +413,7 @@ pub fn prepare_view_uniforms(
                 inverse_projection,
                 world_position: camera.transform.translation(),
                 viewport,
+                frustum,
                 color_grading: camera.color_grading,
                 mip_bias: mip_bias.unwrap_or(&MipBias(0.0)).0,
             }),

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -18,6 +18,7 @@ struct View {
     world_position: vec3<f32>,
     // viewport(x_origin, y_origin, width, height)
     viewport: vec4<f32>,
+    frustum: array<vec4<f32>, 6>,
     color_grading: ColorGrading,
     mip_bias: f32,
 };


### PR DESCRIPTION
# Objective
- Work towards GPU-driven culling (https://github.com/bevyengine/bevy/pull/10164)

## Solution
- Pass the view frustum to the shader view uniform

---

## Changelog
- View Frustums are now extracted to the render world and made available to shaders