### PR TITLE
Implement `Display` for `UiRect`

### DIFF
--- a/crates/bevy_ui/src/geometry.rs
+++ b/crates/bevy_ui/src/geometry.rs
@@ -549,6 +549,18 @@ impl Default for UiRect {
     }
 }
 
+impl Display for UiRect {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.left.fmt(f)?;
+        write!(f, " ")?;
+        self.right.fmt(f)?;
+        write!(f, " ")?;
+        self.top.fmt(f)?;
+        write!(f, " ")?;
+        self.bottom.fmt(f)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::geometry::*;


### PR DESCRIPTION
# Objective

Implement the `Display` trait for `UiRect`.

## Solution

Write the four values interspersed by spaces.

```rust
let r = UiRect::new(Val::Px(10.), Val::Auto, Val::Percent(35.), Val::Vw(7.));
println!("{r:?}");
println!("{r}");
```

output:

```
UiRect { left: Px(10.0), right: Auto, top: Percent(35.0), bottom: Vw(7.0) }
10px auto 35% 7vw
```