### PR TITLE
Add OnTransition::Any that runs on any change to the state `S`

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -135,7 +135,7 @@ impl<S: States> NextState<S> {
 /// The state transition that is currently being applied by [`apply_state_transition::<S>`].
 ///
 /// This resource is only present during the execution of [`apply_state_transition::<S>`]
-/// and can only be use by the [`OnTransition`] schedules.
+/// and can only be used by the [`OnTransition`] schedules.
 #[derive(Resource, Debug)]
 pub struct ActiveTransition<S: States> {
     from: S,


### PR DESCRIPTION
# Objective

I want to be able to run a system in between `OnExit` and `OnEnter` that runs on any change to the state. This can be useful if, for example, you want to cover all the possibilities of the transition with a match statement.

## Solution

1. Replace the `OnTransition { from, to }` schedule with an enum:
```
enum OnTransition {
    Any,
    Exact { from, to },
}
```
2. Add the `ActiveTransition` resource that is made available by the `apply_state_transition` system during the transition. This can be used to access the exiting and entering states.

## Open Questions

- ~Currently the `ActiveTransition` resource is made available to all of `OnExit`/`OnTransition`/`OnEnter`. Maybe it should only be made available for `OnTransition`?~ It is now only available to the  `OnTransition` schedules.

## Changelog

- Replace `OnTransition { from, to }` struct with `OnTransition { Any, Exact { from, to } }` enum
- Add `ActiveTransition` resource

## Migration Guide

```rust
// old
OnTransition { from: MyState::A, to: MyState::B }

// new
OnTransition::Exact { from: MyState::A, to: MyState::B }
```
