### PR TITLE
Update base64 requirement from 0.13.0 to 0.21.5

### DIFF
--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -47,7 +47,7 @@ gltf = { version = "1.3.0", default-features = false, features = [
   "utils",
 ] }
 thiserror = "1.0"
-base64 = "0.13.0"
+base64 = "0.21.5"
 percent-encoding = "2.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1"

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1448,7 +1448,7 @@ impl<'a> DataUri<'a> {
 
     fn decode(&self) -> Result<Vec<u8>, base64::DecodeError> {
         if self.base64 {
-            base64::decode(self.data)
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD_NO_PAD, self.data)
         } else {
             Ok(self.data.as_bytes().to_owned())
         }


### PR DESCRIPTION
# Objective

- Update base64 requirement from 0.13.0 to 0.21.5.
- Closes #10317.

## Solution

- Bumped `base64` requirement and manually migrated code to fix a breaking change after updating.