### PR TITLE
Update default `ClearColor` to better match Bevy's branding

### DIFF
--- a/crates/bevy_core_pipeline/src/clear_color.rs
+++ b/crates/bevy_core_pipeline/src/clear_color.rs
@@ -29,6 +29,7 @@ pub struct ClearColor(pub Color);
 
 impl Default for ClearColor {
     fn default() -> Self {
-        Self(Color::rgb(0.4, 0.4, 0.4))
+        // Match the bevy website code block color by default.
+        Self(Color::rgb_u8(43, 44, 47))
     }
 }

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -11,7 +11,6 @@ use bevy::{
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::DARK_GRAY))
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, update_bloom_settings)

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -17,14 +17,15 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Circle::new(4.0).into()),
+        material: materials.add(Color::WHITE.into()),
+        transform: Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        material: materials.add(Color::rgb_u8(124, 144, 255).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
@@ -40,7 +41,7 @@ fn setup(
     });
     // camera
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
 }

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -99,7 +99,6 @@ fn setup_instructions(mut commands: Commands) {
             "Press Spacebar to Toggle Atmospheric Fog.\nPress S to Toggle Directional Light Fog Influence.",
             TextStyle {
                 font_size: 20.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -188,7 +188,7 @@ fn setup(
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 18.0,
-        color: Color::BLACK,
+        ..default()
     };
 
     let label_text_style = TextStyle {

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -14,7 +14,6 @@ use std::{
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::DARK_GRAY))
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup_scene)
         .add_systems(Update, (update_bloom_settings, bounce_spheres))

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -216,7 +216,6 @@ fn setup(
             "",
             TextStyle {
                 font_size: 18.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -74,7 +74,6 @@ fn setup(
             "Perceptual Roughness",
             TextStyle {
                 font_size: 36.0,
-                color: Color::WHITE,
                 ..default()
             },
         )
@@ -91,7 +90,6 @@ fn setup(
             "Metallic",
             TextStyle {
                 font_size: 36.0,
-                color: Color::WHITE,
                 ..default()
             },
         ),

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -4,7 +4,6 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(ClearColor(Color::BLACK))
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -107,7 +107,7 @@ fn setup(
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                 font_size: 26.0,
-                color: Color::BLACK,
+                ..default()
             },
         )
         .with_style(Style {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -76,7 +76,6 @@ fn setup(
             "",
             TextStyle {
                 font_size: 18.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -149,13 +149,13 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 TextStyle {
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 60.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             ),
             TextSection::from_style(TextStyle {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 60.0,
-                color: Color::WHITE,
+                ..default()
             }),
         ])
         .with_style(Style {

--- a/examples/input/text_input.rs
+++ b/examples/input/text_input.rs
@@ -39,7 +39,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font: font.clone_weak(),
                     font_size: 20.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
             TextSection {
@@ -47,7 +47,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font: font.clone_weak(),
                     font_size: 30.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
             TextSection {
@@ -55,7 +55,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font: font.clone_weak(),
                     font_size: 20.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
             TextSection {
@@ -63,7 +63,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font: font.clone_weak(),
                     font_size: 30.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
             TextSection {
@@ -71,7 +71,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font: font.clone_weak(),
                     font_size: 18.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
             TextSection {
@@ -79,7 +79,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
                 style: TextStyle {
                     font,
                     font_size: 25.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             },
         ])
@@ -97,7 +97,7 @@ fn setup_scene(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextStyle {
                 font: asset_server.load("fonts/FiraMono-Medium.ttf"),
                 font_size: 100.0,
-                color: Color::WHITE,
+                ..default()
             },
         ),
         ..default()

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -151,7 +151,6 @@ fn infotext_system(mut commands: Commands) {
             "Nothing to see in this window! Check the console output!",
             TextStyle {
                 font_size: 50.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -135,7 +135,6 @@ fn setup(
 
     let style = TextStyle {
         font_size: 18.0,
-        color: Color::WHITE,
         ..default()
     };
 

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -43,7 +43,6 @@ fn setup(mut commands: Commands) {
             value: "0123456789".repeat(10_000),
             style: TextStyle {
                 font_size: 4.,
-                color: Color::WHITE,
                 ..default()
             },
         }],

--- a/examples/tools/scene_viewer/morph_viewer_plugin.rs
+++ b/examples/tools/scene_viewer/morph_viewer_plugin.rs
@@ -257,7 +257,7 @@ fn detect_morphs(
     let style = TextStyle {
         font: asset_server.load("assets/fonts/FiraMono-Medium.ttf"),
         font_size: 13.0,
-        color: Color::WHITE,
+        ..default()
     };
     let mut sections = vec![
         TextSection::new("Morph Target Controls\n", style.clone()),

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -76,7 +76,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
         font_size: 24.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     commands.spawn(Camera2dBundle::default());
@@ -151,7 +151,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 let text_style = TextStyle {
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 20.0,
-                    color: Color::WHITE,
+                    ..default()
                 };
 
                 builder.spawn(TextBundle {

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -144,7 +144,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextStyle {
                             font: font.clone(),
                             font_size: 24.0,
-                            color: Color::WHITE,
+                            ..default()
                         },
                     ));
                     builder.spawn(TextBundle::from_section(
@@ -152,7 +152,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextStyle {
                             font: font.clone(),
                             font_size: 16.0,
-                            color: Color::WHITE,
+                            ..default()
                         },
                     ));
                     builder.spawn(NodeBundle::default());

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -17,7 +17,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraMono-Medium.ttf"),
         font_size: 20.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     let image = asset_server.load("branding/icon.png");

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -110,7 +110,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         TextStyle {
                             font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                             font_size: 18.0,
-                            color: Color::WHITE,
+                            ..default()
                         },
                     ));
                 });
@@ -185,7 +185,7 @@ fn spawn_text(
             TextStyle {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 120.0,
-                color: Color::WHITE,
+                ..default()
             },
         ));
     });

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -37,7 +37,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 // This font is loaded and will be used instead of the default font.
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 100.0,
-                color: Color::WHITE,
+                ..default()
             },
         ) // Set the alignment of the Text
         .with_text_alignment(TextAlignment::Center)
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     // This font is loaded and will be used instead of the default font.
                     font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                     font_size: 60.0,
-                    color: Color::WHITE,
+                    ..default()
                 },
             ),
             TextSection::from_style(if cfg!(feature = "default_font") {

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -35,7 +35,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextStyle {
                 font: font.clone(),
                 font_size: 50.0,
-                color: Color::WHITE,
+                ..default()
             },
         )
         .with_style(Style {

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -46,7 +46,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     let text_style = TextStyle {
         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
         font_size: 14.0,
-        color: Color::WHITE,
+        ..default()
     };
 
     let root = commands

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -66,7 +66,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     TextStyle {
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                         font_size: 30.0,
-                                        color: Color::WHITE,
+                                        ..default()
                                     },
                                 )
                                 .with_style(Style {
@@ -101,7 +101,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             TextStyle {
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                                 font_size: 25.,
-                                color: Color::WHITE,
+                                ..default()
                             },
                         ),
                         Label,
@@ -144,7 +144,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                                     font: asset_server
                                                         .load("fonts/FiraSans-Bold.ttf"),
                                                     font_size: 20.,
-                                                    color: Color::WHITE,
+                                                    ..default()
                                                 },
                                             ),
                                             Label,

--- a/examples/ui/ui_texture_atlas.rs
+++ b/examples/ui/ui_texture_atlas.rs
@@ -26,7 +26,6 @@ fn setup(
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {
-        color: Color::ANTIQUE_WHITE,
         font_size: 20.,
         ..default()
     };

--- a/examples/ui/window_fallthrough.rs
+++ b/examples/ui/window_fallthrough.rs
@@ -34,7 +34,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             TextStyle {
                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 100.0, // Nice and big so you can see it!
-                color: Color::WHITE,
+                ..default()
             },
         )
         // Set the style of the TextBundle itself.

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -177,7 +177,6 @@ pub(crate) mod test_setup {
                     "Press spacebar to cycle modes\n",
                     TextStyle {
                         font_size: 50.0,
-                        color: Color::WHITE,
                         ..default()
                     },
                 ),

--- a/examples/window/scale_factor_override.rs
+++ b/examples/window/scale_factor_override.rs
@@ -53,7 +53,6 @@ fn setup(mut commands: Commands) {
                             "Example text",
                             TextStyle {
                                 font_size: 30.0,
-                                color: Color::WHITE,
                                 ..default()
                             },
                         )

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -67,7 +67,6 @@ fn setup(
             "Press <spacebar> to save a screenshot to disk",
             TextStyle {
                 font_size: 25.0,
-                color: Color::WHITE,
                 ..default()
             },
         )

--- a/examples/window/window_resizing.rs
+++ b/examples/window/window_resizing.rs
@@ -48,7 +48,6 @@ fn setup_ui(mut cmd: Commands) {
                 "Resolution",
                 TextStyle {
                     font_size: 50.0,
-                    color: Color::BLACK,
                     ..default()
                 },
             ),


### PR DESCRIPTION
# Objective

- Changes the default clear color to match the code block color on Bevy's website.

## Solution

- Changed the clear color, updated text in examples to ensure adequate contrast.
- Additionally, updated the `3d_scene` example to make it look a bit better, and use bevy's branding colors.

![image](https://github.com/bevyengine/bevy/assets/2632925/540a22c0-826c-4c33-89aa-34905e3e313a)
