### PR TITLE
Make VERTEX_COLORS usable in prepass shader, if available

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -432,10 +432,11 @@ where
         if key.mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
             shader_defs.push("DEFERRED_PREPASS".into());
 
-            if layout.contains(Mesh::ATTRIBUTE_COLOR) {
-                shader_defs.push("VERTEX_COLORS".into());
-                vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(6));
-            }
+        }
+
+        if layout.contains(Mesh::ATTRIBUTE_COLOR) {
+            shader_defs.push("VERTEX_COLORS".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(6));
         }
 
         if key

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -431,7 +431,6 @@ where
 
         if key.mesh_key.contains(MeshPipelineKey::DEFERRED_PREPASS) {
             shader_defs.push("DEFERRED_PREPASS".into());
-
         }
 
         if layout.contains(Mesh::ATTRIBUTE_COLOR) {


### PR DESCRIPTION
# Objective

I was working with forward rendering prepass fragment shaders and ran into an issue of not being able to access vertex colors in the prepass. I was able to access vertex colors in regular fragment shaders as well as in deferred shaders.

## Solution

It seems like this `if` was nested unintentionally as moving it outside of the `deferred` block works.

---

## Changelog

Enable vertex colors in forward rendering prepass fragment shaders
