### PR TITLE
Updated WSL2 dependencies doc

### DIFF
--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -28,6 +28,22 @@ necessary servers for passing graphics and audio between Windows and the WSL ins
 With WSLg, a user's WSL instance can use X11 as well as Wayland.
 For more information, see WSLg [documentation](https://github.com/microsoft/wslg#wslg-architecture-overview).
 
+Aside from the Bevy dependencies require for your WSL2 distro, make sure to have the
+following additional dependencies:
+```bash
+sudo apt-get install libxcursor-dev libxrandr libxi6 mesa-vulkan-drivers
+```
+
+Also, ensure Vulkan is used as wgpu backend, either using `WGPU_BACKEND=vulkan` or Bevy plugin settings:
+```rust
+  .add_plugins(DefaultPlugins.set(RenderPlugin {
+      wgpu_settings: WgpuSettings {
+          backends: Some(Backends::VULKAN),
+          ..default()
+      },
+  }))
+```
+
 Prior to the release of [WSL Gui (WSLg)](https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux#WSLg)
 around 4/20/2021, users had to [manually set up servers](https://wiki.ubuntu.com/WSL#Advanced_Topics) on windows for graphic and audio.
 Make note of the date for documentation found across the internet.

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -32,7 +32,7 @@ Aside from the Bevy dependencies required for your WSL2 distro, make sure to hav
 following additional dependencies:
 
 ```bash
-sudo apt-get install libxcursor-dev libxrandr libxi6 mesa-vulkan-drivers
+sudo apt-get install libxcursor-dev libxrandr2 libxi6 mesa-vulkan-drivers
 ```
 
 Also, ensure Vulkan is used as wgpu backend, either using `WGPU_BACKEND=vulkan` or Bevy plugin settings:

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -30,11 +30,13 @@ For more information, see WSLg [documentation](https://github.com/microsoft/wslg
 
 Aside from the Bevy dependencies require for your WSL2 distro, make sure to have the
 following additional dependencies:
+
 ```bash
 sudo apt-get install libxcursor-dev libxrandr libxi6 mesa-vulkan-drivers
 ```
 
 Also, ensure Vulkan is used as wgpu backend, either using `WGPU_BACKEND=vulkan` or Bevy plugin settings:
+
 ```rust
   .add_plugins(DefaultPlugins.set(RenderPlugin {
       wgpu_settings: WgpuSettings {

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -28,7 +28,7 @@ necessary servers for passing graphics and audio between Windows and the WSL ins
 With WSLg, a user's WSL instance can use X11 as well as Wayland.
 For more information, see WSLg [documentation](https://github.com/microsoft/wslg#wslg-architecture-overview).
 
-Aside from the Bevy dependencies require for your WSL2 distro, make sure to have the
+Aside from the Bevy dependencies required for your WSL2 distro, make sure to have the
 following additional dependencies:
 
 ```bash


### PR DESCRIPTION
# Objective

Current [Linux Dependencies](https://github.com/bevyengine/bevy/blob/main/docs/linux_dependencies.md) doc doesn't list required WSL2 dependencies, in order to run Bevy Engine, so even after installing all Ubuntu dependencies, I still wasn't able to run Bevy Engine inside WSL2.

## Solution

After searching and many try and error, I figured out which dependencies are required to run. This was tested on WSL2 using Ubuntu 22.04.

![image](https://github.com/bevyengine/bevy/assets/1176452/02d22c3f-9b25-4b47-9746-5acd6e08531e)

---

## Changelog

N/A

## Migration Guide

N/A
