### PR TITLE
Allow AccessKit to react to WindowEvents before they reach the engine

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -429,7 +429,7 @@ pub fn winit_runner(mut app: App) {
                         #[cfg(not(target_arch = "wasm32"))]
                         let (
                             commands,
-                            mut created_windows_query,
+                            mut windows,
                             event_writer,
                             winit_windows,
                             adapters,
@@ -440,7 +440,7 @@ pub fn winit_runner(mut app: App) {
                         #[cfg(target_arch = "wasm32")]
                         let (
                             commands,
-                            mut created_windows_query,
+                            mut windows,
                             event_writer,
                             winit_windows,
                             adapters,
@@ -452,7 +452,7 @@ pub fn winit_runner(mut app: App) {
                         create_windows(
                             event_loop,
                             commands,
-                            created_windows_query.iter_mut(),
+                            windows.iter_mut(),
                             event_writer,
                             winit_windows,
                             adapters,
@@ -867,7 +867,7 @@ pub fn winit_runner(mut app: App) {
                     #[cfg(not(target_arch = "wasm32"))]
                     let (
                         commands,
-                        mut created_windows_query,
+                        mut windows,
                         event_writer,
                         winit_windows,
                         adapters,
@@ -878,7 +878,7 @@ pub fn winit_runner(mut app: App) {
                     #[cfg(target_arch = "wasm32")]
                     let (
                         commands,
-                        mut created_windows_query,
+                        mut windows,
                         event_writer,
                         winit_windows,
                         adapters,
@@ -890,7 +890,7 @@ pub fn winit_runner(mut app: App) {
                     create_windows(
                         event_loop,
                         commands,
-                        created_windows_query.iter_mut(),
+                        windows.iter_mut(),
                         event_writer,
                         winit_windows,
                         adapters,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -429,7 +429,7 @@ pub fn winit_runner(mut app: App) {
                         #[cfg(not(target_arch = "wasm32"))]
                         let (
                             commands,
-                            mut windows,
+                            mut created_windows_query,
                             event_writer,
                             winit_windows,
                             adapters,
@@ -440,7 +440,7 @@ pub fn winit_runner(mut app: App) {
                         #[cfg(target_arch = "wasm32")]
                         let (
                             commands,
-                            mut windows,
+                            mut created_windows_query,
                             event_writer,
                             winit_windows,
                             adapters,
@@ -452,7 +452,7 @@ pub fn winit_runner(mut app: App) {
                         create_windows(
                             event_loop,
                             commands,
-                            windows.iter_mut(),
+                            created_windows_query.iter_mut(),
                             event_writer,
                             winit_windows,
                             adapters,
@@ -867,7 +867,7 @@ pub fn winit_runner(mut app: App) {
                     #[cfg(not(target_arch = "wasm32"))]
                     let (
                         commands,
-                        mut windows,
+                        mut created_windows_query,
                         event_writer,
                         winit_windows,
                         adapters,
@@ -878,7 +878,7 @@ pub fn winit_runner(mut app: App) {
                     #[cfg(target_arch = "wasm32")]
                     let (
                         commands,
-                        mut windows,
+                        mut created_windows_query,
                         event_writer,
                         winit_windows,
                         adapters,
@@ -890,7 +890,7 @@ pub fn winit_runner(mut app: App) {
                     create_windows(
                         event_loop,
                         commands,
-                        windows.iter_mut(),
+                        created_windows_query.iter_mut(),
                         event_writer,
                         winit_windows,
                         adapters,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -495,6 +495,18 @@ pub fn winit_runner(mut app: App) {
                     return;
                 };
 
+                // Allow AccessKit to filter `WindowEvent`s before they reach
+                // the engine.
+                if let Some(adapters) = app.world.get_non_send_resource::<AccessKitAdapters>() {
+                    if let Some(adapter) = adapters.get(&window_entity) {
+                        if let Some(window) = winit_windows.get_window(window_entity) {
+                            if !adapter.on_event(window, &event) {
+                                return;
+                            }
+                        }
+                    }
+                }
+
                 runner_state.window_event_received = true;
 
                 match event {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -496,13 +496,15 @@ pub fn winit_runner(mut app: App) {
                     return;
                 };
 
-                // Allow AccessKit to filter `WindowEvent`s before they reach
+                // Allow AccessKit to respond to `WindowEvent`s before they reach
                 // the engine.
                 if let Some(adapter) = access_kit_adapters.get(&window_entity) {
                     if let Some(window) = winit_windows.get_window(window_entity) {
-                        if !adapter.on_event(window, &event) {
-                            return;
-                        }
+                        // Somewhat surprisingly, this call has meaningful side effects 
+                        // See https://github.com/AccessKit/accesskit/issues/300
+                        // AccessKit might later need to filter events based on this, but we currently do not.
+                        // See https://github.com/bevyengine/bevy/pull/10239#issuecomment-1775572176
+                        let _ = adapter.on_event(window, &event);
                     }
                 }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -372,6 +372,7 @@ pub fn winit_runner(mut app: App) {
         WindowAndInputEventWriters,
         NonSend<WinitWindows>,
         Query<(&mut Window, &mut CachedWindow)>,
+        NonSend<AccessKitAdapters>,
     )> = SystemState::new(&mut app.world);
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -476,7 +477,7 @@ pub fn winit_runner(mut app: App) {
             event::Event::WindowEvent {
                 event, window_id, ..
             } => {
-                let (mut event_writers, winit_windows, mut windows) =
+                let (mut event_writers, winit_windows, mut windows, access_kit_adapters) =
                     event_writer_system_state.get_mut(&mut app.world);
 
                 let Some(window_entity) = winit_windows.get_window_entity(window_id) else {
@@ -497,12 +498,10 @@ pub fn winit_runner(mut app: App) {
 
                 // Allow AccessKit to filter `WindowEvent`s before they reach
                 // the engine.
-                if let Some(adapters) = app.world.get_non_send_resource::<AccessKitAdapters>() {
-                    if let Some(adapter) = adapters.get(&window_entity) {
-                        if let Some(window) = winit_windows.get_window(window_entity) {
-                            if !adapter.on_event(window, &event) {
-                                return;
-                            }
+                if let Some(adapter) = access_kit_adapters.get(&window_entity) {
+                    if let Some(window) = winit_windows.get_window(window_entity) {
+                        if !adapter.on_event(window, &event) {
+                            return;
                         }
                     }
                 }
@@ -725,7 +724,7 @@ pub fn winit_runner(mut app: App) {
                 event: DeviceEvent::MouseMotion { delta: (x, y) },
                 ..
             } => {
-                let (mut event_writers, _, _) = event_writer_system_state.get_mut(&mut app.world);
+                let (mut event_writers, ..) = event_writer_system_state.get_mut(&mut app.world);
                 event_writers.mouse_motion.send(MouseMotion {
                     delta: Vec2::new(x as f32, y as f32),
                 });

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -500,7 +500,7 @@ pub fn winit_runner(mut app: App) {
                 // the engine.
                 if let Some(adapter) = access_kit_adapters.get(&window_entity) {
                     if let Some(window) = winit_windows.get_window(window_entity) {
-                        // Somewhat surprisingly, this call has meaningful side effects 
+                        // Somewhat surprisingly, this call has meaningful side effects
                         // See https://github.com/AccessKit/accesskit/issues/300
                         // AccessKit might later need to filter events based on this, but we currently do not.
                         // See https://github.com/bevyengine/bevy/pull/10239#issuecomment-1775572176

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -732,14 +732,14 @@ pub fn winit_runner(mut app: App) {
                 });
             }
             event::Event::Suspended => {
-                let (mut event_writers, _, _) = event_writer_system_state.get_mut(&mut app.world);
+                let (mut event_writers, ..) = event_writer_system_state.get_mut(&mut app.world);
                 event_writers.lifetime.send(ApplicationLifetime::Suspended);
                 // Mark the state as `WillSuspend`. This will let the schedule run one last time
                 // before actually suspending to let the application react
                 runner_state.active = ActiveState::WillSuspend;
             }
             event::Event::Resumed => {
-                let (mut event_writers, _, _) = event_writer_system_state.get_mut(&mut app.world);
+                let (mut event_writers, ..) = event_writer_system_state.get_mut(&mut app.world);
                 match runner_state.active {
                     ActiveState::NotYetStarted => {
                         event_writers.lifetime.send(ApplicationLifetime::Started);


### PR DESCRIPTION
# Objective

- Adopt #10239 to get it in time for the release
- Fix accessibility on macOS and linux

## Solution

- call `on_event` from AcccessKit adapter on winit events

