### PR TITLE
Change From<Handle<A>> for AssetId<A> implementations to implement Borrow<Handle<A>> instead

### DIFF
--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -178,6 +178,13 @@ impl<A: Asset> From<&Handle<A>> for AssetId<A> {
     }
 }
 
+impl<A: Asset> From<&mut Handle<A>> for AssetId<A> {
+    #[inline]
+    fn from(value: &mut Handle<A>) -> Self {
+        value.id()
+    }
+}
+
 impl<A: Asset> From<UntypedHandle> for AssetId<A> {
     #[inline]
     fn from(value: UntypedHandle) -> Self {

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -2,9 +2,10 @@ use crate::{Asset, AssetIndex, Handle, UntypedHandle};
 use bevy_reflect::{Reflect, Uuid};
 use std::{
     any::TypeId,
+    borrow::Borrow,
     fmt::{Debug, Display},
     hash::Hash,
-    marker::PhantomData, borrow::Borrow,
+    marker::PhantomData,
 };
 
 /// A unique runtime-only identifier for an [`Asset`]. This is cheap to [`Copy`]/[`Clone`] and is not directly tied to the

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -4,7 +4,7 @@ use std::{
     any::TypeId,
     fmt::{Debug, Display},
     hash::Hash,
-    marker::PhantomData,
+    marker::PhantomData, borrow::Borrow,
 };
 
 /// A unique runtime-only identifier for an [`Asset`]. This is cheap to [`Copy`]/[`Clone`] and is not directly tied to the
@@ -164,24 +164,10 @@ impl<A: Asset> From<Uuid> for AssetId<A> {
     }
 }
 
-impl<A: Asset> From<Handle<A>> for AssetId<A> {
+impl<T: Borrow<Handle<A>>, A: Asset> From<T> for AssetId<A> {
     #[inline]
-    fn from(value: Handle<A>) -> Self {
-        value.id()
-    }
-}
-
-impl<A: Asset> From<&Handle<A>> for AssetId<A> {
-    #[inline]
-    fn from(value: &Handle<A>) -> Self {
-        value.id()
-    }
-}
-
-impl<A: Asset> From<&mut Handle<A>> for AssetId<A> {
-    #[inline]
-    fn from(value: &mut Handle<A>) -> Self {
-        value.id()
+    fn from(value: T) -> Self {
+        value.borrow().id()
     }
 }
 


### PR DESCRIPTION
# Objective

In my project I used to do `images.get_mut(mutable_reference_to_handle)`, but that no longer works in 0.12.0 because `From<&mut Handle<A>>` isn't implemented for `AssetId<A>`. This PR fixes that.

## Solution

Replace the implementations:
-  `From<Handle<A>>` for `AssetId<A>`
-  `From<&Handle<A>>` for `AssetId<A>`

With: `impl<T: Borrow<Handle<A>>, A: Asset> From<T> for AssetId<A> `

Result: You can now pass mutable references to handles to functions that require `AssetId`s

## Changelog

- Added ability to pass mutable references to `Handle`s as `AssetId`s
