### PR TITLE
docs: use `read` instead of deprecated `iter`

### DIFF
--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -119,7 +119,7 @@ use bevy_utils::Duration;
 /// struct PauseEvent(bool);
 ///
 /// fn pause_system(mut time: ResMut<Time<Virtual>>, mut events: EventReader<PauseEvent>) {
-///     for ev in events.iter() {
+///     for ev in events.read() {
 ///         if ev.0 {
 ///             time.pause();
 ///         } else {


### PR DESCRIPTION
https://docs.rs/bevy/latest/bevy/ecs/event/struct.EventReader.html#method.iter

# Objective

- Remove doc example using deprecated `EventReader.iter` method

## Solution

- Update docs to use `read` instead of `iter`