### PR TITLE
Allow registering boxed systems

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -55,10 +55,18 @@ impl World {
         &mut self,
         system: S,
     ) -> SystemId {
+        self.register_boxed_system(Box::new(IntoSystem::into_system(system)))
+    }
+
+    /// Similar to [`Self::register_system`], but allows passing in a [`BoxedSystem`].
+    ///
+    ///  This is useful if the [`IntoSystem`] implementor has already been turned into a
+    /// [`System`](crate::system::System) trait object and put in a [`Box`].
+    pub fn register_boxed_system(&mut self, system: BoxedSystem) -> SystemId {
         SystemId(
             self.spawn(RegisteredSystem {
                 initialized: false,
-                system: Box::new(IntoSystem::into_system(system)),
+                system,
             })
             .id(),
         )


### PR DESCRIPTION
# Objective

- Allow registration of one-shot systems when those systems have already been `Box`ed.
- Needed for `bevy_eventlisteners` which allows adding event listeners with callbacks in normal systems. The current one shot system implementation requires systems be registered from an exclusive system, and that those systems be passed in as types that implement `IntoSystem`. However, the eventlistener callback crate allows users to define their callbacks in normal systems, by boxing the system and deferring initialization to an exclusive system.

## Solution

- Separate the registration of the system from the boxing of the system. This is non-breaking, and adds a new method.

---

## Changelog

- Added `World::register_boxed_system` to allow registration of already-boxed one shot systems.