### PR TITLE
Fixed unwrap on None when importing embedded assets

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -109,7 +109,7 @@ macro_rules! embedded_path {
 
     ($source_path: expr, $path_str: expr) => {{
         let crate_name = module_path!().split(':').next().unwrap();
-        let after_src = file!().split($source_path).nth(1).unwrap();
+        let after_src = file!().split($source_path).nth(0).unwrap();
         let file_path = std::path::Path::new(after_src)
             .parent()
             .unwrap()


### PR DESCRIPTION
# Objective

- Fixes unwrap on None problem when importing a embedded asset. Just a slight change.

## Solution

- Use the 0th instead of 1th in macro `embedded_path!`
- Before:
- `let after_src = file!().split($source_path).nth(1).unwrap();`
- After:
- `let after_src = file!().split($source_path).nth(0).unwrap();`

---

- The embedded assets can be now imported correctly.
