### PR TITLE
Add 'World::run_system_with_input' function + allow `World::run_system` to get system output

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -5,7 +5,7 @@ use crate::{
     self as bevy_ecs,
     bundle::Bundle,
     entity::{Entities, Entity},
-    system::{RunSystem, SystemId},
+    system::{RunSystemWithInput, SystemId},
     world::{EntityWorldMut, FromWorld, World},
 };
 use bevy_ecs_macros::SystemParam;
@@ -524,7 +524,17 @@ impl<'w, 's> Commands<'w, 's> {
     ///
     /// Calls [`World::run_system`](crate::system::World::run_system).
     pub fn run_system(&mut self, id: SystemId) {
-        self.queue.push(RunSystem::new(id));
+        self.run_system_with_input(id, ())
+    }
+
+    /// Runs the system corresponding to the given [`SystemId`].
+    /// Systems are ran in an exclusive and single threaded way.
+    /// Running slow systems can become a bottleneck.
+    ///
+    /// Calls [`World::run_system_with_input`](crate::system::World::run_system_with_input).
+    pub fn run_system_with_input<I: 'static + Send>(&mut self, id: SystemId<I>, input: I) {
+        self.queue
+            .push(RunSystemWithInput::new_with_input(id, input));
     }
 
     /// Pushes a generic [`Command`] to the command queue.

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -523,8 +523,12 @@ impl<'w, 's> Commands<'w, 's> {
     /// Running slow systems can become a bottleneck.
     ///
     /// Calls [`World::run_system`](crate::system::World::run_system).
+    ///
+    /// There is no way to get the output of a system when run as a command, because the
+    /// execution of the system happens later. To get the output of a system, use
+    /// [`World::run_system`] or [`World::run_system_with_input`] instead of running the system as a command.
     pub fn run_system(&mut self, id: SystemId) {
-        self.run_system_with_input(id, ())
+        self.run_system_with_input(id, ());
     }
 
     /// Runs the system corresponding to the given [`SystemId`].
@@ -532,6 +536,10 @@ impl<'w, 's> Commands<'w, 's> {
     /// Running slow systems can become a bottleneck.
     ///
     /// Calls [`World::run_system_with_input`](crate::system::World::run_system_with_input).
+    ///
+    /// There is no way to get the output of a system when run as a command, because the
+    /// execution of the system happens later. To get the output of a system, use
+    /// [`World::run_system`] or [`World::run_system_with_input`] instead of running the system as a command.
     pub fn run_system_with_input<I: 'static + Send>(&mut self, id: SystemId<I>, input: I) {
         self.queue
             .push(RunSystemWithInput::new_with_input(id, input));

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -309,7 +309,7 @@ impl World {
 ///
 /// There is no way to get the output of a system when run as a command, because the
 /// execution of the system happens later. To get the output of a system, use
-/// [World::run_system] or [World::run_system_with_input] instead of running the system as a command.
+/// [`World::run_system`] or [`World::run_system_with_input`] instead of running the system as a command.
 #[derive(Debug, Clone)]
 pub struct RunSystemWithInput<I: 'static> {
     system_id: SystemId<I>,
@@ -326,7 +326,7 @@ pub struct RunSystemWithInput<I: 'static> {
 ///
 /// There is no way to get the output of a system when run as a command, because the
 /// execution of the system happens later. To get the output of a system, use
-/// [World::run_system] or [World::run_system_with_input] instead of running the system as a command.
+/// [`World::run_system`] or [`World::run_system_with_input`] instead of running the system as a command.
 pub type RunSystem = RunSystemWithInput<()>;
 
 impl RunSystem {

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -322,7 +322,7 @@ pub struct RunSystemWithInput<I: 'static> {
 /// Running slow systems can become a bottleneck.
 ///
 /// If the system needs an [`In<_>`](crate::system::In) input value to run, use the
-/// [crate::system::RunSystemWithInput] type instead.
+/// [`crate::system::RunSystemWithInput`] type instead.
 ///
 /// There is no way to get the output of a system when run as a command, because the
 /// execution of the system happens later. To get the output of a system, use

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -43,28 +43,34 @@ pub struct SystemId<I = (), O = ()>(Entity, std::marker::PhantomData<fn(I) -> O>
 
 // A manual impl is used because the trait bounds should ignore the `I` and `O` phantom parameters.
 impl<I, O> Copy for SystemId<I, O> {}
+
 // A manual impl is used because the trait bounds should ignore the `I` and `O` phantom parameters.
 impl<I, O> Clone for SystemId<I, O> {
     fn clone(&self) -> Self {
         *self
     }
 }
+
 // A manual impl is used because the trait bounds should ignore the `I` and `O` phantom parameters.
 impl<I, O> PartialEq for SystemId<I, O> {
     fn eq(&self, other: &Self) -> bool {
         self.0 == other.0 && self.1 == other.1
     }
 }
+
 // A manual impl is used because the trait bounds should ignore the `I` and `O` phantom parameters.
 impl<I, O> std::hash::Hash for SystemId<I, O> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.0.hash(state);
     }
 }
+
 impl<I, O> std::fmt::Debug for SystemId<I, O> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // The PhantomData field is omitted for simplicity.
-        f.debug_tuple("SystemId").field(&self.0).finish()
+        f.debug_tuple("SystemId")
+            .field(&self.0)
+            .field(&self.1)
+            .finish()
     }
 }
 


### PR DESCRIPTION
# Objective

Allows chained systems taking an `In<_>` input parameter to be run as one-shot systems. This API was mentioned in #8963.

In addition, `run_system(_with_input)` returns the system output, for any `'static` output type.

## Solution

A new function, `World::run_system_with_input` allows a `SystemId<I, O>` to be run by providing an `I` value as input and producing `O` as an output.

`SystemId<I, O>` is now generic over the input type `I` and output type `O`, along with the related functions and types `RegisteredSystem`, `RemovedSystem`, `register_system`, `remove_system`, and `RegisteredSystemError`. These default to `()`, preserving the existing API, for all of the public types.

---

## Changelog

- Added `World::run_system_with_input` function to allow one-shot systems that take `In<_>` input parameters
- Changed `World::run_system` and `World::register_system` to support systems with return types beyond `()`
- Added `Commands::run_system_with_input` command that schedules a one-shot system with an `In<_>` input parameter
