### PR TITLE
Revert `App::run()` behavior/Remove `winit` specific code from `bevy_app`

### DIFF
--- a/crates/bevy_app/src/schedule_runner.rs
+++ b/crates/bevy_app/src/schedule_runner.rs
@@ -84,12 +84,7 @@ impl Plugin for ScheduleRunnerPlugin {
 
             let mut app_exit_event_reader = ManualEventReader::<AppExit>::default();
             match run_mode {
-                RunMode::Once => {
-                    // if plugins where cleaned before the runner start, an update already ran
-                    if plugins_state != PluginsState::Cleaned {
-                        app.update();
-                    }
-                }
+                RunMode::Once => app.update(),
                 RunMode::Loop { wait } => {
                     let mut tick = move |app: &mut App,
                                          wait: Option<Duration>|

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -349,6 +349,14 @@ impl Default for WinitAppRunnerState {
 /// Overriding the app's [runner](bevy_app::App::runner) while using `WinitPlugin` will bypass the
 /// `EventLoop`.
 pub fn winit_runner(mut app: App) {
+    if app.plugins_state() == PluginsState::Ready {
+        // If we're already ready, we finish up now and advance one frame.
+        // This prevents black frames during the launch transition on iOS.
+        app.finish();
+        app.cleanup();
+        app.update();
+    }
+
     let mut event_loop = app
         .world
         .remove_non_send_resource::<EventLoop<()>>()


### PR DESCRIPTION
# Objective
The way `bevy_app` works was changed unnecessarily in #9826 whose changes should have been specific to `bevy_winit`.
I'm somewhat disappointed that happened and we can see in https://github.com/bevyengine/bevy/pull/10195 that it made things more complicated.

Even worse, in #10385 it's clear that this breaks the clean abstraction over another engine someone built with Bevy!

Fixes #10385.

## Solution

- Move the changes made to `bevy_app` in #9826 to `bevy_winit`
- Revert the changes to `ScheduleRunnerPlugin` and the `run_once` runner in #10195 as they're no longer necessary.

While this code is breaking relative to `0.12.0`, it reverts the behavior of `bevy_app` back to how it was in `0.11`.
Due to the nature of the breakage relative to `0.11` I hope this will be considered for `0.12.1`.