### PR TITLE
Add `Image` methods for easy access to a pixel's color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -579,6 +579,17 @@ category = "2D Rendering"
 wasm = true
 
 [[example]]
+name = "cpu_draw"
+path = "examples/2d/cpu_draw.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.cpu_draw]
+name = "CPU Drawing"
+description = "Manually read/write the pixels of a texture"
+category = "2D Rendering"
+wasm = true
+
+[[example]]
 name = "sprite"
 path = "examples/2d/sprite.rs"
 doc-scrape-examples = true

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -6,7 +6,8 @@ use super::dds::*;
 use super::ktx2::*;
 
 use bevy_asset::{Asset, RenderAssetUsages};
-use bevy_math::{AspectRatio, UVec2, Vec2};
+use bevy_color::Color;
+use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
 use serde::{Deserialize, Serialize};
@@ -817,6 +818,356 @@ impl Image {
                 .required_features()
                 .contains(wgpu::Features::TEXTURE_COMPRESSION_ETC2)
     }
+
+    /// Compute the byte offset where the data of a specific pixel is stored
+    ///
+    /// Returns None if the provided coordinates are out of bounds.
+    ///
+    /// For 2D textures, Z is ignored. For 1D textures, Y and Z are ignored.
+    #[inline(always)]
+    pub fn pixel_data_offset(&self, coords: UVec3) -> Option<usize> {
+        let width = self.texture_descriptor.size.width;
+        let height = self.texture_descriptor.size.height;
+        let depth = self.texture_descriptor.size.depth_or_array_layers;
+
+        let pixel_size = self.texture_descriptor.format.pixel_size();
+        let pixel_offset = match self.texture_descriptor.dimension {
+            TextureDimension::D3 => {
+                if coords.x > width || coords.y > height || coords.z > depth {
+                    return None;
+                }
+                coords.z * height * width + coords.y * width + coords.x
+            }
+            TextureDimension::D2 => {
+                if coords.x > width || coords.y > height {
+                    return None;
+                }
+                coords.y * width + coords.x
+            }
+            TextureDimension::D1 => {
+                if coords.x > width {
+                    return None;
+                }
+                coords.x
+            }
+        };
+
+        Some(pixel_offset as usize * pixel_size)
+    }
+
+    /// Get a reference to the data bytes where a specific pixel's value is stored
+    #[inline(always)]
+    pub fn pixel_bytes(&self, coords: UVec3) -> Option<&[u8]> {
+        let len = self.texture_descriptor.format.pixel_size();
+        self.pixel_data_offset(coords)
+            .map(|start| &self.data[start..(start + len)])
+    }
+
+    /// Get a mutable reference to the data bytes where a specific pixel's value is stored
+    #[inline(always)]
+    pub fn pixel_bytes_mut(&mut self, coords: UVec3) -> Option<&mut [u8]> {
+        let len = self.texture_descriptor.format.pixel_size();
+        self.pixel_data_offset(coords)
+            .map(|start| &mut self.data[start..(start + len)])
+    }
+
+    /// Read the color of a specific pixel.
+    ///
+    /// This function will find the raw byte data of a specific pixel and
+    /// decode it into a user-friendly [`Color`] struct for you.
+    ///
+    /// Supports many of the common [`TextureFormat`]s:
+    ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
+    ///  - 16-bit and 32-bit unsigned integer (some precision may be lost, as [`Color`] uses `f32`)
+    ///  - 32-bit float
+    ///
+    /// Single channel (R) formats are assumed to represent greyscale, so the value
+    /// will be copied to all three RGB channels in the resulting [`Color`].
+    ///
+    /// Other [`TextureFormat`]s are unsupported, such as:
+    ///  - block-compressed formats
+    ///  - non-byte-aligned formats like 10-bit
+    ///  - 16-bit float formats
+    ///  - signed integer formats
+    #[inline(always)]
+    pub fn get_color_at(&self, coords: UVec3) -> Result<Color, TextureAccessError> {
+        let Some(bytes) = self.pixel_bytes(coords) else {
+            return Err(TextureAccessError::OutOfBounds(format!(
+                "x: {}, y: {}, z: {}",
+                coords.x, coords.y, coords.z
+            )));
+        };
+
+        match self.texture_descriptor.format {
+            TextureFormat::Rgba8UnormSrgb => Ok(Color::rgba(
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8Uint => Ok(Color::rgba_linear(
+                bytes[0] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Bgra8UnormSrgb => Ok(Color::rgba(
+                bytes[3] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[0] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Bgra8Unorm => Ok(Color::rgba_linear(
+                bytes[3] as f32 / u8::MAX as f32,
+                bytes[2] as f32 / u8::MAX as f32,
+                bytes[1] as f32 / u8::MAX as f32,
+                bytes[0] as f32 / u8::MAX as f32,
+            )),
+            TextureFormat::Rgba32Float => Ok(Color::rgba_linear(
+                f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                f32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                f32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+            )),
+            TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
+                let (r, g, b, a) = (
+                    u16::from_le_bytes([bytes[0], bytes[1]]),
+                    u16::from_le_bytes([bytes[2], bytes[3]]),
+                    u16::from_le_bytes([bytes[4], bytes[5]]),
+                    u16::from_le_bytes([bytes[6], bytes[7]]),
+                );
+                Ok(Color::rgba_linear(
+                    // going via f64 to avoid rounding errors with large numbers and division
+                    (r as f64 / u16::MAX as f64) as f32,
+                    (g as f64 / u16::MAX as f64) as f32,
+                    (b as f64 / u16::MAX as f64) as f32,
+                    (a as f64 / u16::MAX as f64) as f32,
+                ))
+            }
+            TextureFormat::Rgba32Uint => {
+                let (r, g, b, a) = (
+                    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                    u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                    u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                );
+                Ok(Color::rgba_linear(
+                    // going via f64 to avoid rounding errors with large numbers and division
+                    (r as f64 / u32::MAX as f64) as f32,
+                    (g as f64 / u32::MAX as f64) as f32,
+                    (b as f64 / u32::MAX as f64) as f32,
+                    (a as f64 / u32::MAX as f64) as f32,
+                ))
+            }
+            // assume R-only texture format means grayscale (linear)
+            // copy value to all of RGB in Color
+            TextureFormat::R8Unorm | TextureFormat::R8Uint => {
+                let x = bytes[0] as f32 / u8::MAX as f32;
+                Ok(Color::rgba_linear(x, x, x, 1.0))
+            }
+            TextureFormat::R16Unorm | TextureFormat::R16Uint => {
+                let x = u16::from_le_bytes([bytes[0], bytes[1]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let x = (x as f64 / u16::MAX as f64) as f32;
+                Ok(Color::rgba_linear(x, x, x, 1.0))
+            }
+            TextureFormat::R32Uint => {
+                let x = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let x = (x as f64 / u32::MAX as f64) as f32;
+                Ok(Color::rgba_linear(x, x, x, 1.0))
+            }
+            TextureFormat::R32Float => {
+                let x = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                Ok(Color::rgba_linear(x, x, x, 1.0))
+            }
+            TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
+                let r = bytes[0] as f32 / u8::MAX as f32;
+                let g = bytes[1] as f32 / u8::MAX as f32;
+                Ok(Color::rgba_linear(r, g, 0.0, 1.0))
+            }
+            TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
+                let r = u16::from_le_bytes([bytes[0], bytes[1]]);
+                let g = u16::from_le_bytes([bytes[2], bytes[3]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let r = (r as f64 / u16::MAX as f64) as f32;
+                let g = (g as f64 / u16::MAX as f64) as f32;
+                Ok(Color::rgba_linear(r, g, 0.0, 1.0))
+            }
+            TextureFormat::Rg32Uint => {
+                let r = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                // going via f64 to avoid rounding errors with large numbers and division
+                let r = (r as f64 / u32::MAX as f64) as f32;
+                let g = (g as f64 / u32::MAX as f64) as f32;
+                Ok(Color::rgba_linear(r, g, 0.0, 1.0))
+            }
+            TextureFormat::Rg32Float => {
+                let r = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                Ok(Color::rgba_linear(r, g, 0.0, 1.0))
+            }
+            _ => {
+                return Err(TextureAccessError::UnsupportedTextureFormat(format!(
+                    "{:?}",
+                    self.texture_descriptor.format
+                )));
+            }
+        }
+    }
+
+    /// Change the color of a specific pixel.
+    ///
+    /// This function will find the raw byte data of a specific pixel and
+    /// change it according to a [`Color`] you provide. The [`Color`] struct
+    /// will be encoded into the [`Image`]'s [`TextureFormat`].
+    ///
+    /// Supports many of the common [`TextureFormat`]s:
+    ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
+    ///  - 16-bit and 32-bit unsigned integer (with possibly-limited precision, as [`Color`] uses `f32`)
+    ///  - 32-bit float
+    ///
+    /// For R and RG formats, only the respective values from the linear RGB [`Color`] will be used.
+    ///
+    /// Other [`TextureFormat`]s are unsupported, such as:
+    ///  - block-compressed formats
+    ///  - non-byte-aligned formats like 10-bit
+    ///  - 16-bit float formats
+    ///  - signed integer formats
+    #[inline(always)]
+    pub fn set_color_at(&mut self, coords: UVec3, color: Color) -> Result<(), TextureAccessError> {
+        let format = self.texture_descriptor.format;
+
+        let Some(bytes) = self.pixel_bytes_mut(coords) else {
+            return Err(TextureAccessError::OutOfBounds(format!(
+                "x: {}, y: {}, z: {}",
+                coords.x, coords.y, coords.z
+            )));
+        };
+
+        match format {
+            TextureFormat::Rgba8UnormSrgb => {
+                let [r, g, b, a] = color.as_rgba_f32();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (b * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rgba8Unorm | TextureFormat::Rgba8Uint => {
+                let [r, g, b, a] = color.as_linear_rgba_f32();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (b * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Bgra8UnormSrgb => {
+                let [r, g, b, a] = color.as_rgba_f32();
+                bytes[0] = (b * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (r * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Bgra8Unorm => {
+                let [r, g, b, a] = color.as_linear_rgba_f32();
+                bytes[0] = (b * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+                bytes[2] = (r * u8::MAX as f32) as u8;
+                bytes[3] = (a * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rgba32Float => {
+                let [r, g, b, a] = color.as_linear_rgba_f32();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&f32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&f32::to_le_bytes(a));
+            }
+            TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
+                let [r, g, b, a] = color.as_linear_rgba_f32();
+                let [r, g, b, a] = [
+                    (r * u16::MAX as f32) as u16,
+                    (g * u16::MAX as f32) as u16,
+                    (b * u16::MAX as f32) as u16,
+                    (a * u16::MAX as f32) as u16,
+                ];
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+                bytes[4..6].copy_from_slice(&u16::to_le_bytes(b));
+                bytes[6..8].copy_from_slice(&u16::to_le_bytes(a));
+            }
+            TextureFormat::Rgba32Uint => {
+                let [r, g, b, a] = color.as_linear_rgba_f32();
+                let [r, g, b, a] = [
+                    (r * u32::MAX as f32) as u32,
+                    (g * u32::MAX as f32) as u32,
+                    (b * u32::MAX as f32) as u32,
+                    (a * u32::MAX as f32) as u32,
+                ];
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&u32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
+            }
+            TextureFormat::R8Unorm | TextureFormat::R8Uint => {
+                // TODO: this should probably be changed to do
+                // a proper conversion into greyscale
+                let [r, _, _, _] = color.as_linear_rgba_f32();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+            }
+            TextureFormat::R16Unorm | TextureFormat::R16Uint => {
+                // TODO: this should probably be changed to do
+                // a proper conversion into greyscale
+                let [r, _, _, _] = color.as_linear_rgba_f32();
+                let r = (r * u16::MAX as f32) as u16;
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+            }
+            TextureFormat::R32Uint => {
+                // TODO: this should probably be changed to do
+                // a proper conversion into greyscale
+                let [r, _, _, _] = color.as_linear_rgba_f32();
+                // go via f64 to avoid imprecision
+                let r = (r as f64 * u32::MAX as f64) as u32;
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+            }
+            TextureFormat::R32Float => {
+                // TODO: this should probably be changed to do
+                // a proper conversion into greyscale
+                let [r, _, _, _] = color.as_linear_rgba_f32();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+            }
+            TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
+                let [r, g, _, _] = color.as_linear_rgba_f32();
+                bytes[0] = (r * u8::MAX as f32) as u8;
+                bytes[1] = (g * u8::MAX as f32) as u8;
+            }
+            TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
+                let [r, g, _, _] = color.as_linear_rgba_f32();
+                let r = (r * u16::MAX as f32) as u16;
+                let g = (g * u16::MAX as f32) as u16;
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+            }
+            TextureFormat::Rg32Uint => {
+                let [r, g, _, _] = color.as_linear_rgba_f32();
+                // go via f64 to avoid imprecision
+                let r = (r as f64 * u32::MAX as f64) as u32;
+                let g = (g as f64 * u32::MAX as f64) as u32;
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+            }
+            TextureFormat::Rg32Float => {
+                let [r, g, _, _] = color.as_linear_rgba_f32();
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+            }
+            _ => {
+                return Err(TextureAccessError::UnsupportedTextureFormat(format!(
+                    "{:?}",
+                    self.texture_descriptor.format
+                )));
+            }
+        }
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -838,6 +1189,15 @@ pub enum TranscodeFormat {
     Rg8UnormSrgb,
     // Has to be transcoded to Rgba8 for use with `wgpu`
     Rgb8,
+}
+
+/// An error that occurs when accessing specific pixels in a texture
+#[derive(Error, Debug)]
+pub enum TextureAccessError {
+    #[error("out of bounds ({0})")]
+    OutOfBounds(String),
+    #[error("unsupported texture format: {0}")]
+    UnsupportedTextureFormat(String),
 }
 
 /// An error that occurs when loading a texture

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1014,10 +1014,10 @@ impl Image {
                 Ok(Color::rgba_linear(r, g, 0.0, 1.0))
             }
             _ => {
-                return Err(TextureAccessError::UnsupportedTextureFormat(format!(
+                Err(TextureAccessError::UnsupportedTextureFormat(format!(
                     "{:?}",
                     self.texture_descriptor.format
-                )));
+                )))
             }
         }
     }

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1194,23 +1194,20 @@ impl Image {
             TextureFormat::R8Unorm | TextureFormat::R8Uint => {
                 // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
-                        .to_f32_array();
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
                 bytes[0] = (r * u8::MAX as f32) as u8;
             }
             TextureFormat::R16Unorm | TextureFormat::R16Uint => {
                 // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
-                        .to_f32_array();
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
                 bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
             }
             TextureFormat::R32Uint => {
                 // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
-                        .to_f32_array();
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
                 bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
@@ -1218,8 +1215,7 @@ impl Image {
             TextureFormat::R32Float => {
                 // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
-                        .to_f32_array();
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
                 bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -873,7 +873,7 @@ impl Image {
 
     /// Read the color of a specific pixel (1D texture).
     ///
-    /// See [`get_color_at`] for more details.
+    /// See [`get_color_at`](Self::get_color_at) for more details.
     #[inline(always)]
     pub fn get_color_at_1d(&self, x: u32) -> Result<Color, TextureAccessError> {
         if self.texture_descriptor.dimension != TextureDimension::D1 {
@@ -916,7 +916,7 @@ impl Image {
 
     /// Read the color of a specific pixel (3D texture).
     ///
-    /// See [`get_color_at`] for more details.
+    /// See [`get_color_at`](Self::get_color_at) for more details.
     #[inline(always)]
     pub fn get_color_at_3d(&self, x: u32, y: u32, z: u32) -> Result<Color, TextureAccessError> {
         if self.texture_descriptor.dimension != TextureDimension::D3 {
@@ -927,7 +927,7 @@ impl Image {
 
     /// Change the color of a specific pixel (1D texture).
     ///
-    /// See [`set_color_at`] for more details.
+    /// See [`set_color_at`](Self::set_color_at) for more details.
     #[inline(always)]
     pub fn set_color_at_1d(&mut self, x: u32, color: Color) -> Result<(), TextureAccessError> {
         if self.texture_descriptor.dimension != TextureDimension::D1 {
@@ -968,7 +968,7 @@ impl Image {
 
     /// Change the color of a specific pixel (3D texture).
     ///
-    /// See [`set_color_at`] for more details.
+    /// See [`set_color_at`](Self::set_color_at) for more details.
     #[inline(always)]
     pub fn set_color_at_3d(
         &mut self,

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1020,17 +1020,17 @@ impl Image {
                 bytes[3] as f32 / u8::MAX as f32,
             )),
             TextureFormat::Rgba32Float => Ok(Color::linear_rgba(
-                f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-                f32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
-                f32::from_ne_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
-                f32::from_ne_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                f32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                f32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
             )),
             TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
                 let (r, g, b, a) = (
-                    u16::from_ne_bytes([bytes[0], bytes[1]]),
-                    u16::from_ne_bytes([bytes[2], bytes[3]]),
-                    u16::from_ne_bytes([bytes[4], bytes[5]]),
-                    u16::from_ne_bytes([bytes[6], bytes[7]]),
+                    u16::from_le_bytes([bytes[0], bytes[1]]),
+                    u16::from_le_bytes([bytes[2], bytes[3]]),
+                    u16::from_le_bytes([bytes[4], bytes[5]]),
+                    u16::from_le_bytes([bytes[6], bytes[7]]),
                 );
                 Ok(Color::linear_rgba(
                     // going via f64 to avoid rounding errors with large numbers and division
@@ -1042,10 +1042,10 @@ impl Image {
             }
             TextureFormat::Rgba32Uint => {
                 let (r, g, b, a) = (
-                    u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-                    u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
-                    u32::from_ne_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
-                    u32::from_ne_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                    u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                    u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
                 );
                 Ok(Color::linear_rgba(
                     // going via f64 to avoid rounding errors with large numbers and division
@@ -1062,19 +1062,19 @@ impl Image {
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R16Unorm | TextureFormat::R16Uint => {
-                let x = u16::from_ne_bytes([bytes[0], bytes[1]]);
+                let x = u16::from_le_bytes([bytes[0], bytes[1]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let x = (x as f64 / u16::MAX as f64) as f32;
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R32Uint => {
-                let x = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let x = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let x = (x as f64 / u32::MAX as f64) as f32;
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R32Float => {
-                let x = f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let x = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
@@ -1083,24 +1083,24 @@ impl Image {
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
-                let r = u16::from_ne_bytes([bytes[0], bytes[1]]);
-                let g = u16::from_ne_bytes([bytes[2], bytes[3]]);
+                let r = u16::from_le_bytes([bytes[0], bytes[1]]);
+                let g = u16::from_le_bytes([bytes[2], bytes[3]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let r = (r as f64 / u16::MAX as f64) as f32;
                 let g = (g as f64 / u16::MAX as f64) as f32;
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg32Uint => {
-                let r = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                let g = u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                let r = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let r = (r as f64 / u32::MAX as f64) as f32;
                 let g = (g as f64 / u32::MAX as f64) as f32;
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg32Float => {
-                let r = f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                let g = f32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                let r = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             _ => Err(TextureAccessError::UnsupportedTextureFormat(
@@ -1156,10 +1156,10 @@ impl Image {
             }
             TextureFormat::Rgba32Float => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
-                bytes[4..8].copy_from_slice(&f32::to_ne_bytes(g));
-                bytes[8..12].copy_from_slice(&f32::to_ne_bytes(b));
-                bytes[12..16].copy_from_slice(&f32::to_ne_bytes(a));
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&f32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&f32::to_le_bytes(a));
             }
             TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
@@ -1169,10 +1169,10 @@ impl Image {
                     (b * u16::MAX as f32) as u16,
                     (a * u16::MAX as f32) as u16,
                 ];
-                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
-                bytes[2..4].copy_from_slice(&u16::to_ne_bytes(g));
-                bytes[4..6].copy_from_slice(&u16::to_ne_bytes(b));
-                bytes[6..8].copy_from_slice(&u16::to_ne_bytes(a));
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+                bytes[4..6].copy_from_slice(&u16::to_le_bytes(b));
+                bytes[6..8].copy_from_slice(&u16::to_le_bytes(a));
             }
             TextureFormat::Rgba32Uint => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
@@ -1182,10 +1182,10 @@ impl Image {
                     (b * u32::MAX as f32) as u32,
                     (a * u32::MAX as f32) as u32,
                 ];
-                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
-                bytes[4..8].copy_from_slice(&u32::to_ne_bytes(g));
-                bytes[8..12].copy_from_slice(&u32::to_ne_bytes(b));
-                bytes[12..16].copy_from_slice(&u32::to_ne_bytes(a));
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+                bytes[8..12].copy_from_slice(&u32::to_le_bytes(b));
+                bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
             }
             TextureFormat::R8Unorm | TextureFormat::R8Uint => {
                 let [r, _, _, _] =
@@ -1198,7 +1198,7 @@ impl Image {
                     LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
                         .to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
-                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
             }
             TextureFormat::R32Uint => {
                 let [r, _, _, _] =
@@ -1206,13 +1206,13 @@ impl Image {
                         .to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
-                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
             }
             TextureFormat::R32Float => {
                 let [r, _, _, _] =
                     LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
                         .to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
@@ -1223,21 +1223,21 @@ impl Image {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
                 let g = (g * u16::MAX as f32) as u16;
-                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
-                bytes[2..4].copy_from_slice(&u16::to_ne_bytes(g));
+                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
             }
             TextureFormat::Rg32Uint => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
                 let g = (g as f64 * u32::MAX as f64) as u32;
-                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
-                bytes[4..8].copy_from_slice(&u32::to_ne_bytes(g));
+                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
             }
             TextureFormat::Rg32Float => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
-                bytes[4..8].copy_from_slice(&f32::to_ne_bytes(g));
+                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
             }
             _ => {
                 return Err(TextureAccessError::UnsupportedTextureFormat(

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -6,7 +6,7 @@ use super::dds::*;
 use super::ktx2::*;
 
 use bevy_asset::{Asset, RenderAssetUsages};
-use bevy_color::{Color, ColorToComponents, LinearRgba, Oklcha, Srgba};
+use bevy_color::{Color, ColorToComponents, Gray, LinearRgba, Srgba, Xyza};
 use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
 use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
@@ -1192,30 +1192,34 @@ impl Image {
                 bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
             }
             TextureFormat::R8Unorm | TextureFormat::R8Uint => {
-                // Convert to grayscale perceptually
-                let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
                 bytes[0] = (r * u8::MAX as f32) as u8;
             }
             TextureFormat::R16Unorm | TextureFormat::R16Uint => {
-                // Convert to grayscale perceptually
-                let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
                 bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
             }
             TextureFormat::R32Uint => {
-                // Convert to grayscale perceptually
-                let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
                 bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
             }
             TextureFormat::R32Float => {
-                // Convert to grayscale perceptually
-                let [r, _, _, _] =
-                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0)).to_f32_array();
+                // Convert to grayscale with minimal loss if color is already gray
+                let linear = LinearRgba::from(color);
+                let luminance = Xyza::from(linear).y;
+                let [r, _, _, _] = LinearRgba::gray(luminance).to_f32_array();
                 bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -6,9 +6,9 @@ use super::dds::*;
 use super::ktx2::*;
 
 use bevy_asset::{Asset, RenderAssetUsages};
+use bevy_color::{Color, ColorToComponents, Oklcha, LinearRgba, Srgba};
 use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
 use bevy_reflect::Reflect;
-use bevy_color::{Color, ColorToComponents, Hue, Lcha, LinearRgba, Srgba};
 use bevy_reflect::std_traits::ReflectDefault;
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
@@ -1188,29 +1188,33 @@ impl Image {
                 bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
             }
             TextureFormat::R8Unorm | TextureFormat::R8Uint => {
+                // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
                         .to_f32_array();
                 bytes[0] = (r * u8::MAX as f32) as u8;
             }
             TextureFormat::R16Unorm | TextureFormat::R16Uint => {
+                // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
                         .to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
                 bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
             }
             TextureFormat::R32Uint => {
+                // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
                         .to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
                 bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
             }
             TextureFormat::R32Float => {
+                // Convert to grayscale perceptually
                 let [r, _, _, _] =
-                    LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
+                    LinearRgba::from(Oklcha::from(color).with_chroma(0.0))
                         .to_f32_array();
                 bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
             }

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1013,12 +1013,10 @@ impl Image {
                 let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 Ok(Color::rgba_linear(r, g, 0.0, 1.0))
             }
-            _ => {
-                Err(TextureAccessError::UnsupportedTextureFormat(format!(
-                    "{:?}",
-                    self.texture_descriptor.format
-                )))
-            }
+            _ => Err(TextureAccessError::UnsupportedTextureFormat(format!(
+                "{:?}",
+                self.texture_descriptor.format
+            ))),
         }
     }
 

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -6,10 +6,10 @@ use super::dds::*;
 use super::ktx2::*;
 
 use bevy_asset::{Asset, RenderAssetUsages};
-use bevy_color::{Color, ColorToComponents, Oklcha, LinearRgba, Srgba};
+use bevy_color::{Color, ColorToComponents, LinearRgba, Oklcha, Srgba};
 use bevy_math::{AspectRatio, UVec2, UVec3, Vec2};
-use bevy_reflect::Reflect;
 use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
 use core::hash::Hash;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -878,8 +878,14 @@ impl Image {
     ///
     /// Supports many of the common [`TextureFormat`]s:
     ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
-    ///  - 16-bit and 32-bit unsigned integer (some precision may be lost, as [`Color`] uses `f32`)
+    ///  - 16-bit and 32-bit unsigned integer
     ///  - 32-bit float
+    ///
+    /// Be careful: as the data is converted to [`Color`] (which uses `f32` internally),
+    /// there may be issues with precision when using non-float [`TextureFormat`]s.
+    /// If you read a value you previously wrote using `set_color_at`, it will not match.
+    /// If you are working with a 32-bit integer [`TextureFormat`], the value will be
+    /// inaccurate (as `f32` does not have enough bits to represent it exactly).
     ///
     /// Single channel (R) formats are assumed to represent greyscale, so the value
     /// will be copied to all three RGB channels in the resulting [`Color`].
@@ -1026,6 +1032,10 @@ impl Image {
     ///  - RGBA/BGRA 8-bit unsigned integer, both sRGB and Linear
     ///  - 16-bit and 32-bit unsigned integer (with possibly-limited precision, as [`Color`] uses `f32`)
     ///  - 32-bit float
+    ///
+    /// Be careful: writing to non-float [`TextureFormat`]s is lossy! The data has to be converted,
+    /// so if you read it back using `get_color_at`, the `Color` you get will not equal the value
+    /// you used when writing it using this function.
     ///
     /// For R and RG formats, only the respective values from the linear RGB [`Color`] will be used.
     ///

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1202,10 +1202,10 @@ pub enum TranscodeFormat {
 /// An error that occurs when accessing specific pixels in a texture
 #[derive(Error, Debug)]
 pub enum TextureAccessError {
-    #[error("out of bounds ({0})")]
-    OutOfBounds(String),
-    #[error("unsupported texture format: {0}")]
-    UnsupportedTextureFormat(String),
+    #[error("out of bounds (x: {x}, y: {y}, z: {z})")]
+    OutOfBounds { x: f32, y: f32, z: f32 },
+    #[error("unsupported texture format: {0:?}")]
+    UnsupportedTextureFormat(TextureFormat),
 }
 
 /// An error that occurs when loading a texture

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -994,6 +994,8 @@ impl Image {
             });
         };
 
+        // NOTE: GPUs are always Little Endian.
+        // Make sure to respect that when we create color values from bytes.
         match self.texture_descriptor.format {
             TextureFormat::Rgba8UnormSrgb => Ok(Color::srgba(
                 bytes[0] as f32 / u8::MAX as f32,
@@ -1125,6 +1127,8 @@ impl Image {
             });
         };
 
+        // NOTE: GPUs are always Little Endian.
+        // Make sure to respect that when we convert color values to bytes.
         match format {
             TextureFormat::Rgba8UnormSrgb => {
                 let [r, g, b, a] = Srgba::from(color).to_f32_array();

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -1020,17 +1020,17 @@ impl Image {
                 bytes[3] as f32 / u8::MAX as f32,
             )),
             TextureFormat::Rgba32Float => Ok(Color::linear_rgba(
-                f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-                f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
-                f32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
-                f32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                f32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                f32::from_ne_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                f32::from_ne_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
             )),
             TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
                 let (r, g, b, a) = (
-                    u16::from_le_bytes([bytes[0], bytes[1]]),
-                    u16::from_le_bytes([bytes[2], bytes[3]]),
-                    u16::from_le_bytes([bytes[4], bytes[5]]),
-                    u16::from_le_bytes([bytes[6], bytes[7]]),
+                    u16::from_ne_bytes([bytes[0], bytes[1]]),
+                    u16::from_ne_bytes([bytes[2], bytes[3]]),
+                    u16::from_ne_bytes([bytes[4], bytes[5]]),
+                    u16::from_ne_bytes([bytes[6], bytes[7]]),
                 );
                 Ok(Color::linear_rgba(
                     // going via f64 to avoid rounding errors with large numbers and division
@@ -1042,10 +1042,10 @@ impl Image {
             }
             TextureFormat::Rgba32Uint => {
                 let (r, g, b, a) = (
-                    u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
-                    u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
-                    u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
-                    u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
+                    u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),
+                    u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]),
+                    u32::from_ne_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]),
+                    u32::from_ne_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]),
                 );
                 Ok(Color::linear_rgba(
                     // going via f64 to avoid rounding errors with large numbers and division
@@ -1062,19 +1062,19 @@ impl Image {
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R16Unorm | TextureFormat::R16Uint => {
-                let x = u16::from_le_bytes([bytes[0], bytes[1]]);
+                let x = u16::from_ne_bytes([bytes[0], bytes[1]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let x = (x as f64 / u16::MAX as f64) as f32;
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R32Uint => {
-                let x = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let x = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let x = (x as f64 / u32::MAX as f64) as f32;
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::R32Float => {
-                let x = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let x = f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
                 Ok(Color::linear_rgb(x, x, x))
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
@@ -1083,24 +1083,24 @@ impl Image {
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg16Unorm | TextureFormat::Rg16Uint => {
-                let r = u16::from_le_bytes([bytes[0], bytes[1]]);
-                let g = u16::from_le_bytes([bytes[2], bytes[3]]);
+                let r = u16::from_ne_bytes([bytes[0], bytes[1]]);
+                let g = u16::from_ne_bytes([bytes[2], bytes[3]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let r = (r as f64 / u16::MAX as f64) as f32;
                 let g = (g as f64 / u16::MAX as f64) as f32;
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg32Uint => {
-                let r = u32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                let g = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                let r = u32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = u32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 // going via f64 to avoid rounding errors with large numbers and division
                 let r = (r as f64 / u32::MAX as f64) as f32;
                 let g = (g as f64 / u32::MAX as f64) as f32;
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             TextureFormat::Rg32Float => {
-                let r = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
-                let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+                let r = f32::from_ne_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+                let g = f32::from_ne_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 Ok(Color::linear_rgb(r, g, 0.0))
             }
             _ => Err(TextureAccessError::UnsupportedTextureFormat(
@@ -1156,10 +1156,10 @@ impl Image {
             }
             TextureFormat::Rgba32Float => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
-                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
-                bytes[8..12].copy_from_slice(&f32::to_le_bytes(b));
-                bytes[12..16].copy_from_slice(&f32::to_le_bytes(a));
+                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_ne_bytes(g));
+                bytes[8..12].copy_from_slice(&f32::to_ne_bytes(b));
+                bytes[12..16].copy_from_slice(&f32::to_ne_bytes(a));
             }
             TextureFormat::Rgba16Unorm | TextureFormat::Rgba16Uint => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
@@ -1169,10 +1169,10 @@ impl Image {
                     (b * u16::MAX as f32) as u16,
                     (a * u16::MAX as f32) as u16,
                 ];
-                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
-                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
-                bytes[4..6].copy_from_slice(&u16::to_le_bytes(b));
-                bytes[6..8].copy_from_slice(&u16::to_le_bytes(a));
+                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_ne_bytes(g));
+                bytes[4..6].copy_from_slice(&u16::to_ne_bytes(b));
+                bytes[6..8].copy_from_slice(&u16::to_ne_bytes(a));
             }
             TextureFormat::Rgba32Uint => {
                 let [r, g, b, a] = LinearRgba::from(color).to_f32_array();
@@ -1182,10 +1182,10 @@ impl Image {
                     (b * u32::MAX as f32) as u32,
                     (a * u32::MAX as f32) as u32,
                 ];
-                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
-                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
-                bytes[8..12].copy_from_slice(&u32::to_le_bytes(b));
-                bytes[12..16].copy_from_slice(&u32::to_le_bytes(a));
+                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_ne_bytes(g));
+                bytes[8..12].copy_from_slice(&u32::to_ne_bytes(b));
+                bytes[12..16].copy_from_slice(&u32::to_ne_bytes(a));
             }
             TextureFormat::R8Unorm | TextureFormat::R8Uint => {
                 let [r, _, _, _] =
@@ -1198,7 +1198,7 @@ impl Image {
                     LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
                         .to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
-                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
+                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
             }
             TextureFormat::R32Uint => {
                 let [r, _, _, _] =
@@ -1206,13 +1206,13 @@ impl Image {
                         .to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
-                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
+                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
             }
             TextureFormat::R32Float => {
                 let [r, _, _, _] =
                     LinearRgba::from(Lcha::from(color).with_chroma(0.0).with_hue(0.0))
                         .to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
+                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
             }
             TextureFormat::Rg8Unorm | TextureFormat::Rg8Uint => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
@@ -1223,21 +1223,21 @@ impl Image {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
                 let r = (r * u16::MAX as f32) as u16;
                 let g = (g * u16::MAX as f32) as u16;
-                bytes[0..2].copy_from_slice(&u16::to_le_bytes(r));
-                bytes[2..4].copy_from_slice(&u16::to_le_bytes(g));
+                bytes[0..2].copy_from_slice(&u16::to_ne_bytes(r));
+                bytes[2..4].copy_from_slice(&u16::to_ne_bytes(g));
             }
             TextureFormat::Rg32Uint => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
                 // go via f64 to avoid imprecision
                 let r = (r as f64 * u32::MAX as f64) as u32;
                 let g = (g as f64 * u32::MAX as f64) as u32;
-                bytes[0..4].copy_from_slice(&u32::to_le_bytes(r));
-                bytes[4..8].copy_from_slice(&u32::to_le_bytes(g));
+                bytes[0..4].copy_from_slice(&u32::to_ne_bytes(r));
+                bytes[4..8].copy_from_slice(&u32::to_ne_bytes(g));
             }
             TextureFormat::Rg32Float => {
                 let [r, g, _, _] = LinearRgba::from(color).to_f32_array();
-                bytes[0..4].copy_from_slice(&f32::to_le_bytes(r));
-                bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
+                bytes[0..4].copy_from_slice(&f32::to_ne_bytes(r));
+                bytes[4..8].copy_from_slice(&f32::to_ne_bytes(g));
             }
             _ => {
                 return Err(TextureAccessError::UnsupportedTextureFormat(

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -919,16 +919,16 @@ impl Image {
                 bytes[3] as f32 / u8::MAX as f32,
             )),
             TextureFormat::Bgra8UnormSrgb => Ok(Color::rgba(
-                bytes[3] as f32 / u8::MAX as f32,
                 bytes[2] as f32 / u8::MAX as f32,
                 bytes[1] as f32 / u8::MAX as f32,
                 bytes[0] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
             )),
             TextureFormat::Bgra8Unorm => Ok(Color::rgba_linear(
-                bytes[3] as f32 / u8::MAX as f32,
                 bytes[2] as f32 / u8::MAX as f32,
                 bytes[1] as f32 / u8::MAX as f32,
                 bytes[0] as f32 / u8::MAX as f32,
+                bytes[3] as f32 / u8::MAX as f32,
             )),
             TextureFormat::Rgba32Float => Ok(Color::rgba_linear(
                 f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]),

--- a/crates/bevy_image/src/image.rs
+++ b/crates/bevy_image/src/image.rs
@@ -898,10 +898,11 @@ impl Image {
     #[inline(always)]
     pub fn get_color_at(&self, coords: UVec3) -> Result<Color, TextureAccessError> {
         let Some(bytes) = self.pixel_bytes(coords) else {
-            return Err(TextureAccessError::OutOfBounds(format!(
-                "x: {}, y: {}, z: {}",
-                coords.x, coords.y, coords.z
-            )));
+            return Err(TextureAccessError::OutOfBounds {
+                x: coords.x,
+                y: coords.y,
+                z: coords.z,
+            });
         };
 
         match self.texture_descriptor.format {
@@ -1013,10 +1014,9 @@ impl Image {
                 let g = f32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
                 Ok(Color::rgba_linear(r, g, 0.0, 1.0))
             }
-            _ => Err(TextureAccessError::UnsupportedTextureFormat(format!(
-                "{:?}",
-                self.texture_descriptor.format
-            ))),
+            _ => Err(TextureAccessError::UnsupportedTextureFormat(
+                self.texture_descriptor.format,
+            )),
         }
     }
 
@@ -1047,10 +1047,11 @@ impl Image {
         let format = self.texture_descriptor.format;
 
         let Some(bytes) = self.pixel_bytes_mut(coords) else {
-            return Err(TextureAccessError::OutOfBounds(format!(
-                "x: {}, y: {}, z: {}",
-                coords.x, coords.y, coords.z
-            )));
+            return Err(TextureAccessError::OutOfBounds {
+                x: coords.x,
+                y: coords.y,
+                z: coords.z,
+            });
         };
 
         match format {
@@ -1168,10 +1169,9 @@ impl Image {
                 bytes[4..8].copy_from_slice(&f32::to_le_bytes(g));
             }
             _ => {
-                return Err(TextureAccessError::UnsupportedTextureFormat(format!(
-                    "{:?}",
-                    self.texture_descriptor.format
-                )));
+                return Err(TextureAccessError::UnsupportedTextureFormat(
+                    self.texture_descriptor.format,
+                ));
             }
         }
         Ok(())
@@ -1203,7 +1203,7 @@ pub enum TranscodeFormat {
 #[derive(Error, Debug)]
 pub enum TextureAccessError {
     #[error("out of bounds (x: {x}, y: {y}, z: {z})")]
-    OutOfBounds { x: f32, y: f32, z: f32 },
+    OutOfBounds { x: u32, y: u32, z: u32 },
     #[error("unsupported texture format: {0:?}")]
     UnsupportedTextureFormat(TextureFormat),
 }

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -48,7 +48,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
             let center = Vec2::new(IMAGE_WIDTH as f32 / 2.0, IMAGE_HEIGHT as f32 / 2.0);
             let max_radius = IMAGE_HEIGHT.min(IMAGE_WIDTH) as f32 / 2.0;
             let r = Vec2::new(x as f32, y as f32).distance(center);
-            let a = 1.0 - (r / max_radius as f32).clamp(0.0, 1.0);
+            let a = 1.0 - (r / max_radius).clamp(0.0, 1.0);
 
             // here we will set the A value by accessing the raw data bytes
             // (it is the 4th byte of each pixel, as per our `TextureFormat`)

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -10,7 +10,10 @@ const IMAGE_HEIGHT: u32 = 256;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        // Let's make the fixed timestep really fast for this example.
+        // In this example, we will use a fixed timestep to draw a pattern on the screen
+        // one pixel at a time, so the pattern will gradually emerge over time, and
+        // the speed at which it appears is not tied to the framerate.
+        // Let's make the fixed update very fast, so it doesn't take too long. :)
         .insert_resource(Time::<Fixed>::from_hz(256.0))
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, draw)

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -1,0 +1,126 @@
+use bevy::prelude::*;
+use bevy::render::render_resource::Extent3d;
+use bevy::render::render_resource::TextureDimension;
+use bevy::render::render_resource::TextureFormat;
+use rand::Rng;
+
+const IMAGE_WIDTH: u32 = 256;
+const IMAGE_HEIGHT: u32 = 256;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // Let's make the fixed timestep really fast for this example.
+        .insert_resource(Time::<Fixed>::from_hz(256.0))
+        .add_systems(Startup, setup)
+        .add_systems(FixedUpdate, draw)
+        .run();
+}
+
+/// Store the image handle that we will draw to, here.
+#[derive(Resource)]
+struct MyProcGenImage(Handle<Image>);
+
+fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
+    // spawn a camera
+    commands.spawn(Camera2dBundle::default());
+
+    // create an image that we are going to draw into
+    let mut image = Image::new_fill(
+        // 2D image of size 256x256
+        Extent3d {
+            width: IMAGE_WIDTH,
+            height: IMAGE_HEIGHT,
+            depth_or_array_layers: 1,
+        },
+        TextureDimension::D2,
+        // Initialize it with a beige color
+        &(Color::BEIGE.as_rgba_u8()),
+        // Use the most common encoding for the data
+        // (8-bit RGBA with sRGB gamma)
+        TextureFormat::Rgba8UnormSrgb,
+    );
+
+    // to make it extra fancy, we can set the Alpha of each pixel
+    // so that it fades out in a circular fashion
+    for y in 0..IMAGE_HEIGHT {
+        for x in 0..IMAGE_WIDTH {
+            let center = Vec2::new(IMAGE_WIDTH as f32 / 2.0, IMAGE_HEIGHT as f32 / 2.0);
+            let max_radius = IMAGE_HEIGHT.min(IMAGE_WIDTH) as f32 / 2.0;
+            let r = Vec2::new(x as f32, y as f32).distance(center);
+            let a = 1.0 - (r / max_radius as f32).clamp(0.0, 1.0);
+
+            // here we will set the A value by accessing the raw data bytes
+            // (it is the 4th byte of each pixel, as per our `TextureFormat`)
+
+            // find our pixel by its coordinates
+            let pixel_bytes = image.pixel_bytes_mut(UVec3::new(x, y, 0)).unwrap();
+            // convert our f32 to u8
+            pixel_bytes[3] = (a * u8::MAX as f32) as u8;
+        }
+    }
+
+    // add it to Bevy's assets, so it can be used for rendering
+    // this will give us a handle we can use
+    // (to display it in a sprite, or as part of UI, etc.)
+    let handle = images.add(image);
+
+    // create a sprite entity using our image
+    commands.spawn(SpriteBundle {
+        texture: handle.clone(),
+        ..Default::default()
+    });
+
+    commands.insert_resource(MyProcGenImage(handle));
+}
+
+/// Every fixed update tick, draw one more pixel to make a spiral pattern
+fn draw(
+    my_handle: Res<MyProcGenImage>,
+    mut images: ResMut<Assets<Image>>,
+    // used to keep track of where we are
+    mut i: Local<u32>,
+    mut draw_color: Local<Color>,
+) {
+    let mut rng = rand::thread_rng();
+
+    if *i == 0 {
+        // Generate a random color on first run.
+        *draw_color = Color::rgb(rng.gen(), rng.gen(), rng.gen());
+    }
+
+    // Get the image from Bevy's asset storage.
+    let image = images.get_mut(&my_handle.0).expect("Image not found");
+
+    // Compute the position of the pixel to draw.
+
+    let center = Vec2::new(IMAGE_WIDTH as f32 / 2.0, IMAGE_HEIGHT as f32 / 2.0);
+    let max_radius = IMAGE_HEIGHT.min(IMAGE_WIDTH) as f32 / 2.0;
+    let rot_speed = 0.0123;
+    let period = 0.12345;
+
+    let r = (*i as f32 * period).sin() * max_radius;
+    let xy = Vec2::from_angle(*i as f32 * rot_speed) * r + center;
+    let pos = UVec3::new(xy.x as u32, xy.y as u32, 0);
+
+    // Get the old color of that pixel.
+    let old_color = image.get_color_at(pos).unwrap();
+
+    // If the old color is our current color, change our drawing color.
+    // (the values are never going to match exactly,
+    // because of the f32 -> u8 -> f32 conversion)
+    let tolerance = 1.0 / 255.0;
+    if (old_color.r() - draw_color.r()).abs() <= tolerance
+        && (old_color.g() - draw_color.g()).abs() <= tolerance
+        && (old_color.b() - draw_color.b()).abs() <= tolerance
+    {
+        *draw_color = Color::rgb(rng.gen(), rng.gen(), rng.gen());
+    }
+
+    // Set the new color, but keep old alpha value from image.
+    image
+        .set_color_at(pos, draw_color.with_a(old_color.a()))
+        .unwrap();
+
+    *i += 1;
+}

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -104,10 +104,10 @@ fn draw(
 
     let r = (*i as f32 * period).sin() * max_radius;
     let xy = Vec2::from_angle(*i as f32 * rot_speed) * r + center;
-    let pos = UVec3::new(xy.x as u32, xy.y as u32, 0);
+    let (x, y) = (xy.x as u32, xy.y as u32);
 
     // Get the old color of that pixel.
-    let old_color = image.get_color_at(pos).unwrap();
+    let old_color = image.get_color_at(x, y).unwrap();
 
     // If the old color is our current color, change our drawing color.
     // (the values are never going to match exactly,
@@ -122,7 +122,7 @@ fn draw(
 
     // Set the new color, but keep old alpha value from image.
     image
-        .set_color_at(pos, draw_color.with_a(old_color.a()))
+        .set_color_at(x, y, draw_color.with_a(old_color.a()))
         .unwrap();
 
     *i += 1;

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -35,7 +35,7 @@ struct MyProcGenImage(Handle<Image>);
 
 fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
     // spawn a camera
-    commands.spawn(Camera2dBundle::default());
+    commands.spawn(Camera2d);
 
     // create an image that we are going to draw into
     let mut image = Image::new_fill(

--- a/examples/2d/cpu_draw.rs
+++ b/examples/2d/cpu_draw.rs
@@ -1,3 +1,10 @@
+//! Example of how to draw to a texture from the CPU.
+//!
+//! You can set the values of individual pixels to whatever you want.
+//! Bevy provides user-friendly APIs that work with [`Color`](bevy::color::Color)
+//! values and automatically perform any necessary conversions and encoding
+//! into the texture's native pixel format.
+
 use bevy::color::{color_difference::EuclideanDistance, palettes::css};
 use bevy::prelude::*;
 use bevy::render::{
@@ -16,7 +23,7 @@ fn main() {
         // one pixel at a time, so the pattern will gradually emerge over time, and
         // the speed at which it appears is not tied to the framerate.
         // Let's make the fixed update very fast, so it doesn't take too long. :)
-        .insert_resource(Time::<Fixed>::from_hz(256.0))
+        .insert_resource(Time::<Fixed>::from_hz(1024.0))
         .add_systems(Startup, setup)
         .add_systems(FixedUpdate, draw)
         .run();
@@ -104,7 +111,7 @@ fn draw(
     let rot_speed = 0.0123;
     let period = 0.12345;
 
-    let r = (*i as f32 * period).sin() * max_radius;
+    let r = ops::sin(*i as f32 * period) * max_radius;
     let xy = Vec2::from_angle(*i as f32 * rot_speed) * r + center;
     let (x, y) = (xy.x as u32, xy.y as u32);
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -109,6 +109,7 @@ Example | Description
 [2D Viewport To World](../examples/2d/2d_viewport_to_world.rs) | Demonstrates how to use the `Camera::viewport_to_world_2d` method
 [2D Wireframe](../examples/2d/wireframe_2d.rs) | Showcases wireframes for 2d meshes
 [Arc 2D Meshes](../examples/2d/mesh2d_arcs.rs) | Demonstrates UV-mapping of the circular segment and sector primitives
+[CPU Drawing](../examples/2d/cpu_draw.rs) | Manually read/write the pixels of a texture
 [Custom glTF vertex attribute 2D](../examples/2d/custom_gltf_vertex_attribute.rs) | Renders a glTF mesh in 2D with a custom vertex attribute
 [Manual Mesh 2D](../examples/2d/mesh2d_manual.rs) | Renders a custom mesh "manually" with "mid-level" renderer apis
 [Mesh 2D](../examples/2d/mesh2d.rs) | Renders a 2d mesh


### PR DESCRIPTION
# Objective

If you want to draw / generate images from the CPU, such as:
 - to create procedurally-generated assets
 - for games whose artstyle is best implemented by poking pixels directly from the CPU, instead of using shaders

It is currently very unergonomic to do in Bevy, because you have to deal with the raw bytes inside `image.data`, take care of the pixel format, etc.

## Solution

This PR adds some helper methods to `Image` for pixel manipulation. These methods allow you to use Bevy's user-friendly `Color` struct to read and write the colors of pixels, at arbitrary coordinates (specified as `UVec3` to support any texture dimension). They handle encoding/decoding to the `Image`s `TextureFormat`, incl. any sRGB conversion.

While we are at it, also add methods to help with direct access to the raw bytes. It is now easy to compute the offset where the bytes of a specific pixel coordinate are found, or to just get a Rust slice to access them.

Caveat: `Color` roundtrips are obviously going to be lossy for non-float `TextureFormat`s. Using `set_color_at` followed by `get_color_at` will return a different value, due to the data conversions involved (such as `f32` -> `u8` -> `f32` for the common `Rgba8UnormSrgb` texture format). Be careful when comparing colors (such as checking for a color you wrote before)!

Also adding a new example: `cpu_draw` (under `2d`), to showcase these new APIs.

---

## Changelog

### Added

 - `Image` APIs for easy access to the colors of specific pixels.