### PR TITLE
Implement Clone for VisibilityBundle and SpatialBundle

### DIFF
--- a/crates/bevy_render/src/spatial_bundle.rs
+++ b/crates/bevy_render/src/spatial_bundle.rs
@@ -15,7 +15,7 @@ use crate::view::{InheritedVisibility, ViewVisibility, Visibility};
 /// to be rendered correctly.
 ///
 /// [`Component`]: bevy_ecs::component::Component
-#[derive(Bundle, Debug, Default)]
+#[derive(Bundle, Clone, Debug, Default)]
 pub struct SpatialBundle {
     /// The visibility of the entity.
     pub visibility: Visibility,

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -135,7 +135,7 @@ impl ViewVisibility {
 /// * To get the inherited visibility of an entity, you should get its [`InheritedVisibility`].
 /// * For visibility hierarchies to work correctly, you must have both all of [`Visibility`], [`InheritedVisibility`], and [`ViewVisibility`].
 ///   * You may use the [`VisibilityBundle`] to guarantee this.
-#[derive(Bundle, Debug, Default)]
+#[derive(Bundle, Debug, Clone, Default)]
 pub struct VisibilityBundle {
     /// The visibility of the entity.
     pub visibility: Visibility,


### PR DESCRIPTION
# Objective

Had an issue where I had `VisibilityBundle`  inside a bundle that implements `Clone`, but since `VisibilityBundle` doesn't implement `Clone` that wasn't possible. This PR fixes that.

## Solution

Implement `Clone` for `VisibilityBundle` by deriving it. And also `SpatialBundle` too because why not.

---

## Changelog

- Added implementation for `Clone` on `VisibilityBundle` and `SpatialBundle`.
