### PR TITLE
Add Macros to Simplify Struct Definitions & Reduce `..default()`s

### DIFF
--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -18,6 +18,11 @@ pub use font_loader::*;
 pub use glyph_brush::*;
 pub use pipeline::*;
 pub use text::*;
+bevy_utils::define_struct_default_macros!(
+    text: bevy::text::Text,
+    text_section: bevy::text::TextSection,
+    text_style: bevy::text::TextStyle
+);
 pub use text2d::*;
 
 pub mod prelude {

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -6,8 +6,23 @@
 //! This UI is laid out with the Flexbox and CSS Grid layout models (see <https://cssreference.io/flexbox/>)
 
 pub mod camera_config;
+bevy_utils::define_struct_default_macros!(
+    ui_camera_config: bevy::ui::camera_config::UiCameraConfig
+);
 pub mod measurement;
+bevy_utils::define_struct_default_macros!(
+    fixed_measure: bevy::ui::measurement::FixedMeasure
+);
 pub mod node_bundles;
+bevy_utils::define_struct_default_macros!(
+    node_bundle: bevy::ui::node_bundles::NodeBundle,
+    image_bundle: bevy::ui::node_bundles::ImageBundle,
+    atlas_image_bundle: bevy::ui::node_bundles::AtlasImageBundle,
+    text_bundle: bevy::ui::node_bundles::TextBundle,
+    button_bundle: bevy::ui::ButtonBundle,
+    material_node_bundle: bevy::ui::MaterialNodeBundle
+);
+
 pub mod ui_material;
 pub mod update;
 pub mod widget;
@@ -27,11 +42,22 @@ mod ui_node;
 
 pub use focus::*;
 pub use geometry::*;
+bevy_utils::define_struct_default_macros!(
+    ui_rect: bevy::ui::UiRect
+);
 pub use layout::*;
 pub use measurement::*;
 pub use render::*;
 pub use ui_material::*;
 pub use ui_node::*;
+bevy_utils::define_struct_default_macros!(
+    node: bevy::ui::Node,
+    style: bevy::ui::Style,
+    overflow: bevy::ui::Overflow,
+    ui_texture_atlas_image: bevy::ui::UiTextureAtlasImage,
+    outline: bevy::ui::Outline,
+    ui_image: bevy::ui::UiImage
+);
 use widget::UiImageSize;
 
 #[doc(hidden)]

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -15,6 +15,7 @@ pub mod futures;
 pub mod label;
 mod short_names;
 pub use short_names::get_short_name;
+mod struct_default_defines_macro;
 pub mod synccell;
 pub mod syncunsafecell;
 

--- a/crates/bevy_utils/src/struct_default_defines_macro.rs
+++ b/crates/bevy_utils/src/struct_default_defines_macro.rs
@@ -1,0 +1,9 @@
+/// Defines simple default struct initialization macros with the given names and paths.
+#[macro_export]
+macro_rules! define_struct_default_macros {
+    ($($name:ident: $path:path),*) => {
+        $(
+            bevy_utils::define_struct_default_macro!($name, $path);
+        )*
+    };
+}

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -1,6 +1,7 @@
 //! Example demonstrating bordered UI nodes
 
-use bevy::prelude::*;
+use bevy::{prelude::*, ui::{style, node_bundle, outline}};
+use bevy_internal::ui::ui_rect;
 
 fn main() {
     App::new()
@@ -12,20 +13,18 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
     let root = commands
-        .spawn(NodeBundle {
-            style: Style {
+        .spawn(node_bundle!(
+            style: style!(
                 margin: UiRect::all(Val::Px(25.0)),
                 align_self: AlignSelf::Stretch,
                 justify_self: JustifySelf::Stretch,
                 flex_wrap: FlexWrap::Wrap,
                 justify_content: JustifyContent::FlexStart,
                 align_items: AlignItems::FlexStart,
-                align_content: AlignContent::FlexStart,
-                ..Default::default()
-            },
-            background_color: BackgroundColor(Color::DARK_GRAY),
-            ..Default::default()
-        })
+                align_content: AlignContent::FlexStart
+            ),
+            background_color: BackgroundColor(Color::DARK_GRAY)
+        ))
         .id();
 
     // all the different combinations of border edges
@@ -38,85 +37,73 @@ fn setup(mut commands: Commands) {
         UiRect::bottom(Val::Px(10.)),
         UiRect::horizontal(Val::Px(10.)),
         UiRect::vertical(Val::Px(10.)),
-        UiRect {
+        ui_rect!(
             left: Val::Px(10.),
-            top: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
+            top: Val::Px(10.)
+        ),
+        ui_rect!(
             left: Val::Px(10.),
-            bottom: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
+            bottom: Val::Px(10.)
+        ),
+        ui_rect!(
+            right: Val::Px(10.),
+            top: Val::Px(10.)
+        ),
+        ui_rect!(
+            right: Val::Px(10.),
+            bottom: Val::Px(10.)
+        ),
+        ui_rect!(
             right: Val::Px(10.),
             top: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
-            right: Val::Px(10.),
-            bottom: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
-            right: Val::Px(10.),
-            top: Val::Px(10.),
-            bottom: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
+            bottom: Val::Px(10.)
+        ),
+        ui_rect!(
             left: Val::Px(10.),
             top: Val::Px(10.),
-            bottom: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
+            bottom: Val::Px(10.)
+        ),
+        ui_rect!(
             left: Val::Px(10.),
             right: Val::Px(10.),
-            top: Val::Px(10.),
-            ..Default::default()
-        },
-        UiRect {
+            top: Val::Px(10.)
+        ),
+        ui_rect!(
             left: Val::Px(10.),
             right: Val::Px(10.),
-            bottom: Val::Px(10.),
-            ..Default::default()
-        },
+            bottom: Val::Px(10.)
+        )
     ];
 
     for i in 0..64 {
         let inner_spot = commands
-            .spawn(NodeBundle {
-                style: Style {
+            .spawn(node_bundle!(
+                style: style!(
                     width: Val::Px(10.),
-                    height: Val::Px(10.),
-                    ..Default::default()
-                },
-                background_color: Color::YELLOW.into(),
-                ..Default::default()
-            })
+                    height: Val::Px(10.)
+                ),
+                background_color: Color::YELLOW.into()
+            ))
             .id();
         let bordered_node = commands
             .spawn((
-                NodeBundle {
-                    style: Style {
+                node_bundle!(
+                    style: style!(
                         width: Val::Px(50.),
                         height: Val::Px(50.),
                         border: borders[i % borders.len()],
                         margin: UiRect::all(Val::Px(20.)),
                         align_items: AlignItems::Center,
-                        justify_content: JustifyContent::Center,
-                        ..Default::default()
-                    },
+                        justify_content: JustifyContent::Center
+                    ),
                     background_color: Color::MAROON.into(),
-                    border_color: Color::RED.into(),
-                    ..Default::default()
-                },
-                Outline {
+                    border_color: Color::RED.into()
+                ),
+                outline!(
                     width: Val::Px(6.),
                     offset: Val::Px(6.),
-                    color: Color::WHITE,
-                },
+                    color: Color::WHITE
+                ),
             ))
             .add_child(inner_spot)
             .id();

--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -7,6 +7,8 @@ use bevy::{
     },
     input::mouse::{MouseScrollUnit, MouseWheel},
     prelude::*,
+    text::text_style,
+    ui::{node_bundle, style},
     winit::WinitSettings,
 };
 
@@ -26,53 +28,45 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // root node
     commands
-        .spawn(NodeBundle {
-            style: Style {
+        .spawn(node_bundle!(
+            style: style!(
                 width: Val::Percent(100.0),
                 height: Val::Percent(100.0),
-                justify_content: JustifyContent::SpaceBetween,
-                ..default()
-            },
-            ..default()
-        })
+                justify_content: JustifyContent::SpaceBetween
+            )
+        ))
         .with_children(|parent| {
             // left vertical fill (border)
             parent
-                .spawn(NodeBundle {
-                    style: Style {
+                .spawn(node_bundle!(
+                    style: style!(
                         width: Val::Px(200.),
-                        border: UiRect::all(Val::Px(2.)),
-                        ..default()
-                    },
-                    background_color: Color::rgb(0.65, 0.65, 0.65).into(),
-                    ..default()
-                })
+                        border: UiRect::all(Val::Px(2.))
+                    ),
+                    background_color: Color::rgb(0.65, 0.65, 0.65).into()
+                ))
                 .with_children(|parent| {
                     // left vertical fill (content)
                     parent
-                        .spawn(NodeBundle {
-                            style: Style {
-                                width: Val::Percent(100.),
-                                ..default()
-                            },
-                            background_color: Color::rgb(0.15, 0.15, 0.15).into(),
-                            ..default()
-                        })
+                        .spawn(node_bundle!(
+                            style: style!(
+                                width: Val::Percent(100.)
+                            ),
+                            background_color: Color::rgb(0.15, 0.15, 0.15).into()
+                        ))
                         .with_children(|parent| {
                             // text
                             parent.spawn((
                                 TextBundle::from_section(
                                     "Text Example",
-                                    TextStyle {
+                                    text_style!(
                                         font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                        font_size: 30.0,
-                                        ..default()
-                                    },
+                                        font_size: 30.0
+                                    ),
                                 )
-                                .with_style(Style {
-                                    margin: UiRect::all(Val::Px(5.)),
-                                    ..default()
-                                }),
+                                .with_style(style!(
+                                    margin: UiRect::all(Val::Px(5.))
+                                )),
                                 // Because this is a distinct label widget and
                                 // not button/list item text, this is necessary
                                 // for accessibility to treat the text accordingly.
@@ -82,55 +76,48 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 });
             // right vertical fill
             parent
-                .spawn(NodeBundle {
-                    style: Style {
+                .spawn(node_bundle!(
+                    style: style!(
                         flex_direction: FlexDirection::Column,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::Center,
-                        width: Val::Px(200.),
-                        ..default()
-                    },
-                    background_color: Color::rgb(0.15, 0.15, 0.15).into(),
-                    ..default()
-                })
+                        width: Val::Px(200.)
+                    ),
+                    background_color: Color::rgb(0.15, 0.15, 0.15).into()
+                ))
                 .with_children(|parent| {
                     // Title
                     parent.spawn((
                         TextBundle::from_section(
                             "Scrolling list",
-                            TextStyle {
+                            text_style!(
                                 font: asset_server.load("fonts/FiraSans-Bold.ttf"),
-                                font_size: 25.,
-                                ..default()
-                            },
+                                font_size: 25.
+                            ),
                         ),
                         Label,
                     ));
                     // List with hidden overflow
                     parent
-                        .spawn(NodeBundle {
-                            style: Style {
+                        .spawn(node_bundle!(
+                            style: style!(
                                 flex_direction: FlexDirection::Column,
                                 align_self: AlignSelf::Stretch,
                                 height: Val::Percent(50.),
-                                overflow: Overflow::clip_y(),
-                                ..default()
-                            },
-                            background_color: Color::rgb(0.10, 0.10, 0.10).into(),
-                            ..default()
-                        })
+                                overflow: Overflow::clip_y()
+                            ),
+                            background_color: Color::rgb(0.10, 0.10, 0.10).into()
+                        ))
                         .with_children(|parent| {
                             // Moving panel
                             parent
                                 .spawn((
-                                    NodeBundle {
-                                        style: Style {
+                                    node_bundle!(
+                                        style: style!(
                                             flex_direction: FlexDirection::Column,
-                                            align_items: AlignItems::Center,
-                                            ..default()
-                                        },
-                                        ..default()
-                                    },
+                                            align_items: AlignItems::Center
+                                        )
+                                    ),
                                     ScrollingList::default(),
                                     AccessibilityNode(NodeBuilder::new(Role::List)),
                                 ))
@@ -140,12 +127,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                         parent.spawn((
                                             TextBundle::from_section(
                                                 format!("Item {i}"),
-                                                TextStyle {
+                                                text_style!(
                                                     font: asset_server
                                                         .load("fonts/FiraSans-Bold.ttf"),
-                                                    font_size: 20.,
-                                                    ..default()
-                                                },
+                                                    font_size: 20.
+                                                ),
                                             ),
                                             Label,
                                             AccessibilityNode(NodeBuilder::new(Role::ListItem)),
@@ -155,137 +141,117 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         });
                 });
             parent
-                .spawn(NodeBundle {
-                    style: Style {
+                .spawn(node_bundle!(
+                    style: style!(
                         width: Val::Px(200.0),
                         height: Val::Px(200.0),
                         position_type: PositionType::Absolute,
                         left: Val::Px(210.),
                         bottom: Val::Px(10.),
-                        border: UiRect::all(Val::Px(20.)),
-                        ..default()
-                    },
+                        border: UiRect::all(Val::Px(20.))
+                    ),
                     border_color: Color::GREEN.into(),
-                    background_color: Color::rgb(0.4, 0.4, 1.).into(),
-                    ..default()
-                })
+                    background_color: Color::rgb(0.4, 0.4, 1.).into()
+                ))
                 .with_children(|parent| {
-                    parent.spawn(NodeBundle {
-                        style: Style {
+                    parent.spawn(node_bundle!(
+                        style: style!(
                             width: Val::Percent(100.0),
-                            height: Val::Percent(100.0),
-                            ..default()
-                        },
-                        background_color: Color::rgb(0.8, 0.8, 1.).into(),
-                        ..default()
-                    });
+                            height: Val::Percent(100.0)
+                        ),
+                        background_color: Color::rgb(0.8, 0.8, 1.).into()
+                    ));
                 });
             // render order test: reddest in the back, whitest in the front (flex center)
             parent
-                .spawn(NodeBundle {
-                    style: Style {
+                .spawn(node_bundle!(
+                    style: style!(
                         width: Val::Percent(100.0),
                         height: Val::Percent(100.0),
                         position_type: PositionType::Absolute,
                         align_items: AlignItems::Center,
                         justify_content: JustifyContent::Center,
-                        ..default()
-                    },
-                    ..default()
-                })
+                    ),
+                ))
                 .with_children(|parent| {
                     parent
-                        .spawn(NodeBundle {
-                            style: Style {
+                        .spawn(node_bundle!(
+                            style: style!(
                                 width: Val::Px(100.0),
                                 height: Val::Px(100.0),
-                                ..default()
-                            },
+                            ),
                             background_color: Color::rgb(1.0, 0.0, 0.).into(),
-                            ..default()
-                        })
+                        ))
                         .with_children(|parent| {
-                            parent.spawn(NodeBundle {
-                                style: Style {
+                            parent.spawn(node_bundle!(
+                                style: style!(
                                     // Take the size of the parent node.
                                     width: Val::Percent(100.0),
                                     height: Val::Percent(100.0),
                                     position_type: PositionType::Absolute,
                                     left: Val::Px(20.),
                                     bottom: Val::Px(20.),
-                                    ..default()
-                                },
+                                ),
                                 background_color: Color::rgb(1.0, 0.3, 0.3).into(),
-                                ..default()
-                            });
-                            parent.spawn(NodeBundle {
-                                style: Style {
+                            ));
+                            parent.spawn(node_bundle!(
+                                style: style!(
                                     width: Val::Percent(100.0),
                                     height: Val::Percent(100.0),
                                     position_type: PositionType::Absolute,
                                     left: Val::Px(40.),
                                     bottom: Val::Px(40.),
-                                    ..default()
-                                },
+                                ),
                                 background_color: Color::rgb(1.0, 0.5, 0.5).into(),
-                                ..default()
-                            });
-                            parent.spawn(NodeBundle {
-                                style: Style {
+                            ));
+                            parent.spawn(node_bundle!(
+                                style: style!(
                                     width: Val::Percent(100.0),
                                     height: Val::Percent(100.0),
                                     position_type: PositionType::Absolute,
                                     left: Val::Px(60.),
                                     bottom: Val::Px(60.),
-                                    ..default()
-                                },
+                                ),
                                 background_color: Color::rgb(1.0, 0.7, 0.7).into(),
-                                ..default()
-                            });
+                            ));
                             // alpha test
-                            parent.spawn(NodeBundle {
-                                style: Style {
+                            parent.spawn(node_bundle!(
+                                style: style!(
                                     width: Val::Percent(100.0),
                                     height: Val::Percent(100.0),
                                     position_type: PositionType::Absolute,
                                     left: Val::Px(80.),
                                     bottom: Val::Px(80.),
-                                    ..default()
-                                },
+                                ),
                                 background_color: Color::rgba(1.0, 0.9, 0.9, 0.4).into(),
-                                ..default()
-                            });
+                            ));
                         });
                 });
             // bevy logo (flex center)
             parent
-                .spawn(NodeBundle {
-                    style: Style {
+                .spawn(node_bundle!(
+                    style: style!(
                         width: Val::Percent(100.0),
                         position_type: PositionType::Absolute,
                         justify_content: JustifyContent::Center,
                         align_items: AlignItems::FlexStart,
-                        ..default()
-                    },
-                    ..default()
-                })
+                    ),
+                ))
                 .with_children(|parent| {
                     // bevy logo (image)
                     // A `NodeBundle` is used to display the logo the image as an `ImageBundle` can't automatically
                     // size itself with a child node present.
                     parent
                         .spawn((
-                            NodeBundle {
-                                style: Style {
+                            node_bundle!(
+                                style: style!(
                                     width: Val::Px(500.0),
                                     height: Val::Px(125.0),
                                     margin: UiRect::top(Val::VMin(5.)),
-                                    ..default()
-                                },
+                                ),
                                 // a `NodeBundle` is transparent by default, so to see the image we have to its color to `WHITE`
                                 background_color: Color::WHITE.into(),
-                                ..default()
-                            },
+                            ),
                             UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),
                         ))
                         .with_children(|parent| {
@@ -293,13 +259,11 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                             // This UI node takes up no space in the layout and the `Text` component is used by the accessibility module
                             // and is not rendered.
                             parent.spawn((
-                                NodeBundle {
-                                    style: Style {
+                                node_bundle!(
+                                    style: style!(
                                         display: Display::None,
-                                        ..Default::default()
-                                    },
-                                    ..Default::default()
-                                },
+                                    ),
+                                ),
                                 Text::from_section("Bevy logo", TextStyle::default()),
                             ));
                         });


### PR DESCRIPTION
# Objective

This PR tries to reduce the amount of `..default()`s.

Before:
```rs
parent.spawn(NodeBundle {
    style: Style {
        width: Val::Percent(100.0),
        height: Val::Percent(100.0),
        position_type: PositionType::Absolute,
        left: Val::Px(80.),
        bottom: Val::Px(80.),
        ..default()
    },
    background_color: Color::rgba(1.0, 0.9, 0.9, 0.4).into(),
    ..default()
});
```

## Solution

 I have tried to fix the problem by adding macros to simplify struct initialization, as well as macros to generate the generating macros.

After:
```rs
parent.spawn(node_bundle!(
    style: style!(
        width: Val::Percent(100.0),
        height: Val::Percent(100.0),
        position_type: PositionType::Absolute,
        left: Val::Px(80.),
        bottom: Val::Px(80.),
    ),
    background_color: Color::rgba(1.0, 0.9, 0.9, 0.4).into(),
));
```
`rust-analyzer` plays surprisingly well this solution.

---

## Changelog

Added macros to the `bevy::ui` module so far, and changed the `ui/ui` and `ui/border` examples to use the macros. (Will add more later)
