### PR TITLE
Fix float precision issue in the gizmo shader 

### DIFF
--- a/crates/bevy_gizmos/src/lines.wgsl
+++ b/crates/bevy_gizmos/src/lines.wgsl
@@ -102,7 +102,8 @@ fn clip_near_plane(a: vec4<f32>, b: vec4<f32>) -> vec4<f32> {
         // Interpolate a towards b until it's at the near plane.
         let distance_a = a.z - a.w;
         let distance_b = b.z - b.w;
-        // Add an epsilon to the interpolator to ensure the point is not just behind the clip plane.
+        // Add an epsilon to the interpolator to ensure that the point is
+        // not just behind the clip plane due to floating-point imprecision.
         let t = distance_a / (distance_a - distance_b) + EPSILON;
         return mix(a, b, t);
     }


### PR DESCRIPTION
Fix a precision issue with in the manual near-clipping function.
This only affected lines that span large distances (starting at 100_000~ units) in my testing.

Fixes #10403