### PR TITLE
ui material: fix right border width

### DIFF
--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -396,7 +396,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
                 style.border.right,
                 parent_width,
                 ui_logical_viewport_size,
-            ) / uinode.size().y;
+            ) / uinode.size().x;
             let top =
                 resolve_border_thickness(style.border.top, parent_width, ui_logical_viewport_size)
                     / uinode.size().y;


### PR DESCRIPTION
# Objective

- When writing a custom UI material, the right border doesn't have the correct value

## Solution

- Fix the calculation
