### PR TITLE
Fix bevy_pbr shader function name

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -39,7 +39,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
 #ifdef MORPH_TARGETS
-    var vertex = morph::morph_vertex(vertex_no_morph);
+    var vertex = morph_vertex(vertex_no_morph);
 #else
     var vertex = vertex_no_morph;
 #endif


### PR DESCRIPTION
# Objective

Fix a shader error that happens when using pbr morph targets.

## Solution

Fix the function name in the `prepass.wgsl` shader, which is incorrectly prefixed with `morph::` (added in https://github.com/bevyengine/bevy/commit/61bad4eb5704b6859d32c69c3c45c24e77372c10#diff-97e4500f0a36bc6206d7b1490c8dd1a69459ee39dc6822eb9b2f7b160865f49fR42).

This section of the shader is only enabled when using morph targets, so it seems like there are no tests / examples using it?