### PR TITLE
UI Materials: ignore entities with a `BackgroundColor` component

### DIFF
--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -344,6 +344,9 @@ impl Default for ButtonBundle {
 }
 
 /// A UI node that is rendered using a [`UiMaterial`]
+///
+/// Adding a `BackgroundColor` component to an entity with this bundle will ignore the custom
+/// material and use the background color instead.
 #[derive(Bundle, Clone, Debug)]
 pub struct MaterialNodeBundle<M: UiMaterial> {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -354,15 +354,18 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
     materials: Extract<Res<Assets<M>>>,
     ui_stack: Extract<Res<UiStack>>,
     uinode_query: Extract<
-        Query<(
-            Entity,
-            &Node,
-            &Style,
-            &GlobalTransform,
-            &Handle<M>,
-            &ViewVisibility,
-            Option<&CalculatedClip>,
-        )>,
+        Query<
+            (
+                Entity,
+                &Node,
+                &Style,
+                &GlobalTransform,
+                &Handle<M>,
+                &ViewVisibility,
+                Option<&CalculatedClip>,
+            ),
+            Without<BackgroundColor>,
+        >,
     >,
     windows: Extract<Query<&Window, With<PrimaryWindow>>>,
     ui_scale: Extract<Res<UiScale>>,


### PR DESCRIPTION
# Objective

- Entities with both a `BackgroundColor` and a `Handle<CustomUiMaterial>` are extracted by both pipelines and results in entities being overwritten in the render world
- Fixes #10431 

## Solution

- Ignore entities with `BackgroundColor` when extracting ui material entities, and document that limit
