### PR TITLE
Rename `Timer::{percent,percent_left}` to `Timer::{fraction,fraction_left}`

### DIFF
--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -353,7 +353,7 @@ impl Timer {
         }
     }
 
-    /// Returns the percentage of the timer remaining time (goes from 1.0 to 0.0).
+    /// Returns the fraction of the timer remaining time (goes from 1.0 to 0.0).
     ///
     /// # Examples
     /// ```
@@ -361,10 +361,10 @@ impl Timer {
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.percent_left(), 0.75);
+    /// assert_eq!(timer.fraction_left(), 0.75);
     /// ```
     #[inline]
-    pub fn percent_left(&self) -> f32 {
+    pub fn fraction_left(&self) -> f32 {
         1.0 - self.fraction()
     }
 
@@ -453,7 +453,7 @@ mod tests {
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Once);
         assert_eq!(t.fraction(), 0.025);
-        assert_eq!(t.percent_left(), 0.975);
+        assert_eq!(t.fraction_left(), 0.975);
         // Ticking while paused changes nothing
         t.pause();
         t.tick(Duration::from_secs_f32(500.0));
@@ -464,7 +464,7 @@ mod tests {
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Once);
         assert_eq!(t.fraction(), 0.025);
-        assert_eq!(t.percent_left(), 0.975);
+        assert_eq!(t.fraction_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
         t.unpause();
         t.tick(Duration::from_secs_f32(500.0));
@@ -473,7 +473,7 @@ mod tests {
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
         assert_eq!(t.fraction(), 1.0);
-        assert_eq!(t.percent_left(), 0.0);
+        assert_eq!(t.fraction_left(), 0.0);
         // Continuing to tick when finished should only change just_finished
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 10.0);
@@ -481,7 +481,7 @@ mod tests {
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.fraction(), 1.0);
-        assert_eq!(t.percent_left(), 0.0);
+        assert_eq!(t.fraction_left(), 0.0);
     }
 
     #[test]
@@ -496,7 +496,7 @@ mod tests {
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Repeating);
         assert_eq!(t.fraction(), 0.375);
-        assert_eq!(t.percent_left(), 0.625);
+        assert_eq!(t.fraction_left(), 0.625);
         // Tick past the end and make sure elapsed wraps
         t.tick(Duration::from_secs_f32(1.5));
         assert_eq!(t.elapsed_secs(), 0.25);
@@ -504,7 +504,7 @@ mod tests {
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
         assert_eq!(t.fraction(), 0.125);
-        assert_eq!(t.percent_left(), 0.875);
+        assert_eq!(t.fraction_left(), 0.875);
         // Continuing to tick should turn off both finished & just_finished for repeating timers
         t.tick(Duration::from_secs_f32(1.0));
         assert_eq!(t.elapsed_secs(), 1.25);
@@ -512,7 +512,7 @@ mod tests {
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.fraction(), 0.625);
-        assert_eq!(t.percent_left(), 0.375);
+        assert_eq!(t.fraction_left(), 0.375);
     }
 
     #[test]

--- a/crates/bevy_time/src/timer.rs
+++ b/crates/bevy_time/src/timer.rs
@@ -334,7 +334,7 @@ impl Timer {
         self.times_finished_this_tick = 0;
     }
 
-    /// Returns the percentage of the timer elapsed time (goes from 0.0 to 1.0).
+    /// Returns the fraction of the timer elapsed time (goes from 0.0 to 1.0).
     ///
     /// # Examples
     /// ```
@@ -342,10 +342,10 @@ impl Timer {
     /// use std::time::Duration;
     /// let mut timer = Timer::from_seconds(2.0, TimerMode::Once);
     /// timer.tick(Duration::from_secs_f32(0.5));
-    /// assert_eq!(timer.percent(), 0.25);
+    /// assert_eq!(timer.fraction(), 0.25);
     /// ```
     #[inline]
-    pub fn percent(&self) -> f32 {
+    pub fn fraction(&self) -> f32 {
         if self.duration == Duration::ZERO {
             1.0
         } else {
@@ -365,7 +365,7 @@ impl Timer {
     /// ```
     #[inline]
     pub fn percent_left(&self) -> f32 {
-        1.0 - self.percent()
+        1.0 - self.fraction()
     }
 
     /// Returns the remaining time in seconds
@@ -452,7 +452,7 @@ mod tests {
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Once);
-        assert_eq!(t.percent(), 0.025);
+        assert_eq!(t.fraction(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Ticking while paused changes nothing
         t.pause();
@@ -463,7 +463,7 @@ mod tests {
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Once);
-        assert_eq!(t.percent(), 0.025);
+        assert_eq!(t.fraction(), 0.025);
         assert_eq!(t.percent_left(), 0.975);
         // Tick past the end and make sure elapsed doesn't go past 0.0 and other things update
         t.unpause();
@@ -472,7 +472,7 @@ mod tests {
         assert!(t.finished());
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
         assert_eq!(t.percent_left(), 0.0);
         // Continuing to tick when finished should only change just_finished
         t.tick(Duration::from_secs_f32(1.0));
@@ -480,7 +480,7 @@ mod tests {
         assert!(t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
         assert_eq!(t.percent_left(), 0.0);
     }
 
@@ -495,7 +495,7 @@ mod tests {
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.mode(), TimerMode::Repeating);
-        assert_eq!(t.percent(), 0.375);
+        assert_eq!(t.fraction(), 0.375);
         assert_eq!(t.percent_left(), 0.625);
         // Tick past the end and make sure elapsed wraps
         t.tick(Duration::from_secs_f32(1.5));
@@ -503,7 +503,7 @@ mod tests {
         assert!(t.finished());
         assert!(t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 1);
-        assert_eq!(t.percent(), 0.125);
+        assert_eq!(t.fraction(), 0.125);
         assert_eq!(t.percent_left(), 0.875);
         // Continuing to tick should turn off both finished & just_finished for repeating timers
         t.tick(Duration::from_secs_f32(1.0));
@@ -511,7 +511,7 @@ mod tests {
         assert!(!t.finished());
         assert!(!t.just_finished());
         assert_eq!(t.times_finished_this_tick(), 0);
-        assert_eq!(t.percent(), 0.625);
+        assert_eq!(t.fraction(), 0.625);
         assert_eq!(t.percent_left(), 0.375);
     }
 
@@ -543,19 +543,19 @@ mod tests {
         let mut t = Timer::from_seconds(0.0, TimerMode::Repeating);
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.elapsed(), Duration::ZERO);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
         t.tick(Duration::from_secs(1));
         assert_eq!(t.times_finished_this_tick(), u32::MAX);
         assert_eq!(t.elapsed(), Duration::ZERO);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
         t.tick(Duration::from_secs(2));
         assert_eq!(t.times_finished_this_tick(), u32::MAX);
         assert_eq!(t.elapsed(), Duration::ZERO);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
         t.reset();
         assert_eq!(t.times_finished_this_tick(), 0);
         assert_eq!(t.elapsed(), Duration::ZERO);
-        assert_eq!(t.percent(), 1.0);
+        assert_eq!(t.fraction(), 1.0);
     }
 
     #[test]

--- a/examples/time/timers.rs
+++ b/examples/time/timers.rs
@@ -66,7 +66,7 @@ fn countdown(time: Res<Time>, mut countdown: ResMut<Countdown>) {
             // Print the percent complete the main timer is.
             info!(
                 "Timer is {:0.0}% complete!",
-                countdown.main_timer.percent() * 100.0
+                countdown.main_timer.fraction() * 100.0
             );
         } else {
             // The timer has finished so we pause the percent output timer

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -112,7 +112,7 @@ impl TargetScale {
     }
 
     fn current_scale(&self) -> f64 {
-        let completion = self.target_time.percent();
+        let completion = self.target_time.fraction();
         let multiplier = ease_in_expo(completion as f64);
         self.start_scale + (self.target_scale - self.start_scale) * multiplier
     }


### PR DESCRIPTION
# Objective
Fixes #10439

`Timer::percent()` and `Timer::percent_left()` return values in the range of 0.0 to 1.0, even though their names contain "percent".

These functions should be renamed for clarity.

## Solution
- Rename `Timer::percent()` to `Timer::fraction()`
- Rename `Timer::percent_left()` to `Timer::fraction_left()`

---

## Changelog

### Changed
- Renamed `Timer::percent()` to `Timer::fraction()`
- Renamed `Timer::percent_left()` to `Timer::fraction_left()`

## Migration Guide
- `Timer::percent()` has been renamed to `Timer::fraction()`
- `Timer::percent_left()` has been renamed to `Timer::fraction_left()`
