### PR TITLE
Fix intra-doc link warnings

### DIFF
--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -1,4 +1,6 @@
 //! Shows how to render a polygonal [`Mesh`], generated from a [`Quad`] primitive, in a 2D scene.
+//!
+//! [`Quad`]: bevy::prelude::shape::Quad
 
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
 

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -2,6 +2,9 @@
 //! pipeline for 2d meshes.
 //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include vertex color.
 //! Check out the "mesh2d" example for simpler / higher level 2d meshes.
+//!
+//! [`Material2d`]: bevy::sprite::Material2d
+
 #![allow(clippy::type_complexity)]
 
 use bevy::{

--- a/examples/2d/mesh2d_vertex_color_texture.rs
+++ b/examples/2d/mesh2d_vertex_color_texture.rs
@@ -1,5 +1,7 @@
 //! Shows how to render a polygonal [`Mesh`], generated from a [`Quad`] primitive, in a 2D scene.
 //! Adds a texture and colored vertices, giving per-vertex tinting.
+//!
+//! [`Quad`]: bevy::prelude::shape::Quad
 
 use bevy::{
     prelude::*,

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -3,9 +3,9 @@
 //! Illustrates:
 //!
 //! - How to access and modify individual morph target weights.
-//!   See the [`update_weights`] system for details.
-//! - How to read morph target names in [`name_morphs`].
-//! - How to play morph target animations in [`setup_animations`].
+//!   See the `update_weights` system for details.
+//! - How to read morph target names in `name_morphs`.
+//! - How to play morph target animations in `setup_animations`.
 
 use bevy::prelude::*;
 use std::f32::consts::PI;

--- a/examples/app/headless.rs
+++ b/examples/app/headless.rs
@@ -2,9 +2,11 @@
 //! You can also completely remove rendering / windowing Plugin code from bevy
 //! by making your import look like this in your Cargo.toml.
 //!
+//! ```toml
 //! [dependencies]
 //! bevy = { version = "*", default-features = false }
 //! # replace "*" with the most recent version of bevy
+//! ```
 
 use bevy::{app::ScheduleRunnerPlugin, prelude::*, utils::Duration};
 

--- a/examples/ecs/one_shot_systems.rs
+++ b/examples/ecs/one_shot_systems.rs
@@ -4,9 +4,9 @@
 //! reducing the overhead of running extremely rarely run systems
 //! and improving schedule flexibility.
 //!
-//! See the [`World::run_system`](bevy::ecs::World::run_system) or
-//! [`World::run_system_once`](bevy::ecs::World::run_system_once) docs for more
-//! details.
+//! See the [`World::run_system`](bevy::ecs::prelude::World::run_system) or
+//! [`World::run_system_once`](bevy::ecs::prelude::World#method.run_system_once_with)
+//! docs for more details.
 
 use bevy::{
     ecs::system::{RunSystemOnce, SystemId},

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -1,4 +1,4 @@
-//! This example illustrates the [`UIScale`] resource from `bevy_ui`.
+//! This example illustrates the [`UiScale`] resource from `bevy_ui`.
 
 use bevy::{prelude::*, text::TextSettings, utils::Duration};
 


### PR DESCRIPTION
When `cargo doc -Zunstable-options -Zrustdoc-scrape-examples` (trying to figure out why it doesn't work with bevy), I had the following warnings:

```
warning: unresolved link to `Quad`
 --> examples/2d/mesh2d.rs:1:66
  |
1 | //! Shows how to render a polygonal [`Mesh`], generated from a [`Quad`] primitive, in a 2D scene.
  |                                                                  ^^^^ no item named `Quad` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `bevy` (example "mesh2d") generated 1 warning
warning: unresolved link to `update_weights`
 --> examples/animation/morph_targets.rs:6:17
  |
6 | //!   See the [`update_weights`] system for details.
  |                 ^^^^^^^^^^^^^^ no item named `update_weights` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: public documentation for `morph_targets` links to private item `name_morphs`
 --> examples/animation/morph_targets.rs:7:43
  |
7 | //! - How to read morph target names in [`name_morphs`].
  |                                           ^^^^^^^^^^^ this item is private
  |
  = note: this link will resolve properly if you pass `--document-private-items`
  = note: `#[warn(rustdoc::private_intra_doc_links)]` on by default

warning: public documentation for `morph_targets` links to private item `setup_animations`
 --> examples/animation/morph_targets.rs:8:48
  |
8 | //! - How to play morph target animations in [`setup_animations`].
  |                                                ^^^^^^^^^^^^^^^^ this item is private
  |
  = note: this link will resolve properly if you pass `--document-private-items`

warning: `bevy` (example "morph_targets") generated 3 warnings
warning: unresolved link to `Quad`
 --> examples/2d/mesh2d_vertex_color_texture.rs:1:66
  |
1 | //! Shows how to render a polygonal [`Mesh`], generated from a [`Quad`] primitive, in a 2D scene.
  |                                                                  ^^^^ no item named `Quad` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `bevy` (example "mesh2d_vertex_color_texture") generated 1 warning
warning: unresolved link to `UIScale`
 --> examples/ui/ui_scaling.rs:1:36
  |
1 | //! This example illustrates the [`UIScale`] resource from `bevy_ui`.
  |                                    ^^^^^^^ no item named `UIScale` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `bevy` (example "ui_scaling") generated 1 warning
warning: unresolved link to `dependencies`
 --> examples/app/headless.rs:5:6
  |
5 | //! [dependencies]
  |      ^^^^^^^^^^^^ no item named `dependencies` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `bevy` (example "headless") generated 1 warning
warning: unresolved link to `Material2d`
 --> examples/2d/mesh2d_manual.rs:3:26
  |
3 | //! It doesn't use the [`Material2d`] abstraction, but changes the vertex buffer to include verte...
  |                          ^^^^^^^^^^ no item named `Material2d` in scope
  |
  = help: to escape `[` and `]` characters, add '\' before them like `\[` or `\]`
  = note: `#[warn(rustdoc::broken_intra_doc_links)]` on by default

warning: `bevy` (example "mesh2d_manual") generated 1 warning
```