### PR TITLE
Remove unnecessary if statement in scheduler

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -859,10 +859,6 @@ impl ScheduleGraph {
             self.dependency.graph.add_node(set);
         }
 
-        if !self.dependency.graph.contains_node(id) {
-            self.dependency.graph.add_node(id);
-        }
-
         for (kind, set) in dependencies
             .into_iter()
             .map(|Dependency { kind, set }| (kind, self.system_set_ids[&set]))


### PR DESCRIPTION
# Objective

There is an if statement checking if a node is present in a graph moments after it explicitly being added.
Unless the edge function has super weird side effects and the tests don't pass, this is unnecessary.

## Solution

Removed it