### PR TITLE
Rename `Time::<Fixed>::overstep_percentage()` and `Time::<Fixed>::overstep_percentage_f64()`

### DIFF
--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -185,7 +185,7 @@ impl Time<Fixed> {
     /// Returns the amount of overstep time accumulated toward new steps, as an
     /// [`f64`] fraction of the timestep.
     #[inline]
-    pub fn overstep_percentage_f64(&self) -> f64 {
+    pub fn overstep_fraction_f64(&self) -> f64 {
         self.context().overstep.as_secs_f64() / self.context().timestep.as_secs_f64()
     }
 
@@ -266,7 +266,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(1));
         assert_eq!(time.overstep_fraction(), 0.5);
-        assert_eq!(time.overstep_percentage_f64(), 0.5);
+        assert_eq!(time.overstep_fraction_f64(), 0.5);
 
         assert!(!time.expend()); // false
 
@@ -274,7 +274,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(1));
         assert_eq!(time.overstep_fraction(), 0.5);
-        assert_eq!(time.overstep_percentage_f64(), 0.5);
+        assert_eq!(time.overstep_fraction_f64(), 0.5);
 
         time.accumulate(Duration::from_secs(1));
 
@@ -282,7 +282,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(2));
         assert_eq!(time.overstep_fraction(), 1.0);
-        assert_eq!(time.overstep_percentage_f64(), 1.0);
+        assert_eq!(time.overstep_fraction_f64(), 1.0);
 
         assert!(time.expend()); // true
 
@@ -290,7 +290,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::ZERO);
         assert_eq!(time.overstep_fraction(), 0.0);
-        assert_eq!(time.overstep_percentage_f64(), 0.0);
+        assert_eq!(time.overstep_fraction_f64(), 0.0);
 
         assert!(!time.expend()); // false
 
@@ -298,7 +298,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::ZERO);
         assert_eq!(time.overstep_fraction(), 0.0);
-        assert_eq!(time.overstep_percentage_f64(), 0.0);
+        assert_eq!(time.overstep_fraction_f64(), 0.0);
 
         time.accumulate(Duration::from_secs(1));
 
@@ -306,7 +306,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::from_secs(1));
         assert_eq!(time.overstep_fraction(), 0.5);
-        assert_eq!(time.overstep_percentage_f64(), 0.5);
+        assert_eq!(time.overstep_fraction_f64(), 0.5);
 
         assert!(!time.expend()); // false
 
@@ -314,7 +314,7 @@ mod test {
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::from_secs(1));
         assert_eq!(time.overstep_fraction(), 0.5);
-        assert_eq!(time.overstep_percentage_f64(), 0.5);
+        assert_eq!(time.overstep_fraction_f64(), 0.5);
     }
 
     #[test]

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -178,7 +178,7 @@ impl Time<Fixed> {
     /// Returns the amount of overstep time accumulated toward new steps, as an
     /// [`f32`] fraction of the timestep.
     #[inline]
-    pub fn overstep_percentage(&self) -> f32 {
+    pub fn overstep_fraction(&self) -> f32 {
         self.context().overstep.as_secs_f32() / self.context().timestep.as_secs_f32()
     }
 
@@ -265,7 +265,7 @@ mod test {
         assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(1));
-        assert_eq!(time.overstep_percentage(), 0.5);
+        assert_eq!(time.overstep_fraction(), 0.5);
         assert_eq!(time.overstep_percentage_f64(), 0.5);
 
         assert!(!time.expend()); // false
@@ -273,7 +273,7 @@ mod test {
         assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(1));
-        assert_eq!(time.overstep_percentage(), 0.5);
+        assert_eq!(time.overstep_fraction(), 0.5);
         assert_eq!(time.overstep_percentage_f64(), 0.5);
 
         time.accumulate(Duration::from_secs(1));
@@ -281,7 +281,7 @@ mod test {
         assert_eq!(time.delta(), Duration::ZERO);
         assert_eq!(time.elapsed(), Duration::ZERO);
         assert_eq!(time.overstep(), Duration::from_secs(2));
-        assert_eq!(time.overstep_percentage(), 1.0);
+        assert_eq!(time.overstep_fraction(), 1.0);
         assert_eq!(time.overstep_percentage_f64(), 1.0);
 
         assert!(time.expend()); // true
@@ -289,7 +289,7 @@ mod test {
         assert_eq!(time.delta(), Duration::from_secs(2));
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::ZERO);
-        assert_eq!(time.overstep_percentage(), 0.0);
+        assert_eq!(time.overstep_fraction(), 0.0);
         assert_eq!(time.overstep_percentage_f64(), 0.0);
 
         assert!(!time.expend()); // false
@@ -297,7 +297,7 @@ mod test {
         assert_eq!(time.delta(), Duration::from_secs(2));
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::ZERO);
-        assert_eq!(time.overstep_percentage(), 0.0);
+        assert_eq!(time.overstep_fraction(), 0.0);
         assert_eq!(time.overstep_percentage_f64(), 0.0);
 
         time.accumulate(Duration::from_secs(1));
@@ -305,7 +305,7 @@ mod test {
         assert_eq!(time.delta(), Duration::from_secs(2));
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::from_secs(1));
-        assert_eq!(time.overstep_percentage(), 0.5);
+        assert_eq!(time.overstep_fraction(), 0.5);
         assert_eq!(time.overstep_percentage_f64(), 0.5);
 
         assert!(!time.expend()); // false
@@ -313,7 +313,7 @@ mod test {
         assert_eq!(time.delta(), Duration::from_secs(2));
         assert_eq!(time.elapsed(), Duration::from_secs(2));
         assert_eq!(time.overstep(), Duration::from_secs(1));
-        assert_eq!(time.overstep_percentage(), 0.5);
+        assert_eq!(time.overstep_fraction(), 0.5);
         assert_eq!(time.overstep_percentage_f64(), 0.5);
     }
 


### PR DESCRIPTION
# Objective
This is similar to #10439.

`Time::<Fixed>::overstep_percentage()` and `Time::<Fixed>::overstep_percentage_f64()` returns values from 0.0 to 1.0, but their names use the word "percentage". These function names make it easy to misunderstand that they return values from 0.0 to 100.0.

To avoid confusion, these functions should be renamed to "`overstep_fraction(_f64)`".

## Solution
Rename them.

---

## Changelog

### Changed
- Renamed `Time::<Fixed>::overstep_percentage()` to `Time::<Fixed>::overstep_fraction()`
- Renamed `Time::<Fixed>::overstep_percentage_f64()` to `Time::<Fixed>::overstep_fraction_f64()`

## Migration Guide
- `Time::<Fixed>::overstep_percentage()` has been renamed to `Time::<Fixed>::overstep_fraction()`
- `Time::<Fixed>::overstep_percentage_f64()` has been renamed to `Time::<Fixed>::overstep_fraction_f64()`