### PR TITLE
`ReadAssetBytesError::Io`  exposes failing path

### DIFF
--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -559,7 +559,7 @@ pub enum ReadAssetBytesError {
     #[error(transparent)]
     MissingProcessedAssetReaderError(#[from] MissingProcessedAssetReaderError),
     /// Encountered an I/O error while loading an asset.
-    #[error("Encountered an io error while loading asset at "{path}": {source}")]
+    #[error("Encountered an io error while loading asset at `{path}`: {source}")]
     Io {
         path: PathBuf,
         #[source]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -559,7 +559,7 @@ pub enum ReadAssetBytesError {
     #[error(transparent)]
     MissingProcessedAssetReaderError(#[from] MissingProcessedAssetReaderError),
     /// Encountered an I/O error while loading an asset.
-    #[error("Encountered an io error while loading asset {path}: {source}")]
+    #[error("Encountered an io error while loading asset at "{path}": {source}")]
     Io {
         path: PathBuf,
         #[source]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -16,7 +16,7 @@ use ron::error::SpannedError;
 use serde::{Deserialize, Serialize};
 use std::{
     any::{Any, TypeId},
-    path::Path,
+    path::{Path, PathBuf},
 };
 use thiserror::Error;
 
@@ -438,7 +438,13 @@ impl<'a> LoadContext<'a> {
             Default::default()
         };
         let mut bytes = Vec::new();
-        reader.read_to_end(&mut bytes).await?;
+        reader
+            .read_to_end(&mut bytes)
+            .await
+            .map_err(|source| ReadAssetBytesError::Io {
+                path: path.path().to_path_buf(),
+                source,
+            })?;
         self.loader_dependencies.insert(path.clone_owned(), hash);
         Ok(bytes)
     }
@@ -553,8 +559,12 @@ pub enum ReadAssetBytesError {
     #[error(transparent)]
     MissingProcessedAssetReaderError(#[from] MissingProcessedAssetReaderError),
     /// Encountered an I/O error while loading an asset.
-    #[error("Encountered an io error while loading asset: {0}")]
-    Io(#[from] std::io::Error),
+    #[error("Encountered an io error while loading asset {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
     #[error("The LoadContext for this read_asset_bytes call requires hash metadata, but it was not provided. This is likely an internal implementation error.")]
     MissingAssetHash,
 }


### PR DESCRIPTION
# Objective

Addresses #[10438](https://github.com/bevyengine/bevy/issues/10438)

The objective was to include the failing path in the error for the user to see. 

## Solution

Add a `path` field to the `ReadAssetBytesError::Io` variant to expose the failing path in the error message.

## Migration Guide
- The `ReadAssetBytesError::Io` variant now contains two named fields instead of converting from `std::io::Error`. 
    1. `path`: The requested (failing) path (`PathBuf`)
    2. `source`: The source `std::io::Error`
