### PR TITLE
Don't `.unwrap()` in `AssetPath::try_parse`

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -115,7 +115,7 @@ impl<'a> AssetPath<'a> {
     ///
     /// This will return a [`ParseAssetPathError`] if `asset_path` is in an invalid format.
     pub fn try_parse(asset_path: &'a str) -> Result<AssetPath<'a>, ParseAssetPathError> {
-        let (source, path, label) = Self::parse_internal(asset_path).unwrap();
+        let (source, path, label) = Self::parse_internal(asset_path)?;
         Ok(Self {
             source: match source {
                 Some(source) => AssetSourceId::Name(CowArc::Borrowed(source)),


### PR DESCRIPTION
# Objective

- The docs on `AssetPath::try_parse` say that it will return an error when the string is malformed, but it actually just `.unwrap()`s the result.

## Solution

- Use `?` instead of unwrapping the result.