### PR TITLE
Add discard_overstep function to Time<Fixed>

### DIFF
--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -175,7 +175,7 @@ impl Time<Fixed> {
         self.context().overstep
     }
 
-    /// Discard a part of the overstep amount. 
+    /// Discard a part of the overstep amount.
     ///
     /// If `discard` is higher than overstep, the overstep becomes zero.
     #[inline]

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -175,6 +175,14 @@ impl Time<Fixed> {
         self.context().overstep
     }
 
+    /// Discard a part of the overstep amount. If `discard` is higher than overstep,
+    /// overstep becomes zero.
+    #[inline]
+    pub fn discard_overstep(&mut self, discard: Duration) {
+        let context = self.context_mut();
+        context.overstep = context.overstep.saturating_sub(discard);
+    }
+
     /// Returns the amount of overstep time accumulated toward new steps, as an
     /// [`f32`] fraction of the timestep.
     #[inline]

--- a/crates/bevy_time/src/fixed.rs
+++ b/crates/bevy_time/src/fixed.rs
@@ -175,8 +175,9 @@ impl Time<Fixed> {
         self.context().overstep
     }
 
-    /// Discard a part of the overstep amount. If `discard` is higher than overstep,
-    /// overstep becomes zero.
+    /// Discard a part of the overstep amount. 
+    ///
+    /// If `discard` is higher than overstep, the overstep becomes zero.
     #[inline]
     pub fn discard_overstep(&mut self, discard: Duration) {
         let context = self.context_mut();


### PR DESCRIPTION
# Objective

There is no easy way to discard some amount for `Time<Fixed>`'s overstep. This can be useful for online games when the client receives information about a tick (which happens when you get a FPS drop or the ping changes for example) it has not yet processed, it can discard overstep equal to the number of ticks it can jump ahead.

Currently the workaround would be to create a new `Time<Fixed>` copy the old timestep, advance it by the overstep amount that would remain after subtracting the discarded amount, and using `.context_mut()` to overwrite the old context with the new one. If you overwrite the whole `Time<Fixed>` or forget to copy over the timestep you can introduce undesirable side effects.

## Solution

Introduce a `discard_overstep` method, which discards the provided amount of overstep. It uses satuarting_sub to avoid errors (negative `Duration`s do not exist).

---

## Changelog

- Added `discard_overstep` function to `Time<Fixed>`
