### PR TITLE
Make clipped areas of UI nodes non-interactive

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -1,5 +1,4 @@
 use crate::{camera_config::UiCameraConfig, CalculatedClip, Node, UiScale, UiStack};
-use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     entity::Entity,
@@ -9,7 +8,7 @@ use bevy_ecs::{
     system::{Local, Query, Res},
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, Input};
-use bevy_math::{Vec2, Rect};
+use bevy_math::{Rect, Vec2};
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{camera::NormalizedRenderTarget, prelude::Camera, view::ViewVisibility};
 use bevy_transform::components::GlobalTransform;
@@ -60,17 +59,7 @@ impl Default for Interaction {
 /// A None value means that the cursor position is unknown.
 ///
 /// It can be used alongside interaction to get the position of the press.
-#[derive(
-    Component,
-    Copy,
-    Clone,
-    Default,
-    PartialEq,
-    Debug,
-    Reflect,
-    Serialize,
-    Deserialize,
-)]
+#[derive(Component, Copy, Clone, Default, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub struct RelativeCursorPosition {
     pub normalized_visible_node_rect: Rect,
@@ -227,7 +216,7 @@ pub fn ui_focus_system(
                 // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
                 // Coordinates are relative to the entire node, not just the visible region.
                 let relative_cursor_position = cursor_position
-                        .map(|cursor_position| (cursor_position - node_rect.min) / node_rect.size());
+                    .map(|cursor_position| (cursor_position - node_rect.min) / node_rect.size());
 
                 // If the current cursor position is within the bounds of the node's visible area, consider it for
                 // clicking

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -218,14 +218,11 @@ pub fn ui_focus_system(
 
                 let node_rect = node.node.logical_rect(node.global_transform);
 
-                // If there is no `calculated_clip`, intersect with an unbounded `Rect`.
-                let clip_rect = node.calculated_clip.map(|clip| clip.clip).unwrap_or(Rect {
-                    min: Vec2::splat(f32::NEG_INFINITY),
-                    max: Vec2::splat(f32::INFINITY),
-                });
-
-                // Intersect with `clip_rect` to find the bounds of the visible region of the node
-                let visible_rect = node_rect.intersect(clip_rect);
+                // Intersect with the calculated clip rect to find the bounds of the visible region of the node
+                let visible_rect = node
+                    .calculated_clip
+                    .map(|clip| node_rect.intersect(clip.clip))
+                    .unwrap_or(node_rect);
 
                 // The mouse position relative to the node
                 // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     system::{Local, Query, Res},
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, Input};
-use bevy_math::Vec2;
+use bevy_math::{Vec2, Rect};
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{camera::NormalizedRenderTarget, prelude::Camera, view::ViewVisibility};
 use bevy_transform::components::GlobalTransform;
@@ -62,8 +62,6 @@ impl Default for Interaction {
 /// It can be used alongside interaction to get the position of the press.
 #[derive(
     Component,
-    Deref,
-    DerefMut,
     Copy,
     Clone,
     Default,
@@ -75,6 +73,7 @@ impl Default for Interaction {
 )]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub struct RelativeCursorPosition {
+    pub normalized_visible_node_rect: Rect,
     /// Cursor position relative to size and position of the Node.
     pub normalized: Option<Vec2>,
 }
@@ -83,7 +82,7 @@ impl RelativeCursorPosition {
     /// A helper function to check if the mouse is over the node
     pub fn mouse_over(&self) -> bool {
         self.normalized
-            .map(|position| (0.0..1.).contains(&position.x) && (0.0..1.).contains(&position.y))
+            .map(|position| self.normalized_visible_node_rect.contains(position))
             .unwrap_or(false)
     }
 }
@@ -233,10 +232,11 @@ pub fn ui_focus_system(
                 // If the current cursor position is within the bounds of the node's visible area, consider it for
                 // clicking
                 let relative_cursor_position_component = RelativeCursorPosition {
+                    normalized_visible_node_rect: visible_rect.normalize(node_rect),
                     normalized: relative_cursor_position,
                 };
 
-                let contains_cursor = cursor_position.map(|cursor_position| visible_rect.contains(cursor_position)).unwrap_or(false);
+                let contains_cursor = relative_cursor_position_component.mouse_over();
 
                 // Save the relative cursor position to the correct component
                 if let Some(mut node_relative_cursor_position_component) =

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
     system::{Local, Query, Res},
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, Input};
-use bevy_math::{Rect, Vec2};
+use bevy_math::Vec2;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{camera::NormalizedRenderTarget, prelude::Camera, view::ViewVisibility};
 use bevy_transform::components::GlobalTransform;

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -216,7 +216,7 @@ pub fn ui_focus_system(
                     }
                 }
 
-                let node_rect = node.node.logical_rect(&node.global_transform);
+                let node_rect = node.node.logical_rect(node.global_transform);
 
                 // If there is no `calculated_clip`, intersect with an unbounded `Rect`.
                 let clip_rect = node.calculated_clip.map(|clip| clip.clip).unwrap_or(Rect {

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -227,10 +227,8 @@ pub fn ui_focus_system(
                 // The mouse position relative to the node
                 // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
                 // Coordinates are relative to the entire node, not just the visible region.
-                // The `relative_cursor_position` will be `None` if the cursor is over a clipped part of the node.
                 let relative_cursor_position = cursor_position
-                    .filter(|cursor_position| visible_rect.contains(*cursor_position))
-                    .map(|cursor_position| (cursor_position - node_rect.min) / node_rect.size());
+                        .map(|cursor_position| (cursor_position - node_rect.min) / node_rect.size());
 
                 // If the current cursor position is within the bounds of the node's visible area, consider it for
                 // clicking
@@ -238,7 +236,7 @@ pub fn ui_focus_system(
                     normalized: relative_cursor_position,
                 };
 
-                let contains_cursor = relative_cursor_position_component.mouse_over();
+                let contains_cursor = cursor_position.map(|cursor_position| visible_rect.contains(cursor_position)).unwrap_or(false);
 
                 // Save the relative cursor position to the correct component
                 if let Some(mut node_relative_cursor_position_component) =

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -56,14 +56,16 @@ impl Default for Interaction {
 
 /// A component storing the position of the mouse relative to the node, (0., 0.) being the top-left corner and (1., 1.) being the bottom-right
 /// If the mouse is not over the node, the value will go beyond the range of (0., 0.) to (1., 1.)
-/// A None value means that the cursor position is unknown.
+
 ///
 /// It can be used alongside interaction to get the position of the press.
 #[derive(Component, Copy, Clone, Default, PartialEq, Debug, Reflect, Serialize, Deserialize)]
 #[reflect(Component, Serialize, Deserialize, PartialEq)]
 pub struct RelativeCursorPosition {
+    /// Visible area of the Node relative to the size of the entire Node.
     pub normalized_visible_node_rect: Rect,
-    /// Cursor position relative to size and position of the Node.
+    /// Cursor position relative to the size and position of the Node.
+    /// A None value indicates that the cursor position is unknown.
     pub normalized: Option<Vec2>,
 }
 

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -8,6 +8,7 @@ fn main() {
         // Only run the app when there is user input. This will significantly reduce CPU/GPU use.
         .insert_resource(WinitSettings::desktop_app())
         .add_systems(Startup, setup)
+        .add_systems(Update, update_outlines)
         .run();
 }
 
@@ -86,18 +87,39 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                 ..Default::default()
                             })
                             .with_children(|parent| {
-                                parent.spawn(ImageBundle {
-                                    image: UiImage::new(image.clone()),
-                                    style: Style {
-                                        min_width: Val::Px(100.),
-                                        min_height: Val::Px(100.),
+                                parent.spawn((
+                                    ImageBundle {
+                                        image: UiImage::new(image.clone()),
+                                        style: Style {
+                                            min_width: Val::Px(100.),
+                                            min_height: Val::Px(100.),
+                                            ..Default::default()
+                                        },
+                                        background_color: Color::WHITE.into(),
+
                                         ..Default::default()
                                     },
-                                    background_color: Color::WHITE.into(),
-                                    ..Default::default()
-                                });
+                                    Interaction::default(),
+                                    Outline {
+                                        width: Val::Px(2.),
+                                        offset: Val::Px(2.),
+                                        color: Color::NONE,
+                                    },
+                                ));
                             });
                     });
             }
         });
+}
+
+fn update_outlines(mut outlines_query: Query<(&mut Outline, Ref<Interaction>)>) {
+    for (mut outline, interaction) in outlines_query.iter_mut() {
+        if interaction.is_changed() {
+            outline.color = match *interaction {
+                Interaction::Pressed => Color::RED,
+                Interaction::Hovered => Color::WHITE,
+                Interaction::None => Color::NONE,
+            };
+        }
+    }
 }


### PR DESCRIPTION
# Objective

Problems:

* The clipped, non-visible regions of UI nodes are interactive.
* `RelativeCursorPostion` is set relative to the visible part of the node. It should be relative to the whole node.
* The `RelativeCursorPostion::mouse_over` method returns `true` when the mouse is over a clipped part of a node.

fixes #10470

## Solution

Intersect a node's bounding rect with its clipping rect before checking if it contains the cursor.

Added the field `normalized_visible_node_rect` to `RelativeCursorPosition`. This is set to the bounds of the unclipped area of the node rect by `ui_focus_system` expressed in normalized coordinates relative to the entire node.

Instead of checking if the normalized cursor position lies within a unit square, it instead checks if it is contained by `normalized_visible_node_rect`.

Added outlines to the `overflow` example that appear when the cursor is over the visible part of the images, but not the clipped area.

---

## Changelog

* `ui_focus_system` intersects a node's bounding rect with its clipping rect before checking if mouse over.
* Added the field `normalized_visible_node_rect` to `RelativeCursorPosition`. This is set to the bounds of the unclipped area of the node rect by `ui_focus_system` expressed in normalized coordinates relative to the entire node.
* `RelativeCursorPostion` is calculated relative to the whole node's position and size, not only the visible part.
* `RelativeCursorPosition::mouse_over` only returns true when the mouse is over an unclipped region of the UI node.
* Removed the `Deref` and `DerefMut` derives from `RelativeCursorPosition` as it is no longer a single field struct.
* Added some outlines to the `overflow` example that respond to `Interaction` changes.

## Migration Guide

The clipped areas of UI nodes are no longer interactive.

`RelativeCursorPostion` is now calculated relative to the whole node's position and size, not only the visible part. Its `mouse_over` method only returns true when the cursor is over an unclipped part of the node.

`RelativeCursorPosition` no longer implements `Deref` and `DerefMut`.
