### PR TITLE
BufferVec: always allocate a GPU buffer

### DIFF
--- a/crates/bevy_render/src/render_resource/buffer_vec.rs
+++ b/crates/bevy_render/src/render_resource/buffer_vec.rs
@@ -135,7 +135,7 @@ impl<T: NoUninit> RawBufferVec<T> {
     /// is marked as [`BufferUsages::COPY_DST`](BufferUsages).
     pub fn reserve(&mut self, capacity: usize, device: &RenderDevice) {
         let size = self.item_size * capacity;
-        if capacity > self.capacity || (self.changed && size > 0) {
+        if capacity > self.capacity || self.changed || self.buffer.is_none() {
             self.capacity = capacity;
             self.buffer = Some(device.create_buffer(&wgpu::BufferDescriptor {
                 label: self.label.as_deref(),
@@ -153,9 +153,6 @@ impl<T: NoUninit> RawBufferVec<T> {
     /// Before queuing the write, a [`reserve`](RawBufferVec::reserve) operation
     /// is executed.
     pub fn write_buffer(&mut self, device: &RenderDevice, queue: &RenderQueue) {
-        if self.values.is_empty() {
-            return;
-        }
         self.reserve(self.values.len(), device);
         if let Some(buffer) = &self.buffer {
             let range = 0..self.item_size * self.values.len();


### PR DESCRIPTION
# Objective

When `BufferVec::write_buffer` is called without any data in the buffer, it does not allocate a GPU buffer, which then causes draw calls using that buffer to get skipped (usually). If the draw call does important work even with zero elements in the `BufferVec`, such as clearing the render target, this work is skipped as well, resulting in incorrect output.

## Solution

It is unintuitive that `BufferVec` behaves like this, so this PR changes it to always allocate a GPU-side buffer when `write_buffer` or `reserve` is called, even when that buffer ends up with a size of 0.

---

## Changelog

### Fixed

Fixed `BufferVec::write_buffer` and `BufferVec::reserve` not allocating a GPU-side buffer when empty.
