### PR TITLE
return type-erased Errors in AssetLoader::load

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -464,7 +464,7 @@ mod tests {
             reader: &'a mut Reader,
             _settings: &'a Self::Settings,
             load_context: &'a mut LoadContext,
-        ) -> BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
+        ) -> BoxedFuture<'a, Result<Self::Asset, crate::BoxedError>> {
             Box::pin(async move {
                 let mut bytes = Vec::new();
                 reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -89,7 +89,7 @@ pub enum AssetMode {
     ///
     /// When developing an app, you should enable the `asset_processor` cargo feature, which will run the asset processor at startup. This should generally
     /// be used in combination with the `file_watcher` cargo feature, which enables hot-reloading of assets that have changed. When both features are enabled,
-    /// changes to "original/source assets" will be detected, the asset will be re-processed, and then the final processed asset will be hot-reloaded in the app.  
+    /// changes to "original/source assets" will be detected, the asset will be re-processed, and then the final processed asset will be hot-reloaded in the app.
     ///
     /// [`AssetMeta`]: crate::meta::AssetMeta
     /// [`AssetSource`]: crate::io::AssetSource
@@ -459,14 +459,12 @@ mod tests {
 
         type Settings = ();
 
-        type Error = CoolTextLoaderError;
-
         fn load<'a>(
             &'a self,
             reader: &'a mut Reader,
             _settings: &'a Self::Settings,
             load_context: &'a mut LoadContext,
-        ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+        ) -> BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
             Box::pin(async move {
                 let mut bytes = Vec::new();
                 reader.read_to_end(&mut bytes).await?;
@@ -474,7 +472,7 @@ mod tests {
                 let mut embedded = String::new();
                 for dep in ron.embedded_dependencies {
                     let loaded = load_context.load_direct(&dep).await.map_err(|_| {
-                        Self::Error::CannotLoadDependency {
+                        CoolTextLoaderError::CannotLoadDependency {
                             dependency: dep.into(),
                         }
                     })?;

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -20,7 +20,7 @@ use std::{
 };
 use thiserror::Error;
 
-pub type Error = Box<dyn std::error::Error + Send + Sync>;
+pub type BoxedError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Loads an [`Asset`] from a given byte [`Reader`]. This can accept [`AssetLoader::Settings`], which configure how the [`Asset`]
 /// should be loaded.
@@ -35,7 +35,7 @@ pub trait AssetLoader: Send + Sync + 'static {
         reader: &'a mut Reader,
         settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Error>>;
+    ) -> BoxedFuture<'a, Result<Self::Asset, BoxedError>>;
 
     /// Returns a list of extensions supported by this asset loader, without the preceding dot.
     fn extensions(&self) -> &[&str];
@@ -49,7 +49,7 @@ pub trait ErasedAssetLoader: Send + Sync + 'static {
         reader: &'a mut Reader,
         meta: Box<dyn AssetMetaDyn>,
         load_context: LoadContext<'a>,
-    ) -> BoxedFuture<'a, Result<ErasedLoadedAsset, Error>>;
+    ) -> BoxedFuture<'a, Result<ErasedLoadedAsset, BoxedError>>;
 
     /// Returns a list of extensions supported by this asset loader, without the preceding dot.
     fn extensions(&self) -> &[&str];
@@ -77,7 +77,7 @@ where
         reader: &'a mut Reader,
         meta: Box<dyn AssetMetaDyn>,
         mut load_context: LoadContext<'a>,
-    ) -> BoxedFuture<'a, Result<ErasedLoadedAsset, Error>> {
+    ) -> BoxedFuture<'a, Result<ErasedLoadedAsset, BoxedError>> {
         Box::pin(async move {
             let settings = meta
                 .loader_settings()

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -198,7 +198,7 @@ impl AssetLoader for () {
         _reader: &'a mut crate::io::Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut crate::LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Self::Asset, crate::BoxedError>> {
         unreachable!();
     }
 

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -193,13 +193,12 @@ impl VisitAssetDependencies for () {
 impl AssetLoader for () {
     type Asset = ();
     type Settings = ();
-    type Error = std::io::Error;
     fn load<'a>(
         &'a self,
         _reader: &'a mut crate::io::Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut crate::LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
         unreachable!();
     }
 

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -107,7 +107,7 @@ pub enum ProcessError {
     #[error("The wrong meta type was passed into a processor. This is probably an internal implementation error.")]
     WrongMetaType,
     #[error("Encountered an error while saving the asset: {0}")]
-    AssetSaveError(#[from] crate::Error),
+    AssetSaveError(#[from] crate::BoxedError),
     #[error("Assets without extensions are not supported.")]
     ExtensionRequired,
 }

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -107,7 +107,7 @@ pub enum ProcessError {
     #[error("The wrong meta type was passed into a processor. This is probably an internal implementation error.")]
     WrongMetaType,
     #[error("Encountered an error while saving the asset: {0}")]
-    AssetSaveError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+    AssetSaveError(#[from] crate::Error),
     #[error("Assets without extensions are not supported.")]
     ExtensionRequired,
 }
@@ -138,7 +138,7 @@ impl<Loader: AssetLoader, Saver: AssetSaver<Asset = Loader::Asset>> Process
                 .saver
                 .save(writer, saved_asset, &settings.saver_settings)
                 .await
-                .map_err(|error| ProcessError::AssetSaveError(Box::new(error)))?;
+                .map_err(ProcessError::AssetSaveError)?;
             Ok(output_settings)
         })
     }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -21,7 +21,7 @@ pub trait AssetSaver: Send + Sync + 'static {
         writer: &'a mut Writer,
         asset: SavedAsset<'a, Self::Asset>,
         settings: &'a Self::Settings,
-    ) -> BoxedFuture<'a, Result<<Self::OutputLoader as AssetLoader>::Settings, crate::Error>>;
+    ) -> BoxedFuture<'a, Result<<Self::OutputLoader as AssetLoader>::Settings, crate::BoxedError>>;
 }
 
 /// A type-erased dynamic variant of [`AssetSaver`] that allows callers to save assets without knowing the actual type of the [`AssetSaver`].
@@ -33,7 +33,7 @@ pub trait ErasedAssetSaver: Send + Sync + 'static {
         writer: &'a mut Writer,
         asset: &'a ErasedLoadedAsset,
         settings: &'a dyn Settings,
-    ) -> BoxedFuture<'a, Result<(), crate::Error>>;
+    ) -> BoxedFuture<'a, Result<(), crate::BoxedError>>;
 
     /// The type name of the [`AssetSaver`].
     fn type_name(&self) -> &'static str;
@@ -45,7 +45,7 @@ impl<S: AssetSaver> ErasedAssetSaver for S {
         writer: &'a mut Writer,
         asset: &'a ErasedLoadedAsset,
         settings: &'a dyn Settings,
-    ) -> BoxedFuture<'a, Result<(), crate::Error>> {
+    ) -> BoxedFuture<'a, Result<(), crate::BoxedError>> {
         Box::pin(async move {
             let settings = settings
                 .downcast_ref::<S::Settings>()

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1046,7 +1046,7 @@ pub enum AssetLoadError {
     AssetLoaderError {
         path: AssetPath<'static>,
         loader_name: &'static str,
-        error: crate::Error,
+        error: crate::BoxedError,
     },
     #[error("The file at '{base_path}' does not contain the labeled asset '{label}'.")]
     MissingLabel {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -33,7 +33,7 @@ use thiserror::Error;
 /// The general process to load an asset is:
 /// 1. Initialize a new [`Asset`] type with the [`AssetServer`] via [`AssetApp::init_asset`], which will internally call [`AssetServer::register_asset`]
 /// and set up related ECS [`Assets`] storage and systems.
-/// 2. Register one or more [`AssetLoader`]s for that asset with [`AssetApp::init_asset_loader`]  
+/// 2. Register one or more [`AssetLoader`]s for that asset with [`AssetApp::init_asset_loader`]
 /// 3. Add the asset to your asset folder (defaults to `assets`).
 /// 4. Call [`AssetServer::load`] with a path to your asset.
 ///
@@ -957,7 +957,7 @@ enum MaybeAssetLoader {
     },
 }
 
-/// Internal events for asset load results  
+/// Internal events for asset load results
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum InternalAssetEvent {
     Loaded {
@@ -1046,7 +1046,7 @@ pub enum AssetLoadError {
     AssetLoaderError {
         path: AssetPath<'static>,
         loader_name: &'static str,
-        error: Box<dyn std::error::Error + Send + Sync + 'static>,
+        error: crate::Error,
     },
     #[error("The file at '{base_path}' does not contain the labeled asset '{label}'.")]
     MissingLabel {

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -41,14 +41,13 @@ pub struct AudioLoader;
 impl AssetLoader for AudioLoader {
     type Asset = AudioSource;
     type Settings = ();
-    type Error = std::io::Error;
 
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<AudioSource, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<AudioSource, bevy_asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
@@ -113,7 +112,7 @@ pub trait AddAudioSource {
     /// so that it can be converted to a [`rodio::Source`] type,
     /// and [`Asset`], so that it can be registered as an asset.
     /// To use this method on [`App`][bevy_app::App],
-    /// the [audio][super::AudioPlugin] and [asset][bevy_asset::AssetPlugin] plugins must be added first.    
+    /// the [audio][super::AudioPlugin] and [asset][bevy_asset::AssetPlugin] plugins must be added first.
     fn add_audio_source<T>(&mut self) -> &mut Self
     where
         T: Decodable + Asset,

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -47,7 +47,7 @@ impl AssetLoader for AudioLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<AudioSource, bevy_asset::Error>> {
+    ) -> BoxedFuture<'a, Result<AudioSource, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -108,17 +108,16 @@ pub struct GltfLoader {
 impl AssetLoader for GltfLoader {
     type Asset = Gltf;
     type Settings = ();
-    type Error = GltfError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
         load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Gltf, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Gltf, bevy_asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
-            load_gltf(self, &bytes, load_context).await
+            Ok(load_gltf(self, &bytes, load_context).await?)
         })
     }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -113,7 +113,7 @@ impl AssetLoader for GltfLoader {
         reader: &'a mut Reader,
         _settings: &'a (),
         load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Gltf, bevy_asset::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Gltf, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -250,13 +250,12 @@ pub enum ShaderLoaderError {
 impl AssetLoader for ShaderLoader {
     type Asset = Shader;
     type Settings = ();
-    type Error = ShaderLoaderError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Shader, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<Shader, bevy_asset::Error>> {
         Box::pin(async move {
             let ext = load_context.path().extension().unwrap().to_str().unwrap();
 

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -255,7 +255,7 @@ impl AssetLoader for ShaderLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Shader, bevy_asset::Error>> {
+    ) -> BoxedFuture<'a, Result<Shader, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let ext = load_context.path().extension().unwrap().to_str().unwrap();
 

--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -17,14 +17,14 @@ impl AssetSaver for CompressedImageSaver {
 
     type Settings = ();
     type OutputLoader = ImageLoader;
-    type Error = CompressedImageSaverError;
 
     fn save<'a>(
         &'a self,
         writer: &'a mut bevy_asset::io::Writer,
         image: SavedAsset<'a, Self::Asset>,
         _settings: &'a Self::Settings,
-    ) -> bevy_utils::BoxedFuture<'a, std::result::Result<ImageLoaderSettings, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, std::result::Result<ImageLoaderSettings, bevy_asset::Error>>
+    {
         // PERF: this should live inside the future, but CompressorParams and Compressor are not Send / can't be owned by the BoxedFuture (which _is_ Send)
         let mut compressor_params = basis_universal::CompressorParams::new();
         compressor_params.set_basis_format(basis_universal::BasisTextureFormat::UASTC4x4);

--- a/crates/bevy_render/src/texture/compressed_image_saver.rs
+++ b/crates/bevy_render/src/texture/compressed_image_saver.rs
@@ -23,7 +23,7 @@ impl AssetSaver for CompressedImageSaver {
         writer: &'a mut bevy_asset::io::Writer,
         image: SavedAsset<'a, Self::Asset>,
         _settings: &'a Self::Settings,
-    ) -> bevy_utils::BoxedFuture<'a, std::result::Result<ImageLoaderSettings, bevy_asset::Error>>
+    ) -> bevy_utils::BoxedFuture<'a, std::result::Result<ImageLoaderSettings, bevy_asset::BoxedError>>
     {
         // PERF: this should live inside the future, but CompressorParams and Compressor are not Send / can't be owned by the BoxedFuture (which _is_ Send)
         let mut compressor_params = basis_universal::CompressorParams::new();

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -31,7 +31,7 @@ impl AssetLoader for ExrTextureLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
+    ) -> BoxedFuture<'a, Result<Image, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let format = TextureFormat::Rgba32Float;
             debug_assert_eq!(

--- a/crates/bevy_render/src/texture/exr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/exr_texture_loader.rs
@@ -25,14 +25,13 @@ pub enum ExrTextureLoaderError {
 impl AssetLoader for ExrTextureLoader {
     type Asset = Image;
     type Settings = ();
-    type Error = ExrTextureLoaderError;
 
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Image, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
         Box::pin(async move {
             let format = TextureFormat::Rgba32Float;
             debug_assert_eq!(

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -24,7 +24,7 @@ impl AssetLoader for HdrTextureLoader {
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let format = TextureFormat::Rgba32Float;
             debug_assert_eq!(

--- a/crates/bevy_render/src/texture/hdr_texture_loader.rs
+++ b/crates/bevy_render/src/texture/hdr_texture_loader.rs
@@ -19,13 +19,12 @@ pub enum HdrTextureLoaderError {
 impl AssetLoader for HdrTextureLoader {
     type Asset = Image;
     type Settings = ();
-    type Error = HdrTextureLoaderError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Image, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
         Box::pin(async move {
             let format = TextureFormat::Rgba32Float;
             debug_assert_eq!(

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -81,13 +81,12 @@ pub enum ImageLoaderError {
 impl AssetLoader for ImageLoader {
     type Asset = Image;
     type Settings = ImageLoaderSettings;
-    type Error = ImageLoaderError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         settings: &'a ImageLoaderSettings,
         load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Image, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
         Box::pin(async move {
             // use the file extension for the image type
             let ext = load_context.path().extension().unwrap().to_str().unwrap();

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -86,7 +86,7 @@ impl AssetLoader for ImageLoader {
         reader: &'a mut Reader,
         settings: &'a ImageLoaderSettings,
         load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Image, bevy_asset::BoxedError>> {
         Box::pin(async move {
             // use the file extension for the image type
             let ext = load_context.path().extension().unwrap().to_str().unwrap();

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -47,7 +47,7 @@ impl AssetLoader for SceneLoader {
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_scene/src/scene_loader.rs
+++ b/crates/bevy_scene/src/scene_loader.rs
@@ -41,14 +41,13 @@ pub enum SceneLoaderError {
 impl AssetLoader for SceneLoader {
     type Asset = DynamicScene;
     type Settings = ();
-    type Error = SceneLoaderError;
 
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, bevy_asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -20,13 +20,12 @@ pub enum FontLoaderError {
 impl AssetLoader for FontLoader {
     type Asset = Font;
     type Settings = ();
-    type Error = FontLoaderError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Font, Self::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Font, bevy_asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_text/src/font_loader.rs
+++ b/crates/bevy_text/src/font_loader.rs
@@ -25,7 +25,7 @@ impl AssetLoader for FontLoader {
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> bevy_utils::BoxedFuture<'a, Result<Font, bevy_asset::Error>> {
+    ) -> bevy_utils::BoxedFuture<'a, Result<Font, bevy_asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -34,13 +34,12 @@ pub enum CustomAssetLoaderError {
 impl AssetLoader for CustomAssetLoader {
     type Asset = CustomAsset;
     type Settings = ();
-    type Error = CustomAssetLoaderError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, bevy::asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -39,7 +39,7 @@ impl AssetLoader for CustomAssetLoader {
         reader: &'a mut Reader,
         _settings: &'a (),
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Self::Asset, bevy::asset::Error>> {
+    ) -> BoxedFuture<'a, Result<Self::Asset, bevy::asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -84,7 +84,7 @@ impl AssetLoader for TextLoader {
         reader: &'a mut Reader,
         settings: &'a TextSettings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Text, bevy::asset::Error>> {
+    ) -> BoxedFuture<'a, Result<Text, bevy::asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
@@ -138,7 +138,7 @@ impl AssetLoader for CoolTextLoader {
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<CoolText, bevy::asset::Error>> {
+    ) -> BoxedFuture<'a, Result<CoolText, bevy::asset::BoxedError>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
@@ -182,7 +182,7 @@ impl AssetSaver for CoolTextSaver {
         writer: &'a mut Writer,
         asset: SavedAsset<'a, Self::Asset>,
         settings: &'a Self::Settings,
-    ) -> BoxedFuture<'a, Result<TextSettings, bevy::asset::Error>> {
+    ) -> BoxedFuture<'a, Result<TextSettings, bevy::asset::BoxedError>> {
         Box::pin(async move {
             let text = format!("{}{}", asset.text.clone(), settings.appended);
             writer.write_all(text.as_bytes()).await?;

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -79,13 +79,12 @@ struct TextSettings {
 impl AssetLoader for TextLoader {
     type Asset = Text;
     type Settings = TextSettings;
-    type Error = std::io::Error;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         settings: &'a TextSettings,
         _load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<Text, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<Text, bevy::asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
@@ -132,17 +131,14 @@ enum CoolTextLoaderError {
 
 impl AssetLoader for CoolTextLoader {
     type Asset = CoolText;
-
     type Settings = ();
-
-    type Error = CoolTextLoaderError;
 
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
         _settings: &'a Self::Settings,
         load_context: &'a mut LoadContext,
-    ) -> BoxedFuture<'a, Result<CoolText, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<CoolText, bevy::asset::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
@@ -180,14 +176,13 @@ impl AssetSaver for CoolTextSaver {
     type Asset = CoolText;
     type Settings = CoolTextSaverSettings;
     type OutputLoader = TextLoader;
-    type Error = std::io::Error;
 
     fn save<'a>(
         &'a self,
         writer: &'a mut Writer,
         asset: SavedAsset<'a, Self::Asset>,
         settings: &'a Self::Settings,
-    ) -> BoxedFuture<'a, Result<TextSettings, Self::Error>> {
+    ) -> BoxedFuture<'a, Result<TextSettings, bevy::asset::Error>> {
         Box::pin(async move {
             let text = format!("{}{}", asset.text.clone(), settings.appended);
             writer.write_all(text.as_bytes()).await?;


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/10350

ping @bushrat011899, @Roryl-c (*I'm not actually using custom assets, so this needs to be reviewed by someone who does*)

### Objective

Want to allow people to use `anyhow` as the return error value of `AssetLoader`.

### Solution

`ErasedAssetLoader::load` already returns type-erased errors. Why not return the same errors in `AssetLoader::load`?

Also, I aliased `bevy::asset::Error` to `Box<dyn Error + Send + Sync + 'static>` to make changes more backward compatible in the future + easier to type. This was suggested earlier in https://github.com/bevyengine/bevy/pull/5359.

### Changelog

`AssetLoader::load` now returns type-erased Errors.

### Migration Guide

Remove an associated type `Error` from `AssetLoader` and `AssetSaver`. Return error value is now `Box<dyn Error>` to allow for unsized user types.