### PR TITLE
Define a basic set of Primitives

### DIFF
--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -9,6 +9,7 @@
 
 mod affine3;
 pub mod cubic_splines;
+pub mod primitives;
 mod ray;
 mod rects;
 
@@ -24,8 +25,8 @@ pub mod prelude {
             CubicBSpline, CubicBezier, CubicCardinalSpline, CubicGenerator, CubicHermite,
             CubicSegment,
         },
-        BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4, Quat, Ray,
-        Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
+        primitives, BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4,
+        Quat, Ray, Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
         Vec4Swizzles,
     };
 }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1,0 +1,114 @@
+use super::Primitive2d;
+use crate::Vec2;
+
+/// A normalized vector pointing in a direction in 2D space
+pub struct Direction2d(Vec2);
+
+impl From<Vec2> for Direction2d {
+    fn from(value: Vec2) -> Self {
+        Self(value.normalize())
+    }
+}
+
+impl Direction2d {
+    /// Create a direction from a [Vec2] that is already normalized
+    pub fn from_normalized(value: Vec2) -> Self {
+        Self(value)
+    }
+}
+
+/// An infinite half-line pointing in a direction in 2D space
+pub struct Ray2d(pub Direction2d);
+
+/// An alias for [Rectangle]
+pub type Quad = Rectangle;
+
+/// A circle primitive
+pub struct Circle {
+    /// The radius of the circle
+    pub radius: f32,
+}
+impl Primitive2d for Circle {}
+
+/// An unbounded plane in 2D space
+pub struct Plane2d {
+    /// The direction in which the plane points
+    pub normal: Direction2d,
+}
+impl Primitive2d for Plane2d {}
+
+/// An infinite line along a direction in 2D space.
+/// For a finite line: [LineSegment2d]
+pub struct Line2d {
+    /// The direction of the line
+    pub direction: Direction2d,
+}
+impl Primitive2d for Line2d {}
+
+/// A section of a line along a direction in 2D space.
+pub struct LineSegment2d {
+    /// The direction of the line
+    pub direction: Direction2d,
+    /// The point where the line starts
+    pub start: f32,
+    /// The point where the line ends
+    pub end: f32,
+}
+impl Primitive2d for LineSegment2d {}
+
+/// A line alone a path of N vertices in 2D space.
+/// For a version without generics: [BoxedPolyline2d]
+pub struct Polyline2d<const N: usize> {
+    /// The vertices of the polyline
+    pub vertices: [Vec2; N],
+}
+impl<const N: usize> Primitive2d for Polyline2d<N> {}
+
+/// A line alone a path of vertices in 2D space.
+/// For a version without alloc: [Polyline2d]
+pub struct BoxedPolyline2d {
+    /// The vertices of the polyline
+    pub vertices: Box<[Vec2]>,
+}
+impl Primitive2d for BoxedPolyline2d {}
+
+/// A triangle primitive
+pub struct Triangle {
+    /// The vertices of the triangle
+    pub vertcies: [Vec2; 3],
+}
+impl Primitive2d for Triangle {}
+
+/// A rectangle primitive
+pub struct Rectangle {
+    /// The half width of the rectangle
+    pub half_width: f32,
+    /// The half height of the rectangle
+    pub half_height: f32,
+}
+impl Primitive2d for Rectangle {}
+
+/// A polygon with N vertices
+/// For a version without generics: [BoxedPolygon]
+pub struct Polygon<const N: usize> {
+    /// The vertices of the polygon
+    pub vertices: [Vec2; N],
+}
+impl<const N: usize> Primitive2d for Polygon<N> {}
+
+/// A polygon with a variable number of vertices
+/// For a version without alloc: [Polygon]
+pub struct BoxedPolygon {
+    /// The vertices of the polygon
+    pub vertices: Box<[Vec2]>,
+}
+impl Primitive2d for BoxedPolygon {}
+
+/// A polygon where all vertices lie on a circumscribed circle, equally far apart
+pub struct RegularPolygon {
+    /// The circumcircle on which all vertices lie
+    pub circumcircle: Circle,
+    /// The number of vertices
+    pub n_vertices: usize,
+}
+impl Primitive2d for RegularPolygon {}

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -12,7 +12,7 @@ impl From<Vec2> for Direction2d {
 }
 
 impl Direction2d {
-    /// Create a direction from a [Vec2] that is already normalized
+    /// Create a direction from a [`Vec2`] that is already normalized
     pub fn from_normalized(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)
@@ -34,11 +34,11 @@ pub struct Circle {
 }
 impl Primitive2d for Circle {}
 
-/// An unbounded plane in 2D space. It forms a separating surface trough the origin,
+/// An unbounded plane in 2D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
 pub struct Plane2d {
-    /// The normal of the plane, the plane will be placed perpendicular to this direction
+    /// The normal of the plane. The plane will be placed perpendicular to this direction
     pub normal: Direction2d,
 }
 impl Primitive2d for Plane2d {}
@@ -48,8 +48,8 @@ impl Primitive2d for Plane2d {}
 /// For a finite line: [`Segment2d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line2d {
-    /// The direction of the line, the line extends infinitely in both the positive
-    /// and negative of this direction
+    /// The direction of the line. The line extends infinitely in both the given direction
+    /// and its opposite direction
     pub direction: Direction2d,
 }
 impl Primitive2d for Line2d {}
@@ -58,16 +58,16 @@ impl Primitive2d for Line2d {}
 #[doc(alias = "LineSegment2d")]
 #[derive(Clone, Debug)]
 pub struct Segment2d {
-    /// The direction of the line
+    /// The direction of the line segment
     pub direction: Direction2d,
-    /// Half the length of the line segment, the segment extends by this amount in both
-    /// the positive and negative direction
+    /// Half the length of the line segment. The segment extends by this amount in both
+    /// the given direction and its opposite direction
     pub half_length: f32,
 }
 impl Primitive2d for Segment2d {}
 
 impl Segment2d {
-    /// Create a line segment from a direction and full length of the line
+    /// Create a line segment from a direction and full length of the segment
     pub fn new(direction: Direction2d, length: f32) -> Self {
         Self {
             direction,
@@ -108,7 +108,8 @@ pub struct Polyline2d<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
-/// A series of connected line segments in 2D space.
+/// A series of connected line segments in 2D space, allocated on the heap
+/// in a `Box<[Vec2]>`.
 ///
 /// For a version without alloc: [`Polyline2d`]
 #[derive(Clone, Debug)]
@@ -138,12 +139,12 @@ pub struct Rectangle {
 impl Primitive2d for Rectangle {}
 
 impl Rectangle {
-    /// Create a Rectangle from a full width and height
+    /// Create a rectangle from a full width and height
     pub fn new(width: f32, height: f32) -> Self {
         Self::from_size(Vec2::new(width, height))
     }
 
-    /// Create a Rectangle from the full size of a rectangle
+    /// Create a rectangle from a given full size
     pub fn from_size(size: Vec2) -> Self {
         Self {
             half_width: size.x / 2.,
@@ -152,7 +153,8 @@ impl Rectangle {
     }
 }
 
-/// A polygon with N vertices
+/// A polygon with N vertices.
+///
 /// For a version without generics: [`BoxedPolygon`]
 #[derive(Clone, Debug)]
 pub struct Polygon<const N: usize> {
@@ -161,7 +163,9 @@ pub struct Polygon<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polygon<N> {}
 
-/// A polygon with a variable number of vertices
+/// A polygon with a variable number of vertices, allocated on the heap
+/// in a `Box<[Vec2]>`.
+///
 /// For a version without alloc: [`Polygon`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolygon {
@@ -175,7 +179,7 @@ impl Primitive2d for BoxedPolygon {}
 pub struct RegularPolygon {
     /// The circumcircle on which all vertices lie
     pub circumcircle: Circle,
-    /// The number of vertices
-    pub n_vertices: usize,
+    /// The number of sides
+    pub sides: usize,
 }
 impl Primitive2d for RegularPolygon {}

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -44,10 +44,12 @@ pub struct Plane2d {
 impl Primitive2d for Plane2d {}
 
 /// An infinite line along a direction in 2D space.
+///
 /// For a finite line: [`LineSegment2d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line2d {
-    /// The direction of the line
+    /// The direction of the line, the line extends infinitely in both the positive
+    /// and negative of this direction
     pub direction: Direction2d,
 }
 impl Primitive2d for Line2d {}
@@ -57,14 +59,26 @@ impl Primitive2d for Line2d {}
 pub struct LineSegment2d {
     /// The direction of the line
     pub direction: Direction2d,
-    /// The point on the line where the line starts, this value can be either positive of negative,
-    /// depending on where relative to the origin the line should start
-    pub start: f32,
-    /// The point on the line where the line ends, this value can be either positive of negative,
-    /// depending on where relative to the origin the line should start
-    pub end: f32,
+    /// Half the length of the line segment, the segment extends by this amount in both
+    /// the in both the positive and negative direction
+    pub half_length: f32,
 }
 impl Primitive2d for LineSegment2d {}
+
+impl LineSegment2d {
+    /// Get a line segment and translation from a start and end position of a line segment
+    pub fn from_start_end(start: Vec2, end: Vec2) -> (Self, Vec2) {
+        let diff = end - start;
+        let length = diff.length();
+        (
+            Self {
+                direction: Direction2d::from_normalized(diff / length),
+                half_length: length / 2.,
+            },
+            (start + end / 2.),
+        )
+    }
+}
 
 /// A series of connected line segments in 2D space.
 ///
@@ -104,6 +118,16 @@ pub struct Rectangle {
     pub half_height: f32,
 }
 impl Primitive2d for Rectangle {}
+
+impl Rectangle {
+    /// Create a Rectangle from the full size of a rectangle
+    pub fn from_size(size: Vec2) -> Self {
+        Self {
+            half_width: size.x / 2.,
+            half_height: size.y / 2.,
+        }
+    }
+}
 
 /// A polygon with N vertices
 /// For a version without generics: [`BoxedPolygon`]

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -45,7 +45,7 @@ impl Primitive2d for Plane2d {}
 
 /// An infinite line along a direction in 2D space.
 ///
-/// For a finite line: [`LineSegment2d`]
+/// For a finite line: [`Segment2d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line2d {
     /// The direction of the line, the line extends infinitely in both the positive
@@ -54,40 +54,46 @@ pub struct Line2d {
 }
 impl Primitive2d for Line2d {}
 
-/// A section of a line along a direction in 2D space.
+/// A segment of a line along a direction in 2D space.
+#[doc(alias = "LineSegment2d")]
 #[derive(Clone, Debug)]
-pub struct LineSegment2d {
+pub struct Segment2d {
     /// The direction of the line
     pub direction: Direction2d,
     /// Half the length of the line segment, the segment extends by this amount in both
     /// the positive and negative direction
     pub half_length: f32,
 }
-impl Primitive2d for LineSegment2d {}
+impl Primitive2d for Segment2d {}
 
-impl LineSegment2d {
-    /// Get a line segment and translation from a start and end position of a line segment
+impl Segment2d {
+    /// Create a line segment from a direction and full length of the line
+    pub fn new(direction: Direction2d, length: f32) -> Self {
+        Self {
+            direction,
+            half_length: length / 2.,
+        }
+    }
+
+    /// Get a line segment and translation from two points at each end of a line segment
     ///
-    /// Panics if start == end
-    pub fn from_start_end(start: Vec2, end: Vec2) -> (Self, Vec2) {
-        let diff = end - start;
+    /// Panics if point1 == point2
+    pub fn from_points(point1: Vec2, point2: Vec2) -> (Self, Vec2) {
+        let diff = point2 - point1;
         let length = diff.length();
         (
-            Self {
-                direction: Direction2d::from_normalized(diff / length),
-                half_length: length / 2.,
-            },
-            (start + end) / 2.,
+            Self::new(Direction2d::from_normalized(diff / length), length),
+            (point1 + point2) / 2.,
         )
     }
 
-    /// Get the start position of the line
-    pub fn get_start_pos(&self) -> Vec2 {
+    /// Get the position of the first point on the line segment
+    pub fn point1(&self) -> Vec2 {
         *self.direction * -self.half_length
     }
 
-    /// Get the end position of the line
-    pub fn get_end_pos(&self) -> Vec2 {
+    /// Get the position of the second point on the line segment
+    pub fn point2(&self) -> Vec2 {
         *self.direction * self.half_length
     }
 }
@@ -112,13 +118,13 @@ pub struct BoxedPolyline2d {
 }
 impl Primitive2d for BoxedPolyline2d {}
 
-/// A triangle primitive
+/// A triangle in 2d space
 #[derive(Clone, Debug)]
-pub struct Triangle {
+pub struct Triangle2d {
     /// The vertices of the triangle
     pub vertices: [Vec2; 3],
 }
-impl Primitive2d for Triangle {}
+impl Primitive2d for Triangle2d {}
 
 /// A rectangle primitive
 #[doc(alias = "Quad")]
@@ -132,6 +138,11 @@ pub struct Rectangle {
 impl Primitive2d for Rectangle {}
 
 impl Rectangle {
+    /// Create a Rectangle from a full width and height
+    pub fn new(width: f32, height: f32) -> Self {
+        Self::from_size(Vec2::new(width, height))
+    }
+
     /// Create a Rectangle from the full size of a rectangle
     pub fn from_size(size: Vec2) -> Self {
         Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -78,6 +78,16 @@ impl LineSegment2d {
             (start + end / 2.),
         )
     }
+
+    /// Get the start position of the line
+    pub fn get_start_pos(&self) -> Vec2 {
+        *self.direction * -self.half_length
+    }
+
+    /// Get the end position of the line
+    pub fn get_end_pos(&self) -> Vec2 {
+        *self.direction * self.half_length
+    }
 }
 
 /// A series of connected line segments in 2D space.

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -118,7 +118,7 @@ pub struct BoxedPolyline2d {
 }
 impl Primitive2d for BoxedPolyline2d {}
 
-/// A triangle in 2d space
+/// A triangle in 2D space
 #[derive(Clone, Debug)]
 pub struct Triangle2d {
     /// The vertices of the triangle

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -46,7 +46,7 @@ pub struct Plane2d {
 impl Primitive2d for Plane2d {}
 
 /// An infinite line along a direction in 2D space.
-/// For a finite line: [LineSegment2d]
+/// For a finite line: [`LineSegment2d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line2d {
     /// The direction of the line
@@ -67,7 +67,7 @@ pub struct LineSegment2d {
 impl Primitive2d for LineSegment2d {}
 
 /// A line alone a path of N vertices in 2D space.
-/// For a version without generics: [BoxedPolyline2d]
+/// For a version without generics: [`BoxedPolyline2d`]
 #[derive(Clone, Debug)]
 pub struct Polyline2d<const N: usize> {
     /// The vertices of the polyline
@@ -76,7 +76,7 @@ pub struct Polyline2d<const N: usize> {
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
 /// A line alone a path of vertices in 2D space.
-/// For a version without alloc: [Polyline2d]
+/// For a version without alloc: [`Polyline2d`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolyline2d {
     /// The vertices of the polyline
@@ -106,7 +106,7 @@ impl Primitive2d for Rectangle {}
 pub type Quad = Rectangle;
 
 /// A polygon with N vertices
-/// For a version without generics: [BoxedPolygon]
+/// For a version without generics: [`BoxedPolygon`]
 #[derive(Clone, Debug)]
 pub struct Polygon<const N: usize> {
     /// The vertices of the polygon
@@ -115,7 +115,7 @@ pub struct Polygon<const N: usize> {
 impl<const N: usize> Primitive2d for Polygon<N> {}
 
 /// A polygon with a variable number of vertices
-/// For a version without alloc: [Polygon]
+/// For a version without alloc: [`Polygon`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolygon {
     /// The vertices of the polygon

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -14,6 +14,7 @@ impl From<Vec2> for Direction2d {
 impl Direction2d {
     /// Create a direction from a [Vec2] that is already normalized
     pub fn from_normalized(value: Vec2) -> Self {
+        debug_assert!(value.is_normalized());
         Self(value)
     }
 }
@@ -25,10 +26,6 @@ impl std::ops::Deref for Direction2d {
     }
 }
 
-/// An infinite half-line pointing in a direction in 2D space
-#[derive(Clone, Copy, Debug)]
-pub struct Ray2d(pub Direction2d);
-
 /// A circle primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Circle {
@@ -37,10 +34,11 @@ pub struct Circle {
 }
 impl Primitive2d for Circle {}
 
-/// An unbounded plane in 2D space
+/// An unbounded plane in 2D space. It forms a separating surface trough the origin,
+/// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
 pub struct Plane2d {
-    /// The direction in which the plane points
+    /// The normal of the plane, the plane will be placed perpendicular to this direction
     pub normal: Direction2d,
 }
 impl Primitive2d for Plane2d {}
@@ -59,14 +57,17 @@ impl Primitive2d for Line2d {}
 pub struct LineSegment2d {
     /// The direction of the line
     pub direction: Direction2d,
-    /// The point where the line starts
+    /// The point on the line where the line starts, this value can be either positive of negative,
+    /// depending on where relative to the origin the line should start
     pub start: f32,
-    /// The point where the line ends
+    /// The point on the line where the line ends, this value can be either positive of negative,
+    /// depending on where relative to the origin the line should start
     pub end: f32,
 }
 impl Primitive2d for LineSegment2d {}
 
-/// A line alone a path of N vertices in 2D space.
+/// A series of connected line segments in 2D space.
+///
 /// For a version without generics: [`BoxedPolyline2d`]
 #[derive(Clone, Debug)]
 pub struct Polyline2d<const N: usize> {
@@ -75,7 +76,8 @@ pub struct Polyline2d<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
-/// A line alone a path of vertices in 2D space.
+/// A series of connected line segments in 2D space.
+///
 /// For a version without alloc: [`Polyline2d`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolyline2d {
@@ -88,11 +90,12 @@ impl Primitive2d for BoxedPolyline2d {}
 #[derive(Clone, Debug)]
 pub struct Triangle {
     /// The vertices of the triangle
-    pub vertcies: [Vec2; 3],
+    pub vertices: [Vec2; 3],
 }
 impl Primitive2d for Triangle {}
 
 /// A rectangle primitive
+#[doc(alias = "Quad")]
 #[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
     /// The half width of the rectangle
@@ -101,9 +104,6 @@ pub struct Rectangle {
     pub half_height: f32,
 }
 impl Primitive2d for Rectangle {}
-
-/// An alias for [Rectangle]
-pub type Quad = Rectangle;
 
 /// A polygon with N vertices
 /// For a version without generics: [`BoxedPolygon`]
@@ -123,7 +123,7 @@ pub struct BoxedPolygon {
 }
 impl Primitive2d for BoxedPolygon {}
 
-/// A polygon where all vertices lie on a circumscribed circle, equally far apart
+/// A polygon where all vertices lie on a circle, equally far apart
 #[derive(Clone, Copy, Debug)]
 pub struct RegularPolygon {
     /// The circumcircle on which all vertices lie

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -60,13 +60,15 @@ pub struct LineSegment2d {
     /// The direction of the line
     pub direction: Direction2d,
     /// Half the length of the line segment, the segment extends by this amount in both
-    /// the in both the positive and negative direction
+    /// the positive and negative direction
     pub half_length: f32,
 }
 impl Primitive2d for LineSegment2d {}
 
 impl LineSegment2d {
     /// Get a line segment and translation from a start and end position of a line segment
+    ///
+    /// Panics if start == end
     pub fn from_start_end(start: Vec2, end: Vec2) -> (Self, Vec2) {
         let diff = end - start;
         let length = diff.length();
@@ -75,7 +77,7 @@ impl LineSegment2d {
                 direction: Direction2d::from_normalized(diff / length),
                 half_length: length / 2.,
             },
-            (start + end / 2.),
+            (start + end) / 2.,
         )
     }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -2,6 +2,7 @@ use super::Primitive2d;
 use crate::Vec2;
 
 /// A normalized vector pointing in a direction in 2D space
+#[derive(Clone, Copy, Debug)]
 pub struct Direction2d(Vec2);
 
 impl From<Vec2> for Direction2d {
@@ -17,13 +18,19 @@ impl Direction2d {
     }
 }
 
+impl std::ops::Deref for Direction2d {
+    type Target = Vec2;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// An infinite half-line pointing in a direction in 2D space
+#[derive(Clone, Copy, Debug)]
 pub struct Ray2d(pub Direction2d);
 
-/// An alias for [Rectangle]
-pub type Quad = Rectangle;
-
 /// A circle primitive
+#[derive(Clone, Copy, Debug)]
 pub struct Circle {
     /// The radius of the circle
     pub radius: f32,
@@ -31,6 +38,7 @@ pub struct Circle {
 impl Primitive2d for Circle {}
 
 /// An unbounded plane in 2D space
+#[derive(Clone, Copy, Debug)]
 pub struct Plane2d {
     /// The direction in which the plane points
     pub normal: Direction2d,
@@ -39,6 +47,7 @@ impl Primitive2d for Plane2d {}
 
 /// An infinite line along a direction in 2D space.
 /// For a finite line: [LineSegment2d]
+#[derive(Clone, Copy, Debug)]
 pub struct Line2d {
     /// The direction of the line
     pub direction: Direction2d,
@@ -46,6 +55,7 @@ pub struct Line2d {
 impl Primitive2d for Line2d {}
 
 /// A section of a line along a direction in 2D space.
+#[derive(Clone, Debug)]
 pub struct LineSegment2d {
     /// The direction of the line
     pub direction: Direction2d,
@@ -58,6 +68,7 @@ impl Primitive2d for LineSegment2d {}
 
 /// A line alone a path of N vertices in 2D space.
 /// For a version without generics: [BoxedPolyline2d]
+#[derive(Clone, Debug)]
 pub struct Polyline2d<const N: usize> {
     /// The vertices of the polyline
     pub vertices: [Vec2; N],
@@ -66,6 +77,7 @@ impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
 /// A line alone a path of vertices in 2D space.
 /// For a version without alloc: [Polyline2d]
+#[derive(Clone, Debug)]
 pub struct BoxedPolyline2d {
     /// The vertices of the polyline
     pub vertices: Box<[Vec2]>,
@@ -73,6 +85,7 @@ pub struct BoxedPolyline2d {
 impl Primitive2d for BoxedPolyline2d {}
 
 /// A triangle primitive
+#[derive(Clone, Debug)]
 pub struct Triangle {
     /// The vertices of the triangle
     pub vertcies: [Vec2; 3],
@@ -80,6 +93,7 @@ pub struct Triangle {
 impl Primitive2d for Triangle {}
 
 /// A rectangle primitive
+#[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
     /// The half width of the rectangle
     pub half_width: f32,
@@ -88,8 +102,12 @@ pub struct Rectangle {
 }
 impl Primitive2d for Rectangle {}
 
+/// An alias for [Rectangle]
+pub type Quad = Rectangle;
+
 /// A polygon with N vertices
 /// For a version without generics: [BoxedPolygon]
+#[derive(Clone, Debug)]
 pub struct Polygon<const N: usize> {
     /// The vertices of the polygon
     pub vertices: [Vec2; N],
@@ -98,6 +116,7 @@ impl<const N: usize> Primitive2d for Polygon<N> {}
 
 /// A polygon with a variable number of vertices
 /// For a version without alloc: [Polygon]
+#[derive(Clone, Debug)]
 pub struct BoxedPolygon {
     /// The vertices of the polygon
     pub vertices: Box<[Vec2]>,
@@ -105,6 +124,7 @@ pub struct BoxedPolygon {
 impl Primitive2d for BoxedPolygon {}
 
 /// A polygon where all vertices lie on a circumscribed circle, equally far apart
+#[derive(Clone, Copy, Debug)]
 pub struct RegularPolygon {
     /// The circumcircle on which all vertices lie
     pub circumcircle: Circle,

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -58,14 +58,16 @@ impl Primitive3d for Line3d {}
 pub struct LineSegment3d {
     /// The direction of the line
     pub direction: Direction3d,
-    /// Half the length of the line segment, the segment extends by this amount in both the
-    /// in both the positive and negative direction
+    /// Half the length of the line segment, the segment extends by this amount in both
+    /// the positive and negative direction
     pub half_length: f32,
 }
 impl Primitive3d for LineSegment3d {}
 
 impl LineSegment3d {
     /// Get a line segment and translation from a start and end position of a line segment
+    ///
+    /// Panics if start == end
     pub fn from_start_end(start: Vec3, end: Vec3) -> (Self, Vec3) {
         let diff = end - start;
         let length = diff.length();
@@ -74,7 +76,7 @@ impl LineSegment3d {
                 direction: Direction3d::from_normalized(diff / length),
                 half_length: length / 2.,
             },
-            (start + end / 2.),
+            (start + end) / 2.,
         )
     }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -44,6 +44,7 @@ pub struct Plane3d {
 impl Primitive3d for Plane3d {}
 
 /// An infinite line along a direction in 3D space.
+///
 /// For a finite line: [`LineSegment3d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line3d {
@@ -57,14 +58,26 @@ impl Primitive3d for Line3d {}
 pub struct LineSegment3d {
     /// The direction of the line
     pub direction: Direction3d,
-    /// The point on the line where the line starts, this value can be either positive of negative,
-    /// depending on where relative to the origin the line should start
-    pub start: f32,
-    /// The point on the line where the line ends, this value can be either positive of negative,
-    /// depending on where relative to the origin the line should start
-    pub end: f32,
+    /// Half the length of the line segment, the segment extends by this amount in both the
+    /// in both the positive and negative direction
+    pub half_length: f32,
 }
 impl Primitive3d for LineSegment3d {}
+
+impl LineSegment3d {
+    /// Get a line segment and translation from a start and end position of a line segment
+    pub fn from_start_end(start: Vec3, end: Vec3) -> (Self, Vec3) {
+        let diff = end - start;
+        let length = diff.length();
+        (
+            Self {
+                direction: Direction3d::from_normalized(diff / length),
+                half_length: length / 2.,
+            },
+            (start + end / 2.),
+        )
+    }
+}
 
 /// A series of connected line segments in 3D space.
 ///
@@ -94,6 +107,15 @@ pub struct Cuboid {
 }
 impl Primitive3d for Cuboid {}
 
+impl Cuboid {
+    /// Create a cuboid from the full size of the cuboid
+    pub fn from_size(size: Vec3) -> Self {
+        Self {
+            half_extents: size / 2.,
+        }
+    }
+}
+
 /// A cylinder primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Cylinder {
@@ -103,6 +125,16 @@ pub struct Cylinder {
     pub half_height: f32,
 }
 impl Primitive3d for Cylinder {}
+
+impl Cylinder {
+    /// Create a cylinder from a radius and full height
+    pub fn from_radius_height(radius: f32, height: f32) -> Self {
+        Self {
+            radius,
+            half_height: height / 2.,
+        }
+    }
+}
 
 /// A capsule primitive
 #[derive(Clone, Copy, Debug)]

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -45,7 +45,7 @@ impl Primitive3d for Plane3d {}
 
 /// An infinite line along a direction in 3D space.
 ///
-/// For a finite line: [`LineSegment3d`]
+/// For a finite line: [`Segment3d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line3d {
     /// The direction of the line
@@ -53,40 +53,46 @@ pub struct Line3d {
 }
 impl Primitive3d for Line3d {}
 
-/// A section of a line along a direction in 3D space.
+/// A segment of a line along a direction in 3D space.
+#[doc(alias = "LineSegment3d")]
 #[derive(Clone, Debug)]
-pub struct LineSegment3d {
+pub struct Segment3d {
     /// The direction of the line
     pub direction: Direction3d,
     /// Half the length of the line segment, the segment extends by this amount in both
     /// the positive and negative direction
     pub half_length: f32,
 }
-impl Primitive3d for LineSegment3d {}
+impl Primitive3d for Segment3d {}
 
-impl LineSegment3d {
-    /// Get a line segment and translation from a start and end position of a line segment
+impl Segment3d {
+    /// Create a line segment from a direction and full length of the line
+    pub fn new(direction: Direction3d, length: f32) -> Self {
+        Self {
+            direction,
+            half_length: length / 2.,
+        }
+    }
+
+    /// Get a line segment and translation from two points at each end of a line segment
     ///
-    /// Panics if start == end
-    pub fn from_start_end(start: Vec3, end: Vec3) -> (Self, Vec3) {
-        let diff = end - start;
+    /// Panics if point1 == point2
+    pub fn from_points(point1: Vec3, point2: Vec3) -> (Self, Vec3) {
+        let diff = point2 - point1;
         let length = diff.length();
         (
-            Self {
-                direction: Direction3d::from_normalized(diff / length),
-                half_length: length / 2.,
-            },
-            (start + end) / 2.,
+            Self::new(Direction3d::from_normalized(diff / length), length),
+            (point1 + point2) / 2.,
         )
     }
 
-    /// Get the start position of the line
-    pub fn get_start_pos(&self) -> Vec3 {
+    /// Get the position of the first point on the line segment
+    pub fn point1(&self) -> Vec3 {
         *self.direction * -self.half_length
     }
 
-    /// Get the end position of the line
-    pub fn get_end_pos(&self) -> Vec3 {
+    /// Get the position of the second point on the line segment
+    pub fn point2(&self) -> Vec3 {
         *self.direction * self.half_length
     }
 }
@@ -120,6 +126,11 @@ pub struct Cuboid {
 impl Primitive3d for Cuboid {}
 
 impl Cuboid {
+    /// Create a cuboid from a full x, y and z length
+    pub fn new(x_length: f32, y_length: f32, z_length: f32) -> Self {
+        Self::from_size(Vec3::new(x_length, y_length, z_length))
+    }
+
     /// Create a cuboid from the full size of the cuboid
     pub fn from_size(size: Vec3) -> Self {
         Self {
@@ -140,7 +151,7 @@ impl Primitive3d for Cylinder {}
 
 impl Cylinder {
     /// Create a cylinder from a radius and full height
-    pub fn from_radius_height(radius: f32, height: f32) -> Self {
+    pub fn new(radius: f32, height: f32) -> Self {
         Self {
             radius,
             half_height: height / 2.,
@@ -148,12 +159,14 @@ impl Cylinder {
     }
 }
 
-/// A capsule primitive
+/// A capsule primitive.
+/// A capsule is defined as a surface at a distance (radius) from a line
 #[derive(Clone, Copy, Debug)]
 pub struct Capsule {
     /// The radius of the capsule
     pub radius: f32,
     /// Half the height of the capsule, excluding the hemispheres
-    pub half_extent: f32,
+    pub half_length: f32,
 }
+impl super::Primitive2d for Capsule {}
 impl Primitive3d for Capsule {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -2,6 +2,7 @@ use super::Primitive3d;
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
+#[derive(Clone, Copy, Debug)]
 pub struct Direction3d(Vec3);
 
 impl From<Vec3> for Direction3d {
@@ -17,10 +18,19 @@ impl Direction3d {
     }
 }
 
+impl std::ops::Deref for Direction3d {
+    type Target = Vec3;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 /// An infinite half-line pointing in a direction in 3D space
+#[derive(Clone, Copy, Debug)]
 pub struct Ray3d(pub Direction3d);
 
 /// A sphere primitive
+#[derive(Clone, Copy, Debug)]
 pub struct Sphere {
     /// The radius of the sphere
     pub radius: f32,
@@ -28,6 +38,7 @@ pub struct Sphere {
 impl Primitive3d for Sphere {}
 
 /// An unbounded plane in 3D space
+#[derive(Clone, Copy, Debug)]
 pub struct Plane3d {
     /// The direction in which the plane points
     pub normal: Direction3d,
@@ -36,6 +47,7 @@ impl Primitive3d for Plane3d {}
 
 /// An infinite line along a direction in 3D space.
 /// For a finite line: [LineSegment3d]
+#[derive(Clone, Copy, Debug)]
 pub struct Line3d {
     /// The direction of the line
     pub direction: Direction3d,
@@ -43,6 +55,7 @@ pub struct Line3d {
 impl Primitive3d for Line3d {}
 
 /// A section of a line along a direction in 3D space.
+#[derive(Clone, Debug)]
 pub struct LineSegment3d {
     /// The direction of the line
     pub direction: Direction3d,
@@ -55,6 +68,7 @@ impl Primitive3d for LineSegment3d {}
 
 /// A line alone a path of N vertices in 3D space.
 /// For a version without generics: [BoxedPolyline3d]
+#[derive(Clone, Debug)]
 pub struct Polyline3d<const N: usize> {
     /// The vertices of the polyline
     pub vertices: [Vec3; N],
@@ -63,6 +77,7 @@ impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
 /// A line alone a path of vertices in 3D space.
 /// For a version without alloc: [Polyline3d]
+#[derive(Clone, Debug)]
 pub struct BoxedPolyline3d {
     /// The vertices of the polyline
     pub vertices: Box<[Vec3]>,
@@ -70,6 +85,7 @@ pub struct BoxedPolyline3d {
 impl Primitive3d for BoxedPolyline3d {}
 
 /// A cuboid primitive, more commonly known as a box.
+#[derive(Clone, Copy, Debug)]
 pub struct Cuboid {
     /// Half of the width, height and depth of the cuboid
     pub half_extents: Vec3,
@@ -77,6 +93,7 @@ pub struct Cuboid {
 impl Primitive3d for Cuboid {}
 
 /// A cylinder primitive
+#[derive(Clone, Copy, Debug)]
 pub struct Cylinder {
     /// The radius of the cylinder
     pub radius: f32,
@@ -86,6 +103,7 @@ pub struct Cylinder {
 impl Primitive3d for Cylinder {}
 
 /// A capsule primitive
+#[derive(Clone, Copy, Debug)]
 pub struct Capsule {
     /// The radius of the capsule
     pub radius: f32,

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -46,7 +46,7 @@ pub struct Plane3d {
 impl Primitive3d for Plane3d {}
 
 /// An infinite line along a direction in 3D space.
-/// For a finite line: [LineSegment3d]
+/// For a finite line: [`LineSegment3d`]
 #[derive(Clone, Copy, Debug)]
 pub struct Line3d {
     /// The direction of the line
@@ -67,7 +67,7 @@ pub struct LineSegment3d {
 impl Primitive3d for LineSegment3d {}
 
 /// A line alone a path of N vertices in 3D space.
-/// For a version without generics: [BoxedPolyline3d]
+/// For a version without generics: [`BoxedPolyline3d`]
 #[derive(Clone, Debug)]
 pub struct Polyline3d<const N: usize> {
     /// The vertices of the polyline
@@ -76,7 +76,7 @@ pub struct Polyline3d<const N: usize> {
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
 /// A line alone a path of vertices in 3D space.
-/// For a version without alloc: [Polyline3d]
+/// For a version without alloc: [`Polyline3d`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolyline3d {
     /// The vertices of the polyline

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -14,6 +14,7 @@ impl From<Vec3> for Direction3d {
 impl Direction3d {
     /// Create a direction from a [Vec3] that is already normalized
     pub fn from_normalized(value: Vec3) -> Self {
+        debug_assert!(value.is_normalized());
         Self(value)
     }
 }
@@ -25,10 +26,6 @@ impl std::ops::Deref for Direction3d {
     }
 }
 
-/// An infinite half-line pointing in a direction in 3D space
-#[derive(Clone, Copy, Debug)]
-pub struct Ray3d(pub Direction3d);
-
 /// A sphere primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Sphere {
@@ -37,10 +34,11 @@ pub struct Sphere {
 }
 impl Primitive3d for Sphere {}
 
-/// An unbounded plane in 3D space
+/// An unbounded plane in 3D space. It forms a separating surface trough the origin,
+/// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
 pub struct Plane3d {
-    /// The direction in which the plane points
+    /// The normal of the plane, the plane will be placed perpendicular to this direction
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
@@ -59,14 +57,17 @@ impl Primitive3d for Line3d {}
 pub struct LineSegment3d {
     /// The direction of the line
     pub direction: Direction3d,
-    /// The point where the line starts
+    /// The point on the line where the line starts, this value can be either positive of negative,
+    /// depending on where relative to the origin the line should start
     pub start: f32,
-    /// The point where the line ends
+    /// The point on the line where the line ends, this value can be either positive of negative,
+    /// depending on where relative to the origin the line should start
     pub end: f32,
 }
 impl Primitive3d for LineSegment3d {}
 
-/// A line alone a path of N vertices in 3D space.
+/// A series of connected line segments in 3D space.
+///
 /// For a version without generics: [`BoxedPolyline3d`]
 #[derive(Clone, Debug)]
 pub struct Polyline3d<const N: usize> {
@@ -75,7 +76,8 @@ pub struct Polyline3d<const N: usize> {
 }
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
-/// A line alone a path of vertices in 3D space.
+/// A series of connected line segments in 3D space.
+///
 /// For a version without alloc: [`Polyline3d`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolyline3d {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -77,6 +77,16 @@ impl LineSegment3d {
             (start + end / 2.),
         )
     }
+
+    /// Get the start position of the line
+    pub fn get_start_pos(&self) -> Vec3 {
+        *self.direction * -self.half_length
+    }
+
+    /// Get the end position of the line
+    pub fn get_end_pos(&self) -> Vec3 {
+        *self.direction * self.half_length
+    }
 }
 
 /// A series of connected line segments in 3D space.

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -12,7 +12,7 @@ impl From<Vec3> for Direction3d {
 }
 
 impl Direction3d {
-    /// Create a direction from a [Vec3] that is already normalized
+    /// Create a direction from a [`Vec3`] that is already normalized
     pub fn from_normalized(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)
@@ -34,11 +34,11 @@ pub struct Sphere {
 }
 impl Primitive3d for Sphere {}
 
-/// An unbounded plane in 3D space. It forms a separating surface trough the origin,
+/// An unbounded plane in 3D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
 pub struct Plane3d {
-    /// The normal of the plane, the plane will be placed perpendicular to this direction
+    /// The normal of the plane. The plane will be placed perpendicular to this direction
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
@@ -59,14 +59,14 @@ impl Primitive3d for Line3d {}
 pub struct Segment3d {
     /// The direction of the line
     pub direction: Direction3d,
-    /// Half the length of the line segment, the segment extends by this amount in both
-    /// the positive and negative direction
+    /// Half the length of the line segment. The segment extends by this amount in both
+    /// the given direction and its opposite direction
     pub half_length: f32,
 }
 impl Primitive3d for Segment3d {}
 
 impl Segment3d {
-    /// Create a line segment from a direction and full length of the line
+    /// Create a line segment from a direction and full length of the segment
     pub fn new(direction: Direction3d, length: f32) -> Self {
         Self {
             direction,
@@ -107,7 +107,8 @@ pub struct Polyline3d<const N: usize> {
 }
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
-/// A series of connected line segments in 3D space.
+/// A series of connected line segments in 3D space, allocated on the heap
+/// in a `Box<[Vec3]>`.
 ///
 /// For a version without alloc: [`Polyline3d`]
 #[derive(Clone, Debug)]
@@ -131,7 +132,7 @@ impl Cuboid {
         Self::from_size(Vec3::new(x_length, y_length, z_length))
     }
 
-    /// Create a cuboid from the full size of the cuboid
+    /// Create a cuboid from a given full size
     pub fn from_size(size: Vec3) -> Self {
         Self {
             half_extents: size / 2.,

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1,0 +1,95 @@
+use super::Primitive3d;
+use crate::Vec3;
+
+/// A normalized vector pointing in a direction in 3D space
+pub struct Direction3d(Vec3);
+
+impl From<Vec3> for Direction3d {
+    fn from(value: Vec3) -> Self {
+        Self(value.normalize())
+    }
+}
+
+impl Direction3d {
+    /// Create a direction from a [Vec3] that is already normalized
+    pub fn from_normalized(value: Vec3) -> Self {
+        Self(value)
+    }
+}
+
+/// An infinite half-line pointing in a direction in 3D space
+pub struct Ray3d(pub Direction3d);
+
+/// A sphere primitive
+pub struct Sphere {
+    /// The radius of the sphere
+    pub radius: f32,
+}
+impl Primitive3d for Sphere {}
+
+/// An unbounded plane in 3D space
+pub struct Plane3d {
+    /// The direction in which the plane points
+    pub normal: Direction3d,
+}
+impl Primitive3d for Plane3d {}
+
+/// An infinite line along a direction in 3D space.
+/// For a finite line: [LineSegment3d]
+pub struct Line3d {
+    /// The direction of the line
+    pub direction: Direction3d,
+}
+impl Primitive3d for Line3d {}
+
+/// A section of a line along a direction in 3D space.
+pub struct LineSegment3d {
+    /// The direction of the line
+    pub direction: Direction3d,
+    /// The point where the line starts
+    pub start: f32,
+    /// The point where the line ends
+    pub end: f32,
+}
+impl Primitive3d for LineSegment3d {}
+
+/// A line alone a path of N vertices in 3D space.
+/// For a version without generics: [BoxedPolyline3d]
+pub struct Polyline3d<const N: usize> {
+    /// The vertices of the polyline
+    pub vertices: [Vec3; N],
+}
+impl<const N: usize> Primitive3d for Polyline3d<N> {}
+
+/// A line alone a path of vertices in 3D space.
+/// For a version without alloc: [Polyline3d]
+pub struct BoxedPolyline3d {
+    /// The vertices of the polyline
+    pub vertices: Box<[Vec3]>,
+}
+impl Primitive3d for BoxedPolyline3d {}
+
+/// A cuboid primitive, more commonly known as a box.
+pub struct Cuboid {
+    /// Half of the width, height and depth of the cuboid
+    pub half_extents: Vec3,
+}
+impl Primitive3d for Cuboid {}
+
+/// A cylinder primitive
+pub struct Cylinder {
+    /// The radius of the cylinder
+    pub radius: f32,
+    /// The half height of the cylinder
+    pub half_height: f32,
+}
+impl Primitive3d for Cylinder {}
+
+/// A capsule primitive
+pub struct Capsule {
+    /// The radius of the capsule
+    pub radius: f32,
+    /// Half the height of the capsule, excluding the hemispheres
+    pub half_extent: f32,
+}
+impl Primitive3d for Capsule {}

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -1,0 +1,13 @@
+//! This module defines primitive shapes.
+//! The origin of all primitives is at 0,0(,0) unless stated otherwise
+
+mod dim2;
+pub use dim2::*;
+mod dim3;
+pub use dim3::*;
+
+/// A trait marker trait for 2D primitives
+pub trait Primitive2d {}
+
+/// A trait marker trait for 3D primitives
+pub trait Primitive3d {}

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -1,13 +1,13 @@
 //! This module defines primitive shapes.
-//! The origin of all primitives is at 0,0(,0) unless stated otherwise
+//! The origin of all primitives is at 0,0(,0) unless stated otherwise.
 
 mod dim2;
 pub use dim2::*;
 mod dim3;
 pub use dim3::*;
 
-/// A trait marker trait for 2D primitives
+/// A marker trait for 2D primitives
 pub trait Primitive2d {}
 
-/// A trait marker trait for 3D primitives
+/// A marker trait for 3D primitives
 pub trait Primitive3d {}

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -1,5 +1,6 @@
 //! This module defines primitive shapes.
-//! The origin of all primitives is at 0,0(,0) unless stated otherwise.
+//! The origin is (0, 0) for 2D primitives and (0, 0, 0) for 3D primitives,
+//! unless stated otherwise.
 
 mod dim2;
 pub use dim2::*;


### PR DESCRIPTION
# Objective

- Implement a subset of https://github.com/bevyengine/rfcs/blob/main/rfcs/12-primitive-shapes.md#feature-name-primitive-shapes

## Solution

- Define a very basic set of primitives in bevy_math
- Assume a 0,0,0 origin for most shapes
- Use radius and half extents to avoid unnecessary computational overhead wherever they get used
- Provide both Boxed and const generics variants for shapes with variable sizes
  - Boxed is useful if a 3rd party crate wants to use something like enum-dispatch for all supported primitives
  - Const generics is useful when just working on a single primitive, as it causes no allocs

#### Some discrepancies from the RFC:

- Box was changed to Cuboid, because Box is already used for an alloc type
- Skipped Cone because it's unclear where the origin should be for different uses
- Skipped Wedge because it's too niche for an initial PR (we also don't implement Torus, Pyramid or a Death Star (there's an SDF for that!))
- Skipped Frustum because while it would be a useful math type, it's not really a common primitive
- Skipped Triangle3d and Quad3d because those are just rotated 2D shapes

## Future steps

- Add more primitives
- Add helper methods to make primitives easier to construct (especially when half extents are involved)
- Add methods to calculate AABBs for primitives (useful for physics, BVH construction, for the mesh AABBs, etc)
- Add wrappers for common and cheap operations, like extruding 2D shapes and translating them
- Use the primitives to generate meshes
- Provide signed distance functions and gradients for primitives (maybe)

---

## Changelog

- Added a collection of primitives to the bevy_math crate
