### PR TITLE
Add `run_system_singleton`

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -529,7 +529,7 @@ impl<'w, 's> Commands<'w, 's> {
 
     /// Runs the system by referring it. This method will register the system newly called with,
     /// whether you have registered or not. Different calls with same system will share same state.
-    /// 
+    ///
     /// Specially note when running closures with capture, the captured value won't update after first call.
     /// Examples see [`World::run_system_singleton`]. Register them each, use [`World::run_system`] instead.
     ///

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -527,11 +527,16 @@ impl<'w, 's> Commands<'w, 's> {
         self.queue.push(RunSystem::new(id));
     }
 
-    /// Runs the system by itself.
+    /// Runs the system by referring it. This method will register the system newly called with,
+    /// whether you have registered or not. Different calls with same system will share same state.
+    /// 
+    /// Specially note when running closures with capture, the captured value won't update after first call.
+    /// Examples see [`World::run_system_singleton`]. Register them each, use [`World::run_system`] instead.
+    ///
     /// Systems are ran in an exclusive and single threaded way.
     /// Running slow systems can become a bottleneck.
     ///
-    /// Calls [`World::run_system_singleton`](crate::system::World::run_system_singleton).
+    /// Calls [`World::run_system_singleton`].
     pub fn run_system_singleton<M>(&mut self, system: impl IntoSystem<(), (), M>) {
         self.queue.push(RunSystemSingleton::new(
             IntoSystem::<(), (), M>::into_system(system),

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -14,7 +14,7 @@ pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
 
-use super::{Deferred, Resource, SystemBuffer, SystemMeta};
+use super::{Deferred, IntoSystem, Resource, RunSystemSingleton, SystemBuffer, SystemMeta};
 
 /// A [`World`] mutation.
 ///
@@ -525,6 +525,17 @@ impl<'w, 's> Commands<'w, 's> {
     /// Calls [`World::run_system`](crate::system::World::run_system).
     pub fn run_system(&mut self, id: SystemId) {
         self.queue.push(RunSystem::new(id));
+    }
+
+    /// Runs the system by itself.
+    /// Systems are ran in an exclusive and single threaded way.
+    /// Running slow systems can become a bottleneck.
+    ///
+    /// Calls [`World::run_system_singleton`](crate::system::World::run_system_singleton).
+    pub fn run_system_singleton<M>(&mut self, system: impl IntoSystem<(), (), M>) {
+        self.queue.push(RunSystemSingleton::new(
+            IntoSystem::<(), (), M>::into_system(system),
+        ));
     }
 
     /// Pushes a generic [`Command`] to the command queue.

--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -193,16 +193,9 @@ impl World {
         system: T,
     ) -> Result<(), UnregisteredSystemError> {
         // create the hashmap if it doesn't exist
-        let mut system_map = {
-            let mut map = self.get_resource_mut::<SystemMap>();
-            if map.is_none() {
-                self.insert_resource::<SystemMap>(SystemMap {
-                    map: bevy_utils::HashMap::default(),
-                });
-                map = self.get_resource_mut::<SystemMap>();
-            };
-            map.unwrap()
-        };
+        let mut system_map = self.get_resource_or_init_with(|| SystemMap {
+            map: bevy_utils::HashMap::default(),
+        });
 
         let system = IntoSystem::<(), (), M>::into_system(system);
         // use the system name as the key
@@ -219,7 +212,7 @@ impl World {
         } = system_map
             .map
             .remove(system_name.deref())
-            .unwrap_or(RegisteredSystem {
+            .unwrap_or_else(|| RegisteredSystem {
                 initialized: false,
                 system: Box::new(system),
             });


### PR DESCRIPTION
# Objective

- Add a handy way running one-shot system for some casual cases. You will not have to register an id and store it if you just call systems from single source.
- Resolves #10382

## Solution

- Add a new method that runs systems directly and keeps their states indexed by names.

---

## Changelog

- Added `World::run_system_singleton` and corresponding command `Command::run_system_singleton`.

