### PR TITLE
Revert changes to bevymark and many_cubes window settings

### DIFF
--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -98,8 +98,7 @@ fn main() {
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     title: "BevyMark".into(),
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
+                    resolution: (800., 600.).into(),
                     present_mode: PresentMode::AutoNoVsync,
                     ..default()
                 }),

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -16,7 +16,7 @@ use bevy::{
     math::{DVec2, DVec3},
     prelude::*,
     render::render_resource::{Extent3d, TextureDimension, TextureFormat},
-    window::{PresentMode, WindowPlugin, WindowResolution},
+    window::{PresentMode, WindowPlugin},
 };
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
@@ -70,8 +70,6 @@ fn main() {
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     present_mode: PresentMode::AutoNoVsync,
-                    resolution: WindowResolution::new(1920.0, 1080.0)
-                        .with_scale_factor_override(1.0),
                     ..default()
                 }),
                 ..default()


### PR DESCRIPTION
# Objective

I noticed recently that everything in bevymark became tiny, but also the window became larger. I thought maybe I would be bisecting a bug from the "remove black frames" PR, but it turned out to just be an accidental change to the benchmark itself.

These examples were made to be 1080p with a `scale_factor` of `1.0` in #9903.

This seems like potentially a reasonable thing to do to all of the stress tests, but I believe this was accidental and not discussed anywhere.

## Solution

Revert the changes.

## Alternatives

Decide on a standard "stress test resolution" with a fixed scale factor and apply it to all of the stress tests.
