### PR TITLE
Reflect and register audio-related types

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -3,9 +3,10 @@ use bevy_asset::{Asset, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
+use bevy_reflect::Reflect;
 
 /// Defines the volume to play an audio source at.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Reflect)]
 pub enum Volume {
     /// A volume level relative to the global volume.
     Relative(VolumeLevel),
@@ -31,7 +32,7 @@ impl Volume {
 }
 
 /// A volume level equivalent to a non-negative float.
-#[derive(Clone, Copy, Deref, DerefMut, Debug)]
+#[derive(Clone, Copy, Deref, DerefMut, Debug, Reflect)]
 pub struct VolumeLevel(pub(crate) f32);
 
 impl Default for VolumeLevel {
@@ -56,7 +57,7 @@ impl VolumeLevel {
 }
 
 /// The way Bevy manages the sound playback.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Reflect)]
 pub enum PlaybackMode {
     /// Play the sound once. Do nothing when it ends.
     Once,
@@ -72,7 +73,7 @@ pub enum PlaybackMode {
 /// If you would like to control the audio while it is playing, query for the
 /// [`AudioSink`][crate::AudioSink] or [`SpatialAudioSink`][crate::SpatialAudioSink]
 /// components. Changes to this component will *not* be applied to already-playing audio.
-#[derive(Component, Clone, Copy, Debug)]
+#[derive(Component, Clone, Copy, Debug, Reflect)]
 pub struct PlaybackSettings {
     /// The desired playback behavior.
     pub mode: PlaybackMode,
@@ -166,7 +167,7 @@ impl PlaybackSettings {
 ///
 /// This must be accompanied by `Transform` and `GlobalTransform`.
 /// Only one entity with a `SpatialListener` should be present at any given time.
-#[derive(Component, Clone, Debug)]
+#[derive(Component, Clone, Debug, Reflect)]
 pub struct SpatialListener {
     /// Left ear position relative to the `GlobalTransform`.
     pub left_ear_offset: Vec3,
@@ -196,7 +197,7 @@ impl SpatialListener {
 /// Use this [`Resource`] to control the global volume of all audio with a [`Volume::Relative`] volume.
 ///
 /// Note: changing this value will not affect already playing audio.
-#[derive(Resource, Default, Clone, Copy)]
+#[derive(Resource, Default, Clone, Copy, Reflect)]
 pub struct GlobalVolume {
     /// The global volume of all audio.
     pub volume: VolumeLevel,
@@ -217,7 +218,7 @@ impl GlobalVolume {
 /// You may need to adjust this scale to fit your world's units.
 ///
 /// Default is `Vec3::ONE`.
-#[derive(Resource, Clone, Copy)]
+#[derive(Resource, Clone, Copy, Reflect)]
 pub struct SpatialScale(pub Vec3);
 
 impl SpatialScale {

--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -3,7 +3,7 @@ use bevy_asset::{Asset, Handle};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
-use bevy_reflect::Reflect;
+use bevy_reflect::prelude::*;
 
 /// Defines the volume to play an audio source at.
 #[derive(Clone, Copy, Debug, Reflect)]
@@ -74,6 +74,7 @@ pub enum PlaybackMode {
 /// [`AudioSink`][crate::AudioSink] or [`SpatialAudioSink`][crate::SpatialAudioSink]
 /// components. Changes to this component will *not* be applied to already-playing audio.
 #[derive(Component, Clone, Copy, Debug, Reflect)]
+#[reflect(Default, Component)]
 pub struct PlaybackSettings {
     /// The desired playback behavior.
     pub mode: PlaybackMode,
@@ -168,6 +169,7 @@ impl PlaybackSettings {
 /// This must be accompanied by `Transform` and `GlobalTransform`.
 /// Only one entity with a `SpatialListener` should be present at any given time.
 #[derive(Component, Clone, Debug, Reflect)]
+#[reflect(Default, Component)]
 pub struct SpatialListener {
     /// Left ear position relative to the `GlobalTransform`.
     pub left_ear_offset: Vec3,
@@ -198,6 +200,7 @@ impl SpatialListener {
 ///
 /// Note: changing this value will not affect already playing audio.
 #[derive(Resource, Default, Clone, Copy, Reflect)]
+#[reflect(Resource)]
 pub struct GlobalVolume {
     /// The global volume of all audio.
     pub volume: VolumeLevel,
@@ -219,6 +222,7 @@ impl GlobalVolume {
 ///
 /// Default is `Vec3::ONE`.
 #[derive(Resource, Clone, Copy, Reflect)]
+#[reflect(Resource)]
 pub struct SpatialScale(pub Vec3);
 
 impl SpatialScale {

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -72,7 +72,14 @@ pub struct AudioPlugin {
 
 impl Plugin for AudioPlugin {
     fn build(&self, app: &mut App) {
-        app.insert_resource(self.global_volume)
+        app.register_type::<VolumeLevel>()
+            .register_type::<GlobalVolume>()
+            .register_type::<SpatialListener>()
+            .register_type::<SpatialScale>()
+            .register_type::<PlaybackMode>()
+            .register_type::<Volume>()
+            .register_type::<PlaybackSettings>()
+            .insert_resource(self.global_volume)
             .insert_resource(self.spatial_scale)
             .configure_sets(
                 PostUpdate,


### PR DESCRIPTION
# Objective

These type are unavailable to editors and scripting interfaces making use of reflection.

## Solution

`#[derive(Reflect)]` and call `.register_type` during plugin initialization.

---

## Changelog

### Added

- Implement `Reflect` for audio-related types, and register them.