### PR TITLE
Register `WireframeColor`

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -36,6 +36,7 @@ impl Plugin for WireframePlugin {
         app.register_type::<Wireframe>()
             .register_type::<NoWireframe>()
             .register_type::<WireframeConfig>()
+            .register_type::<WireframeColor>()
             .init_resource::<WireframeConfig>()
             .add_plugins(MaterialPlugin::<WireframeMaterial>::default())
             .add_systems(Startup, setup_global_wireframe_material)


### PR DESCRIPTION
This makes it usable via reflection by adding its data to the `TypeRegistry`.