### PR TITLE
Add Wireframe2d plugin

### DIFF
--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -9,6 +9,7 @@ mod texture_atlas;
 mod texture_atlas_builder;
 
 pub mod collide_aabb;
+pub mod wireframe;
 
 pub mod prelude {
     #[doc(hidden)]

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -112,6 +112,12 @@ pub trait Material2d: AsBindGroup + Asset + Clone + Sized {
         ShaderRef::Default
     }
 
+    /// Add a bias to the view depth of the mesh which can be used to force a specific render order.
+    #[inline]
+    fn depth_bias(&self) -> f32 {
+        0.0
+    }
+
     /// Customizes the default [`RenderPipelineDescriptor`].
     #[allow(unused_variables)]
     #[inline]
@@ -448,7 +454,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
                 // lowest sort key and getting closer should increase. As we have
                 // -z in front of the camera, the largest distance is -far with values increasing toward the
                 // camera. As such we can just use mesh_z as the distance
-                sort_key: FloatOrd(mesh_z),
+                sort_key: FloatOrd(mesh_z + material2d.depth_bias),
                 // Batching is done in batch_and_prepare_render_phase
                 batch_range: 0..1,
                 dynamic_offset: None,
@@ -465,6 +471,7 @@ pub struct PreparedMaterial2d<T: Material2d> {
     pub bindings: Vec<(u32, OwnedBindingResource)>,
     pub bind_group: BindGroup,
     pub key: T::Data,
+    pub depth_bias: f32,
 }
 
 impl<T: Material2d> PreparedMaterial2d<T> {
@@ -617,6 +624,7 @@ fn prepare_material2d<M: Material2d>(
         bindings: prepared.bindings,
         bind_group: prepared.bind_group,
         key: prepared.data,
+        depth_bias: material.depth_bias(),
     })
 }
 

--- a/crates/bevy_sprite/src/mesh2d/wireframe.wgsl
+++ b/crates/bevy_sprite/src/mesh2d/wireframe.wgsl
@@ -1,0 +1,12 @@
+#import bevy_sprite::mesh2d_vertex_output::VertexOutput
+
+struct WireframeMaterial {
+    color: vec4<f32>,
+};
+
+@group(1) @binding(0)
+var<uniform> material: WireframeMaterial;
+@fragment
+fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
+    return material.color;
+}

--- a/crates/bevy_sprite/src/wireframe.rs
+++ b/crates/bevy_sprite/src/wireframe.rs
@@ -210,6 +210,11 @@ impl Material2d for Wireframe2dMaterial {
         WIREFRAME_SHADER_HANDLE.into()
     }
 
+    fn depth_bias(&self) -> f32 {
+        // Make the wireframe show up in front of the base mesh.
+        1.0
+    }
+
     fn specialize(
         descriptor: &mut RenderPipelineDescriptor,
         _layout: &MeshVertexBufferLayout,

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -1,10 +1,26 @@
 //! Shows how to render simple primitive shapes with a single color.
 
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy::{
+    prelude::*,
+    sprite::{
+        wireframe::{Wireframe2dConfig, Wireframe2dPlugin},
+        MaterialMesh2dBundle,
+    },
+};
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins)
+        .add_plugins((DefaultPlugins, Wireframe2dPlugin))
+        // Wireframes can be configured with this resource. This can be changed at runtime.
+        .insert_resource(Wireframe2dConfig {
+            // The global wireframe config enables drawing of wireframes on every mesh,
+            // except those with `NoWireframe`. Meshes with `Wireframe` will always have a wireframe,
+            // regardless of the global configuration.
+            global: true,
+            // Controls the default color of all wireframes. Used as the default color for global wireframes.
+            // Can be changed per mesh using the `WireframeColor` component.
+            default_color: Color::WHITE,
+        })
         .add_systems(Startup, setup)
         .run();
 }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/5881

## Solution

- This PR implements a solution by duplicating the 3D wireframe module, creating a 2d variant of it.
- It may be better to move both of them into a common crate that depends on both `bevy_pbr` and `bevy_sprite`, and let them share code and types. Opinions welcome!

---

## Changelog

### Added

- Added `Wireframe2d` plugin for drawing 2D meshes as wireframes.