### PR TITLE
Make AssetLoader/Saver Error type bounds compatible with anyhow::Error

### DIFF
--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -138,7 +138,7 @@ impl<Loader: AssetLoader, Saver: AssetSaver<Asset = Loader::Asset>> Process
                 .saver
                 .save(writer, saved_asset, &settings.saver_settings)
                 .await
-                .map_err(|error| ProcessError::AssetSaveError(Box::new(error)))?;
+                .map_err(|error| ProcessError::AssetSaveError(error.into()))?;
             Ok(output_settings)
         })
     }


### PR DESCRIPTION
# Objective

* In Bevy 0.11 asset loaders used `anyhow::Error` for returning errors. In Bevy 0.12 `AssetLoader` (and `AssetSaver`) have associated `Error` type. Unfortunately it's type bounds does not allow `anyhow::Error` to be used despite migration guide claiming otherwise. This makes migration to 0.12 more challenging. Solve this by changing type bounds for associated `Error` type.
* Fix #10350

## Solution

Change associated `Error` type bounds to require `Into<Box<dyn std::error::Error + Send + Sync + 'static>>` to be implemented instead of `std::error::Error + Send + Sync + 'static`. Both `anyhow::Error` and errors generated by `thiserror` seems to be fine with such type bound.

---

## Changelog

### Fixed
* Fixed compatibility with `anyhow::Error` in `AssetLoader` and `AssetSaver` associated `Error` type