### PR TITLE
Add `Tilde` name to `KeyCode::Grave` comment

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -317,6 +317,7 @@ pub enum KeyCode {
     /// The `Equals` / `=` key.
     Equals,
     /// The `Grave` / `Backtick` / `Tilde` / `` ` `` / `~` key.
+    #[doc(alias = "Tilde")]
     Grave,
     /// The `Kana` key.
     Kana,

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -316,7 +316,7 @@ pub enum KeyCode {
     NumpadDivide,
     /// The `Equals` / `=` key.
     Equals,
-    /// The `Grave` / `Backtick` / `` ` `` key.
+    /// The `Grave` / `Backtick` / `Grave` / `` ` `` / `~` key.
     Grave,
     /// The `Kana` key.
     Kana,

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -316,7 +316,7 @@ pub enum KeyCode {
     NumpadDivide,
     /// The `Equals` / `=` key.
     Equals,
-    /// The `Grave` / `Backtick` / `Grave` / `` ` `` / `~` key.
+    /// The `Grave` / `Backtick` / `Tilde` / `` ` `` / `~` key.
     Grave,
     /// The `Kana` key.
     Kana,


### PR DESCRIPTION
# Objective

I had trouble finding the `` ` `` / `~` key, because I usually call it the tilde key.

## Solution

Add the name `Tilde` to `KeyCode::Grave`'s doc comment.
