### PR TITLE
Fix shader import hot reloading on windows

### DIFF
--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -261,7 +261,7 @@ impl AssetLoader for ShaderLoader {
             let ext = load_context.path().extension().unwrap().to_str().unwrap();
             let path = load_context.asset_path().to_string();
             // On windows, the path will inconsistently use \ or /.
-            // TODO: remove this once AssetPath forces cross-platform "slash" consistency
+            // TODO: remove this once AssetPath forces cross-platform "slash" consistency. See #10511
             let path = path.replace("\\", "/");
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -262,7 +262,7 @@ impl AssetLoader for ShaderLoader {
             let path = load_context.asset_path().to_string();
             // On windows, the path will inconsistently use \ or /.
             // TODO: remove this once AssetPath forces cross-platform "slash" consistency. See #10511
-            let path = path.replace("\\", "/");
+            let path = path.replace(std::path::MAIN_SEPARATOR, "/");
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
             let mut shader = match ext {


### PR DESCRIPTION
# Objective

Hot reloading shader imports on windows is currently broken due to inconsistent `/` and `\` usage ('/` is used in the user facing APIs and `\` is produced by notify-rs (and likely other OS apis).

Fixes #10500

## Solution

Standardize import paths when loading a `Shader`. The correct long term fix is to standardize AssetPath on `/`-only, but this is the right scope of fix for a patch release.
