### PR TITLE
Remove rogue : from embedded_asset! docs

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -156,7 +156,7 @@ macro_rules! embedded_path {
 /// ```
 ///
 /// Some things to note in the path:
-/// 1. The non-default `embedded:://` [`AssetSource`]
+/// 1. The non-default `embedded://` [`AssetSource`]
 /// 2. `src` is trimmed from the path
 ///
 /// The default behavior also works for cargo workspaces. Pretend the `bevy_rock` crate now exists in a larger workspace in


### PR DESCRIPTION
# Objective

- Fix a random typo I noticed in the docs of `embedded_asset`

## Solution

- fixed the typo