### PR TITLE
Make FakeTask public on singlethreaded context

### DIFF
--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -16,7 +16,7 @@ pub use task_pool::{Scope, TaskPool, TaskPoolBuilder};
 #[cfg(any(target_arch = "wasm32", not(feature = "multi-threaded")))]
 mod single_threaded_task_pool;
 #[cfg(any(target_arch = "wasm32", not(feature = "multi-threaded")))]
-pub use single_threaded_task_pool::{Scope, TaskPool, TaskPoolBuilder, ThreadExecutor};
+pub use single_threaded_task_pool::{FakeTask, Scope, TaskPool, TaskPoolBuilder, ThreadExecutor};
 
 mod usages;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/bevy_tasks/src/single_threaded_task_pool.rs
+++ b/crates/bevy_tasks/src/single_threaded_task_pool.rs
@@ -186,6 +186,9 @@ impl TaskPool {
     }
 }
 
+/// An empty task used in single-threaded contexts.
+///
+/// This does nothing and is therefore safe, and recommended, to ignore.
 #[derive(Debug)]
 pub struct FakeTask;
 


### PR DESCRIPTION
# Objective

- When compiling bevy for both singlethreaded and multithreaded contexts and using `Task` directly, you can run into errors where you expect a `Task` to be returned but `FakeTask` is instead. Due to `FakeTask` being private the only solution is to ignore the return at all however because it *is* returned that isn't totally clear. The error is confusing and doesn't provide a solution or help figuring it out.


## Solution

- Made `FakeTask` public and added brief documentation providing a use (none) that helps guide usage (no usage) of FakeTask.
