### PR TITLE
use `tree` syntax to explain bevy_rock file structure

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -131,13 +131,15 @@ macro_rules! embedded_path {
 /// For example, consider the following file structure in the theoretical `bevy_rock` crate, which provides a Bevy [`Plugin`](bevy_app::Plugin)
 /// that renders fancy rocks for scenes.
 ///
-/// * `bevy_rock`
-///     * `src`
-///         * `render`
-///             * `rock.wgsl`
-///             * `mod.rs`
-///         * `lib.rs`
-///     * `Cargo.toml`
+/// ```text
+/// bevy_rock
+/// ├── src
+/// │   ├── render
+/// │   │   ├── rock.wgsl
+/// │   │   └── mod.rs
+/// │   └── lib.rs
+/// └── Cargo.toml
+/// ```
 ///
 /// `rock.wgsl` is a WGSL shader asset that the `bevy_rock` plugin author wants to bundle with their crate. They invoke the following
 /// in `bevy_rock/src/render/mod.rs`:


### PR DESCRIPTION
# Objective

The current way it's written is just kinda hard to read
![image](https://github.com/bevyengine/bevy/assets/14184826/3102f50a-9220-4f86-99e0-41ea23822ea7)


## Solution

the box-drawing characters stolen from `tree`
![image](https://github.com/bevyengine/bevy/assets/14184826/e66c027b-ed69-469d-a0ee-1d73e2c7be18)

---

would've added this to my previous PR but i woke up this morning and it was merged