### PR TITLE
Prepend `root_path` to meta path in HttpWasmAssetReader

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -77,7 +77,7 @@ impl AssetReader for HttpWasmAssetReader {
         path: &'a Path,
     ) -> BoxedFuture<'a, Result<Box<Reader<'a>>, AssetReaderError>> {
         Box::pin(async move {
-            let meta_path = get_meta_path(path);
+            let meta_path = get_meta_path(&self.root_path.join(path));
             Ok(self.fetch_bytes(meta_path).await?)
         })
     }


### PR DESCRIPTION
# Objective

Fixes an issue where Bevy will look for `.meta` files in the root of the server instead of `imported_assets/Default` on the web.

## Solution

`self.root_path.join` was seemingly forgotten in the `read_meta` function on `HttpWasmAssetReader`, though it was included in the `read` function.  This PR simply adds the missing function call.
