### PR TITLE
Fixes bevy_tasks/async-executor in a wasm build (#10530)

### DIFF
--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 multi-threaded = []
 
 [dependencies]
-futures-lite = "1.4.0"
+futures-lite = "2.0.1"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 async-io = { version = "2.0.0", optional = true }


### PR DESCRIPTION
# Objective

Fixes #10530 where bevy wouldn't build with the wasm target.

## Solution

Updated `futures-lite` from `1.4.0` to `2.0.1` in `bevy_tasks`.