### PR TITLE
Improved Text Rendering

### DIFF
--- a/crates/bevy_text/src/font.rs
+++ b/crates/bevy_text/src/font.rs
@@ -20,11 +20,11 @@ impl Font {
 
     pub fn get_outlined_glyph_texture(outlined_glyph: OutlinedGlyph) -> Image {
         let bounds = outlined_glyph.px_bounds();
-        let width = bounds.width() as usize;
-        let height = bounds.height() as usize;
+        let width = bounds.width() as usize + 2;
+        let height = bounds.height() as usize + 2;
         let mut alpha = vec![0.0; width * height];
         outlined_glyph.draw(|x, y, v| {
-            alpha[y as usize * width + x as usize] = v;
+            alpha[(y + 1) as usize * width + x as usize + 1] = v;
         });
 
         // TODO: make this texture grayscale

--- a/crates/bevy_text/src/font_atlas.rs
+++ b/crates/bevy_text/src/font_atlas.rs
@@ -65,7 +65,7 @@ impl FontAtlas {
         Self {
             texture_atlas: texture_atlases.add(texture_atlas),
             glyph_to_atlas_index: HashMap::default(),
-            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 1),
+            dynamic_texture_atlas_builder: DynamicTextureAtlasBuilder::new(size, 0),
         }
     }
 

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -628,8 +628,6 @@ pub fn extract_text_uinodes(
 
     let inverse_scale_factor = scale_factor.recip();
 
-    
-
     for (uinode, global_transform, text, text_layout_info, view_visibility, clip) in
         uinode_query.iter()
     {
@@ -641,7 +639,7 @@ pub fn extract_text_uinodes(
         let (scale, rotation, translation) = global_transform.to_scale_rotation_translation();
 
         // Align the text to the nearest physical pixel:
-        // * Translate by minus the text node's half-size 
+        // * Translate by minus the text node's half-size
         //      (The transform translates to the center of the node but the text coordinates are relative to the node's top left corner)
         // * Multiply the logical coordinates by the scale factor to get its position in physical coordinates
         // * Round the physical position to the nearest physical pixel
@@ -650,8 +648,8 @@ pub fn extract_text_uinodes(
         let physical_nearest_pixel = (logical_top_left * scale_factor as f32).round();
         let logical_top_left_nearest_pixel = physical_nearest_pixel * inverse_scale_factor;
         let transform = Mat4::from_scale_rotation_translation(
-            scale, 
-            rotation, 
+            scale,
+            rotation,
             logical_top_left_nearest_pixel.extend(0.),
         );
 


### PR DESCRIPTION
# Objective

The quality of rendered text can be improved dramatically with some small changes.

In Bevy main text quality can vary wildly depending on the font, font size, pixel alignment and scale factor.

## Solution

* Text node positions are rounded to the nearest physical pixel before rendering.
* Each glyph texture has a 1-pixel wide padding added along its edges.

## Results

Screenshots are from the 'ui' example with a scale factor of 1.5. 

Things can get much uglier with the right font and worst scale factor<sup>tm</sup>.

### before 
<img width="300" alt="list-bad-text" src="https://github.com/bevyengine/bevy/assets/27962798/482b384d-8743-4bae-9a65-468ff1b4c301">

### after
<img width="300" alt="good_list_text" src="https://github.com/bevyengine/bevy/assets/27962798/34323b0a-f714-47ba-9728-a59804987bc8">
 
---

## Changelog
* Font texture atlases are no longer padded.
* Each glyph texture has a 1-pixel wide padding added along its edges.
* Text node positions are rounded to the nearest physical pixel before rendering.
