### PR TITLE
Fix animations resetting after repeat count

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -190,15 +190,20 @@ impl PlayingAnimation {
         self.elapsed += delta;
         self.seek_time += delta * self.speed;
 
-        if (self.seek_time > clip_duration && self.speed > 0.0)
-            || (self.seek_time < 0.0 && self.speed < 0.0)
-        {
-            self.completions += 1;
-        }
+        let over_time = self.speed > 0.0 && self.seek_time >= clip_duration;
+        let under_time = self.speed < 0.0 && self.seek_time < 0.0;
 
+        if over_time || under_time {
+            self.completions += 1;
+
+            if self.is_finished() {
+                return;
+            }
+        }
         if self.seek_time >= clip_duration {
             self.seek_time %= clip_duration;
         }
+        // Note: assumes delta is never lower than -clip_duration
         if self.seek_time < 0.0 {
             self.seek_time += clip_duration;
         }


### PR DESCRIPTION
# Objective

After #9002, it seems that "single shot" animations were broken. When completing, they would reset to their initial value. Which is generally not what you want.

- Fixes #10480

## Solution

Avoid `%`-ing the animation after the number of completions exceeds the specified one. Instead, we early-return. This is also true when the player is playing in reverse.

---

## Changelog

- Avoid resetting animations after `Repeat::Never` animation completion.