### PR TITLE
Document that KeyCode::Capital is the Caps Lock key

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -302,7 +302,7 @@ pub enum KeyCode {
     Backslash,
     /// The `Calculator` key.
     Calculator,
-    /// The `Capital` key.
+    /// The `Caps Lock` key.
     Capital,
     /// The `Colon` / `:` key.
     Colon,


### PR DESCRIPTION
## Problem

- I was trying to find what the `KeyCode` for Caps Lock was and was very confused

## Solution

- changed the documentation of `KeyCode::Capital`