### PR TITLE
Improve shader_material example

### DIFF
--- a/assets/shaders/custom_material.frag
+++ b/assets/shaders/custom_material.frag
@@ -3,9 +3,7 @@ layout(location = 0) in vec2 v_Uv;
 
 layout(location = 0) out vec4 o_Target;
 
-layout(set = 1, binding = 0) uniform CustomMaterial {
-    vec4 Color;
-};
+layout(set = 1, binding = 0) uniform vec4 CustomMaterial_color;
 
 layout(set = 1, binding = 1) uniform texture2D CustomMaterial_texture;
 layout(set = 1, binding = 2) uniform sampler CustomMaterial_sampler;
@@ -16,5 +14,5 @@ layout(set = 1, binding = 2) uniform sampler CustomMaterial_sampler;
 
 void main() {
     // o_Target = PbrFuncs::tone_mapping(Color * texture(sampler2D(CustomMaterial_texture,CustomMaterial_sampler), v_Uv));
-    o_Target = Color * texture(sampler2D(CustomMaterial_texture,CustomMaterial_sampler), v_Uv);
+    o_Target = CustomMaterial_color * texture(sampler2D(CustomMaterial_texture,CustomMaterial_sampler), v_Uv);
 }

--- a/assets/shaders/custom_material.wgsl
+++ b/assets/shaders/custom_material.wgsl
@@ -2,11 +2,7 @@
 // we can import items from shader modules in the assets folder with a quoted path
 #import "shaders/custom_material_import.wgsl"::COLOR_MULTIPLIER
 
-struct CustomMaterial {
-    color: vec4<f32>,
-};
-
-@group(1) @binding(0) var<uniform> material: CustomMaterial;
+@group(1) @binding(0) var<uniform> material_color: vec4<f32>;
 @group(1) @binding(1) var base_color_texture: texture_2d<f32>;
 @group(1) @binding(2) var base_color_sampler: sampler;
 
@@ -14,5 +10,5 @@ struct CustomMaterial {
 fn fragment(
     mesh: VertexOutput,
 ) -> @location(0) vec4<f32> {
-    return material.color * textureSample(base_color_texture, base_color_sampler, mesh.uv) * COLOR_MULTIPLIER;
+    return material_color * textureSample(base_color_texture, base_color_sampler, mesh.uv) * COLOR_MULTIPLIER;
 }

--- a/assets/shaders/custom_material.wgsl
+++ b/assets/shaders/custom_material.wgsl
@@ -3,12 +3,12 @@
 #import "shaders/custom_material_import.wgsl"::COLOR_MULTIPLIER
 
 @group(1) @binding(0) var<uniform> material_color: vec4<f32>;
-@group(1) @binding(1) var base_color_texture: texture_2d<f32>;
-@group(1) @binding(2) var base_color_sampler: sampler;
+@group(1) @binding(1) var material_color_texture: texture_2d<f32>;
+@group(1) @binding(2) var material_color_sampler: sampler;
 
 @fragment
 fn fragment(
     mesh: VertexOutput,
 ) -> @location(0) vec4<f32> {
-    return material_color * textureSample(base_color_texture, base_color_sampler, mesh.uv) * COLOR_MULTIPLIER;
+    return material_color * textureSample(material_color_texture, material_color_sampler, mesh.uv) * COLOR_MULTIPLIER;
 }

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -39,6 +39,17 @@ fn setup(
     });
 }
 
+// This struct defines the data that will be passed to your shader
+#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
+pub struct CustomMaterial {
+    #[uniform(0)]
+    color: Color,
+    #[texture(1)]
+    #[sampler(2)]
+    color_texture: Option<Handle<Image>>,
+    alpha_mode: AlphaMode,
+}
+
 /// The Material trait is very configurable, but comes with sensible defaults for all methods.
 /// You only need to implement functions for features that need non-default behavior. See the Material api docs for details!
 impl Material for CustomMaterial {
@@ -49,15 +60,4 @@ impl Material for CustomMaterial {
     fn alpha_mode(&self) -> AlphaMode {
         self.alpha_mode
     }
-}
-
-// This is the struct that will be passed to your shader
-#[derive(Asset, TypePath, AsBindGroup, Debug, Clone)]
-pub struct CustomMaterial {
-    #[uniform(0)]
-    color: Color,
-    #[texture(1)]
-    #[sampler(2)]
-    color_texture: Option<Handle<Image>>,
-    alpha_mode: AlphaMode,
 }


### PR DESCRIPTION
# Objective

- The current shader code is misleading since it makes it look like a struct is passed to the bind group 0 but in reality only the color is passed. They just happen to have the exact same memory layout so wgsl doesn't complain and it works.
- The struct is defined after the `impl Material` block which is backwards from pretty much every other usage of the `impl` block in bevy.

## Solution

- Remove the unnecessary struct in the shader
- move the impl block
