### PR TITLE
Ensure ExtendedMaterial works with reflection (to enable bevy_egui_inspector integration)

### DIFF
--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{Asset, Handle};
-use bevy_reflect::{Reflect, FromReflect};
+use bevy_reflect::{FromReflect, Reflect};
 use bevy_render::{
     mesh::MeshVertexBufferLayout,
     render_asset::RenderAssets,
@@ -103,7 +103,9 @@ pub struct ExtendedMaterial<B: Material + FromReflect, E: MaterialExtension + Fr
     pub extension: E,
 }
 
-impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> AsBindGroup for ExtendedMaterial<B, E> {
+impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> AsBindGroup
+    for ExtendedMaterial<B, E>
+{
     type Data = (<B as AsBindGroup>::Data, <E as AsBindGroup>::Data);
 
     fn unprepared_bind_group(
@@ -148,7 +150,9 @@ impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> AsBindGroup 
     }
 }
 
-impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> Material for ExtendedMaterial<B, E> {
+impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> Material
+    for ExtendedMaterial<B, E>
+{
     fn vertex_shader() -> bevy_render::render_resource::ShaderRef {
         match E::vertex_shader() {
             ShaderRef::Default => B::vertex_shader(),

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -108,9 +108,7 @@ pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
 // causes the `TypePath` derive to not generate an implementation.
 impl_type_path!((in bevy_pbr::extended_material) ExtendedMaterial<B: Material, E: MaterialExtension>);
 
-impl<B: Material, E: MaterialExtension> AsBindGroup
-    for ExtendedMaterial<B, E>
-{
+impl<B: Material, E: MaterialExtension> AsBindGroup for ExtendedMaterial<B, E> {
     type Data = (<B as AsBindGroup>::Data, <E as AsBindGroup>::Data);
 
     fn unprepared_bind_group(
@@ -155,9 +153,7 @@ impl<B: Material, E: MaterialExtension> AsBindGroup
     }
 }
 
-impl<B: Material, E: MaterialExtension> Material
-    for ExtendedMaterial<B, E>
-{
+impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
     fn vertex_shader() -> bevy_render::render_resource::ShaderRef {
         match E::vertex_shader() {
             ShaderRef::Default => B::vertex_shader(),

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{Asset, Handle};
-use bevy_reflect::{FromReflect, Reflect};
+use bevy_reflect::{impl_type_path, FromReflect, Reflect, TypePath};
 use bevy_render::{
     mesh::MeshVertexBufferLayout,
     render_asset::RenderAssets,
@@ -98,12 +98,17 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
 /// present, so the `pbr_fragment` shader functions can be called from the extension shader (see
 /// the `extended_material` example).
 #[derive(Asset, Clone, Reflect)]
-pub struct ExtendedMaterial<B: Material + FromReflect, E: MaterialExtension + FromReflect> {
+#[reflect(type_path = false)]
+pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
     pub base: B,
     pub extension: E,
 }
 
-impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> AsBindGroup
+// We don't use the `TypePath` derive here due to a bug where `#[reflect(type_path = false)]`
+// causes the `TypePath` derive to not generate an implementation.
+impl_type_path!((in bevy_pbr::extended_material) ExtendedMaterial<B: Material, E: MaterialExtension>);
+
+impl<B: Material + Reflect + TypePath, E: MaterialExtension + Reflect + TypePath> AsBindGroup
     for ExtendedMaterial<B, E>
 {
     type Data = (<B as AsBindGroup>::Data, <E as AsBindGroup>::Data);

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{Asset, Handle};
-use bevy_reflect::{impl_type_path, FromReflect, Reflect, TypePath};
+use bevy_reflect::{impl_type_path, Reflect};
 use bevy_render::{
     mesh::MeshVertexBufferLayout,
     render_asset::RenderAssets,
@@ -108,7 +108,7 @@ pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
 // causes the `TypePath` derive to not generate an implementation.
 impl_type_path!((in bevy_pbr::extended_material) ExtendedMaterial<B: Material, E: MaterialExtension>);
 
-impl<B: Material + Reflect + TypePath, E: MaterialExtension + Reflect + TypePath> AsBindGroup
+impl<B: Material, E: MaterialExtension> AsBindGroup
     for ExtendedMaterial<B, E>
 {
     type Data = (<B as AsBindGroup>::Data, <E as AsBindGroup>::Data);
@@ -155,7 +155,7 @@ impl<B: Material + Reflect + TypePath, E: MaterialExtension + Reflect + TypePath
     }
 }
 
-impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> Material
+impl<B: Material, E: MaterialExtension> Material
     for ExtendedMaterial<B, E>
 {
     fn vertex_shader() -> bevy_render::render_resource::ShaderRef {

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -1,5 +1,5 @@
 use bevy_asset::{Asset, Handle};
-use bevy_reflect::TypePath;
+use bevy_reflect::{Reflect, FromReflect};
 use bevy_render::{
     mesh::MeshVertexBufferLayout,
     render_asset::RenderAssets,
@@ -97,13 +97,13 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
 /// When used with `StandardMaterial` as the base, all the standard material fields are
 /// present, so the `pbr_fragment` shader functions can be called from the extension shader (see
 /// the `extended_material` example).
-#[derive(Asset, Clone, TypePath)]
-pub struct ExtendedMaterial<B: Material, E: MaterialExtension> {
+#[derive(Asset, Clone, Reflect)]
+pub struct ExtendedMaterial<B: Material + FromReflect, E: MaterialExtension + FromReflect> {
     pub base: B,
     pub extension: E,
 }
 
-impl<B: Material, E: MaterialExtension> AsBindGroup for ExtendedMaterial<B, E> {
+impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> AsBindGroup for ExtendedMaterial<B, E> {
     type Data = (<B as AsBindGroup>::Data, <E as AsBindGroup>::Data);
 
     fn unprepared_bind_group(
@@ -148,7 +148,7 @@ impl<B: Material, E: MaterialExtension> AsBindGroup for ExtendedMaterial<B, E> {
     }
 }
 
-impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
+impl<B: Material + FromReflect, E: MaterialExtension + FromReflect> Material for ExtendedMaterial<B, E> {
     fn vertex_shader() -> bevy_render::render_resource::ShaderRef {
         match E::vertex_shader() {
             ShaderRef::Default => B::vertex_shader(),

--- a/examples/shader/extended_material.rs
+++ b/examples/shader/extended_material.rs
@@ -1,6 +1,5 @@
 //! Demonstrates using a custom extension to the `StandardMaterial` to modify the results of the builtin pbr shader.
 
-use bevy::reflect::TypePath;
 use bevy::{
     pbr::{ExtendedMaterial, MaterialExtension, OpaqueRendererMethod},
     prelude::*,
@@ -73,7 +72,7 @@ fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
     }
 }
 
-#[derive(Asset, AsBindGroup, TypePath, Debug, Clone)]
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
 struct MyExtension {
     // We need to ensure that the bindings of the base material and the extension do not conflict,
     // so we start from binding slot 100, leaving slots 0-99 for the base material.


### PR DESCRIPTION
# Objective

- Ensure ExtendedMaterial can be referenced in bevy_egui_inspector correctly

## Solution

Add a more manual `TypePath` implementation to work around bugs in the derive macro.
