### PR TITLE
Gizmo Arrows

### DIFF
--- a/crates/bevy_gizmos/src/arrows.rs
+++ b/crates/bevy_gizmos/src/arrows.rs
@@ -1,0 +1,57 @@
+//! Additional Gizmo Functions -- Arrows
+
+use crate::prelude::Gizmos;
+use bevy_math::{Quat, Vec2, Vec3};
+use bevy_render::color::Color;
+
+pub struct ArrowBuilder<'a, 's> {
+    gizmos: &'a mut Gizmos<'s>,
+    start: Vec3,
+    end: Vec3,
+    color: Color,
+    tip_length: f32,
+}
+
+impl Drop for ArrowBuilder<'_, '_> {
+    fn drop(&mut self) {
+        // draw the body of the arrow
+        self.gizmos.line(self.start, self.end, self.color);
+        // now the hard part is to draw the head in a sensible way
+        // put us in a coordinate system where the arrow is pointing up and ends at the origin
+        let pointing = (self.end - self.start).normalize();
+        let rotation = Quat::from_rotation_arc(Vec3::X, pointing);
+        let tips = [(1, 0), (0, 1), (-1, 0), (0, -1)]
+            .into_iter()
+            .map(|(y, z)| Vec3 {
+                x: -1.,
+                y: y as f32,
+                z: z as f32,
+            })
+            .map(|v| v * self.tip_length)
+            .map(|v| rotation.mul_vec3(v))
+            .map(|v| v + self.end);
+        for v in tips {
+            self.gizmos.line(self.end, v, self.color);
+        }
+    }
+}
+
+impl<'s> Gizmos<'s> {
+    /// draw an arrow.
+    pub fn arrow(&mut self, start: Vec3, end: Vec3, color: Color) -> ArrowBuilder<'_, 's> {
+        // self.line_2d(start, end, color);
+        let length = (end - start).length();
+        ArrowBuilder {
+            gizmos: self,
+            start,
+            end,
+            color,
+            tip_length: length / 10.,
+        }
+    }
+
+    /// draw an arrow in 2d space, on the x-y plane.
+    pub fn arrow_2d(&mut self, start: Vec2, end: Vec2, color: Color) -> ArrowBuilder<'_, 's> {
+        self.arrow(start.extend(0.), end.extend(0.), color)
+    }
+}

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -16,6 +16,7 @@
 //!
 //! See the documentation on [`Gizmos`] for more examples.
 
+mod arrows;
 pub mod gizmos;
 
 #[cfg(feature = "bevy_sprite")]

--- a/examples/2d/2d_gizmos.rs
+++ b/examples/2d/2d_gizmos.rs
@@ -53,6 +53,12 @@ fn system(mut gizmos: Gizmos, time: Res<Time>) {
     // Arcs default amount of segments is linearly interpolated between
     // 1 and 32, using the arc length as scalar.
     gizmos.arc_2d(Vec2::ZERO, sin / 10., PI / 2., 350., Color::ORANGE_RED);
+
+    gizmos.arrow_2d(
+        Vec2::ZERO,
+        Vec2::from_angle(sin / -10. + PI / 2.) * 50.,
+        Color::YELLOW,
+    );
 }
 
 fn update_config(mut config: ResMut<GizmoConfig>, keyboard: Res<Input<KeyCode>>, time: Res<Time>) {

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -96,6 +96,8 @@ fn system(mut gizmos: Gizmos, time: Res<Time>) {
     gizmos
         .sphere(Vec3::ZERO, Quat::IDENTITY, 3.2, Color::BLACK)
         .circle_segments(64);
+
+    gizmos.arrow(Vec3::ZERO, Vec3::ONE * 1.5, Color::YELLOW);
 }
 
 fn rotate_camera(mut query: Query<&mut Transform, With<Camera>>, time: Res<Time>) {


### PR DESCRIPTION
## Objective

- Add an arrow gizmo as suggested by #9400 

## Solution

Wasn't horribly hard when i remembered i can change coordinate systems whenever I want. Gave them four tips (as suggested by @alice-i-cecile in discord) instead of trying to decide what direction the tips should point.

---

## Changelog

- Added `gizmos.arrow()` and `gizmos.arrow_2d()`
- Added arrows to `2d_gizmos` and `3d_gizmos` examples

## Migration Guide

N/A