### PR TITLE
Remove `A: Asset` bound from struct `Handle` definition

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -121,7 +121,7 @@ impl std::fmt::Debug for StrongHandle {
 /// [`Handle::Strong`] also provides access to useful [`Asset`] metadata, such as the [`AssetPath`] (if it exists).
 #[derive(Component, Reflect)]
 #[reflect(Component)]
-pub enum Handle<A: Asset> {
+pub enum Handle<A> {
     /// A "strong" reference to a live (or loading) [`Asset`]. If a [`Handle`] is [`Handle::Strong`], the [`Asset`] will be kept
     /// alive until the [`Handle`] is dropped. Strong handles also provide access to additional asset metadata.  
     Strong(Arc<StrongHandle>),
@@ -198,7 +198,7 @@ impl<A: Asset> Handle<A> {
     }
 }
 
-impl<A: Asset> Default for Handle<A> {
+impl<A> Default for Handle<A> {
     fn default() -> Self {
         Handle::Weak(AssetId::default())
     }

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -14,7 +14,7 @@ use std::{
 ///
 /// For an "untyped" / "generic-less" id, see [`UntypedAssetId`].
 #[derive(Reflect)]
-pub enum AssetId<A: Asset> {
+pub enum AssetId<A> {
     /// A small / efficient runtime identifier that can be used to efficiently look up an asset stored in [`Assets`]. This is
     /// the "default" identifier used for assets. The alternative(s) (ex: [`AssetId::Uuid`]) will only be used if assets are
     /// explicitly registered that way.
@@ -32,7 +32,7 @@ pub enum AssetId<A: Asset> {
     Uuid { uuid: Uuid },
 }
 
-impl<A: Asset> AssetId<A> {
+impl<A> AssetId<A> {
     /// The uuid for the default [`AssetId`]. It is valid to assign a value to this in [`Assets`](crate::Assets)
     /// and by convention (where appropriate) assets should support this pattern.
     pub const DEFAULT_UUID: Uuid = Uuid::from_u128(200809721996911295814598172825939264631);
@@ -49,6 +49,16 @@ impl<A: Asset> AssetId<A> {
         }
     }
 
+    #[inline]
+    pub(crate) fn internal(self) -> InternalAssetId {
+        match self {
+            AssetId::Index { index, .. } => InternalAssetId::Index(index),
+            AssetId::Uuid { uuid } => InternalAssetId::Uuid(uuid),
+        }
+    }
+}
+
+impl<A: Asset> AssetId<A> {
     /// Converts this to an "untyped" / "generic-less" [`Asset`] identifier that stores the type information
     /// _inside_ the [`UntypedAssetId`].
     #[inline]
@@ -64,17 +74,9 @@ impl<A: Asset> AssetId<A> {
             },
         }
     }
-
-    #[inline]
-    pub(crate) fn internal(self) -> InternalAssetId {
-        match self {
-            AssetId::Index { index, .. } => InternalAssetId::Index(index),
-            AssetId::Uuid { uuid } => InternalAssetId::Uuid(uuid),
-        }
-    }
 }
 
-impl<A: Asset> Default for AssetId<A> {
+impl<A> Default for AssetId<A> {
     fn default() -> Self {
         AssetId::Uuid {
             uuid: Self::DEFAULT_UUID,


### PR DESCRIPTION
# Objective

The Asset trait doesn't have any associated types or constants used in the struct definition, so this bound is just making things more strict for no benefit.

## Solution

Remove the `A: Asset` bound in the definition of `struct Handle`.
