### PR TITLE
More inactive camera checks

### DIFF
--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -828,9 +828,13 @@ fn clip_to_view(inverse_projection: Mat4, clip: Vec4) -> Vec4 {
 
 pub fn add_clusters(
     mut commands: Commands,
-    cameras: Query<(Entity, Option<&ClusterConfig>), (With<Camera>, Without<Clusters>)>,
+    cameras: Query<(Entity, Option<&ClusterConfig>, &Camera), Without<Clusters>>,
 ) {
-    for (entity, config) in &cameras {
+    for (entity, config, camera) in &cameras {
+        if !camera.is_active {
+            continue;
+        }
+
         let config = config.copied().unwrap_or_default();
         // actual settings here don't matter - they will be overwritten in assign_lights_to_clusters
         commands

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -263,9 +263,13 @@ pub struct ExtractedClustersPointLights {
 
 pub fn extract_clusters(
     mut commands: Commands,
-    views: Extract<Query<(Entity, &Clusters), With<Camera>>>,
+    views: Extract<Query<(Entity, &Clusters, &Camera)>>,
 ) {
-    for (entity, clusters) in &views {
+    for (entity, clusters, camera) in &views {
+        if !camera.is_active {
+            continue;
+        }
+
         commands.get_or_spawn(entity).insert((
             ExtractedClustersPointLights {
                 data: clusters.lights.clone(),


### PR DESCRIPTION
# Objective

- Reduce work from inactive cameras

Tracing was done on the `3d_shapes` example on PR https://github.com/bevyengine/bevy/pull/10543 .
Doing tracing on a "real" application showed more instances of unnecessary work.

## Solution

- Skip work on inactive cameras