### PR TITLE
Make sure added image assets are checked in camera_system

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -585,6 +585,8 @@ pub fn camera_system<T: CameraProjection + Component>(
         .filter_map(|event| {
             if let AssetEvent::Modified { id } = event {
                 Some(id)
+            } else if let AssetEvent::Added { id } = event {
+                Some(id)
             } else {
                 None
             }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -583,13 +583,8 @@ pub fn camera_system<T: CameraProjection + Component>(
     let changed_image_handles: HashSet<&AssetId<Image>> = image_asset_events
         .read()
         .filter_map(|event| {
-            if let AssetEvent::Modified { id } = event {
-                Some(id)
-            } else if let AssetEvent::Added { id } = event {
-                Some(id)
-            } else {
-                None
-            }
+            AssetEvent::Modified { id } | AssetEvent::Added { id } => Some(id),
+            _ => None,
         })
         .collect();
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -582,7 +582,7 @@ pub fn camera_system<T: CameraProjection + Component>(
 
     let changed_image_handles: HashSet<&AssetId<Image>> = image_asset_events
         .read()
-        .filter_map(|event| {
+        .filter_map(|event| match event {
             AssetEvent::Modified { id } | AssetEvent::Added { id } => Some(id),
             _ => None,
         })


### PR DESCRIPTION
# Objective

Make sure a camera which has had its render target changed recomputes its info.

On main, the following is possible:

- System A has an inactive camera with render target set to the default `Image` (i.e. white 1x1 rgba texture)

Later:

- System B sets the same camera active and sets the `camera.target` to a newly created `Image`

**Bug**: Since `camera_system` only checks `Modified` and not `Added` events, the size of the render target is not recomputed, which means the camera will render with 1x1 size even though the new target is an entirely different size.

## Solution

- Ensure `camera_system` checks `Added` image assets events

## Changelog

### Fixed

- Cameras which have their render targets changed to a newly created target with a different size than the previous target will now render properly