### PR TITLE
Make it clearer that new_time is only used for Automatic time updates

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -135,7 +135,7 @@ fn time_system(
             } else {
                 Instant::now()
             };
-            time.update_with_instant(new_time)
+            time.update_with_instant(new_time);
         }
         TimeUpdateStrategy::ManualInstant(instant) => time.update_with_instant(*instant),
         TimeUpdateStrategy::ManualDuration(duration) => time.update_with_duration(*duration),


### PR DESCRIPTION
# Objective

Tiny PR to make the code structure of the `time_system` slightly clearer by putting the code to receive the render time only in the branch where it's actually needed.