### PR TITLE
support required features in wasm examples showcase

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1109,7 +1109,7 @@ required-features = ["file_watcher"]
 name = "Hot Reloading of Assets"
 description = "Demonstrates automatic reloading of assets when modified on disk"
 category = "Assets"
-wasm = true
+wasm = false
 
 [[example]]
 name = "asset_processing"

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     #[arg(short, long)]
     /// Optimize the wasm file for size with wasm-opt
     optimize_size: bool,
+
+    #[arg(long)]
+    /// Additional features to enable
+    features: Vec<String>,
 }
 
 fn main() {
@@ -41,7 +45,7 @@ fn main() {
     assert!(!cli.examples.is_empty(), "must have at least one example");
 
     let mut default_features = true;
-    let mut features = vec![];
+    let mut features: Vec<&str> = cli.features.iter().map(|f| f.as_str()).collect();
     if let Some(frames) = cli.frames {
         let mut file = File::create("ci_testing_config.ron").unwrap();
         file.write_fmt(format_args!("(exit_after: Some({frames}))"))

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -581,17 +581,26 @@ header_message = \"Examples ({})\"
             for to_build in work_to_do() {
                 let sh = Shell::new().unwrap();
                 let example = &to_build.technical_name;
+                let required_features = if to_build.required_features.is_empty() {
+                    vec![]
+                } else {
+                    vec![
+                        "--features".to_string(),
+                        to_build.required_features.join(","),
+                    ]
+                };
+
                 if optimize_size {
                     cmd!(
                         sh,
-                        "cargo run -p build-wasm-example -- --api {api} {example} --optimize-size"
+                        "cargo run -p build-wasm-example -- --api {api} {example} --optimize-size {required_features...}"
                     )
                     .run()
                     .unwrap();
                 } else {
                     cmd!(
                         sh,
-                        "cargo run -p build-wasm-example -- --api {api} {example}"
+                        "cargo run -p build-wasm-example -- --api {api} {example} {required_features...}"
                     )
                     .run()
                     .unwrap();


### PR DESCRIPTION
# Objective

- Examples with required features fail to build
- If you're fixing a specific issue, say "Fixes #X".

## Solution

- Pass them along when building examples for wasm showcase
- Also mark example `hot_asset_reloading` as not wasm compatible as it isn't even with the right features enabled