### PR TITLE
Add missing asset load error logs for load_folder and load_untyped

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -351,7 +351,7 @@ impl AssetServer {
                     }),
                     Err(err) => {
                         error!("{err}");
-                        server.send_asset_event(InternalAssetEvent::Failed { id })
+                        server.send_asset_event(InternalAssetEvent::Failed { id });
                     }
                 }
             })

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -349,7 +349,10 @@ impl AssetServer {
                         )
                         .into(),
                     }),
-                    Err(_) => server.send_asset_event(InternalAssetEvent::Failed { id }),
+                    Err(err) => {
+                        error!("{err}");
+                        server.send_asset_event(InternalAssetEvent::Failed { id })
+                    }
                 }
             })
             .detach();
@@ -652,7 +655,10 @@ impl AssetServer {
                         )
                         .into(),
                     }),
-                    Err(_) => server.send_asset_event(InternalAssetEvent::Failed { id }),
+                    Err(err) => {
+                        error!("Failed to load folder. {err}");
+                        server.send_asset_event(InternalAssetEvent::Failed { id });
+                    },
                 }
             })
             .detach();


### PR DESCRIPTION
# Objective

Fixes #10515 

## Solution

Add missing error logs.
