### PR TITLE
Add and impl Primitives

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -135,6 +135,19 @@ pub struct Polyline2d<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
+impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
+    fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
+        let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
+
+        let mut index = 0;
+        for i in iter {
+            vertices[index] = i;
+            index += 1;
+        }
+        return Self { vertices };
+    }
+}
+
 impl<const N: usize> Polyline2d<N> {
     /// Create a new `Polyline2d` from an array of vertices
     pub fn new(vertices: [Vec2; N]) -> Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -132,10 +132,9 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
     fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
         let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
 
+        let iter = iter.into_iter().take(N);
+
         for (index, i) in iter.into_iter().enumerate() {
-            if index >= N {
-                break;
-            }
             vertices[index] = i;
         }
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -137,7 +137,7 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
             vertices[index] = i;
             index += 1;
         }
-        return Self { vertices };
+        Self { vertices }
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -34,6 +34,16 @@ pub struct Circle {
 }
 impl Primitive2d for Circle {}
 
+/// An ellipse primitive
+#[derive(Clone, Copy, Debug)]
+pub struct Ellipse {
+    /// The "width" of the ellipse
+    pub width: f32,
+    /// The "height" of the ellipse
+    pub height: f32,
+}
+impl Primitive2d for Ellipse {}
+
 /// An unbounded plane in 2D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -157,10 +157,19 @@ pub struct BoxedPolyline2d {
 }
 impl Primitive2d for BoxedPolyline2d {}
 
+impl FromIterator<Vec2> for BoxedPolyline2d {
+    fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
+        let vertices: Vec<Vec2> = iter.into_iter().collect();
+        Self {
+            vertices: vertices.into_boxed_slice(),
+        }
+    }
+}
+
 impl BoxedPolyline2d {
-    /// Create a new `Polyline2d` from an array of vertices
-    pub fn new(vertices: Box<[Vec2]>) -> Self {
-        Self { vertices }
+    /// Create a new `BoxedPolyline2d` from an array of vertices
+    pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
+        Self::from_iter(vertices)
     }
 }
 
@@ -233,10 +242,19 @@ pub struct BoxedPolygon {
 }
 impl Primitive2d for BoxedPolygon {}
 
+impl FromIterator<Vec2> for BoxedPolygon {
+    fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
+        let vertices: Vec<Vec2> = iter.into_iter().collect();
+        Self {
+            vertices: vertices.into_boxed_slice(),
+        }
+    }
+}
+
 impl BoxedPolygon {
     /// Create a new `BoxedPolygon` from an array of vertices
-    pub fn new(vertices: Box<[Vec2]>) -> Self {
-        Self { vertices }
+    pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
+        Self::from_iter(vertices)
     }
 }
 
@@ -253,7 +271,12 @@ impl Primitive2d for RegularPolygon {}
 impl RegularPolygon {
     /// Create a new `RegularPolygon`
     /// from the radius of the circumcircle and number of sides
+    ///
+    /// # Panics
+    ///
+    /// Panics if `circumcircle_radius` is non-positive
     pub fn new(circumcircle_radius: f32, sides: usize) -> Self {
+        assert!(circumcircle_radius > 0.0);
         Self {
             circumcircle: Circle {
                 radius: circumcircle_radius,

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -132,9 +132,7 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
     fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
         let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
 
-        let iter = iter.into_iter().take(N);
-
-        for (index, i) in iter.into_iter().enumerate() {
+        for (index, i) in iter.into_iter().take(N).enumerate() {
             vertices[index] = i;
         }
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -167,7 +167,7 @@ impl FromIterator<Vec2> for BoxedPolyline2d {
 }
 
 impl BoxedPolyline2d {
-    /// Create a new `BoxedPolyline2d` from an array of vertices
+    /// Create a new `BoxedPolyline2d` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
         Self::from_iter(vertices)
     }
@@ -238,7 +238,7 @@ impl<const N: usize> FromIterator<Vec2> for Polygon<N> {
 }
 
 impl<const N: usize> Polygon<N> {
-    /// Create a new `Polygon` from an array of vertices
+    /// Create a new `Polygon` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
         Self::from_iter(vertices)
     }
@@ -265,7 +265,7 @@ impl FromIterator<Vec2> for BoxedPolygon {
 }
 
 impl BoxedPolygon {
-    /// Create a new `BoxedPolygon` from an array of vertices
+    /// Create a new `BoxedPolygon` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
         Self::from_iter(vertices)
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -140,7 +140,7 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
 }
 
 impl<const N: usize> Polyline2d<N> {
-    /// Create a new `Polyline2d` from an array of vertices
+    /// Create a new `Polyline2d` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
         Self::from_iter(vertices)
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -133,6 +133,9 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
         let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
 
         for (index, i) in iter.into_iter().enumerate() {
+            if index >= N {
+                break;
+            }
             vertices[index] = i;
         }
         Self { vertices }
@@ -141,8 +144,8 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
 
 impl<const N: usize> Polyline2d<N> {
     /// Create a new `Polyline2d` from an array of vertices
-    pub fn new(vertices: [Vec2; N]) -> Self {
-        Self { vertices }
+    pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
+        Self::from_iter(vertices.into_iter())
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -34,27 +34,23 @@ pub struct Circle {
 }
 impl Primitive2d for Circle {}
 
-impl Circle {
-    /// Create a `Circle` from a radius
-    pub fn new(radius: f32) -> Self {
-        Self { radius }
-    }
-}
-
 /// An ellipse primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Ellipse {
-    /// The "width" of the ellipse
-    pub width: f32,
-    /// The "height" of the ellipse
-    pub height: f32,
+    /// The half "width" of the ellipse
+    pub half_width: f32,
+    /// The half "height" of the ellipse
+    pub half_height: f32,
 }
 impl Primitive2d for Ellipse {}
 
 impl Ellipse {
     /// Create a new `Ellipse` from a "width" and a "height"
     pub fn new(width: f32, height: f32) -> Self {
-        Self { width, height }
+        Self {
+            half_width: width / 2.0,
+            half_height: height / 2.0,
+        }
     }
 }
 
@@ -252,10 +248,12 @@ impl Primitive2d for RegularPolygon {}
 
 impl RegularPolygon {
     /// Create a new `RegularPolygon`
-    /// from a circumcircle and number of sides
-    pub fn new(circumcircle: Circle, sides: usize) -> Self {
+    /// from the radius of the circumcircle and number of sides
+    pub fn new(circumcircle_radius: f32, sides: usize) -> Self {
         Self {
-            circumcircle,
+            circumcircle: Circle {
+                radius: circumcircle_radius,
+            },
             sides,
         }
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -145,7 +145,7 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
 impl<const N: usize> Polyline2d<N> {
     /// Create a new `Polyline2d` from an array of vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
-        Self::from_iter(vertices.into_iter())
+        Self::from_iter(vertices)
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -34,6 +34,13 @@ pub struct Circle {
 }
 impl Primitive2d for Circle {}
 
+impl Circle {
+    /// Create a `Circle` from a radius
+    pub fn new(radius: f32) -> Self {
+        Self { radius }
+    }
+}
+
 /// An ellipse primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Ellipse {
@@ -44,6 +51,13 @@ pub struct Ellipse {
 }
 impl Primitive2d for Ellipse {}
 
+impl Ellipse {
+    /// Create a new `Ellipse` from a "width" and a "height"
+    pub fn new(width: f32, height: f32) -> Self {
+        Self { width, height }
+    }
+}
+
 /// An unbounded plane in 2D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
@@ -52,6 +66,13 @@ pub struct Plane2d {
     pub normal: Direction2d,
 }
 impl Primitive2d for Plane2d {}
+
+impl Plane2d {
+    /// Create a new `Plane2d` from the normal of the plane
+    pub fn new(normal: Direction2d) -> Self {
+        Self { normal }
+    }
+}
 
 /// An infinite line along a direction in 2D space.
 ///
@@ -118,6 +139,13 @@ pub struct Polyline2d<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polyline2d<N> {}
 
+impl<const N: usize> Polyline2d<N> {
+    /// Create a new `Polyline2d` from an array of vertices
+    pub fn new(vertices: [Vec2; N]) -> Self {
+        Self { vertices }
+    }
+}
+
 /// A series of connected line segments in 2D space, allocated on the heap
 /// in a `Box<[Vec2]>`.
 ///
@@ -129,6 +157,13 @@ pub struct BoxedPolyline2d {
 }
 impl Primitive2d for BoxedPolyline2d {}
 
+impl BoxedPolyline2d {
+    /// Create a new `Polyline2d` from an array of vertices
+    pub fn new(vertices: Box<[Vec2]>) -> Self {
+        Self { vertices }
+    }
+}
+
 /// A triangle in 2D space
 #[derive(Clone, Debug)]
 pub struct Triangle2d {
@@ -136,6 +171,13 @@ pub struct Triangle2d {
     pub vertices: [Vec2; 3],
 }
 impl Primitive2d for Triangle2d {}
+
+impl Triangle2d {
+    /// Create a new `Triangle2d` from a list of Vertices
+    pub fn new(vertices: [Vec2; 3]) -> Self {
+        Self { vertices }
+    }
+}
 
 /// A rectangle primitive
 #[doc(alias = "Quad")]
@@ -168,10 +210,17 @@ impl Rectangle {
 /// For a version without generics: [`BoxedPolygon`]
 #[derive(Clone, Debug)]
 pub struct Polygon<const N: usize> {
-    /// The vertices of the polygon
+    /// The vertices of the `Polygon`
     pub vertices: [Vec2; N],
 }
 impl<const N: usize> Primitive2d for Polygon<N> {}
+
+impl<const N: usize> Polygon<N> {
+    /// Create a new `Polygon` from an array of vertices
+    pub fn new(vertices: [Vec2; N]) -> Self {
+        Self { vertices }
+    }
+}
 
 /// A polygon with a variable number of vertices, allocated on the heap
 /// in a `Box<[Vec2]>`.
@@ -179,10 +228,17 @@ impl<const N: usize> Primitive2d for Polygon<N> {}
 /// For a version without alloc: [`Polygon`]
 #[derive(Clone, Debug)]
 pub struct BoxedPolygon {
-    /// The vertices of the polygon
+    /// The vertices of the `BoxedPolygon`
     pub vertices: Box<[Vec2]>,
 }
 impl Primitive2d for BoxedPolygon {}
+
+impl BoxedPolygon {
+    /// Create a new `BoxedPolygon` from an array of vertices
+    pub fn new(vertices: Box<[Vec2]>) -> Self {
+        Self { vertices }
+    }
+}
 
 /// A polygon where all vertices lie on a circle, equally far apart
 #[derive(Clone, Copy, Debug)]
@@ -193,3 +249,14 @@ pub struct RegularPolygon {
     pub sides: usize,
 }
 impl Primitive2d for RegularPolygon {}
+
+impl RegularPolygon {
+    /// Create a new `RegularPolygon`
+    /// from a circumcircle and number of sides
+    pub fn new(circumcircle: Circle, sides: usize) -> Self {
+        Self {
+            circumcircle,
+            sides,
+        }
+    }
+}

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -182,9 +182,11 @@ pub struct Triangle2d {
 impl Primitive2d for Triangle2d {}
 
 impl Triangle2d {
-    /// Create a new `Triangle2d` from an array of vertices
-    pub fn new(vertices: [Vec2; 3]) -> Self {
-        Self { vertices }
+    /// Create a new `Triangle2d` from `a`, `b`, and `c`,
+    pub fn new(a: Vec2, b: Vec2, c: Vec2) -> Self {
+        Self {
+            vertices: [a, b, c],
+        }
     }
 }
 
@@ -224,10 +226,21 @@ pub struct Polygon<const N: usize> {
 }
 impl<const N: usize> Primitive2d for Polygon<N> {}
 
+impl<const N: usize> FromIterator<Vec2> for Polygon<N> {
+    fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
+        let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
+
+        for (index, i) in iter.into_iter().take(N).enumerate() {
+            vertices[index] = i;
+        }
+        Self { vertices }
+    }
+}
+
 impl<const N: usize> Polygon<N> {
     /// Create a new `Polygon` from an array of vertices
-    pub fn new(vertices: [Vec2; N]) -> Self {
-        Self { vertices }
+    pub fn new(vertices: impl IntoIterator<Item = Vec2>) -> Self {
+        Self::from_iter(vertices)
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -63,13 +63,6 @@ pub struct Plane2d {
 }
 impl Primitive2d for Plane2d {}
 
-impl Plane2d {
-    /// Create a new `Plane2d` from the normal of the plane
-    pub fn new(normal: Direction2d) -> Self {
-        Self { normal }
-    }
-}
-
 /// An infinite line along a direction in 2D space.
 ///
 /// For a finite line: [`Segment2d`]

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -173,7 +173,7 @@ pub struct Triangle2d {
 impl Primitive2d for Triangle2d {}
 
 impl Triangle2d {
-    /// Create a new `Triangle2d` from a list of Vertices
+    /// Create a new `Triangle2d` from an array of vertices
     pub fn new(vertices: [Vec2; 3]) -> Self {
         Self { vertices }
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -132,10 +132,8 @@ impl<const N: usize> FromIterator<Vec2> for Polyline2d<N> {
     fn from_iter<I: IntoIterator<Item = Vec2>>(iter: I) -> Self {
         let mut vertices: [Vec2; N] = [Vec2::ZERO; N];
 
-        let mut index = 0;
-        for i in iter {
+        for (index, i) in iter.into_iter().enumerate() {
             vertices[index] = i;
-            index += 1;
         }
         Self { vertices }
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -199,9 +199,9 @@ impl Capsule {
 /// A cone primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Cone {
-    /// The radius of the cone's base
+    /// radius of the base
     pub radius: f32,
-    /// The height of the cone
+    /// height of the cone
     pub height: f32,
 }
 impl Primitive3d for Cone {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -34,13 +34,6 @@ pub struct Sphere {
 }
 impl Primitive3d for Sphere {}
 
-impl Sphere {
-    /// Create a new `Sphere` from a radius
-    pub fn new(radius: f32) -> Self {
-        Self { radius }
-    }
-}
-
 /// An unbounded plane in 3D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
@@ -49,13 +42,6 @@ pub struct Plane3d {
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
-
-impl Plane3d {
-    /// Create a new `Plane3d` from the normal of the plane
-    pub fn new(normal: Direction3d) -> Self {
-        Self { normal }
-    }
-}
 
 /// An infinite line along a direction in 3D space.
 ///
@@ -66,13 +52,6 @@ pub struct Line3d {
     pub direction: Direction3d,
 }
 impl Primitive3d for Line3d {}
-
-impl Line3d {
-    /// Create a new `Line3d` from the direction of the line
-    pub fn new(direction: Direction3d) -> Self {
-        Self { direction }
-    }
-}
 
 /// A segment of a line along a direction in 3D space.
 #[doc(alias = "LineSegment3d")]
@@ -209,10 +188,10 @@ impl Primitive3d for Capsule {}
 
 impl Capsule {
     /// Create a new `Capsule` from a radius and half-length
-    pub fn new(radius: f32, half_length: f32) -> Self {
+    pub fn new(radius: f32, length: f32) -> Self {
         Self {
             radius,
-            half_length,
+            half_length: length / 2.0,
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1,5 +1,4 @@
 use super::Primitive3d;
-use crate::Vec2;
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
@@ -35,6 +34,13 @@ pub struct Sphere {
 }
 impl Primitive3d for Sphere {}
 
+impl Sphere {
+    /// Create a new `Sphere` from a radius
+    pub fn new(radius: f32) -> Self {
+        Self { radius }
+    }
+}
+
 /// An unbounded plane in 3D space. It forms a separating surface through the origin,
 /// stretching infinitely far
 #[derive(Clone, Copy, Debug)]
@@ -43,6 +49,13 @@ pub struct Plane3d {
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
+
+impl Plane3d {
+    /// Create a new `Plane3d` from the normal of the plane
+    pub fn new(normal: Direction3d) -> Self {
+        Self { normal }
+    }
+}
 
 /// An infinite line along a direction in 3D space.
 ///
@@ -53,6 +66,13 @@ pub struct Line3d {
     pub direction: Direction3d,
 }
 impl Primitive3d for Line3d {}
+
+impl Line3d {
+    /// Create a new `Line3d` from the direction of the line
+    pub fn new(direction: Direction3d) -> Self {
+        Self { direction }
+    }
+}
 
 /// A segment of a line along a direction in 3D space.
 #[doc(alias = "LineSegment3d")]
@@ -108,6 +128,13 @@ pub struct Polyline3d<const N: usize> {
 }
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
+impl<const N: usize> Polyline3d<N> {
+    /// Create a new `Polyline3d` from a list of vertices
+    pub fn new(vertices: [Vec3; N]) -> Self {
+        Self { vertices }
+    }
+}
+
 /// A series of connected line segments in 3D space, allocated on the heap
 /// in a `Box<[Vec3]>`.
 ///
@@ -118,6 +145,13 @@ pub struct BoxedPolyline3d {
     pub vertices: Box<[Vec3]>,
 }
 impl Primitive3d for BoxedPolyline3d {}
+
+impl BoxedPolyline3d {
+    /// Create a new `BoxedPolyline3d` from a list of vertices
+    pub fn new(vertices: Box<[Vec3]>) -> Self {
+        Self { vertices }
+    }
+}
 
 /// A cuboid primitive, more commonly known as a box.
 #[derive(Clone, Copy, Debug)]
@@ -173,6 +207,16 @@ pub struct Capsule {
 impl super::Primitive2d for Capsule {}
 impl Primitive3d for Capsule {}
 
+impl Capsule {
+    /// Create a new `Capsule` from a radius and half-length
+    pub fn new(radius: f32, half_length: f32) -> Self {
+        Self {
+            radius,
+            half_length,
+        }
+    }
+}
+
 /// A cone primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Cone {
@@ -182,6 +226,13 @@ pub struct Cone {
     pub height: f32,
 }
 impl Primitive3d for Cone {}
+
+impl Cone {
+    /// Create a new `Cone` from a radius and height
+    pub fn new(radius: f32, height: f32) -> Self {
+        Self { radius, height }
+    }
+}
 
 /// A conical frustum primitive.
 /// A conical frustum can be created
@@ -197,6 +248,18 @@ pub struct ConicalFrustum {
 }
 impl Primitive3d for ConicalFrustum {}
 
+impl ConicalFrustum {
+    /// Create a new `ConicalFrustum` from a top
+    /// radius, bottom radius, and height
+    pub fn new(radius_top: f32, radius_bottom: f32, height: f32) -> Self {
+        Self {
+            radius_top,
+            radius_bottom,
+            height,
+        }
+    }
+}
+
 /// A torus (AKA donut) primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Torus {
@@ -205,5 +268,14 @@ pub struct Torus {
     /// The radius of the ring
     pub ring_radius: f32,
 }
-
 impl Primitive3d for Torus {}
+
+impl Torus {
+    /// Create a new `Torus` from a radius and ring radius
+    pub fn new(radius: f32, ring_radius: f32) -> Self {
+        Self {
+            radius,
+            ring_radius,
+        }
+    }
+}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -111,10 +111,9 @@ impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
     fn from_iter<I: IntoIterator<Item = Vec3>>(iter: I) -> Self {
         let mut vertices: [Vec3; N] = [Vec3::ZERO; N];
 
+        let iter = iter.into_iter().take(N);
+
         for (index, i) in iter.into_iter().enumerate() {
-            if index >= N {
-                break;
-            }
             vertices[index] = i;
         }
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1,4 +1,5 @@
 use super::Primitive3d;
+use crate::Vec2;
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
@@ -171,3 +172,38 @@ pub struct Capsule {
 }
 impl super::Primitive2d for Capsule {}
 impl Primitive3d for Capsule {}
+
+/// A cone primitive.
+#[derive(Clone, Copy, Debug)]
+pub struct Cone {
+    /// radius of the base
+    pub radius: f32,
+    /// height of the cone
+    pub height: f32,
+}
+impl Primitive3d for Cone {}
+
+/// A conical frustum primitive.
+/// A conical frustum can be created
+/// by slicing off a section of a cone.
+#[derive(Clone, Copy, Debug)]
+pub struct ConicalFrustum {
+    /// Radius of the top of the frustum
+    pub radius_top: f32,
+    /// Radius of the base of the frustum
+    pub radius_bottom: f32,
+    /// Height of the frustum
+    pub height: f32,
+}
+impl Primitive3d for ConicalFrustum {}
+
+/// A torus (AKA donut) primitive.
+#[derive(Clone, Copy, Debug)]
+pub struct Torus {
+    /// The radius of the overall shape
+    pub radius: f32,
+    /// The radius of the ring
+    pub ring_radius: f32,
+}
+
+impl Primitive3d for Torus {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -225,7 +225,7 @@ impl Primitive3d for ConicalFrustum {}
 pub struct Torus {
     /// The radius of the overall shape
     pub radius: f32,
-    /// The radius of the ring
+    /// The radius of the internal ring
     pub ring_radius: f32,
 }
 impl Primitive3d for Torus {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -199,9 +199,9 @@ impl Capsule {
 /// A cone primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Cone {
-    /// radius of the base
+    /// The radius of the cone's base
     pub radius: f32,
-    /// height of the cone
+    /// The height of the cone
     pub height: f32,
 }
 impl Primitive3d for Cone {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -206,13 +206,6 @@ pub struct Cone {
 }
 impl Primitive3d for Cone {}
 
-impl Cone {
-    /// Create a new `Cone` from a radius and height
-    pub fn new(radius: f32, height: f32) -> Self {
-        Self { radius, height }
-    }
-}
-
 /// A conical frustum primitive.
 /// A conical frustum can be created
 /// by slicing off a section of a cone.
@@ -227,18 +220,6 @@ pub struct ConicalFrustum {
 }
 impl Primitive3d for ConicalFrustum {}
 
-impl ConicalFrustum {
-    /// Create a new `ConicalFrustum` from a top
-    /// radius, bottom radius, and height
-    pub fn new(radius_top: f32, radius_bottom: f32, height: f32) -> Self {
-        Self {
-            radius_top,
-            radius_bottom,
-            height,
-        }
-    }
-}
-
 /// A torus (AKA donut) primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Torus {
@@ -248,13 +229,3 @@ pub struct Torus {
     pub ring_radius: f32,
 }
 impl Primitive3d for Torus {}
-
-impl Torus {
-    /// Create a new `Torus` from a radius and ring radius
-    pub fn new(radius: f32, ring_radius: f32) -> Self {
-        Self {
-            radius,
-            ring_radius,
-        }
-    }
-}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -231,11 +231,11 @@ impl Primitive3d for Cone {}
 /// by slicing off a section of a cone.
 #[derive(Clone, Copy, Debug)]
 pub struct ConicalFrustum {
-    /// Radius of the top of the frustum
+    /// The radius of the top of the frustum
     pub radius_top: f32,
-    /// Radius of the base of the frustum
+    /// The radius of the base of the frustum
     pub radius_bottom: f32,
-    /// Height of the frustum
+    /// The height of the frustum
     pub height: f32,
 }
 impl Primitive3d for ConicalFrustum {}

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -113,7 +113,7 @@ impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
 
         let iter = iter.into_iter().take(N);
 
-        for (index, i) in iter.into_iter().enumerate() {
+        for (index, i) in iter.into_iter().take(N).enumerate() {
             vertices[index] = i;
         }
         Self { vertices }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -111,8 +111,6 @@ impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
     fn from_iter<I: IntoIterator<Item = Vec3>>(iter: I) -> Self {
         let mut vertices: [Vec3; N] = [Vec3::ZERO; N];
 
-        let iter = iter.into_iter().take(N);
-
         for (index, i) in iter.into_iter().take(N).enumerate() {
             vertices[index] = i;
         }
@@ -138,10 +136,19 @@ pub struct BoxedPolyline3d {
 }
 impl Primitive3d for BoxedPolyline3d {}
 
+impl FromIterator<Vec3> for BoxedPolyline3d {
+    fn from_iter<I: IntoIterator<Item = Vec3>>(iter: I) -> Self {
+        let vertices: Vec<Vec3> = iter.into_iter().collect();
+        Self {
+            vertices: vertices.into_boxed_slice(),
+        }
+    }
+}
+
 impl BoxedPolyline3d {
-    /// Create a new `BoxedPolyline3d` from a list of vertices
-    pub fn new(vertices: Box<[Vec3]>) -> Self {
-        Self { vertices }
+    /// Create a new `BoxedPolyline3d` from an array of vertices
+    pub fn new(vertices: impl IntoIterator<Item = Vec3>) -> Self {
+        Self::from_iter(vertices)
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -124,7 +124,7 @@ impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
 impl<const N: usize> Polyline3d<N> {
     /// Create a new `Polyline3d` from an array of vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec3>) -> Self {
-        Self::from_iter(vertices.into_iter())
+        Self::from_iter(vertices)
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -107,10 +107,24 @@ pub struct Polyline3d<const N: usize> {
 }
 impl<const N: usize> Primitive3d for Polyline3d<N> {}
 
-impl<const N: usize> Polyline3d<N> {
-    /// Create a new `Polyline3d` from a list of vertices
-    pub fn new(vertices: [Vec3; N]) -> Self {
+impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
+    fn from_iter<I: IntoIterator<Item = Vec3>>(iter: I) -> Self {
+        let mut vertices: [Vec3; N] = [Vec3::ZERO; N];
+
+        for (index, i) in iter.into_iter().enumerate() {
+            if index >= N {
+                break;
+            }
+            vertices[index] = i;
+        }
         Self { vertices }
+    }
+}
+
+impl<const N: usize> Polyline3d<N> {
+    /// Create a new `Polyline3d` from an array of vertices
+    pub fn new(vertices: impl IntoIterator<Item = Vec3>) -> Self {
+        Self::from_iter(vertices.into_iter())
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -119,7 +119,7 @@ impl<const N: usize> FromIterator<Vec3> for Polyline3d<N> {
 }
 
 impl<const N: usize> Polyline3d<N> {
-    /// Create a new `Polyline3d` from an array of vertices
+    /// Create a new `Polyline3d` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec3>) -> Self {
         Self::from_iter(vertices)
     }
@@ -146,7 +146,7 @@ impl FromIterator<Vec3> for BoxedPolyline3d {
 }
 
 impl BoxedPolyline3d {
-    /// Create a new `BoxedPolyline3d` from an array of vertices
+    /// Create a new `BoxedPolyline3d` from its vertices
     pub fn new(vertices: impl IntoIterator<Item = Vec3>) -> Self {
         Self::from_iter(vertices)
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -187,7 +187,7 @@ impl super::Primitive2d for Capsule {}
 impl Primitive3d for Capsule {}
 
 impl Capsule {
-    /// Create a new `Capsule` from a radius and half-length
+    /// Create a new `Capsule` from a radius and length
     pub fn new(radius: f32, length: f32) -> Self {
         Self {
             radius,

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -219,9 +219,9 @@ impl Capsule {
 /// A cone primitive.
 #[derive(Clone, Copy, Debug)]
 pub struct Cone {
-    /// radius of the base
+    /// The radius of the base
     pub radius: f32,
-    /// height of the cone
+    /// The height of the cone
     pub height: f32,
 }
 impl Primitive3d for Cone {}


### PR DESCRIPTION
# Add and implement constructors for Primitives

- Adds more Primitive types and adds a constructor for almost all of them
- Works towards finishing #10572 

## Solution

- Created new primitives
    - Torus
    - Conical Frustum
    - Cone
    - Ellipse
- Implemented constructors (`Primitive::new`) for almost every single other primitive.