### PR TITLE
Fix file_watcher feature hanging indefinitely

### DIFF
--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-file_watcher = ["notify-debouncer-full", "watch", "multi-threaded"]
+file_watcher = ["notify-debouncer-full", "watch"]
 embedded_watcher = ["file_watcher"]
 multi-threaded = ["bevy_tasks/multi-threaded"]
 asset_processor = []

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-file_watcher = ["notify-debouncer-full", "watch"]
+file_watcher = ["notify-debouncer-full", "watch", "multi-threaded"]
 embedded_watcher = ["file_watcher"]
 multi-threaded = ["bevy_tasks/multi-threaded"]
 asset_processor = []

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -54,6 +54,13 @@ use bevy_log::error;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
 use std::{any::TypeId, sync::Arc};
 
+#[cfg(all(feature = "file_watcher", not(feature = "multi-threaded")))]
+compile_error!(
+    "The \"file_watcher\" feature for hot reloading requires the \
+    \"multi-threaded\" feature to be functional.\n\
+    Consider either disabling the \"file_watcher\" feature or enabling \"multi-threaded\""
+);
+
 /// Provides "asset" loading and processing functionality. An [`Asset`] is a "runtime value" that is loaded from an [`AssetSource`],
 /// which can be something like a filesystem, a network, etc.
 ///


### PR DESCRIPTION
# Objective

Fix the `bevy_asset/file_watcher` feature in practice depending on multithreading, while not informing the user of it.

**As I understand it** (I didn't check it), the file watcher feature depends on spawning a concurrent thread to receive file update events from the `notify-debouncer-full` crate. But if multithreading is disabled, that thread will never have time to read the events and consume them.

- Fixes #10573 


## Solution

Add a `compile_error!` causing compilation failure if `file_watcher` is enabled while `multi-threaded` is disabled.

This is considered better than adding a dependency on `multi-threaded` on the `file_watcher`, as (according to @mockersf) toggling on/off `multi-threaded` has a non-zero chance of changing behavior. And we shouldn't implicitly change behavior. A compilation failure prevents compilation of code that is invalid, while informing the user of the steps needed to fix it.