### PR TITLE
Fix panic when using image in UiMaterial

### DIFF
--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -298,10 +298,10 @@ impl<P: PhaseItem, M: UiMaterial, const I: usize> RenderCommand<P>
         materials: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
-        let material = materials
-            .into_inner()
-            .get(&material_handle.material)
-            .unwrap();
+        let Some(material) = materials.into_inner().get(&material_handle.material) else {
+            return RenderCommandResult::Failure;
+
+        };
         pass.set_bind_group(I, &material.bind_group, &[]);
         RenderCommandResult::Success
     }
@@ -732,7 +732,9 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
     let draw_function = draw_functions.read().id::<DrawUiMaterial<M>>();
 
     for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
-        let material = render_materials.get(&extracted_uinode.material).unwrap();
+        let Some(material) = render_materials.get(&extracted_uinode.material) else {
+            continue
+        };
         for (view, mut transparent_phase) in &mut views {
             let pipeline = pipelines.specialize(
                 &pipeline_cache,

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -300,7 +300,6 @@ impl<P: PhaseItem, M: UiMaterial, const I: usize> RenderCommand<P>
     ) -> RenderCommandResult {
         let Some(material) = materials.into_inner().get(&material_handle.material) else {
             return RenderCommandResult::Failure;
-
         };
         pass.set_bind_group(I, &material.bind_group, &[]);
         RenderCommandResult::Success
@@ -733,7 +732,7 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
 
     for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
         let Some(material) = render_materials.get(&extracted_uinode.material) else {
-            continue
+            continue;
         };
         for (view, mut transparent_phase) in &mut views {
             let pipeline = pipelines.specialize(


### PR DESCRIPTION
# Objective

- Fix the panic on using Images in UiMaterials due to assets not being loaded.
- Fixes #10513 

## Solution

- add `let else` statement that `return`s or `continue`s instead of unwrapping, causing a panic.
