### PR TITLE
Add `Transform::is_finite`

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -396,6 +396,13 @@ impl Transform {
         point += self.translation;
         point
     }
+
+    /// Returns `true` if, and only if, translation, rotation and scale all are
+    /// finite. If any of them contains a `NaN`, positive or negative infinity,
+    /// this will return `false`.
+    pub fn is_finite(&self) -> bool {
+        self.translation.is_finite() && self.rotation.is_finite() && self.scale.is_finite()
+    }
 }
 
 impl Default for Transform {

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -400,6 +400,8 @@ impl Transform {
     /// Returns `true` if, and only if, translation, rotation and scale all are
     /// finite. If any of them contains a `NaN`, positive or negative infinity,
     /// this will return `false`.
+    #[inline]
+    #[must_use]
     pub fn is_finite(&self) -> bool {
         self.translation.is_finite() && self.rotation.is_finite() && self.scale.is_finite()
     }


### PR DESCRIPTION
# Objective

- Sometimes it's very useful to know if a `Transform` contains any `NaN` or infinite values. It's a bit boiler-plate heavy to check translation, rotation and scale individually.

## Solution

- Add a new method `is_finite` that returns true if, and only if translation, rotation and scale all are finite.
- It's a natural extension of `Quat::is_finite`, and `Vec3::is_finite`, which return true if, and only if all their components' `is_finite()` returns true.

---

## Changelog

- Added `Transform::is_finite`
