### PR TITLE
fix lint err result_large_err

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -852,6 +852,7 @@ fn load_material(
     })
 }
 
+#[allow(clippy::result_large_err)]
 /// Loads a glTF node.
 fn load_node(
     gltf_node: &gltf::Node,
@@ -1235,6 +1236,7 @@ fn texture_address_mode(gltf_address_mode: &gltf::texture::WrappingMode) -> Imag
     }
 }
 
+#[allow(clippy::result_large_err)]
 /// Maps the `primitive_topology` form glTF to `wgpu`.
 fn get_primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     match mode {

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -78,7 +78,7 @@ pub enum GltfError {
     ReadAssetBytesError(#[from] ReadAssetBytesError),
     /// Failed to load asset from an asset path.
     #[error("failed to load asset from an asset path: {0}")]
-    AssetLoadError(#[from] AssetLoadError),
+    AssetLoadError(#[from] Box<AssetLoadError>),
     /// Missing sampler for an animation.
     #[error("Missing sampler for animation {0}")]
     MissingAnimationSampler(usize),
@@ -852,7 +852,6 @@ fn load_material(
     })
 }
 
-#[allow(clippy::result_large_err)]
 /// Loads a glTF node.
 fn load_node(
     gltf_node: &gltf::Node,
@@ -1236,7 +1235,6 @@ fn texture_address_mode(gltf_address_mode: &gltf::texture::WrappingMode) -> Imag
     }
 }
 
-#[allow(clippy::result_large_err)]
 /// Maps the `primitive_topology` form glTF to `wgpu`.
 fn get_primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     match mode {


### PR DESCRIPTION
# Objective

- Fix errors when I run `cargo run -p ci lints`

```
error: the `Err`-variant returned from this function is very large
   --> crates/bevy_gltf/src/loader.rs:864:6
    |
81  |     AssetLoadError(#[from] AssetLoadError),
    |     -------------------------------------- the largest variant contains at least 128 bytes
...
864 | ) -> Result<(), GltfError> {
    |      ^^^^^^^^^^^^^^^^^^^^^
    |
    = help: try reducing the size of `loader::GltfError`, for example by boxing large elements or replacing it with `Box<loader::GltfError>`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err
    = note: `-D clippy::result-large-err` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::result_large_err)]`

error: the `Err`-variant returned from this function is very large
    --> crates/bevy_gltf/src/loader.rs:1239:42
     |
81   |     AssetLoadError(#[from] AssetLoadError),
     |     -------------------------------------- the largest variant contains at least 128 bytes
...
1239 | fn get_primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     |                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     |
     = help: try reducing the size of `loader::GltfError`, for example by boxing large elements or replacing it with `Box<loader::GltfError>`
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#result_large_err

error: could not compile `bevy_gltf` (lib) due to 2 previous errors
```

## Solution

- Box AssetLoadError : `AssetLoadError(#[from] Box<AssetLoadError>),`
