### PR TITLE
examples showcase: use patches instead of sed for wasm hacks

### DIFF
--- a/tools/example-showcase/asset-source-website.patch
+++ b/tools/example-showcase/asset-source-website.patch
@@ -1,0 +1,13 @@
+diff --git a/crates/bevy_asset/src/lib.rs b/crates/bevy_asset/src/lib.rs
+index 004f87a85..3c8656efc 100644
+--- a/crates/bevy_asset/src/lib.rs
++++ b/crates/bevy_asset/src/lib.rs
+@@ -105,7 +105,7 @@ impl Default for AssetPlugin {
+     fn default() -> Self {
+         Self {
+             mode: AssetMode::Unprocessed,
+-            file_path: Self::DEFAULT_UNPROCESSED_FILE_PATH.to_string(),
++            file_path: "/assets/examples".to_string(),
+             processed_file_path: Self::DEFAULT_PROCESSED_FILE_PATH.to_string(),
+             watch_for_changes_override: None,
+         }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -562,11 +562,20 @@ header_message = \"Examples ({})\"
                 let sh = Shell::new().unwrap();
 
                 // setting a canvas by default to help with integration
-                cmd!(sh, "sed -i.bak 's/canvas: None,/canvas: Some(\"#bevy\".to_string()),/' crates/bevy_window/src/window.rs").run().unwrap();
-                cmd!(sh, "sed -i.bak 's/fit_canvas_to_parent: false,/fit_canvas_to_parent: true,/' crates/bevy_window/src/window.rs").run().unwrap();
+                cmd!(
+                    sh,
+                    "git apply --ignore-whitespace tools/example-showcase/window-settings-wasm.patch"
+                )
+                .run()
+                .unwrap();
 
                 // setting the asset folder root to the root url of this domain
-                cmd!(sh, "sed -i.bak 's/asset_folder: \"assets\"/asset_folder: \"\\/assets\\/examples\\/\"/' crates/bevy_asset/src/lib.rs").run().unwrap();
+                cmd!(
+                    sh,
+                    "git apply --ignore-whitespace tools/example-showcase/asset-source-website.patch"
+                )
+                .run()
+                .unwrap();
             }
 
             let work_to_do = || {

--- a/tools/example-showcase/window-settings-wasm.patch
+++ b/tools/example-showcase/window-settings-wasm.patch
@@ -1,0 +1,16 @@
+diff --git a/crates/bevy_window/src/window.rs b/crates/bevy_window/src/window.rs
+index 7b5c75d38..8e9404b93 100644
+--- a/crates/bevy_window/src/window.rs
++++ b/crates/bevy_window/src/window.rs
+@@ -245,9 +245,9 @@ impl Default for Window {
+             transparent: false,
+             focused: true,
+             window_level: Default::default(),
+-            fit_canvas_to_parent: false,
++            fit_canvas_to_parent: true,
+             prevent_default_event_handling: true,
+-            canvas: None,
++            canvas: Some("#bevy".to_string()),
+             window_theme: None,
+             visible: true,
+         }


### PR DESCRIPTION
# Objective

- Fix the asset hack for wasm examples so that they work on the website
- Use patches instead of sed for wasm hacks so that it fails explicitly when they need to be updated
