### PR TITLE
Add `AccessFilters` utilities

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -483,13 +483,13 @@ impl<T: SparseSetIndex> AccessFilters<T> {
 
     /// Returns whether a `With` constraint exists for `index`.
     #[inline]
-    pub fn get_with(&self, index: T) -> bool {
+    pub fn contains_with(&self, index: T) -> bool {
         self.with.contains(index.sparse_set_index())
     }
 
     /// Returns whether a `Without` constraint exists for `index`.
     #[inline]
-    pub fn get_without(&self, index: T) -> bool {
+    pub fn contains_without(&self, index: T) -> bool {
         self.without.contains(index.sparse_set_index())
     }
 


### PR DESCRIPTION
[`AccessFilters`](https://github.com/WinstonHartnett/bevy/blob/8791f0bf4c0cc2a1b6403398f9c77eb3764e99d8/crates/bevy_ecs/src/query/access.rs#L446) tracks the `With` and `Without` constraints for a `FilteredAccess` set, but is currently private without any way to extend or view underlying filters. This pull just makes `AccessFilters` public, and adds a few utility functions:

- Im/mutable field accessors for `FilteredAccess`
- Functions to add/get `With` and `Without` constraints for `AccessFilters`
- Function to perform in-place union w/ another `AccessFilters`

And updates a few lines to make use of those utilities.