### PR TITLE
Add `VolumeLevel::ZERO`

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -50,6 +50,9 @@ impl VolumeLevel {
     pub fn get(&self) -> f32 {
         self.0
     }
+
+    /// Zero (silent) volume level
+    pub const ZERO: Self = VolumeLevel(0.0);
 }
 
 /// The way Bevy manages the sound playback.


### PR DESCRIPTION
# Objective

- Handy to have a constant instead of `VolumeLevel::new(0.0)`
- `VolumeLevel::new` is not `const`

## Solution

- Adds a `VolumeLevel::ZERO` constant, which we have for most of our other types where it makes sense.

---

## Changelog

- Add `VolumeLevel::ZERO`