### PR TITLE
Do not panic when failing to create assets folder (#10613)

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -6,6 +6,7 @@ mod file_asset;
 #[cfg(not(feature = "multi-threaded"))]
 mod sync_file_asset;
 
+use bevy_log::warn;
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
 
@@ -44,12 +45,12 @@ impl FileAssetReader {
     /// See `get_base_path` below.
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         let root_path = Self::get_base_path().join(path.as_ref());
-        std::fs::create_dir_all(&root_path).unwrap_or_else(|e| {
-            panic!(
+        if let Err(e) = std::fs::create_dir_all(&root_path) {
+            warn!(
                 "Failed to create root directory {:?} for file asset reader: {:?}",
                 root_path, e
-            )
-        });
+            );
+        }
         Self { root_path }
     }
 


### PR DESCRIPTION
# Objective

- Allow bevy applications that does not have any assets folder to start from a read-only directory. (typically installed to a systems folder)

Fixes #10613

## Solution

- warn instead of panic when assets folder creation fails.