### PR TITLE
RFC: Barriers with Before/After markers

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -188,6 +188,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
             {
                 type State = (#(#param::State,)*);
                 type Item<'w, 's> = ParamSet<'w, 's, (#(#param,)*)>;
+                type BarrierList = (#(#param::BarrierList,)*);
 
                 fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
                     #(
@@ -392,6 +393,7 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
             {
                 type State = #state_struct_name<#punctuated_generic_idents>;
                 type Item<'w, 's> = #struct_name #ty_generics;
+                type BarrierList = ();
 
                 fn init_state(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta) -> Self::State {
                     #state_struct_name {

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -263,6 +263,7 @@ unsafe impl<'a> ReadOnlySystemParam for &'a RemovedComponentEvents {}
 unsafe impl<'a> SystemParam for &'a RemovedComponentEvents {
     type State = ();
     type Item<'w, 's> = &'w RemovedComponentEvents;
+    type BarrierList = ();
 
     fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {}
 

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -79,10 +79,18 @@ impl SystemConfigs {
     fn new_system(system: BoxedSystem) -> Self {
         // include system in its default sets
         let sets = system.default_system_sets().into_iter().collect();
+        let mut dependencies = Vec::new();
+        for before in system.before_list() {
+            dependencies.push(Dependency::new(DependencyKind::Before, before));
+        }
+        for after in system.after_list() {
+            dependencies.push(Dependency::new(DependencyKind::After, after));
+        }
         Self::NodeConfig(SystemConfig {
             node: system,
             graph_info: GraphInfo {
                 sets,
+                dependencies,
                 ..Default::default()
             },
             conditions: Vec::new(),

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -146,6 +146,14 @@ where
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         self.system.default_system_sets()
     }
+
+    fn before_list(&self) -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
+
+    fn after_list(&self) -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
 }
 
 // SAFETY: The inner system is read-only.

--- a/crates/bevy_ecs/src/system/barrier.rs
+++ b/crates/bevy_ecs/src/system/barrier.rs
@@ -1,0 +1,119 @@
+use bevy_utils::all_tuples;
+
+use crate::component::Tick;
+use crate::prelude::World;
+use crate::schedule::{InternedSystemSet, SystemSet};
+use crate::system::{SystemMeta, SystemParam};
+use crate::world::unsafe_world_cell::UnsafeWorldCell;
+use std::marker::PhantomData;
+
+/// List of barrier dependencies for the system.
+pub trait BarrierList {
+    /// System sets before this system.
+    fn before_list() -> Vec<InternedSystemSet>;
+    /// System sets after this system.
+    fn after_list() -> Vec<InternedSystemSet>;
+}
+
+/// System param to mark current system to run before a given system set.
+pub struct Before<S: SystemSet + Default> {
+    marker: PhantomData<S>,
+}
+
+/// System param to mark current system to run after a given system set.
+pub struct After<S: SystemSet + Default> {
+    marker: PhantomData<S>,
+}
+
+unsafe impl<S: SystemSet + Default> SystemParam for Before<S> {
+    type State = ();
+    type Item<'world, 'state> = Self;
+    type BarrierList = BeforeBarrierList<S>;
+
+    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {
+        ()
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        _state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        _world: UnsafeWorldCell<'world>,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        Before {
+            marker: PhantomData,
+        }
+    }
+}
+
+unsafe impl<S: SystemSet + Default> SystemParam for After<S> {
+    type State = ();
+    type Item<'world, 'state> = Self;
+
+    type BarrierList = AfterBarrierList<S>;
+
+    fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {
+        ()
+    }
+
+    unsafe fn get_param<'world, 'state>(
+        _state: &'state mut Self::State,
+        _system_meta: &SystemMeta,
+        _world: UnsafeWorldCell<'world>,
+        _change_tick: Tick,
+    ) -> Self::Item<'world, 'state> {
+        After {
+            marker: PhantomData,
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct BeforeBarrierList<S: SystemSet + Default>(PhantomData<S>);
+#[doc(hidden)]
+pub struct AfterBarrierList<S: SystemSet + Default>(PhantomData<S>);
+
+impl<S: SystemSet + Default> BarrierList for BeforeBarrierList<S> {
+    fn before_list() -> Vec<InternedSystemSet> {
+        vec![S::default().intern()]
+    }
+
+    fn after_list() -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
+}
+
+impl<S: SystemSet + Default> BarrierList for AfterBarrierList<S> {
+    fn before_list() -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
+
+    fn after_list() -> Vec<InternedSystemSet> {
+        vec![S::default().intern()]
+    }
+}
+
+macro_rules! barrier_list_for_tuple {
+    ($($barrier: ident),*) => {
+        impl<$($barrier),*> BarrierList for ($($barrier,)*)
+        where
+            $($barrier: BarrierList),*
+        {
+            fn before_list() -> Vec<InternedSystemSet> {
+                let mut list = Vec::new();
+                let _ignore_empty = &mut list;
+                $(list.extend($barrier::before_list());)*
+                list
+            }
+
+            fn after_list() -> Vec<InternedSystemSet> {
+                let mut list = Vec::new();
+                let _ignore_empty = &mut list;
+                $(list.extend($barrier::after_list());)*
+                list
+            }
+        }
+    }
+}
+
+all_tuples!(barrier_list_for_tuple, 0, 16, P);

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -232,6 +232,22 @@ where
         default_sets.append(&mut self.b.default_system_sets());
         default_sets
     }
+
+    fn before_list(&self) -> Vec<InternedSystemSet> {
+        self.a
+            .before_list()
+            .into_iter()
+            .chain(self.b.before_list())
+            .collect()
+    }
+
+    fn after_list(&self) -> Vec<InternedSystemSet> {
+        self.a
+            .after_list()
+            .into_iter()
+            .chain(self.b.after_list())
+            .collect()
+    }
 }
 
 /// SAFETY: Both systems are read-only, so any system created by combining them will only read from the world.

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -155,6 +155,14 @@ where
         let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
     }
+
+    fn before_list(&self) -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
+
+    fn after_list(&self) -> Vec<InternedSystemSet> {
+        Vec::new()
+    }
 }
 
 /// A trait implemented for all exclusive system functions that can be used as [`System`]s.

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -11,6 +11,7 @@ use crate::{
 use bevy_utils::all_tuples;
 use std::{any::TypeId, borrow::Cow, marker::PhantomData};
 
+use crate::system::barrier::BarrierList;
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::{info_span, Span};
 
@@ -532,6 +533,14 @@ where
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
+    }
+
+    fn before_list(&self) -> Vec<InternedSystemSet> {
+        <F::Param as SystemParam>::BarrierList::before_list()
+    }
+
+    fn after_list(&self) -> Vec<InternedSystemSet> {
+        <F::Param as SystemParam>::BarrierList::after_list()
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -103,6 +103,7 @@
 //! - [`()` (unit primitive type)](https://doc.rust-lang.org/stable/std/primitive.unit.html)
 
 mod adapter_system;
+mod barrier;
 mod combinator;
 mod commands;
 mod exclusive_function_system;
@@ -117,6 +118,7 @@ mod system_registry;
 use std::borrow::Cow;
 
 pub use adapter_system::*;
+pub use barrier::*;
 pub use combinator::*;
 pub use commands::*;
 pub use exclusive_function_system::*;

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -39,6 +39,9 @@ pub trait System: Send + Sync + 'static {
     /// Returns true if the system is [`Send`].
     fn is_send(&self) -> bool;
 
+    fn before_list(&self) -> Vec<InternedSystemSet>;
+    fn after_list(&self) -> Vec<InternedSystemSet>;
+
     /// Returns true if the system must be run exclusively.
     fn is_exclusive(&self) -> bool;
 

--- a/crates/bevy_ecs/src/world/identifier.rs
+++ b/crates/bevy_ecs/src/world/identifier.rs
@@ -53,6 +53,8 @@ unsafe impl SystemParam for WorldId {
 
     type Item<'world, 'state> = WorldId;
 
+    type BarrierList = ();
+
     fn init_state(_: &mut super::World, _: &mut crate::system::SystemMeta) -> Self::State {}
 
     unsafe fn get_param<'world, 'state>(


### PR DESCRIPTION
# Why

Explicit ordering of systems is hard: during refactoring you forgot one edge, and your program befomes non-deterministic.

# How

This draft PR proposes implementing ordering based on function signature params (`SystemParam`).

Basically, the idea is this. We introduce two new system params:

```
Before<T>
After<T>
```

where `T` must be a `SystemSet + Default`.

And it can be used like this:

```
#[derive(SystemSet)]
struct MyBarrier;

fn first(_before: Before<MyBarrier>) {}
fn second(_after: After<MyBarrier>) {}
```

Now if `first` and `second` are added to the same schedule, they will be ordered like if `first.before(after)` was done explicitly.

Working example for this is in this commit as `test_before_after_from_param`.

# Composable

`SystemParam` are composable, so it is possible to build higher level constructs on top of it. For example, we may want to schedule all event writers before all event writers:

```
#[derive(SystemParam)]
struct MyOrderedEventWriter<T> {
    writer: EventWriter<T>,
    after: After<MyOrderedEventBarrier<T>>,
}

#[derive(SystemParam)]
struct MyOrderedEventReader<T> {
    reader: EventReader<T>,
    after: Before<MyOrderedEventBarrier<T>>,
}
```

# Feedback?

Want to get early feedback before spending several more hours on it.

WDYT?