### PR TITLE
Add winding order for `Triangle2d`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -206,7 +206,7 @@ impl Triangle2d {
     /// Reverse the [`WindingOrder`] of the triangle
     /// by swapping the second and third vertices
     pub fn reverse(&mut self) {
-        self.vertices.swap(1, 2)
+        self.vertices.swap(1, 2);
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -319,31 +319,36 @@ impl RegularPolygon {
     }
 }
 
-#[test]
-fn triangle_winding_order() {
-    let mut cw_triangle = Triangle2d::new(
-        Vec2::new(0.0, 2.0),
-        Vec2::new(-0.5, -1.2),
-        Vec2::new(-1.0, -1.0),
-    );
-    assert_eq!(cw_triangle.winding_order(), WindingOrder::Clockwise);
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let ccw_triangle = Triangle2d::new(
-        Vec2::new(0.0, 2.0),
-        Vec2::new(-1.0, -1.0),
-        Vec2::new(-0.5, -1.2),
-    );
-    assert_eq!(ccw_triangle.winding_order(), WindingOrder::Counterclockwise);
+    #[test]
+    fn triangle_winding_order() {
+        let mut cw_triangle = Triangle2d::new(
+            Vec2::new(0.0, 2.0),
+            Vec2::new(-0.5, -1.2),
+            Vec2::new(-1.0, -1.0),
+        );
+        assert_eq!(cw_triangle.winding_order(), WindingOrder::Clockwise);
 
-    // The clockwise triangle should be the same as the counterclockwise
-    // triangle when reversed
-    cw_triangle.reverse();
-    assert_eq!(cw_triangle, ccw_triangle);
+        let ccw_triangle = Triangle2d::new(
+            Vec2::new(0.0, 2.0),
+            Vec2::new(-1.0, -1.0),
+            Vec2::new(-0.5, -1.2),
+        );
+        assert_eq!(ccw_triangle.winding_order(), WindingOrder::Counterclockwise);
 
-    let invalid_triangle = Triangle2d::new(
-        Vec2::new(0.0, 2.0),
-        Vec2::new(0.0, -1.0),
-        Vec2::new(0.0, -1.2),
-    );
-    assert_eq!(invalid_triangle.winding_order(), WindingOrder::Invalid);
+        // The clockwise triangle should be the same as the counterclockwise
+        // triangle when reversed
+        cw_triangle.reverse();
+        assert_eq!(cw_triangle, ccw_triangle);
+
+        let invalid_triangle = Triangle2d::new(
+            Vec2::new(0.0, 2.0),
+            Vec2::new(0.0, -1.0),
+            Vec2::new(0.0, -1.2),
+        );
+        assert_eq!(invalid_triangle.winding_order(), WindingOrder::Invalid);
+    }
 }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -195,7 +195,7 @@ impl Triangle2d {
         let [a, b, c] = self.vertices;
         let area = (b - a).perp_dot(c - a);
         if area > f32::EPSILON {
-            WindingOrder::Counterclockwise
+            WindingOrder::CounterClockwise
         } else if area < -f32::EPSILON {
             WindingOrder::Clockwise
         } else {
@@ -337,7 +337,7 @@ mod tests {
             Vec2::new(-1.0, -1.0),
             Vec2::new(-0.5, -1.2),
         );
-        assert_eq!(ccw_triangle.winding_order(), WindingOrder::Counterclockwise);
+        assert_eq!(ccw_triangle.winding_order(), WindingOrder::CounterClockwise);
 
         // The clockwise triangle should be the same as the counterclockwise
         // triangle when reversed

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -12,3 +12,14 @@ pub trait Primitive2d {}
 
 /// A marker trait for 3D primitives
 pub trait Primitive3d {}
+
+/// The winding order for a set of points
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WindingOrder {
+    /// A clockwise winding order
+    Clockwise,
+    /// A counterclockwise winding order
+    Counterclockwise,
+    /// An invalid winding order indicating that it could not be computed reliably
+    Invalid,
+}

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -19,7 +19,6 @@ pub enum WindingOrder {
     /// A clockwise winding order
     Clockwise,
     /// A counterclockwise winding order
-    Counterclockwise,
-    /// An invalid winding order indicating that it could not be computed reliably
+    CounterClockwise,
     Invalid,
 }

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -20,5 +20,8 @@ pub enum WindingOrder {
     Clockwise,
     /// A counterclockwise winding order
     CounterClockwise,
+    /// An invalid winding order indicating that it could not be computed reliably.
+    /// This often happens in *degenerate cases* where the points lie on the same line
+    #[doc(alias = "Degenerate")]
     Invalid,
 }


### PR DESCRIPTION
# Objective

This PR adds some helpers for `Triangle2d` to work with its winding order. This could also be extended to polygons (and `Triangle3d` once it's added).

## Solution

- Add `WindingOrder` enum with `Clockwise`, `Counterclockwise` and `Invalid` variants
  - `Invalid` is for cases where the winding order can not be reliably computed, i.e. the points lie on a single line and the area is zero
- Add `Triangle2d::winding_order` method that uses a signed surface area to determine the winding order
- Add `Triangle2d::reverse` method that reverses the winding order by swapping the second and third vertices

The API looks like this:

```rust
let mut triangle = Triangle2d::new(
    Vec2::new(0.0, 2.0),
    Vec2::new(-0.5, -1.2),
    Vec2::new(-1.0, -1.0),
);
assert_eq!(triangle.winding_order(), WindingOrder::Clockwise);

// Reverse winding order
triangle.reverse();
assert_eq!(triangle.winding_order(), WindingOrder::Counterclockwise);
```

I also added tests to make sure the methods work correctly. For now, they live in the same file as the primitives.

## Open questions

- Should it be `Counterclockwise` or `CounterClockwise`? The first one is more correct but perhaps a bit less readable. Counter-clockwise is also a valid spelling, but it seems to be a lot less common than counterclockwise.
- Is `WindingOrder::Invalid` a good name? Parry uses `TriangleOrientation::Degenerate`, but I'm not a huge fan, at least as a non-native English speaker. Any better suggestions?
- Is `WindingOrder` fine in `bevy_math::primitives`? It's not specific to a dimension, so I put it there for now.