### PR TITLE
Mesh rendering support for Gizmos

### DIFF
--- a/assets/shaders/custom_material_screenspace_texture.wgsl
+++ b/assets/shaders/custom_material_screenspace_texture.wgsl
@@ -1,7 +1,7 @@
+#import bevy_render::view::coords_to_viewport_uv
 #import bevy_pbr::{
     mesh_view_bindings::view,
     forward_io::VertexOutput,
-    utils::coords_to_viewport_uv,
 }
 
 @group(1) @binding(0) var texture: texture_2d<f32>;

--- a/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
+++ b/crates/bevy_core_pipeline/src/skybox/skybox.wgsl
@@ -1,33 +1,8 @@
-#import bevy_render::view::View
-#import bevy_pbr::utils::coords_to_viewport_uv
+#import bevy_render::view::{View, coords_to_ray_direction}
 
 @group(0) @binding(0) var skybox: texture_cube<f32>;
 @group(0) @binding(1) var skybox_sampler: sampler;
 @group(0) @binding(2) var<uniform> view: View;
-
-fn coords_to_ray_direction(position: vec2<f32>, viewport: vec4<f32>) -> vec3<f32> {
-    // Using world positions of the fragment and camera to calculate a ray direction
-    // breaks down at large translations. This code only needs to know the ray direction.
-    // The ray direction is along the direction from the camera to the fragment position.
-    // In view space, the camera is at the origin, so the view space ray direction is
-    // along the direction of the fragment position - (0,0,0) which is just the
-    // fragment position.
-    // Use the position on the near clipping plane to avoid -inf world position
-    // because the far plane of an infinite reverse projection is at infinity.
-    let view_position_homogeneous = view.inverse_projection * vec4(
-        coords_to_viewport_uv(position, viewport) * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
-        1.0,
-        1.0,
-    );
-    let view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
-    // Transforming the view space ray direction by the view matrix, transforms the
-    // direction to world space. Note that the w element is set to 0.0, as this is a
-    // vector direction, not a position, That causes the matrix multiplication to ignore
-    // the translations from the view matrix.
-    let ray_direction = (view.view * vec4(view_ray_direction, 0.0)).xyz;
-
-    return normalize(ray_direction);
-}
 
 struct VertexOutput {
     @builtin(position) position: vec4<f32>,
@@ -59,7 +34,7 @@ fn skybox_vertex(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
 
 @fragment
 fn skybox_fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    let ray_direction = coords_to_ray_direction(in.position.xy, view.viewport);
+    let ray_direction = coords_to_ray_direction(in.position.xy, view);
 
     // Cube maps are left-handed so we negate the z coordinate.
     return textureSample(skybox, skybox_sampler, ray_direction * vec3(1.0, 1.0, -1.0));

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -25,3 +25,7 @@ bevy_core = { path = "../bevy_core", version = "0.12.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
+bevy_log = { path = "../bevy_log", version = "0.12.0" }
+# Other
+thread_local = "1.0"

--- a/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh.wgsl
+++ b/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh.wgsl
@@ -1,0 +1,112 @@
+#import bevy_render::{maths::{affine_to_square, mat2x4_f32_to_mat3x3_unpack}, instance_index::get_instance_index, view::{View, coords_to_ray_direction}}
+#import bevy_core_pipeline::tonemapping::{screen_space_dither, powsafe, tone_mapping}
+// #import bevy_gizmos::utils::calculate_depth
+
+@group(0) @binding(0) var<uniform> view: View;
+
+struct Gizmo {
+    // Affine 4x3 matrices transposed to 3x4
+    // Use bevy_render::maths::affine_to_square to unpack
+    transform: mat3x4<f32>,
+    // 3x3 matrix packed in mat2x4 and f32 as:
+    // [0].xyz, [1].x,
+    // [1].yz, [2].xy
+    // [2].z
+    // Use bevy_render::maths::mat2x4_f32_to_mat3x3_unpack to unpack
+    inverse_transpose_transform_a: mat2x4<f32>,
+    inverse_transpose_transform_b: f32,
+    color: vec4<f32>
+};
+
+#ifdef PER_OBJECT_BUFFER_BATCH_SIZE
+@group(1) @binding(0) var<uniform> gizmos: array<Gizmo, #{PER_OBJECT_BUFFER_BATCH_SIZE}u>;
+#else
+@group(1) @binding(0) var<storage> gizmos: array<Gizmo>;
+#endif
+
+struct VertexInput {
+    @builtin(instance_index) instance_index: u32,
+    @location(0) position: vec3<f32>,
+#ifdef VERTEX_NORMALS
+    @location(1) normal: vec3<f32>,
+#endif
+#ifdef VERTEX_COLORS
+    @location(5) color: vec4<f32>,
+#endif
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+    @location(1) world_normal: vec3<f32>,
+}
+
+@vertex
+fn vertex(in: VertexInput) -> VertexOutput {
+    var out: VertexOutput;
+
+    let gizmo = gizmos[in.instance_index];
+
+    let transform = affine_to_square(gizmo.transform);
+    out.position = view.view_proj * transform * vec4(in.position, 1.0);
+
+#ifdef VERTEX_COLORS
+    out.color = in.color * gizmo.color;
+#elseif
+    out.color = gizmo.color;
+#endif
+
+#ifdef VERTEX_NORMALS
+    let inverse_transform = mat2x4_f32_to_mat3x3_unpack(
+        gizmo.inverse_transpose_transform_a,
+        gizmo.inverse_transpose_transform_b,
+    );
+    out.world_normal = normalize(inverse_transform * in.normal);
+#endif
+
+    return out;
+}
+
+struct FragmentOutput {
+    @location(0) color: vec4<f32>,
+}
+
+@fragment
+fn fragment(in: VertexOutput) -> FragmentOutput {
+    var out: FragmentOutput;
+
+    var color = in.color;
+
+#ifdef VERTEX_NORMALS
+    #ifdef 3D 
+        let view_direction = coords_to_ray_direction(in.position.xy, view);
+    #elseif
+        let view_direction = vec3(0., 0., -1.);
+    #endif
+    // Fake lighting
+    let d = dot(view_direction, in.world_normal);
+    color = mix(color, vec4(vec3(0.), 1.), d);
+#endif
+
+// TODO: We don't need tonemapping in this shader, but screen_space_dither would be nice to have.
+// The fake lighting above also doesn't work without tonemapping for some reason.
+
+#ifdef TONEMAP_IN_SHADER
+    color = tone_mapping(color, view.color_grading);
+#ifdef DEBAND_DITHER
+    var color_rgb = color.rgb;
+
+    // Convert to sRGB
+    color_rgb = powsafe(color_rgb, 1.0 / 2.2);
+    color_rgb += screen_space_dither(in.position.xy);
+    // Convert back to Linear sRGB
+    color_rgb = powsafe(color_rgb, 2.2);
+
+    color = vec4(color_rgb, color.a);
+#endif
+#endif
+
+    out.color = color;
+
+    return out;
+}

--- a/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_pipeline_2d.rs
@@ -1,0 +1,281 @@
+use bevy_app::{App, Plugin};
+use bevy_asset::AssetId;
+use bevy_core_pipeline::{
+    core_2d::Transparent2d,
+    tonemapping::{DebandDither, Tonemapping},
+};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{QueryItem, With},
+    schedule::IntoSystemConfigs,
+    system::{lifetimeless::SRes, Query, Res, ResMut, Resource, SystemParamItem, SystemState},
+    world::{FromWorld, World},
+};
+use bevy_log::error;
+use bevy_render::{
+    batching::{batch_and_prepare_render_phase, write_batched_instance_buffer, GetBatchData},
+    globals::GlobalsUniform,
+    mesh::{Mesh, MeshVertexBufferLayout},
+    render_asset::{prepare_assets, RenderAssets},
+    render_phase::*,
+    render_resource::*,
+    renderer::RenderDevice,
+    texture::BevyDefault,
+    view::{ExtractedView, Msaa, ViewTarget, ViewUniform, VisibleEntities},
+    Render, RenderApp, RenderSet,
+};
+use bevy_sprite::{tonemapping_pipeline_key, Mesh2dPipelineKey, SetMesh2dViewBindGroup};
+use bevy_utils::FloatOrd;
+
+use crate::mesh_pipeline::{
+    gizmo_mesh_shared::{get_batch_data, DrawGizmo, GizmoMeshShared, SetGizmoBindGroup},
+    GizmoUniform, Immediate, RenderGizmoInstances,
+};
+
+pub struct GizmoMesh2dPlugin;
+
+impl Plugin for GizmoMesh2dPlugin {
+    fn build(&self, app: &mut App) {
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .init_resource::<SpecializedMeshPipelines<GizmoMesh2dPipeline>>()
+                .add_render_command::<Transparent2d, DrawGizmo2d>()
+                .add_systems(
+                    Render,
+                    (
+                        queue_gizmos_2d
+                            .in_set(RenderSet::QueueMeshes)
+                            .after(prepare_assets::<Mesh>),
+                        batch_and_prepare_render_phase::<Transparent2d, GizmoMesh2dPipeline>
+                            .in_set(RenderSet::PrepareResources),
+                        write_batched_instance_buffer::<GizmoMesh2dPipeline>
+                            .in_set(RenderSet::PrepareResourcesFlush),
+                    ),
+                );
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app.init_resource::<GizmoMesh2dPipeline>();
+    }
+}
+
+#[derive(Component)]
+pub(super) struct Gizmo2d;
+
+#[derive(Resource, Clone)]
+struct GizmoMesh2dPipeline {
+    pub gizmo_pipeline: GizmoMeshShared,
+    pub view_layout: BindGroupLayout,
+}
+
+impl FromWorld for GizmoMesh2dPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let mut system_state: SystemState<Res<RenderDevice>> = SystemState::new(world);
+        let render_device = system_state.get_mut(world);
+
+        let view_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[
+                // View
+                BindGroupLayoutEntry {
+                    binding: 0,
+                    visibility: ShaderStages::VERTEX | ShaderStages::FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: true,
+                        min_binding_size: Some(ViewUniform::min_size()),
+                    },
+                    count: None,
+                },
+                BindGroupLayoutEntry {
+                    binding: 1,
+                    visibility: ShaderStages::VERTEX_FRAGMENT,
+                    ty: BindingType::Buffer {
+                        ty: BufferBindingType::Uniform,
+                        has_dynamic_offset: false,
+                        min_binding_size: Some(GlobalsUniform::min_size()),
+                    },
+                    count: None,
+                },
+            ],
+            label: Some("mesh2d_view_layout"),
+        });
+
+        GizmoMesh2dPipeline {
+            view_layout,
+            gizmo_pipeline: world.resource::<GizmoMeshShared>().clone(),
+        }
+    }
+}
+
+impl GetBatchData for GizmoMesh2dPipeline {
+    type Param = SRes<RenderGizmoInstances>;
+    type Query = Entity;
+    type QueryFilter = With<Gizmo2d>;
+    type CompareData = AssetId<Mesh>;
+    type BufferData = GizmoUniform;
+
+    fn get_batch_data(
+        gizmo_instances: &SystemParamItem<Self::Param>,
+        entity: &QueryItem<Self::Query>,
+    ) -> (Self::BufferData, Option<Self::CompareData>) {
+        get_batch_data(gizmo_instances, entity)
+    }
+}
+
+impl SpecializedMeshPipeline for GizmoMesh2dPipeline {
+    type Key = Mesh2dPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut shader_defs = Vec::new();
+        if key.contains(Mesh2dPipelineKey::TONEMAP_IN_SHADER) {
+            shader_defs.push("TONEMAP_IN_SHADER".into());
+
+            let method = key.intersection(Mesh2dPipelineKey::TONEMAP_METHOD_RESERVED_BITS);
+
+            match method {
+                Mesh2dPipelineKey::TONEMAP_METHOD_NONE => {
+                    shader_defs.push("TONEMAP_METHOD_NONE".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_REINHARD => {
+                    shader_defs.push("TONEMAP_METHOD_REINHARD".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE => {
+                    shader_defs.push("TONEMAP_METHOD_REINHARD_LUMINANCE".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_ACES_FITTED => {
+                    shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_AGX => {
+                    shader_defs.push("TONEMAP_METHOD_AGX".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM => {
+                    shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC => {
+                    shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
+                }
+                Mesh2dPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE => {
+                    shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+                }
+                _ => {}
+            }
+            // Debanding is tied to tonemapping in the shader, cannot run without it.
+            if key.contains(Mesh2dPipelineKey::DEBAND_DITHER) {
+                shader_defs.push("DEBAND_DITHER".into());
+            }
+        }
+        let mut descriptor = self.gizmo_pipeline.get_descriptor(layout)?;
+
+        descriptor.vertex.shader_defs.extend(shader_defs.clone());
+
+        let fragment = descriptor.fragment.as_mut().unwrap();
+
+        fragment.shader_defs.extend(shader_defs);
+
+        let format = if key.contains(Mesh2dPipelineKey::HDR) {
+            ViewTarget::TEXTURE_FORMAT_HDR
+        } else {
+            TextureFormat::bevy_default()
+        };
+
+        fragment.targets.push(Some(ColorTargetState {
+            format,
+            blend: Some(BlendState::ALPHA_BLENDING),
+            write_mask: ColorWrites::ALL,
+        }));
+
+        descriptor.layout.insert(0, self.view_layout.clone());
+        descriptor.primitive.topology = key.primitive_topology();
+        descriptor.multisample.count = key.msaa_samples();
+        descriptor.label = Some("transparent_gizmo_mesh2d_pipeline".into());
+
+        Ok(descriptor)
+    }
+}
+
+type DrawGizmo2d = (
+    SetItemPipeline,
+    SetMesh2dViewBindGroup<0>,
+    SetGizmoBindGroup<1>,
+    DrawGizmo,
+);
+
+fn queue_gizmos_2d(
+    opaque_draw_functions: Res<DrawFunctions<Transparent2d>>,
+    pipeline_cache: Res<PipelineCache>,
+    msaa: Res<Msaa>,
+    pipeline: Res<GizmoMesh2dPipeline>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<GizmoMesh2dPipeline>>,
+    render_meshes: Res<RenderAssets<Mesh>>,
+    mut render_mesh_instances: ResMut<RenderGizmoInstances>,
+    mut views: Query<(
+        &ExtractedView,
+        &VisibleEntities,
+        Option<&Tonemapping>,
+        Option<&DebandDither>,
+        &mut RenderPhase<Transparent2d>,
+    )>,
+    immediate: Query<Entity, With<Immediate>>,
+) {
+    for (view, visible_entities, tonemapping, dither, mut opaque_phase) in &mut views {
+        let draw_opaque_pbr = opaque_draw_functions.read().id::<DrawGizmo2d>();
+
+        let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
+            | Mesh2dPipelineKey::from_hdr(view.hdr);
+
+        if !view.hdr {
+            if let Some(tonemapping) = tonemapping {
+                view_key |= Mesh2dPipelineKey::TONEMAP_IN_SHADER;
+                view_key |= tonemapping_pipeline_key(*tonemapping);
+            }
+            if let Some(DebandDither::Enabled) = dither {
+                view_key |= Mesh2dPipelineKey::DEBAND_DITHER;
+            }
+        }
+
+        let visibile = visible_entities.entities.iter();
+        // Mesh gizmos created via the immediate mode API won't be in the views VisibleEntities but may be visible.
+        for entity in visibile.copied().chain(immediate.iter()) {
+            let Some(gizmo_instance) = render_mesh_instances.get_mut(&entity) else {
+                continue;
+            };
+            let Some(mesh) = render_meshes.get(gizmo_instance.mesh_asset_id) else {
+                continue;
+            };
+
+            let mut mesh_key = view_key;
+
+            mesh_key |= Mesh2dPipelineKey::from_primitive_topology(mesh.primitive_topology);
+
+            let pipeline_id =
+                pipelines.specialize(&pipeline_cache, &pipeline, mesh_key, &mesh.layout);
+            let pipeline_id = match pipeline_id {
+                Ok(id) => id,
+                Err(err) => {
+                    error!("{}", err);
+                    continue;
+                }
+            };
+
+            // + material.properties.depth_bias;
+            opaque_phase.add(Transparent2d {
+                entity,
+                draw_function: draw_opaque_pbr,
+                pipeline: pipeline_id,
+                sort_key: FloatOrd(gizmo_instance.transform.translation.z),
+                batch_range: 0..1,
+                dynamic_offset: None,
+            });
+        }
+    }
+}

--- a/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_pipeline_3d.rs
@@ -1,0 +1,299 @@
+use bevy_app::{App, Plugin};
+use bevy_asset::AssetId;
+use bevy_core_pipeline::{
+    core_3d::{Opaque3d, CORE_3D_DEPTH_FORMAT},
+    tonemapping::{DebandDither, Tonemapping},
+};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{QueryItem, With},
+    schedule::IntoSystemConfigs,
+    system::{lifetimeless::SRes, Query, Res, ResMut, Resource, SystemParamItem, SystemState},
+    world::{FromWorld, World},
+};
+use bevy_log::error;
+use bevy_pbr::*;
+use bevy_render::{
+    batching::{batch_and_prepare_render_phase, write_batched_instance_buffer, GetBatchData},
+    camera::Projection,
+    mesh::{Mesh, MeshVertexBufferLayout},
+    render_asset::{prepare_assets, RenderAssets},
+    render_phase::*,
+    render_resource::*,
+    renderer::RenderDevice,
+    texture::BevyDefault,
+    view::{ExtractedView, Msaa, ViewTarget, VisibleEntities},
+    Render, RenderApp, RenderSet,
+};
+
+use crate::mesh_pipeline::{
+    gizmo_mesh_shared::{get_batch_data, DrawGizmo, GizmoMeshShared, SetGizmoBindGroup},
+    GizmoUniform, Immediate, RenderGizmoInstances,
+};
+
+pub struct GizmoMesh3dPlugin;
+
+impl Plugin for GizmoMesh3dPlugin {
+    fn build(&self, app: &mut App) {
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .init_resource::<SpecializedMeshPipelines<GizmoMesh3dPipeline>>()
+                .add_render_command::<Opaque3d, DrawGizmo3d>()
+                .add_systems(
+                    Render,
+                    (
+                        queue_gizmos_3d
+                            .in_set(RenderSet::QueueMeshes)
+                            .after(prepare_assets::<Mesh>),
+                        batch_and_prepare_render_phase::<Opaque3d, GizmoMesh3dPipeline>
+                            .in_set(RenderSet::PrepareResources),
+                        write_batched_instance_buffer::<GizmoMesh3dPipeline>
+                            .in_set(RenderSet::PrepareResourcesFlush),
+                    ),
+                );
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app.init_resource::<GizmoMesh3dPipeline>();
+    }
+}
+
+#[derive(Component)]
+pub(super) struct Gizmo3d;
+
+#[derive(Resource, Clone)]
+struct GizmoMesh3dPipeline {
+    pub gizmo_pipeline: GizmoMeshShared,
+    view_layouts: [MeshPipelineViewLayout; MeshPipelineViewLayoutKey::COUNT],
+}
+
+impl GizmoMesh3dPipeline {
+    pub fn get_view_layout(&self, layout_key: MeshPipelineViewLayoutKey) -> &BindGroupLayout {
+        let index = layout_key.bits() as usize;
+        let layout = &self.view_layouts[index];
+        &layout.bind_group_layout
+    }
+}
+
+impl FromWorld for GizmoMesh3dPipeline {
+    fn from_world(world: &mut World) -> Self {
+        let mut system_state: SystemState<Res<RenderDevice>> = SystemState::new(world);
+        let render_device = system_state.get_mut(world);
+
+        let clustered_forward_buffer_binding_type = render_device
+            .get_supported_read_only_binding_type(CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT);
+
+        let view_layouts =
+            generate_view_layouts(&render_device, clustered_forward_buffer_binding_type);
+
+        GizmoMesh3dPipeline {
+            gizmo_pipeline: world.resource::<GizmoMeshShared>().clone(),
+            view_layouts,
+        }
+    }
+}
+
+impl GetBatchData for GizmoMesh3dPipeline {
+    type Param = SRes<RenderGizmoInstances>;
+    type Query = Entity;
+    type QueryFilter = With<Gizmo3d>;
+    type CompareData = AssetId<Mesh>;
+    type BufferData = GizmoUniform;
+
+    fn get_batch_data(
+        gizmo_instances: &SystemParamItem<Self::Param>,
+        entity: &QueryItem<Self::Query>,
+    ) -> (Self::BufferData, Option<Self::CompareData>) {
+        get_batch_data(gizmo_instances, entity)
+    }
+}
+
+impl SpecializedMeshPipeline for GizmoMesh3dPipeline {
+    type Key = MeshPipelineKey;
+
+    fn specialize(
+        &self,
+        key: Self::Key,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut shader_defs = Vec::new();
+
+        shader_defs.push("3D".into());
+
+        shader_defs.push("VERTEX_OUTPUT_INSTANCE_INDEX".into());
+
+        if key.msaa_samples() > 1 {
+            shader_defs.push("MULTISAMPLED".into());
+        };
+
+        let view_projection = key.intersection(MeshPipelineKey::VIEW_PROJECTION_RESERVED_BITS);
+        if view_projection == MeshPipelineKey::VIEW_PROJECTION_NONSTANDARD {
+            shader_defs.push("VIEW_PROJECTION_NONSTANDARD".into());
+        } else if view_projection == MeshPipelineKey::VIEW_PROJECTION_PERSPECTIVE {
+            shader_defs.push("VIEW_PROJECTION_PERSPECTIVE".into());
+        } else if view_projection == MeshPipelineKey::VIEW_PROJECTION_ORTHOGRAPHIC {
+            shader_defs.push("VIEW_PROJECTION_ORTHOGRAPHIC".into());
+        }
+
+        #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
+        shader_defs.push("WEBGL2".into());
+
+        if key.contains(MeshPipelineKey::TONEMAP_IN_SHADER) {
+            shader_defs.push("TONEMAP_IN_SHADER".into());
+
+            let method = key.intersection(MeshPipelineKey::TONEMAP_METHOD_RESERVED_BITS);
+
+            if method == MeshPipelineKey::TONEMAP_METHOD_NONE {
+                shader_defs.push("TONEMAP_METHOD_NONE".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_REINHARD {
+                shader_defs.push("TONEMAP_METHOD_REINHARD".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_REINHARD_LUMINANCE {
+                shader_defs.push("TONEMAP_METHOD_REINHARD_LUMINANCE".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_ACES_FITTED {
+                shader_defs.push("TONEMAP_METHOD_ACES_FITTED ".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_AGX {
+                shader_defs.push("TONEMAP_METHOD_AGX".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM {
+                shader_defs.push("TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_BLENDER_FILMIC {
+                shader_defs.push("TONEMAP_METHOD_BLENDER_FILMIC".into());
+            } else if method == MeshPipelineKey::TONEMAP_METHOD_TONY_MC_MAPFACE {
+                shader_defs.push("TONEMAP_METHOD_TONY_MC_MAPFACE".into());
+            }
+
+            // Debanding is tied to tonemapping in the shader, cannot run without it.
+            if key.contains(MeshPipelineKey::DEBAND_DITHER) {
+                shader_defs.push("DEBAND_DITHER".into());
+            }
+        }
+
+        let mut descriptor = self.gizmo_pipeline.get_descriptor(layout)?;
+
+        descriptor.vertex.shader_defs.extend(shader_defs.clone());
+
+        let fragment = descriptor.fragment.as_mut().unwrap();
+        fragment.shader_defs.extend(shader_defs);
+
+        let format = if key.contains(MeshPipelineKey::HDR) {
+            ViewTarget::TEXTURE_FORMAT_HDR
+        } else {
+            TextureFormat::bevy_default()
+        };
+
+        fragment.targets.push(Some(ColorTargetState {
+            format,
+            blend: None,
+            write_mask: ColorWrites::ALL,
+        }));
+
+        descriptor
+            .layout
+            .insert(0, self.get_view_layout(key.into()).clone());
+        descriptor.primitive.topology = key.primitive_topology();
+        descriptor.multisample.count = key.msaa_samples();
+        descriptor.depth_stencil = Some(DepthStencilState {
+            format: CORE_3D_DEPTH_FORMAT,
+            depth_write_enabled: true,
+            depth_compare: CompareFunction::GreaterEqual,
+            stencil: StencilState::default(),
+            bias: DepthBiasState::default(),
+        });
+
+        descriptor.label = Some("opaque_gizmo_mesh_pipeline".into());
+
+        Ok(descriptor)
+    }
+}
+
+type DrawGizmo3d = (
+    SetItemPipeline,
+    SetMeshViewBindGroup<0>,
+    SetGizmoBindGroup<1>,
+    DrawGizmo,
+);
+
+fn queue_gizmos_3d(
+    opaque_draw_functions: Res<DrawFunctions<Opaque3d>>,
+    pipeline_cache: Res<PipelineCache>,
+    msaa: Res<Msaa>,
+    pipeline: Res<GizmoMesh3dPipeline>,
+    mut pipelines: ResMut<SpecializedMeshPipelines<GizmoMesh3dPipeline>>,
+    render_meshes: Res<RenderAssets<Mesh>>,
+    mut render_mesh_instances: ResMut<RenderGizmoInstances>,
+    mut views: Query<(
+        &ExtractedView,
+        &VisibleEntities,
+        Option<&Tonemapping>,
+        Option<&DebandDither>,
+        Option<&Projection>,
+        &mut RenderPhase<Opaque3d>,
+    )>,
+    immediate: Query<Entity, With<Immediate>>,
+) {
+    for (view, visible_entities, tonemapping, dither, projection, mut opaque_phase) in &mut views {
+        let draw_opaque_pbr = opaque_draw_functions.read().id::<DrawGizmo3d>();
+
+        let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples())
+            | MeshPipelineKey::from_hdr(view.hdr);
+
+        if let Some(projection) = projection {
+            view_key |= match projection {
+                Projection::Perspective(_) => MeshPipelineKey::VIEW_PROJECTION_PERSPECTIVE,
+                Projection::Orthographic(_) => MeshPipelineKey::VIEW_PROJECTION_ORTHOGRAPHIC,
+            };
+        }
+
+        if !view.hdr {
+            if let Some(tonemapping) = tonemapping {
+                view_key |= MeshPipelineKey::TONEMAP_IN_SHADER;
+                view_key |= tonemapping_pipeline_key(*tonemapping);
+            }
+            if let Some(DebandDither::Enabled) = dither {
+                view_key |= MeshPipelineKey::DEBAND_DITHER;
+            }
+        }
+        let rangefinder = view.rangefinder3d();
+
+        let visibile = visible_entities.entities.iter();
+        // Mesh gizmos created via the immediate mode API won't be in the views VisibleEntities but may be visible.
+        for entity in visibile.copied().chain(immediate.iter()) {
+            let Some(gizmo_instance) = render_mesh_instances.get_mut(&entity) else {
+                continue;
+            };
+            let Some(mesh) = render_meshes.get(gizmo_instance.mesh_asset_id) else {
+                continue;
+            };
+
+            let mut mesh_key = view_key;
+
+            mesh_key |= MeshPipelineKey::from_primitive_topology(mesh.primitive_topology);
+
+            let pipeline_id =
+                pipelines.specialize(&pipeline_cache, &pipeline, mesh_key, &mesh.layout);
+            let pipeline_id = match pipeline_id {
+                Ok(id) => id,
+                Err(err) => {
+                    error!("{}", err);
+                    continue;
+                }
+            };
+
+            let distance = rangefinder.distance_translation(&gizmo_instance.transform.translation);
+            // TODO: + material.properties.depth_bias;
+            opaque_phase.add(Opaque3d {
+                entity,
+                draw_function: draw_opaque_pbr,
+                pipeline: pipeline_id,
+                distance,
+                batch_range: 0..1,
+                dynamic_offset: None,
+            });
+        }
+    }
+}

--- a/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_shared.rs
+++ b/crates/bevy_gizmos/src/mesh_pipeline/gizmo_mesh_shared.rs
@@ -1,0 +1,225 @@
+//! Shared setup for 2D and 3D
+
+use bevy_asset::AssetId;
+use bevy_ecs::{
+    entity::Entity,
+    system::{lifetimeless::SRes, Res, ResMut, Resource, SystemParamItem, SystemState},
+    world::{FromWorld, World},
+};
+use bevy_render::{
+    mesh::{GpuBufferInfo, Mesh, MeshVertexBufferLayout},
+    render_asset::RenderAssets,
+    render_phase::*,
+    render_resource::*,
+    renderer::RenderDevice,
+};
+
+use crate::mesh_pipeline::{GizmoUniform, RenderGizmoInstances, GIZMO_MESH_SHADER_HANDLE};
+
+#[derive(Resource, Clone)]
+pub(super) struct GizmoMeshShared {
+    pub gizmo_layout: BindGroupLayout,
+}
+
+impl GizmoMeshShared {
+    pub fn get_descriptor(
+        &self,
+        layout: &MeshVertexBufferLayout,
+    ) -> Result<RenderPipelineDescriptor, SpecializedMeshPipelineError> {
+        let mut shader_defs = Vec::new();
+        let mut vertex_attributes = Vec::new();
+
+        if layout.contains(Mesh::ATTRIBUTE_POSITION) {
+            shader_defs.push("VERTEX_POSITIONS".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_POSITION.at_shader_location(0));
+        }
+
+        if layout.contains(Mesh::ATTRIBUTE_NORMAL) {
+            shader_defs.push("VERTEX_NORMALS".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_NORMAL.at_shader_location(1));
+        }
+
+        if layout.contains(Mesh::ATTRIBUTE_COLOR) {
+            shader_defs.push("VERTEX_COLORS".into());
+            vertex_attributes.push(Mesh::ATTRIBUTE_COLOR.at_shader_location(4));
+        }
+
+        let vertex_buffer_layout = layout.get_layout(&vertex_attributes)?;
+
+        let mut push_constant_ranges = Vec::with_capacity(1);
+        if cfg!(all(feature = "webgl", target_arch = "wasm32")) {
+            push_constant_ranges.push(PushConstantRange {
+                stages: ShaderStages::VERTEX,
+                range: 0..4,
+            });
+        }
+
+        Ok(RenderPipelineDescriptor {
+            vertex: VertexState {
+                shader: GIZMO_MESH_SHADER_HANDLE,
+                entry_point: "vertex".into(),
+                shader_defs: shader_defs.clone(),
+                buffers: vec![vertex_buffer_layout],
+            },
+            fragment: Some(FragmentState {
+                shader: GIZMO_MESH_SHADER_HANDLE,
+                shader_defs,
+                entry_point: "fragment".into(),
+                targets: vec![],
+            }),
+            layout: vec![self.gizmo_layout.clone()],
+            push_constant_ranges,
+            primitive: PrimitiveState {
+                cull_mode: Some(Face::Back),
+                ..Default::default()
+            },
+            depth_stencil: None,
+            multisample: Default::default(),
+            label: None,
+        })
+    }
+}
+
+impl FromWorld for GizmoMeshShared {
+    fn from_world(world: &mut World) -> Self {
+        let mut system_state: SystemState<Res<RenderDevice>> = SystemState::new(world);
+        let render_device = system_state.get_mut(world);
+
+        let gizmo_layout = render_device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            entries: &[GpuArrayBuffer::<GizmoUniform>::binding_layout(
+                0,
+                ShaderStages::VERTEX_FRAGMENT,
+                &render_device,
+            )],
+            label: Some("gizmo_layout"),
+        });
+
+        GizmoMeshShared { gizmo_layout }
+    }
+}
+
+pub(super) fn get_batch_data(
+    gizmo_instances: &RenderGizmoInstances,
+    entity: &Entity,
+) -> (GizmoUniform, Option<AssetId<Mesh>>) {
+    let gizmo_instance = gizmo_instances.get(entity).unwrap();
+
+    let (inverse_transpose_model_a, inverse_transpose_model_b) =
+        gizmo_instance.transform.inverse_transpose_3x3();
+    (
+        GizmoUniform {
+            color: gizmo_instance.color,
+            transform: gizmo_instance.transform.to_transpose(),
+            inverse_transpose_model_a,
+            inverse_transpose_model_b,
+        },
+        Some(gizmo_instance.mesh_asset_id),
+    )
+}
+
+/// Bind groups for meshes currently loaded.
+#[derive(Resource, Default)]
+pub struct GizmoBindgroup {
+    model: Option<BindGroup>,
+}
+
+pub(super) fn prepare_gizmo_bind_group(
+    mut group: ResMut<GizmoBindgroup>,
+    gizmo_pipeline: Res<GizmoMeshShared>,
+    render_device: Res<RenderDevice>,
+    gizmo_uniforms: Res<GpuArrayBuffer<GizmoUniform>>,
+) {
+    group.model = None;
+    let Some(model) = gizmo_uniforms.binding() else {
+        return;
+    };
+
+    group.model = Some(render_device.create_bind_group(
+        "gizmo_uniform_bind_group",
+        &gizmo_pipeline.gizmo_layout,
+        &[BindGroupEntry {
+            binding: 0,
+            resource: model.clone(),
+        }],
+    ));
+}
+
+pub struct SetGizmoBindGroup<const I: usize>;
+impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetGizmoBindGroup<I> {
+    type Param = SRes<GizmoBindgroup>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = ();
+
+    #[inline]
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        _item_query: (),
+        bind_group: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let bind_group = bind_group.into_inner();
+        let Some(bind_group) = bind_group.model.as_ref() else {
+            return RenderCommandResult::Failure;
+        };
+
+        let mut dynamic_offsets: [u32; 1] = Default::default();
+        let mut offset_count = 0;
+        if let Some(dynamic_offset) = item.dynamic_offset() {
+            dynamic_offsets[offset_count] = dynamic_offset.get();
+            offset_count += 1;
+        }
+        pass.set_bind_group(I, bind_group, &dynamic_offsets[0..offset_count]);
+
+        RenderCommandResult::Success
+    }
+}
+
+pub(super) struct DrawGizmo;
+impl<P: PhaseItem> RenderCommand<P> for DrawGizmo {
+    type Param = (SRes<RenderAssets<Mesh>>, SRes<RenderGizmoInstances>);
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = ();
+    #[inline]
+    fn render<'w>(
+        item: &P,
+        _view: (),
+        _item_query: (),
+        (meshes, gizmo_instances): SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let meshes = meshes.into_inner();
+        let gizmo_instances = gizmo_instances.into_inner();
+
+        let Some(gizmo_instance) = gizmo_instances.get(&item.entity()) else {
+            return RenderCommandResult::Failure;
+        };
+        let Some(gpu_mesh) = meshes.get(gizmo_instance.mesh_asset_id) else {
+            return RenderCommandResult::Failure;
+        };
+
+        pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));
+
+        let batch_range = item.batch_range();
+        #[cfg(all(feature = "webgl", target_arch = "wasm32"))]
+        pass.set_push_constants(
+            ShaderStages::VERTEX,
+            0,
+            &(batch_range.start as i32).to_le_bytes(),
+        );
+        match &gpu_mesh.buffer_info {
+            GpuBufferInfo::Indexed {
+                buffer,
+                index_format,
+                count,
+            } => {
+                pass.set_index_buffer(buffer.slice(..), 0, *index_format);
+                pass.draw_indexed(0..*count, 0, batch_range.clone());
+            }
+            GpuBufferInfo::NonIndexed => {
+                pass.draw(0..gpu_mesh.vertex_count, batch_range.clone());
+            }
+        }
+        RenderCommandResult::Success
+    }
+}

--- a/crates/bevy_gizmos/src/mesh_pipeline/mod.rs
+++ b/crates/bevy_gizmos/src/mesh_pipeline/mod.rs
@@ -1,0 +1,243 @@
+use std::cell::Cell;
+
+use bevy_app::{Plugin, First};
+use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::{
+    bundle::Bundle,
+    component::Component,
+    entity::Entity,
+    schedule::IntoSystemConfigs,
+    system::{Commands, Local, Query, Res, ResMut, Resource},
+};
+use bevy_math::{Affine3, Vec4};
+use bevy_render::{
+    color::Color,
+    mesh::Mesh,
+    render_resource::{GpuArrayBuffer, Shader, ShaderDefVal, ShaderType},
+    renderer::RenderDevice,
+    view::{InheritedVisibility, ViewVisibility, Visibility},
+    Extract, ExtractSchedule, RenderApp, RenderSet, Render,
+};
+use bevy_transform::components::{GlobalTransform, Transform};
+use bevy_utils::EntityHashMap;
+use thread_local::ThreadLocal;
+
+use crate::{gizmos::GizmoStorage, mesh_pipeline::gizmo_mesh_shared::{GizmoMeshShared, GizmoBindgroup, prepare_gizmo_bind_group}};
+
+#[cfg(feature = "bevy_sprite")]
+mod gizmo_mesh_pipeline_2d;
+#[cfg(feature = "bevy_pbr")]
+mod gizmo_mesh_pipeline_3d;
+
+mod gizmo_mesh_shared;
+
+const GIZMO_MESH_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7012430448968376275);
+
+pub struct GizmoMeshPlugin;
+
+impl Plugin for GizmoMeshPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .init_resource::<RenderGizmoInstances>()
+            .init_resource::<GizmoBindgroup>()
+            .add_systems(
+                ExtractSchedule,
+                (extract_gizmos_meshes, extract_immediate_gizmo_meshes).chain(),
+            )
+            .add_systems(
+                Render,
+                prepare_gizmo_bind_group.in_set(RenderSet::PrepareBindGroups),
+            );
+
+        
+        #[cfg(feature = "bevy_sprite")]
+        app.add_plugins(gizmo_mesh_pipeline_2d::GizmoMesh2dPlugin);
+        #[cfg(feature = "bevy_pbr")]
+        app.add_plugins(gizmo_mesh_pipeline_3d::GizmoMesh3dPlugin);
+
+        app.add_systems(First, clear_immediate_mode_meshes);
+    }
+
+    fn finish(&self, app: &mut bevy_app::App) {
+        let mut gizmo_bindings_shader_defs = Vec::new();
+
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            if let Some(per_object_buffer_batch_size) = GpuArrayBuffer::<GizmoUniform>::batch_size(
+                render_app.world.resource::<RenderDevice>(),
+            ) {
+                gizmo_bindings_shader_defs.push(ShaderDefVal::UInt(
+                    "PER_OBJECT_BUFFER_BATCH_SIZE".into(),
+                    per_object_buffer_batch_size,
+                ));
+            }
+
+            render_app.insert_resource(GpuArrayBuffer::<GizmoUniform>::new(
+                render_app.world.resource::<RenderDevice>(),
+            ));
+
+            render_app.init_resource::<GizmoMeshShared>();
+        }
+
+        // Load the shader here as it depends on runtime information about
+        // whether storage buffers are supported, or the maximum uniform buffer binding size.
+        load_internal_asset!(
+            app,
+            GIZMO_MESH_SHADER_HANDLE,
+            "gizmo_mesh.wgsl",
+            Shader::from_wgsl_with_defs,
+            gizmo_bindings_shader_defs
+        );
+    }
+}
+
+#[derive(ShaderType, Clone)]
+struct GizmoUniform {
+    // Affine 4x3 matrices transposed to 3x4
+    pub transform: [Vec4; 3],
+    // 3x3 matrix packed in mat2x4 and f32 as:
+    //   [0].xyz, [1].x,
+    //   [1].yz, [2].xy
+    //   [2].z
+    pub inverse_transpose_model_a: [Vec4; 2],
+    pub inverse_transpose_model_b: f32,
+    pub color: Vec4,
+}
+
+struct RenderGizmoInstance {
+    pub transform: Affine3,
+    pub mesh_asset_id: AssetId<Mesh>,
+    pub color: Vec4,
+}
+
+#[derive(Default, Resource, Deref, DerefMut)]
+struct RenderGizmoInstances(EntityHashMap<Entity, RenderGizmoInstance>);
+
+/// Controls the way the gizmo will be rendered.
+#[derive(Component, Default, Clone, Debug)]
+pub struct GizmoStyle {
+    /// Color
+    pub color: Color,
+}
+
+/// 
+#[derive(Bundle, Default, Clone, Debug)]
+pub struct GizmoMeshBundle {
+    /// Controls the look of the gizmo.
+    pub style: GizmoStyle,
+    /// The mesh to be rendered.
+    pub mesh: Handle<Mesh>,
+    /// The transform of the entity.
+    pub transform: Transform,
+    /// The computed global transform of the entity.
+    pub global_transform: GlobalTransform,
+    /// The visibility of the entity.
+    pub visibility: Visibility,
+    /// The inherited visibility of the entity.
+    pub inherited_visibility: InheritedVisibility,
+    /// The view visibility of the entity.
+    pub view_visibility: ViewVisibility,
+}
+
+/// Extracts gizmo meshes from main world .
+fn extract_gizmos_meshes(
+    mut commands: Commands,
+    mut previous_len: Local<usize>,
+    mut render_mesh_instances: ResMut<RenderGizmoInstances>,
+    mut thread_local_queues: Local<ThreadLocal<Cell<Vec<(Entity, RenderGizmoInstance)>>>>,
+    gizmos_query: Extract<
+        Query<(
+            Entity,
+            &ViewVisibility,
+            &GlobalTransform,
+            &Handle<Mesh>,
+            &GizmoStyle,
+        )>,
+    >,
+) {
+    gizmos_query
+        .par_iter()
+        .for_each(|(entity, view_visibility, transform, handle, gizmo)| {
+            if !view_visibility.get() {
+                return;
+            }
+            let transform = transform.affine();
+            let tls = thread_local_queues.get_or_default();
+            let mut queue = tls.take();
+            queue.push((
+                entity,
+                RenderGizmoInstance {
+                    mesh_asset_id: handle.id(),
+                    transform: (&transform).into(),
+                    color: gizmo.color.as_linear_rgba_f32().into(),
+                },
+            ));
+            tls.set(queue);
+        });
+
+    render_mesh_instances.clear();
+    let mut entities = Vec::with_capacity(*previous_len);
+    for queue in thread_local_queues.iter_mut() {
+        // FIXME: Remove this - it is just a workaround to enable rendering to work as
+        // render commands require an entity to exist at the moment.
+
+        entities.extend(queue.get_mut().iter().map(|(e, _)| {
+            (
+                *e,
+                (
+                    #[cfg(feature = "bevy_sprite")]
+                    gizmo_mesh_pipeline_2d::Gizmo2d,
+                    #[cfg(feature = "bevy_pbr")]
+                    gizmo_mesh_pipeline_3d::Gizmo3d,
+                ),
+            )
+        }));
+        render_mesh_instances.extend(queue.get_mut().drain(..));
+    }
+    *previous_len = entities.len();
+    commands.insert_or_spawn_batch(entities);
+}
+
+/// Marker component for gizmo meshes created in the render world via the immediate mode API.
+#[derive(Component)]
+struct Immediate;
+
+/// Extracts gizmo meshes from the immediate mode API.
+fn extract_immediate_gizmo_meshes(
+    mut commands: Commands,
+    gizmo_storage: Extract<Res<GizmoStorage>>,
+    mut render_gizmo_instances: ResMut<RenderGizmoInstances>,
+) {
+    for (mesh_id, transform, color) in &gizmo_storage.meshes {
+        let transform = GlobalTransform::from(*transform);
+        let entity = commands
+            .spawn((
+                #[cfg(feature = "bevy_pbr")]
+                (gizmo_mesh_pipeline_3d::Gizmo3d, Handle::Weak(*mesh_id)),
+                #[cfg(feature = "bevy_sprite")]
+                (
+                    gizmo_mesh_pipeline_2d::Gizmo2d,
+                    bevy_sprite::Mesh2dHandle(Handle::Weak(*mesh_id)),
+                ),
+                Immediate,
+            ))
+            .id();
+
+        render_gizmo_instances.insert(
+            entity,
+            RenderGizmoInstance {
+                color: color.as_linear_rgba_f32().into(),
+                transform: (&transform.affine()).into(),
+                mesh_asset_id: mesh_id.clone(),
+            },
+        );
+    }
+}
+
+fn clear_immediate_mode_meshes(mut storage: ResMut<GizmoStorage>) {
+    storage.meshes.clear();
+}

--- a/crates/bevy_gizmos/src/utils.wgsl
+++ b/crates/bevy_gizmos/src/utils.wgsl
@@ -1,0 +1,18 @@
+#define_import_path bevy_gizmos::utils
+
+const EPSILON: f32 = 4.88e-04;
+
+fn calculate_depth(depth_bias: f32, clip: vec4<f32>) -> f32 {
+    if depth_bias >= 0. {
+        return clip.z * (1. - depth_bias);
+    } else {
+        // depth * (clip.w / depth)^-depth_bias. So that when -depth_bias is 1.0, this is equal to clip.w
+        // and when equal to 0.0, it is exactly equal to depth.
+        // the epsilon is here to prevent the depth from exceeding clip.w when -depth_bias = 1.0 
+        // clip.w represents the near plane in homogeneous clip space in bevy, having a depth
+        // of this value means nothing can be in front of this
+        // The reason this uses an exponential function is that it makes it much easier for the 
+        // user to chose a value that is convenient for them
+        return clip.z * exp2(-depth_bias * log2(clip.w / clip.z - EPSILON));
+    }
+}

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -416,7 +416,7 @@ const fn alpha_mode_pipeline_key(alpha_mode: AlphaMode) -> MeshPipelineKey {
     }
 }
 
-const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> MeshPipelineKey {
+pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> MeshPipelineKey {
     match tonemapping {
         Tonemapping::None => MeshPipelineKey::TONEMAP_METHOD_NONE,
         Tonemapping::Reinhard => MeshPipelineKey::TONEMAP_METHOD_REINHARD,

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -9,7 +9,7 @@ struct Mesh {
     // [0].xyz, [1].x,
     // [1].yz, [2].xy
     // [2].z
-    // Use bevy_pbr::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
+    // Use bevy_render::maths::mat2x4_f32_to_mat3x3_unpack to unpack
     inverse_transpose_model_a: mat2x4<f32>,
     inverse_transpose_model_b: f32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.

--- a/crates/bevy_pbr/src/render/utils.wgsl
+++ b/crates/bevy_pbr/src/render/utils.wgsl
@@ -21,14 +21,6 @@ fn random1D(s: f32) -> f32 {
     return fract(sin(s * 12.9898) * 43758.5453123);
 }
 
-// returns the (0-1, 0-1) position within the given viewport for the current buffer coords .
-// buffer coords can be obtained from `@builtin(position).xy`.
-// the view uniform struct contains the current camera viewport in `view.viewport`.
-// topleft = 0,0
-fn coords_to_viewport_uv(position: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
-    return (position - viewport.xy) / viewport.zw;
-}
-
 // https://jcgt.org/published/0003/02/01/paper.pdf
 
 // For encoding normals or unit direction vectors as octahedral coordinates.

--- a/crates/bevy_render/src/view/view.wgsl
+++ b/crates/bevy_render/src/view/view.wgsl
@@ -22,3 +22,34 @@ struct View {
     color_grading: ColorGrading,
     mip_bias: f32,
 };
+
+// returns the (0-1, 0-1) position within the given viewport for the current buffer coords .
+// buffer coords can be obtained from `@builtin(position).xy` in the fragment shader.
+// topleft = 0,0
+fn coords_to_viewport_uv(position: vec2<f32>, viewport: vec4<f32>) -> vec2<f32> {
+    return (position - viewport.xy) / viewport.zw;
+}
+
+fn coords_to_ray_direction(position: vec2<f32>, view: View) -> vec3<f32> {
+    // Using world positions of the fragment and camera to calculate a ray direction
+    // breaks down at large translations. This code only needs to know the ray direction.
+    // The ray direction is along the direction from the camera to the fragment position.
+    // In view space, the camera is at the origin, so the view space ray direction is
+    // along the direction of the fragment position - (0,0,0) which is just the
+    // fragment position.
+    // Use the position on the near clipping plane to avoid -inf world position
+    // because the far plane of an infinite reverse projection is at infinity.
+    let view_position_homogeneous = view.inverse_projection * vec4(
+        coords_to_viewport_uv(position, view.viewport) * vec2(2.0, -2.0) + vec2(-1.0, 1.0),
+        1.0,
+        1.0,
+    );
+    let view_ray_direction = view_position_homogeneous.xyz / view_position_homogeneous.w;
+    // Transforming the view space ray direction by the view matrix, transforms the
+    // direction to world space. Note that the w element is set to 0.0, as this is a
+    // vector direction, not a position, That causes the matrix multiplication to ignore
+    // the translations from the view matrix.
+    let ray_direction = (view.view * vec4(view_ray_direction, 0.0)).xyz;
+
+    return normalize(ray_direction);
+}

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -348,7 +348,7 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
     }
 }
 
-const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> Mesh2dPipelineKey {
+pub const fn tonemapping_pipeline_key(tonemapping: Tonemapping) -> Mesh2dPipelineKey {
     match tonemapping {
         Tonemapping::None => Mesh2dPipelineKey::TONEMAP_METHOD_NONE,
         Tonemapping::Reinhard => Mesh2dPipelineKey::TONEMAP_METHOD_REINHARD,

--- a/examples/2d/2d_gizmos.rs
+++ b/examples/2d/2d_gizmos.rs
@@ -3,7 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::prelude::*;
-
+use bevy::render::camera::ScalingMode;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
@@ -12,8 +12,20 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
-    commands.spawn(Camera2dBundle::default());
+fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>, asset_server: Res<AssetServer>) {
+    commands.insert_resource(MyMesh(meshes.add(shape::Cube { size: 1.0 }.into())));
+    commands.spawn(Camera2dBundle {
+        projection: OrthographicProjection {
+            scaling_mode: ScalingMode::FixedVertical(1080.),
+            ..default()
+        },
+        ..default()
+    });
+
+    commands.spawn(SpriteBundle {
+        texture: asset_server.load("branding/icon.png"),
+        ..default()
+    });
     // text
     commands.spawn(TextBundle::from_section(
         "Hold 'Left' or 'Right' to change the line width",
@@ -24,8 +36,18 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         },
     ));
 }
+#[derive(Resource)]
+struct MyMesh(Handle<Mesh>);
 
-fn system(mut gizmos: Gizmos, time: Res<Time>) {
+fn system(mut gizmos: Gizmos, time: Res<Time>, mesh: Res<MyMesh>) {
+    gizmos.mesh(
+        &mesh.0,
+        Transform::from_xyz(0., 1., -50.)
+            .with_rotation(Quat::from_rotation_x(-time.elapsed_seconds()))
+            .with_scale(Vec3::splat(50.)),
+        Color::RED,
+    );
+
     let sin = time.elapsed_seconds().sin() * 50.;
     gizmos.line_2d(Vec2::Y * -sin, Vec2::splat(-80.), Color::RED);
     gizmos.ray_2d(Vec2::Y * sin, Vec2::splat(80.), Color::GREEN);

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -17,6 +17,8 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    commands.insert_resource(MyMesh(meshes.add(shape::Cube { size: 1.0 }.into())));
+
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0., 1.5, 6.).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
@@ -28,9 +30,11 @@ fn setup(
         ..default()
     });
     // cube
-    commands.spawn(PbrBundle {
+    commands.spawn(GizmoMeshBundle {
+        style: GizmoStyle {
+            color: Color::rgb(0.8, 0.7, 0.6),
+        },
         mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
@@ -65,7 +69,16 @@ fn setup(
     );
 }
 
-fn system(mut gizmos: Gizmos, time: Res<Time>) {
+#[derive(Resource)]
+struct MyMesh(Handle<Mesh>);
+
+fn system(mut gizmos: Gizmos, time: Res<Time>, mesh: Res<MyMesh>) {
+    gizmos.mesh(
+        &mesh.0,
+        Transform::from_xyz(1., 1., 0.)
+            .with_rotation(Quat::from_rotation_x(time.elapsed_seconds())),
+        Color::RED,
+    );
     gizmos.cuboid(
         Transform::from_translation(Vec3::Y * 0.5).with_scale(Vec3::splat(1.)),
         Color::BLACK,


### PR DESCRIPTION
# Objective
Add support for rendering meshes to `bevy_gizmos`.

## Solution
Adapt the mesh rendering code from `bevy_pbr` and `bevy_sprite` for gizmo rendering.

I copied the `mesh.rs` files from both `bevy_pbr` and `bevy_sprite` and dumbed them down to rendering just a mesh with a color and some fake shading via a single uniform, removing support for any materials, textures or lighting, hopefully gaining some performance.

`gizmo_mesh_pipeline_3d.rs` is `mesh.rs` adapted from `bevy_pbr`.
`gizmo_mesh_pipeline_2d.rs` is `mesh.rs` adapted from `bevy_sprite`.
`gizmo_mesh_shared.rs` has the code that can be shared between those files.
Additional types and extraction to the render world is in `mesh_pipeline/mod.rs`.

The new API can be seen used in the `3d_gizmos` example. (It needs some cleaning up though) 

## Changelog
Added `mesh` method to the `Gizmos` system parameter for drawing meshes as gizmos.
Added `GizmoMeshBundle` that act much like `PbrBundle` but instead of having a material asset it has a simple `GizmoStyle` component containing only an option for color at the moment.

TODO
Test whether the performance is worth the code duplication between this and `bevy_pbr` + `bevy_sprite` or whether something more janky but with less code duplication is better
Split some changes from this PR 
Yeet tonemapping
Wail in terror
Test that bevy_gizmos still compiles when either bevy_pbr or bevy_sprite is disabled
Some additional cleanup, probably
