### PR TITLE
AssetMetaMode

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -77,7 +77,7 @@ pub struct AssetPlugin {
     /// The [`AssetMode`] to use for this server.
     pub mode: AssetMode,
     /// How meta files should be accessed. This will be ignored for processed assets, as this mode require meta files.
-    pub meta_mode: AssetMetaMode,
+    pub meta_check: MetaCheck,
 }
 
 #[derive(Debug)]
@@ -104,15 +104,16 @@ pub enum AssetMode {
     Processed,
 }
 
-/// Configures how asset meta will be used.
+/// Configures how / if meta files will be checked. If an asset's meta file is not checked, the default meta for the asset
+/// will be used.
 #[derive(Debug, Default, Clone)]
-pub enum AssetMetaMode {
-    /// Always assume assets have meta files.
+pub enum MetaCheck {
+    /// Always check if assets have meta files. If the meta does not exist, the default meta will be used.
     #[default]
     Always,
     /// Only look up meta files for the provided paths. The default meta will be used for any paths not contained in this set.
     Paths(HashSet<AssetPath<'static>>),
-    /// Never assume assets have meta files. If meta files exist, they will be ignored and the default meta will be used.
+    /// Never check if assets have meta files and always use the default meta. If meta files exist, they will be ignored and the default meta will be used.
     Never,
 }
 
@@ -123,7 +124,7 @@ impl Default for AssetPlugin {
             file_path: Self::DEFAULT_UNPROCESSED_FILE_PATH.to_string(),
             processed_file_path: Self::DEFAULT_PROCESSED_FILE_PATH.to_string(),
             watch_for_changes_override: None,
-            meta_mode: Default::default(),
+            meta_check: Default::default(),
         }
     }
 }
@@ -162,7 +163,7 @@ impl Plugin for AssetPlugin {
                     app.insert_resource(AssetServer::new(
                         sources,
                         AssetServerMode::Unprocessed,
-                        self.meta_mode.clone(),
+                        self.meta_check.clone(),
                         watch,
                     ));
                 }
@@ -178,7 +179,7 @@ impl Plugin for AssetPlugin {
                             sources,
                             processor.server().data.loaders.clone(),
                             AssetServerMode::Processed,
-                            AssetMetaMode::Always,
+                            MetaCheck::Always,
                             watch,
                         ))
                         .insert_resource(processor)
@@ -191,7 +192,7 @@ impl Plugin for AssetPlugin {
                         app.insert_resource(AssetServer::new(
                             sources,
                             AssetServerMode::Processed,
-                            AssetMetaMode::Always,
+                            MetaCheck::Always,
                             watch,
                         ));
                     }

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
+    AssetLoadError, AssetMetaMode, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
     MissingAssetLoaderForExtensionError,
 };
 use bevy_ecs::prelude::*;
@@ -72,7 +72,12 @@ impl AssetProcessor {
         // The asset processor uses its own asset server with its own id space
         let mut sources = source.build_sources(false, false);
         sources.gate_on_processor(data.clone());
-        let server = AssetServer::new(sources, AssetServerMode::Processed, false);
+        let server = AssetServer::new(
+            sources,
+            AssetServerMode::Processed,
+            AssetMetaMode::Always,
+            false,
+        );
         Self { server, data }
     }
 

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError, MetaCheck,
+    AssetLoadError, AssetMetaCheck, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
     MissingAssetLoaderForExtensionError,
 };
 use bevy_ecs::prelude::*;
@@ -72,10 +72,10 @@ impl AssetProcessor {
         // The asset processor uses its own asset server with its own id space
         let mut sources = source.build_sources(false, false);
         sources.gate_on_processor(data.clone());
-        let server = AssetServer::new(
+        let server = AssetServer::new_with_meta_check(
             sources,
             AssetServerMode::Processed,
-            MetaCheck::Always,
+            AssetMetaCheck::Always,
             false,
         );
         Self { server, data }

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -13,7 +13,7 @@ use crate::{
         get_asset_hash, get_full_asset_hash, AssetAction, AssetActionMinimal, AssetHash, AssetMeta,
         AssetMetaDyn, AssetMetaMinimal, ProcessedInfo, ProcessedInfoMinimal,
     },
-    AssetLoadError, AssetMetaMode, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError,
+    AssetLoadError, AssetPath, AssetServer, AssetServerMode, DeserializeMetaError, MetaCheck,
     MissingAssetLoaderForExtensionError,
 };
 use bevy_ecs::prelude::*;
@@ -75,7 +75,7 @@ impl AssetProcessor {
         let server = AssetServer::new(
             sources,
             AssetServerMode::Processed,
-            AssetMetaMode::Always,
+            MetaCheck::Always,
             false,
         );
         Self { server, data }

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -12,8 +12,8 @@ use crate::{
         MetaTransform, Settings,
     },
     path::AssetPath,
-    Asset, AssetEvent, AssetHandleProvider, AssetId, AssetMetaMode, Assets, DeserializeMetaError,
-    ErasedLoadedAsset, Handle, LoadedUntypedAsset, UntypedAssetId, UntypedHandle,
+    Asset, AssetEvent, AssetHandleProvider, AssetId, Assets, DeserializeMetaError,
+    ErasedLoadedAsset, Handle, LoadedUntypedAsset, MetaCheck, UntypedAssetId, UntypedHandle,
 };
 use bevy_ecs::prelude::*;
 use bevy_log::{error, info, warn};
@@ -54,7 +54,7 @@ pub(crate) struct AssetServerData {
     asset_event_receiver: Receiver<InternalAssetEvent>,
     sources: AssetSources,
     mode: AssetServerMode,
-    meta_mode: AssetMetaMode,
+    meta_mode: MetaCheck,
 }
 
 /// The "asset mode" the server is currently in.
@@ -72,7 +72,7 @@ impl AssetServer {
     pub fn new(
         sources: AssetSources,
         mode: AssetServerMode,
-        meta_mode: AssetMetaMode,
+        meta_mode: MetaCheck,
         watching_for_changes: bool,
     ) -> Self {
         Self::new_with_loaders(
@@ -88,7 +88,7 @@ impl AssetServer {
         sources: AssetSources,
         loaders: Arc<RwLock<AssetLoaders>>,
         mode: AssetServerMode,
-        meta_mode: AssetMetaMode,
+        meta_mode: MetaCheck,
         watching_for_changes: bool,
     ) -> Self {
         let (asset_event_sender, asset_event_receiver) = crossbeam_channel::unbounded();
@@ -826,9 +826,9 @@ impl AssetServer {
         };
         let reader = asset_reader.read(asset_path.path()).await?;
         let read_meta = match &self.data.meta_mode {
-            AssetMetaMode::Always => true,
-            AssetMetaMode::Paths(paths) => paths.contains(asset_path),
-            AssetMetaMode::Never => false,
+            MetaCheck::Always => true,
+            MetaCheck::Paths(paths) => paths.contains(asset_path),
+            MetaCheck::Never => false,
         };
 
         if read_meta {


### PR DESCRIPTION
# Objective

Fixes #10157

## Solution

Add `AssetMetaCheck` resource which can configure when/if asset meta files will be read:

```rust
app
  // Never attempts to look up meta files. The default meta configuration will be used for each asset.
  .insert_resource(AssetMetaCheck::Never)
  .add_plugins(DefaultPlugins)
```


This serves as a band-aid fix for the issue with wasm's `HttpWasmAssetReader` creating a bunch of requests for non-existent meta, which can slow down asset loading (by waiting for the 404 response) and creates a bunch of noise in the logs. This also provides a band-aid fix for the more serious issue of itch.io deployments returning 403 responses, which results in full failure of asset loads.

If users don't want to include meta files for all deployed assets for web builds, and they aren't using meta files at all, they should set this to `AssetMetaCheck::Never`.

If users do want to include meta files for specific assets, they can use `AssetMetaCheck::Paths`, which will only look up meta for those paths.

Currently, this defaults to `AssetMetaCheck::Always`, which makes this fully non-breaking for the `0.12.1` release. _**However it _is_ worth discussing making this `AssetMetaCheck::Never` by default**_, given that I doubt most people are using meta files without the Asset Processor enabled. This would be a breaking change, but it would make WASM / Itch deployments work by default, which is a pretty big win imo. The downside is that people using meta files _without_ processing would need to manually enable `AssetMetaCheck::Always`, which is also suboptimal.

When in `AssetMetaCheck::Processed`, the meta check resource is ignored, as processing requires asset meta files to function. 

In general, I don't love adding this knob as things should ideally "just work" in all cases. But this is the reality of the current situation.

---

## Changelog

- Added `AssetMetaCheck` resource, which can configure when/if asset meta files will be read