### PR TITLE
Make IntoSystemConfigs::into_configs public API (visible in docs)

### DIFF
--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -244,7 +244,6 @@ where
     Self: Sized,
 {
     /// Convert into a [`SystemConfigs`].
-    #[doc(hidden)]
     fn into_configs(self) -> SystemConfigs;
 
     /// Add these systems to the provided `set`.


### PR DESCRIPTION
`IntoSystemConfigs::into_configs` function is public, but hidden from documentation. This PR makes it visible.

Fixes #10622.