### PR TITLE
fix `insert_reflect` panic caused by `clone_value`

### DIFF
--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -189,20 +189,15 @@ fn insert_reflect(
     type_registry: &TypeRegistry,
     component: Box<dyn Reflect>,
 ) {
-    let type_info = component.reflect_type_path();
+    let type_info = component.get_represented_type_info().expect("Could not get type information for component type because it doesn't represent any type.").type_path();
     let Some(mut entity) = world.get_entity_mut(entity) else {
-        panic!("error[B0003]: Could not insert a reflected component (of type {}) for entity {entity:?} because it doesn't exist in this World.", component.reflect_type_path());
+        panic!("error[B0003]: Could not insert a reflected component (of type {}) for entity {entity:?} because it doesn't exist in this World.", type_info);
     };
-    let Some(type_registration) = type_registry.get_with_type_path(type_info).or_else(|| {
-        let Some(component_type) = component.get_represented_type_info() else {
-            panic!("Could not get type information for component type {} because it doesn't represent any type.", component.reflect_type_path());
-        };
-        type_registry.get_with_type_path(component_type.type_path())
-    }) else {
-        panic!("Could not get type registration (for component type {}) because it doesn't exist in the TypeRegistry.", component.reflect_type_path());
+    let Some(type_registration) = type_registry.get_with_type_path(type_info) else {
+        panic!("Could not get type registration (for component type {}) because it doesn't exist in the TypeRegistry.", type_info);
     };
     let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
-        panic!("Could not get ReflectComponent data (for component type {}) because it doesn't exist in this TypeRegistration.", component.reflect_type_path());
+        panic!("Could not get ReflectComponent data (for component type {}) because it doesn't exist in this TypeRegistration.", type_info);
     };
     reflect_component.insert(&mut entity, &*component);
 }

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -189,10 +189,10 @@ fn insert_reflect(
     type_registry: &TypeRegistry,
     component: Box<dyn Reflect>,
 ) {
-    let type_path = component
+    let type_info = component
         .get_represented_type_info()
-        .expect("component should represent a type.")
-        .type_path();
+        .expect("component should represent a type.");
+    let type_path = type_info.type_path();
     let Some(mut entity) = world.get_entity_mut(entity) else {
         panic!("error[B0003]: Could not insert a reflected component (of type {type_path}) for entity {entity:?} because it doesn't exist in this World.");
     };

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -189,15 +189,18 @@ fn insert_reflect(
     type_registry: &TypeRegistry,
     component: Box<dyn Reflect>,
 ) {
-    let type_info = component.get_represented_type_info().expect("Could not get type information for component type because it doesn't represent any type.").type_path();
+    let type_path = component
+        .get_represented_type_info()
+        .expect("component should represent a type.")
+        .type_path();
     let Some(mut entity) = world.get_entity_mut(entity) else {
-        panic!("error[B0003]: Could not insert a reflected component (of type {}) for entity {entity:?} because it doesn't exist in this World.", type_info);
+        panic!("error[B0003]: Could not insert a reflected component (of type {type_path}) for entity {entity:?} because it doesn't exist in this World.");
     };
-    let Some(type_registration) = type_registry.get_with_type_path(type_info) else {
-        panic!("Could not get type registration (for component type {}) because it doesn't exist in the TypeRegistry.", type_info);
+    let Some(type_registration) = type_registry.get_with_type_path(type_path) else {
+        panic!("Could not get type registration (for component type {type_path}) because it doesn't exist in the TypeRegistry.");
     };
     let Some(reflect_component) = type_registration.data::<ReflectComponent>() else {
-        panic!("Could not get ReflectComponent data (for component type {}) because it doesn't exist in this TypeRegistration.", type_info);
+        panic!("Could not get ReflectComponent data (for component type {type_path}) because it doesn't exist in this TypeRegistration.");
     };
     reflect_component.insert(&mut entity, &*component);
 }


### PR DESCRIPTION
# Objective

- `insert_reflect` relies on `reflect_type_path`, which doesn't gives the actual type path for object created by `clone_value`, leading to an unexpected panic. This is a workaround for it.
- Fix #10590 

## Solution

- Tries to get type path from `get_represented_type_info` if get failed from `reflect_type_path`.

---

## Defect remaining

- `get_represented_type_info` implies a shortage on performance than using `TypeRegistry`.