### PR TITLE
Add doc_markdown clippy linting config to cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
 
 [workspace.lints.clippy]
 type_complexity = "allow"
+doc_markdown = "forbid"
 
 [lints]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.lints.clippy]
 type_complexity = "allow"
-doc_markdown = "forbid"
+doc_markdown = "warning"
 
 [lints]
 workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 
 [workspace.lints.clippy]
 type_complexity = "allow"
-doc_markdown = "warning"
+doc_markdown = "warn"
 
 [lints]
 workspace = true

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,8 +17,7 @@ bitflags! {
     }
 }
 
-const CLIPPY_FLAGS: [&str; 6] = [
-    "-Wclippy::doc_markdown",
+const CLIPPY_FLAGS: [&str; 5] = [
     "-Wclippy::redundant_else",
     "-Wclippy::match_same_arms",
     "-Wclippy::semicolon_if_nothing_returned",


### PR DESCRIPTION
# Objective

Partially Addresses #10612

fix: add clippy::doc_markdown linting to cargo workspace

Rather than do all the warnings in `tools/ci/src/main.rs` in one-shot, just wanted to have an initial pr adding the first one to get the form correct as some may trigger build errors and require changes to get merged more easily.

## Solution

- adding the doc_markdown and removing it from the ci check as it'll now be a build error during normal compilation.


