### PR TITLE
Add an `Entry` api to `EntityWorldMut`.

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1117,8 +1117,8 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
         }
     }
 
-    /// Ensures the entry has this component by inserting the default if empty, and returns a
-    /// mutable reference to this component in the entry.
+    /// Ensures the entry has this component by inserting the given default if empty, and
+    /// returns a mutable reference to this component in the entry.
     ///
     /// # Examples
     ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1072,7 +1072,7 @@ impl<'w> EntityWorldMut<'w> {
 
 /// A view into a single entity and component in a world, which may either be vacant or occupied.
 ///
-/// This `enum` is constructed from the [`entry`] method on [`EntityWorldMut`].
+/// This `enum` can only be constructed from the [`entry`] method on [`EntityWorldMut`].
 ///
 /// [`entry`]: EntityWorldMut::entry
 pub enum Entry<'w, 'a, T: Component> {
@@ -1219,6 +1219,8 @@ impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
 }
 
 /// A view into an occupied entry in a [`EntityWorldMut`]. It is part of the [`Entry`] enum.
+///
+/// The contained entity must have the component type parameter if we have this struct.
 pub struct OccupiedEntry<'w, 'a, T: Component> {
     entity_world: &'a mut EntityWorldMut<'w>,
     _marker: PhantomData<T>,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1086,6 +1086,14 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
             Entry::Vacant(mut entry) => entry.insert(default),
         }
     }
+
+    #[inline]
+    pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> Mut<'a, T> {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(mut entry) => entry.insert(default()),
+        }
+    }
 }
 
 impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1034,6 +1034,26 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Gets an Entry into the world for this entity and component for in-place manipulation.
+    ///
+    /// The type parameter specifies which component to get.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// let mut world = World::new();
+    ///
+    /// let mut entity = world.spawn(Comp(0));
+    /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
+    /// # assert_eq!(world.query::<&Comp>().single(&world).0, 1);
+    ///
+    /// let mut new_entity = world.spawn_empty();
+    /// entity.entry().or_insert_with(|| Comp(4));
+    /// # assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// ```
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
         if self.contains::<T>() {
             Entry::Occupied(OccupiedEntry {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1245,8 +1245,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// ```
     #[inline]
     pub fn get(&self) -> &T {
-        // SAFETY: If we have an OccupiedEntry the component must exist.
-        unsafe { self.entity_world.get::<T>().unwrap_unchecked() }
+        // This shouldn't panic because if we have an OccupiedEntry the component must exist.
+        self.entity_world.get::<T>().unwrap()
     }
 
     /// Gets a mutable reference to the component in the entry.
@@ -1278,8 +1278,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// ```
     #[inline]
     pub fn get_mut(&mut self) -> Mut<'_, T> {
-        // SAFETY: If we have an OccupiedEntry the component must exist.
-        unsafe { self.entity_world.get_mut::<T>().unwrap_unchecked() }
+        // This shouldn't panic because if we have an OccupiedEntry the component must exist.
+        self.entity_world.get_mut::<T>().unwrap()
     }
 
     /// Converts the `OccupiedEntry` into a mutable reference to the value in the entry with
@@ -1307,8 +1307,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// ```
     #[inline]
     pub fn into_mut(self) -> Mut<'a, T> {
-        // SAFETY: If we have an OccupiedEntry the component must exist.
-        unsafe { self.entity_world.get_mut().unwrap_unchecked() }
+        // This shouldn't panic because if we have an OccupiedEntry the component must exist.
+        self.entity_world.get_mut().unwrap()
     }
 
     /// Replaces the component of the entry.
@@ -1354,8 +1354,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// ```
     #[inline]
     pub fn take(self) -> T {
-        // SAFETY: If we have an OccupiedEntry the component must exist.
-        unsafe { self.entity_world.take().unwrap_unchecked() }
+        // This shouldn't panic because if we have an OccupiedEntry the component must exist.
+        self.entity_world.take().unwrap()
     }
 }
 
@@ -1387,8 +1387,8 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     #[inline]
     pub fn insert(self, component: T) -> Mut<'a, T> {
         self.entity_world.insert(component);
-        // SAFETY: We just added this component.
-        unsafe { self.entity_world.get_mut::<T>().unwrap_unchecked() }
+        // This shouldn't panic because we just added this component
+        self.entity_world.get_mut::<T>().unwrap()
     }
 
     /// Inserts the component into the `VacantEntry` and returns an `OccupiedEntry`.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1063,6 +1063,20 @@ pub enum Entry<'w, 'a, T: Component> {
 
 impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     /// Provides in-place mutable access to an occupied entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(0));
+    ///
+    /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 1);
+    /// ```
     #[inline]
     pub fn and_modify<F: FnOnce(Mut<'_, T>)>(self, f: F) -> Self {
         match self {
@@ -1074,7 +1088,24 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
         }
     }
 
-    /// Sets the value of the entry, and returns an [`OccupiedEntry`].
+    /// Replaces the component of the entry, and returns an [`OccupiedEntry`].
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// let entry = entity.entry().insert_entry(Comp(4));
+    /// assert_eq!(entry.get(), &Comp(4));
+    ///
+    /// let entry = entity.entry().insert_entry(Comp(2));
+    /// assert_eq!(entry.get(), &Comp(2));
+    /// ```
     #[inline]
     pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
         match self {
@@ -1088,6 +1119,25 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
 
     /// Ensures the entry has this component by inserting the default if empty, and returns a
     /// mutable reference to this component in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// entity.entry().or_insert(Comp(4));
+    /// # let entity_id = entity.id();
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    ///
+    /// # let mut entity = world.get_entity_mut(entity_id).unwrap();
+    /// entity.entry().or_insert(Comp(15)).0 *= 2;
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 8);
+    /// ```
     #[inline]
     pub fn or_insert(self, default: T) -> Mut<'a, T> {
         match self {
@@ -1098,6 +1148,20 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
 
     /// Ensures the entry has this component by inserting the result of the default function if
     /// empty, and returns a mutable reference to this component in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// entity.entry().or_insert_with(|| Comp(4));
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// ```
     #[inline]
     pub fn or_insert_with<F: FnOnce() -> T>(self, default: F) -> Mut<'a, T> {
         match self {
@@ -1110,6 +1174,20 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
 impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
     /// Ensures the entry has this component by inserting the default value if empty, and
     /// returns a mutable reference to this component in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::prelude::*;
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// entity.entry::<Comp>().or_default();
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 0);
+    /// ```
     #[inline]
     pub fn or_default(self) -> Mut<'a, T> {
         match self {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1108,7 +1108,13 @@ pub struct OccupiedEntry<'w, 'a, T: Component> {
     entity_world: &'a mut EntityWorldMut<'w>,
 }
 
-impl<'a, T: Component> OccupiedEntry<'_, 'a, T> {
+impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
+    #[inline]
+    pub fn get(&self) -> &T {
+        // SAFETY: If we have an OccupiedEntry the component must exist.
+        unsafe { self.entity_world.get::<T>().unwrap_unchecked() }
+    }
+
     #[inline]
     pub fn get_mut(&mut self) -> Mut<'_, T> {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1124,6 +1130,12 @@ impl<'a, T: Component> OccupiedEntry<'_, 'a, T> {
     #[inline]
     pub fn insert(&mut self, component: T) {
         self.entity_world.insert(component);
+    }
+
+    #[inline]
+    pub fn take(self) -> T {
+        // SAFETY: If we have an OccupiedEntry the component must exist.
+        unsafe { self.entity_world.take().unwrap_unchecked() }
     }
 }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1064,6 +1064,20 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
             Entry::Vacant(entry) => Entry::Vacant(entry),
         }
     }
+
+    #[inline]
+    pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
+        match self {
+            Entry::Occupied(entry) => entry,
+            Entry::Vacant(mut entry) => {
+                entry.insert(component);
+                OccupiedEntry {
+                    _marker: PhantomData::default(),
+                    entity_world: entry.entity_world,
+                }
+            }
+        }
+    }
 }
 
 impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
@@ -1075,6 +1089,7 @@ impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
         }
     }
 }
+
 pub struct OccupiedEntry<'w, 'a, T: Component> {
     _marker: PhantomData<T>,
     entity_world: &'a mut EntityWorldMut<'w>,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1205,6 +1205,21 @@ pub struct OccupiedEntry<'w, 'a, T: Component> {
 
 impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// Gets a reference to the component in the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(5));
+    ///
+    /// if let Entry::Occupied(o) = entity.entry::<Comp>() {
+    ///     assert_eq!(o.get().0, 5);
+    /// }
+    /// ```
     #[inline]
     pub fn get(&self) -> &T {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1217,6 +1232,27 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// the `Entry` value, see [`into_mut`].
     ///
     /// [`into_mut`]: Self::into_mut
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(5));
+    ///
+    /// if let Entry::Occupied(mut o) = entity.entry::<Comp>() {
+    ///     o.get_mut().0 += 10;
+    ///     assert_eq!(o.get().0, 15);
+    ///
+    ///     // We can use the same Entry multiple times.
+    ///     o.get_mut().0 += 2
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 17);
+    /// ```
     #[inline]
     pub fn get_mut(&mut self) -> Mut<'_, T> {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1229,6 +1265,23 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// If you need multiple references to the `OccupiedEntry`, see [`get_mut`].
     ///
     /// [`get_mut`]: Self::get_mut
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(5));
+    ///
+    /// if let Entry::Occupied(o) = entity.entry::<Comp>() {
+    ///     o.into_mut().0 += 10;
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 15);
+    /// ```
     #[inline]
     pub fn into_mut(self) -> Mut<'a, T> {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1236,12 +1289,46 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     }
 
     /// Replaces the component of the entry.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(5));
+    ///
+    /// if let Entry::Occupied(mut o) = entity.entry::<Comp>() {
+    ///     o.insert(Comp(10));
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// ```
     #[inline]
     pub fn insert(&mut self, component: T) {
         self.entity_world.insert(component);
     }
 
-    /// Removes the component from the entry and returns its value.
+    /// Removes the component from the entry and returns it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn(Comp(5));
+    ///
+    /// if let Entry::Occupied(o) = entity.entry::<Comp>() {
+    ///     assert_eq!(o.take(), Comp(5));
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().iter(&world).len(), 0);
+    /// ```
     #[inline]
     pub fn take(self) -> T {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1257,6 +1344,23 @@ pub struct VacantEntry<'w, 'a, T: Component> {
 
 impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     /// Inserts the component into the `VacantEntry` and returns a mutable reference to it.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// if let Entry::Vacant(v) = entity.entry::<Comp>() {
+    ///     v.insert(Comp(10));
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// ```
     #[inline]
     pub fn insert(self, component: T) -> Mut<'a, T> {
         self.entity_world.insert(component);
@@ -1265,6 +1369,23 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     }
 
     /// Inserts the component into the `VacantEntry` and returns an `OccupiedEntry`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bevy_ecs::{prelude::*, world::Entry};
+    /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
+    /// struct Comp(u32);
+    ///
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
+    ///
+    /// if let Entry::Vacant(v) = entity.entry::<Comp>() {
+    ///     v.insert_entry(Comp(10));
+    /// }
+    ///
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 10);
+    /// ```
     #[inline]
     pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
         self.entity_world.insert(component);

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1044,15 +1044,16 @@ impl<'w> EntityWorldMut<'w> {
     /// #[derive(Component, Default, Clone, Copy, Debug, PartialEq)]
     /// struct Comp(u32);
     ///
-    /// let mut world = World::new();
-    ///
-    /// let mut entity = world.spawn(Comp(0));
-    /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
-    /// # assert_eq!(world.query::<&Comp>().single(&world).0, 1);
-    ///
-    /// let mut new_entity = world.spawn_empty();
+    /// # let mut world = World::new();
+    /// let mut entity = world.spawn_empty();
     /// entity.entry().or_insert_with(|| Comp(4));
-    /// # assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    /// # let entity_id = entity.id();
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 4);
+    ///
+    /// # let mut entity = world.get_entity_mut(entity_id).unwrap();
+    /// entity.entry::<Comp>().and_modify(|mut c| c.0 += 1);
+    /// assert_eq!(world.query::<&Comp>().single(&world).0, 5);
+    ///
     /// ```
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
         if self.contains::<T>() {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1035,15 +1035,15 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Gets an Entry into the world for this entity and component for in-place manipulation.
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
-        if let Some(_) = self.get::<T>() {
+        if self.contains::<T>() {
             Entry::Occupied(OccupiedEntry {
                 entity_world: self,
-                _marker: PhantomData::default(),
+                _marker: PhantomData,
             })
         } else {
             Entry::Vacant(VacantEntry {
                 entity_world: self,
-                _marker: PhantomData::default(),
+                _marker: PhantomData,
             })
         }
     }
@@ -1391,7 +1391,7 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
         self.entity_world.insert(component);
         OccupiedEntry {
             entity_world: self.entity_world,
-            _marker: PhantomData::default(),
+            _marker: PhantomData,
         }
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1051,9 +1051,13 @@ impl<'w> EntityWorldMut<'w> {
 
 /// A view into a single entity and component in a world, which may either be vacant or occupied.
 ///
-/// This `enum` is constructed from the [`entry`] method on [`WorldEntityMut`].
+/// This `enum` is constructed from the [`entry`] method on [`EntityWorldMut`].
+///
+/// [`entry`]: EntityWorldMut::entry
 pub enum Entry<'w, 'a, T: Component> {
+    /// An occupied entry.
     Occupied(OccupiedEntry<'w, 'a, T>),
+    /// A vacant entry.
     Vacant(VacantEntry<'w, 'a, T>),
 }
 
@@ -1115,7 +1119,7 @@ impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
     }
 }
 
-/// A view into an occupied entry in a [`WorldEntityMut`]. It is part of the [`Entry`] enum.
+/// A view into an occupied entry in a [`EntityWorldMut`]. It is part of the [`Entry`] enum.
 pub struct OccupiedEntry<'w, 'a, T: Component> {
     entity_world: &'a mut EntityWorldMut<'w>,
     _marker: PhantomData<T>,
@@ -1133,6 +1137,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     ///
     /// If you need a reference to the `OccupiedEntry` which may outlive the destruction of
     /// the `Entry` value, see [`into_mut`].
+    ///
+    /// [`into_mut`]: Self::into_mut
     #[inline]
     pub fn get_mut(&mut self) -> Mut<'_, T> {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1143,6 +1149,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     /// a lifetime bound to the `EntityWorldMut`.
     ///
     /// If you need multiple references to the `OccupiedEntry`, see [`get_mut`].
+    ///
+    /// [`get_mut`]: Self::get_mut
     #[inline]
     pub fn into_mut(self) -> Mut<'a, T> {
         // SAFETY: If we have an OccupiedEntry the component must exist.
@@ -1163,7 +1171,7 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
     }
 }
 
-/// A view into a vacant entry in a [`WorldEntityMut`]. It is part of the [`Entry`] enum.
+/// A view into a vacant entry in a [`EntityWorldMut`]. It is part of the [`Entry`] enum.
 pub struct VacantEntry<'w, 'a, T: Component> {
     entity_world: &'a mut EntityWorldMut<'w>,
     _marker: PhantomData<T>,

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1036,13 +1036,13 @@ impl<'w> EntityWorldMut<'w> {
     pub fn entry<'a, T: Component>(&'a mut self) -> Entry<'w, 'a, T> {
         if let Some(_) = self.get::<T>() {
             Entry::Occupied(OccupiedEntry {
-                _marker: PhantomData::default(),
                 entity_world: self,
+                _marker: PhantomData::default(),
             })
         } else {
             Entry::Vacant(VacantEntry {
-                _marker: PhantomData::default(),
                 entity_world: self,
+                _marker: PhantomData::default(),
             })
         }
     }
@@ -1104,8 +1104,8 @@ impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {
 }
 
 pub struct OccupiedEntry<'w, 'a, T: Component> {
-    _marker: PhantomData<T>,
     entity_world: &'a mut EntityWorldMut<'w>,
+    _marker: PhantomData<T>,
 }
 
 impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
@@ -1140,8 +1140,8 @@ impl<'w, 'a, T: Component> OccupiedEntry<'w, 'a, T> {
 }
 
 pub struct VacantEntry<'w, 'a, T: Component> {
-    _marker: PhantomData<T>,
     entity_world: &'a mut EntityWorldMut<'w>,
+    _marker: PhantomData<T>,
 }
 
 impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
@@ -1156,8 +1156,8 @@ impl<'w, 'a, T: Component> VacantEntry<'w, 'a, T> {
     pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
         self.entity_world.insert(component);
         OccupiedEntry {
-            _marker: PhantomData::default(),
             entity_world: self.entity_world,
+            _marker: PhantomData::default(),
         }
     }
 }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1068,14 +1068,11 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
     #[inline]
     pub fn insert_entry(self, component: T) -> OccupiedEntry<'w, 'a, T> {
         match self {
-            Entry::Occupied(entry) => entry,
-            Entry::Vacant(mut entry) => {
+            Entry::Occupied(mut entry) => {
                 entry.insert(component);
-                OccupiedEntry {
-                    _marker: PhantomData::default(),
-                    entity_world: entry.entity_world,
-                }
+                entry
             }
+            Entry::Vacant(entry) => entry.insert_entry(component),
         }
     }
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1078,6 +1078,14 @@ impl<'w, 'a, T: Component> Entry<'w, 'a, T> {
             }
         }
     }
+
+    #[inline]
+    pub fn or_insert(self, default: T) -> Mut<'a, T> {
+        match self {
+            Entry::Occupied(entry) => entry.into_mut(),
+            Entry::Vacant(mut entry) => entry.insert(default),
+        }
+    }
 }
 
 impl<'w, 'a, T: Component + Default> Entry<'w, 'a, T> {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -7,7 +7,7 @@ pub mod unsafe_world_cell;
 mod world_cell;
 
 pub use crate::change_detection::{Mut, Ref, CHECK_TICK_THRESHOLD};
-pub use entity_ref::{EntityMut, EntityRef, EntityWorldMut};
+pub use entity_ref::{EntityMut, EntityRef, EntityWorldMut, Entry, OccupiedEntry, VacantEntry};
 pub use spawn_batch::*;
 pub use world_cell::*;
 


### PR DESCRIPTION
# Objective

Adds `.entry` to `EntityWorldMut` with `Entry`, `OccupiedEntry` and `VacantEntry` for easier in-situ modification, based on `HashMap.entry`.

Fixes #10635

## Solution

This adds the `entry` method to `EntityWorldMut` which returns an `Entry`. This is an enum of `OccupiedEntry` and `VacantEntry` and has the methods `and_modify`, `insert_entry`, `or_insert`, `or_insert_with` and `or_default`. The only difference between `OccupiedEntry` and `VacantEntry` is the type, they are both a mutable reference to the `EntityWorldMut` and a marker for the component type, `HashMap` also stores things to make it quicker to access the data in `OccupiedEntry` but I wasn't sure if we had anything it would be logical to store to make accessing/modifying the component faster? As such, the differences are that `OccupiedEntry` assumes the entity has the component (because nothing else can have an `EntityWorldMut` so it can't be changed outside the entry api) and has different methods.

All the methods are based very closely off `hashbrown::HashMap` (because its easier to read the source of) with a couple of quirks like `OccupiedEntry.insert` doesn't return the old value because we don't appear to have an api for mem::replacing components.

---

## Changelog

- Added a new function `EntityWorldMut.entry` which returns an `Entry`, allowing easier in-situ modification of a component.
