### PR TITLE
Make impl block for RemovedSystem generic

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -21,7 +21,7 @@ pub struct RemovedSystem<I = (), O = ()> {
     system: BoxedSystem<I, O>,
 }
 
-impl RemovedSystem {
+impl<I, O> RemovedSystem<I, O> {
     /// Is the system initialized?
     /// A system is initialized the first time it's ran.
     pub fn initialized(&self) -> bool {
@@ -29,7 +29,7 @@ impl RemovedSystem {
     }
 
     /// The system removed from the storage.
-    pub fn system(self) -> BoxedSystem {
+    pub fn system(self) -> BoxedSystem<I, O> {
         self.system
     }
 }


### PR DESCRIPTION
# Objective

Make the impl block for RemovedSystem generic so that the methods can be called for systems that have inputs or outputs.

## Solution

Simply adding generics to the impl block.
