### PR TITLE
prepass vertex shader should always output world position

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -89,9 +89,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.color = vertex.color;
 #endif
 
-#ifdef MOTION_VECTOR_PREPASS_OR_DEFERRED_PREPASS
     out.world_position = mesh_functions::mesh_position_local_to_world(model, vec4<f32>(vertex.position, 1.0));
-#endif // MOTION_VECTOR_PREPASS_OR_DEFERRED_PREPASS
 
 #ifdef MOTION_VECTOR_PREPASS
     // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.


### PR DESCRIPTION
# Objective

the pbr prepass vertex shader currently only sets `VertexOutput::world_position` when deferred or motion prepasses are enabled.
the field is always in the vertex output so is otherwise undetermined, and the calculation is very cheap.

## Solution

always set the world position in the pbr prepass vert shader.

