### PR TITLE
prepass globals binding -> 9

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -702,8 +702,8 @@ pub fn prepare_prepass_view_bind_group<M: Material>(
                 &prepass_pipeline.view_layout_motion_vectors,
                 &BindGroupEntries::with_indices((
                     (0, view_binding),
-                    (9, globals_binding),
                     (2, previous_view_proj_binding),
+                    (9, globals_binding),
                 )),
             ));
         }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -690,17 +690,20 @@ pub fn prepare_prepass_view_bind_group<M: Material>(
         prepass_view_bind_group.no_motion_vectors = Some(render_device.create_bind_group(
             "prepass_view_no_motion_vectors_bind_group",
             &prepass_pipeline.view_layout_no_motion_vectors,
-            &BindGroupEntries::sequential((view_binding.clone(), globals_binding.clone())),
+            &BindGroupEntries::with_indices((
+                (0, view_binding.clone()),
+                (9, globals_binding.clone()),
+            )),
         ));
 
         if let Some(previous_view_proj_binding) = previous_view_proj_uniforms.uniforms.binding() {
             prepass_view_bind_group.motion_vectors = Some(render_device.create_bind_group(
                 "prepass_view_motion_vectors_bind_group",
                 &prepass_pipeline.view_layout_motion_vectors,
-                &BindGroupEntries::sequential((
-                    view_binding,
-                    globals_binding,
-                    previous_view_proj_binding,
+                &BindGroupEntries::with_indices((
+                    (0, view_binding),
+                    (9, globals_binding),
+                    (2, previous_view_proj_binding),
                 )),
             ));
         }

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -245,7 +245,7 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
                     },
                     // Globals
                     BindGroupLayoutEntry {
-                        binding: 1,
+                        binding: 9,
                         visibility: ShaderStages::VERTEX_FRAGMENT,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,
@@ -285,7 +285,7 @@ impl<M: Material> FromWorld for PrepassPipeline<M> {
                     },
                     // Globals
                     BindGroupLayoutEntry {
-                        binding: 1,
+                        binding: 9,
                         visibility: ShaderStages::VERTEX_FRAGMENT,
                         ty: BindingType::Buffer {
                             ty: BufferBindingType::Uniform,


### PR DESCRIPTION
# Objective

in pbr prepass, the globals binding is bound to slot 1, whereas in main pass it is bound to slot 9. the import (mesh_view_bindings.wgsl) also assumes slot 9.

## Solution

move it to slot 9

## Migration Guide

if you manually import the `global` binding in a prepass fragment shader, change your binding slot to 9, or alternatively `#import bevy_pbr::mesh_view_bindings::globals` directly.