### PR TITLE
Reintroduce missing prepass bindings

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass_bindings.wgsl
@@ -1,5 +1,8 @@
 #define_import_path bevy_pbr::prepass_bindings
+#import bevy_render::{view::View, globals::Globals}
 
+@group(0) @binding(0) var<uniform> view: View;
+@group(0) @binding(1) var<uniform> globals: Globals;
 #ifdef MOTION_VECTOR_PREPASS
 @group(0) @binding(2) var<uniform> previous_view_proj: mat4x4<f32>;
 #endif // MOTION_VECTOR_PREPASS


### PR DESCRIPTION
# Objective

- Some prepass bindings were removed from the shader module but they still exist

## Solution

- Re-introduce the bindings in the prepas_bindings shader module

Closes: https://github.com/bevyengine/bevy/issues/10652