### PR TITLE
Re-export `futures_lite` in `bevy_tasks`

### DIFF
--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -35,6 +35,8 @@ pub use futures_lite::future::block_on;
 mod iter;
 pub use iter::ParallelIterator;
 
+pub use futures_lite as future;
+
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -35,7 +35,7 @@ pub use futures_lite::future::block_on;
 mod iter;
 pub use iter::ParallelIterator;
 
-pub use futures_lite as future;
+pub use futures_lite;
 
 #[allow(missing_docs)]
 pub mod prelude {

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -3,9 +3,8 @@
 
 use bevy::{
     prelude::*,
-    tasks::{block_on, AsyncComputeTaskPool, Task},
+    tasks::{block_on, future::future, AsyncComputeTaskPool, Task},
 };
-use futures_lite::future;
 use rand::Rng;
 use std::time::{Duration, Instant};
 

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -3,7 +3,7 @@
 
 use bevy::{
     prelude::*,
-    tasks::{block_on, future::future, AsyncComputeTaskPool, Task},
+    tasks::{block_on, futures_lite::future, AsyncComputeTaskPool, Task},
 };
 use rand::Rng;
 use std::time::{Duration, Instant};


### PR DESCRIPTION
# Objective

- Fixes #10664

## Solution

- `pub use futures_lite as future` :)

---

## Changelog

- Made `futures_lite` available as `future` in the `bevy_tasks` module.

## Migration Guide

- Remove `futures_lite` from `Cargo.toml`.

```diff
[dependencies]
bevy = "0.12.0"
- futures-lite = "1.4.0"
```

- Replace `futures_lite` imports with `bevy::tasks::future`.

```diff
- use futures_lite::poll_once;
+ use bevy::tasks::future::poll_once;
```