### PR TITLE
Move remaining clippy lint definitions to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,10 @@ members = [
 type_complexity = "allow"
 doc_markdown = "warn"
 undocumented_unsafe_blocks = "warn"
+redundant_else = "warn"
+match_same_arms = "warn"
+semicolon_if_nothing_returned = "warn"
+map_flatten = "warn"
 
 [lints]
 workspace = true

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,13 +17,7 @@ bitflags! {
     }
 }
 
-const CLIPPY_FLAGS: [&str; 5] = [
-    "-Wclippy::redundant_else",
-    "-Wclippy::match_same_arms",
-    "-Wclippy::semicolon_if_nothing_returned",
-    "-Wclippy::map_flatten",
-    "-Dwarnings",
-];
+const CLIPPY_FLAGS: [&str; 1] = ["-Dwarnings"];
 
 fn main() {
     // When run locally, results may differ from actual CI runs triggered by

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -17,8 +17,6 @@ bitflags! {
     }
 }
 
-const CLIPPY_FLAGS: [&str; 1] = ["-Dwarnings"];
-
 fn main() {
     // When run locally, results may differ from actual CI runs triggered by
     // .github/workflows/ci.yml
@@ -73,7 +71,7 @@ fn main() {
         // - Type complexity must be ignored because we use huge templates for queries
         cmd!(
             sh,
-            "cargo clippy --workspace --all-targets --all-features -- {CLIPPY_FLAGS...}"
+            "cargo clippy --workspace --all-targets --all-features -- -Dwarnings"
         )
         .run()
         .expect("Please fix clippy errors in output above.");


### PR DESCRIPTION
# Objective

Partially addresses #10612
After moving the initial docs_markdown warning, this is a PR that moves the rest of the CI clippy lint definitions to the cargo.toml.

## Solution

- the `tools/ci/src/main.rs` clippy lints removed and just the warning flag remains.
- the warnings moved to the root cargo workspace toml.


