### PR TITLE
examples/ecs/iter_combinations: Initialize velocity using fixed timestep

### DIFF
--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -38,7 +38,7 @@ struct BodyBundle {
 }
 
 fn generate_bodies(
-    time: Res<Time>,
+    time: Res<Time<Fixed>>,
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
@@ -94,7 +94,7 @@ fn generate_bodies(
                         rng.gen_range(vel_range.clone()),
                         rng.gen_range(vel_range.clone()),
                         rng.gen_range(vel_range.clone()),
-                    ) * time.delta_seconds(),
+                    ) * time.timestep().as_secs_f32(),
             ),
         });
     }


### PR DESCRIPTION

# Objective

On some platforms (observed on Windows and Linux, works fine on web), velocity of all entities would be initialized to zero, making them simply fall into the star.

## Solution

Using `Time<Fixed>::timestep` instead of `Time::delta_seconds` to initialize velocity. Since the entities are generated in the startup schedule, no time has elapsed yet and `Time::delta_seconds` would return zero on some platforms. `Time<Fixed>::timestep` will always return the expected time step of `FixedUpdate` schedule.
