### PR TITLE
bump bevy_tasks futures-lite to 2.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -294,7 +294,7 @@ flate2 = "1.0"
 serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"
 # Needed to poll Task examples
-futures-lite = { version = "2.0.1" }
+futures-lite = "2.0.1"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,9 +34,6 @@ type_complexity = "allow"
 doc_markdown = "warn"
 undocumented_unsafe_blocks = "warn"
 
-[workspace.dependencies]
-futures-lite = { version = "2.0.1" }
-
 [lints]
 workspace = true
 
@@ -297,7 +294,7 @@ flate2 = "1.0"
 serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"
 # Needed to poll Task examples
-futures-lite = { workspace = true }
+futures-lite = { version = "2.0.1" }
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ type_complexity = "allow"
 doc_markdown = "warn"
 undocumented_unsafe_blocks = "warn"
 
+[workspace.dependencies]
+futures-lite = { version = "2.0.1" }
+
 [lints]
 workspace = true
 
@@ -294,7 +297,7 @@ flate2 = "1.0"
 serde = { version = "1", features = ["derive"] }
 bytemuck = "1.7"
 # Needed to poll Task examples
-futures-lite = "1.11.3"
+futures-lite = { workspace = true }
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
 

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ async-lock = "3.0"
 crossbeam-channel = "0.5"
 downcast-rs = "1.2"
 futures-io = "0.3"
-futures-lite = "1.12"
+futures-lite = { workspace = true }
 blake3 = "1.5"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ async-lock = "3.0"
 crossbeam-channel = "0.5"
 downcast-rs = "1.2"
 futures-io = "0.3"
-futures-lite = { workspace = true }
+futures-lite = { version = "2.0.1" }
 blake3 = "1.5"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -32,7 +32,7 @@ async-lock = "3.0"
 crossbeam-channel = "0.5"
 downcast-rs = "1.2"
 futures-io = "0.3"
-futures-lite = { version = "2.0.1" }
+futures-lite = "2.0.1" 
 blake3 = "1.5"
 parking_lot = { version = "0.12", features = ["arc_lock", "send_guard"] }
 ron = "0.8"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -75,7 +75,7 @@ smallvec = { version = "1.6", features = ["union", "const_generics"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"
-futures-lite = { version = "2.0.1" }
+futures-lite = "2.0.1" 
 hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -75,7 +75,7 @@ smallvec = { version = "1.6", features = ["union", "const_generics"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"
-futures-lite = "1.4.0"
+futures-lite = { workspace = true }
 hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -75,7 +75,7 @@ smallvec = { version = "1.6", features = ["union", "const_generics"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"
-futures-lite = { workspace = true }
+futures-lite = { version = "2.0.1" }
 hexasphere = "9.0"
 ddsfile = { version = "0.5.0", optional = true }
 ktx2 = { version = "0.3.0", optional = true }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 multi-threaded = []
 
 [dependencies]
-futures-lite = "1.4.0"
+futures-lite = "2.0.1"
 async-executor = "1.3.0"
 async-channel = "1.4.2"
 async-io = { version = "2.0.0", optional = true }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,8 +12,8 @@ keywords = ["bevy"]
 multi-threaded = []
 
 [dependencies]
-futures-lite = "2.0.1"
-async-executor = "1.3.0"
+futures-lite = { workspace = true }
+async-executor = "1.7.2"
 async-channel = "1.4.2"
 async-io = { version = "2.0.0", optional = true }
 async-task = "4.2.0"

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 multi-threaded = []
 
 [dependencies]
-futures-lite = { workspace = true }
+futures-lite = { version = "2.0.1" }
 async-executor = "1.7.2"
 async-channel = "1.4.2"
 async-io = { version = "2.0.0", optional = true }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 multi-threaded = []
 
 [dependencies]
-futures-lite = { version = "2.0.1" }
+futures-lite = "2.0.1"
 async-executor = "1.7.2"
 async-channel = "1.4.2"
 async-io = { version = "2.0.0", optional = true }


### PR DESCRIPTION
# Objective

Updates [`futures-lite`](https://github.com/smol-rs/futures-lite) in bevy_tasks to the next major version (1 -> 2).

Also removes the duplication of `futures-lite`, as `async-fs` requires v 2, so there are currently 2 copies of futures-lite in the dependency tree.

Futures-lite has received [a number of updates](https://github.com/smol-rs/futures-lite/blob/master/CHANGELOG.md) since bevy's current version `1.4`.