### PR TITLE
RFC: SystemParam::user_meta

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -410,6 +410,10 @@ pub fn derive_system_param(input: TokenStream) -> TokenStream {
                 type State = #state_struct_name<#punctuated_generic_idents>;
                 type Item<'w, 's> = #struct_name #ty_generics;
 
+                fn user_meta(request: &mut #path::system::SystemParamUserMetaRequest) {
+                    <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::user_meta(request);
+                }
+
                 fn init_state(world: &mut #path::world::World, system_meta: &mut #path::system::SystemMeta) -> Self::State {
                     #state_struct_name {
                         state: <#fields_alias::<'_, '_, #punctuated_generic_idents> as #path::system::SystemParam>::init_state(world, system_meta),

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use super::{ReadOnlySystem, System};
+use super::{ReadOnlySystem, System, SystemParamUserMetaRequest};
 use crate::{schedule::InternedSystemSet, world::unsafe_world_cell::UnsafeWorldCell};
 
 /// Customizes the behavior of an [`AdapterSystem`]
@@ -145,6 +145,10 @@ where
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         self.system.default_system_sets()
+    }
+
+    fn param_user_meta(&self, request: &mut SystemParamUserMetaRequest) {
+        self.system.param_user_meta(request);
     }
 }
 

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -11,7 +11,7 @@ use crate::{
     world::unsafe_world_cell::UnsafeWorldCell,
 };
 
-use super::{ReadOnlySystem, System};
+use super::{ReadOnlySystem, System, SystemParamUserMetaRequest};
 
 /// Customizes the behavior of a [`CombinatorSystem`].
 ///
@@ -231,6 +231,11 @@ where
         let mut default_sets = self.a.default_system_sets();
         default_sets.append(&mut self.b.default_system_sets());
         default_sets
+    }
+
+    fn param_user_meta(&self, request: &mut SystemParamUserMetaRequest) {
+        self.a.param_user_meta(request);
+        self.b.param_user_meta(request);
     }
 }
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use bevy_utils::all_tuples;
 use std::{any::TypeId, borrow::Cow, marker::PhantomData};
+use crate::system::{ SystemParamUserMetaRequest};
 
 /// A function system that runs with exclusive [`World`] access.
 ///
@@ -154,6 +155,10 @@ where
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
+    }
+
+    fn param_user_meta(&self, _request: &mut SystemParamUserMetaRequest) {
+        // Exclusive system param does not have user meta.
     }
 }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -14,7 +14,7 @@ use std::{any::TypeId, borrow::Cow, marker::PhantomData};
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::{info_span, Span};
 
-use super::{In, IntoSystem, ReadOnlySystem};
+use super::{In, IntoSystem, ReadOnlySystem, SystemParamUserMetaRequest};
 
 /// The metadata of a [`System`].
 #[derive(Clone)]
@@ -532,6 +532,10 @@ where
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
         let set = crate::schedule::SystemTypeSet::<F>::new();
         vec![set.intern()]
+    }
+
+    fn param_user_meta(&self, request: &mut SystemParamUserMetaRequest) {
+        F::Param::user_meta(request);
     }
 }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -112,6 +112,7 @@ mod query;
 #[allow(clippy::module_inception)]
 mod system;
 mod system_param;
+mod system_param_user_meta;
 mod system_registry;
 
 use std::borrow::Cow;
@@ -126,6 +127,7 @@ pub use query::*;
 pub use system::*;
 pub use system_param::*;
 pub use system_registry::*;
+pub use system_param_user_meta::*;
 
 use crate::world::World;
 

--- a/crates/bevy_ecs/src/system/system_param_user_meta.rs
+++ b/crates/bevy_ecs/src/system/system_param_user_meta.rs
@@ -1,0 +1,167 @@
+use std::any::TypeId;
+use std::mem;
+use std::mem::MaybeUninit;
+
+struct SystemParamUserMetaRequestImpl<T: 'static> {
+    values: Vec<T>,
+}
+
+trait SystemParamUserMetaRequestDyn {
+    fn item_type_id(&self) -> TypeId;
+    unsafe fn provide_value(&mut self, value: *const ());
+}
+
+/// Request arbitrary metadata from [`SystemParam`](crate::system::SystemParam).
+///
+/// See [`SystemParam::user_meta`](crate::system::SystemParam::user_meta) for more information.
+pub struct SystemParamUserMetaRequest<'a> {
+    request: &'a mut dyn SystemParamUserMetaRequestDyn,
+}
+
+impl<T: 'static> SystemParamUserMetaRequestDyn for SystemParamUserMetaRequestImpl<T> {
+    fn item_type_id(&self) -> TypeId {
+        TypeId::of::<T>()
+    }
+
+    unsafe fn provide_value(&mut self, value: *const ()) {
+        let value = value as *const T;
+        self.values.push(mem::transmute_copy(&*value));
+    }
+}
+
+impl<'a> SystemParamUserMetaRequest<'a> {
+    /// Provide the metadata value.
+    ///
+    /// This is a shortcut for [`provide_value_with`](Self::provide_value_with).
+    pub fn provide_value<T: 'static>(&mut self, value: T) {
+        self.provide_value_with(|| value)
+    }
+
+    /// Provide the metadata value.
+    pub fn provide_value_with<T: 'static>(&mut self, value: impl FnOnce() -> T) {
+        unsafe {
+            if self.request.item_type_id() == TypeId::of::<T>() {
+                let value = value();
+                let value = MaybeUninit::new(value);
+                self.request.provide_value(value.as_ptr() as *const ());
+            }
+        }
+    }
+
+    pub(crate) fn with<T: 'static>(
+        mut cb: impl FnMut(&mut SystemParamUserMetaRequest<'_>),
+    ) -> Vec<T> {
+        let mut req_typed = SystemParamUserMetaRequestImpl { values: Vec::new() };
+        let mut req = SystemParamUserMetaRequest {
+            request: &mut req_typed,
+        };
+        cb(&mut req);
+        req_typed.values
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as bevy_ecs;
+    use crate::component::Tick;
+    use crate::prelude::IntoSystem;
+    use crate::prelude::World;
+    use crate::system::system::System;
+    use crate::system::{
+        ReadOnlySystemParam, Res, SystemMeta, SystemParam, SystemParamUserMetaRequest,
+    };
+    use crate::world::unsafe_world_cell::UnsafeWorldCell;
+    use bevy_ecs_macros::Resource;
+    use std::any;
+    use std::marker::PhantomData;
+
+    // Shortcut for test.
+    fn system_param_user_meta_request<P: SystemParam, T: 'static>() -> Vec<T> {
+        SystemParamUserMetaRequest::with(|req| P::user_meta(req))
+    }
+
+    struct MyTestParam<T: 'static>(PhantomData<T>);
+
+    unsafe impl<T> SystemParam for MyTestParam<T> {
+        type State = ();
+        type Item<'world, 'state> = MyTestParam<T>;
+
+        fn init_state(_world: &mut World, _system_meta: &mut SystemMeta) -> Self::State {
+            unreachable!("not needed in test")
+        }
+
+        fn user_meta(request: &mut SystemParamUserMetaRequest) {
+            // In test we provide metadata as strings.
+            // In production we may provide something like `InternedSystemSet`.
+            request.provide_value(format!("meta {}", any::type_name::<T>()));
+            // We can provide multiple values. This is not used in test.
+            request.provide_value(10);
+        }
+
+        unsafe fn get_param<'world, 'state>(
+            _state: &'state mut Self::State,
+            _system_meta: &SystemMeta,
+            _world: UnsafeWorldCell<'world>,
+            _change_tick: Tick,
+        ) -> Self::Item<'world, 'state> {
+            unreachable!("not needed in test")
+        }
+    }
+
+    unsafe impl<T> ReadOnlySystemParam for MyTestParam<T> {}
+
+    #[derive(Resource)]
+    struct MyRes(f32);
+
+    #[derive(SystemParam)]
+    struct DerivedParam<'w, T: 'static> {
+        _p0: MyTestParam<u32>,
+        _p1: MyTestParam<T>,
+        _p2: Res<'w, MyRes>,
+    }
+
+    #[test]
+    fn test_param_meta() {
+        // Simple
+        assert_eq!(
+            vec![format!("meta {}", any::type_name::<u32>())],
+            system_param_user_meta_request::<MyTestParam<u32>, String>()
+        );
+
+        // Tuple
+        assert_eq!(
+            vec![
+                format!("meta {}", any::type_name::<u32>()),
+                format!("meta {}", any::type_name::<Vec<u32>>()),
+            ],
+            system_param_user_meta_request::<(MyTestParam<u32>, MyTestParam<Vec<u32>>), String>()
+        );
+
+        // Derive
+        assert_eq!(
+            vec![
+                format!("meta {}", any::type_name::<u32>()),
+                format!("meta {}", any::type_name::<Vec<u32>>()),
+            ],
+            system_param_user_meta_request::<DerivedParam<'_, Vec<u32>>, String>()
+        );
+    }
+
+    #[test]
+    fn test_system_param_meta() {
+        fn my_system(_a: MyTestParam<u8>, _b: DerivedParam<Vec<u32>>) {}
+
+        let my_system = IntoSystem::into_system(my_system);
+
+        let my_system: &dyn System<In = (), Out = ()> = &my_system;
+
+        assert_eq!(
+            vec![
+                format!("meta {}", any::type_name::<u8>()),
+                format!("meta {}", any::type_name::<u32>()),
+                format!("meta {}", any::type_name::<Vec<u32>>()),
+            ],
+            my_system.param_user_meta_dyn::<String>()
+        );
+    }
+}


### PR DESCRIPTION
# Objective

The objective of this RFC is the same as in https://github.com/bevyengine/bevy/pull/10618: how to declare one system dependent on the other.

# Solution

Previous RFC suggested making it native to Bevy: each system param could declare before/after system sets.

Some considered that RFC too controversial and not fitting well into Bevy ESC model.

## API: user metadata

This RFC proposes alternative solution to the problem. Each `SystemParam` can supply arbitrary metadata. Metadata is a Rust value of arbitrary type.

```rust
trait SystemParam {
  fn user_meta(request: &mut SystemParamUserMetaRequest);
}

// This type cannot be instantiated by a user (no need).
impl SystemParamUserMetaRequest {
  // Collect the value of type `T` if requested, ignore otherwise
  fn provide_value<T>(&mut self, value: T) { ... }
}

impl dyn System {
  fn param_user_meta_dyn<T>(&self) -> Vec<T> {
    // Initialize SystemParamUserMetaRequest
    // collect meta from all the params
  }
}
```

API is similar to [Error::provide](https://doc.rust-lang.org/std/error/trait.Error.html#method.provide) API from rust stdlib.

## How it can be used

A user outside of Bevy can declare two special parameter types: `Before<T: SystemSet>` and `After<T: SystemSet>`. These parameter types would emit metadata like `BeforeItem(InternedSystemSet)` and `AfterItem(InternedSystemSet)`.

Bevy would not automatically do anything with this knowledge (it is just opaque metadata for the scheduler).

But a user can implement utilities over `App` to account for this metadata to adjust the scheduler.

In pseudocode:

```rust
fn my_add_system(app: &mut App, schedule: ScheduleLabel, system: IntoSystem) {
  let system = system.into_system();
  let before = system.param_user_meta_dyn::<BeforeItem>();
  let after = system.param_user_meta_dyn::<AfterItem>();
  let mut system = system.into_system_configs();
  for before in before {
    system = system.before(before);
  }
  for after in after {
    system = system.after(after);
  }
  app.add_systems(schedule, system)
}
```

## Meta vs builtin

Frankly I don't see any applications of param meta outside of these scheduling labels, and this meta will not be very ergonomic (although it would solve the problems I described in the previous RFC). So I would prefer scheduling instructions to be built in Bevy.

But I'd be fine with any solution which would solve the problem, even if user code would be verbose.

And, last words, I'm not going to die on this hill. If this idea is not good enough either, I think I can live with existing API which requires looking very hard to verify schedule correctness.