### PR TITLE
Warn that Added/Changed filters do not see deferred changes

### DIFF
--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -554,7 +554,7 @@ impl_tick_filter!(
     /// # Deferred
     ///
     /// Note, that entity modifications issued with [`Commands`](crate::system::Commands)
-    /// are visible only after deferreds are applied,
+    /// are visible only after deferred operations are applied,
     /// typically at the end of the schedule iteration.
     ///
     /// # Examples

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -597,7 +597,7 @@ impl_tick_filter!(
     ///
     /// Note, that entity modifications issued with [`Commands`](crate::system::Commands)
     /// (like entity creation or entity component addition or removal)
-    /// are visible only after deferreds are applied,
+    /// are visible only after deferred operations are applied,
     /// typically at the end of the schedule iteration.
     ///
     /// # Examples

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -551,6 +551,12 @@ impl_tick_filter!(
     /// To retain all results without filtering but still check whether they were added after the
     /// system last ran, use [`Ref<T>`](crate::change_detection::Ref).
     ///
+    /// # Deferred
+    ///
+    /// Note, that entity modifications issued with [`Commands`](crate::system::Commands)
+    /// are visible only after deferreds are applied,
+    /// typically at the end of the schedule iteration.
+    ///
     /// # Examples
     ///
     /// ```
@@ -586,6 +592,13 @@ impl_tick_filter!(
     ///
     /// To retain all results without filtering but still check whether they were changed after the
     /// system last ran, use [`Ref<T>`](crate::change_detection::Ref).
+    ///
+    /// # Deferred
+    ///
+    /// Note, that entity modifications issued with [`Commands`](crate::system::Commands)
+    /// (like entity creation or entity component addition or removal)
+    /// are visible only after deferreds are applied,
+    /// typically at the end of the schedule iteration.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Explain https://github.com/bevyengine/bevy/issues/10625.

This might be obvious to those familiar with Bevy internals, but it surprised me.