### PR TITLE
Add `clippy::manual_let_else` at warn level to lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
 [workspace.lints.clippy]
 type_complexity = "allow"
 doc_markdown = "warn"
+manual_let_else = "warn"
 undocumented_unsafe_blocks = "warn"
 
 [lints]

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -268,13 +268,12 @@ mod tests {
         };
 
         let handle = reflect_asset.add(&mut app.world, &value);
-        let strukt = match reflect_asset
+        let ReflectMut::Struct(strukt) = reflect_asset
             .get_mut(&mut app.world, handle)
             .unwrap()
             .reflect_mut()
-        {
-            ReflectMut::Struct(s) => s,
-            _ => unreachable!(),
+        else {
+            unreachable!();
         };
         strukt
             .field_mut("field")

--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -55,9 +55,8 @@ impl Plugin for BloomPlugin {
             UniformComponentPlugin::<BloomUniforms>::default(),
         ));
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app
@@ -101,9 +100,8 @@ impl Plugin for BloomPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -113,9 +113,8 @@ impl Plugin for CASPlugin {
             UniformComponentPlugin::<CASUniform>::default(),
         ));
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
         render_app
             .init_resource::<SpecializedRenderPipelines<CASPipeline>>()
@@ -152,9 +151,8 @@ impl Plugin for CASPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
         render_app.init_resource::<CASPipeline>();
     }

--- a/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/main_pass_2d_node.rs
@@ -46,13 +46,12 @@ impl Node for MainPass2dNode {
         world: &World,
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
-        let (camera, transparent_phase, target, camera_2d) =
-            if let Ok(result) = self.query.get_manual(world, view_entity) {
-                result
-            } else {
-                // no target
-                return Ok(());
-            };
+        let Ok((camera, transparent_phase, target, camera_2d)) =
+            self.query.get_manual(world, view_entity)
+        else {
+            // no target
+            return Ok(());
+        };
         {
             #[cfg(feature = "trace")]
             let _main_pass_2d = info_span!("main_pass_2d").entered();

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -48,9 +48,8 @@ impl Plugin for Core2dPlugin {
         app.register_type::<Camera2d>()
             .add_plugins(ExtractComponentPlugin::<Camera2d>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -86,9 +86,8 @@ impl Plugin for Core3dPlugin {
             .add_plugins((SkyboxPlugin, ExtractComponentPlugin::<Camera3d>::default()))
             .add_systems(PostUpdate, check_msaa);
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -86,9 +86,8 @@ impl Plugin for FxaaPlugin {
         app.register_type::<Fxaa>();
         app.add_plugins(ExtractComponentPlugin::<Fxaa>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
         render_app
             .init_resource::<SpecializedRenderPipelines<FxaaPipeline>>()
@@ -114,9 +113,8 @@ impl Plugin for FxaaPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
         render_app.init_resource::<FxaaPipeline>();
     }

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -36,9 +36,8 @@ impl Plugin for SkyboxPlugin {
 
         app.add_plugins(ExtractComponentPlugin::<Skybox>::default());
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app
@@ -53,9 +52,8 @@ impl Plugin for SkyboxPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         let render_device = render_app.world.resource::<RenderDevice>().clone();

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -51,9 +51,8 @@ impl ViewNode for TonemappingNode {
             return Ok(());
         }
 
-        let pipeline = match pipeline_cache.get_render_pipeline(view_tonemapping_pipeline.0) {
-            Some(pipeline) => pipeline,
-            None => return Ok(()),
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(view_tonemapping_pipeline.0) else {
+            return Ok(());
         };
 
         let post_process = target.post_process_write();

--- a/crates/bevy_core_pipeline/src/upscaling/node.rs
+++ b/crates/bevy_core_pipeline/src/upscaling/node.rs
@@ -67,9 +67,8 @@ impl ViewNode for UpscalingNode {
             }
         };
 
-        let pipeline = match pipeline_cache.get_render_pipeline(upscaling_target.0) {
-            Some(pipeline) => pipeline,
-            None => return Ok(()),
+        let Some(pipeline) = pipeline_cache.get_render_pipeline(upscaling_target.0) else {
+            return Ok(());
         };
 
         let pass_descriptor = RenderPassDescriptor {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -124,9 +124,8 @@ where
     unsafe fn fetch_next_aliased_unchecked(&mut self) -> Option<Q::Item<'w>> {
         for entity in self.entity_iter.by_ref() {
             let entity = *entity.borrow();
-            let location = match self.entities.get(entity) {
-                Some(location) => location,
-                None => continue,
+            let Some(location) = self.entities.get(entity) else {
+                continue;
             };
 
             if !self

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -656,9 +656,8 @@ impl<'w> UnsafeEntityCell<'w> {
     /// - If you have a [`ComponentId`] instead of a [`TypeId`], consider using [`Self::contains_id`].
     #[inline]
     pub fn contains_type_id(self, type_id: TypeId) -> bool {
-        let id = match self.world.components().get_id(type_id) {
-            Some(id) => id,
-            None => return false,
+        let Some(id) = self.world.components().get_id(type_id) else {
+            return false;
         };
         self.contains_id(id)
     }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -329,9 +329,8 @@ impl Plugin for PbrPlugin {
             },
         );
 
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         // Extract the required data from the main world
@@ -365,9 +364,8 @@ impl Plugin for PbrPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         // Extract the required data from the main world

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -1189,9 +1189,8 @@ pub(crate) fn assign_lights_to_clusters(
     mut max_point_lights_warning_emitted: Local<bool>,
     render_device: Option<Res<RenderDevice>>,
 ) {
-    let render_device = match render_device {
-        Some(render_device) => render_device,
-        None => return,
+    let Some(render_device) = render_device else {
+        return;
     };
 
     global_lights.entities.clear();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -8,6 +8,8 @@ use uuid::Uuid;
 
 pub(crate) fn type_uuid_derive(input: DeriveInput) -> syn::Result<TokenStream> {
     let mut uuid = None;
+
+    #[allow(clippy::manual_let_else)]
     for attribute in input
         .attrs
         .iter()
@@ -17,12 +19,9 @@ pub(crate) fn type_uuid_derive(input: DeriveInput) -> syn::Result<TokenStream> {
             continue;
         };
 
-        let Expr::Lit(ExprLit {
-            lit: Lit::Str(uuid_str),
-            ..
-        }) = &name_value.value
-        else {
-            return Err(syn::Error::new_spanned(attribute, "`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"]`."));
+        let uuid_str = match &name_value.value {
+            Expr::Lit(ExprLit{lit: Lit::Str(lit_str), ..}) => lit_str,
+            _ => return Err(syn::Error::new_spanned(attribute, "`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"]`.")),
         };
 
         uuid =

--- a/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/type_uuid.rs
@@ -17,9 +17,12 @@ pub(crate) fn type_uuid_derive(input: DeriveInput) -> syn::Result<TokenStream> {
             continue;
         };
 
-        let uuid_str = match &name_value.value {
-            Expr::Lit(ExprLit{lit: Lit::Str(lit_str), ..}) => lit_str,
-            _ => return Err(syn::Error::new_spanned(attribute, "`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"]`.")),
+        let Expr::Lit(ExprLit {
+            lit: Lit::Str(uuid_str),
+            ..
+        }) = &name_value.value
+        else {
+            return Err(syn::Error::new_spanned(attribute, "`uuid` attribute must take the form `#[uuid = \"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx\"]`."));
         };
 
         uuid =

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -449,9 +449,8 @@ impl Mesh {
             indices.map(|i| values[i]).collect()
         }
 
-        let indices = match self.indices.take() {
-            Some(indices) => indices,
-            None => return,
+        let Some(indices) = self.indices.take() else {
+            return;
         };
 
         for attributes in self.attributes.values_mut() {
@@ -1173,38 +1172,33 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
         other => return Err(GenerateTangentsError::UnsupportedTopology(other)),
     };
 
-    let positions = match mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
-        GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
-    )? {
-        VertexAttributeValues::Float32x3(vertices) => vertices,
-        _ => {
-            return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
-                Mesh::ATTRIBUTE_POSITION.name,
-                VertexFormat::Float32x3,
-            ))
-        }
+    let VertexAttributeValues::Float32x3(positions) =
+        mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
+            GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
+        )?
+    else {
+        return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
+            Mesh::ATTRIBUTE_POSITION.name,
+            VertexFormat::Float32x3,
+        ));
     };
-    let normals = match mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
+    let VertexAttributeValues::Float32x3(normals) = mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_NORMAL.name),
-    )? {
-        VertexAttributeValues::Float32x3(vertices) => vertices,
-        _ => {
-            return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
-                Mesh::ATTRIBUTE_NORMAL.name,
-                VertexFormat::Float32x3,
-            ))
-        }
+    )?
+    else {
+        return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
+            Mesh::ATTRIBUTE_NORMAL.name,
+            VertexFormat::Float32x3,
+        ));
     };
-    let uvs = match mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
+    let VertexAttributeValues::Float32x2(uvs) = mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_UV_0.name),
-    )? {
-        VertexAttributeValues::Float32x2(vertices) => vertices,
-        _ => {
-            return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
-                Mesh::ATTRIBUTE_UV_0.name,
-                VertexFormat::Float32x2,
-            ))
-        }
+    )?
+    else {
+        return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
+            Mesh::ATTRIBUTE_UV_0.name,
+            VertexFormat::Float32x2,
+        ));
     };
 
     let len = positions.len();

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1172,29 +1172,28 @@ fn generate_tangents_for_mesh(mesh: &Mesh) -> Result<Vec<[f32; 4]>, GenerateTang
         other => return Err(GenerateTangentsError::UnsupportedTopology(other)),
     };
 
-    let VertexAttributeValues::Float32x3(positions) =
-        mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
-            GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
-        )?
-    else {
+    let positions = mesh.attribute(Mesh::ATTRIBUTE_POSITION).ok_or(
+        GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_POSITION.name),
+    )?;
+    let VertexAttributeValues::Float32x3(positions) = positions else {
         return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
             Mesh::ATTRIBUTE_POSITION.name,
             VertexFormat::Float32x3,
         ));
     };
-    let VertexAttributeValues::Float32x3(normals) = mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
+    let normals = mesh.attribute(Mesh::ATTRIBUTE_NORMAL).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_NORMAL.name),
-    )?
-    else {
+    )?;
+    let VertexAttributeValues::Float32x3(normals) = normals else {
         return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
             Mesh::ATTRIBUTE_NORMAL.name,
             VertexFormat::Float32x3,
         ));
     };
-    let VertexAttributeValues::Float32x2(uvs) = mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
+    let uvs = mesh.attribute(Mesh::ATTRIBUTE_UV_0).ok_or(
         GenerateTangentsError::MissingVertexAttribute(Mesh::ATTRIBUTE_UV_0.name),
-    )?
-    else {
+    )?;
+    let VertexAttributeValues::Float32x2(uvs) = uvs else {
         return Err(GenerateTangentsError::InvalidVertexAttributeFormat(
             Mesh::ATTRIBUTE_UV_0.name,
             VertexFormat::Float32x2,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -195,9 +195,8 @@ impl Plugin for UiPlugin {
     }
 
     fn finish(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app.init_resource::<UiPipeline>();

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -65,9 +65,8 @@ pub enum RenderUiSystem {
 pub fn build_ui_render(app: &mut App) {
     load_internal_asset!(app, UI_SHADER_HANDLE, "ui.wgsl", Shader::from_wgsl);
 
-    let render_app = match app.get_sub_app_mut(RenderApp) {
-        Ok(render_app) => render_app,
-        Err(_) => return,
+    let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+        return;
     };
 
     render_app

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -259,9 +259,8 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
         let Some(mesh_instance) = render_mesh_instances.get(&item.entity()) else {
             return RenderCommandResult::Failure;
         };
-        let gpu_mesh = match meshes.into_inner().get(mesh_instance.mesh_asset_id) {
-            Some(gpu_mesh) => gpu_mesh,
-            None => return RenderCommandResult::Failure,
+        let Some(gpu_mesh) = meshes.into_inner().get(mesh_instance.mesh_asset_id) else {
+            return RenderCommandResult::Failure;
         };
 
         pass.set_vertex_buffer(0, gpu_mesh.vertex_buffer.slice(..));

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -153,9 +153,8 @@ struct LogVisibleLights;
 
 impl Plugin for LogVisibleLights {
     fn build(&self, app: &mut App) {
-        let render_app = match app.get_sub_app_mut(RenderApp) {
-            Ok(render_app) => render_app,
-            Err(_) => return,
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
         };
 
         render_app.add_systems(Render, print_visible_light_count.in_set(RenderSet::Prepare));


### PR DESCRIPTION
# Objective

Related to #10612.

Enable the [`clippy::manual_let_else`](https://rust-lang.github.io/rust-clippy/master/#manual_let_else) lint as a warning.  The `let else` form seems more idiomatic to me than a `match`/`if else` that either match a pattern or diverge, and from the clippy doc, the lint doesn't seem to have any possible false positive.

## Solution

Add the lint as warning in `Cargo.toml`, refactor places where the lint triggers.
