### PR TITLE
Upgrade to Taffy 0.4

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -31,7 +31,7 @@ bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
 # other
-taffy = { version = "0.3.10" }
+taffy = { version = "0.4" }
 serde = { version = "1", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", features = ["derive"] }
 thiserror = "1.0.0"

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -246,7 +246,7 @@ impl From<OverflowAxis> for taffy::style::Overflow {
         match value {
             OverflowAxis::Visible => taffy::style::Overflow::Visible,
             OverflowAxis::Clip => taffy::style::Overflow::Clip,
-            // TODO: Add OverflowAxis::Hidden to Bevy
+            OverflowAxis::Hidden => taffy::style::Overflow::Hidden,
         }
     }
 }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -236,6 +236,7 @@ impl From<Display> for taffy::style::Display {
         match value {
             Display::Flex => taffy::style::Display::Flex,
             Display::Grid => taffy::style::Display::Grid,
+            Display::Block => taffy::style::Display::Block,
             Display::None => taffy::style::Display::None,
         }
     }

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -610,18 +610,18 @@ mod tests {
         );
         assert_eq!(
             taffy_style.grid_template_rows,
-            vec![sh::points(10.0), sh::percent(0.5), sh::fr(1.0)]
+            vec![sh::length(10.0), sh::percent(0.5), sh::fr(1.0)]
         );
         assert_eq!(
             taffy_style.grid_template_columns,
-            vec![sh::repeat(5, vec![sh::points(10.0)])]
+            vec![sh::repeat(5, vec![sh::length(10.0)])]
         );
         assert_eq!(
             taffy_style.grid_auto_rows,
             vec![
                 sh::fit_content(taffy::style::LengthPercentage::Length(10.0)),
                 sh::fit_content(taffy::style::LengthPercentage::Percent(0.25)),
-                sh::minmax(sh::points(0.0), sh::fr(2.0)),
+                sh::minmax(sh::length(0.0), sh::fr(2.0)),
             ]
         );
         assert_eq!(

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -185,7 +185,7 @@ pub fn ui_layout_system(
                 ui_surface.upsert_node(&layout_context, entity, &style, measure);
             }
         } else {
-            ui_surface.upsert_node(entity, &Style::default(), &LayoutContext::default());
+            ui_surface.upsert_node(&LayoutContext::DEFAULT, entity, &Style::default(), None);
         }
     }
     scale_factor_events.clear();

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
 use bevy_ecs::{
     change_detection::{DetectChanges, DetectChangesMut},
     entity::Entity,
@@ -17,8 +18,6 @@ use bevy_utils::tracing::warn;
 use bevy_utils::{HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use ui_surface::UiSurface;
-
-use crate::{ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiScale};
 
 mod convert;
 pub mod debug;
@@ -60,7 +59,7 @@ pub enum LayoutError {
     #[error("Invalid hierarchy")]
     InvalidHierarchy,
     #[error("Taffy error: {0}")]
-    TaffyError(#[from] taffy::error::TaffyError),
+    TaffyError(#[from] taffy::TaffyError),
 }
 
 #[derive(SystemParam)]
@@ -176,11 +175,11 @@ pub fn ui_layout_system(
 
     // When a `ContentSize` component is removed from an entity, we need to remove the measure from the corresponding taffy node.
     for entity in removed_components.removed_content_sizes.read() {
-        ui_surface.try_remove_measure(entity);
+        ui_surface.try_remove_node_context(entity);
     }
     for (entity, mut content_size) in &mut measure_query {
-        if let Some(measure_func) = content_size.measure_func.take() {
-            ui_surface.try_update_measure(entity, measure_func);
+        if let Some(measure) = content_size.measure.take() {
+            ui_surface.update_node_context(entity, measure);
         }
     }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -336,7 +336,7 @@ fn round_layout_coords(value: Vec2) -> Vec2 {
 
 #[cfg(test)]
 mod tests {
-    use taffy::tree::LayoutTree;
+    use taffy::TraversePartialTree;
 
     use bevy_asset::AssetEvent;
     use bevy_asset::Assets;
@@ -577,7 +577,7 @@ mod tests {
         let ui_parent_node = ui_surface.entity_to_taffy[&ui_parent_entity];
 
         // `ui_parent_node` shouldn't have any children yet
-        assert_eq!(ui_surface.taffy.child_count(ui_parent_node).unwrap(), 0);
+        assert_eq!(ui_surface.taffy.child_count(ui_parent_node), 0);
 
         let mut ui_child_entities = (0..10)
             .map(|_| {
@@ -596,7 +596,7 @@ mod tests {
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node).unwrap(),
+            ui_surface.taffy.child_count(ui_parent_node),
             ui_child_entities.len()
         );
 
@@ -627,7 +627,7 @@ mod tests {
             1 + ui_child_entities.len()
         );
         assert_eq!(
-            ui_surface.taffy.child_count(ui_parent_node).unwrap(),
+            ui_surface.taffy.child_count(ui_parent_node),
             ui_child_entities.len()
         );
 
@@ -940,8 +940,8 @@ mod tests {
         let ui_surface = world.resource::<UiSurface>();
         let ui_node = ui_surface.entity_to_taffy[&ui_entity];
 
-        // a node with a content size needs to be measured
-        assert!(ui_surface.taffy.needs_measure(ui_node));
+        // a node with a content size should have taffy context
+        assert!(ui_surface.taffy.get_node_context(ui_node).is_some());
         let layout = ui_surface.get_layout(ui_entity).unwrap();
         assert_eq!(layout.size.width, content_size.x);
         assert_eq!(layout.size.height, content_size.y);
@@ -951,8 +951,8 @@ mod tests {
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
-        // a node without a content size does not need to be measured
-        assert!(!ui_surface.taffy.needs_measure(ui_node));
+        // a node without a content size should not have taffy context
+        assert!(ui_surface.taffy.get_node_context(ui_node).is_none());
 
         // Without a content size, the node has no width or height constraints so the length of both dimensions is 0.
         let layout = ui_surface.get_layout(ui_entity).unwrap();

--- a/crates/bevy_ui/src/layout/ui_surface.rs
+++ b/crates/bevy_ui/src/layout/ui_surface.rs
@@ -1,7 +1,6 @@
 use std::fmt;
 
-use taffy::prelude::LayoutTree;
-use taffy::Taffy;
+use taffy::TaffyTree;
 
 use bevy_ecs::entity::{Entity, EntityHashMap};
 use bevy_ecs::prelude::Resource;
@@ -11,28 +10,28 @@ use bevy_utils::default;
 use bevy_utils::tracing::warn;
 
 use crate::layout::convert;
-use crate::{LayoutContext, LayoutError, Style};
+use crate::{LayoutContext, LayoutError, Measure, NodeMeasure, Style};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RootNodePair {
     // The implicit "viewport" node created by Bevy
-    pub(super) implicit_viewport_node: taffy::node::Node,
+    pub(super) implicit_viewport_node: taffy::NodeId,
     // The root (parentless) node specified by the user
-    pub(super) user_root_node: taffy::node::Node,
+    pub(super) user_root_node: taffy::NodeId,
 }
 
 #[derive(Resource)]
 pub struct UiSurface {
-    pub(super) entity_to_taffy: EntityHashMap<taffy::node::Node>,
-    pub(super) camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::node::Node>>,
+    pub(super) entity_to_taffy: EntityHashMap<taffy::NodeId>,
+    pub(super) camera_entity_to_taffy: EntityHashMap<EntityHashMap<taffy::NodeId>>,
     pub(super) camera_roots: EntityHashMap<Vec<RootNodePair>>,
-    pub(super) taffy: Taffy,
+    pub(super) taffy: TaffyTree<NodeMeasure>,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
-    _assert_send_sync::<EntityHashMap<taffy::node::Node>>();
-    _assert_send_sync::<Taffy>();
+    _assert_send_sync::<EntityHashMap<taffy::NodeId>>();
+    _assert_send_sync::<TaffyTree<NodeMeasure>>();
     _assert_send_sync::<UiSurface>();
 }
 
@@ -47,7 +46,7 @@ impl fmt::Debug for UiSurface {
 
 impl Default for UiSurface {
     fn default() -> Self {
-        let mut taffy = Taffy::new();
+        let mut taffy: TaffyTree<NodeMeasure> = TaffyTree::new();
         taffy.disable_rounding();
         Self {
             entity_to_taffy: Default::default(),
@@ -77,14 +76,9 @@ impl UiSurface {
     }
 
     /// Update the `MeasureFunc` of the taffy node corresponding to the given [`Entity`] if the node exists.
-    pub fn try_update_measure(
-        &mut self,
-        entity: Entity,
-        measure_func: taffy::node::MeasureFunc,
-    ) -> Option<()> {
+    pub fn update_node_context(&mut self, entity: Entity, context: NodeMeasure) -> Option<()> {
         let taffy_node = self.entity_to_taffy.get(&entity)?;
-
-        self.taffy.set_measure(*taffy_node, Some(measure_func)).ok()
+        self.taffy.set_node_context(*taffy_node, Some(context)).ok()
     }
 
     /// Update the children of the taffy node corresponding to the given [`Entity`].
@@ -115,9 +109,9 @@ without UI components as a child of an entity with UI components, results may be
     }
 
     /// Removes the measure from the entity's taffy node if it exists. Does nothing otherwise.
-    pub fn try_remove_measure(&mut self, entity: Entity) {
+    pub fn try_remove_node_context(&mut self, entity: Entity) {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
-            self.taffy.set_measure(*taffy_node, None).unwrap();
+            self.taffy.set_node_context(*taffy_node, None).unwrap();
         }
     }
 
@@ -183,7 +177,30 @@ without UI components as a child of an entity with UI components, results may be
         };
         for root_nodes in camera_root_nodes {
             self.taffy
-                .compute_layout(root_nodes.implicit_viewport_node, available_space)
+                .compute_layout_with_measure(
+                    root_nodes.implicit_viewport_node,
+                    available_space,
+                    |known_dimensions: taffy::Size<Option<f32>>,
+                     available_space: taffy::Size<taffy::AvailableSpace>,
+                     _node_id: taffy::NodeId,
+                     context: Option<&mut NodeMeasure>|
+                     -> taffy::Size<f32> {
+                        context
+                            .map(|ctx| {
+                                let size = ctx.measure(
+                                    known_dimensions.width,
+                                    known_dimensions.height,
+                                    available_space.width,
+                                    available_space.height,
+                                );
+                                taffy::Size {
+                                    width: size.x,
+                                    height: size.y,
+                                }
+                            })
+                            .unwrap_or(taffy::Size::ZERO)
+                    },
+                )
                 .unwrap();
         }
     }
@@ -210,7 +227,7 @@ without UI components as a child of an entity with UI components, results may be
 
     /// Get the layout geometry for the taffy node corresponding to the ui node [`Entity`].
     /// Does not compute the layout geometry, `compute_window_layouts` should be run before using this function.
-    pub fn get_layout(&self, entity: Entity) -> Result<&taffy::layout::Layout, LayoutError> {
+    pub fn get_layout(&self, entity: Entity) -> Result<&taffy::Layout, LayoutError> {
         if let Some(taffy_node) = self.entity_to_taffy.get(&entity) {
             self.taffy
                 .layout(*taffy_node)

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -29,6 +29,10 @@ pub trait Measure: Send + Sync + 'static {
     ) -> Vec2;
 }
 
+/// A type to serve as Taffy's node context (which allows the content size of leaf nodes to be computed)
+///
+/// It has specific variants for common built-in types to avoid making them opaque and needing to box them
+/// by wrapping them in a closure and a Custom variant that allows arbitrary measurement closures if required.
 pub enum NodeMeasure {
     Fixed(FixedMeasure),
     #[cfg(feature = "bevy_text")]

--- a/crates/bevy_ui/src/measurement.rs
+++ b/crates/bevy_ui/src/measurement.rs
@@ -4,7 +4,11 @@ use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use std::fmt::Formatter;
 pub use taffy::style::AvailableSpace;
-use taffy::{node::MeasureFunc, prelude::Size as TaffySize};
+
+use crate::widget::ImageMeasure;
+
+#[cfg(feature = "bevy_text")]
+use crate::widget::TextMeasure;
 
 impl std::fmt::Debug for ContentSize {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -23,6 +27,40 @@ pub trait Measure: Send + Sync + 'static {
         available_width: AvailableSpace,
         available_height: AvailableSpace,
     ) -> Vec2;
+}
+
+pub enum NodeMeasure {
+    Fixed(FixedMeasure),
+    #[cfg(feature = "bevy_text")]
+    Text(TextMeasure),
+    Image(ImageMeasure),
+    Custom(Box<dyn Measure>),
+}
+
+impl Measure for NodeMeasure {
+    fn measure(
+        &self,
+        width: Option<f32>,
+        height: Option<f32>,
+        available_width: AvailableSpace,
+        available_height: AvailableSpace,
+    ) -> Vec2 {
+        match self {
+            NodeMeasure::Fixed(fixed) => {
+                fixed.measure(width, height, available_width, available_height)
+            }
+            #[cfg(feature = "bevy_text")]
+            NodeMeasure::Text(text) => {
+                text.measure(width, height, available_width, available_height)
+            }
+            NodeMeasure::Image(image) => {
+                image.measure(width, height, available_width, available_height)
+            }
+            NodeMeasure::Custom(custom) => {
+                custom.measure(width, height, available_width, available_height)
+            }
+        }
+    }
 }
 
 /// A `FixedMeasure` is a `Measure` that ignores all constraints and
@@ -51,26 +89,19 @@ impl Measure for FixedMeasure {
 pub struct ContentSize {
     /// The `Measure` used to compute the intrinsic size
     #[reflect(ignore)]
-    pub(crate) measure_func: Option<MeasureFunc>,
+    pub(crate) measure: Option<NodeMeasure>,
 }
 
 impl ContentSize {
     /// Set a `Measure` for the UI node entity with this component
-    pub fn set(&mut self, measure: impl Measure) {
-        let measure_func = move |size: TaffySize<_>, available: TaffySize<_>| {
-            let size = measure.measure(size.width, size.height, available.width, available.height);
-            TaffySize {
-                width: size.x,
-                height: size.y,
-            }
-        };
-        self.measure_func = Some(MeasureFunc::Boxed(Box::new(measure_func)));
+    pub fn set(&mut self, measure: NodeMeasure) {
+        self.measure = Some(measure);
     }
 
     /// Creates a `ContentSize` with a `Measure` that always returns given `size` argument, regardless of the UI layout's constraints.
     pub fn fixed_size(size: Vec2) -> ContentSize {
         let mut content_size = Self::default();
-        content_size.set(FixedMeasure { size });
+        content_size.set(NodeMeasure::Fixed(FixedMeasure { size }));
         content_size
     }
 }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -896,8 +896,10 @@ impl Default for Overflow {
 pub enum OverflowAxis {
     /// Show overflowing items.
     Visible,
-    /// Hide overflowing items.
+    /// Hide overflowing items by clipping.
     Clip,
+    /// Hide overflowing items by influencing layout and then clipping.
+    Hidden,
 }
 
 impl OverflowAxis {

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -770,10 +770,12 @@ impl Default for Direction {
     reflect(Serialize, Deserialize)
 )]
 pub enum Display {
-    /// Use Flexbox layout model to determine the position of this [`Node`].
+    /// Use Flexbox layout model to determine the position of this [`Node`]'s children.
     Flex,
-    /// Use CSS Grid layout model to determine the position of this [`Node`].
+    /// Use CSS Grid layout model to determine the position of this [`Node`]'s children.
     Grid,
+    /// Use CSS Block layout model to determine the position of this [`Node`]'s children.
+    Block,
     /// Use no layout, don't render this node and its children.
     ///
     /// If you want to hide a node and its children,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,4 +1,6 @@
-use crate::{measurement::AvailableSpace, ContentSize, Measure, Node, UiImage, UiScale};
+use crate::{
+    measurement::AvailableSpace, ContentSize, Measure, Node, NodeMeasure, UiImage, UiScale,
+};
 use bevy_asset::Assets;
 use bevy_ecs::prelude::*;
 use bevy_math::{UVec2, Vec2};
@@ -72,6 +74,7 @@ pub fn update_image_content_size_system(
     windows: Query<&Window, With<PrimaryWindow>>,
     ui_scale: Res<UiScale>,
     textures: Res<Assets<Image>>,
+
     atlases: Res<Assets<TextureAtlasLayout>>,
     mut query: Query<
         (
@@ -100,10 +103,10 @@ pub fn update_image_content_size_system(
                 || content_size.is_added()
             {
                 image_size.size = size;
-                content_size.set(ImageMeasure {
+                content_size.set(NodeMeasure::Image(ImageMeasure {
                     // multiply the image size by the scale factor to get the physical size
                     size: size.as_vec2() * combined_scale_factor,
-                });
+                }));
             }
         }
     }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -1,4 +1,4 @@
-use crate::{ContentSize, FixedMeasure, Measure, Node, UiScale};
+use crate::{ContentSize, FixedMeasure, Measure, Node, NodeMeasure, UiScale};
 use bevy_asset::Assets;
 use bevy_ecs::{
     prelude::{Component, DetectChanges},
@@ -88,9 +88,9 @@ fn create_text_measure(
     match TextMeasureInfo::from_text(&text, fonts, scale_factor) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
-                content_size.set(FixedMeasure { size: measure.max });
+                content_size.set(NodeMeasure::Fixed(FixedMeasure { size: measure.max }));
             } else {
-                content_size.set(TextMeasure { info: measure });
+                content_size.set(NodeMeasure::Text(TextMeasure { info: measure }));
             }
 
             // Text measure func created successfully, so set `TextFlags` to schedule a recompute

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -55,6 +55,7 @@ impl TargetUpdate for Target<Display> {
             Display::Flex => Display::None,
             Display::None => Display::Flex,
             Display::Grid => unreachable!(),
+            Display::Block => unreachable!(),
         };
         format!("{}::{:?} ", Self::NAME, style.display)
     }

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -54,8 +54,7 @@ impl TargetUpdate for Target<Display> {
         style.display = match style.display {
             Display::Flex => Display::None,
             Display::None => Display::Flex,
-            Display::Grid => unreachable!(),
-            Display::Block => unreachable!(),
+            Display::Block | Display::Grid => unreachable!(),
         };
         format!("{}::{:?} ", Self::NAME, style.display)
     }

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -124,7 +124,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         // Align content towards the center in the horizontal axis
                         justify_items: JustifyItems::Center,
                         // Add 10px padding
-                        // padding: UiRect::all(Val::Px(10.)),
+                        padding: UiRect::all(Val::Px(10.)),
                         // Add an fr track to take up all the available space at the bottom of the column so that the text nodes
                         // can be top-aligned. Normally you'd use flexbox for this, but this is the CSS Grid example so we're using grid.
                         grid_template_rows: vec![GridTrack::auto(), GridTrack::auto(), GridTrack::fr(1.0)],
@@ -143,10 +143,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                             font_size: 24.0,
                             ..default()
                         },
-                    ).with_style(Style {
-                    padding: UiRect::all(Val::Px(10.)),
-                    ..Default::default()
-                }));
+                    ));
                     builder.spawn(TextBundle::from_section(
                         "A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely.",
                         TextStyle {
@@ -154,10 +151,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                             font_size: 16.0,
                             ..default()
                         },
-                    ).with_style(Style {
-                    padding: UiRect::all(Val::Px(10.)),
-                    ..Default::default()
-                }));
+                    ));
                     builder.spawn(NodeBundle::default());
                 });
 

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -124,7 +124,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         // Align content towards the center in the horizontal axis
                         justify_items: JustifyItems::Center,
                         // Add 10px padding
-                        padding: UiRect::all(Val::Px(10.)),
+                        // padding: UiRect::all(Val::Px(10.)),
                         // Add an fr track to take up all the available space at the bottom of the column so that the text nodes
                         // can be top-aligned. Normally you'd use flexbox for this, but this is the CSS Grid example so we're using grid.
                         grid_template_rows: vec![GridTrack::auto(), GridTrack::auto(), GridTrack::fr(1.0)],
@@ -143,7 +143,10 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                             font_size: 24.0,
                             ..default()
                         },
-                    ));
+                    ).with_style(Style {
+                    padding: UiRect::all(Val::Px(10.)),
+                    ..Default::default()
+                }));
                     builder.spawn(TextBundle::from_section(
                         "A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely. A paragraph of text which ought to wrap nicely.",
                         TextStyle {
@@ -151,7 +154,10 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                             font_size: 16.0,
                             ..default()
                         },
-                    ));
+                    ).with_style(Style {
+                    padding: UiRect::all(Val::Px(10.)),
+                    ..Default::default()
+                }));
                     builder.spawn(NodeBundle::default());
                 });
 


### PR DESCRIPTION
# Objective

- Enables support for `Display::Block`
- Enables support for `Overflow::Hidden`
- Allows for cleaner integration with text, image and other content layout.
- Unblocks https://github.com/bevyengine/bevy/pull/8104
- Unlocks the possibility of Bevy creating a custom layout tree over which Taffy operates.
- Enables #8808 / #10193 to remove a Mutex around the font system.

## Todo

- [x] ~Fix rendering of text/images to account for padding/border on nodes (should size/position to content box rather than border box)~ In order get this into a mergeable state this PR instead zeroes out padding/border when syncing leaf node styles into Taffy to preserve the existing behaviour. https://github.com/bevyengine/bevy/issues/6879 can be fixed in a followup PR.

## Solution

- Update the version of Taffy
- Update code to work with the new version

Note: Taffy 0.4 has not yet been released. This PR is being created in advance of the release to ensure that there are no blockers to upgrading once the release occurs.

---

## Changelog

- Bevy now supports the `Display::Block` and `Overflow::Hidden` styles.

