### PR TITLE
Fix Asset Loading Bug

### DIFF
--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -271,7 +271,7 @@ impl Display for UntypedAssetId {
 impl PartialEq for UntypedAssetId {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
-        self.internal().eq(&other.internal())
+        self.type_id() == other.type_id() && self.internal().eq(&other.internal())
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #10695

## Solution

Fixed obvious blunder in `PartialEq` implementation for `UntypedAssetId`'s where the `TypeId` was not included in the comparison. This was not picked up in the unit tests I added because they only tested over a single asset type.
