### PR TITLE
remove double-hasing of typeid for handle

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -223,7 +223,6 @@ impl<A: Asset> Hash for Handle<A> {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id().hash(state);
-        TypeId::of::<A>().hash(state);
     }
 }
 
@@ -393,7 +392,6 @@ impl Hash for UntypedHandle {
     #[inline]
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.id().hash(state);
-        self.type_id().hash(state);
     }
 }
 


### PR DESCRIPTION
# Objective

There is a double hash for the typeid for asset handles. (see [this](https://github.com/bevyengine/bevy/issues/10695#issuecomment-1822340727) for more info)

## Solution

- Remove the second hash of the typeid