### PR TITLE
Fix issue with `Option` serialization

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -42,6 +42,7 @@ smol_str = { version = "0.2.0", optional = true }
 ron = "0.8.0"
 rmp-serde = "1.1"
 bincode = "1.3"
+serde_json = "1.0"
 serde = { version = "1", features = ["derive"] }
 
 [[example]]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -41,7 +41,9 @@ smol_str = { version = "0.2.0", optional = true }
 [dev-dependencies]
 ron = "0.8.0"
 rmp-serde = "1.1"
+serde_json = "1.0"
 bincode = "1.3"
+serde = { version = "1", features = ["derive"] }
 
 [[example]]
 name = "reflect_docs"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -41,7 +41,6 @@ smol_str = { version = "0.2.0", optional = true }
 [dev-dependencies]
 ron = "0.8.0"
 rmp-serde = "1.1"
-serde_json = "1.0"
 bincode = "1.3"
 serde = { version = "1", features = ["derive"] }
 

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -317,10 +317,8 @@ impl<'a> Serialize for EnumSerializer<'a> {
 
         match variant_type {
             VariantType::Unit => {
-                let table = type_info.map(|i| i.type_path_table());
-
-                if table.and_then(|t| t.module_path()) == Some("core::option")
-                    && table.and_then(|t| t.ident()) == Some("Option")
+                if type_info.type_path_table().module_path() == Some("core::option")
+                    && type_info.type_path_table().ident() == Some("Option")
                 {
                     serializer.serialize_none()
                 } else {
@@ -354,13 +352,9 @@ impl<'a> Serialize for EnumSerializer<'a> {
             }
             VariantType::Tuple if field_len == 1 => {
                 let field = self.enum_value.field_at(0).unwrap();
-                let table = self
-                    .enum_value
-                    .get_represented_type_info()
-                    .map(|i| i.type_path_table());
 
-                if table.and_then(|t| t.module_path()) == Some("core::option")
-                    && table.and_then(|t| t.ident()) == Some("Option")
+                if type_info.type_path_table().module_path() == Some("core::option")
+                    && type_info.type_path_table().ident() == Some("Option")
                 {
                     serializer.serialize_some(&TypedReflectSerializer::new(field, self.registry))
                 } else {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -317,10 +317,7 @@ impl<'a> Serialize for EnumSerializer<'a> {
 
         match variant_type {
             VariantType::Unit => {
-                let table = self
-                    .enum_value
-                    .get_represented_type_info()
-                    .map(|i| i.type_path_table());
+                let table = type_info.map(|i| i.type_path_table());
 
                 if table.and_then(|t| t.module_path()) == Some("core::option")
                     && table.and_then(|t| t.ident()) == Some("Option")

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -478,6 +478,7 @@ mod tests {
         primitive_value: i8,
         option_value: Option<String>,
         option_value_complex: Option<SomeStruct>,
+        option_none_value: Option<String>,
         tuple_value: (f32, usize),
         list_value: Vec<i32>,
         array_value: [i32; 5],
@@ -577,6 +578,7 @@ mod tests {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
             option_value_complex: Some(SomeStruct { foo: 123 }),
+            option_none_value: None,
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
@@ -777,6 +779,7 @@ mod tests {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
             option_value_complex: Some(SomeStruct { foo: 123 }),
+            option_none_value: None,
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
@@ -835,6 +838,7 @@ mod tests {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
             option_value_complex: Some(SomeStruct { foo: 123 }),
+            option_none_value: None,
             tuple_value: (PI, 1337),
             list_value: vec![-2, -1, 0, 1, 2],
             array_value: [-2, -1, 0, 1, 2],
@@ -880,5 +884,115 @@ mod tests {
         ];
 
         assert_eq!(expected, bytes);
+    }
+
+    #[test]
+    fn should_serialize_json() {
+        let mut map = HashMap::new();
+        map.insert(64, 32);
+
+        let input = MyStruct {
+            primitive_value: 123,
+            option_value: Some(String::from("Hello world!")),
+            option_value_complex: Some(SomeStruct { foo: 123 }),
+            option_none_value: None,
+            tuple_value: (PI, 1337),
+            list_value: vec![-2, -1, 0, 1, 2],
+            array_value: [-2, -1, 0, 1, 2],
+            map_value: map,
+            struct_value: SomeStruct { foo: 999999999 },
+            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
+            unit_struct: SomeUnitStruct,
+            unit_enum: SomeEnum::Unit,
+            newtype_enum: SomeEnum::NewType(123),
+            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
+            struct_enum: SomeEnum::Struct {
+                foo: String::from("Struct variant value"),
+            },
+            ignored_struct: SomeIgnoredStruct { ignored: 123 },
+            ignored_tuple_struct: SomeIgnoredTupleStruct(123),
+            ignored_struct_variant: SomeIgnoredEnum::Struct {
+                foo: String::from("Struct Variant"),
+            },
+            ignored_tuple_variant: SomeIgnoredEnum::Tuple(1.23, 3.45),
+            custom_serialize: CustomSerialize {
+                value: 100,
+                inner_struct: SomeSerializableStruct { foo: 101 },
+            },
+        };
+
+        let registry = get_registry();
+        let serializer = ReflectSerializer::new(&input, &registry);
+
+        let output = serde_json::to_string_pretty(&serializer).unwrap();
+        let expected = r#"{
+  "bevy_reflect::serde::ser::tests::MyStruct": {
+    "primitive_value": 123,
+    "option_value": "Hello world!",
+    "option_value_complex": {
+      "foo": 123
+    },
+    "option_none_value": null,
+    "tuple_value": [
+      3.1415927,
+      1337
+    ],
+    "list_value": [
+      -2,
+      -1,
+      0,
+      1,
+      2
+    ],
+    "array_value": [
+      -2,
+      -1,
+      0,
+      1,
+      2
+    ],
+    "map_value": {
+      "64": 32
+    },
+    "struct_value": {
+      "foo": 999999999
+    },
+    "tuple_struct_value": [
+      "Tuple Struct"
+    ],
+    "unit_struct": {},
+    "unit_enum": "Unit",
+    "newtype_enum": {
+      "NewType": 123
+    },
+    "tuple_enum": {
+      "Tuple": [
+        1.23,
+        3.21
+      ]
+    },
+    "struct_enum": {
+      "Struct": {
+        "foo": "Struct variant value"
+      }
+    },
+    "ignored_struct": {},
+    "ignored_tuple_struct": [],
+    "ignored_struct_variant": {
+      "Struct": {}
+    },
+    "ignored_tuple_variant": {
+      "Tuple": []
+    },
+    "custom_serialize": {
+      "value": 100,
+      "renamed": {
+        "foo": 101
+      }
+    }
+  }
+}"#;
+
+        assert_eq!(expected, output);
     }
 }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -317,16 +317,13 @@ impl<'a> Serialize for EnumSerializer<'a> {
 
         match variant_type {
             VariantType::Unit => {
-                if self
+                let table = self
                     .enum_value
                     .get_represented_type_info()
-                    .and_then(|i| i.type_path_table().module_path())
-                    == Some("core::option")
-                    && self
-                        .enum_value
-                        .get_represented_type_info()
-                        .and_then(|i| i.type_path_table().ident())
-                        == Some("Option")
+                    .map(|i| i.type_path_table());
+
+                if table.and_then(|t| t.module_path()) == Some("core::option")
+                    && table.and_then(|t| t.ident()) == Some("Option")
                 {
                     serializer.serialize_none()
                 } else {
@@ -360,16 +357,13 @@ impl<'a> Serialize for EnumSerializer<'a> {
             }
             VariantType::Tuple if field_len == 1 => {
                 let field = self.enum_value.field_at(0).unwrap();
-                if self
+                let table = self
                     .enum_value
                     .get_represented_type_info()
-                    .and_then(|i| i.type_path_table().module_path())
-                    == Some("core::option")
-                    && self
-                        .enum_value
-                        .get_represented_type_info()
-                        .and_then(|i| i.type_path_table().ident())
-                        == Some("Option")
+                    .map(|i| i.type_path_table());
+
+                if table.and_then(|t| t.module_path()) == Some("core::option")
+                    && table.and_then(|t| t.ident()) == Some("Option")
                 {
                     serializer.serialize_some(&TypedReflectSerializer::new(field, self.registry))
                 } else {

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -897,7 +897,7 @@ mod tests {
     }
 
     #[test]
-    fn should_serialize_dynamic() {
+    fn should_serialize_dynamic_option() {
         #[derive(Default, Reflect)]
         struct OtherStruct {
             some: Option<SomeStruct>,


### PR DESCRIPTION
# Objective

- Fix #10499 

## Solution

- Use `.get_represented_type_info()` module path and type ident instead of `.reflect_*` module path and type ident when serializing the `Option` enum

---

## Changelog

- Fix serialization bug
- Add simple test
  - Add `serde_json` dev dependency
  - Add `serde` with `derive` feature dev dependency (wouldn't compile for me without it)