### PR TITLE
Ensure instance_index push constant is always used in prepass.wgsl

### DIFF
--- a/crates/bevy_pbr/src/prepass/prepass.wgsl
+++ b/crates/bevy_pbr/src/prepass/prepass.wgsl
@@ -107,6 +107,12 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     // See https://github.com/gfx-rs/naga/issues/2416
     out.instance_index = get_instance_index(vertex_no_morph.instance_index);
 #endif
+#ifdef BASE_INSTANCE_WORKAROUND
+    // Hack: this ensures the push constant is always used, which works around this issue:
+    // https://github.com/bevyengine/bevy/issues/10509
+    // This can be removed when wgpu 0.19 is released
+    out.position.x += f32(get_instance_index(0u)) * 0.00001;
+#endif
 
     return out;
 }


### PR DESCRIPTION
# Objective

 Kind of helps #10509 

## Solution

Add a line to `prepass.wgsl` that ensure the `instance_index` push constant is always used on WebGL 2. This is not a full fix, as the _second_ a custom shader is used that doesn't use the push constant, the breakage will resurface. We have satisfying medium term and long term solutions. See #10509 for more details.
