### PR TITLE
`Callback` as `Asset`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1103,6 +1103,17 @@ category = "Assets"
 wasm = false
 
 [[example]]
+name = "callbacks"
+path = "examples/asset/callbacks.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.callbacks]
+name = "Callbacks"
+description = "Demonstrates using Callbacks"
+category = "Assets"
+wasm = true
+
+[[example]]
 name = "custom_asset"
 path = "examples/asset/custom_asset.rs"
 doc-scrape-examples = true

--- a/crates/bevy_asset/src/callback.rs
+++ b/crates/bevy_asset/src/callback.rs
@@ -1,0 +1,383 @@
+use bevy_ecs::{
+    prelude::*,
+    system::{Command, DriveSystem},
+};
+use bevy_reflect::prelude::*;
+use bevy_utils::tracing;
+use thiserror::Error;
+
+use crate::{Asset, Assets, Handle, VisitAssetDependencies};
+
+// TODO: Add docs
+#[derive(TypePath)]
+pub struct Callback<I = (), O = ()> {
+    inner: Option<DriveSystem<I, O>>,
+}
+
+impl<I: 'static, O: 'static> Callback<I, O> {
+    // TODO: Add docs
+    pub fn from_system<M, S: IntoSystem<I, O, M>>(system: S) -> Self {
+        Self {
+            inner: Some(DriveSystem::new(Box::new(IntoSystem::into_system(system)))),
+        }
+    }
+}
+
+impl<I, O> VisitAssetDependencies for Callback<I, O> {
+    fn visit_dependencies(&self, _visit: &mut impl FnMut(crate::UntypedAssetId)) {
+        // TODO: Would there be a way to get this info from the IntoSystem used to contruct the callback?
+        // TODO: Should there be a way to pass this info through a different construct function?
+    }
+}
+
+impl<I: TypePath, O: TypePath> Asset for Callback<I, O> {}
+
+// TODO: Add docs
+#[derive(Error)]
+pub enum CallbackError<I: TypePath, O: TypePath> {
+    // TODO: Add docs
+    #[error("Callback {0:?} was not found")]
+    HandleNotFound(Handle<Callback<I, O>>),
+    // TODO: Add docs
+    #[error("Callback {0:?} tried to run itself recursively")]
+    Recursive(Handle<Callback<I, O>>),
+    // TODO: Add docs
+    #[error("Callback {0:?} removed itself")]
+    RemovedSelf(Handle<Callback<I, O>>),
+}
+
+impl<I: TypePath, O: TypePath> std::fmt::Debug for CallbackError<I, O> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HandleNotFound(arg0) => f.debug_tuple("HandleNotFound").field(arg0).finish(),
+            Self::Recursive(arg0) => f.debug_tuple("Recursive").field(arg0).finish(),
+            Self::RemovedSelf(arg0) => f.debug_tuple("RemovedSelf").field(arg0).finish(),
+        }
+    }
+}
+
+// TODO: Add docs
+pub trait RunCallbackWorld {
+    // TODO: Add docs
+    fn run_callback_with_input<In: TypePath + Send + 'static, Out: TypePath + 'static>(
+        &mut self,
+        handle: Handle<Callback<In, Out>>,
+        input: In,
+    ) -> Result<Out, CallbackError<In, Out>>;
+
+    // TODO: Add docs
+    fn run_callback<Out: TypePath + 'static>(
+        &mut self,
+        handle: Handle<Callback<(), Out>>,
+    ) -> Result<Out, CallbackError<(), Out>> {
+        self.run_callback_with_input(handle, ())
+    }
+}
+
+impl RunCallbackWorld for World {
+    fn run_callback_with_input<In: TypePath + Send + 'static, Out: TypePath + 'static>(
+        &mut self,
+        handle: Handle<Callback<In, Out>>,
+        input: In,
+    ) -> Result<Out, CallbackError<In, Out>> {
+        let mut assets = self.resource_mut::<Assets<Callback<In, Out>>>();
+        let mut callback = assets
+            .get_mut(&handle)
+            .ok_or_else(|| CallbackError::HandleNotFound(handle.clone()))?
+            .inner
+            .take()
+            .ok_or_else(|| CallbackError::Recursive(handle.clone()))?;
+
+        let result = callback.run_with_input(self, input);
+        let mut assets = self.resource_mut::<Assets<Callback<In, Out>>>();
+        assets
+            .get_mut(&handle)
+            .ok_or_else(|| CallbackError::RemovedSelf(handle))?
+            .inner = Some(callback);
+
+        Ok(result)
+    }
+}
+
+// TODO: add docs
+#[derive(Debug, Clone)]
+pub struct RunCallbackWithInput<I: TypePath + 'static> {
+    handle: Handle<Callback<I>>,
+    input: I,
+}
+
+// TODO: add docs
+pub type RunCallback = RunCallbackWithInput<()>;
+
+impl RunCallback {
+    // TODO: add docs
+    pub fn new(handle: Handle<Callback>) -> Self {
+        Self::new_with_input(handle, ())
+    }
+}
+
+impl<I: TypePath + 'static> RunCallbackWithInput<I> {
+    // TODO: add docs
+    pub fn new_with_input(handle: Handle<Callback<I>>, input: I) -> Self {
+        Self { handle, input }
+    }
+}
+
+impl<I: TypePath + Send + 'static> Command for RunCallbackWithInput<I> {
+    #[inline]
+    fn apply(self, world: &mut World) {
+        if let Err(error) = world.run_callback_with_input(self.handle, self.input) {
+            tracing::error!("{error}");
+        }
+    }
+}
+
+// TODO: Add docs
+pub trait RunCallbackCommands {
+    // TODO: Add docs
+    fn run_callback_with_input<I: TypePath + Send + 'static>(
+        &mut self,
+        handle: Handle<Callback<I>>,
+        input: I,
+    );
+
+    // TODO: Add docs
+    fn run_callback(&mut self, handle: Handle<Callback>) {
+        self.run_callback_with_input(handle, ());
+    }
+}
+
+impl<'w, 's> RunCallbackCommands for Commands<'w, 's> {
+    fn run_callback_with_input<I: TypePath + Send + 'static>(
+        &mut self,
+        handle: Handle<Callback<I>>,
+        input: I,
+    ) {
+        self.add(RunCallbackWithInput::new_with_input(handle, input));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::*;
+    use bevy_ecs::prelude::*;
+
+    #[derive(Resource, Default, PartialEq, Debug)]
+    struct Counter(u8);
+
+    #[test]
+    fn change_detection() {
+        #[derive(Resource, Default)]
+        struct ChangeDetector;
+
+        fn count_up_iff_changed(
+            mut counter: ResMut<Counter>,
+            change_detector: ResMut<ChangeDetector>,
+        ) {
+            if change_detector.is_changed() {
+                counter.0 += 1;
+            }
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.init_resource::<ChangeDetector>();
+        app.init_resource::<Counter>();
+        assert_eq!(*app.world.resource::<Counter>(), Counter(0));
+
+        // Resources are changed when they are first added.
+        let mut callbacks = app.world.resource_mut::<Assets<Callback>>();
+        let handle = callbacks.add(Callback::from_system(count_up_iff_changed));
+        app.world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+        // Nothing changed
+        app.world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+        // Making a change
+        app.world.resource_mut::<ChangeDetector>().set_changed();
+        app.world
+            .run_callback(handle)
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(2));
+    }
+
+    #[test]
+    fn local_variables() {
+        // The `Local` begins at the default value of 0
+        fn doubling(mut last_counter: Local<Counter>, mut counter: ResMut<Counter>) {
+            counter.0 += last_counter.0;
+            last_counter.0 = counter.0;
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.insert_resource(Counter(1));
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+
+        let mut callbacks = app.world.resource_mut::<Assets<Callback>>();
+        let handle = callbacks.add(Callback::from_system(doubling));
+        app.world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+        app.world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(2));
+        app.world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(4));
+        app.world
+            .run_callback(handle)
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(8));
+    }
+
+    #[test]
+    fn input_values() {
+        // Verify that a non-Copy, non-Clone type can be passed in.
+        #[derive(TypePath)]
+        struct NonCopy(u8);
+
+        fn increment_sys(In(NonCopy(increment_by)): In<NonCopy>, mut counter: ResMut<Counter>) {
+            counter.0 += increment_by;
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.init_asset::<Callback<NonCopy>>();
+
+        let mut callbacks = app.world.resource_mut::<Assets<Callback<NonCopy>>>();
+        let handle = callbacks.add(Callback::from_system(increment_sys));
+
+        // Insert the resource after registering the system.
+        app.insert_resource(Counter(1));
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+
+        app.world
+            .run_callback_with_input(handle.clone(), NonCopy(1))
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(2));
+
+        app.world
+            .run_callback_with_input(handle.clone(), NonCopy(1))
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(3));
+
+        app.world
+            .run_callback_with_input(handle.clone(), NonCopy(20))
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(23));
+
+        app.world
+            .run_callback_with_input(handle, NonCopy(1))
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(24));
+    }
+
+    #[test]
+    fn output_values() {
+        // Verify that a non-Copy, non-Clone type can be returned.
+        #[derive(TypePath, Eq, PartialEq, Debug)]
+        struct NonCopy(u8);
+
+        fn increment_sys(mut counter: ResMut<Counter>) -> NonCopy {
+            counter.0 += 1;
+            NonCopy(counter.0)
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.init_asset::<Callback<(), NonCopy>>();
+
+        let mut callbacks = app.world.resource_mut::<Assets<Callback<(), NonCopy>>>();
+        let handle = callbacks.add(Callback::from_system(increment_sys));
+
+        // Insert the resource after registering the system.
+        app.insert_resource(Counter(1));
+        assert_eq!(*app.world.resource::<Counter>(), Counter(1));
+
+        let output = app
+            .world
+            .run_callback(handle.clone())
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(2));
+        assert_eq!(output, NonCopy(2));
+
+        let output = app
+            .world
+            .run_callback(handle)
+            .expect("system runs successfully");
+        assert_eq!(*app.world.resource::<Counter>(), Counter(3));
+        assert_eq!(output, NonCopy(3));
+    }
+
+    #[test]
+    fn nested_systems() {
+        #[derive(Component)]
+        struct Call(Handle<Callback>);
+
+        fn nested(query: Query<&Call>, mut commands: Commands) {
+            for call in query.iter() {
+                commands.run_callback(call.0.clone());
+            }
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.insert_resource(Counter(0));
+
+        let mut callbacks = app.world.resource_mut::<Assets<Callback>>();
+
+        let increment_two = callbacks.add(Callback::from_system(|mut counter: ResMut<Counter>| {
+            counter.0 += 2;
+        }));
+        let increment_three =
+            callbacks.add(Callback::from_system(|mut counter: ResMut<Counter>| {
+                counter.0 += 3;
+            }));
+        let nested_handle = callbacks.add(Callback::from_system(nested));
+
+        app.world.spawn(Call(increment_two));
+        app.world.spawn(Call(increment_three));
+        let _ = app.world.run_callback(nested_handle);
+        assert_eq!(*app.world.resource::<Counter>(), Counter(5));
+    }
+
+    #[test]
+    fn nested_systems_with_inputs() {
+        #[derive(Component)]
+        struct Call(Handle<Callback<u8>>, u8);
+
+        fn nested(query: Query<&Call>, mut commands: Commands) {
+            for callback in query.iter() {
+                commands.run_callback_with_input(callback.0.clone(), callback.1);
+            }
+        }
+
+        let mut app = App::new();
+        app.add_plugins(AssetPlugin::default());
+        app.init_asset::<Callback<u8>>();
+        app.insert_resource(Counter(0));
+
+        let mut callbacks = app.world.resource_mut::<Assets<Callback<u8>>>();
+
+        let increment_by = callbacks.add(Callback::from_system(
+            |In(amt): In<u8>, mut counter: ResMut<Counter>| {
+                counter.0 += amt;
+            },
+        ));
+        let mut callbacks = app.world.resource_mut::<Assets<Callback>>();
+        let nested_id = callbacks.add(Callback::from_system(nested));
+
+        app.world.spawn(Call(increment_by.clone(), 2));
+        app.world.spawn(Call(increment_by, 3));
+        let _ = app.world.run_callback(nested_id);
+        assert_eq!(*app.world.resource::<Counter>(), Counter(5));
+    }
+}

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -6,8 +6,8 @@ pub mod saver;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        Asset, AssetApp, AssetEvent, AssetId, AssetMode, AssetPlugin, AssetServer, Assets, Handle,
-        UntypedHandle,
+        Asset, AssetApp, AssetEvent, AssetId, AssetMode, AssetPlugin, AssetServer, Assets,
+        Callback, Handle, RunCallbackCommands, RunCallbackWorld, UntypedHandle,
     };
 }
 

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -12,6 +12,7 @@ pub mod prelude {
 }
 
 mod assets;
+mod callback;
 mod event;
 mod folder;
 mod handle;
@@ -23,6 +24,7 @@ mod server;
 
 pub use assets::*;
 pub use bevy_asset_macros::Asset;
+pub use callback::*;
 pub use event::*;
 pub use folder::*;
 pub use futures_lite::{AsyncReadExt, AsyncWriteExt};
@@ -213,6 +215,7 @@ impl Plugin for AssetPlugin {
             .init_asset::<LoadedFolder>()
             .init_asset::<LoadedUntypedAsset>()
             .init_asset::<()>()
+            .init_asset::<Callback>()
             .configure_sets(
                 UpdateAssets,
                 TrackAssets.after(handle_internal_asset_events),

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -6,8 +6,8 @@ pub mod saver;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        Asset, AssetApp, AssetEvent, AssetId, AssetMode, AssetPlugin, AssetServer, Assets,
-        Callback, Handle, RunCallbackCommands, RunCallbackWorld, UntypedHandle,
+        Asset, AssetApp, AssetEvent, AssetId, AssetMode, AssetPlugin, AssetServer, Assets, Handle,
+        RunCallbackCommands, RunCallbackWorld, UntypedHandle,
     };
 }
 
@@ -48,7 +48,7 @@ use bevy_app::{App, First, MainScheduleOrder, Plugin, PostUpdate};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
     schedule::{IntoSystemConfigs, IntoSystemSetConfigs, ScheduleLabel, SystemSet},
-    system::Resource,
+    system::{Callback, Resource},
     world::FromWorld,
 };
 use bevy_log::error;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -43,8 +43,9 @@ pub mod prelude {
             OnTransition, Schedule, Schedules, State, States, SystemSet,
         },
         system::{
-            Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
-            ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System, SystemParamFunction,
+            Callback, Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut,
+            ParallelCommands, ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System,
+            SystemParamFunction,
         },
         world::{EntityMut, EntityRef, EntityWorldMut, FromWorld, World},
     };

--- a/examples/README.md
+++ b/examples/README.md
@@ -184,6 +184,7 @@ Example | Description
 [Asset Decompression](../examples/asset/asset_decompression.rs) | Demonstrates loading a compressed asset
 [Asset Loading](../examples/asset/asset_loading.rs) | Demonstrates various methods to load assets
 [Asset Processing](../examples/asset/processing/asset_processing.rs) | Demonstrates how to process and load custom assets
+[Callbacks](../examples/asset/callbacks.rs) | Demonstrates using Callbacks
 [Custom Asset](../examples/asset/custom_asset.rs) | Implements a custom asset loader
 [Custom Asset IO](../examples/asset/custom_asset_reader.rs) | Implements a custom AssetReader
 [Hot Reloading of Assets](../examples/asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk

--- a/examples/asset/callbacks.rs
+++ b/examples/asset/callbacks.rs
@@ -1,0 +1,108 @@
+//! Demonstrates the use of [`Callback`]s, which run once when triggered.
+//!
+//! These can be useful to help structure your logic in a push-based fashion,
+//! reducing the overhead of running extremely rarely run systems
+//! and improving schedule flexibility. Their advantage over [`SystemId`]s is
+//! that they are [`Asset`]s.
+//!
+//! See the [`RunCallbackWorld::run_callback`](bevy::prelude::RunCallbackWorld::run_callback)
+//! docs for more details.
+
+use bevy::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // `init_asset` must be called for new types of callbacks.
+        // By default, only `Callback` (no input or output) is inited.
+        .init_asset::<Callback<PressedDown>>()
+        .add_systems(Startup, setup)
+        .add_systems(Update, evaluate_callbacks)
+        .run();
+}
+
+// Need to store the `Handle` to the callback
+#[derive(Component)]
+struct OnPressedDown(Handle<Callback<PressedDown>>);
+
+// Input and output of `Callback`s must implement `TypePath`
+#[derive(TypePath)]
+struct PressedDown(Entity);
+
+// Need mutible access to `Assets` to add a callback
+fn setup(mut commands: Commands, mut callbacks: ResMut<Assets<Callback<PressedDown>>>) {
+    // Camera
+    commands.spawn(Camera2dBundle::default());
+
+    // root node
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                justify_content: JustifyContent::Center,
+                align_items: AlignItems::Center,
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|parent| {
+            // button
+            parent
+                .spawn((
+                    ButtonBundle {
+                        style: Style {
+                            width: Val::Px(250.0),
+                            height: Val::Px(65.0),
+                            margin: UiRect::all(Val::Px(20.0)),
+                            justify_content: JustifyContent::Center,
+                            align_items: AlignItems::Center,
+                            ..default()
+                        },
+                        background_color: Color::TEAL.into(),
+                        ..default()
+                    },
+                    // Add callback
+                    OnPressedDown(callbacks.add(Callback::from_system(toggle))),
+                ))
+                .with_children(|parent| {
+                    // text
+                    parent.spawn(TextBundle::from_section(
+                        "false",
+                        TextStyle {
+                            font_size: 40.0,
+                            color: Color::BLACK,
+                            ..default()
+                        },
+                    ));
+                });
+        });
+}
+
+// `Callback`s can be created from any system.
+fn toggle(
+    In(pressed_down): In<PressedDown>,
+    mut text: Query<&mut Text>,
+    children: Query<&Children>,
+    mut value: Local<bool>,
+) {
+    *value = !*value;
+    let children = children.get(pressed_down.0).unwrap();
+    let mut text = text.iter_many_mut(children);
+    let mut text = text.fetch_next().unwrap();
+    text.sections[0].value = value.to_string();
+}
+
+/// Runs the systems associated with each `OnPressedDown` component if button is pressed.
+///
+/// This could be done in an exclusive system rather than using `Commands` if preferred.
+fn evaluate_callbacks(
+    on_pressed_down: Query<(Entity, &OnPressedDown, &Interaction), Changed<Interaction>>,
+    mut commands: Commands,
+) {
+    for (entity, on_button_pressed, interaction) in &on_pressed_down {
+        if *interaction == Interaction::Pressed {
+            commands.run_callback_with_input(on_button_pressed.0.clone(), PressedDown(entity));
+        }
+    }
+}


### PR DESCRIPTION
# Objective

Make managing one shot systems easier.
Addresses concerns brought up in #10582 and #10426.


## Solution

Models `Callback`s as `Asset`s. This allows calling systems through `Handle`s.

This is largely pulled from an implementation from my own game and I'm happy with the ergonomics.

This approach has many advantages:
- can be created without `&mut World`
- `System`s are automatically cleaned up when no more strong `Handle`s exist.
- `System`s could be loaded in using asset loaders (I have already started experimenting with this).
- It seems like the future scenes will be able to embed assets. This will allow for embedding `Callback`s which will be helpful if `Callback`s are used with UI.

But does have some disadvantages:
- The inputs and outputs of `Callback`s must implement `TypePath`.
  - This requirement comes from the `Asset` trait.
  - This could be surprising to users especially because I don't think most users know about this trait (I didn't until I implemented this). 
  - Luckily this is easily derived. But can be bad when using types from other crates.
- When using a new type `Callback` (new combination of input and output), the user must call `app.init_asset::<Callback<I, O>>()`.
- `&mut Assets<Callback<I, O>>` is required to create a `Handle`. This a double edge sword.
  - this allows in-lining callback creation in `spawn` calls. But you can't in-line the creation of a callback in another callback.
  - Different types of `Callback`s require different `Assets` types to create `Handle`s.

Alternatives explored before landing on this implementation:
- Using `SystemId` internally in `Callback`
  - made the implementation more complicated because the requirement for `&mut World` to create `SystemId`
  - used `Command` to create them and a `Mutex` to update the internal state of the `Callback` once the `Command` was run
- Using internal `Arc<Mutex<...>>` in `Callback` and not use `Handle`s.
  - This was the simplest implementation.
  - Made creating, cloning, and calling `Callbacks` extremely easy.
  - Downside was that it would be really hard to allow sharing of `Callback`s in Scenes.

I'm creating this as a Draft to gather feedback and see if others think that the tradeoffs and implementation make sense.

TODO:
- [ ] Example
- [ ] Docs
- [ ] More Tests?
- [ ] Changelog
---

## Changelog

TODO
> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!
