### PR TITLE
Fix non-functional nondeterministic_system_order example

### DIFF
--- a/examples/ecs/nondeterministic_system_order.rs
+++ b/examples/ecs/nondeterministic_system_order.rs
@@ -19,8 +19,10 @@ use bevy::{
 
 fn main() {
     App::new()
-        // We can modify the reporting strategy for system execution order ambiguities on a per-schedule basis
-        .edit_schedule(Main, |schedule| {
+        // We can modify the reporting strategy for system execution order ambiguities on a per-schedule basis.
+        // You must do this for each schedule you want to inspect; child schedules executed within an inspected
+        // schedule do not inherit this modification.
+        .edit_schedule(Update, |schedule| {
             schedule.set_build_settings(ScheduleBuildSettings {
                 ambiguity_detection: LogLevel::Warn,
                 ..default()


### PR DESCRIPTION
# Objective

The `nondeterministic_system_order` example doesn't actually detect and log its deliberate order ambiguities! It should, tho. 

## Solution

Update the schedule label, and explain in a comment that you can't turn it on for the whole `Main` schedule in one go (alas, that would be nice, but it makes sense that it doesn't work that way). 