### PR TITLE
Add wgpu_pass method to TrackedRenderPass

### DIFF
--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -121,7 +121,7 @@ impl<'a> TrackedRenderPass<'a> {
         }
     }
 
-    /// Returns the wgpu [`RenderPass`](wgpu::RenderPass).
+    /// Returns the wgpu [`RenderPass`].
     pub fn wgpu_pass(&self) -> &RenderPass<'a> {
         &self.pass
     }

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -122,8 +122,8 @@ impl<'a> TrackedRenderPass<'a> {
     }
 
     /// Returns the wgpu [`RenderPass`].
-    pub fn wgpu_pass(&self) -> &RenderPass<'a> {
-        &self.pass
+    pub fn wgpu_pass(&mut self) -> &mut RenderPass<'a> {
+        &mut self.pass
     }
 
     /// Sets the active [`RenderPipeline`].

--- a/crates/bevy_render/src/render_phase/draw_state.rs
+++ b/crates/bevy_render/src/render_phase/draw_state.rs
@@ -121,6 +121,11 @@ impl<'a> TrackedRenderPass<'a> {
         }
     }
 
+    /// Returns the wgpu [`RenderPass`](wgpu::RenderPass).
+    pub fn wgpu_pass(&self) -> &RenderPass<'a> {
+        &self.pass
+    }
+
     /// Sets the active [`RenderPipeline`].
     ///
     /// Subsequent draw calls will exhibit the behavior defined by the `pipeline`.


### PR DESCRIPTION
# Objective

- Fixes  #10707 

## Solution

- Add a method to obtain `RenderPass` to `TrackedRenderPass` simillar to `RenderDevice::wgpu_device`

---

## Changelog

Added `wgpu_pass` method to `TrackedRenderPass`
