### PR TITLE
bevy_mocks crate

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -31,6 +31,8 @@ serde = "1"
 thiserror = "1.0"
 
 [dev-dependencies]
+bevy_mocks = { path = "../bevy_mocks", version = "0.12.0" }
+
 rand = "0.8"
 
 [[example]]

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -214,19 +214,14 @@ impl<T> NodeConfigs<T> {
 /// # Examples
 ///
 /// ```
-/// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # struct AppMock;
-/// # struct Update;
-/// # impl AppMock {
-/// #     pub fn add_systems<M>(
-/// #         &mut self,
-/// #         schedule: Update,
-/// #         systems: impl IntoSystemConfigs<M>,
-/// #    ) -> &mut Self { self }
-/// # }
-/// # let mut app = AppMock;
+/// # use bevy_mocks::app_schedule::Update;
+/// # use bevy_mocks::input::Input;
+/// # use bevy_mocks::keyboard::KeyCode;
+/// # use bevy_mocks::schedule::IntoSystemConfigs;
+/// # use bevy_mocks::system::Res;
+/// # let mut app = bevy_mocks::app::App;
 ///
-/// fn handle_input() {}
+/// fn handle_input(keys: Res<Input<KeyCode>>) {}
 ///
 /// fn update_camera() {}
 /// fn update_character() {}

--- a/crates/bevy_mocks/Cargo.toml
+++ b/crates/bevy_mocks/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "bevy_mocks"
+version = "0.12.0"
+edition = "2021"
+description = "API mocks for Bevy for doctests"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+
+[dependencies]
+# We could add dependency crates like `bevy_ecs` here, it works locally, but according to this,
+# such crates cannot be published:
+# https://github.com/rust-lang/cargo/issues/4242
+
+[lints]
+workspace = true

--- a/crates/bevy_mocks/src/app.rs
+++ b/crates/bevy_mocks/src/app.rs
@@ -1,0 +1,7 @@
+pub struct App;
+
+impl App {
+    pub fn add_systems<C, S>(&mut self, _schedule: C, _systems: S) -> &mut Self {
+        self
+    }
+}

--- a/crates/bevy_mocks/src/app_schedule.rs
+++ b/crates/bevy_mocks/src/app_schedule.rs
@@ -1,0 +1,1 @@
+pub struct Update;

--- a/crates/bevy_mocks/src/input.rs
+++ b/crates/bevy_mocks/src/input.rs
@@ -1,0 +1,1 @@
+pub struct Input<T>(T);

--- a/crates/bevy_mocks/src/keyboard.rs
+++ b/crates/bevy_mocks/src/keyboard.rs
@@ -1,0 +1,3 @@
+pub enum KeyCode {
+    A,
+}

--- a/crates/bevy_mocks/src/lib.rs
+++ b/crates/bevy_mocks/src/lib.rs
@@ -1,0 +1,8 @@
+//! API mocks for Bevy compile-only doctests as illustrations.
+
+pub mod app;
+pub mod app_schedule;
+pub mod input;
+pub mod keyboard;
+pub mod schedule;
+pub mod system;

--- a/crates/bevy_mocks/src/schedule.rs
+++ b/crates/bevy_mocks/src/schedule.rs
@@ -1,0 +1,7 @@
+pub trait IntoSystemConfigs: Sized {
+    fn after<T>(self, _other: T) -> Self {
+        self
+    }
+}
+
+impl<T> IntoSystemConfigs for T {}

--- a/crates/bevy_mocks/src/system.rs
+++ b/crates/bevy_mocks/src/system.rs
@@ -1,0 +1,1 @@
+pub struct Res<T>(T);


### PR DESCRIPTION
# Objective

To be able to write illustrative examples in bevy crates which do not depend on each other.

For example, to write good examples in `bevy_ecs` crate, we really need dependencies on crates like `bevy_app` or `bevy_pbr`.

dev-dependencies are used in doctests. Also dev-dependencies can be cyclic (e.g. `bevy_ecs` can dev-depend on `bevy_app`), but such crates [cannot be published](https://github.com/rust-lang/cargo/issues/4242).

## Solution

The proposed solution is to add `bevy_mocks` crate which basically contains `bevy` crate API with mock implementations.

So doctests won't really test much, but are useful as published code examples.