### PR TITLE
Fix typo in resolve_outlines_system

### DIFF
--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -410,7 +410,7 @@ pub fn resolve_outlines_system(
             .max(0.);
 
         node.outline_offset = outline
-            .width
+            .offset
             .resolve(node.size().x, viewport_size)
             .unwrap_or(0.)
             .max(0.);


### PR DESCRIPTION
# Objective

Resolves  #10727.

`outline.width` was being assigned to `node.outline_offset` instead of `outline.offset`.

## Solution

Changed `.width` to `.offset` in line 413.