### PR TITLE
impl From<Color> for ClearColorConfig

### DIFF
--- a/crates/bevy_core_pipeline/src/clear_color.rs
+++ b/crates/bevy_core_pipeline/src/clear_color.rs
@@ -19,6 +19,12 @@ pub enum ClearColorConfig {
     None,
 }
 
+impl From<Color> for ClearColorConfig {
+    fn from(color: Color) -> Self {
+        Self::Custom(color)
+    }
+}
+
 /// A [`Resource`] that stores the color that is used to clear the screen between frames.
 ///
 /// This color appears as the "background" color for simple apps,

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -97,7 +97,7 @@ fn setup(
     commands.spawn((
         Camera3dBundle {
             camera_3d: Camera3d {
-                clear_color: ClearColorConfig::Custom(Color::WHITE),
+                clear_color: Color::WHITE.into(),
                 ..default()
             },
             camera: Camera {

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -3,7 +3,6 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    core_pipeline::clear_color::ClearColorConfig,
     prelude::*,
     render::{
         camera::RenderTarget,

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -330,7 +330,7 @@ fn setup(
             transform: Transform::from_translation(Vec3::new(0.0, 0.0, 5.0))
                 .looking_at(Vec3::default(), Vec3::Y),
             camera_3d: Camera3d {
-                clear_color: ClearColorConfig::Custom(Color::WHITE),
+                clear_color: Color::WHITE.into(),
                 ..default()
             },
             ..default()

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -6,10 +6,7 @@
 //! This is a fairly low level example and assumes some familiarity with rendering concepts and wgpu.
 
 use bevy::{
-    core_pipeline::{
-        clear_color::ClearColorConfig, core_3d,
-        fullscreen_vertex_shader::fullscreen_shader_vertex_state,
-    },
+    core_pipeline::{core_3d, fullscreen_vertex_shader::fullscreen_shader_vertex_state},
     ecs::query::QueryItem,
     prelude::*,
     render::{


### PR DESCRIPTION
# Objective

I tried setting `ClearColorConfig` in my app via `Color::FOO.into()` expecting it to work, but the impl was missing.

## Solution

- Add `impl From<Color> for ClearColorConfig`
- Change examples to use this impl

## Changelog

### Added

- `ClearColorConfig` can be constructed via `.into()` on a `Color`