### PR TITLE
don't run update before window creation in winit

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -349,11 +349,8 @@ impl Default for WinitAppRunnerState {
 /// `EventLoop`.
 pub fn winit_runner(mut app: App) {
     if app.plugins_state() == PluginsState::Ready {
-        // If we're already ready, we finish up now and advance one frame.
-        // This prevents black frames during the launch transition on iOS.
         app.finish();
         app.cleanup();
-        app.update();
     }
 
     let mut event_loop = app


### PR DESCRIPTION
# Objective

- Window size, scale and position are not correct on the first execution of the systems
- Fixes #10407,  fixes #10642

## Solution

- Don't run `update` before we get a chance to create the window in winit
- Finish reverting #9826 after #10389
