### PR TITLE
Run all OnExit before all OnEnter

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -29,6 +29,7 @@ pub mod prelude {
     #[cfg(feature = "bevy_reflect")]
     pub use crate::reflect::{AppTypeRegistry, ReflectComponent, ReflectResource};
     #[doc(hidden)]
+    #[allow(deprecated)] // Remove after `apply_state_transition` removed.
     pub use crate::{
         bundle::Bundle,
         change_detection::{DetectChanges, DetectChangesMut, Mut, Ref},
@@ -38,9 +39,10 @@ pub mod prelude {
         query::{Added, AnyOf, Changed, Has, Or, QueryState, With, Without},
         removal_detection::RemovedComponents,
         schedule::{
-            apply_deferred, apply_state_transition, common_conditions::*, Condition,
-            IntoSystemConfigs, IntoSystemSet, IntoSystemSetConfigs, NextState, OnEnter, OnExit,
-            OnTransition, Schedule, Schedules, State, States, SystemSet,
+            apply_deferred, apply_state_transition, apply_state_transition_systems,
+            common_conditions::*, Condition, IntoSystemConfigs, IntoSystemSet,
+            IntoSystemSetConfigs, NextState, OnEnter, OnExit, OnTransition, Schedule, Schedules,
+            State, StateTransitionSet, States, SystemSet,
         },
         system::{
             Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,


### PR DESCRIPTION
Fixes #10732. Copying description from that issue.

# Objective

`StateTransition` schedule executes `apply_state_transition` system for each state in order. `apply_state_transition` executes `OnExit`, `OnTransition`, `OnEnter` schedules in order.

https://github.com/bevyengine/bevy/blob/4eafd60ce9dd3dd579c07798ceb43f88a13d7094/crates/bevy_ecs/src/schedule/state.rs#L154-L161

This is somewhat inconvenient.

For example, application state can be controller by two state types, `StateA` and `StateB` (for example, state and substate).

Each state may want to for example, set cursor icon on enter and reset it to default on exit (clean up). This is not possible now, because cleanup of second system (`OnExit`) can be executed after init of first system (`OnEnter`).

## Solution

Execute systems in order:

```rust
OnExit<A>
OnExit<B>
OnTransition<A>
OnTransition<B>
OnEnter<A>
OnEnter<B>
```

## Changelog

- Deprecate `apply_state_transition::<T>` system
- Add `apply_state_transition_on_exit::<T>`, `apply_state_transition_on_transition::<T>`, `apply_state_transition_on_enter::<T>` systems
- Add non-generic `AfterOnExit`, `BeforeOnEnter` labels to order the systems

## Migration Guide

No migration needed if only one state was used which was initialized with `.add_state`.

If more than one state is used, order of state callback execution was changed, need to review the code to make sure it is not broken.

If `apply_state_transition` system was used directly, it will still work, but this function is deprecated and will be eventually removed.

## Side note

I proposed implicit system ordering (#10678, #10618) before, and I think this is another illustration where implicit ordering would be beneficial.

In current setup (before or after this PR) all systems are exclusive and thus not parallel. I imagine it could be like this:

```rust
app.add_systems(
  ScheduleTransition,
  enter_main_menu.on_enter(GameState::MainMenu),
)
```

~~`enter_main_menu.on_enter(GameState::MainMenu)` could create a system with after-dependency on non-generic `BeforeOnEnter`.~~ **Edit**: actually we can already do that, by adding the same before/after as this diff does.

So all the systems in `ScheduleTransition` will run concurrently, but with proper ordering, no subschedules.

Moreover, we would not even need to run `enter_main_menu` in `ScheduleTransition`, we could run it in `Update` (or any other schedule), if we could implicitly order all regular systems which read or update state after all systems which are triggered on state change.

But that is somewhat offtopic here. For now I mostly want to deal with this ordering issue.