### PR TITLE
HSV color picker UI widget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2137,6 +2137,17 @@ category = "UI (User Interface)"
 wasm = true
 
 [[example]]
+name = "color_picker"
+path = "examples/ui/color_picker.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.color_picker]
+name = "Color Picker"
+description = "Illustrates color picking"
+category = "UI (User Interface)"
+wasm = true
+
+[[example]]
 name = "display_and_visibility"
 path = "examples/ui/display_and_visibility.rs"
 doc-scrape-examples = true

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -192,6 +192,8 @@ impl Plugin for UiPlugin {
         );
 
         build_ui_render(app);
+
+        app.add_plugins(widget::ColorPickerPlugin);
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -3,9 +3,9 @@
 #[cfg(feature = "bevy_text")]
 use crate::widget::TextFlags;
 use crate::{
-    widget::{Button, UiImageSize},
-    BackgroundColor, BorderColor, ContentSize, FocusPolicy, Interaction, Node, Style, UiImage,
-    UiMaterial, UiTextureAtlasImage, ZIndex,
+    widget::{self, Button, UiImageSize},
+    BackgroundColor, BorderColor, ContentSize, FocusPolicy, Interaction, Node,
+    RelativeCursorPosition, Style, UiImage, UiMaterial, UiTextureAtlasImage, ZIndex,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -391,6 +391,114 @@ impl<M: UiMaterial> Default for MaterialNodeBundle<M> {
             inherited_visibility: Default::default(),
             view_visibility: Default::default(),
             z_index: Default::default(),
+        }
+    }
+}
+
+/// A UI node that is rendered using a [`widget::HueWheelMaterial`].
+///
+/// Normal use is to add this bundle to a common parent alongside [`SaturationValueBoxBundle`].
+///
+/// NOTE: If a material handle is not given, nothing will render.
+#[derive(Bundle, Clone, Debug, Default)]
+pub struct HueWheelBundle {
+    /// Marks the entity as a hue wheel
+    pub marker: widget::HueWheel,
+    /// Describes the logical size of the node
+    pub node: Node,
+    /// Styles which control the layout (size and position) of the node and it's children
+    /// In some cases these styles also affect how the node drawn/painted.
+    pub style: Style,
+    /// Describes whether and how the button has been interacted with by the input
+    pub interaction: Interaction,
+    /// Allows getting a relative cursor position within this node
+    pub relative_cursor_position: RelativeCursorPosition,
+    /// The [`widget::HueWheelMaterial`] used to render the node.
+    pub material: Handle<widget::HueWheelMaterial>,
+    /// Whether this node should block interaction with lower nodes
+    pub focus_policy: FocusPolicy,
+    /// The transform of the node
+    ///
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub transform: Transform,
+    /// The global transform of the node
+    ///
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub global_transform: GlobalTransform,
+    /// Describes the visibility properties of the node
+    pub visibility: Visibility,
+    /// Inherited visibility of an entity.
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+    /// Indicates the depth at which the node should appear in the UI
+    pub z_index: ZIndex,
+}
+
+/// A UI node that is rendered using a [`widget::SaturationValueBoxMaterial`].
+///
+/// Normal use is to add this bundle to a common parent alongside [`HueWheelBundle`].
+///
+/// NOTE: If a material handle is not given, nothing will render.
+#[derive(Bundle, Clone, Debug)]
+pub struct SaturationValueBoxBundle {
+    /// Marks the entity as a hue wheel
+    pub marker: widget::SaturationValueBox,
+    /// Describes the logical size of the node
+    pub node: Node,
+    /// Styles which control the layout (size and position) of the node and it's children
+    /// In some cases these styles also affect how the node drawn/painted.
+    pub style: Style,
+    /// Describes whether and how the button has been interacted with by the input
+    pub interaction: Interaction,
+    /// Allows getting a relative cursor position within this node
+    pub relative_cursor_position: RelativeCursorPosition,
+    /// The [`widget::SaturationValueBoxMaterial`] used to render the node.
+    pub material: Handle<widget::SaturationValueBoxMaterial>,
+    /// Whether this node should block interaction with lower nodes
+    pub focus_policy: FocusPolicy,
+    /// The transform of the node
+    ///
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub transform: Transform,
+    /// The global transform of the node
+    ///
+    /// This field is automatically managed by the UI layout system.
+    /// To alter the position of the `NodeBundle`, use the properties of the [`Style`] component.
+    pub global_transform: GlobalTransform,
+    /// Describes the visibility properties of the node
+    pub visibility: Visibility,
+    /// Inherited visibility of an entity.
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+    /// Indicates the depth at which the node should appear in the UI
+    pub z_index: ZIndex,
+}
+
+impl Default for SaturationValueBoxBundle {
+    fn default() -> Self {
+        Self {
+            node: Default::default(),
+            style: Default::default(),
+            interaction: Default::default(),
+            relative_cursor_position: Default::default(),
+            material: Default::default(),
+
+            // By default it's expected that the box is in front of the hue wheel,
+            // and passing events through creates extra wasted work.
+            focus_policy: FocusPolicy::Block,
+
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            inherited_visibility: Default::default(),
+            view_visibility: Default::default(),
+            z_index: Default::default(),
+            marker: Default::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/widget/color_picker.rs
+++ b/crates/bevy_ui/src/widget/color_picker.rs
@@ -1,0 +1,287 @@
+use std::f32::consts::PI;
+
+use crate::{Interaction, RelativeCursorPosition};
+use crate::{UiMaterial, UiMaterialPlugin};
+use bevy_app::{Plugin, Update};
+use bevy_asset::{load_internal_asset, Asset, Assets, Handle};
+use bevy_derive::Deref;
+use bevy_ecs::entity::Entity;
+use bevy_ecs::event::{Event, EventReader, EventWriter};
+use bevy_ecs::prelude::Component;
+use bevy_ecs::query::{Added, Changed, With};
+use bevy_ecs::reflect::ReflectComponent;
+use bevy_ecs::schedule::IntoSystemConfigs;
+use bevy_ecs::system::{Commands, Query};
+use bevy_ecs::system::{Res, ResMut};
+use bevy_hierarchy::Parent;
+use bevy_log::warn;
+use bevy_math::Vec3;
+use bevy_reflect::std_traits::ReflectDefault;
+use bevy_reflect::Reflect;
+use bevy_reflect::TypePath;
+use bevy_render::color::Color;
+use bevy_render::render_resource::{AsBindGroup, Shader, ShaderRef};
+
+pub const COLOR_PICKER_HUE_WHEEL_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(864139486189741938413);
+pub const COLOR_PICKER_SATURATION_VALUE_BOX_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(821381985132985160161);
+
+#[derive(Debug, Default)]
+pub struct ColorPickerPlugin;
+
+impl Plugin for ColorPickerPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        load_internal_asset!(
+            app,
+            COLOR_PICKER_HUE_WHEEL_SHADER_HANDLE,
+            "color_picker/hue_wheel.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            COLOR_PICKER_SATURATION_VALUE_BOX_SHADER_HANDLE,
+            "color_picker/saturation_value_box.wgsl",
+            Shader::from_wgsl
+        );
+
+        app.add_event::<HueWheelEvent>()
+            .add_event::<SaturationValueBoxEvent>()
+            .add_systems(
+                Update,
+                (
+                    add_sibling_component,
+                    hue_wheel_events,
+                    update_saturation_value_box_hue,
+                    saturation_value_box_events,
+                )
+                    .chain(),
+            )
+            .add_plugins((
+                UiMaterialPlugin::<HueWheelMaterial>::default(),
+                UiMaterialPlugin::<SaturationValueBoxMaterial>::default(),
+            ));
+    }
+}
+
+/// When the hue wheel is pressed, this event is generated
+#[derive(Debug, Event)]
+pub struct HueWheelEvent {
+    /// The [`HueWheel`] entity which produced the event
+    pub entity: Entity,
+
+    /// The color pressed on the wheel
+    pub color: Color,
+
+    /// The (0., 1.) range hue value pressed
+    pub hue: f32,
+}
+
+/// When the saturation-value box is pressed, this event is generated
+#[derive(Debug, Event)]
+pub struct SaturationValueBoxEvent {
+    /// The [`SaturationValueBox`] entity which produced the event
+    pub entity: Entity,
+
+    /// The color pressed within the box
+    pub color: Color,
+}
+
+/// The entity which has this component is a sibling to the wrapped hue wheel entity.
+/// A [`SaturationValueBox`] can have this component in order to store which hue wheel it is related to.
+#[derive(Debug, Component, Deref)]
+struct HueWheelSibling(Entity);
+
+fn hue_wheel_events(
+    interaction_query: Query<
+        (
+            Entity,
+            &Handle<HueWheelMaterial>,
+            &Interaction,
+            &RelativeCursorPosition,
+        ),
+        (Changed<Interaction>, With<HueWheel>),
+    >,
+    wheels: Res<Assets<HueWheelMaterial>>,
+    mut event_writer: EventWriter<HueWheelEvent>,
+) {
+    for (entity, material_handle, interaction, relative_position) in &interaction_query {
+        if *interaction == Interaction::Pressed {
+            if let Some(uv) = relative_position.normalized {
+                // NOTE: The UV and hue calculations must sync with similar calculations in `hue_wheel.wgsl`
+                let uv = (uv * 2.) - 1.;
+
+                let Some(HueWheelMaterial { inner_radius }) = wheels.get(material_handle) else {
+                    warn!("unexpected: a saturation-value box was pressed but found no asset containing its material");
+                    continue;
+                };
+                let length = uv.length();
+                if length < *inner_radius || length > 1.0 {
+                    // the wheel is cut-out if below the radius in the shader so don't
+                    // generate events either.
+                    // similarly, don't send events from interactions outside the outer radius
+                    continue;
+                }
+
+                let hue = (uv.y.atan2(uv.x) + PI) / (2. * PI);
+
+                event_writer.send(HueWheelEvent {
+                    entity,
+                    color: hsv_to_rgb(hue, 1., 1.),
+                    hue,
+                });
+            }
+        }
+    }
+}
+
+/// It's expected that a [`crate::node_bundles::SaturationValueBoxBundle`] and [`crate::node_bundles::HueWheelBundle`] is added to a common parent.
+/// To help other systems, add the hue wheel as a sibling to the saturation value box.
+fn add_sibling_component(
+    sat_val_boxes: Query<(Entity, &Parent), Added<SaturationValueBox>>,
+    hue_wheels: Query<(Entity, &Parent), Added<HueWheel>>,
+    mut commands: Commands,
+) {
+    for (sv_e, sv_parent) in &sat_val_boxes {
+        if let Some(hue_e) =
+            hue_wheels
+                .iter()
+                .find_map(|(e, parent)| if sv_parent == parent { Some(e) } else { None })
+        {
+            commands.entity(sv_e).insert(HueWheelSibling(hue_e));
+        } else {
+            warn!("Found no box wheel sibling");
+        }
+    }
+}
+
+/// When hue wheels produce events the selected hue has changed.
+/// The box UI is updated to match here.
+fn update_saturation_value_box_hue(
+    box_query: Query<
+        (
+            Entity,
+            &Handle<SaturationValueBoxMaterial>,
+            &HueWheelSibling,
+        ),
+        With<SaturationValueBox>,
+    >,
+    mut hue: EventReader<HueWheelEvent>,
+    mut boxes: ResMut<Assets<SaturationValueBoxMaterial>>,
+) {
+    for event in hue.read() {
+        let HueWheelEvent {
+            entity,
+            color: _,
+            hue,
+        } = event;
+
+        if let Some((_, handle, _)) = box_query.iter().find(|(.., sibling)| *entity == ***sibling) {
+            let Some(material) = boxes.get_mut(handle) else {
+                continue;
+            };
+
+            material.hue = *hue;
+        } else {
+            continue;
+        }
+    }
+}
+
+fn saturation_value_box_events(
+    interaction_query: Query<
+        (
+            Entity,
+            &Interaction,
+            &RelativeCursorPosition,
+            &Handle<SaturationValueBoxMaterial>,
+        ),
+        (Changed<Interaction>, With<SaturationValueBox>),
+    >,
+    boxes: Res<Assets<SaturationValueBoxMaterial>>,
+    mut event_writer: EventWriter<SaturationValueBoxEvent>,
+) {
+    for (entity, interaction, relative_position, material_handle) in &interaction_query {
+        if *interaction == Interaction::Pressed {
+            if let Some(uv) = relative_position.normalized {
+                let Some(SaturationValueBoxMaterial { hue }) = boxes.get(material_handle) else {
+                    warn!("unexpected: a saturation-value box was pressed but found no asset containing its material");
+                    continue;
+                };
+
+                // NOTE: We want "value" to increase vertically which looks most natural hence the flip
+                let color = hsv_to_rgb(*hue, uv.x, 1.0 - uv.y);
+                event_writer.send(SaturationValueBoxEvent { entity, color });
+            }
+        }
+    }
+}
+
+/// As ported from utils.wgsl:
+///
+/// ```wgsl
+/// fn hsv2rgb(hue: f32, saturation: f32, value: f32) -> vec3<f32> {
+///     let rgb = clamp(
+///         abs(
+///             ((hue * 6.0 + vec3<f32>(0.0, 4.0, 2.0)) % 6.0) - 3.0
+///         ) - 1.0,
+///         vec3<f32>(0.0),
+///         vec3<f32>(1.0)
+///     );
+///
+///     return value * mix(vec3<f32>(1.0), rgb, vec3<f32>(saturation));
+/// }
+/// ```
+///
+/// All inputs in range (0., 1.)
+///
+fn hsv_to_rgb(hue: f32, saturation: f32, value: f32) -> Color {
+    let rgb = ((((Vec3::splat(hue * 6.0) + Vec3::new(0.0, 4.0, 2.0)) % 6.0) - 3.0).abs() - 1.0)
+        .clamp(Vec3::ZERO, Vec3::ONE);
+
+    let result = value * Vec3::ONE.lerp(rgb, saturation);
+
+    Color::rgb_linear(result.x, result.y, result.z)
+}
+
+/// Marker struct for hue wheels
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component, Default)]
+pub struct HueWheel;
+
+#[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
+pub struct HueWheelMaterial {
+    /// The ratio of the inner radius (when the hue wheel cuts off) compared to the
+    /// outer radius.
+    #[uniform(0)]
+    pub inner_radius: f32,
+}
+
+impl Default for HueWheelMaterial {
+    fn default() -> Self {
+        Self { inner_radius: 0.85 }
+    }
+}
+
+/// Marker struct for saturation-value boxes
+#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[reflect(Component, Default)]
+pub struct SaturationValueBox;
+
+#[derive(AsBindGroup, Asset, TypePath, Debug, Clone, Default)]
+pub struct SaturationValueBoxMaterial {
+    #[uniform(0)]
+    hue: f32,
+}
+
+impl UiMaterial for HueWheelMaterial {
+    fn fragment_shader() -> ShaderRef {
+        COLOR_PICKER_HUE_WHEEL_SHADER_HANDLE.into()
+    }
+}
+
+impl UiMaterial for SaturationValueBoxMaterial {
+    fn fragment_shader() -> ShaderRef {
+        COLOR_PICKER_SATURATION_VALUE_BOX_SHADER_HANDLE.into()
+    }
+}

--- a/crates/bevy_ui/src/widget/color_picker/hue_wheel.wgsl
+++ b/crates/bevy_ui/src/widget/color_picker/hue_wheel.wgsl
@@ -2,8 +2,13 @@
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 #import bevy_pbr::utils::{PI, hsv2rgb}
 
+struct HueUniform {
+    hue: f32,
+    inner_radius: f32
+}
+
 struct HueWheelMaterial {
-    @location(0) inner_radius: f32
+    @location(0) values: HueUniform
     // padding?
 }
 
@@ -15,20 +20,36 @@ var<uniform> material: HueWheelMaterial;
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // remap to (-1, 1) range
     let uv = in.uv * 2.0 - 1.0;
-    let d = length(uv);
-
-    // circle with smoothed edge
-    let alpha = 1.-pow(d, 100.0);
-    // cut out inner part
-    let cutout = step(material.inner_radius, d);
+    let wh_dist = length(uv);
 
     // normalized hue angle
     let hue = (atan2(uv.y, uv.x) + PI) / (2. * PI);
     let rgb = hsv2rgb(hue, 1., 1.);
 
+    // make ring signal for wheel alpha
+    let wh_radius = material.values.inner_radius;
+    let wh_slope = 0.017;
+    let wh_w = 0.13;
+
+    let wheel_signal = smoothstep(wh_radius, wh_radius+wh_slope, wh_dist)-smoothstep(wh_radius+wh_w, wh_radius+wh_w+wh_slope, wh_dist);
+
+    // make ring signal for white marker on wheel
+    let m_radius = 0.025;
+    let m_slope = 0.008;
+    let m_w = 0.012;
+
+    // hue angle in radians
+    let hue_rad = material.values.hue * 2. * PI + PI;
+    let m_pos = (wh_radius + wh_w * 0.55) * vec2(cos(hue_rad), sin(hue_rad));
+    let m_dist = length(-uv + m_pos);
+
+    let marker_signal = smoothstep(m_radius, m_radius+m_slope, m_dist)-smoothstep(m_radius+m_w, m_radius+m_w+m_slope, m_dist);
+
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
-    let output_rgb = powsafe(rgb, 2.2);
-    return vec4<f32>(output_rgb, alpha * cutout);
+    var output_rgb = powsafe(rgb, 2.2);
+
+    output_rgb += marker_signal;
+    return vec4<f32>(saturate(output_rgb), wheel_signal);
 }
 

--- a/crates/bevy_ui/src/widget/color_picker/hue_wheel.wgsl
+++ b/crates/bevy_ui/src/widget/color_picker/hue_wheel.wgsl
@@ -1,0 +1,34 @@
+#import bevy_core_pipeline::tonemapping::powsafe
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+#import bevy_pbr::utils::{PI, hsv2rgb}
+
+struct HueWheelMaterial {
+    @location(0) inner_radius: f32
+    // padding?
+}
+
+@group(1) @binding(0)
+var<uniform> material: HueWheelMaterial;
+
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    // remap to (-1, 1) range
+    let uv = in.uv * 2.0 - 1.0;
+    let d = length(uv);
+
+    // circle with smoothed edge
+    let alpha = 1.-pow(d, 100.0);
+    // cut out inner part
+    let cutout = step(material.inner_radius, d);
+
+    // normalized hue angle
+    let hue = (atan2(uv.y, uv.x) + PI) / (2. * PI);
+    let rgb = hsv2rgb(hue, 1., 1.);
+
+    // This conversion back to linear space is required because our output texture format is
+    // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
+    let output_rgb = powsafe(rgb, 2.2);
+    return vec4<f32>(output_rgb, alpha * cutout);
+}
+

--- a/crates/bevy_ui/src/widget/color_picker/saturation_value_box.wgsl
+++ b/crates/bevy_ui/src/widget/color_picker/saturation_value_box.wgsl
@@ -1,0 +1,23 @@
+#import bevy_core_pipeline::tonemapping::powsafe
+#import bevy_ui::ui_vertex_output::UiVertexOutput
+#import bevy_pbr::utils::{PI, hsv2rgb}
+
+struct SaturationValueBoxMaterial {
+    @location(0) hue: f32,
+    // padding?
+}
+
+@group(1) @binding(0)
+var<uniform> material: SaturationValueBoxMaterial;
+
+@fragment
+fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+    // NOTE: We want "value" to increase vertically which looks most natural hence the flip
+    let rgb = hsv2rgb(material.hue, in.uv.x, 1.-in.uv.y);
+
+    // This conversion back to linear space is required because our output texture format is
+    // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
+    let output_rgb = powsafe(rgb, 2.2);
+    return vec4<f32>(output_rgb, 1.);
+}
+

--- a/crates/bevy_ui/src/widget/color_picker/saturation_value_box.wgsl
+++ b/crates/bevy_ui/src/widget/color_picker/saturation_value_box.wgsl
@@ -2,8 +2,13 @@
 #import bevy_ui::ui_vertex_output::UiVertexOutput
 #import bevy_pbr::utils::{PI, hsv2rgb}
 
+struct SaturationValueUniform {
+    hue: f32,
+    marker: vec2<f32>,
+}
+
 struct SaturationValueBoxMaterial {
-    @location(0) hue: f32,
+    @location(0) values: SaturationValueUniform,
     // padding?
 }
 
@@ -13,11 +18,26 @@ var<uniform> material: SaturationValueBoxMaterial;
 @fragment
 fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
     // NOTE: We want "value" to increase vertically which looks most natural hence the flip
-    let rgb = hsv2rgb(material.hue, in.uv.x, 1.-in.uv.y);
-
+    let rgb = hsv2rgb(material.values.hue, in.uv.x, 1.-in.uv.y);
     // This conversion back to linear space is required because our output texture format is
     // SRGB; the GPU will assume our output is linear and will apply an SRGB conversion.
-    let output_rgb = powsafe(rgb, 2.2);
-    return vec4<f32>(output_rgb, 1.);
+    var output_rgb = powsafe(rgb, 2.2);
+
+    // add a marker to the selected saturation, value coordinate
+
+    // uv in (-1., 1.) range, +x right, +y up
+    let uv = (in.uv * 2. - 1.) * vec2(1., -1.);
+
+    let dist = length(-material.values.marker+uv);
+
+    // the radius and thickness of the white marker
+    let radius = 0.03;
+    let th = 0.02;
+
+    let ring_signal = smoothstep(radius, radius+th, dist) - smoothstep(radius+th, radius+(2. * th), dist);
+
+    output_rgb += ring_signal;
+
+    return vec4<f32>(saturate(output_rgb), 1.);
 }
 

--- a/crates/bevy_ui/src/widget/mod.rs
+++ b/crates/bevy_ui/src/widget/mod.rs
@@ -1,12 +1,14 @@
 //! This module contains the basic building blocks of Bevy's UI
 
 mod button;
+mod color_picker;
 mod image;
 mod label;
 #[cfg(feature = "bevy_text")]
 mod text;
 
 pub use button::*;
+pub use color_picker::*;
 pub use image::*;
 pub use label::*;
 #[cfg(feature = "bevy_text")]

--- a/examples/README.md
+++ b/examples/README.md
@@ -359,6 +359,7 @@ Example | Description
 [Borders](../examples/ui/borders.rs) | Demonstrates how to create a node with a border
 [Button](../examples/ui/button.rs) | Illustrates creating and updating a button
 [CSS Grid](../examples/ui/grid.rs) | An example for CSS Grid layout
+[Color Picker](../examples/ui/color_picker.rs) | Illustrates color picking
 [Display and Visibility](../examples/ui/display_and_visibility.rs) | Demonstrates how Display and Visibility work in the UI.
 [Flex Layout](../examples/ui/flex_layout.rs) | Demonstrates how the AlignItems and JustifyContent properties can be composed to layout nodes and position text
 [Font Atlas Debug](../examples/ui/font_atlas_debug.rs) | Illustrates how FontAtlases are populated (used to optimize text rendering internally)

--- a/examples/ui/color_picker.rs
+++ b/examples/ui/color_picker.rs
@@ -5,6 +5,7 @@ use std::f32::consts::PI;
 use bevy::prelude::*;
 use bevy::ui::widget;
 use bevy::ui::widget::{HueWheelMaterial, SaturationValueBoxEvent};
+use bevy_internal::ui::widget::HueWheelSibling;
 
 fn main() {
     App::new()
@@ -117,40 +118,38 @@ fn setup_ui(
     commands
         .spawn(NodeBundle {
             style: Style {
-                display: Display::Grid,
-                width: Val::Percent(100.0),
-                height: Val::Percent(50.0),
-                grid_template_columns: vec![
-                    GridTrack::auto(),
-                    GridTrack::percent(50.0),
-                    GridTrack::auto(),
-                ],
-                grid_template_rows: vec![GridTrack::auto()],
+                display: Display::Flex,
+                height: Val::Percent(100.0),
+                flex_direction: FlexDirection::Column,
                 ..default()
             },
             ..default()
         })
-        .with_children(|grid: &mut ChildBuilder<'_, '_, '_>| {
+        .with_children(|flex: &mut ChildBuilder<'_, '_, '_>| {
             // picker 1
-            grid.spawn(NodeBundle {
+            flex.spawn(NodeBundle {
                 style: Style {
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::Center,
+                    width: Val::Px(wheel_diameter),
+                    height: Val::Px(wheel_diameter),
                     ..default()
                 },
                 ..default()
             })
             .with_children(|picker1| {
-                picker1.spawn(HueWheelBundle {
-                    style: Style {
-                        position_type: PositionType::Absolute,
-                        width: Val::Px(wheel_diameter),
-                        height: Val::Px(wheel_diameter),
+                let hue_wheel = picker1
+                    .spawn(HueWheelBundle {
+                        style: Style {
+                            position_type: PositionType::Absolute,
+                            width: Val::Percent(100.),
+                            height: Val::Percent(100.),
+                            ..default()
+                        },
+                        material: hue_materials.add(hue_wheel_material.clone()),
                         ..default()
-                    },
-                    material: hue_materials.add(hue_wheel_material.clone()),
-                    ..default()
-                });
+                    })
+                    .id();
                 picker1.spawn((
                     SaturationValueBoxBundle {
                         style: Style {
@@ -163,32 +162,35 @@ fn setup_ui(
                         ..default()
                     },
                     SaturationValueBox1,
+                    // added to make the saturation-value box update automatically
+                    HueWheelSibling(hue_wheel),
                 ));
             });
 
-            // empty space to separate the pickers
-            grid.spawn(NodeBundle { ..default() });
-
             // picker 2
-            grid.spawn(NodeBundle {
+            flex.spawn(NodeBundle {
                 style: Style {
                     align_items: AlignItems::Center,
                     justify_content: JustifyContent::Center,
+                    width: Val::Px(wheel_diameter),
+                    height: Val::Px(wheel_diameter),
                     ..default()
                 },
                 ..default()
             })
             .with_children(|picker2| {
-                picker2.spawn(HueWheelBundle {
-                    style: Style {
-                        position_type: PositionType::Absolute,
-                        width: Val::Px(wheel_diameter),
-                        height: Val::Px(wheel_diameter),
+                let hue_wheel = picker2
+                    .spawn(HueWheelBundle {
+                        style: Style {
+                            position_type: PositionType::Absolute,
+                            width: Val::Percent(100.),
+                            height: Val::Percent(100.),
+                            ..default()
+                        },
+                        material: hue_materials.add(hue_wheel_material.clone()),
                         ..default()
-                    },
-                    material: hue_materials.add(hue_wheel_material),
-                    ..default()
-                });
+                    })
+                    .id();
                 picker2.spawn((
                     SaturationValueBoxBundle {
                         style: Style {
@@ -201,6 +203,8 @@ fn setup_ui(
                         ..default()
                     },
                     SaturationValueBox2,
+                    // added to make the saturation-value box update automatically
+                    HueWheelSibling(hue_wheel),
                 ));
             });
         });

--- a/examples/ui/color_picker.rs
+++ b/examples/ui/color_picker.rs
@@ -3,9 +3,9 @@
 use std::f32::consts::PI;
 
 use bevy::prelude::*;
-use bevy::ui::widget;
-use bevy::ui::widget::{HueWheelMaterial, SaturationValueBoxEvent};
-use bevy_internal::ui::widget::HueWheelSibling;
+use bevy::ui::widget::{
+    HueWheelMaterial, HueWheelSibling, SaturationValueBoxEvent, SaturationValueBoxMaterial,
+};
 
 fn main() {
     App::new()
@@ -101,8 +101,8 @@ fn setup_3d(
 
 fn setup_ui(
     mut commands: Commands,
-    mut hue_materials: ResMut<Assets<widget::HueWheelMaterial>>,
-    mut satval_materials: ResMut<Assets<widget::SaturationValueBoxMaterial>>,
+    mut hue_materials: ResMut<Assets<HueWheelMaterial>>,
+    mut satval_materials: ResMut<Assets<SaturationValueBoxMaterial>>,
 ) {
     let hue_wheel_material = HueWheelMaterial::default();
 

--- a/examples/ui/color_picker.rs
+++ b/examples/ui/color_picker.rs
@@ -92,12 +92,7 @@ fn hue_wheel_system(
     base_wheel: Query<Entity, With<BaseColorWheel>>,
     cube_wheel: Query<Entity, With<CubeColorWheel>>,
 ) {
-    for HueWheelEvent {
-        entity,
-        color: _,
-        hue,
-    } in events.read()
-    {
+    for HueWheelEvent { entity, hue } in events.read() {
         if base_wheel.single() == *entity {
             colors.base.hue = *hue;
         } else if cube_wheel.single() == *entity {
@@ -182,7 +177,7 @@ fn setup_ui(
     // ..some math is required in order to have the inner box UI element
     // exactly touch the wheel
     let wheel_radius = wheel_diameter / 2.;
-    let inner_wheel_radius = wheel_radius * hue_wheel_material.inner_radius;
+    let inner_wheel_radius = wheel_radius * hue_wheel_material.uniform.inner_radius;
     let box_size = (inner_wheel_radius * 2.) * (PI / 4.).cos();
 
     commands

--- a/examples/ui/color_picker.rs
+++ b/examples/ui/color_picker.rs
@@ -4,9 +4,9 @@ use std::f32::consts::PI;
 
 use bevy::prelude::*;
 use bevy::ui::widget::{
-    HueWheelMaterial, HueWheelSibling, SaturationValueBoxEvent, SaturationValueBoxMaterial,
+    hsv_to_rgb, HueWheelEvent, HueWheelMaterial, HueWheelSibling, SaturationValueBoxEvent,
+    SaturationValueBoxMaterial,
 };
-use bevy_internal::ui::widget::{hsv_to_rgb, HueWheelEvent};
 
 fn main() {
     App::new()

--- a/examples/ui/color_picker.rs
+++ b/examples/ui/color_picker.rs
@@ -1,0 +1,207 @@
+//! Demonstrates the use of color pickers.
+
+use std::f32::consts::PI;
+
+use bevy::prelude::*;
+use bevy::ui::widget;
+use bevy::ui::widget::{HueWheelMaterial, SaturationValueBoxEvent};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, (setup_ui, setup_3d))
+        .add_systems(Update, saturation_value_box_system)
+        .run();
+}
+
+#[derive(Debug, Component)]
+struct SaturationValueBox1;
+
+#[derive(Debug, Component)]
+struct SaturationValueBox2;
+
+#[derive(Debug, Component)]
+struct Cube;
+
+#[derive(Debug, Component)]
+struct Base;
+
+// Looks at events from saturation-value boxes.
+// If found, checks which one the event stemmed from,
+// then applies the color to either the cube or base.
+fn saturation_value_box_system(
+    mut events: EventReader<SaturationValueBoxEvent>,
+    mut color_materials: ResMut<Assets<StandardMaterial>>,
+    svb1: Query<Entity, With<SaturationValueBox1>>,
+    svb2: Query<Entity, With<SaturationValueBox2>>,
+    base: Query<&Handle<StandardMaterial>, With<Base>>,
+    cube: Query<&Handle<StandardMaterial>, With<Cube>>,
+) {
+    for SaturationValueBoxEvent { entity, color } in events.read() {
+        let handle = if svb1.single() == *entity {
+            base.single()
+        } else if svb2.single() == *entity {
+            cube.single()
+        } else {
+            continue;
+        };
+
+        let Some(material) = color_materials.get_mut(handle) else {
+            continue;
+        };
+
+        material.base_color = *color;
+    }
+}
+
+fn setup_3d(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+) {
+    // circular base
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(shape::Circle::new(4.0).into()),
+            material: materials.add(Color::WHITE.into()),
+            transform: Transform::from_rotation(Quat::from_rotation_x(
+                -std::f32::consts::FRAC_PI_2,
+            )),
+            ..default()
+        },
+        Base,
+    ));
+    // cube
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            material: materials.add(Color::rgb_u8(124, 144, 255).into()),
+            transform: Transform::from_xyz(0.0, 0.5, 0.0),
+            ..default()
+        },
+        Cube,
+    ));
+    // light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 1500.0,
+            shadows_enabled: true,
+            ..default()
+        },
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
+        ..default()
+    });
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+fn setup_ui(
+    mut commands: Commands,
+    mut hue_materials: ResMut<Assets<widget::HueWheelMaterial>>,
+    mut satval_materials: ResMut<Assets<widget::SaturationValueBoxMaterial>>,
+) {
+    let hue_wheel_material = HueWheelMaterial::default();
+
+    // Given a desired px diameter of the wheel..
+    let wheel_diameter = 200.0;
+
+    // ..some math is required in order to have the inner box UI element
+    // exactly touch the wheel
+    let wheel_radius = wheel_diameter / 2.;
+    let inner_wheel_radius = wheel_radius * hue_wheel_material.inner_radius;
+    let box_size = (inner_wheel_radius * 2.) * (PI / 4.).cos();
+
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                display: Display::Grid,
+                width: Val::Percent(100.0),
+                height: Val::Percent(50.0),
+                grid_template_columns: vec![
+                    GridTrack::auto(),
+                    GridTrack::percent(50.0),
+                    GridTrack::auto(),
+                ],
+                grid_template_rows: vec![GridTrack::auto()],
+                ..default()
+            },
+            ..default()
+        })
+        .with_children(|grid: &mut ChildBuilder<'_, '_, '_>| {
+            // picker 1
+            grid.spawn(NodeBundle {
+                style: Style {
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    ..default()
+                },
+                ..default()
+            })
+            .with_children(|picker1| {
+                picker1.spawn(HueWheelBundle {
+                    style: Style {
+                        position_type: PositionType::Absolute,
+                        width: Val::Px(wheel_diameter),
+                        height: Val::Px(wheel_diameter),
+                        ..default()
+                    },
+                    material: hue_materials.add(hue_wheel_material.clone()),
+                    ..default()
+                });
+                picker1.spawn((
+                    SaturationValueBoxBundle {
+                        style: Style {
+                            position_type: PositionType::Absolute,
+                            width: Val::Px(box_size),
+                            height: Val::Px(box_size),
+                            ..default()
+                        },
+                        material: satval_materials.add(default()),
+                        ..default()
+                    },
+                    SaturationValueBox1,
+                ));
+            });
+
+            // empty space to separate the pickers
+            grid.spawn(NodeBundle { ..default() });
+
+            // picker 2
+            grid.spawn(NodeBundle {
+                style: Style {
+                    align_items: AlignItems::Center,
+                    justify_content: JustifyContent::Center,
+                    ..default()
+                },
+                ..default()
+            })
+            .with_children(|picker2| {
+                picker2.spawn(HueWheelBundle {
+                    style: Style {
+                        position_type: PositionType::Absolute,
+                        width: Val::Px(wheel_diameter),
+                        height: Val::Px(wheel_diameter),
+                        ..default()
+                    },
+                    material: hue_materials.add(hue_wheel_material),
+                    ..default()
+                });
+                picker2.spawn((
+                    SaturationValueBoxBundle {
+                        style: Style {
+                            position_type: PositionType::Absolute,
+                            width: Val::Px(box_size),
+                            height: Val::Px(box_size),
+                            ..default()
+                        },
+                        material: satval_materials.add(default()),
+                        ..default()
+                    },
+                    SaturationValueBox2,
+                ));
+            });
+        });
+}


### PR DESCRIPTION
# Objective

- Bevy is lacking a way to pick colors interactively

## Solution

_It's very likely that my solution might not be the best approach, looking for input_.

### Iteration 1 video

https://github.com/bevyengine/bevy/assets/52322338/b8af2a45-b81e-450b-8e7f-c307b7bff20e

### Iteration 2 video


https://github.com/bevyengine/bevy/assets/52322338/3b4c64bd-e276-4253-9d43-53a5a70e02b0

- Added a marker within the sat-val box
- Example uses flex column
- User must mark a relationship between wheel and box with a component

### Iteration 3 video

https://github.com/bevyengine/bevy/assets/52322338/4e043afc-032a-496c-b313-4063a381ac40

- Added a marker on the hue wheel
- Colors update both if color is picked on hue wheel as well as sat-val box now

### Description

The color picker is made out of two parts: The outer wheel (the "hue wheel") and the inner box (the "saturation-value box").

Each have their own shader used to display the colors to pick.

Interaction is done via relative cursor positions- which is why the split into two UI nodes was done. It made the math a lot simpler.

`bevy_ui` now sends events when:

- A hue wheel is pressed
- A saturation-value box is pressed

If the `HueWheelSibling` component is added to the box, the box will be kept in sync when the wheel hue changes.

---

## Changelog

### Added

- Added HSV color pickers now usable via UI bundles
- Added an example to showcase independent color pickers