### PR TITLE
support all types of animation interpolation from gltf

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -616,6 +616,7 @@ fn get_keyframe(target_count: usize, keyframes: &[f32], key_index: usize) -> &[f
 
 // Helper macro for cubic spline interpolation
 // it needs to work on `f32`, `Vec3` and `Quat`
+// TODO: replace by a function if the proper trait bounds can be figured out
 macro_rules! cubic_spline_interpolation {
     ($value_start: expr, $tangent_out_start: expr, $tangent_in_end: expr, $value_end: expr, $lerp: expr, $step_duration: expr,) => {
         $value_start * (2.0 * $lerp.powi(3) - 3.0 * $lerp.powi(2) + 1.0)

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -754,7 +754,7 @@ fn apply_animation(
                             lerp,
                             ts_end - ts_start,
                         );
-                        transform.rotation = transform.rotation.lerp(result.normalize(), weight);
+                        transform.rotation = transform.rotation.slerp(result.normalize(), weight);
                     }
                     (Interpolation::Step, Keyframes::Translation(keyframes)) => {
                         transform.translation =

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -811,7 +811,7 @@ fn apply_animation(
                             let morph_start = get_keyframe(target_count, keyframes, step_start);
                             lerp_morph_weights(
                                 morphs.weights_mut(),
-                                morph_start.into_iter().map(|&v| v),
+                                morph_start.iter().copied(),
                                 weight,
                             );
                         }

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -50,6 +50,7 @@ fn setup(
                 // be the same as the first one
                 Vec3::new(1.0, 0.0, 1.0),
             ]),
+            interpolation: Interpolation::Linear,
         },
     );
     // Or it can modify the rotation of the transform.
@@ -68,6 +69,7 @@ fn setup(
                 Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                 Quat::IDENTITY,
             ]),
+            interpolation: Interpolation::Linear,
         },
     );
     // If a curve in an animation is shorter than the other, it will not repeat
@@ -90,6 +92,7 @@ fn setup(
                 Vec3::splat(1.2),
                 Vec3::splat(0.8),
             ]),
+            interpolation: Interpolation::Linear,
         },
     );
     // There can be more than one curve targeting the same entity path
@@ -106,6 +109,7 @@ fn setup(
                 Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                 Quat::IDENTITY,
             ]),
+            interpolation: Interpolation::Linear,
         },
     );
 


### PR DESCRIPTION
# Objective

- Support step and cubic spline interpolation from gltf

## Solution

- Support step and cubic spline interpolation from gltf

Tested with https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/InterpolationTest
expected: 
![](https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/InterpolationTest/screenshot/screenshot.gif)
result: 
![output](https://github.com/bevyengine/bevy/assets/8672791/e7f1afd5-20c9-4921-97d4-8d0c82203068)

---

## Migration Guide

When manually specifying an animation `VariableCurve`, the interpolation type must be specified:

- Bevy 0.12
```rust
        VariableCurve {
            keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
            keyframes: Keyframes::Rotation(vec![
                Quat::IDENTITY,
                Quat::from_axis_angle(Vec3::Y, PI / 2.),
                Quat::from_axis_angle(Vec3::Y, PI / 2. * 2.),
                Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                Quat::IDENTITY,
            ]),
        },
```

- Bevy 0.13
```rust
        VariableCurve {
            keyframe_timestamps: vec![0.0, 1.0, 2.0, 3.0, 4.0],
            keyframes: Keyframes::Rotation(vec![
                Quat::IDENTITY,
                Quat::from_axis_angle(Vec3::Y, PI / 2.),
                Quat::from_axis_angle(Vec3::Y, PI / 2. * 2.),
                Quat::from_axis_angle(Vec3::Y, PI / 2. * 3.),
                Quat::IDENTITY,
            ]),
            interpolation: Interpolation::Linear,
        },
```
