### PR TITLE
Make AnonymousSet::new public

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -449,7 +449,6 @@ pub struct ScheduleGraph {
     ambiguous_with: UnGraphMap<NodeId, ()>,
     ambiguous_with_all: HashSet<NodeId>,
     conflicting_systems: Vec<(NodeId, NodeId, Vec<ComponentId>)>,
-    anonymous_sets: usize,
     changed: bool,
     settings: ScheduleBuildSettings,
 }
@@ -469,7 +468,6 @@ impl ScheduleGraph {
             ambiguous_with: UnGraphMap::new(),
             ambiguous_with_all: HashSet::new(),
             conflicting_systems: Vec::new(),
-            anonymous_sets: 0,
             changed: false,
             settings: default(),
         }
@@ -780,9 +778,7 @@ impl ScheduleGraph {
     }
 
     fn create_anonymous_set(&mut self) -> AnonymousSet {
-        let id = self.anonymous_sets;
-        self.anonymous_sets += 1;
-        AnonymousSet::new(id)
+        AnonymousSet::new()
     }
 
     fn check_sets(


### PR DESCRIPTION
# Objective

`AnonymousSet` might be useful outside of `bevy_ecs` for the same reason it is used in `bevy_ecs`.

## Solution

- Make `AnonymousSet::new` public
- Use global `u64` counter to generate unique labels

---

## Changelog

- Make `AnonymousSet::new` public