### PR TITLE
Added `InputSource` as an ID for input events

### DIFF
--- a/crates/bevy_gilrs/src/converter.rs
+++ b/crates/bevy_gilrs/src/converter.rs
@@ -1,8 +1,4 @@
-use bevy_input::gamepad::{Gamepad, GamepadAxisType, GamepadButtonType};
-
-pub fn convert_gamepad_id(gamepad_id: gilrs::GamepadId) -> Gamepad {
-    Gamepad::new(gamepad_id.into())
-}
+use bevy_input::gamepad::{GamepadAxisType, GamepadButtonType};
 
 pub fn convert_button(button: gilrs::Button) -> Option<GamepadButtonType> {
     match button {

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -11,9 +11,9 @@ mod rumble;
 
 use bevy_app::{App, Plugin, PostUpdate, PreStartup, PreUpdate};
 use bevy_ecs::prelude::*;
-use bevy_input::InputSystem;
-use bevy_utils::tracing::error;
-use gilrs::GilrsBuilder;
+use bevy_input::{InputSource, InputSystem};
+use bevy_utils::{tracing::error, HashMap};
+use gilrs::{GamepadId, GilrsBuilder};
 use gilrs_system::{gilrs_event_startup_system, gilrs_event_system};
 use rumble::{play_gilrs_rumble, RunningRumbleEffects};
 
@@ -34,6 +34,7 @@ impl Plugin for GilrsPlugin {
         {
             Ok(gilrs) => {
                 app.insert_non_send_resource(gilrs)
+                    .init_resource::<GilrsGamepads>()
                     .init_non_send_resource::<RunningRumbleEffects>()
                     .add_systems(PreStartup, gilrs_event_startup_system)
                     .add_systems(PreUpdate, gilrs_event_system.before(InputSystem))
@@ -42,4 +43,10 @@ impl Plugin for GilrsPlugin {
             Err(err) => error!("Failed to start Gilrs. {}", err),
         }
     }
+}
+
+/// Registry of all Gilrs gamepads and their [`InputSource`] IDs.
+#[derive(Resource, Default)]
+struct GilrsGamepads {
+    mapping: HashMap<GamepadId, InputSource>,
 }

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -80,7 +80,7 @@ where
 mod tests {
     use crate::{
         gamepad::{Gamepad, GamepadButton, GamepadButtonType},
-        Axis,
+        Axis, InputSources,
     };
 
     #[test]
@@ -99,9 +99,11 @@ mod tests {
             (1.6, Some(1.0)),
         ];
 
+        let mut input_sources = InputSources::default();
+        let gamepad = Gamepad::new(input_sources.register());
+
         for (value, expected) in cases {
-            let gamepad_button =
-                GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger);
+            let gamepad_button = GamepadButton::new(gamepad, GamepadButtonType::RightTrigger);
             let mut axis = Axis::<GamepadButton>::default();
 
             axis.set(gamepad_button, value);
@@ -115,9 +117,11 @@ mod tests {
     fn test_axis_remove() {
         let cases = [-1.0, -0.9, -0.1, 0.0, 0.1, 0.9, 1.0];
 
+        let mut input_sources = InputSources::default();
+        let gamepad = Gamepad::new(input_sources.register());
+
         for value in cases {
-            let gamepad_button =
-                GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger);
+            let gamepad_button = GamepadButton::new(gamepad, GamepadButtonType::RightTrigger);
             let mut axis = Axis::<GamepadButton>::default();
 
             axis.set(gamepad_button, value);
@@ -133,31 +137,31 @@ mod tests {
 
     #[test]
     fn test_axis_devices() {
+        let mut input_sources = InputSources::default();
+        let gamepad = Gamepad::new(input_sources.register());
+
         let mut axis = Axis::<GamepadButton>::default();
         assert_eq!(axis.devices().count(), 0);
 
         axis.set(
-            GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger),
+            GamepadButton::new(gamepad, GamepadButtonType::RightTrigger),
             0.1,
         );
         assert_eq!(axis.devices().count(), 1);
 
         axis.set(
-            GamepadButton::new(Gamepad::new(1), GamepadButtonType::LeftTrigger),
+            GamepadButton::new(gamepad, GamepadButtonType::LeftTrigger),
             0.5,
         );
         assert_eq!(axis.devices().count(), 2);
 
         axis.set(
-            GamepadButton::new(Gamepad::new(1), GamepadButtonType::RightTrigger),
+            GamepadButton::new(gamepad, GamepadButtonType::RightTrigger),
             -0.1,
         );
         assert_eq!(axis.devices().count(), 2);
 
-        axis.remove(GamepadButton::new(
-            Gamepad::new(1),
-            GamepadButtonType::RightTrigger,
-        ));
+        axis.remove(GamepadButton::new(gamepad, GamepadButtonType::RightTrigger));
         assert_eq!(axis.devices().count(), 1);
     }
 }

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,6 +1,6 @@
 //! The gamepad input functionality.
 
-use crate::{Axis, ButtonState, Input};
+use crate::{Axis, ButtonState, Input, InputSource};
 use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
@@ -89,12 +89,12 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 )]
 pub struct Gamepad {
     /// The `ID` of the gamepad.
-    pub id: usize,
+    pub id: InputSource,
 }
 
 impl Gamepad {
     /// Creates a new [`Gamepad`].
-    pub fn new(id: usize) -> Self {
+    pub fn new(id: InputSource) -> Self {
         Self { id }
     }
 }
@@ -252,10 +252,11 @@ impl GamepadButton {
     /// # Examples
     ///
     /// ```
-    /// # use bevy_input::gamepad::{GamepadButton, GamepadButtonType, Gamepad};
-    /// #
+    /// # use bevy_input::{InputSources, gamepad::{GamepadButton, GamepadButtonType, Gamepad}};
+    /// # let mut input_sources = InputSources::default();
+    /// # let gamepad = Gamepad::new(input_sources.register());
     /// let gamepad_button = GamepadButton::new(
-    ///     Gamepad::new(1),
+    ///     gamepad,
     ///     GamepadButtonType::South,
     /// );
     /// ```
@@ -345,10 +346,12 @@ impl GamepadAxis {
     /// # Examples
     ///
     /// ```
-    /// # use bevy_input::gamepad::{GamepadAxis, GamepadAxisType, Gamepad};
+    /// # use bevy_input::{InputSources, gamepad::{GamepadAxis, GamepadAxisType, Gamepad}};
+    /// # let mut input_sources = InputSources::default();
+    /// # let gamepad = Gamepad::new(input_sources.register());
     /// #
     /// let gamepad_axis = GamepadAxis::new(
-    ///     Gamepad::new(1),
+    ///     gamepad,
     ///     GamepadAxisType::LeftStickX,
     /// );
     /// ```
@@ -395,10 +398,12 @@ impl GamepadSettings {
     /// # Examples
     ///
     /// ```
-    /// # use bevy_input::gamepad::{GamepadSettings, GamepadButton, Gamepad, GamepadButtonType};
+    /// # use bevy_input::{InputSources, gamepad::{GamepadSettings, GamepadButton, Gamepad, GamepadButtonType}};
+    /// # let mut input_sources = InputSources::default();
+    /// # let gamepad = Gamepad::new(input_sources.register());
     /// #
     /// # let settings = GamepadSettings::default();
-    /// let button = GamepadButton::new(Gamepad::new(1), GamepadButtonType::South);
+    /// let button = GamepadButton::new(gamepad, GamepadButtonType::South);
     /// let button_settings = settings.get_button_settings(button);
     /// ```
     pub fn get_button_settings(&self, button: GamepadButton) -> &ButtonSettings {
@@ -414,10 +419,12 @@ impl GamepadSettings {
     /// # Examples
     ///
     /// ```
-    /// # use bevy_input::gamepad::{GamepadSettings, GamepadAxis, Gamepad, GamepadAxisType};
+    /// # use bevy_input::{InputSources, gamepad::{GamepadSettings, GamepadAxis, Gamepad, GamepadAxisType}};
+    /// # let mut input_sources = InputSources::default();
+    /// # let gamepad = Gamepad::new(input_sources.register());
     /// #
     /// # let settings = GamepadSettings::default();
-    /// let axis = GamepadAxis::new(Gamepad::new(1), GamepadAxisType::LeftStickX);
+    /// let axis = GamepadAxis::new(gamepad, GamepadAxisType::LeftStickX);
     /// let axis_settings = settings.get_axis_settings(axis);
     /// ```
     pub fn get_axis_settings(&self, axis: GamepadAxis) -> &AxisSettings {
@@ -433,10 +440,12 @@ impl GamepadSettings {
     /// # Examples
     ///
     /// ```
-    /// # use bevy_input::gamepad::{GamepadSettings, GamepadButton, Gamepad, GamepadButtonType};
+    /// # use bevy_input::{InputSources, gamepad::{GamepadSettings, GamepadButton, Gamepad, GamepadButtonType}};
+    /// # let mut input_sources = InputSources::default();
+    /// # let gamepad = Gamepad::new(input_sources.register());
     /// #
     /// # let settings = GamepadSettings::default();
-    /// let button = GamepadButton::new(Gamepad::new(1), GamepadButtonType::South);
+    /// let button = GamepadButton::new(gamepad, GamepadButtonType::South);
     /// let button_axis_settings = settings.get_button_axis_settings(button);
     /// ```
     pub fn get_button_axis_settings(&self, button: GamepadButton) -> &ButtonAxisSettings {

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1,6 +1,6 @@
 //! The keyboard input functionality.
 
-use crate::{ButtonState, Input};
+use crate::{ButtonState, Input, InputSource};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
@@ -37,6 +37,8 @@ pub struct KeyboardInput {
     pub state: ButtonState,
     /// Window that received the input.
     pub window: Entity,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// Updates the [`Input<KeyCode>`] resource with the latest [`KeyboardInput`] events.

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -13,11 +13,13 @@ pub mod gamepad;
 mod input;
 pub mod keyboard;
 pub mod mouse;
+mod source;
 pub mod touch;
 pub mod touchpad;
 
 pub use axis::*;
 pub use input::*;
+pub use source::*;
 
 /// Most commonly used re-exported types.
 pub mod prelude {
@@ -66,6 +68,8 @@ pub struct InputSystem;
 impl Plugin for InputPlugin {
     fn build(&self, app: &mut App) {
         app
+            // sources
+            .init_resource::<InputSources>()
             // keyboard
             .add_event::<KeyboardInput>()
             .init_resource::<Input<KeyCode>>()
@@ -109,6 +113,9 @@ impl Plugin for InputPlugin {
             .add_event::<TouchInput>()
             .init_resource::<Touches>()
             .add_systems(PreUpdate, touch_screen_input_system.in_set(InputSystem));
+
+        // Register input source types
+        app.register_type::<InputSource>();
 
         // Register common types
         app.register_type::<ButtonState>();

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -1,6 +1,6 @@
 //! The mouse input functionality.
 
-use crate::{ButtonState, Input};
+use crate::{ButtonState, Input, InputSource};
 use bevy_ecs::entity::Entity;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
@@ -35,6 +35,8 @@ pub struct MouseButtonInput {
     pub state: ButtonState,
     /// Window that received the input.
     pub window: Entity,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// A button on a mouse device.
@@ -84,6 +86,8 @@ pub enum MouseButton {
 pub struct MouseMotion {
     /// The change in the position of the pointing device since the last event was sent.
     pub delta: Vec2,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// The scroll unit.
@@ -131,6 +135,8 @@ pub struct MouseWheel {
     pub y: f32,
     /// Window that received the input.
     pub window: Entity,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// Updates the [`Input<MouseButton>`] resource with the latest [`MouseButtonInput`] events.

--- a/crates/bevy_input/src/source.rs
+++ b/crates/bevy_input/src/source.rs
@@ -1,0 +1,45 @@
+//! Provides a platform and library agnostic identifier for input sources, [`InputSource`].
+
+use bevy_ecs::system::Resource;
+use bevy_reflect::Reflect;
+use std::hash::Hash;
+
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
+/// Represents a source of input [`events`](`bevy_ecs::event::Event`).
+/// This can be used to differentiate events of the same type but from different sources.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Reflect)]
+#[cfg_attr(
+    feature = "serialize",
+    derive(serde::Serialize, serde::Deserialize),
+    reflect(Serialize, Deserialize)
+)]
+pub struct InputSource(usize);
+
+/// Provides unique [`InputSource`]'s when requested.
+#[derive(Resource, Default, Reflect)]
+pub struct InputSources {
+    counter: usize,
+}
+
+impl InputSources {
+    /// Attempt to register a new [`InputSource`]. Returns [`None`] if a registration is not possible.
+    pub fn try_register(&mut self) -> Option<InputSource> {
+        let source = InputSource(self.counter);
+        self.counter = self.counter.checked_add(1)?;
+        Some(source)
+    }
+
+    /// Register a new [`InputSource`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if registration fails.
+    pub fn register(&mut self) -> InputSource {
+        let Some(source) = self.try_register() else {
+            panic!("Ran out of InputSource IDs!")
+        };
+        source
+    }
+}

--- a/crates/bevy_input/src/touchpad.rs
+++ b/crates/bevy_input/src/touchpad.rs
@@ -6,6 +6,8 @@ use bevy_reflect::Reflect;
 #[cfg(feature = "serialize")]
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 
+use crate::InputSource;
+
 /// Touchpad magnification event with two-finger pinch gesture.
 ///
 /// Positive delta values indicate magnification (zooming in) and
@@ -21,7 +23,12 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct TouchpadMagnify(pub f32);
+pub struct TouchpadMagnify {
+    /// The amount of magnification.
+    pub delta: f32,
+    /// The source of this input event.
+    pub source: InputSource,
+}
 
 /// Touchpad rotation event with two-finger rotation gesture.
 ///
@@ -38,4 +45,9 @@ pub struct TouchpadMagnify(pub f32);
     derive(serde::Serialize, serde::Deserialize),
     reflect(Serialize, Deserialize)
 )]
-pub struct TouchpadRotate(pub f32);
+pub struct TouchpadRotate {
+    /// The amount of rotation.
+    pub delta: f32,
+    /// The source of this input event.
+    pub source: InputSource,
+}

--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use bevy_ecs::entity::Entity;
 use bevy_ecs::event::Event;
+use bevy_input::InputSource;
 use bevy_math::{IVec2, Vec2};
 use bevy_reflect::Reflect;
 
@@ -132,6 +133,8 @@ pub struct CursorMoved {
     pub window: Entity,
     /// The cursor position in logical pixels.
     pub position: Vec2,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// An event that is sent whenever the user's cursor enters a window.
@@ -145,6 +148,8 @@ pub struct CursorMoved {
 pub struct CursorEntered {
     /// Window that the cursor entered.
     pub window: Entity,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// An event that is sent whenever the user's cursor leaves a window.
@@ -158,6 +163,8 @@ pub struct CursorEntered {
 pub struct CursorLeft {
     /// Window that the cursor left.
     pub window: Entity,
+    /// The source of this input event.
+    pub source: InputSource,
 }
 
 /// An event that is sent whenever a window receives a character from the OS or underlying system.

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -3,7 +3,7 @@ use bevy_input::{
     keyboard::{KeyCode, KeyboardInput},
     mouse::MouseButton,
     touch::{ForceTouch, TouchInput, TouchPhase},
-    ButtonState,
+    ButtonState, InputSource,
 };
 use bevy_math::Vec2;
 use bevy_window::{CursorIcon, EnabledButtons, WindowLevel, WindowTheme};
@@ -11,12 +11,14 @@ use bevy_window::{CursorIcon, EnabledButtons, WindowLevel, WindowTheme};
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyboardInput,
     window: Entity,
+    source: InputSource,
 ) -> KeyboardInput {
     KeyboardInput {
         scan_code: keyboard_input.scancode,
         state: convert_element_state(keyboard_input.state),
         key_code: keyboard_input.virtual_keycode.map(convert_virtual_key_code),
         window,
+        source,
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #15
- Increase parity between gamepad and non-gamepad input types.

## Solution

- Added `InputSource` as a platform and library agnostic identifier for input-like events. This type is purely an identifier with no inherit meaning beyond its self comparison. It is up to the writers of input events to provide any additional meaning to these 
- Updated input events to include an `InputSource` field, disambiguating the source of the event.

---

## Changelog

- Added `InputSource` identifier type.
- Added `InputSources` resource for creating `InputSource` IDs. Since `InputSource` is purely a unique ID, `InputSources` is just a counter.
- Updated gamepad, mouse, keyboard, touchpad, etc. inputs to include a `source: InputSource` field.

## Migration Guide

- Input types now include a `source` field of type `InputSource`. If you don't require it when reading, discard its value (e.g., during pattern matching). If writing one of these input events, use the `InputSources` resource to create an `InputSource` ID that you must manage.

---

## Tasks

- [ ] Capture `winit::event::Event::DeviceEvent`'s, not just `WindowEvent::DeviceEvent` (these are confusingly different). Currently this only provides meaningful disambiguation for `Gamepad` events, and `MouseMotion` (at least on my test platform). `winit` provides a `DeviceId` with `WindowEvent`'s, but for whatever cause (Windows, `winit`, etc.), the ID provided for those events is always for the "primary" device. Whereas, `DeviceEvent` events _do_ include the specific device. This can currently be best observed in the `mouse_input_events` example, which will disambiguate `MouseMotion`, but not `MouseButtonInput`. I think the solution to this is to duplicate the event types (similar to `CursorPosition` vs `MouseDelta`).
- [ ] Expand documentation. It's the bare minimum to avoid linting issues.
- [ ] Explore "input sources as entities". Currently, I don't like this framework, since we don't have an efficient way to retrieve an `Entity` by an arbitrary value (e.g., a `winit` `DeviceId` component), and registering a new input source would require world access for allocating an `Entity`. But, it could be powerful for adding arbitrary metadata (e.g., `GamepadInfo`) to input sources.

## Notes

- I'm deliberately _not_ modifying the `Inputs` resources to provide this extra information right now to keep the scope of changes small. Providing this information on the input events is, in my opinion, the bare minimum to allow a Bevy user to utilise multiple mice, keyboards, etc.
- While this may seem like a pretty esoteric feature to support in Bevy, I do think it's worthwhile. There are many instances of [flight simulator gamers](https://forums.flightsimulator.com/t/tutorial-how-to-use-any-secondary-pc-keyboard-to-control-msfs-events-and-variables-via-spad-next-and-midi-commands/470346) trying to retroactively add this support to existing games. Macro-heavy applications have a [similar problem](https://www.youtube.com/playlist?list=PLH1gH0v9E3ruYrNyRbHhDe6XDfw4sZdZr). Exposing this to Bevy users will allow them to decide if these kinds of features are something they'd like to support.
- I want this to eventually reach a form of feature parity with gamepads, since we have an established API for disambiguation between them already. This is why I've modified the `Gamepad` type to contain an `InputSource` instead of a `usize` as its ID.