### PR TITLE
Move Resource and related types to a dedicated bevy_ecs::resource file

### DIFF
--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -14,8 +14,8 @@ use bevy_app::Plugin;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::{Component, Entity, Event},
+    resource::Resource,
     schedule::SystemSet,
-    system::Resource,
 };
 
 /// Wrapper struct for [`accesskit::ActionRequest`]. Required to allow it to be used as an `Event`.

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,7 +1,8 @@
 use crate::{App, Plugin};
+use bevy_ecs::resource::Resource;
 use bevy_ecs::{
     schedule::{ExecutorKind, InternedScheduleLabel, Schedule, ScheduleLabel},
-    system::{Local, Resource},
+    system::Local,
     world::{Mut, World},
 };
 

--- a/crates/bevy_app/src/plugin_group.rs
+++ b/crates/bevy_app/src/plugin_group.rs
@@ -28,7 +28,7 @@ impl PluginGroup for PluginGroupBuilder {
 }
 
 /// Facilitates the creation and configuration of a [`PluginGroup`].
-/// Provides a build ordering to ensure that [`Plugin`]s which produce/require a [`Resource`](bevy_ecs::system::Resource)
+/// Provides a build ordering to ensure that [`Plugin`]s which produce/require a [`Resource`](bevy_ecs::resource::Resource)
 /// are built before/after dependent/depending [`Plugin`]s. [`Plugin`]s inside the group
 /// can be disabled, enabled or reordered.
 pub struct PluginGroupBuilder {

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -2,7 +2,7 @@ use crate as bevy_asset;
 use crate::{Asset, AssetEvent, AssetHandleProvider, AssetId, AssetServer, Handle, UntypedHandle};
 use bevy_ecs::{
     prelude::EventWriter,
-    system::{Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
 };
 use bevy_reflect::{Reflect, TypePath, Uuid};
 use bevy_utils::HashMap;

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -8,7 +8,7 @@ use crate::io::{
     memory::{Dir, MemoryAssetReader, Value},
     AssetSource, AssetSourceBuilders,
 };
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use std::path::{Path, PathBuf};
 
 pub const EMBEDDED: &str = "embedded";

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     processor::AssetProcessorData,
 };
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_log::{error, warn};
 use bevy_utils::{CowArc, Duration, HashMap};
 use std::{fmt::Display, hash::Hash, sync::Arc};

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -45,8 +45,8 @@ use crate::{
 use bevy_app::{App, First, MainScheduleOrder, Plugin, PostUpdate};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
+    resource::Resource,
     schedule::{IntoSystemConfigs, IntoSystemSetConfigs, ScheduleLabel, SystemSet},
-    system::Resource,
     world::FromWorld,
 };
 use bevy_log::error;

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -325,7 +325,7 @@ impl AssetServer {
     ///
     /// ```
     /// use bevy_asset::{Assets, Handle, LoadedUntypedAsset};
-    /// use bevy_ecs::system::{Res, Resource};
+    /// use bevy_ecs::resource::{Res, Resource};
     ///
     /// #[derive(Resource)]
     /// struct LoadingUntypedHandle(Handle<LoadedUntypedAsset>);

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -7,7 +7,7 @@ mod name;
 mod serde;
 mod task_pool_options;
 
-use bevy_ecs::system::{ResMut, Resource};
+use bevy_ecs::resource::{NonSend, ResMut, Resource};
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
 pub use task_pool_options::*;

--- a/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/downsampling_pipeline.rs
@@ -2,7 +2,8 @@ use super::{BloomSettings, BLOOM_SHADER_HANDLE, BLOOM_TEXTURE_FORMAT};
 use crate::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 use bevy_ecs::{
     prelude::{Component, Entity},
-    system::{Commands, Query, Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
+    system::{Commands, Query},
     world::{FromWorld, World},
 };
 use bevy_math::Vec4;

--- a/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
+++ b/crates/bevy_core_pipeline/src/bloom/upsampling_pipeline.rs
@@ -5,7 +5,8 @@ use super::{
 use crate::fullscreen_vertex_shader::fullscreen_shader_vertex_state;
 use bevy_ecs::{
     prelude::{Component, Entity},
-    system::{Commands, Query, Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
+    system::{Commands, Query},
     world::{FromWorld, World},
 };
 use bevy_render::{

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -3,8 +3,9 @@ use bevy_asset::{load_internal_asset, Handle};
 use bevy_ecs::{
     prelude::{Component, Entity},
     query::With,
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{Commands, Query, Res, ResMut, Resource},
+    system::{Commands, Query},
 };
 use bevy_render::{
     extract_component::{ExtractComponent, ExtractComponentPlugin},

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -10,8 +10,9 @@ use bevy_core::FrameCount;
 use bevy_ecs::{
     prelude::{Bundle, Component, Entity},
     query::{QueryItem, With},
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{Commands, Query, Res, ResMut, Resource},
+    system::{Commands, Query},
     world::{FromWorld, World},
 };
 use bevy_math::vec2;

--- a/crates/bevy_diagnostic/src/diagnostic.rs
+++ b/crates/bevy_diagnostic/src/diagnostic.rs
@@ -1,5 +1,6 @@
 use bevy_app::App;
-use bevy_ecs::system::{Deferred, Res, Resource, SystemBuffer, SystemParam};
+use bevy_ecs::resource::{Res, Resource};
+use bevy_ecs::system::{Deferred, SystemBuffer, SystemParam};
 use bevy_log::warn;
 use bevy_utils::{Duration, Instant, StableHashMap, Uuid};
 use std::{borrow::Cow, collections::VecDeque};

--- a/crates/bevy_ecs/macros/src/component.rs
+++ b/crates/bevy_ecs/macros/src/component.rs
@@ -34,7 +34,7 @@ pub fn derive_resource(input: TokenStream) -> TokenStream {
     let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
 
     TokenStream::from(quote! {
-        impl #impl_generics #bevy_ecs_path::system::Resource for #struct_name #type_generics #where_clause {
+        impl #impl_generics #bevy_ecs_path::resource::Resource for #struct_name #type_generics #where_clause {
         }
     })
 }

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -583,7 +583,7 @@ struct ArchetypeComponents {
 ///
 /// [`Component`]: crate::component::Component
 /// [`World`]: crate::world::World
-/// [`Resource`]: crate::system::Resource
+/// [`Resource`]: crate::resource::Resource
 /// [many-to-many relationship]: https://en.wikipedia.org/wiki/Many-to-many_(data_model)
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct ArchetypeComponentId(usize);

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -1,10 +1,11 @@
 //! Types for declaring and storing [`Component`]s.
 
+use crate::resource::Resource;
 use crate::{
     self as bevy_ecs,
     change_detection::MAX_CHANGE_AGE,
     storage::{SparseSetIndex, Storages},
-    system::{Local, Resource, SystemParam},
+    system::{Local, SystemParam},
     world::{FromWorld, World},
     TypeIdMap,
 };
@@ -634,7 +635,7 @@ impl Components {
         }
     }
 
-    /// Initializes a [non-send resource](crate::system::NonSend) of type `T` with this instance.
+    /// Initializes a [non-send resource](crate::resource::NonSend) of type `T` with this instance.
     /// If a resource of this type has already been initialized, this will return
     /// the ID of the pre-existing resource.
     #[inline]
@@ -809,7 +810,7 @@ impl ComponentTicks {
     /// Manually sets the change tick.
     ///
     /// This is normally done automatically via the [`DerefMut`](std::ops::DerefMut) implementation
-    /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::change_detection::ResMut), etc.
+    /// on [`Mut<T>`](crate::change_detection::Mut), [`ResMut<T>`](crate::resource::ResMut), etc.
     /// However, components and resources that make use of interior mutability might require manual updates.
     ///
     /// # Example

--- a/crates/bevy_ecs/src/event.rs
+++ b/crates/bevy_ecs/src/event.rs
@@ -1,7 +1,9 @@
 //! Event handling types.
 
 use crate as bevy_ecs;
-use crate::system::{Local, Res, ResMut, Resource, SystemParam};
+use crate::resource::Resource;
+use crate::resource::{Res, ResMut};
+use crate::system::{Local, SystemParam};
 pub use bevy_ecs_macros::Event;
 use bevy_utils::detailed_trace;
 use std::ops::{Deref, DerefMut};
@@ -13,6 +15,7 @@ use std::{
     marker::PhantomData,
     slice::Iter,
 };
+
 /// A type that can be stored in an [`Events<E>`] resource
 /// You can conveniently access events using the [`EventReader`] and [`EventWriter`] system parameter.
 ///

--- a/crates/bevy_ecs/src/impl_macros.rs
+++ b/crates/bevy_ecs/src/impl_macros.rs
@@ -1,0 +1,167 @@
+//! Private macros used in various types.
+
+macro_rules! impl_debug {
+    ($name:ident < $( $generics:tt ),+ >, $($traits:ident)?) => {
+        impl<$($generics),* : ?Sized $(+ $traits)?> std::fmt::Debug for $name<$($generics),*>
+            where T: std::fmt::Debug
+        {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.debug_tuple(stringify!($name))
+                    .field(&self.value)
+                    .finish()
+            }
+        }
+
+    };
+}
+macro_rules! change_detection_impl {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
+        impl<$($generics),* : ?Sized $(+ $traits)?> crate::change_detection::DetectChanges for $name<$($generics),*> {
+            #[inline]
+            fn is_added(&self) -> bool {
+                self.ticks
+                    .added
+                    .is_newer_than(self.ticks.last_run, self.ticks.this_run)
+            }
+
+            #[inline]
+            fn is_changed(&self) -> bool {
+                self.ticks
+                    .changed
+                    .is_newer_than(self.ticks.last_run, self.ticks.this_run)
+            }
+
+            #[inline]
+            fn last_changed(&self) -> crate::component::Tick {
+                *self.ticks.changed
+            }
+        }
+
+        impl<$($generics),*: ?Sized $(+ $traits)?> ::std::ops::Deref for $name<$($generics),*> {
+            type Target = $target;
+
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                self.value
+            }
+        }
+
+        impl<$($generics),* $(: $traits)?> AsRef<$target> for $name<$($generics),*> {
+            #[inline]
+            fn as_ref(&self) -> &$target {
+                ::std::ops::Deref::deref(self)
+            }
+        }
+    }
+}
+
+macro_rules! change_detection_mut_impl {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
+        impl<$($generics),* : ?Sized $(+ $traits)?> crate::prelude::DetectChangesMut for $name<$($generics),*> {
+            type Inner = $target;
+
+            #[inline]
+            fn set_changed(&mut self) {
+                *self.ticks.changed = self.ticks.this_run;
+            }
+
+            #[inline]
+            fn set_last_changed(&mut self, last_changed: crate::component::Tick) {
+                *self.ticks.changed = last_changed;
+            }
+
+            #[inline]
+            fn bypass_change_detection(&mut self) -> &mut Self::Inner {
+                self.value
+            }
+        }
+
+        impl<$($generics),* : ?Sized $(+ $traits)?> ::std::ops::DerefMut for $name<$($generics),*> {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                self.set_changed();
+                self.value
+            }
+        }
+
+        impl<$($generics),* $(: $traits)?> AsMut<$target> for $name<$($generics),*> {
+            #[inline]
+            fn as_mut(&mut self) -> &mut $target {
+                ::std::ops::DerefMut::deref_mut(self)
+            }
+        }
+    };
+}
+
+macro_rules! impl_methods {
+    ($name:ident < $( $generics:tt ),+ >, $target:ty, $($traits:ident)?) => {
+        impl<$($generics),* : ?Sized $(+ $traits)?> $name<$($generics),*> {
+            /// Consume `self` and return a mutable reference to the
+            /// contained value while marking `self` as "changed".
+            #[inline]
+            pub fn into_inner(mut self) -> &'a mut $target {
+                self.set_changed();
+                self.value
+            }
+
+            /// Returns a `Mut<>` with a smaller lifetime.
+            /// This is useful if you have `&mut
+            #[doc = stringify!($name)]
+            /// <T>`, but you need a `Mut<T>`.
+            pub fn reborrow(&mut self) -> Mut<'_, $target> {
+                Mut {
+                    value: self.value,
+                    ticks: TicksMut {
+                        added: self.ticks.added,
+                        changed: self.ticks.changed,
+                        last_run: self.ticks.last_run,
+                        this_run: self.ticks.this_run,
+                    }
+                }
+            }
+
+            /// Maps to an inner value by applying a function to the contained reference, without flagging a change.
+            ///
+            /// You should never modify the argument passed to the closure -- if you want to modify the data
+            /// without flagging a change, consider using [`DetectChangesMut::bypass_change_detection`] to make your intent explicit.
+            ///
+            /// ```rust
+            /// # use bevy_ecs::prelude::*;
+            /// # #[derive(PartialEq)] pub struct Vec2;
+            /// # impl Vec2 { pub const ZERO: Self = Self; }
+            /// # #[derive(Component)] pub struct Transform { translation: Vec2 }
+            /// // When run, zeroes the translation of every entity.
+            /// fn reset_positions(mut transforms: Query<&mut Transform>) {
+            ///     for transform in &mut transforms {
+            ///         // We pinky promise not to modify `t` within the closure.
+            ///         // Breaking this promise will result in logic errors, but will never cause undefined behavior.
+            ///         let mut translation = transform.map_unchanged(|t| &mut t.translation);
+            ///         // Only reset the translation if it isn't already zero;
+            ///         translation.set_if_neq(Vec2::ZERO);
+            ///     }
+            /// }
+            /// # bevy_ecs::system::assert_is_system(reset_positions);
+            /// ```
+            pub fn map_unchanged<U: ?Sized>(self, f: impl FnOnce(&mut $target) -> &mut U) -> Mut<'a, U> {
+                Mut {
+                    value: f(self.value),
+                    ticks: self.ticks,
+                }
+            }
+
+            /// Allows you access to the dereferenced value of this pointer without immediately
+            /// triggering change detection.
+            pub fn as_deref_mut(&mut self) -> Mut<'_, <$target as ::std::ops::Deref>::Target>
+                where $target: ::std::ops::DerefMut
+            {
+                self.reborrow().map_unchanged(|v| v.deref_mut())
+            }
+
+        }
+    };
+}
+
+pub(crate) use change_detection_impl;
+pub(crate) use change_detection_mut_impl;
+pub(crate) use impl_debug;
+pub(crate) use impl_methods;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -10,10 +10,12 @@ pub mod change_detection;
 pub mod component;
 pub mod entity;
 pub mod event;
+pub(crate) mod impl_macros;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;
 pub mod removal_detection;
+pub mod resource;
 pub mod schedule;
 pub mod storage;
 pub mod system;
@@ -37,14 +39,15 @@ pub mod prelude {
         event::{Event, EventReader, EventWriter, Events},
         query::{Added, AnyOf, Changed, Has, Or, QueryState, With, Without},
         removal_detection::RemovedComponents,
+        resource::{NonSend, NonSendMut, Res, ResMut, Resource},
         schedule::{
             apply_deferred, apply_state_transition, common_conditions::*, Condition,
             IntoSystemConfigs, IntoSystemSet, IntoSystemSetConfigs, NextState, OnEnter, OnExit,
             OnTransition, Schedule, Schedules, State, States, SystemSet,
         },
         system::{
-            Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,
-            ParamSet, Query, ReadOnlySystem, Res, ResMut, Resource, System, SystemParamFunction,
+            Commands, Deferred, In, IntoSystem, Local, ParallelCommands, ParamSet, Query,
+            ReadOnlySystem, System, SystemParamFunction,
         },
         world::{EntityMut, EntityRef, EntityWorldMut, FromWorld, World},
     };
@@ -59,13 +62,13 @@ type TypeIdMap<V> = rustc_hash::FxHashMap<TypeId, V>;
 mod tests {
     use crate as bevy_ecs;
     use crate::prelude::Or;
+    use crate::resource::Resource;
     use crate::{
         bundle::Bundle,
         change_detection::Ref,
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, With, Without, WorldQueryFilter},
-        system::Resource,
         world::{EntityRef, Mut, World},
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
@@ -1089,8 +1092,6 @@ mod tests {
 
     #[test]
     fn resource() {
-        use crate::system::Resource;
-
         #[derive(Resource, PartialEq, Debug)]
         struct Num(i32);
 

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,6 +1,7 @@
 use crate::prelude::Mut;
 use crate::reflect::AppTypeRegistry;
-use crate::system::{Command, EntityCommands, Resource};
+use crate::resource::Resource;
+use crate::system::{Command, EntityCommands};
 use crate::{entity::Entity, reflect::ReflectComponent, world::World};
 use bevy_reflect::{Reflect, TypeRegistry};
 use std::borrow::Cow;

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -3,7 +3,7 @@
 use std::ops::{Deref, DerefMut};
 
 use crate as bevy_ecs;
-use crate::{entity::Entity, system::Resource};
+use crate::{entity::Entity, resource::Resource};
 use bevy_reflect::{impl_reflect_value, ReflectDeserialize, ReflectSerialize, TypeRegistryArc};
 
 mod bundle;

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -4,9 +4,9 @@
 //!
 //! See the module doc for [`crate::reflect::component`].
 
+use crate::resource::Resource;
 use crate::{
     change_detection::Mut,
-    system::Resource,
     world::{unsafe_world_cell::UnsafeWorldCell, FromWorld, World},
 };
 use bevy_reflect::{FromType, Reflect};

--- a/crates/bevy_ecs/src/resource.rs
+++ b/crates/bevy_ecs/src/resource.rs
@@ -1,0 +1,774 @@
+//! Resource is data stored in the world uniquely by type.
+//!
+//! See the [`Resource`] documentation for more details.
+
+use crate::change_detection::{DetectChangesMut, Mut, Ticks, TicksMut};
+use crate::component::{ComponentId, ComponentTicks, Tick};
+use crate::impl_macros::{
+    change_detection_impl, change_detection_mut_impl, impl_debug, impl_methods,
+};
+use crate::system::{ReadOnlySystemParam, SystemMeta, SystemParam};
+use crate::world::unsafe_world_cell::UnsafeWorldCell;
+use crate::world::World;
+pub use bevy_ecs_macros::Resource;
+use bevy_ptr::UnsafeCellDeref;
+use std::fmt::Debug;
+use std::ops::Deref;
+
+/// A type that can be inserted into a [`World`] as a singleton.
+///
+/// You can access resource data in systems using the [`Res`] and [`ResMut`] system parameters
+///
+/// Only one resource of each type can be stored in a [`World`] at any given time.
+///
+/// # Examples
+///
+/// ```
+/// # let mut world = World::default();
+/// # let mut schedule = Schedule::default();
+/// # use bevy_ecs::prelude::*;
+/// #[derive(Resource)]
+/// struct MyResource { value: u32 }
+///
+/// world.insert_resource(MyResource { value: 42 });
+///
+/// fn read_resource_system(resource: Res<MyResource>) {
+///     assert_eq!(resource.value, 42);
+/// }
+///
+/// fn write_resource_system(mut resource: ResMut<MyResource>) {
+///     assert_eq!(resource.value, 42);
+///     resource.value = 0;
+///     assert_eq!(resource.value, 0);
+/// }
+/// # schedule.add_systems((read_resource_system, write_resource_system).chain());
+/// # schedule.run(&mut world);
+/// ```
+///
+/// # `!Sync` Resources
+/// A `!Sync` type cannot implement `Resource`. However, it is possible to wrap a `Send` but not `Sync`
+/// type in [`SyncCell`] or the currently unstable [`Exclusive`] to make it `Sync`. This forces only
+/// having mutable access (`&mut T` only, never `&T`), but makes it safe to reference across multiple
+/// threads.
+///
+/// This will fail to compile since `RefCell` is `!Sync`.
+/// ```compile_fail
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::resource::Resource;
+///
+/// #[derive(Resource)]
+/// struct NotSync {
+///    counter: RefCell<usize>,
+/// }
+/// ```
+///
+/// This will compile since the `RefCell` is wrapped with `SyncCell`.
+/// ```
+/// # use std::cell::RefCell;
+/// # use bevy_ecs::resource::Resource;
+/// # use bevy_utils::synccell::SyncCell;
+///
+/// #[derive(Resource)]
+/// struct ActuallySync {
+///    counter: SyncCell<RefCell<usize>>,
+/// }
+/// ```
+///
+/// [`SyncCell`]: bevy_utils::synccell::SyncCell
+/// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
+pub trait Resource: Send + Sync + 'static {}
+
+/// Shared borrow of a [`Resource`].
+///
+/// See the [`Resource`] documentation for usage.
+///
+/// If you need a unique mutable borrow, use [`ResMut`] instead.
+///
+/// # Panics
+///
+/// Panics when used as a [`SystemParameter`](crate::system::SystemParam) if the resource does not exist.
+///
+/// Use `Option<Res<T>>` instead if the resource might not always exist.
+pub struct Res<'w, T: ?Sized + Resource> {
+    pub(crate) value: &'w T,
+    pub(crate) ticks: Ticks<'w>,
+}
+
+impl<'w, T: Resource> Res<'w, T> {
+    /// Copies a reference to a resource.
+    ///
+    /// Note that unless you actually need an instance of `Res<T>`, you should
+    /// prefer to just convert it to `&T` which can be freely copied.
+    #[allow(clippy::should_implement_trait)]
+    pub fn clone(this: &Self) -> Self {
+        Self {
+            value: this.value,
+            ticks: this.ticks.clone(),
+        }
+    }
+
+    /// Due to lifetime limitations of the `Deref` trait, this method can be used to obtain a
+    /// reference of the [`Resource`] with a lifetime bound to `'w` instead of the lifetime of the
+    /// struct itself.
+    pub fn into_inner(self) -> &'w T {
+        self.value
+    }
+}
+
+change_detection_impl!(Res<'w, T>, T, Resource);
+impl_debug!(Res<'w, T>, Resource);
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a Res<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'w, T: Resource> From<ResMut<'w, T>> for Res<'w, T> {
+    fn from(res: ResMut<'w, T>) -> Self {
+        Self {
+            value: res.value,
+            ticks: res.ticks.into(),
+        }
+    }
+}
+
+/// Unique mutable borrow of a [`Resource`].
+///
+/// See the [`Resource`] documentation for usage.
+///
+/// If you need a shared borrow, use [`Res`] instead.
+///
+/// # Panics
+///
+/// Panics when used as a [`SystemParam`] if the resource does not exist.
+///
+/// Use `Option<ResMut<T>>` instead if the resource might not always exist.
+pub struct ResMut<'a, T: ?Sized + Resource> {
+    pub(crate) value: &'a mut T,
+    pub(crate) ticks: TicksMut<'a>,
+}
+
+change_detection_impl!(ResMut<'a, T>, T, Resource);
+change_detection_mut_impl!(ResMut<'a, T>, T, Resource);
+impl_debug!(ResMut<'a, T>, Resource);
+impl_methods!(ResMut<'a, T>, T, Resource);
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a ResMut<'w, T>
+where
+    &'a T: IntoIterator,
+{
+    type Item = <&'a T as IntoIterator>::Item;
+    type IntoIter = <&'a T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.value.into_iter()
+    }
+}
+
+impl<'w, 'a, T: Resource> IntoIterator for &'a mut ResMut<'w, T>
+where
+    &'a mut T: IntoIterator,
+{
+    type Item = <&'a mut T as IntoIterator>::Item;
+    type IntoIter = <&'a mut T as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.set_changed();
+        self.value.into_iter()
+    }
+}
+
+impl<'a, T: Resource> From<ResMut<'a, T>> for Mut<'a, T> {
+    /// Convert this `ResMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
+    /// while losing the specificity of `ResMut` for resources.
+    fn from(other: ResMut<'a, T>) -> Mut<'a, T> {
+        Mut {
+            value: other.value,
+            ticks: other.ticks,
+        }
+    }
+}
+
+// SAFETY: Res only reads a single World resource
+unsafe impl<'a, T: Resource> ReadOnlySystemParam for Res<'a, T> {}
+
+// SAFETY: Res ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this Res
+// conflicts with any prior access, a panic will occur.
+unsafe impl<'a, T: Resource> SystemParam for Res<'a, T> {
+    type State = ComponentId;
+    type Item<'w, 's> = Res<'w, T>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let component_id = world.initialize_resource::<T>();
+        let combined_access = system_meta.component_access_set.combined_access();
+        assert!(
+            !combined_access.has_write(component_id),
+            "error[B0002]: Res<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access.",
+            std::any::type_name::<T>(),
+            system_meta.name,
+        );
+        system_meta
+            .component_access_set
+            .add_unfiltered_read(component_id);
+
+        let archetype_component_id = world
+            .get_resource_archetype_component_id(component_id)
+            .unwrap();
+        system_meta
+            .archetype_component_access
+            .add_read(archetype_component_id);
+
+        component_id
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        let (ptr, ticks) = world
+            .get_resource_with_ticks(component_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Resource requested by {} does not exist: {}",
+                    system_meta.name,
+                    std::any::type_name::<T>()
+                )
+            });
+        Res {
+            value: ptr.deref(),
+            ticks: Ticks {
+                added: ticks.added.deref(),
+                changed: ticks.changed.deref(),
+                last_run: system_meta.last_run,
+                this_run: change_tick,
+            },
+        }
+    }
+}
+
+// SAFETY: Only reads a single World resource
+unsafe impl<'a, T: Resource> ReadOnlySystemParam for Option<Res<'a, T>> {}
+
+// SAFETY: this impl defers to `Res`, which initializes and validates the correct world access.
+unsafe impl<'a, T: Resource> SystemParam for Option<Res<'a, T>> {
+    type State = ComponentId;
+    type Item<'w, 's> = Option<Res<'w, T>>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        Res::<T>::init_state(world, system_meta)
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        world
+            .get_resource_with_ticks(component_id)
+            .map(|(ptr, ticks)| Res {
+                value: ptr.deref(),
+                ticks: Ticks {
+                    added: ticks.added.deref(),
+                    changed: ticks.changed.deref(),
+                    last_run: system_meta.last_run,
+                    this_run: change_tick,
+                },
+            })
+    }
+}
+
+// SAFETY: Res ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this Res
+// conflicts with any prior access, a panic will occur.
+unsafe impl<'a, T: Resource> SystemParam for ResMut<'a, T> {
+    type State = ComponentId;
+    type Item<'w, 's> = ResMut<'w, T>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        let component_id = world.initialize_resource::<T>();
+        let combined_access = system_meta.component_access_set.combined_access();
+        if combined_access.has_write(component_id) {
+            panic!(
+                "error[B0002]: ResMut<{}> in system {} conflicts with a previous ResMut<{0}> access. Consider removing the duplicate access.",
+                std::any::type_name::<T>(), system_meta.name);
+        } else if combined_access.has_read(component_id) {
+            panic!(
+                "error[B0002]: ResMut<{}> in system {} conflicts with a previous Res<{0}> access. Consider removing the duplicate access.",
+                std::any::type_name::<T>(), system_meta.name);
+        }
+        system_meta
+            .component_access_set
+            .add_unfiltered_write(component_id);
+
+        let archetype_component_id = world
+            .get_resource_archetype_component_id(component_id)
+            .unwrap();
+        system_meta
+            .archetype_component_access
+            .add_write(archetype_component_id);
+
+        component_id
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        let value = world
+            .get_resource_mut_by_id(component_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Resource requested by {} does not exist: {}",
+                    system_meta.name,
+                    std::any::type_name::<T>()
+                )
+            });
+        ResMut {
+            value: value.value.deref_mut::<T>(),
+            ticks: TicksMut {
+                added: value.ticks.added,
+                changed: value.ticks.changed,
+                last_run: system_meta.last_run,
+                this_run: change_tick,
+            },
+        }
+    }
+}
+
+// SAFETY: this impl defers to `ResMut`, which initializes and validates the correct world access.
+unsafe impl<'a, T: Resource> SystemParam for Option<ResMut<'a, T>> {
+    type State = ComponentId;
+    type Item<'w, 's> = Option<ResMut<'w, T>>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        ResMut::<T>::init_state(world, system_meta)
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        world
+            .get_resource_mut_by_id(component_id)
+            .map(|value| ResMut {
+                value: value.value.deref_mut::<T>(),
+                ticks: TicksMut {
+                    added: value.ticks.added,
+                    changed: value.ticks.changed,
+                    last_run: system_meta.last_run,
+                    this_run: change_tick,
+                },
+            })
+    }
+}
+
+/// Shared borrow of a non-[`Send`] resource.
+///
+/// Only `Send` resources may be accessed with the [`Res`] [`SystemParam`].
+/// In case that the resource does not implement `Send`, this `SystemParam` wrapper can be used.
+/// This will instruct the scheduler to instead run the system on the main thread
+/// so that it doesn't send the resource over to another thread.
+///
+/// # Panics
+///
+/// Panics when used as a `SystemParameter` if the resource does not exist.
+///
+/// Use `Option<NonSend<T>>` instead if the resource might not always exist.
+pub struct NonSend<'w, T: 'static> {
+    pub(crate) value: &'w T,
+    ticks: ComponentTicks,
+    last_run: Tick,
+    this_run: Tick,
+}
+
+// SAFETY: Only reads a single World non-send resource
+unsafe impl<'w, T> ReadOnlySystemParam for NonSend<'w, T> {}
+
+// SAFETY: NonSendComponentId and ArchetypeComponentId access is applied to SystemMeta. If this
+// NonSend conflicts with any prior access, a panic will occur.
+unsafe impl<'a, T: 'static> SystemParam for NonSend<'a, T> {
+    type State = ComponentId;
+    type Item<'w, 's> = NonSend<'w, T>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        system_meta.set_non_send();
+
+        let component_id = world.initialize_non_send_resource::<T>();
+        let combined_access = system_meta.component_access_set.combined_access();
+        assert!(
+            !combined_access.has_write(component_id),
+            "error[B0002]: NonSend<{}> in system {} conflicts with a previous mutable resource access ({0}). Consider removing the duplicate access.",
+            std::any::type_name::<T>(),
+            system_meta.name,
+        );
+        system_meta
+            .component_access_set
+            .add_unfiltered_read(component_id);
+
+        let archetype_component_id = world
+            .get_non_send_archetype_component_id(component_id)
+            .unwrap();
+        system_meta
+            .archetype_component_access
+            .add_read(archetype_component_id);
+
+        component_id
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        let (ptr, ticks) = world
+            .get_non_send_with_ticks(component_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Non-send resource requested by {} does not exist: {}",
+                    system_meta.name,
+                    std::any::type_name::<T>()
+                )
+            });
+
+        NonSend {
+            value: ptr.deref(),
+            ticks: ticks.read(),
+            last_run: system_meta.last_run,
+            this_run: change_tick,
+        }
+    }
+}
+
+impl<'w, T> Debug for NonSend<'w, T>
+where
+    T: Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("NonSend").field(&self.value).finish()
+    }
+}
+
+impl<'w, T: 'static> NonSend<'w, T> {
+    /// Returns `true` if the resource was added after the system last ran.
+    pub fn is_added(&self) -> bool {
+        self.ticks.is_added(self.last_run, self.this_run)
+    }
+
+    /// Returns `true` if the resource was added or mutably dereferenced after the system last ran.
+    pub fn is_changed(&self) -> bool {
+        self.ticks.is_changed(self.last_run, self.this_run)
+    }
+}
+
+impl<'w, T> Deref for NonSend<'w, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+impl<'a, T> From<NonSendMut<'a, T>> for NonSend<'a, T> {
+    fn from(nsm: NonSendMut<'a, T>) -> Self {
+        Self {
+            value: nsm.value,
+            ticks: ComponentTicks {
+                added: nsm.ticks.added.to_owned(),
+                changed: nsm.ticks.changed.to_owned(),
+            },
+            this_run: nsm.ticks.this_run,
+            last_run: nsm.ticks.last_run,
+        }
+    }
+}
+
+// SAFETY: Only reads a single World non-send resource
+unsafe impl<T: 'static> ReadOnlySystemParam for Option<NonSend<'_, T>> {}
+
+// SAFETY: this impl defers to `NonSend`, which initializes and validates the correct world access.
+unsafe impl<T: 'static> SystemParam for Option<NonSend<'_, T>> {
+    type State = ComponentId;
+    type Item<'w, 's> = Option<NonSend<'w, T>>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        NonSend::<T>::init_state(world, system_meta)
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        world
+            .get_non_send_with_ticks(component_id)
+            .map(|(ptr, ticks)| NonSend {
+                value: ptr.deref(),
+                ticks: ticks.read(),
+                last_run: system_meta.last_run,
+                this_run: change_tick,
+            })
+    }
+}
+
+/// Unique borrow of a non-[`Send`] resource.
+///
+/// Only [`Send`] resources may be accessed with the [`ResMut`] [`SystemParam`]. In case that the
+/// resource does not implement `Send`, this `SystemParam` wrapper can be used. This will instruct
+/// the scheduler to instead run the system on the main thread so that it doesn't send the resource
+/// over to another thread.
+///
+/// # Panics
+///
+/// Panics when used as a `SystemParameter` if the resource does not exist.
+///
+/// Use `Option<NonSendMut<T>>` instead if the resource might not always exist.
+pub struct NonSendMut<'a, T: ?Sized + 'static> {
+    pub(crate) value: &'a mut T,
+    pub(crate) ticks: TicksMut<'a>,
+}
+
+change_detection_impl!(NonSendMut<'a, T>, T,);
+change_detection_mut_impl!(NonSendMut<'a, T>, T,);
+impl_methods!(NonSendMut<'a, T>, T,);
+impl_debug!(NonSendMut<'a, T>,);
+
+// SAFETY: NonSendMut ComponentId and ArchetypeComponentId access is applied to SystemMeta. If this
+// NonSendMut conflicts with any prior access, a panic will occur.
+unsafe impl<'a, T: 'static> SystemParam for NonSendMut<'a, T> {
+    type State = ComponentId;
+    type Item<'w, 's> = NonSendMut<'w, T>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        system_meta.set_non_send();
+
+        let component_id = world.initialize_non_send_resource::<T>();
+        let combined_access = system_meta.component_access_set.combined_access();
+        if combined_access.has_write(component_id) {
+            panic!(
+                "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous mutable resource access ({0}). Consider removing the duplicate access.",
+                std::any::type_name::<T>(), system_meta.name);
+        } else if combined_access.has_read(component_id) {
+            panic!(
+                "error[B0002]: NonSendMut<{}> in system {} conflicts with a previous immutable resource access ({0}). Consider removing the duplicate access.",
+                std::any::type_name::<T>(), system_meta.name);
+        }
+        system_meta
+            .component_access_set
+            .add_unfiltered_write(component_id);
+
+        let archetype_component_id = world
+            .get_non_send_archetype_component_id(component_id)
+            .unwrap();
+        system_meta
+            .archetype_component_access
+            .add_write(archetype_component_id);
+
+        component_id
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        let (ptr, ticks) = world
+            .get_non_send_with_ticks(component_id)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Non-send resource requested by {} does not exist: {}",
+                    system_meta.name,
+                    std::any::type_name::<T>()
+                )
+            });
+        NonSendMut {
+            value: ptr.assert_unique().deref_mut(),
+            ticks: TicksMut::from_tick_cells(ticks, system_meta.last_run, change_tick),
+        }
+    }
+}
+
+impl<'a, T: 'static> From<NonSendMut<'a, T>> for Mut<'a, T> {
+    /// Convert this `NonSendMut` into a `Mut`. This allows keeping the change-detection feature of `Mut`
+    /// while losing the specificity of `NonSendMut`.
+    fn from(other: NonSendMut<'a, T>) -> Mut<'a, T> {
+        Mut {
+            value: other.value,
+            ticks: other.ticks,
+        }
+    }
+}
+
+// SAFETY: this impl defers to `NonSendMut`, which initializes and validates the correct world access.
+unsafe impl<'a, T: 'static> SystemParam for Option<NonSendMut<'a, T>> {
+    type State = ComponentId;
+    type Item<'w, 's> = Option<NonSendMut<'w, T>>;
+
+    fn init_state(world: &mut World, system_meta: &mut SystemMeta) -> Self::State {
+        NonSendMut::<T>::init_state(world, system_meta)
+    }
+
+    #[inline]
+    unsafe fn get_param<'w, 's>(
+        &mut component_id: &'s mut Self::State,
+        system_meta: &SystemMeta,
+        world: UnsafeWorldCell<'w>,
+        change_tick: Tick,
+    ) -> Self::Item<'w, 's> {
+        world
+            .get_non_send_with_ticks(component_id)
+            .map(|(ptr, ticks)| NonSendMut {
+                value: ptr.assert_unique().deref_mut(),
+                ticks: TicksMut::from_tick_cells(ticks, system_meta.last_run, change_tick),
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate as bevy_ecs;
+    use crate::change_detection::{Mut, TicksMut};
+    use crate::component::{ComponentTicks, Tick};
+    use crate::resource::Resource;
+    use crate::resource::{NonSend, NonSendMut, ResMut};
+    use crate::schedule::Schedule;
+    use crate::system::{IntoSystem, ParamSet};
+    use crate::world::World;
+
+    #[derive(Resource)]
+    struct R;
+
+    #[derive(Resource, PartialEq, Debug)]
+    enum SystemRan {
+        Yes,
+        No,
+    }
+
+    fn run_system<Marker, S: IntoSystem<(), (), Marker>>(world: &mut World, system: S) {
+        let mut schedule = Schedule::default();
+        schedule.add_systems(system);
+        schedule.run(world);
+    }
+
+    #[test]
+    fn non_send_option_system() {
+        let mut world = World::default();
+
+        world.insert_resource(SystemRan::No);
+        struct NotSend1(std::rc::Rc<i32>);
+        struct NotSend2(std::rc::Rc<i32>);
+        world.insert_non_send_resource(NotSend1(std::rc::Rc::new(0)));
+
+        fn sys(
+            op: Option<NonSend<NotSend1>>,
+            mut _op2: Option<NonSendMut<NotSend2>>,
+            mut system_ran: ResMut<SystemRan>,
+        ) {
+            op.expect("NonSend should exist");
+            *system_ran = SystemRan::Yes;
+        }
+
+        run_system(&mut world, sys);
+        // ensure the system actually ran
+        assert_eq!(*world.resource::<SystemRan>(), SystemRan::Yes);
+    }
+
+    #[test]
+    fn non_send_system() {
+        let mut world = World::default();
+
+        world.insert_resource(SystemRan::No);
+        struct NotSend1(std::rc::Rc<i32>);
+        struct NotSend2(std::rc::Rc<i32>);
+
+        world.insert_non_send_resource(NotSend1(std::rc::Rc::new(1)));
+        world.insert_non_send_resource(NotSend2(std::rc::Rc::new(2)));
+
+        fn sys(
+            _op: NonSend<NotSend1>,
+            mut _op2: NonSendMut<NotSend2>,
+            mut system_ran: ResMut<SystemRan>,
+        ) {
+            *system_ran = SystemRan::Yes;
+        }
+
+        run_system(&mut world, sys);
+        assert_eq!(*world.resource::<SystemRan>(), SystemRan::Yes);
+    }
+
+    #[test]
+    fn mut_from_non_send_mut() {
+        let mut component_ticks = ComponentTicks {
+            added: Tick::new(1),
+            changed: Tick::new(2),
+        };
+        let ticks = TicksMut {
+            added: &mut component_ticks.added,
+            changed: &mut component_ticks.changed,
+            last_run: Tick::new(3),
+            this_run: Tick::new(4),
+        };
+        let mut res = R {};
+        let non_send_mut = NonSendMut {
+            value: &mut res,
+            ticks,
+        };
+
+        let into_mut: Mut<R> = non_send_mut.into();
+        assert_eq!(1, into_mut.ticks.added.get());
+        assert_eq!(2, into_mut.ticks.changed.get());
+        assert_eq!(3, into_mut.ticks.last_run.get());
+        assert_eq!(4, into_mut.ticks.this_run.get());
+    }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/10207.
+    #[test]
+    fn param_set_non_send_first() {
+        fn non_send_param_set(mut p: ParamSet<(NonSend<*mut u8>, ())>) {
+            let _ = p.p0();
+            p.p1();
+        }
+
+        let mut world = World::new();
+        world.insert_non_send_resource(std::ptr::null_mut::<u8>());
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
+        schedule.run(&mut world);
+    }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/10207.
+    #[test]
+    fn param_set_non_send_second() {
+        fn non_send_param_set(mut p: ParamSet<((), NonSendMut<*mut u8>)>) {
+            p.p0();
+            let _ = p.p1();
+        }
+
+        let mut world = World::new();
+        world.insert_non_send_resource(std::ptr::null_mut::<u8>());
+        let mut schedule = crate::schedule::Schedule::default();
+        schedule.add_systems((non_send_param_set, non_send_param_set, non_send_param_set));
+        schedule.run(&mut world);
+    }
+}

--- a/crates/bevy_ecs/src/schedule/condition.rs
+++ b/crates/bevy_ecs/src/schedule/condition.rs
@@ -195,13 +195,14 @@ mod sealed {
 /// A collection of [run conditions](Condition) that may be useful in any bevy app.
 pub mod common_conditions {
     use super::NotSystem;
+    use crate::resource::{Res, Resource};
     use crate::{
         change_detection::DetectChanges,
         event::{Event, EventReader},
         prelude::{Component, Query, With},
         removal_detection::RemovedComponents,
         schedule::{State, States},
-        system::{IntoSystem, Res, Resource, System},
+        system::{IntoSystem, System},
     };
 
     /// Generates a [`Condition`](super::Condition)-satisfying closure that returns `true`
@@ -1077,10 +1078,11 @@ mod tests {
     use super::{common_conditions::*, Condition};
     use crate as bevy_ecs;
     use crate::component::Component;
+    use crate::resource::ResMut;
     use crate::schedule::IntoSystemConfigs;
     use crate::schedule::{common_conditions::not, State, States};
     use crate::system::Local;
-    use crate::{change_detection::ResMut, schedule::Schedule, world::World};
+    use crate::{schedule::Schedule, world::World};
     use bevy_ecs_macros::Event;
     use bevy_ecs_macros::Resource;
 

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -22,12 +22,13 @@ pub use self::graph_utils::NodeId;
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::resource::Resource;
     use std::sync::atomic::{AtomicU32, Ordering};
 
     pub use crate as bevy_ecs;
+    pub use crate::prelude::World;
+    use crate::resource::{Res, ResMut};
     pub use crate::schedule::{IntoSystemSetConfigs, Schedule, SystemSet};
-    pub use crate::system::{Res, ResMut};
-    pub use crate::{prelude::World, system::Resource};
 
     #[derive(SystemSet, Clone, Debug, PartialEq, Eq, Hash)]
     enum TestSet {
@@ -725,6 +726,7 @@ mod tests {
         use crate as bevy_ecs;
         use crate::event::Events;
         use crate::prelude::*;
+        use crate::resource::{NonSend, NonSendMut};
 
         #[derive(Resource)]
         struct R;

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -16,12 +16,13 @@ use bevy_utils::{
 
 use fixedbitset::FixedBitSet;
 
+use crate::resource::Resource;
 use crate::{
     self as bevy_ecs,
     component::{ComponentId, Components, Tick},
     prelude::Component,
     schedule::*,
-    system::{BoxedSystem, Resource, System},
+    system::{BoxedSystem, System},
     world::World,
 };
 

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -192,10 +192,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        schedule::{tests::ResMut, Schedule},
-        system::Resource,
-    };
+    use crate::resource::{ResMut, Resource};
+    use crate::schedule::Schedule;
 
     use super::*;
 

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -7,8 +7,8 @@ use crate as bevy_ecs;
 use crate::change_detection::DetectChangesMut;
 #[cfg(feature = "bevy_reflect")]
 use crate::reflect::ReflectResource;
+use crate::resource::Resource;
 use crate::schedule::ScheduleLabel;
-use crate::system::Resource;
 use crate::world::World;
 #[cfg(feature = "bevy_reflect")]
 use bevy_reflect::std_traits::ReflectDefault;

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -207,7 +207,7 @@ impl<const SEND: bool> ResourceData<SEND> {
 
 /// The backing store for all [`Resource`]s stored in the [`World`].
 ///
-/// [`Resource`]: crate::system::Resource
+/// [`Resource`]: crate::resource::Resource
 /// [`World`]: crate::world::World
 #[derive(Default)]
 pub struct Resources<const SEND: bool> {

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -14,7 +14,8 @@ pub use command_queue::CommandQueue;
 pub use parallel_scope::*;
 use std::marker::PhantomData;
 
-use super::{Deferred, Resource, SystemBuffer, SystemMeta};
+use super::{Deferred, SystemBuffer, SystemMeta};
+use crate::resource::Resource;
 
 /// A [`World`] mutation.
 ///
@@ -1169,10 +1170,11 @@ impl Command for LogComponents {
 #[cfg(test)]
 #[allow(clippy::float_cmp, clippy::approx_constant)]
 mod tests {
+    use crate::resource::Resource;
     use crate::{
         self as bevy_ecs,
         component::Component,
-        system::{CommandQueue, Commands, Resource},
+        system::{CommandQueue, Commands},
         world::World,
     };
     use std::sync::{

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -288,6 +288,7 @@ mod tests {
     use super::*;
     use crate as bevy_ecs;
     use crate::prelude::*;
+    use crate::resource::NonSendMut;
 
     #[test]
     fn run_system_once() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -20,9 +20,9 @@ use crate::{
     event::{Event, EventId, Events, SendBatchIds},
     query::{DebugCheckedUnwrap, QueryEntityError, QueryState, WorldQueryData, WorldQueryFilter},
     removal_detection::RemovedComponentEvents,
+    resource::Resource,
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
-    system::Resource,
     world::error::TryRunScheduleError,
 };
 use bevy_ptr::{OwningPtr, Ptr};
@@ -1807,7 +1807,7 @@ impl World {
     }
 
     /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_resources`](Self::clear_resources),
-    /// invalidating all [`Entity`] and resource fetches such as [`Res`](crate::system::Res), [`ResMut`](crate::system::ResMut)
+    /// invalidating all [`Entity`] and resource fetches such as [`Res`](crate::resource::Res), [`ResMut`](crate::resource::ResMut)
     pub fn clear_all(&mut self) {
         self.clear_entities();
         self.clear_resources();
@@ -2150,11 +2150,11 @@ impl<T: Default> FromWorld for T {
 #[cfg(test)]
 mod tests {
     use super::{FromWorld, World};
+    use crate::resource::Resource;
     use crate::{
         change_detection::DetectChangesMut,
         component::{ComponentDescriptor, ComponentInfo, StorageType},
         ptr::OwningPtr,
-        system::Resource,
     };
     use bevy_ecs_macros::Component;
     use bevy_utils::{HashMap, HashSet};

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -3,6 +3,7 @@
 #![warn(unsafe_op_in_unsafe_fn)]
 
 use super::{Mut, Ref, World, WorldId};
+use crate::resource::Resource;
 use crate::{
     archetype::{Archetype, ArchetypeComponentId, Archetypes},
     bundle::Bundles,
@@ -14,7 +15,6 @@ use crate::{
     prelude::Component,
     removal_detection::RemovedComponentEvents,
     storage::{Column, ComponentSparseSet, Storages},
-    system::Resource,
 };
 use bevy_ptr::Ptr;
 use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
@@ -47,7 +47,7 @@ use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
 /// ```
 /// use bevy_ecs::world::World;
 /// use bevy_ecs::change_detection::Mut;
-/// use bevy_ecs::system::Resource;
+/// use bevy_ecs::resource::Resource;
 /// use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 ///
 /// // INVARIANT: existence of this struct means that users of it are the only ones being able to access resources in the world

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -1,10 +1,10 @@
 use bevy_utils::tracing::error;
 
+use crate::resource::Resource;
 use crate::{
     archetype::ArchetypeComponentId,
     event::{Event, Events},
     storage::SparseSet,
-    system::Resource,
     world::{Mut, World},
 };
 use std::{
@@ -365,7 +365,8 @@ impl<'w> WorldCell<'w> {
 mod tests {
     use super::BASE_ACCESS;
     use crate as bevy_ecs;
-    use crate::{system::Resource, world::World};
+    use crate::resource::Resource;
+    use crate::world::World;
     use std::any::TypeId;
 
     #[derive(Resource)]

--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -1,6 +1,7 @@
 use crate::converter::{convert_axis, convert_button, convert_gamepad_id};
 use bevy_ecs::event::EventWriter;
-use bevy_ecs::system::{NonSend, NonSendMut, Res, ResMut};
+use bevy_ecs::resource::NonSend;
+use bevy_ecs::resource::{NonSendMut, Res, ResMut};
 use bevy_input::gamepad::{
     GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadConnection, GamepadConnectionEvent,
     GamepadSettings,

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -1,7 +1,7 @@
 //! Handle user specified rumble request events.
 use bevy_ecs::{
     prelude::{EventReader, Res},
-    system::NonSendMut,
+    resource::NonSendMut,
 };
 use bevy_input::gamepad::{GamepadRumbleIntensity, GamepadRumbleRequest};
 use bevy_log::{debug, warn};

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -4,7 +4,8 @@ use std::iter;
 
 use crate::circles::DEFAULT_CIRCLE_SEGMENTS;
 use bevy_ecs::{
-    system::{Deferred, Resource, SystemBuffer, SystemMeta, SystemParam},
+    resource::Resource,
+    system::{Deferred, SystemBuffer, SystemMeta, SystemParam},
     world::World,
 };
 use bevy_math::{Mat2, Quat, Vec2, Vec3};

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -40,10 +40,11 @@ use bevy_ecs::{
     entity::Entity,
     query::{ROQueryItem, Without},
     reflect::{ReflectComponent, ReflectResource},
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
     system::{
         lifetimeless::{Read, SRes},
-        Commands, Query, Res, ResMut, Resource, SystemParamItem,
+        Commands, Query, SystemParamItem,
     },
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -8,8 +8,9 @@ use bevy_core_pipeline::core_2d::Transparent2d;
 
 use bevy_ecs::{
     prelude::Entity,
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{Query, Res, ResMut, Resource},
+    system::Query,
     world::{FromWorld, World},
 };
 use bevy_render::{

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -12,8 +12,9 @@ use bevy_core_pipeline::{
 use bevy_ecs::{
     prelude::Entity,
     query::Has,
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{Query, Res, ResMut, Resource},
+    system::Query,
     world::{FromWorld, World},
 };
 use bevy_pbr::{MeshPipeline, MeshPipelineKey, SetMeshViewBindGroup};

--- a/crates/bevy_input/src/axis.rs
+++ b/crates/bevy_input/src/axis.rs
@@ -1,6 +1,6 @@
 //! The generic axis type.
 
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_utils::HashMap;
 use std::hash::Hash;
 

--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -1,5 +1,5 @@
 use crate::Input;
-use bevy_ecs::system::Res;
+use bevy_ecs::resource::Res;
 use std::hash::Hash;
 
 /// Stateful run condition that can be toggled via a input press using [`Input::just_pressed`].

--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -4,7 +4,7 @@ use crate::{Axis, ButtonState, Input};
 use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
-    system::{Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::Duration;

--- a/crates/bevy_input/src/input.rs
+++ b/crates/bevy_input/src/input.rs
@@ -1,6 +1,6 @@
 //! The generic input type.
 
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::HashSet;
 use std::hash::Hash;
@@ -41,7 +41,7 @@ use bevy_ecs::schedule::State;
 /// It may be preferable to use [`DetectChangesMut::bypass_change_detection`]
 /// to avoid causing the resource to always be marked as changed.
 ///
-///[`ResMut`]: bevy_ecs::system::ResMut
+///[`ResMut`]: bevy_ecs::resource::ResMut
 ///[`DetectChangesMut::bypass_change_detection`]: bevy_ecs::change_detection::DetectChangesMut::bypass_change_detection
 #[derive(Debug, Clone, Resource, Reflect)]
 #[reflect(Default)]

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -5,7 +5,7 @@ use bevy_ecs::entity::Entity;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     event::{Event, EventReader},
-    system::ResMut,
+    resource::ResMut,
 };
 use bevy_reflect::Reflect;
 

--- a/crates/bevy_input/src/mouse.rs
+++ b/crates/bevy_input/src/mouse.rs
@@ -5,7 +5,7 @@ use bevy_ecs::entity::Entity;
 use bevy_ecs::{
     change_detection::DetectChangesMut,
     event::{Event, EventReader},
-    system::ResMut,
+    resource::ResMut,
 };
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -1,7 +1,7 @@
 //! The touch input functionality.
 
 use bevy_ecs::event::{Event, EventReader};
-use bevy_ecs::system::{ResMut, Resource};
+use bevy_ecs::resource::{ResMut, Resource};
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;
 use bevy_utils::HashMap;

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -552,7 +552,7 @@ fn calculate_cascade(
 /// Make ambient light slightly brighter:
 ///
 /// ```
-/// # use bevy_ecs::system::ResMut;
+/// # use bevy_ecs::resource::ResMut;
 /// # use bevy_pbr::AmbientLight;
 /// fn setup_ambient_light(mut ambient_light: ResMut<AmbientLight>) {
 ///    ambient_light.brightness = 0.3;

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -10,7 +10,8 @@ use bevy_core_pipeline::{
 use bevy_ecs::{
     component::Component,
     entity::Entity,
-    system::{Commands, Query, Res},
+    resource::Res,
+    system::{Commands, Query},
 };
 use bevy_render::{
     globals::{GlobalsBuffer, GlobalsUniform},

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -9,8 +9,9 @@ use bevy_ecs::{
     prelude::{Bundle, Component, Entity},
     query::{QueryItem, With},
     reflect::ReflectComponent,
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{Commands, Query, Res, ResMut, Resource},
+    system::{Commands, Query},
     world::{FromWorld, World},
 };
 use bevy_reflect::Reflect;

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -1,8 +1,9 @@
+use bevy_ecs::resource::ResMut;
 use bevy_ecs::{
     component::Component,
     prelude::Res,
     query::{QueryItem, ReadOnlyWorldQueryData, WorldQueryFilter},
-    system::{Query, ResMut, StaticSystemParam, SystemParam, SystemParamItem},
+    system::{Query, StaticSystemParam, SystemParam, SystemParamItem},
 };
 use bevy_utils::nonmax::NonMaxU32;
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -17,7 +17,8 @@ use bevy_ecs::{
     event::EventReader,
     prelude::With,
     reflect::ReflectComponent,
-    system::{Commands, Query, Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
+    system::{Commands, Query},
 };
 use bevy_log::warn;
 use bevy_math::{vec2, Mat4, Ray, Rect, URect, UVec2, UVec4, Vec2, Vec3};

--- a/crates/bevy_render/src/camera/manual_texture_view.rs
+++ b/crates/bevy_render/src/camera/manual_texture_view.rs
@@ -1,7 +1,7 @@
 use crate::extract_resource::ExtractResource;
 use crate::render_resource::TextureView;
 use crate::texture::BevyDefault;
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_ecs::{prelude::Component, reflect::ReflectComponent};
 use bevy_math::UVec2;
 use bevy_reflect::prelude::*;

--- a/crates/bevy_render/src/extract_instances.rs
+++ b/crates/bevy_render/src/extract_instances.rs
@@ -12,7 +12,8 @@ use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::Entity,
     query::{QueryItem, ReadOnlyWorldQueryData, WorldQueryFilter},
-    system::{lifetimeless::Read, Query, ResMut, Resource},
+    resource::{ResMut, Resource},
+    system::{lifetimeless::Read, Query},
 };
 use bevy_utils::EntityHashMap;
 

--- a/crates/bevy_render/src/gpu_component_array_buffer.rs
+++ b/crates/bevy_render/src/gpu_component_array_buffer.rs
@@ -6,8 +6,9 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::{
     prelude::{Component, Entity},
+    resource::{Res, ResMut},
     schedule::IntoSystemConfigs,
-    system::{Commands, Query, Res, ResMut},
+    system::{Commands, Query},
 };
 use std::marker::PhantomData;
 

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -2,8 +2,8 @@ use async_channel::{Receiver, Sender};
 
 use bevy_app::{App, AppLabel, Main, Plugin, SubApp};
 use bevy_ecs::{
+    resource::Resource,
     schedule::MainThreadExecutor,
-    system::Resource,
     world::{Mut, World},
 };
 use bevy_tasks::ComputeTaskPool;

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -5,7 +5,7 @@ use crate::{
     },
     renderer::RenderContext,
 };
-use bevy_ecs::{prelude::World, system::Resource};
+use bevy_ecs::{prelude::World, resource::Resource};
 use bevy_utils::HashMap;
 use std::{borrow::Cow, fmt::Debug};
 

--- a/crates/bevy_render/src/render_phase/draw.rs
+++ b/crates/bevy_render/src/render_phase/draw.rs
@@ -3,7 +3,8 @@ use bevy_app::App;
 use bevy_ecs::{
     entity::Entity,
     query::{QueryState, ROQueryItem, ReadOnlyWorldQueryData},
-    system::{ReadOnlySystemParam, Resource, SystemParam, SystemParamItem, SystemState},
+    resource::Resource,
+    system::{ReadOnlySystemParam, SystemParam, SystemParamItem, SystemState},
     world::World,
 };
 use bevy_utils::{all_tuples, HashMap};

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -6,7 +6,7 @@ use crate::{
     render_resource::batched_uniform_buffer::BatchedUniformBuffer,
     renderer::{RenderDevice, RenderQueue},
 };
-use bevy_ecs::{prelude::Component, system::Resource};
+use bevy_ecs::{prelude::Component, resource::Resource};
 use bevy_utils::nonmax::NonMaxU32;
 use encase::{private::WriteInto, ShaderSize, ShaderType};
 use std::{marker::PhantomData, mem};

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -8,8 +8,8 @@ use crate::{
     Extract,
 };
 use bevy_asset::{AssetEvent, AssetId, Assets};
-use bevy_ecs::system::{Res, ResMut};
-use bevy_ecs::{event::EventReader, system::Resource};
+use bevy_ecs::event::EventReader;
+use bevy_ecs::resource::{Res, ResMut, Resource};
 use bevy_utils::{
     default,
     tracing::{debug, error},

--- a/crates/bevy_render/src/render_resource/pipeline_specializer.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_specializer.rs
@@ -6,7 +6,7 @@ use crate::{
         VertexBufferLayout,
     },
 };
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_utils::{
     default, hashbrown::hash_map::RawEntryMut, tracing::error, Entry, HashMap, PreHashMap,
     PreHashMapExt,

--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -2,7 +2,7 @@ use crate::render_resource::{
     BindGroup, BindGroupLayout, Buffer, ComputePipeline, RawRenderPipelineDescriptor,
     RenderPipeline, Sampler, Texture,
 };
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use wgpu::{
     util::DeviceExt, BindGroupDescriptor, BindGroupEntry, BindGroupLayoutDescriptor,
     BindGroupLayoutEntry, BufferAsyncError, BufferBindingType,

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -2,7 +2,8 @@ use crate::{render_resource::*, texture::DefaultImageSampler};
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
     prelude::{FromWorld, Res, ResMut},
-    system::{Resource, SystemParam},
+    resource::Resource,
+    system::SystemParam,
 };
 use bevy_utils::HashMap;
 use wgpu::{Extent3d, TextureFormat};

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -13,7 +13,8 @@ use crate::{
 };
 use bevy_asset::Asset;
 use bevy_derive::{Deref, DerefMut};
-use bevy_ecs::system::{lifetimeless::SRes, Resource, SystemParamItem};
+use bevy_ecs::resource::Resource;
+use bevy_ecs::system::{lifetimeless::SRes, SystemParamItem};
 use bevy_math::{UVec2, Vec2};
 use bevy_reflect::Reflect;
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_render/src/texture/texture_cache.rs
+++ b/crates/bevy_render/src/texture/texture_cache.rs
@@ -2,7 +2,7 @@ use crate::{
     render_resource::{Texture, TextureView},
     renderer::RenderDevice,
 };
-use bevy_ecs::{prelude::ResMut, system::Resource};
+use bevy_ecs::{prelude::ResMut, resource::Resource};
 use bevy_utils::{Entry, HashMap};
 use wgpu::{TextureDescriptor, TextureViewDescriptor};
 

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
+use bevy_ecs::resource::NonSend;
 use bevy_utils::{default, tracing::debug, HashMap, HashSet};
 use bevy_window::{
     CompositeAlphaMode, PresentMode, PrimaryWindow, RawHandleWrapper, Window, WindowClosed,

--- a/crates/bevy_scene/src/bundle.rs
+++ b/crates/bevy_scene/src/bundle.rs
@@ -1,8 +1,8 @@
 use bevy_asset::Handle;
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::resource::ResMut;
 use bevy_ecs::{
     bundle::Bundle,
-    change_detection::ResMut,
     entity::Entity,
     prelude::{Changed, Component, Without},
     system::{Commands, Query},

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,6 +1,6 @@
 use crate::{DynamicEntity, DynamicScene, SceneFilter};
 use bevy_ecs::component::{Component, ComponentId};
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_ecs::{
     prelude::Entity,
     reflect::{AppTypeRegistry, ReflectComponent, ReflectResource},

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,10 +1,11 @@
 use crate::{DynamicScene, Scene};
 use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
+use bevy_ecs::resource::Resource;
 use bevy_ecs::{
     entity::Entity,
     event::{Event, Events, ManualEventReader},
     reflect::AppTypeRegistry,
-    system::{Command, Resource},
+    system::Command,
     world::{Mut, World},
 };
 use bevy_hierarchy::{AddChild, Parent};

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -7,7 +7,7 @@ use ab_glyph::PxScale;
 use bevy_asset::{AssetId, Assets, Handle};
 use bevy_ecs::component::Component;
 use bevy_ecs::prelude::ReflectComponent;
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_math::Vec2;
 use bevy_reflect::prelude::ReflectDefault;
 use bevy_reflect::Reflect;

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -11,7 +11,8 @@ use bevy_ecs::{
     event::EventReader,
     prelude::With,
     reflect::ReflectComponent,
-    system::{Commands, Local, Query, Res, ResMut},
+    resource::{Res, ResMut},
+    system::{Commands, Local, Query},
 };
 use bevy_math::Vec2;
 use bevy_reflect::Reflect;

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,5 +1,5 @@
 use crate::{Real, Time, Timer, TimerMode};
-use bevy_ecs::system::Res;
+use bevy_ecs::resource::Res;
 use bevy_utils::Duration;
 
 /// Run condition that is active on a regular time interval, using [`Time`] to advance

--- a/crates/bevy_time/src/time.rs
+++ b/crates/bevy_time/src/time.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::{reflect::ReflectResource, system::Resource};
+use bevy_ecs::{reflect::ReflectResource, resource::Resource};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_utils::Duration;
 

--- a/crates/bevy_time/src/virt.rs
+++ b/crates/bevy_time/src/virt.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::system::{Res, ResMut};
+use bevy_ecs::resource::{Res, ResMut};
 use bevy_reflect::Reflect;
 use bevy_utils::{tracing::debug, Duration};
 

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -5,7 +5,8 @@ use bevy_ecs::{
     prelude::{Component, With},
     query::WorldQueryData,
     reflect::ReflectComponent,
-    system::{Local, Query, Res},
+    resource::Res,
+    system::{Local, Query},
 };
 use bevy_input::{mouse::MouseButton, touch::Touches, Input};
 use bevy_math::{Rect, Vec2};

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -8,7 +8,8 @@ use bevy_ecs::{
     event::EventReader,
     query::{With, Without},
     removal_detection::RemovedComponents,
-    system::{Query, Res, ResMut, Resource},
+    resource::{Res, ResMut, Resource},
+    system::Query,
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -9,7 +9,8 @@ use bevy_ecs::{
     prelude::Component,
     query::With,
     reflect::ReflectComponent,
-    system::{Local, Query, Res},
+    resource::Res,
+    system::{Local, Query},
 };
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -4,7 +4,8 @@ use bevy_ecs::{
     prelude::{Component, DetectChanges},
     query::With,
     reflect::ReflectComponent,
-    system::{Local, Query, Res, ResMut},
+    resource::{Res, ResMut},
+    system::{Local, Query},
     world::{Mut, Ref},
 };
 use bevy_math::Vec2;

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -15,11 +15,14 @@ use bevy_a11y::{
 use bevy_a11y::{ActionRequest as ActionRequestWrapper, ManageAccessibilityUpdates};
 use bevy_app::{App, Plugin, PostUpdate};
 use bevy_derive::{Deref, DerefMut};
+use bevy_ecs::resource::NonSend;
 use bevy_ecs::{
     prelude::{DetectChanges, Entity, EventReader, EventWriter},
     query::With,
+    resource::NonSendMut,
+    resource::{Res, ResMut, Resource},
     schedule::IntoSystemConfigs,
-    system::{NonSend, NonSendMut, Query, Res, ResMut, Resource},
+    system::Query,
 };
 use bevy_hierarchy::{Children, Parent};
 use bevy_utils::HashMap;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -49,6 +49,7 @@ use bevy_window::{PrimaryWindow, RawHandleWrapper};
 #[cfg(target_os = "android")]
 pub use winit::platform::android::activity::AndroidApp;
 
+use bevy_ecs::resource::{NonSend, NonSendMut};
 use winit::{
     event::{self, DeviceEvent, Event, StartCause, WindowEvent},
     event_loop::{ControlFlow, EventLoop, EventLoopBuilder, EventLoopWindowTarget},

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -4,7 +4,8 @@ use bevy_ecs::{
     event::EventWriter,
     prelude::{Changed, Component, Resource},
     removal_detection::RemovedComponents,
-    system::{Commands, NonSendMut, Query, ResMut},
+    resource::NonSendMut,
+    system::{Commands, Query},
     world::Mut,
 };
 use bevy_utils::{
@@ -14,6 +15,7 @@ use bevy_utils::{
 use bevy_window::{RawHandleWrapper, Window, WindowClosed, WindowCreated};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
 
+use bevy_ecs::resource::ResMut;
 use winit::{
     dpi::{LogicalPosition, LogicalSize, PhysicalPosition, PhysicalSize},
     event_loop::EventLoopWindowTarget,

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -1,4 +1,4 @@
-use bevy_ecs::system::Resource;
+use bevy_ecs::resource::Resource;
 use bevy_utils::Duration;
 
 /// Settings for the [`WinitPlugin`](super::WinitPlugin).


### PR DESCRIPTION
Move `Resource`, `Res`, `ResMut`, `NonSend`, `NonSendMut` to `bevy_ecs::resource`.

Motivation for this PR is:
* `Resource` and `ResMut` live in separate mods (`system`, `change_detection`), while they are related, making hard to find one from another when looking at public API
* moreover `ResMut` is exported twice is public API (in both `system` and `change_detection`)
* internally it's better when related code is closer
* `system/mod.rs` is 1700 lines of code, too long
* event has in a separate mod, why not resource?
* resources are not necessary tied to systems

This is my subjective opinion how code should be organized, I spent like 15 minutes on this PR, no hard feeling if this is not considered useful.