### PR TITLE
Enable Wayland by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ default = [
   "tonemapping_luts",
   "default_font",
   "webgl2",
+  "wayland"
 ]
 
 # Force dynamic linking, which improves iterative compile times


### PR DESCRIPTION
# Objective

- Fixes #4106

## Solution

Just one commit to add `wayland` to the default features indeed

# Why should it be merged?

The discussion in #4106 seems to be overwhelmingly positive toward adding `wayland` to the default features, as it can greatly improve user experience for Linux users who use Wayland.

Many of the most popular Linux Desktop Environments (DE) like KDE Plasma Desktop and GNOME have Wayland support. With the release of Plasma 6, Wayland is now used by default, and in GNOME, Wayland has been the default for quite a while now.

With Plasma and GNOME, the most popular Linux DEs, now defaulting to Wayland, it seems like enabling Wayland support would truly indeed positively affect quite a lot of Linux users indeed.