### PR TITLE
try_insert Aabbs

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -269,7 +269,7 @@ pub fn calculate_bounds(
     for (entity, mesh_handle) in &without_aabb {
         if let Some(mesh) = meshes.get(mesh_handle) {
             if let Some(aabb) = mesh.compute_aabb() {
-                commands.entity(entity).insert(aabb);
+                commands.entity(entity).try_insert(aabb);
             }
         }
     }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -129,7 +129,7 @@ pub fn calculate_bounds_2d(
     for (entity, mesh_handle) in &meshes_without_aabb {
         if let Some(mesh) = meshes.get(&mesh_handle.0) {
             if let Some(aabb) = mesh.compute_aabb() {
-                commands.entity(entity).insert(aabb);
+                commands.entity(entity).try_insert(aabb);
             }
         }
     }
@@ -142,7 +142,7 @@ pub fn calculate_bounds_2d(
                 center: (-sprite.anchor.as_vec() * size).extend(0.0).into(),
                 half_extents: (0.5 * size).extend(0.0).into(),
             };
-            commands.entity(entity).insert(aabb);
+            commands.entity(entity).try_insert(aabb);
         }
     }
     for (entity, atlas_sprite, atlas_handle) in &atlases_without_aabb {
@@ -156,7 +156,7 @@ pub fn calculate_bounds_2d(
                 center: (-atlas_sprite.anchor.as_vec() * size).extend(0.0).into(),
                 half_extents: (0.5 * size).extend(0.0).into(),
             };
-            commands.entity(entity).insert(aabb);
+            commands.entity(entity).try_insert(aabb);
         }
     }
 }


### PR DESCRIPTION
# Objective

avoid panics from `calculate_bounds` systems if entities are despawned in PostUpdate.

there's a running general discussion (#10166) about command panicking. in the meantime we may as well fix up some cases where it's clear a failure to insert is safe.

## Solution

change `.insert(aabb)` to `.try_insert(aabb)`