### PR TITLE
Add helper macro's for logging only once

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -11,6 +11,8 @@
 //! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
 //! `DefaultPlugins` during app initialization.
 
+mod once;
+
 #[cfg(feature = "trace")]
 use std::panic;
 
@@ -28,6 +30,8 @@ pub mod prelude {
     pub use bevy_utils::tracing::{
         debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     };
+
+    pub use crate::{debug_once, error_once, info_once, trace_once, warn_once};
 }
 
 pub use bevy_utils::tracing::{

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -90,7 +90,7 @@ macro_rules! error_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            info!($($arg)+);
+            error!($($arg)+);
             true
         } else {
             false

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,4 +1,6 @@
-/// Call some expression only once
+/// Call some expression only once per call site.
+///
+/// Returns `Some(<result-of-expression>)` on first-time call, and `None` all other times.
 #[macro_export]
 macro_rules! once {
     ($expression:expr) => {{
@@ -6,19 +8,18 @@ macro_rules! once {
 
         static SHOULD_FIRE: AtomicBool = AtomicBool::new(true);
         if SHOULD_FIRE.swap(false, Ordering::Relaxed) {
-            $expression;
-            true
+            Some($expression)
         } else {
-            false
+            None
         }
     }};
 }
 
-/// Call [`trace!`] once per call site.
+/// Call [`trace!`](crate::trace) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
-/// Returns true the first time this is called
+/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
@@ -26,11 +27,11 @@ macro_rules! trace_once {
     });
 }
 
-/// Call [`debug!`] once per call site.
+/// Call [`debug!`](crate::debug) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
-/// Returns true the first time this is called
+/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
@@ -38,11 +39,11 @@ macro_rules! debug_once {
     });
 }
 
-/// Call [`info!`] once per call site.
+/// Call [`info!`](crate::info) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
-/// Returns true the first time this is called
+/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
@@ -50,11 +51,11 @@ macro_rules! info_once {
     });
 }
 
-/// Call [`warn!`] once per call site.
+/// Call [`warn!`](crate::warn) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
-/// Returns true the first time this is called
+/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
@@ -62,11 +63,11 @@ macro_rules! warn_once {
     });
 }
 
-/// Call [`error!`] once per call site.
+/// Call [`error!`](crate::error) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
-/// Returns true the first time this is called
+/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,3 +1,19 @@
+/// Call some expression only once
+#[macro_export]
+macro_rules! once {
+    ($expression:expr) => {{
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static SHOULD_FIRE: AtomicBool = AtomicBool::new(true);
+        if SHOULD_FIRE.swap(false, Ordering::Relaxed) {
+            $expression;
+            true
+        } else {
+            false
+        }
+    }};
+}
+
 /// Call [`trace!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
@@ -6,15 +22,7 @@
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
-        use ::std::sync::atomic::{AtomicBool, Ordering};
-
-        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
-        if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            $crate::trace!($($arg)+);
-            true
-        } else {
-            false
-        }
+        $crate::once!($crate::trace!($($arg)+))
     });
 }
 
@@ -26,15 +34,7 @@ macro_rules! trace_once {
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
-        use ::std::sync::atomic::{AtomicBool, Ordering};
-
-        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
-        if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            $crate::debug!($($arg)+);
-            true
-        } else {
-            false
-        }
+        $crate::once!($crate::debug!($($arg)+))
     });
 }
 
@@ -46,15 +46,7 @@ macro_rules! debug_once {
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
-        use ::std::sync::atomic::{AtomicBool, Ordering};
-
-        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
-        if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            $crate::info!($($arg)+);
-            true
-        } else {
-            false
-        }
+        $crate::once!($crate::info!($($arg)+))
     });
 }
 
@@ -66,15 +58,7 @@ macro_rules! info_once {
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
-        use ::std::sync::atomic::{AtomicBool, Ordering};
-
-        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
-        if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            $crate::warn!($($arg)+);
-            true
-        } else {
-            false
-        }
+        $crate::once!($crate::warn!($($arg)+))
     });
 }
 
@@ -86,14 +70,6 @@ macro_rules! warn_once {
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({
-        use ::std::sync::atomic::{AtomicBool, Ordering};
-
-        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
-        if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            $crate::error!($($arg)+);
-            true
-        } else {
-            false
-        }
+        $crate::once!($crate::error!($($arg)+))
     });
 }

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,6 +1,8 @@
 /// Call `trace!(...)` once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
+///
+/// Returns true the first time this is called
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
@@ -8,7 +10,10 @@ macro_rules! trace_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            trace!("{}", format!($($arg)+));
+            trace!($($arg)+);
+            true
+        } else {
+            false
         }
     });
 }
@@ -16,6 +21,8 @@ macro_rules! trace_once {
 /// Call `debug!(...)` once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
+///
+/// Returns true the first time this is called
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
@@ -23,7 +30,10 @@ macro_rules! debug_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            debug!("{}", format!($($arg)+));
+            debug!($($arg)+);
+            true
+        } else {
+            false
         }
     });
 }
@@ -31,6 +41,8 @@ macro_rules! debug_once {
 /// Call `info!(...)` once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
+///
+/// Returns true the first time this is called
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
@@ -38,7 +50,10 @@ macro_rules! info_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            info!("{}", format!($($arg)+));
+            info!($($arg)+);
+            true
+        } else {
+            false
         }
     });
 }
@@ -46,6 +61,8 @@ macro_rules! info_once {
 /// Call `warn!(...)` once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
+///
+/// Returns true the first time this is called
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
@@ -53,7 +70,10 @@ macro_rules! warn_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            warn!("{}", format!($($arg)+));
+            warn!($($arg)+);
+            true
+        } else {
+            false
         }
     });
 }
@@ -61,6 +81,8 @@ macro_rules! warn_once {
 /// Call `error!(...)` once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
+///
+/// Returns true the first time this is called
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({
@@ -68,7 +90,10 @@ macro_rules! error_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            error!("{}", format!($($arg)+));
+            info!($($arg)+);
+            true
+        } else {
+            false
         }
     });
 }

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,4 +1,4 @@
-/// Call `trace!(...)` once per call site.
+/// Call [`trace!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
@@ -10,7 +10,7 @@ macro_rules! trace_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            trace!($($arg)+);
+            $crate::trace!($($arg)+);
             true
         } else {
             false
@@ -18,7 +18,7 @@ macro_rules! trace_once {
     });
 }
 
-/// Call `debug!(...)` once per call site.
+/// Call [`debug!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
@@ -30,7 +30,7 @@ macro_rules! debug_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            debug!($($arg)+);
+            $crate::debug!($($arg)+);
             true
         } else {
             false
@@ -38,7 +38,7 @@ macro_rules! debug_once {
     });
 }
 
-/// Call `info!(...)` once per call site.
+/// Call [`info!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
@@ -50,7 +50,7 @@ macro_rules! info_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            info!($($arg)+);
+            $crate::info!($($arg)+);
             true
         } else {
             false
@@ -58,7 +58,7 @@ macro_rules! info_once {
     });
 }
 
-/// Call `warn!(...)` once per call site.
+/// Call [`warn!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
@@ -70,7 +70,7 @@ macro_rules! warn_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            warn!($($arg)+);
+            $crate::warn!($($arg)+);
             true
         } else {
             false
@@ -78,7 +78,7 @@ macro_rules! warn_once {
     });
 }
 
-/// Call `error!(...)` once per call site.
+/// Call [`error!`] once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 ///
@@ -90,7 +90,7 @@ macro_rules! error_once {
 
         static FIRST_TIME: AtomicBool = AtomicBool::new(true);
         if FIRST_TIME.swap(false, Ordering::Relaxed) {
-            error!($($arg)+);
+            $crate::error!($($arg)+);
             true
         } else {
             false

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,0 +1,74 @@
+/// Call `trace!(...)` once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! trace_once {
+    ($($arg:tt)+) => ({
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
+        if FIRST_TIME.swap(false, Ordering::Relaxed) {
+            trace!("{}", format!($($arg)+));
+        }
+    });
+}
+
+/// Call `debug!(...)` once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! debug_once {
+    ($($arg:tt)+) => ({
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
+        if FIRST_TIME.swap(false, Ordering::Relaxed) {
+            debug!("{}", format!($($arg)+));
+        }
+    });
+}
+
+/// Call `info!(...)` once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! info_once {
+    ($($arg:tt)+) => ({
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
+        if FIRST_TIME.swap(false, Ordering::Relaxed) {
+            info!("{}", format!($($arg)+));
+        }
+    });
+}
+
+/// Call `warn!(...)` once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! warn_once {
+    ($($arg:tt)+) => ({
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
+        if FIRST_TIME.swap(false, Ordering::Relaxed) {
+            warn!("{}", format!($($arg)+));
+        }
+    });
+}
+
+/// Call `error!(...)` once per call site.
+///
+/// Useful for logging within systems which are called every frame.
+#[macro_export]
+macro_rules! error_once {
+    ($($arg:tt)+) => ({
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        static FIRST_TIME: AtomicBool = AtomicBool::new(true);
+        if FIRST_TIME.swap(false, Ordering::Relaxed) {
+            error!("{}", format!($($arg)+));
+        }
+    });
+}

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -8,9 +8,7 @@ macro_rules! once {
 
         static SHOULD_FIRE: AtomicBool = AtomicBool::new(true);
         if SHOULD_FIRE.swap(false, Ordering::Relaxed) {
-            Some($expression)
-        } else {
-            None
+            $expression;
         }
     }};
 }
@@ -18,8 +16,6 @@ macro_rules! once {
 /// Call [`trace!`](crate::trace) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
-///
-/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
@@ -30,8 +26,6 @@ macro_rules! trace_once {
 /// Call [`debug!`](crate::debug) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
-///
-/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
@@ -42,8 +36,6 @@ macro_rules! debug_once {
 /// Call [`info!`](crate::info) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
-///
-/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
@@ -54,8 +46,6 @@ macro_rules! info_once {
 /// Call [`warn!`](crate::warn) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
-///
-/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
@@ -66,8 +56,6 @@ macro_rules! warn_once {
 /// Call [`error!`](crate::error) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
-///
-/// Returns `Some(())`` the first time its called
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({

--- a/crates/bevy_log/src/once.rs
+++ b/crates/bevy_log/src/once.rs
@@ -1,6 +1,4 @@
 /// Call some expression only once per call site.
-///
-/// Returns `Some(<result-of-expression>)` on first-time call, and `None` all other times.
 #[macro_export]
 macro_rules! once {
     ($expression:expr) => {{

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -11,6 +11,7 @@ fn main() {
             ..default()
         }))
         .add_systems(Update, log_system)
+        .add_systems(Update, log_once_system)
         .run();
 }
 
@@ -29,4 +30,19 @@ fn log_system() {
     // ex: RUST_LOG=trace, RUST_LOG=info,bevy_ecs=warn
     // the format used here is super flexible. check out this documentation for more info:
     // https://docs.rs/tracing-subscriber/*/tracing_subscriber/filter/struct.EnvFilter.html
+}
+
+fn log_once_system() {
+    // The 'once' variants of each log level are useful when a system is called every frame,
+    // but we still wish to inform the user only once. In other words, use these to prevent spam :)
+
+    trace_once!("one time noisy message");
+    debug_once!("one time debug message");
+    info_once!("some info which is printed only once");
+    warn_once!("some warning we wish to call out only once");
+    error_once!("some error we wish to report only once");
+
+    for i in 0..10 {
+        error_once!("logs once per call site, so this works just fine: {}", i);
+    }
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -1,6 +1,7 @@
 //! This example illustrates how to use logs in bevy.
 
 use bevy::prelude::*;
+use bevy_internal::log::once;
 
 fn main() {
     App::new()
@@ -46,7 +47,21 @@ fn log_once_system() {
         info_once!("logs once per call site, so this works just fine: {}", i);
     }
 
-    if info_once!("some more info") {
+    if info_once!("some more info").is_some() {
         info!("this is the first and only time 'some more info' was printed");
+    }
+
+    // you can also use the 'once!' macro directly, in situations you want do do
+    // something expensive only once within the context of a continous system.
+    if let Some(result) = once!({
+        info!("doing expensive things");
+        let mut a: u64 = 0;
+        for i in 0..100000000 {
+            // ... doing expensive things
+            a += i;
+        }
+        a
+    }) {
+        info!("result of some expensive one time calculation: {}", result);
     }
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -1,7 +1,7 @@
 //! This example illustrates how to use logs in bevy.
 
+use bevy::log::once;
 use bevy::prelude::*;
-use bevy_internal::log::once;
 
 fn main() {
     App::new()
@@ -53,7 +53,6 @@ fn log_once_system() {
         info!("doing expensive things");
         let mut a: u64 = 0;
         for i in 0..100000000 {
-            // ... doing expensive things
             a += i;
         }
         info!("result of some expensive one time calculation: {}", a);

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -43,6 +43,10 @@ fn log_once_system() {
     error_once!("some error we wish to report only once");
 
     for i in 0..10 {
-        error_once!("logs once per call site, so this works just fine: {}", i);
+        info_once!("logs once per call site, so this works just fine: {}", i);
+    }
+
+    if info_once!("some more info") {
+        info!("this is the first and only time 'some more info' was printed");
     }
 }

--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -47,21 +47,15 @@ fn log_once_system() {
         info_once!("logs once per call site, so this works just fine: {}", i);
     }
 
-    if info_once!("some more info").is_some() {
-        info!("this is the first and only time 'some more info' was printed");
-    }
-
     // you can also use the 'once!' macro directly, in situations you want do do
     // something expensive only once within the context of a continous system.
-    if let Some(result) = once!({
+    once!({
         info!("doing expensive things");
         let mut a: u64 = 0;
         for i in 0..100000000 {
             // ... doing expensive things
             a += i;
         }
-        a
-    }) {
-        info!("result of some expensive one time calculation: {}", result);
-    }
+        info!("result of some expensive one time calculation: {}", a);
+    });
 }


### PR DESCRIPTION
# Objective

Fixes #10291

This adds a way to easily log messages once within system which are called every frame.  

## Solution

Opted for a macro-based approach. The fact that the 'once' call is tracked per call site makes the `log_once!()` macro very versatile and easy-to-use. I suspect it will be very handy for all of us, but especially beginners, to get some initial feedback from systems without spamming up the place!

I've made the macro's return its internal `has_fired` state, for situations in which that might be useful to know (trigger  something else alongside the log, for example).

Please let me know if I placed the macro's in the right location, and if you would like me to do something more clever with the macro's themselves, since its looking quite copy-pastey at the moment. I've tried ways to replace 5 with 1 macro's, but no success yet.

One downside of this approach is: Say you wish to warn the user if a resource is invalid. In this situation, the 
`resource.is_valid()` check would still be performed every frame:
```rust
fn my_system(my_res: Res<MyResource>) {
   if !my_res.is_valid() {
      warn_once!("resource is invalid!");
   }
}
```
If you want to prevent that, you would still need to introduce a local boolean. I don't think this is a very big deal, as expensive checks shouldn't be called every frame in any case. 


## Changelog
Added: `trace_once!()`, `debug_once!()`, `info_once!()`, `warn_once!()`, and `error_once!()` log macros which fire only once per call site.