### PR TITLE
Reduced `TableRow` `as` Casting

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -605,7 +605,7 @@ unsafe impl<T: Component> WorldQuery for &T {
             StorageType::Table => fetch
                 .table_components
                 .debug_checked_unwrap()
-                .get(table_row.index())
+                .get(table_row.as_usize())
                 .deref(),
             StorageType::SparseSet => fetch
                 .sparse_set
@@ -760,10 +760,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
                 let (table_components, added_ticks, changed_ticks) =
                     fetch.table_data.debug_checked_unwrap();
                 Ref {
-                    value: table_components.get(table_row.index()).deref(),
+                    value: table_components.get(table_row.as_usize()).deref(),
                     ticks: Ticks {
-                        added: added_ticks.get(table_row.index()).deref(),
-                        changed: changed_ticks.get(table_row.index()).deref(),
+                        added: added_ticks.get(table_row.as_usize()).deref(),
+                        changed: changed_ticks.get(table_row.as_usize()).deref(),
                         this_run: fetch.this_run,
                         last_run: fetch.last_run,
                     },
@@ -927,10 +927,10 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
                 let (table_components, added_ticks, changed_ticks) =
                     fetch.table_data.debug_checked_unwrap();
                 Mut {
-                    value: table_components.get(table_row.index()).deref_mut(),
+                    value: table_components.get(table_row.as_usize()).deref_mut(),
                     ticks: TicksMut {
-                        added: added_ticks.get(table_row.index()).deref_mut(),
-                        changed: changed_ticks.get(table_row.index()).deref_mut(),
+                        added: added_ticks.get(table_row.as_usize()).deref_mut(),
+                        changed: changed_ticks.get(table_row.as_usize()).deref_mut(),
                         this_run: fetch.this_run,
                         last_run: fetch.last_run,
                     },

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -626,7 +626,7 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
             StorageType::Table => fetch
                 .table_ticks
                 .debug_checked_unwrap()
-                .get(table_row.index())
+                .get(table_row.as_usize())
                 .deref()
                 .is_newer_than(fetch.last_run, fetch.this_run),
             StorageType::SparseSet => {
@@ -802,7 +802,7 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
             StorageType::Table => fetch
                 .table_ticks
                 .debug_checked_unwrap()
-                .get(table_row.index())
+                .get(table_row.as_usize())
                 .deref()
                 .is_newer_than(fetch.last_run, fetch.this_run),
             StorageType::SparseSet => {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -106,6 +106,11 @@ impl<'w, 's, Q: WorldQueryData, F: WorldQueryFilter> QueryIter<'w, 's, Q, F> {
     where
         Func: FnMut(B, Q::Item<'w>) -> B,
     {
+        assert!(
+            rows.end <= u32::MAX as usize,
+            "TableRow is only valid up to u32::MAX"
+        );
+
         Q::set_table(&mut self.cursor.fetch, &self.query_state.fetch_state, table);
         F::set_table(
             &mut self.cursor.filter,
@@ -117,7 +122,7 @@ impl<'w, 's, Q: WorldQueryData, F: WorldQueryFilter> QueryIter<'w, 's, Q, F> {
         for row in rows {
             // SAFETY: Caller assures `row` in range of the current archetype.
             let entity = entities.get_unchecked(row);
-            let row = TableRow::new(row);
+            let row = TableRow::from_usize(row);
             // SAFETY: set_table was called prior.
             // Caller assures `row` in range of the current archetype.
             if !F::filter_fetch(&mut self.cursor.filter, *entity, row) {

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -517,7 +517,11 @@ impl<'w, 's, Q: WorldQueryData, F: WorldQueryFilter> QueryIterationCursor<'w, 's
             let index = self.current_row - 1;
             if Self::IS_DENSE {
                 let entity = self.table_entities.get_unchecked(index);
-                Some(Q::fetch(&mut self.fetch, *entity, TableRow::new(index)))
+                Some(Q::fetch(
+                    &mut self.fetch,
+                    *entity,
+                    TableRow::from_usize(index),
+                ))
             } else {
                 let archetype_entity = self.archetype_entities.get_unchecked(index);
                 Some(Q::fetch(
@@ -578,7 +582,7 @@ impl<'w, 's, Q: WorldQueryData, F: WorldQueryFilter> QueryIterationCursor<'w, 's
                 // SAFETY: set_table was called prior.
                 // `current_row` is a table row in range of the current table, because if it was not, then the if above would have been executed.
                 let entity = self.table_entities.get_unchecked(self.current_row);
-                let row = TableRow::new(self.current_row);
+                let row = TableRow::from_usize(self.current_row);
                 if !F::filter_fetch(&mut self.filter, *entity, row) {
                     self.current_row += 1;
                     continue;

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -267,7 +267,7 @@ impl<Q: WorldQueryData, F: WorldQueryFilter> QueryState<Q, F> {
                 self.matched_archetypes.set(archetype_index, true);
                 self.matched_archetype_ids.push(archetype.id());
             }
-            let table_index = archetype.table_id().index();
+            let table_index = archetype.table_id().as_usize();
             if !self.matched_tables.contains(table_index) {
                 self.matched_tables.grow(table_index + 1);
                 self.matched_tables.set(table_index, true);
@@ -1128,7 +1128,7 @@ impl<Q: WorldQueryData, F: WorldQueryFilter> QueryState<Q, F> {
                 let entities = table.entities();
                 for row in 0..table.entity_count() {
                     let entity = entities.get_unchecked(row);
-                    let row = TableRow::new(row);
+                    let row = TableRow::from_usize(row);
                     if !F::filter_fetch(&mut filter, *entity, row) {
                         continue;
                     }
@@ -1221,7 +1221,7 @@ impl<Q: WorldQueryData, F: WorldQueryFilter> QueryState<Q, F> {
                             F::set_table(&mut filter, &self.filter_state, table);
                             for row in offset..offset + len {
                                 let entity = entities.get_unchecked(row);
-                                let row = TableRow::new(row);
+                                let row = TableRow::from_usize(row);
                                 if !F::filter_fetch(&mut filter, *entity, row) {
                                     continue;
                                 }

--- a/crates/bevy_ecs/src/storage/resource.rs
+++ b/crates/bevy_ecs/src/storage/resource.rs
@@ -40,7 +40,7 @@ impl<const SEND: bool> Drop for ResourceData<SEND> {
 
 impl<const SEND: bool> ResourceData<SEND> {
     /// The only row in the underlying column.
-    const ROW: TableRow = TableRow::new(0);
+    const ROW: TableRow = TableRow::from_u32(0);
 
     /// Validates the access to `!Send` resources is only done on the thread they were created from.
     ///

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -53,10 +53,10 @@ impl TableId {
     ///
     /// # Panics
     ///
-    /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
+    /// Will panic if the provided value does not fit within a [`u32`].
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        debug_assert!(index as u32 as usize == index);
+        assert!(index as u32 as usize == index);
         Self(index as u32)
     }
 
@@ -67,13 +67,9 @@ impl TableId {
     }
 
     /// Gets the underlying table index from the ID.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
     #[inline]
     pub const fn as_usize(self) -> usize {
-        debug_assert!(self.0 as usize as u32 == self.0);
+        // usize is at least u32 in Bevy
         self.0 as usize
     }
 
@@ -117,21 +113,17 @@ impl TableRow {
     ///
     /// # Panics
     ///
-    /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
+    /// Will panic if the provided value does not fit within a [`u32`].
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        debug_assert!(index as u32 as usize == index);
+        assert!(index as u32 as usize == index);
         Self(index as u32)
     }
 
     /// Gets the index of the row as a [`usize`].
-    ///
-    /// # Panics
-    ///
-    /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
     #[inline]
     pub const fn as_usize(self) -> usize {
-        debug_assert!(self.0 as usize as u32 == self.0);
+        // usize is at least u32 in Bevy
         self.0 as usize
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -41,7 +41,7 @@ impl TableId {
     /// [`World`]: crate::world::World
     #[inline]
     pub const fn from_u32(index: u32) -> Self {
-        TableId(index)
+        Self(index)
     }
 
     /// Creates a new [`TableId`].
@@ -56,8 +56,8 @@ impl TableId {
     /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        debug_assert!((index as u128) < (u32::MAX as u128));
-        TableId(index as u32)
+        debug_assert!(index as u32 as usize == index);
+        Self(index as u32)
     }
 
     /// Gets the underlying table index from the ID.
@@ -73,13 +73,13 @@ impl TableId {
     /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
     #[inline]
     pub const fn as_usize(self) -> usize {
-        debug_assert!((self.0 as u128) < (usize::MAX as u128));
+        debug_assert!(self.0 as usize as u32 == self.0);
         self.0 as usize
     }
 
     /// The [`TableId`] of the [`Table`] without any components.
     #[inline]
-    pub const fn empty() -> TableId {
+    pub const fn empty() -> Self {
         Self(0)
     }
 }
@@ -120,7 +120,7 @@ impl TableRow {
     /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
     #[inline]
     pub const fn from_usize(index: usize) -> Self {
-        debug_assert!((index as u128) < (u32::MAX as u128));
+        debug_assert!(index as u32 as usize == index);
         Self(index as u32)
     }
 
@@ -131,7 +131,7 @@ impl TableRow {
     /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
     #[inline]
     pub const fn as_usize(self) -> usize {
-        debug_assert!((self.0 as u128) < (usize::MAX as u128));
+        debug_assert!(self.0 as usize as u32 == self.0);
         self.0 as usize
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -35,25 +35,52 @@ impl TableId {
 
     /// Creates a new [`TableId`].
     ///
-    /// `index` *must* be retrieved from calling [`TableId::index`] on a `TableId` you got
+    /// `index` *must* be retrieved from calling [`TableId::as_u32`] on a `TableId` you got
     /// from a table of a given [`World`] or the created ID may be invalid.
     ///
     /// [`World`]: crate::world::World
     #[inline]
-    pub fn new(index: usize) -> Self {
+    pub const fn from_u32(index: u32) -> Self {
+        TableId(index)
+    }
+
+    /// Creates a new [`TableId`].
+    ///
+    /// `index` *must* be retrieved from calling [`TableId::as_usize`] on a `TableId` you got
+    /// from a table of a given [`World`] or the created ID may be invalid.
+    ///
+    /// [`World`]: crate::world::World
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
+    #[inline]
+    pub const fn from_usize(index: usize) -> Self {
+        debug_assert!((index as u128) < (u32::MAX as u128));
         TableId(index as u32)
     }
 
     /// Gets the underlying table index from the ID.
     #[inline]
-    pub fn index(self) -> usize {
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    /// Gets the underlying table index from the ID.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
+    #[inline]
+    pub const fn as_usize(self) -> usize {
+        debug_assert!((self.0 as u128) < (usize::MAX as u128));
         self.0 as usize
     }
 
     /// The [`TableId`] of the [`Table`] without any components.
     #[inline]
     pub const fn empty() -> TableId {
-        TableId(0)
+        Self(0)
     }
 }
 
@@ -82,14 +109,36 @@ impl TableRow {
 
     /// Creates a `TableRow`.
     #[inline]
-    pub const fn new(index: usize) -> Self {
+    pub const fn from_u32(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Creates a `TableRow` from a [`usize`] index.
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the provided value does not fit within a [`u32`] with `debug_assertions`.
+    #[inline]
+    pub const fn from_usize(index: usize) -> Self {
+        debug_assert!((index as u128) < (u32::MAX as u128));
         Self(index as u32)
     }
 
-    /// Gets the index of the row.
+    /// Gets the index of the row as a [`usize`].
+    ///
+    /// # Panics
+    ///
+    /// Will panic if the inner value does not fit within a [`usize`] with `debug_assertions`.
     #[inline]
-    pub const fn index(self) -> usize {
+    pub const fn as_usize(self) -> usize {
+        debug_assert!((self.0 as u128) < (usize::MAX as u128));
         self.0 as usize
+    }
+
+    /// Gets the index of the row as a [`usize`].
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0
     }
 }
 
@@ -139,10 +188,13 @@ impl Column {
     /// Assumes data has already been allocated for the given row.
     #[inline]
     pub(crate) unsafe fn initialize(&mut self, row: TableRow, data: OwningPtr<'_>, tick: Tick) {
-        debug_assert!(row.index() < self.len());
-        self.data.initialize_unchecked(row.index(), data);
-        *self.added_ticks.get_unchecked_mut(row.index()).get_mut() = tick;
-        *self.changed_ticks.get_unchecked_mut(row.index()).get_mut() = tick;
+        debug_assert!(row.as_usize() < self.len());
+        self.data.initialize_unchecked(row.as_usize(), data);
+        *self.added_ticks.get_unchecked_mut(row.as_usize()).get_mut() = tick;
+        *self
+            .changed_ticks
+            .get_unchecked_mut(row.as_usize())
+            .get_mut() = tick;
     }
 
     /// Writes component data to the column at given row.
@@ -152,9 +204,12 @@ impl Column {
     /// Assumes data has already been allocated for the given row.
     #[inline]
     pub(crate) unsafe fn replace(&mut self, row: TableRow, data: OwningPtr<'_>, change_tick: Tick) {
-        debug_assert!(row.index() < self.len());
-        self.data.replace_unchecked(row.index(), data);
-        *self.changed_ticks.get_unchecked_mut(row.index()).get_mut() = change_tick;
+        debug_assert!(row.as_usize() < self.len());
+        self.data.replace_unchecked(row.as_usize(), data);
+        *self
+            .changed_ticks
+            .get_unchecked_mut(row.as_usize())
+            .get_mut() = change_tick;
     }
 
     /// Writes component data to the column at given row.
@@ -165,8 +220,8 @@ impl Column {
     /// Assumes data has already been allocated for the given row.
     #[inline]
     pub(crate) unsafe fn replace_untracked(&mut self, row: TableRow, data: OwningPtr<'_>) {
-        debug_assert!(row.index() < self.len());
-        self.data.replace_unchecked(row.index(), data);
+        debug_assert!(row.as_usize() < self.len());
+        self.data.replace_unchecked(row.as_usize(), data);
     }
 
     /// Gets the current number of elements stored in the column.
@@ -193,9 +248,9 @@ impl Column {
     ///
     #[inline]
     pub(crate) unsafe fn swap_remove_unchecked(&mut self, row: TableRow) {
-        self.data.swap_remove_and_drop_unchecked(row.index());
-        self.added_ticks.swap_remove(row.index());
-        self.changed_ticks.swap_remove(row.index());
+        self.data.swap_remove_and_drop_unchecked(row.as_usize());
+        self.added_ticks.swap_remove(row.as_usize());
+        self.changed_ticks.swap_remove(row.as_usize());
     }
 
     /// Removes an element from the [`Column`] and returns it and its change detection ticks.
@@ -214,11 +269,11 @@ impl Column {
         &mut self,
         row: TableRow,
     ) -> Option<(OwningPtr<'_>, ComponentTicks)> {
-        (row.index() < self.data.len()).then(|| {
+        (row.as_usize() < self.data.len()).then(|| {
             // SAFETY: The row was length checked before this.
-            let data = unsafe { self.data.swap_remove_and_forget_unchecked(row.index()) };
-            let added = self.added_ticks.swap_remove(row.index()).into_inner();
-            let changed = self.changed_ticks.swap_remove(row.index()).into_inner();
+            let data = unsafe { self.data.swap_remove_and_forget_unchecked(row.as_usize()) };
+            let added = self.added_ticks.swap_remove(row.as_usize()).into_inner();
+            let changed = self.changed_ticks.swap_remove(row.as_usize()).into_inner();
             (data, ComponentTicks { added, changed })
         })
     }
@@ -241,9 +296,9 @@ impl Column {
         &mut self,
         row: TableRow,
     ) -> (OwningPtr<'_>, ComponentTicks) {
-        let data = self.data.swap_remove_and_forget_unchecked(row.index());
-        let added = self.added_ticks.swap_remove(row.index()).into_inner();
-        let changed = self.changed_ticks.swap_remove(row.index()).into_inner();
+        let data = self.data.swap_remove_and_forget_unchecked(row.as_usize());
+        let added = self.added_ticks.swap_remove(row.as_usize()).into_inner();
+        let changed = self.changed_ticks.swap_remove(row.as_usize()).into_inner();
         (data, ComponentTicks { added, changed })
     }
 
@@ -266,12 +321,12 @@ impl Column {
         dst_row: TableRow,
     ) {
         debug_assert!(self.data.layout() == other.data.layout());
-        let ptr = self.data.get_unchecked_mut(dst_row.index());
-        other.data.swap_remove_unchecked(src_row.index(), ptr);
-        *self.added_ticks.get_unchecked_mut(dst_row.index()) =
-            other.added_ticks.swap_remove(src_row.index());
-        *self.changed_ticks.get_unchecked_mut(dst_row.index()) =
-            other.changed_ticks.swap_remove(src_row.index());
+        let ptr = self.data.get_unchecked_mut(dst_row.as_usize());
+        other.data.swap_remove_unchecked(src_row.as_usize(), ptr);
+        *self.added_ticks.get_unchecked_mut(dst_row.as_usize()) =
+            other.added_ticks.swap_remove(src_row.as_usize());
+        *self.changed_ticks.get_unchecked_mut(dst_row.as_usize()) =
+            other.changed_ticks.swap_remove(src_row.as_usize());
     }
 
     /// Pushes a new value onto the end of the [`Column`].
@@ -338,15 +393,15 @@ impl Column {
     /// Returns `None` if `row` is out of bounds.
     #[inline]
     pub fn get(&self, row: TableRow) -> Option<(Ptr<'_>, TickCells<'_>)> {
-        (row.index() < self.data.len())
+        (row.as_usize() < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.
             .then(|| unsafe {
                 (
-                    self.data.get_unchecked(row.index()),
+                    self.data.get_unchecked(row.as_usize()),
                     TickCells {
-                        added: self.added_ticks.get_unchecked(row.index()),
-                        changed: self.changed_ticks.get_unchecked(row.index()),
+                        added: self.added_ticks.get_unchecked(row.as_usize()),
+                        changed: self.changed_ticks.get_unchecked(row.as_usize()),
                     },
                 )
             })
@@ -357,9 +412,11 @@ impl Column {
     /// Returns `None` if `row` is out of bounds.
     #[inline]
     pub fn get_data(&self, row: TableRow) -> Option<Ptr<'_>> {
-        // SAFETY: The row is length checked before fetching the pointer. This is being
-        // accessed through a read-only reference to the column.
-        (row.index() < self.data.len()).then(|| unsafe { self.data.get_unchecked(row.index()) })
+        (row.as_usize() < self.data.len()).then(|| {
+            // SAFETY: The row is length checked before fetching the pointer. This is being
+            // accessed through a read-only reference to the column.
+            unsafe { self.data.get_unchecked(row.as_usize()) }
+        })
     }
 
     /// Fetches a read-only reference to the data at `row`. Unlike [`Column::get`] this does not
@@ -370,8 +427,8 @@ impl Column {
     /// - no other mutable reference to the data of the same row can exist at the same time
     #[inline]
     pub unsafe fn get_data_unchecked(&self, row: TableRow) -> Ptr<'_> {
-        debug_assert!(row.index() < self.data.len());
-        self.data.get_unchecked(row.index())
+        debug_assert!(row.as_usize() < self.data.len());
+        self.data.get_unchecked(row.as_usize())
     }
 
     /// Fetches a mutable reference to the data at `row`.
@@ -379,9 +436,11 @@ impl Column {
     /// Returns `None` if `row` is out of bounds.
     #[inline]
     pub fn get_data_mut(&mut self, row: TableRow) -> Option<PtrMut<'_>> {
-        // SAFETY: The row is length checked before fetching the pointer. This is being
-        // accessed through an exclusive reference to the column.
-        (row.index() < self.data.len()).then(|| unsafe { self.data.get_unchecked_mut(row.index()) })
+        (row.as_usize() < self.data.len()).then(|| {
+            // SAFETY: The row is length checked before fetching the pointer. This is being
+            // accessed through an exclusive reference to the column.
+            unsafe { self.data.get_unchecked_mut(row.as_usize()) }
+        })
     }
 
     /// Fetches a mutable reference to the data at `row`. Unlike [`Column::get_data_mut`] this does not
@@ -392,8 +451,8 @@ impl Column {
     /// - no other reference to the data of the same row can exist at the same time
     #[inline]
     pub(crate) unsafe fn get_data_unchecked_mut(&mut self, row: TableRow) -> PtrMut<'_> {
-        debug_assert!(row.index() < self.data.len());
-        self.data.get_unchecked_mut(row.index())
+        debug_assert!(row.as_usize() < self.data.len());
+        self.data.get_unchecked_mut(row.as_usize())
     }
 
     /// Fetches the "added" change detection tick for the value at `row`.
@@ -405,7 +464,7 @@ impl Column {
     /// adhere to the safety invariants of [`UnsafeCell`].
     #[inline]
     pub fn get_added_tick(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
-        self.added_ticks.get(row.index())
+        self.added_ticks.get(row.as_usize())
     }
 
     /// Fetches the "changed" change detection tick for the value at `row`.
@@ -417,7 +476,7 @@ impl Column {
     /// adhere to the safety invariants of [`UnsafeCell`].
     #[inline]
     pub fn get_changed_tick(&self, row: TableRow) -> Option<&UnsafeCell<Tick>> {
-        self.changed_ticks.get(row.index())
+        self.changed_ticks.get(row.as_usize())
     }
 
     /// Fetches the change detection ticks for the value at `row`.
@@ -425,7 +484,7 @@ impl Column {
     /// Returns `None` if `row` is out of bounds.
     #[inline]
     pub fn get_ticks(&self, row: TableRow) -> Option<ComponentTicks> {
-        if row.index() < self.data.len() {
+        if row.as_usize() < self.data.len() {
             // SAFETY: The size of the column has already been checked.
             Some(unsafe { self.get_ticks_unchecked(row) })
         } else {
@@ -440,8 +499,8 @@ impl Column {
     /// `row` must be within the range `[0, self.len())`.
     #[inline]
     pub unsafe fn get_added_tick_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
-        debug_assert!(row.index() < self.added_ticks.len());
-        self.added_ticks.get_unchecked(row.index())
+        debug_assert!(row.as_usize() < self.added_ticks.len());
+        self.added_ticks.get_unchecked(row.as_usize())
     }
 
     /// Fetches the "changed" change detection tick for the value at `row`. Unlike [`Column::get_changed_tick`]
@@ -451,8 +510,8 @@ impl Column {
     /// `row` must be within the range `[0, self.len())`.
     #[inline]
     pub unsafe fn get_changed_tick_unchecked(&self, row: TableRow) -> &UnsafeCell<Tick> {
-        debug_assert!(row.index() < self.changed_ticks.len());
-        self.changed_ticks.get_unchecked(row.index())
+        debug_assert!(row.as_usize() < self.changed_ticks.len());
+        self.changed_ticks.get_unchecked(row.as_usize())
     }
 
     /// Fetches the change detection ticks for the value at `row`. Unlike [`Column::get_ticks`]
@@ -462,11 +521,11 @@ impl Column {
     /// `row` must be within the range `[0, self.len())`.
     #[inline]
     pub unsafe fn get_ticks_unchecked(&self, row: TableRow) -> ComponentTicks {
-        debug_assert!(row.index() < self.added_ticks.len());
-        debug_assert!(row.index() < self.changed_ticks.len());
+        debug_assert!(row.as_usize() < self.added_ticks.len());
+        debug_assert!(row.as_usize() < self.changed_ticks.len());
         ComponentTicks {
-            added: self.added_ticks.get_unchecked(row.index()).read(),
-            changed: self.changed_ticks.get_unchecked(row.index()).read(),
+            added: self.added_ticks.get_unchecked(row.as_usize()).read(),
+            changed: self.changed_ticks.get_unchecked(row.as_usize()).read(),
         }
     }
 
@@ -565,12 +624,12 @@ impl Table {
         for column in self.columns.values_mut() {
             column.swap_remove_unchecked(row);
         }
-        let is_last = row.index() == self.entities.len() - 1;
-        self.entities.swap_remove(row.index());
+        let is_last = row.as_usize() == self.entities.len() - 1;
+        self.entities.swap_remove(row.as_usize());
         if is_last {
             None
         } else {
-            Some(self.entities[row.index()])
+            Some(self.entities[row.as_usize()])
         }
     }
 
@@ -587,9 +646,9 @@ impl Table {
         row: TableRow,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row.index() < self.entity_count());
-        let is_last = row.index() == self.entities.len() - 1;
-        let new_row = new_table.allocate(self.entities.swap_remove(row.index()));
+        debug_assert!(row.as_usize() < self.entity_count());
+        let is_last = row.as_usize() == self.entities.len() - 1;
+        let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.columns.iter_mut() {
             if let Some(new_column) = new_table.get_column_mut(*component_id) {
                 new_column.initialize_from_unchecked(column, row, new_row);
@@ -603,7 +662,7 @@ impl Table {
             swapped_entity: if is_last {
                 None
             } else {
-                Some(self.entities[row.index()])
+                Some(self.entities[row.as_usize()])
             },
         }
     }
@@ -619,9 +678,9 @@ impl Table {
         row: TableRow,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row.index() < self.entity_count());
-        let is_last = row.index() == self.entities.len() - 1;
-        let new_row = new_table.allocate(self.entities.swap_remove(row.index()));
+        debug_assert!(row.as_usize() < self.entity_count());
+        let is_last = row.as_usize() == self.entities.len() - 1;
+        let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.columns.iter_mut() {
             if let Some(new_column) = new_table.get_column_mut(*component_id) {
                 new_column.initialize_from_unchecked(column, row, new_row);
@@ -634,7 +693,7 @@ impl Table {
             swapped_entity: if is_last {
                 None
             } else {
-                Some(self.entities[row.index()])
+                Some(self.entities[row.as_usize()])
             },
         }
     }
@@ -650,9 +709,9 @@ impl Table {
         row: TableRow,
         new_table: &mut Table,
     ) -> TableMoveResult {
-        debug_assert!(row.index() < self.entity_count());
-        let is_last = row.index() == self.entities.len() - 1;
-        let new_row = new_table.allocate(self.entities.swap_remove(row.index()));
+        debug_assert!(row.as_usize() < self.entity_count());
+        let is_last = row.as_usize() == self.entities.len() - 1;
+        let new_row = new_table.allocate(self.entities.swap_remove(row.as_usize()));
         for (component_id, column) in self.columns.iter_mut() {
             new_table
                 .get_column_mut(*component_id)
@@ -664,7 +723,7 @@ impl Table {
             swapped_entity: if is_last {
                 None
             } else {
-                Some(self.entities[row.index()])
+                Some(self.entities[row.as_usize()])
             },
         }
     }
@@ -728,7 +787,7 @@ impl Table {
             column.added_ticks.push(UnsafeCell::new(Tick::new(0)));
             column.changed_ticks.push(UnsafeCell::new(Tick::new(0)));
         }
-        TableRow::new(index)
+        TableRow::from_usize(index)
     }
 
     /// Gets the number of entities currently being stored in the table.
@@ -819,7 +878,7 @@ impl Tables {
     /// Returns `None` if `id` is invalid.
     #[inline]
     pub fn get(&self, id: TableId) -> Option<&Table> {
-        self.tables.get(id.index())
+        self.tables.get(id.as_usize())
     }
 
     /// Fetches mutable references to two different [`Table`]s.
@@ -829,12 +888,12 @@ impl Tables {
     /// Panics if `a` and `b` are equal.
     #[inline]
     pub(crate) fn get_2_mut(&mut self, a: TableId, b: TableId) -> (&mut Table, &mut Table) {
-        if a.index() > b.index() {
-            let (b_slice, a_slice) = self.tables.split_at_mut(a.index());
-            (&mut a_slice[0], &mut b_slice[b.index()])
+        if a.as_usize() > b.as_usize() {
+            let (b_slice, a_slice) = self.tables.split_at_mut(a.as_usize());
+            (&mut a_slice[0], &mut b_slice[b.as_usize()])
         } else {
-            let (a_slice, b_slice) = self.tables.split_at_mut(b.index());
-            (&mut a_slice[a.index()], &mut b_slice[0])
+            let (a_slice, b_slice) = self.tables.split_at_mut(b.as_usize());
+            (&mut a_slice[a.as_usize()], &mut b_slice[0])
         }
     }
 
@@ -859,7 +918,10 @@ impl Tables {
                     table = table.add_column(components.get_info_unchecked(*component_id));
                 }
                 tables.push(table.build());
-                (component_ids.to_vec(), TableId::new(tables.len() - 1))
+                (
+                    component_ids.to_vec(),
+                    TableId::from_usize(tables.len() - 1),
+                )
             });
 
         *value
@@ -889,14 +951,14 @@ impl Index<TableId> for Tables {
 
     #[inline]
     fn index(&self, index: TableId) -> &Self::Output {
-        &self.tables[index.index()]
+        &self.tables[index.as_usize()]
     }
 }
 
 impl IndexMut<TableId> for Tables {
     #[inline]
     fn index_mut(&mut self, index: TableId) -> &mut Self::Output {
-        &mut self.tables[index.index()]
+        &mut self.tables[index.as_usize()]
     }
 }
 

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -39,7 +39,7 @@ use gltf::{
     texture::{MagFilter, MinFilter, WrappingMode},
     Material, Node, Primitive, Semantic,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::{
     collections::VecDeque,
     path::{Path, PathBuf},
@@ -105,20 +105,57 @@ pub struct GltfLoader {
     pub custom_vertex_attributes: HashMap<String, MeshVertexAttribute>,
 }
 
+/// Specifies optional settings for processing gltfs at load time. By default, all recognized contents of
+/// the gltf will be loaded.
+///
+/// # Example
+///
+/// To load a gltf but exclude the cameras, replace a call to `asset_server.load("my.gltf")` with
+/// ```no_run
+/// # use bevy_asset::{AssetServer, Handle};
+/// # use bevy_gltf::*;
+/// # let asset_server: AssetServer = panic!();
+/// let gltf_handle: Handle<Gltf> = asset_server.load_with_settings(
+///     "my.gltf",
+///     |s: &mut GltfLoaderSettings| {
+///         s.load_cameras = false;
+///     }
+/// );    
+/// ```
+#[derive(Serialize, Deserialize)]
+pub struct GltfLoaderSettings {
+    /// If true, the loader will load mesh nodes and the associated materials.
+    pub load_meshes: bool,
+    /// If true, the loader will spawn cameras for gltf camera nodes.
+    pub load_cameras: bool,
+    /// If true, the loader will spawn lights for gltf light nodes.
+    pub load_lights: bool,
+}
+
+impl Default for GltfLoaderSettings {
+    fn default() -> Self {
+        Self {
+            load_meshes: true,
+            load_cameras: true,
+            load_lights: true,
+        }
+    }
+}
+
 impl AssetLoader for GltfLoader {
     type Asset = Gltf;
-    type Settings = ();
+    type Settings = GltfLoaderSettings;
     type Error = GltfError;
     fn load<'a>(
         &'a self,
         reader: &'a mut Reader,
-        _settings: &'a (),
+        settings: &'a GltfLoaderSettings,
         load_context: &'a mut LoadContext,
     ) -> bevy_utils::BoxedFuture<'a, Result<Gltf, Self::Error>> {
         Box::pin(async move {
             let mut bytes = Vec::new();
             reader.read_to_end(&mut bytes).await?;
-            load_gltf(self, &bytes, load_context).await
+            load_gltf(self, &bytes, load_context, settings).await
         })
     }
 
@@ -132,6 +169,7 @@ async fn load_gltf<'a, 'b, 'c>(
     loader: &GltfLoader,
     bytes: &'a [u8],
     load_context: &'b mut LoadContext<'c>,
+    settings: &'b GltfLoaderSettings,
 ) -> Result<Gltf, GltfError> {
     let gltf = gltf::Gltf::from_slice(bytes)?;
     let buffer_data = load_buffers(&gltf, load_context).await?;
@@ -555,6 +593,7 @@ async fn load_gltf<'a, 'b, 'c>(
                         parent,
                         load_context,
                         &mut scene_load_context,
+                        settings,
                         &mut node_index_to_entity_map,
                         &mut entity_to_skin_index_map,
                         &mut active_camera_found,
@@ -860,6 +899,7 @@ fn load_node(
     world_builder: &mut WorldChildBuilder,
     root_load_context: &LoadContext,
     load_context: &mut LoadContext,
+    settings: &GltfLoaderSettings,
     node_index_to_entity_map: &mut HashMap<usize, Entity>,
     entity_to_skin_index_map: &mut HashMap<Entity, usize>,
     active_camera_found: &mut bool,
@@ -887,46 +927,48 @@ fn load_node(
     }
 
     // create camera node
-    if let Some(camera) = gltf_node.camera() {
-        let projection = match camera.projection() {
-            gltf::camera::Projection::Orthographic(orthographic) => {
-                let xmag = orthographic.xmag();
-                let orthographic_projection = OrthographicProjection {
-                    near: orthographic.znear(),
-                    far: orthographic.zfar(),
-                    scaling_mode: ScalingMode::FixedHorizontal(1.0),
-                    scale: xmag,
-                    ..Default::default()
-                };
+    if settings.load_cameras {
+        if let Some(camera) = gltf_node.camera() {
+            let projection = match camera.projection() {
+                gltf::camera::Projection::Orthographic(orthographic) => {
+                    let xmag = orthographic.xmag();
+                    let orthographic_projection = OrthographicProjection {
+                        near: orthographic.znear(),
+                        far: orthographic.zfar(),
+                        scaling_mode: ScalingMode::FixedHorizontal(1.0),
+                        scale: xmag,
+                        ..Default::default()
+                    };
 
-                Projection::Orthographic(orthographic_projection)
-            }
-            gltf::camera::Projection::Perspective(perspective) => {
-                let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
-                    fov: perspective.yfov(),
-                    near: perspective.znear(),
+                    Projection::Orthographic(orthographic_projection)
+                }
+                gltf::camera::Projection::Perspective(perspective) => {
+                    let mut perspective_projection: PerspectiveProjection = PerspectiveProjection {
+                        fov: perspective.yfov(),
+                        near: perspective.znear(),
+                        ..Default::default()
+                    };
+                    if let Some(zfar) = perspective.zfar() {
+                        perspective_projection.far = zfar;
+                    }
+                    if let Some(aspect_ratio) = perspective.aspect_ratio() {
+                        perspective_projection.aspect_ratio = aspect_ratio;
+                    }
+                    Projection::Perspective(perspective_projection)
+                }
+            };
+            node.insert(Camera3dBundle {
+                projection,
+                transform,
+                camera: Camera {
+                    is_active: !*active_camera_found,
                     ..Default::default()
-                };
-                if let Some(zfar) = perspective.zfar() {
-                    perspective_projection.far = zfar;
-                }
-                if let Some(aspect_ratio) = perspective.aspect_ratio() {
-                    perspective_projection.aspect_ratio = aspect_ratio;
-                }
-                Projection::Perspective(perspective_projection)
-            }
-        };
-        node.insert(Camera3dBundle {
-            projection,
-            transform,
-            camera: Camera {
-                is_active: !*active_camera_found,
+                },
                 ..Default::default()
-            },
-            ..Default::default()
-        });
+            });
 
-        *active_camera_found = true;
+            *active_camera_found = true;
+        }
     }
 
     // Map node index to entity
@@ -935,140 +977,144 @@ fn load_node(
     let mut morph_weights = None;
 
     node.with_children(|parent| {
-        if let Some(mesh) = gltf_node.mesh() {
-            // append primitives
-            for primitive in mesh.primitives() {
-                let material = primitive.material();
-                let material_label = material_label(&material, is_scale_inverted);
+        if settings.load_meshes {
+            if let Some(mesh) = gltf_node.mesh() {
+                // append primitives
+                for primitive in mesh.primitives() {
+                    let material = primitive.material();
+                    let material_label = material_label(&material, is_scale_inverted);
 
-                // This will make sure we load the default material now since it would not have been
-                // added when iterating over all the gltf materials (since the default material is
-                // not explicitly listed in the gltf).
-                // It also ensures an inverted scale copy is instantiated if required.
-                if !root_load_context.has_labeled_asset(&material_label)
-                    && !load_context.has_labeled_asset(&material_label)
-                {
-                    load_material(&material, load_context, is_scale_inverted);
-                }
-
-                let primitive_label = primitive_label(&mesh, &primitive);
-                let bounds = primitive.bounding_box();
-
-                let mut mesh_entity = parent.spawn(PbrBundle {
-                    // TODO: handle missing label handle errors here?
-                    mesh: load_context.get_label_handle(&primitive_label),
-                    material: load_context.get_label_handle(&material_label),
-                    ..Default::default()
-                });
-                let target_count = primitive.morph_targets().len();
-                if target_count != 0 {
-                    let weights = match mesh.weights() {
-                        Some(weights) => weights.to_vec(),
-                        None => vec![0.0; target_count],
-                    };
-
-                    if morph_weights.is_none() {
-                        morph_weights = Some(weights.clone());
+                    // This will make sure we load the default material now since it would not have been
+                    // added when iterating over all the gltf materials (since the default material is
+                    // not explicitly listed in the gltf).
+                    // It also ensures an inverted scale copy is instantiated if required.
+                    if !root_load_context.has_labeled_asset(&material_label)
+                        && !load_context.has_labeled_asset(&material_label)
+                    {
+                        load_material(&material, load_context, is_scale_inverted);
                     }
 
-                    // unwrap: the parent's call to `MeshMorphWeights::new`
-                    // means this code doesn't run if it returns an `Err`.
-                    // According to https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets
-                    // they should all have the same length.
-                    // > All morph target accessors MUST have the same count as
-                    // > the accessors of the original primitive.
-                    mesh_entity.insert(MeshMorphWeights::new(weights).unwrap());
-                }
-                mesh_entity.insert(Aabb::from_min_max(
-                    Vec3::from_slice(&bounds.min),
-                    Vec3::from_slice(&bounds.max),
-                ));
+                    let primitive_label = primitive_label(&mesh, &primitive);
+                    let bounds = primitive.bounding_box();
 
-                if let Some(extras) = primitive.extras() {
-                    mesh_entity.insert(GltfExtras {
-                        value: extras.get().to_string(),
+                    let mut mesh_entity = parent.spawn(PbrBundle {
+                        // TODO: handle missing label handle errors here?
+                        mesh: load_context.get_label_handle(&primitive_label),
+                        material: load_context.get_label_handle(&material_label),
+                        ..Default::default()
                     });
-                }
+                    let target_count = primitive.morph_targets().len();
+                    if target_count != 0 {
+                        let weights = match mesh.weights() {
+                            Some(weights) => weights.to_vec(),
+                            None => vec![0.0; target_count],
+                        };
 
-                mesh_entity.insert(Name::new(primitive_name(&mesh, &primitive)));
-                // Mark for adding skinned mesh
-                if let Some(skin) = gltf_node.skin() {
-                    entity_to_skin_index_map.insert(mesh_entity.id(), skin.index());
+                        if morph_weights.is_none() {
+                            morph_weights = Some(weights.clone());
+                        }
+
+                        // unwrap: the parent's call to `MeshMorphWeights::new`
+                        // means this code doesn't run if it returns an `Err`.
+                        // According to https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#morph-targets
+                        // they should all have the same length.
+                        // > All morph target accessors MUST have the same count as
+                        // > the accessors of the original primitive.
+                        mesh_entity.insert(MeshMorphWeights::new(weights).unwrap());
+                    }
+                    mesh_entity.insert(Aabb::from_min_max(
+                        Vec3::from_slice(&bounds.min),
+                        Vec3::from_slice(&bounds.max),
+                    ));
+
+                    if let Some(extras) = primitive.extras() {
+                        mesh_entity.insert(GltfExtras {
+                            value: extras.get().to_string(),
+                        });
+                    }
+
+                    mesh_entity.insert(Name::new(primitive_name(&mesh, &primitive)));
+                    // Mark for adding skinned mesh
+                    if let Some(skin) = gltf_node.skin() {
+                        entity_to_skin_index_map.insert(mesh_entity.id(), skin.index());
+                    }
                 }
             }
         }
 
-        if let Some(light) = gltf_node.light() {
-            match light.kind() {
-                gltf::khr_lights_punctual::Kind::Directional => {
-                    let mut entity = parent.spawn(DirectionalLightBundle {
-                        directional_light: DirectionalLight {
-                            color: Color::rgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for directional
-                            // lights in lux (lm/m^2) which is what we need.
-                            illuminance: light.intensity(),
+        if settings.load_lights {
+            if let Some(light) = gltf_node.light() {
+                match light.kind() {
+                    gltf::khr_lights_punctual::Kind::Directional => {
+                        let mut entity = parent.spawn(DirectionalLightBundle {
+                            directional_light: DirectionalLight {
+                                color: Color::rgb_from_array(light.color()),
+                                // NOTE: KHR_punctual_lights defines the intensity units for directional
+                                // lights in lux (lm/m^2) which is what we need.
+                                illuminance: light.intensity(),
+                                ..Default::default()
+                            },
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    });
-                    if let Some(name) = light.name() {
-                        entity.insert(Name::new(name.to_string()));
-                    }
-                    if let Some(extras) = light.extras() {
-                        entity.insert(GltfExtras {
-                            value: extras.get().to_string(),
                         });
+                        if let Some(name) = light.name() {
+                            entity.insert(Name::new(name.to_string()));
+                        }
+                        if let Some(extras) = light.extras() {
+                            entity.insert(GltfExtras {
+                                value: extras.get().to_string(),
+                            });
+                        }
                     }
-                }
-                gltf::khr_lights_punctual::Kind::Point => {
-                    let mut entity = parent.spawn(PointLightBundle {
-                        point_light: PointLight {
-                            color: Color::rgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for point lights in
-                            // candela (lm/sr) which is luminous intensity and we need luminous power.
-                            // For a point light, luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * std::f32::consts::PI * 4.0,
-                            range: light.range().unwrap_or(20.0),
-                            radius: 0.0,
+                    gltf::khr_lights_punctual::Kind::Point => {
+                        let mut entity = parent.spawn(PointLightBundle {
+                            point_light: PointLight {
+                                color: Color::rgb_from_array(light.color()),
+                                // NOTE: KHR_punctual_lights defines the intensity units for point lights in
+                                // candela (lm/sr) which is luminous intensity and we need luminous power.
+                                // For a point light, luminous power = 4 * pi * luminous intensity
+                                intensity: light.intensity() * std::f32::consts::PI * 4.0,
+                                range: light.range().unwrap_or(20.0),
+                                radius: 0.0,
+                                ..Default::default()
+                            },
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    });
-                    if let Some(name) = light.name() {
-                        entity.insert(Name::new(name.to_string()));
-                    }
-                    if let Some(extras) = light.extras() {
-                        entity.insert(GltfExtras {
-                            value: extras.get().to_string(),
                         });
+                        if let Some(name) = light.name() {
+                            entity.insert(Name::new(name.to_string()));
+                        }
+                        if let Some(extras) = light.extras() {
+                            entity.insert(GltfExtras {
+                                value: extras.get().to_string(),
+                            });
+                        }
                     }
-                }
-                gltf::khr_lights_punctual::Kind::Spot {
-                    inner_cone_angle,
-                    outer_cone_angle,
-                } => {
-                    let mut entity = parent.spawn(SpotLightBundle {
-                        spot_light: SpotLight {
-                            color: Color::rgb_from_array(light.color()),
-                            // NOTE: KHR_punctual_lights defines the intensity units for spot lights in
-                            // candela (lm/sr) which is luminous intensity and we need luminous power.
-                            // For a spot light, we map luminous power = 4 * pi * luminous intensity
-                            intensity: light.intensity() * std::f32::consts::PI * 4.0,
-                            range: light.range().unwrap_or(20.0),
-                            radius: light.range().unwrap_or(0.0),
-                            inner_angle: inner_cone_angle,
-                            outer_angle: outer_cone_angle,
+                    gltf::khr_lights_punctual::Kind::Spot {
+                        inner_cone_angle,
+                        outer_cone_angle,
+                    } => {
+                        let mut entity = parent.spawn(SpotLightBundle {
+                            spot_light: SpotLight {
+                                color: Color::rgb_from_array(light.color()),
+                                // NOTE: KHR_punctual_lights defines the intensity units for spot lights in
+                                // candela (lm/sr) which is luminous intensity and we need luminous power.
+                                // For a spot light, we map luminous power = 4 * pi * luminous intensity
+                                intensity: light.intensity() * std::f32::consts::PI * 4.0,
+                                range: light.range().unwrap_or(20.0),
+                                radius: light.range().unwrap_or(0.0),
+                                inner_angle: inner_cone_angle,
+                                outer_angle: outer_cone_angle,
+                                ..Default::default()
+                            },
                             ..Default::default()
-                        },
-                        ..Default::default()
-                    });
-                    if let Some(name) = light.name() {
-                        entity.insert(Name::new(name.to_string()));
-                    }
-                    if let Some(extras) = light.extras() {
-                        entity.insert(GltfExtras {
-                            value: extras.get().to_string(),
                         });
+                        if let Some(name) = light.name() {
+                            entity.insert(Name::new(name.to_string()));
+                        }
+                        if let Some(extras) = light.extras() {
+                            entity.insert(GltfExtras {
+                                value: extras.get().to_string(),
+                            });
+                        }
                     }
                 }
             }
@@ -1081,6 +1127,7 @@ fn load_node(
                 parent,
                 root_load_context,
                 load_context,
+                settings,
                 node_index_to_entity_map,
                 entity_to_skin_index_map,
                 active_camera_found,
@@ -1092,10 +1139,12 @@ fn load_node(
         }
     });
 
-    if let (Some(mesh), Some(weights)) = (gltf_node.mesh(), morph_weights) {
-        let primitive_label = mesh.primitives().next().map(|p| primitive_label(&mesh, &p));
-        let first_mesh = primitive_label.map(|label| load_context.get_label_handle(label));
-        node.insert(MorphWeights::new(weights, first_mesh)?);
+    if settings.load_meshes {
+        if let (Some(mesh), Some(weights)) = (gltf_node.mesh(), morph_weights) {
+            let primitive_label = mesh.primitives().next().map(|p| primitive_label(&mesh, &p));
+            let first_mesh = primitive_label.map(|label| load_context.get_label_handle(label));
+            node.insert(MorphWeights::new(weights, first_mesh)?);
+        }
     }
 
     if let Some(err) = gltf_error {


### PR DESCRIPTION
# Objective

- Fixes #10806

## Solution

Replaced `new` and `index` methods for both `TableRow` and `TableId` with `from_*` and `as_*` methods. These remove the need to perform casting at call sites, reducing the total number of casts in the Bevy codebase. Within these methods, an appropriate `debug_assertion` ensures the cast will behave in an expected manner (no wrapping, etc.). I am using a `debug_assertion` instead of an `assert` to reduce any possible runtime overhead, however minimal. This choice is something I am open to changing (or leaving up to another PR) if anyone has any strong arguments for it.

---

## Changelog

- `ComponentSparseSet::sparse` stores a `TableRow` instead of a `u32` (private change)
- Replaced `TableRow::new` and `TableRow::index` methods with `TableRow::from_*` and `TableRow::as_*`, with `debug_assertions` protecting any internal casting.
- Replaced `TableId::new` and `TableId::index` methods with `TableId::from_*` and `TableId::as_*`, with `debug_assertions` protecting any internal casting.
- All `TableId` methods are now `const`

## Migration Guide

- `TableRow::new` -> `TableRow::from_usize`
- `TableRow::index` -> `TableRow::as_usize`
- `TableId::new` -> `TableId::from_usize`
- `TableId::index` -> `TableId::as_usize`

---

## Notes

I have chosen to remove the `index` and `new` methods for the following chain of reasoning:

- Across the codebase, `new` was called with a mixture of `u32` and `usize` values. Likewise for `index`.
- Choosing `new` to either be `usize` or `u32` would break half of these call-sites, requiring `as` casting at the site.
- Adding a second method `new_u32` or `new_usize` avoids the above, bu looks visually inconsistent.
- Therefore, they should be replaced with `from_*` and `as_*` methods instead.

Worth noting is that by updating `ComponentSparseSet`, there are now zero instances of interacting with the inner value of `TableRow` as a `u32`, it is exclusively used as a `usize` value (due to interactions with methods like `len` and slice indexing). I have left the `as_u32` and `from_u32` methods as the "proper" constructors/getters.