### PR TITLE
Allow UiMaterial to provide a custom draw function

### DIFF
--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -100,8 +100,8 @@ where
 
 #[derive(Resource)]
 pub struct UiMaterialMeta<M: UiMaterial> {
-    vertices: BufferVec<UiMaterialVertex>,
-    view_bind_group: Option<BindGroup>,
+    pub vertices: BufferVec<UiMaterialVertex>,
+    pub view_bind_group: Option<BindGroup>,
     marker: PhantomData<M>,
 }
 
@@ -731,7 +731,7 @@ pub fn queue_ui_material_nodes<M: UiMaterial>(
 ) where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    let draw_function = draw_functions.read().id::<DrawUiMaterial<M>>();
+    let draw_function = M::draw_function_id(draw_functions.into_inner());
 
     for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
         let Some(material) = render_materials.get(&extracted_uinode.material) else {

--- a/crates/bevy_ui/src/ui_material.rs
+++ b/crates/bevy_ui/src/ui_material.rs
@@ -113,8 +113,8 @@ pub trait UiMaterial: AsBindGroup + Asset + Clone + Sized {
 
     /// Returns the ID of the registered draw function that will be used for this material.
     ///
-    /// The default draw function for UI is [DrawUiMaterial]. If you use a custom draw function,
-    /// make sure to adapt the pipeline descriptor in [UiMaterial::specialize()]
+    /// The default draw function for UI is [`DrawUiMaterial`]. If you use a custom draw function,
+    /// make sure to adapt the pipeline descriptor in [`UiMaterial::specialize()`]
     fn draw_function_id<P: PhaseItem>(draw_functions: &DrawFunctions<P>) -> DrawFunctionId {
         draw_functions.read().id::<DrawUiMaterial<Self>>()
     }

--- a/crates/bevy_ui/src/ui_material.rs
+++ b/crates/bevy_ui/src/ui_material.rs
@@ -1,7 +1,10 @@
 use std::hash::Hash;
 
 use bevy_asset::Asset;
-use bevy_render::{render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef}, render_phase::{DrawFunctionId, PhaseItem, DrawFunctions}};
+use bevy_render::{
+    render_phase::{DrawFunctionId, DrawFunctions, PhaseItem},
+    render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef},
+};
 
 use crate::DrawUiMaterial;
 
@@ -109,7 +112,7 @@ pub trait UiMaterial: AsBindGroup + Asset + Clone + Sized {
     fn specialize(descriptor: &mut RenderPipelineDescriptor, key: UiMaterialKey<Self>) {}
 
     /// Returns the ID of the registered draw function that will be used for this material.
-    /// 
+    ///
     /// The default draw function for UI is [DrawUiMaterial]. If you use a custom draw function,
     /// make sure to adapt the pipeline descriptor in [UiMaterial::specialize()]
     fn draw_function_id<P: PhaseItem>(draw_functions: &DrawFunctions<P>) -> DrawFunctionId {

--- a/crates/bevy_ui/src/ui_material.rs
+++ b/crates/bevy_ui/src/ui_material.rs
@@ -1,7 +1,9 @@
 use std::hash::Hash;
 
 use bevy_asset::Asset;
-use bevy_render::render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef};
+use bevy_render::{render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef}, render_phase::{DrawFunctionId, PhaseItem, DrawFunctions}};
+
+use crate::DrawUiMaterial;
 
 /// Materials are used alongside [`UiMaterialPlugin`](crate::UiMaterialPipeline) and [`MaterialNodeBundle`](crate::prelude::MaterialNodeBundle)
 /// to spawn entities that are rendered with a specific [`UiMaterial`] type. They serve as an easy to use high level
@@ -105,6 +107,14 @@ pub trait UiMaterial: AsBindGroup + Asset + Clone + Sized {
     #[allow(unused_variables)]
     #[inline]
     fn specialize(descriptor: &mut RenderPipelineDescriptor, key: UiMaterialKey<Self>) {}
+
+    /// Returns the ID of the registered draw function that will be used for this material.
+    /// 
+    /// The default draw function for UI is [DrawUiMaterial]. If you use a custom draw function,
+    /// make sure to adapt the pipeline descriptor in [UiMaterial::specialize()]
+    fn draw_function_id<P: PhaseItem>(draw_functions: &DrawFunctions<P>) -> DrawFunctionId {
+        draw_functions.read().id::<DrawUiMaterial<Self>>()
+    }
 }
 
 pub struct UiMaterialKey<M: UiMaterial> {


### PR DESCRIPTION
# Objective

The `UiMaterial` abstraction can currently be used to have custom shaders and one custom bind group. By allowing the material to select its own draw function, it could freely define all ~~bind groups and~~ vertex buffers, while reusing all the parts of the pipeline that it wants. (Edit: adding more bind groups will require more than this PR)

## Solution

Add a method to the `UiMaterial` trait that returns the draw function's ID, with a default implementation.

Make the members of `UiMaterialMeta` public so that they can be reused.

---

## Changelog

Allow `UiMaterial`s to provide a custom draw function