### PR TITLE
Add support for updating the tracing subscriber in LogPlugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1014,6 +1014,16 @@ category = "Application"
 wasm = true
 
 [[example]]
+name = "log_layers"
+path = "examples/app/log_layers.rs"
+
+[package.metadata.example.log_layers]
+name = "Log layers"
+description = "Illustrate how to add custom log layers"
+category = "Application"
+wasm = false
+
+[[example]]
 name = "plugin"
 path = "examples/app/plugin.rs"
 doc-scrape-examples = true

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -36,13 +36,12 @@ pub use bevy_utils::tracing::{
 };
 pub use tracing_subscriber;
 
-
 use bevy_app::{App, Plugin};
+use bevy_utils::tracing::Subscriber;
 use tracing_log::LogTracer;
 #[cfg(feature = "tracing-chrome")]
 use tracing_subscriber::fmt::{format::DefaultFields, FormattedFields};
 use tracing_subscriber::{prelude::*, registry::Registry, EnvFilter};
-use bevy_utils::tracing::Subscriber;
 
 /// Adds logging to Apps. This plugin is part of the `DefaultPlugins`. Adding
 /// this plugin will setup a collector appropriate to your target platform:
@@ -103,7 +102,7 @@ pub struct LogPlugin {
 
     /// Optionally apply extra transformations to the tracing subscriber.
     /// For example add [`Layers`](tracing_subscriber::layer::Layer)
-    pub update_subscriber: Option<fn(BoxedSubscriber) -> BoxedSubscriber>
+    pub update_subscriber: Option<fn(BoxedSubscriber) -> BoxedSubscriber>,
 }
 
 /// Alias for a boxed [`tracing_subscriber::Subscriber`].

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -105,7 +105,7 @@ pub struct LogPlugin {
     pub update_subscriber: Option<fn(BoxedSubscriber) -> BoxedSubscriber>,
 }
 
-/// Alias for a boxed [`tracing_subscriber::Subscriber`].
+/// Alias for a boxed [`Subscriber`].
 pub type BoxedSubscriber = Box<dyn Subscriber + Send + Sync + 'static>;
 
 impl Default for LogPlugin {

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -106,6 +106,7 @@ pub struct LogPlugin {
     pub update_subscriber: Option<fn(BoxedSubscriber) -> BoxedSubscriber>
 }
 
+/// Alias for a boxed [`tracing_subscriber::Subscriber`].
 pub type BoxedSubscriber = Box<dyn Subscriber + Send + Sync + 'static>;
 
 impl Default for LogPlugin {

--- a/examples/README.md
+++ b/examples/README.md
@@ -169,6 +169,7 @@ Example | Description
 [Empty](../examples/app/empty.rs) | An empty application (does nothing)
 [Empty with Defaults](../examples/app/empty_defaults.rs) | An empty application with default plugins
 [Headless](../examples/app/headless.rs) | An application that runs without default plugins
+[Log layers](../examples/app/log_layers.rs) | Illustrate how to add custom log layers
 [Logs](../examples/app/logs.rs) | Illustrate how to use generate log output
 [No Renderer](../examples/app/no_renderer.rs) | An application that runs with default plugins and displays an empty window, but without an actual renderer
 [Plugin](../examples/app/plugin.rs) | Demonstrates the creation and registration of a custom plugin

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,0 +1,50 @@
+//! This example illustrates how to add custom log layers in bevy.
+
+use bevy::{
+    log::tracing_subscriber::{Layer, layer::SubscriberExt},
+    prelude::*,
+    utils::tracing::{Subscriber},
+};
+use bevy_internal::log::{BoxedSubscriber};
+
+struct CustomLayer;
+
+impl<S: Subscriber> Layer<S> for CustomLayer {
+    fn on_event(
+        &self,
+        event: &bevy::utils::tracing::Event<'_>,
+        _ctx: bevy::log::tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        println!("Got event!");
+        println!("  level={:?}", event.metadata().level());
+        println!("  target={:?}", event.metadata().target());
+        println!("  name={:?}", event.metadata().name());
+    }
+}
+
+fn update_subscriber(subscriber: BoxedSubscriber) -> BoxedSubscriber {
+    Box::new(subscriber.with(CustomLayer))
+}
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(bevy::log::LogPlugin {
+            update_subscriber: Some(update_subscriber),
+            ..default()
+        }))
+        .add_systems(Update, log_system)
+        .run();
+}
+
+
+
+fn log_system() {
+    // here is how you write new logs at each "log level" (in "most import" to
+    // "least important" order)
+    error!("something failed");
+    warn!("something bad happened that isn't a failure, but thats worth calling out");
+    info!("helpful information that is worth printing by default");
+    debug!("helpful for debugging");
+    trace!("very noisy");
+}
+

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,11 +1,11 @@
 //! This example illustrates how to add custom log layers in bevy.
 
 use bevy::{
+    log::BoxedSubscriber,
     log::tracing_subscriber::{Layer, layer::SubscriberExt},
     prelude::*,
     utils::tracing::{Subscriber},
 };
-use bevy_internal::log::{BoxedSubscriber};
 
 struct CustomLayer;
 

--- a/examples/app/log_layers.rs
+++ b/examples/app/log_layers.rs
@@ -1,10 +1,10 @@
 //! This example illustrates how to add custom log layers in bevy.
 
 use bevy::{
+    log::tracing_subscriber::{layer::SubscriberExt, Layer},
     log::BoxedSubscriber,
-    log::tracing_subscriber::{Layer, layer::SubscriberExt},
     prelude::*,
-    utils::tracing::{Subscriber},
+    utils::tracing::Subscriber,
 };
 
 struct CustomLayer;
@@ -36,8 +36,6 @@ fn main() {
         .run();
 }
 
-
-
 fn log_system() {
     // here is how you write new logs at each "log level" (in "most import" to
     // "least important" order)
@@ -47,4 +45,3 @@ fn log_system() {
     debug!("helpful for debugging");
     trace!("very noisy");
 }
-

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -14,6 +14,7 @@ fn main() {
         .add_plugins(LogPlugin {
             level: Level::TRACE,
             filter: "".to_string(),
+            ..default()
         })
         .add_systems(
             Update,


### PR DESCRIPTION
# Objective

This PR is heavily inspired by https://github.com/bevyengine/bevy/pull/7682
It aims to solve the same problem: allowing the user to extend the tracing subscriber with extra layers.

(in my case, I'd like to use `use metrics_tracing_context::{MetricsLayer, TracingContextLayer};`)


## Solution

I'm proposing a different api where the user has the opportunity to take the existing `subscriber` and apply any transformations on it.

---

## Changelog

- Added a `update_subscriber` option on the `LogPlugin` that lets the user modify the `subscriber` (for example to extend it with more tracing `Layers`


## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- Added a new field `update_subscriber` in the `LogPlugin`