### PR TITLE
Remove references to specific projects from the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,14 +86,6 @@ fn main(){
 
 Bevy can be built just fine using default configuration on stable Rust. However for really fast iterative compiles, you should enable the "fast compiles" setup by [following the instructions here](http://bevyengine.org/learn/book/getting-started/setup/).
 
-## Libraries Used
-
-Bevy is only possible because of the hard work put into these foundational technologies:
-
-* [wgpu](https://wgpu.rs/): modern / low-level / cross-platform graphics library based on the [WebGPU](https://gpuweb.github.io/gpuweb/) API.
-* [glam-rs](https://github.com/bitshifter/glam-rs): a simple and fast 3D math library for games and graphics
-* [winit](https://github.com/rust-windowing/winit): cross-platform window creation and management in Rust
-
 ## [Bevy Cargo Features][cargo_features]
 
 This [list][cargo_features] outlines the different cargo features supported by Bevy. These allow you to customize the Bevy feature set for your use-case.
@@ -106,9 +98,11 @@ Plugins are very welcome to extend Bevy's features. [Guidelines][plugin_guidelin
 
 [plugin_guidelines]: docs/plugins_guidelines.md
 
-## Thanks and Alternatives
+## Thanks
 
-Additionally, we would like to thank the [Amethyst](https://github.com/amethyst/amethyst), [macroquad](https://github.com/not-fl3/macroquad), [coffee](https://github.com/hecrj/coffee), [ggez](https://github.com/ggez/ggez), [Fyrox](https://github.com/FyroxEngine/Fyrox), and [Piston](https://github.com/PistonDevelopers/piston) projects for providing solid examples of game engine development in Rust. If you are looking for a Rust game engine, it is worth considering all of your options. Each engine has different design goals, and some will likely resonate with you more than others.
+Bevy is the result of the hard work of many people. A huge thanks to all Bevy contributors, the many open source projects that have come before us, the Rust gamedev ecosystem, and the many libraries we build on.
+
+A huge thanks to Bevy's [generous sponsors](https://bevyengine.org). Bevy will always be free and open source, but it isn't free to make. Please consider [sponsoring our work](https://bevyengine.org/community/donate/) if you like what we're building.
 
 <!-- This next line need to stay exactly as is. It is required for BrowserStack sponsorship. -->
 This project is tested with BrowserStack.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Plugins are very welcome to extend Bevy's features. [Guidelines][plugin_guidelin
 
 ## Thanks
 
-Bevy is the result of the hard work of many people. A huge thanks to all Bevy contributors, the many open source projects that have come before us, the Rust gamedev ecosystem, and the many libraries we build on.
+Bevy is the result of the hard work of many people. A huge thanks to all Bevy contributors, the many open source projects that have come before us, the [Rust gamedev ecosystem](https://arewegameyet.rs/), and the many libraries we build on.
 
 A huge thanks to Bevy's [generous sponsors](https://bevyengine.org). Bevy will always be free and open source, but it isn't free to make. Please consider [sponsoring our work](https://bevyengine.org/community/donate/) if you like what we're building.
 


### PR DESCRIPTION
Bevy builds on a ton of different libraries. Choosing who gets "prime real estate" in the readme is hard / political. Closing that can of worms makes a lot of sense to me.

I have also removed the "alternatives" section for similar reasons. There are a number of engines/libs that aren't credited there, some of those listed no longer exist / aren't maintained, and it isn't really our job to be the canonical source.  Each alternative listed is a soft endorsement of the project (and the reverse is true for projects we don't include). Again, closing this can of worms feels like the right call.