### PR TITLE
Add `Ray2d` and `Ray3d` primitives

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -2,7 +2,7 @@ use super::{Primitive2d, WindingOrder};
 use crate::Vec2;
 
 /// A normalized vector pointing in a direction in 2D space
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Direction2d(Vec2);
 
 impl From<Vec2> for Direction2d {
@@ -62,6 +62,32 @@ pub struct Plane2d {
     pub normal: Direction2d,
 }
 impl Primitive2d for Plane2d {}
+
+/// An infinite half-line starting at `origin` and going in `direction` in 2D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ray2d {
+    /// The origin of the ray.
+    pub origin: Vec2,
+    /// The direction of the ray.
+    pub direction: Direction2d,
+}
+
+impl Ray2d {
+    /// Create a new `Ray2d` from a given origin and direction
+    #[inline]
+    pub fn new(origin: Vec2, direction: Vec2) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
+    #[inline]
+    pub fn get_point(&self, distance: f32) -> Vec2 {
+        self.origin + *self.direction * distance
+    }
+}
 
 /// An infinite line along a direction in 2D space.
 ///
@@ -322,6 +348,13 @@ impl RegularPolygon {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ray_math() {
+        let ray = Ray2d::new(Vec2::ZERO, Vec2::Y * 10.0);
+        assert_eq!(*ray.direction, Vec2::Y, "ray direction is not normalized");
+        assert_eq!(ray.get_point(2.0), Vec2::Y * 2.0);
+    }
 
     #[test]
     fn triangle_winding_order() {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -2,7 +2,7 @@ use super::Primitive3d;
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Direction3d(Vec3);
 
 impl From<Vec3> for Direction3d {
@@ -42,6 +42,32 @@ pub struct Plane3d {
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
+
+/// An infinite half-line starting at `origin` and going in `direction` in 3D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ray3d {
+    /// The origin of the ray.
+    pub origin: Vec3,
+    /// The direction of the ray.
+    pub direction: Direction3d,
+}
+
+impl Ray3d {
+    /// Create a new `Ray3d` from a given origin and direction
+    #[inline]
+    pub fn new(origin: Vec3, direction: Vec3) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
+    #[inline]
+    pub fn get_point(&self, distance: f32) -> Vec3 {
+        self.origin + *self.direction * distance
+    }
+}
 
 /// An infinite line along a direction in 3D space.
 ///
@@ -329,5 +355,17 @@ impl Torus {
             std::cmp::Ordering::Equal => TorusKind::Horn,
             std::cmp::Ordering::Less => TorusKind::Spindle,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ray_math() {
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::Z * 10.0);
+        assert_eq!(*ray.direction, Vec3::Z, "ray direction is not normalized");
+        assert_eq!(ray.get_point(2.0), Vec3::Z * 2.0);
     }
 }


### PR DESCRIPTION
# Objective

Add 2D and 3D geometric primitives for rays as defined in the [Primitive Shapes RFC](https://github.com/bevyengine/rfcs/blob/main/rfcs/12-primitive-shapes.md), continuing the work on #10572.

## Solution

Add `Ray2d` and `Ray3d`, defined like this:

```rust
/// An infinite half-line starting at `origin` and going in `direction` in 2D space.
#[derive(Clone, Copy, Debug, PartialEq)]
pub struct Ray2d {
    /// The origin of the ray.
    pub origin: Vec2,
    /// The direction of the ray.
    pub direction: Direction2d,
}
```

```rust
/// An infinite half-line starting at `origin` and going in `direction` in 3D space.
#[derive(Clone, Copy, Debug, PartialEq)]
pub struct Ray3d {
    /// The origin of the ray.
    pub origin: Vec3,
    /// The direction of the ray.
    pub direction: Direction3d,
}
```

They are mostly a copy of the existing `Ray` struct, but I decided not to add `intersect_plane` because ray intersections are out of scope for this PR and the method would be better handled by a general raycasting trait that is implemented for each shape separately.

## Questions

Should the old `Ray` be removed already? It could be replaced by `Ray3d`, but it would be a breaking change as `intersect_plane` wouldn't exist anymore (for now). I could also just add `intersect_plane` if people find it to be important to have.