### PR TITLE
sprite material v1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -444,6 +444,17 @@ category = "2D Rendering"
 wasm = true
 
 [[example]]
+name = "sprite_material"
+path = "examples/2d/sprite_material.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.sprite_material]
+name = "Sprite Material"
+description = "Renders a sprite with custom material"
+category = "2D Rendering"
+wasm = true
+
+[[example]]
 name = "sprite_sheet"
 path = "examples/2d/sprite_sheet.rs"
 doc-scrape-examples = true

--- a/assets/shaders/grayscale.wgsl
+++ b/assets/shaders/grayscale.wgsl
@@ -1,0 +1,20 @@
+// This shader draws a circle with a given input color
+#import bevy_sprite::sprite_vertex_output::SpriteVertexOutput
+
+// struct CustomSpriteMaterial {
+//     @location(0) color: vec4<f32>
+// }
+
+@group(1) @binding(0) var sprite_texture: texture_2d<f32>;
+@group(1) @binding(1) var sprite_sampler: sampler;
+
+// @group(2) @binding(0)
+// var<uniform> input: CustomSpriteMaterial;
+
+@fragment
+fn fragment(in: SpriteVertexOutput) -> @location(0) vec4<f32> {
+    var color = textureSample(sprite_texture, sprite_sampler, in.uv);
+    // let g = input.color.r * color.r + input.color.g * color.g + input.color.b * color.b;
+    let g = 0.21 * color.r + 0.72 * color.g + 0.07 * color.b;
+    return vec4<f32>(g, g, g, color.a);
+}

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -1,6 +1,6 @@
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite,
+    Sprite, SpriteMaterial, SpriteWithMaterial, TextureAtlasSpriteWithMaterial,
 };
 use bevy_asset::Handle;
 use bevy_ecs::bundle::Bundle;
@@ -40,4 +40,64 @@ pub struct SpriteSheetBundle {
     pub inherited_visibility: InheritedVisibility,
     /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
     pub view_visibility: ViewVisibility,
+}
+
+#[derive(Bundle, Clone)]
+pub struct SpriteWithMaterialBundle<M: SpriteMaterial> {
+    pub sprite: SpriteWithMaterial<M>,
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    pub texture: Handle<Image>,
+    /// User indication of whether an entity is visible
+    pub visibility: Visibility,
+    /// Inherited visibility of an entity.
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+}
+
+impl<M: SpriteMaterial> Default for SpriteWithMaterialBundle<M> {
+    fn default() -> Self {
+        Self {
+            sprite: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            texture: Default::default(),
+            visibility: Default::default(),
+            inherited_visibility: Default::default(),
+            view_visibility: Default::default(),
+        }
+    }
+}
+
+/// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
+/// to as a `TextureAtlas`)
+#[derive(Bundle, Clone)]
+pub struct SpriteSheetWithMaterialBundle<M: SpriteMaterial> {
+    /// The specific sprite from the texture atlas to be drawn, defaulting to the sprite at index 0.
+    pub sprite: TextureAtlasSpriteWithMaterial<M>,
+    /// A handle to the texture atlas that holds the sprite images
+    pub texture_atlas: Handle<TextureAtlas>,
+    /// Data pertaining to how the sprite is drawn on the screen
+    pub transform: Transform,
+    pub global_transform: GlobalTransform,
+    /// User indication of whether an entity is visible
+    pub visibility: Visibility,
+    pub inherited_visibility: InheritedVisibility,
+    /// Algorithmically-computed indication of whether an entity is visible and should be extracted for rendering
+    pub view_visibility: ViewVisibility,
+}
+
+impl<M: SpriteMaterial> Default for SpriteSheetWithMaterialBundle<M> {
+    fn default() -> Self {
+        Self {
+            sprite: Default::default(),
+            texture_atlas: Default::default(),
+            transform: Default::default(),
+            global_transform: Default::default(),
+            visibility: Default::default(),
+            inherited_visibility: Default::default(),
+            view_visibility: Default::default(),
+        }
+    }
 }

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -3,6 +3,7 @@ mod dynamic_texture_atlas_builder;
 mod mesh2d;
 mod render;
 mod sprite;
+mod sprite_material;
 mod texture_atlas;
 mod texture_atlas_builder;
 
@@ -25,7 +26,8 @@ pub use render::*;
 pub use sprite::*;
 pub use texture_atlas::*;
 pub use texture_atlas_builder::*;
-
+pub use sprite_material::*;
+pub use sprite_material_pipeline::SpriteMaterialPlugin;
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetApp, Assets, Handle};
 use bevy_core_pipeline::core_2d::Transparent2d;

--- a/crates/bevy_sprite/src/render/sprite_material.wgsl
+++ b/crates/bevy_sprite/src/render/sprite_material.wgsl
@@ -1,0 +1,45 @@
+
+#import bevy_render::{
+    maths::affine_to_square,
+    view::View,
+}
+#import bevy_sprite::sprite_vertex_output::SpriteVertexOutput
+
+@group(0) @binding(0) var<uniform> view: View;
+
+struct VertexInput {
+    @builtin(vertex_index) index: u32,
+    // NOTE: Instance-rate vertex buffer members prefixed with i_
+    // NOTE: i_model_transpose_colN are the 3 columns of a 3x4 matrix that is the transpose of the
+    // affine 4x3 model matrix.
+    @location(0) i_model_transpose_col0: vec4<f32>,
+    @location(1) i_model_transpose_col1: vec4<f32>,
+    @location(2) i_model_transpose_col2: vec4<f32>,
+    @location(3) i_uv_offset_scale: vec4<f32>,
+}
+
+@vertex
+fn vertex(in: VertexInput) -> SpriteVertexOutput {
+    var out: SpriteVertexOutput;
+
+    let vertex_position = vec3<f32>(
+        f32(in.index & 0x1u),
+        f32((in.index & 0x2u) >> 1u),
+        0.0
+    );
+
+    out.clip_position = view.view_proj * affine_to_square(mat3x4<f32>(
+        in.i_model_transpose_col0,
+        in.i_model_transpose_col1,
+        in.i_model_transpose_col2,
+    )) * vec4<f32>(vertex_position, 1.0);
+    out.uv = vec2<f32>(vertex_position.xy) * in.i_uv_offset_scale.zw + in.i_uv_offset_scale.xy;
+
+    return out;
+}
+
+
+@fragment
+fn fragment(in: SpriteVertexOutput) -> @location(0) vec4<f32> {
+    return vec4<f32>(1.0);
+}

--- a/crates/bevy_sprite/src/render/sprite_material_pipeline.rs
+++ b/crates/bevy_sprite/src/render/sprite_material_pipeline.rs
@@ -1,62 +1,154 @@
-pub mod sprite_material_pipeline;
+use std::{hash::Hash, marker::PhantomData, ops::Range};
 
-use std::ops::Range;
-
-use crate::{
-    texture_atlas::{TextureAtlas, TextureAtlasSprite},
-    Sprite, SPRITE_SHADER_HANDLE,
-};
-use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
+use bevy_app::{App, Plugin};
+use bevy_asset::{load_internal_asset, AssetApp, AssetEvent, AssetId, AssetServer, Assets, Handle};
 use bevy_core_pipeline::{
     core_2d::Transparent2d,
     tonemapping::{DebandDither, Tonemapping},
 };
+use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
-    prelude::*,
-    system::{lifetimeless::*, SystemParamItem, SystemState},
+    component::Component,
+    entity::Entity,
+    event::EventReader,
+    query::ROQueryItem,
+    schedule::IntoSystemConfigs,
+    system::{
+        lifetimeless::{Read, SRes},
+        Commands, Local, Query, Res, ResMut, Resource, SystemParamItem, SystemState,
+    },
+    world::{FromWorld, World},
 };
 use bevy_math::{Affine3A, Quat, Rect, Vec2, Vec4};
 use bevy_render::{
-    color::Color,
+    extract_component::ExtractComponentPlugin,
     render_asset::RenderAssets,
     render_phase::{
-        DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult, RenderPhase, SetItemPipeline,
-        TrackedRenderPass,
+        AddRenderCommand, DrawFunctions, PhaseItem, RenderCommand, RenderCommandResult,
+        RenderPhase, SetItemPipeline, TrackedRenderPass,
     },
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
-        BindGroupEntries, *,
+        AsBindGroupError, BindGroup, BindGroupEntries, BindGroupLayout, BindGroupLayoutEntries,
+        BlendState, BufferUsages, BufferVec, ColorTargetState, ColorWrites, FragmentState,
+        FrontFace, ImageDataLayout, IndexFormat, MultisampleState, OwnedBindingResource,
+        PipelineCache, PolygonMode, PrimitiveState, PrimitiveTopology, RenderPipelineDescriptor,
+        SamplerBindingType, Shader, ShaderRef, ShaderStages, SpecializedRenderPipeline,
+        SpecializedRenderPipelines, TextureFormat, TextureSampleType, TextureViewDescriptor,
+        VertexAttribute, VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
     },
     renderer::{RenderDevice, RenderQueue},
     texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
+        BevyDefault, DefaultImageSampler, FallbackImage, GpuImage, Image, ImageSampler,
+        TextureFormatPixelInfo,
     },
     view::{
         ExtractedView, Msaa, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms,
         ViewVisibility, VisibleEntities,
     },
-    Extract,
+    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::GlobalTransform;
-use bevy_utils::{EntityHashMap, FloatOrd, HashMap};
+use bevy_utils::{EntityHashMap, FloatOrd, HashMap, HashSet};
 use bytemuck::{Pod, Zeroable};
 use fixedbitset::FixedBitSet;
 
-#[derive(Resource)]
-pub struct SpritePipeline {
-    view_layout: BindGroupLayout,
-    material_layout: BindGroupLayout,
-    pub dummy_white_gpu_image: GpuImage,
+use crate::{
+    sprite_material::{SpriteMaterial, SpriteMaterialKey},
+    ImageBindGroups, SpriteAssetEvents, SpritePipelineKey, SpriteSystem, SpriteWithMaterial,
+    TextureAtlas, TextureAtlasSpriteWithMaterial,
+};
+
+pub const SPRITE_MATERIAL_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(270703992682389545502295514338037592175);
+
+const SPRITE_VERTEX_OUTPUT_SHADER_HANDLE: Handle<Shader> =
+    Handle::weak_from_u128(246203203511184449262050107766870630166);
+
+/// Adds the necessary ECS resources and render logic to enable rendering entities using the given
+/// [`UiMaterial`] asset type (which includes [`UiMaterial`] types).
+pub struct SpriteMaterialPlugin<M: SpriteMaterial>(PhantomData<M>);
+
+impl<M: SpriteMaterial> Default for SpriteMaterialPlugin<M> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
 }
 
-impl FromWorld for SpritePipeline {
+impl<M: SpriteMaterial> Plugin for SpriteMaterialPlugin<M>
+where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(
+            app,
+            SPRITE_VERTEX_OUTPUT_SHADER_HANDLE,
+            "sprite_vertex_output.wgsl",
+            Shader::from_wgsl
+        );
+        load_internal_asset!(
+            app,
+            SPRITE_MATERIAL_SHADER_HANDLE,
+            "sprite_material.wgsl",
+            Shader::from_wgsl
+        );
+        app.init_asset::<M>()
+            .add_plugins(ExtractComponentPlugin::<Handle<M>>::extract_visible());
+
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app
+                .add_render_command::<Transparent2d, DrawSprite<M>>()
+                .init_resource::<ExtractedSpriteMaterials<M>>()
+                .init_resource::<ExtractedSpriteWithMaterials<M>>()
+                .init_resource::<RenderMaterials<M>>()
+                .init_resource::<SpriteMeta<M>>()
+                .init_resource::<SpecializedRenderPipelines<SpriteMaterialPipeline<M>>>()
+                .add_systems(
+                    ExtractSchedule,
+                    (
+                        extract_sprite_materials::<M>,
+                        extract_sprite_with_materials::<M>.in_set(SpriteSystem::ExtractSprites),
+                    ),
+                )
+                .add_systems(
+                    Render,
+                    (
+                        prepare_sprite_materials::<M>.in_set(RenderSet::PrepareAssets),
+                        queue_sprites::<M>.in_set(RenderSet::Queue),
+                        prepare_sprites::<M>.in_set(RenderSet::PrepareBindGroups),
+                    ),
+                );
+        }
+    }
+
+    fn finish(&self, app: &mut App) {
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.init_resource::<SpriteMaterialPipeline<M>>();
+        }
+    }
+}
+
+#[derive(Resource)]
+pub struct SpriteMaterialPipeline<M: SpriteMaterial> {
+    pub view_layout: BindGroupLayout,
+    pub texture_layout: BindGroupLayout,
+    pub material_layout: BindGroupLayout,
+    pub vertex_shader: Option<Handle<Shader>>,
+    pub fragment_shader: Option<Handle<Shader>>,
+    pub dummy_white_gpu_image: GpuImage,
+    marker: PhantomData<M>,
+}
+
+impl<M: SpriteMaterial> FromWorld for SpriteMaterialPipeline<M> {
     fn from_world(world: &mut World) -> Self {
         let mut system_state: SystemState<(
+            Res<AssetServer>,
             Res<RenderDevice>,
             Res<DefaultImageSampler>,
             Res<RenderQueue>,
         )> = SystemState::new(world);
-        let (render_device, default_sampler, render_queue) = system_state.get_mut(world);
+        let (asset_server, render_device, default_sampler, render_queue) =
+            system_state.get_mut(world);
 
         let view_layout = render_device.create_bind_group_layout(
             "sprite_view_layout",
@@ -66,8 +158,8 @@ impl FromWorld for SpritePipeline {
             ),
         );
 
-        let material_layout = render_device.create_bind_group_layout(
-            "sprite_material_layout",
+        let texture_layout = render_device.create_bind_group_layout(
+            "sprite_texture_layout",
             &BindGroupLayoutEntries::sequential(
                 ShaderStages::FRAGMENT,
                 (
@@ -76,6 +168,9 @@ impl FromWorld for SpritePipeline {
                 ),
             ),
         );
+
+        let material_layout = M::bind_group_layout(&render_device);
+
         let dummy_white_gpu_image = {
             let image = Image::default();
             let texture = render_device.create_texture(&image.texture_descriptor);
@@ -108,85 +203,43 @@ impl FromWorld for SpritePipeline {
             }
         };
 
-        SpritePipeline {
+        SpriteMaterialPipeline {
             view_layout,
+            texture_layout,
             material_layout,
             dummy_white_gpu_image,
+            vertex_shader: match M::vertex_shader() {
+                ShaderRef::Default => None,
+                ShaderRef::Handle(handle) => Some(handle),
+                ShaderRef::Path(path) => Some(asset_server.load(path)),
+            },
+            fragment_shader: match M::fragment_shader() {
+                ShaderRef::Default => None,
+                ShaderRef::Handle(handle) => Some(handle),
+                ShaderRef::Path(path) => Some(asset_server.load(path)),
+            },
+            marker: PhantomData,
         }
     }
 }
 
-bitflags::bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-    #[repr(transparent)]
-    // NOTE: Apparently quadro drivers support up to 64x MSAA.
-    // MSAA uses the highest 3 bits for the MSAA log2(sample count) to support up to 128x MSAA.
-    pub struct SpritePipelineKey: u32 {
-        const NONE                              = 0;
-        const COLORED                           = (1 << 0);
-        const HDR                               = (1 << 1);
-        const TONEMAP_IN_SHADER                 = (1 << 2);
-        const DEBAND_DITHER                     = (1 << 3);
-        const MSAA_RESERVED_BITS                = Self::MSAA_MASK_BITS << Self::MSAA_SHIFT_BITS;
-        const TONEMAP_METHOD_RESERVED_BITS      = Self::TONEMAP_METHOD_MASK_BITS << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_NONE               = 0 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_REINHARD           = 1 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_REINHARD_LUMINANCE = 2 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_ACES_FITTED        = 3 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_AGX                = 4 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_SOMEWHAT_BORING_DISPLAY_TRANSFORM = 5 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_TONY_MC_MAPFACE    = 6 << Self::TONEMAP_METHOD_SHIFT_BITS;
-        const TONEMAP_METHOD_BLENDER_FILMIC     = 7 << Self::TONEMAP_METHOD_SHIFT_BITS;
-    }
-}
-
-impl SpritePipelineKey {
-    const MSAA_MASK_BITS: u32 = 0b111;
-    const MSAA_SHIFT_BITS: u32 = 32 - Self::MSAA_MASK_BITS.count_ones();
-    const TONEMAP_METHOD_MASK_BITS: u32 = 0b111;
-    const TONEMAP_METHOD_SHIFT_BITS: u32 =
-        Self::MSAA_SHIFT_BITS - Self::TONEMAP_METHOD_MASK_BITS.count_ones();
-
-    #[inline]
-    pub const fn from_msaa_samples(msaa_samples: u32) -> Self {
-        let msaa_bits =
-            (msaa_samples.trailing_zeros() & Self::MSAA_MASK_BITS) << Self::MSAA_SHIFT_BITS;
-        Self::from_bits_retain(msaa_bits)
-    }
-
-    #[inline]
-    pub const fn msaa_samples(&self) -> u32 {
-        1 << ((self.bits() >> Self::MSAA_SHIFT_BITS) & Self::MSAA_MASK_BITS)
-    }
-
-    #[inline]
-    pub const fn from_colored(colored: bool) -> Self {
-        if colored {
-            SpritePipelineKey::COLORED
-        } else {
-            SpritePipelineKey::NONE
-        }
-    }
-
-    #[inline]
-    pub const fn from_hdr(hdr: bool) -> Self {
-        if hdr {
-            SpritePipelineKey::HDR
-        } else {
-            SpritePipelineKey::NONE
-        }
-    }
-}
-
-impl SpecializedRenderPipeline for SpritePipeline {
-    type Key = SpritePipelineKey;
+impl<M: SpriteMaterial> SpecializedRenderPipeline for SpriteMaterialPipeline<M>
+where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
+    type Key = SpriteMaterialKey<M>;
 
     fn specialize(&self, key: Self::Key) -> RenderPipelineDescriptor {
         let mut shader_defs = Vec::new();
-        if key.contains(SpritePipelineKey::TONEMAP_IN_SHADER) {
+        if key
+            .pipeline_key
+            .contains(SpritePipelineKey::TONEMAP_IN_SHADER)
+        {
             shader_defs.push("TONEMAP_IN_SHADER".into());
 
-            let method = key.intersection(SpritePipelineKey::TONEMAP_METHOD_RESERVED_BITS);
+            let method = key
+                .pipeline_key
+                .intersection(SpritePipelineKey::TONEMAP_METHOD_RESERVED_BITS);
 
             if method == SpritePipelineKey::TONEMAP_METHOD_NONE {
                 shader_defs.push("TONEMAP_METHOD_NONE".into());
@@ -208,18 +261,18 @@ impl SpecializedRenderPipeline for SpritePipeline {
             }
 
             // Debanding is tied to tonemapping in the shader, cannot run without it.
-            if key.contains(SpritePipelineKey::DEBAND_DITHER) {
+            if key.pipeline_key.contains(SpritePipelineKey::DEBAND_DITHER) {
                 shader_defs.push("DEBAND_DITHER".into());
             }
         }
 
-        let format = match key.contains(SpritePipelineKey::HDR) {
+        let format = match key.pipeline_key.contains(SpritePipelineKey::HDR) {
             true => ViewTarget::TEXTURE_FORMAT_HDR,
             false => TextureFormat::bevy_default(),
         };
 
         let instance_rate_vertex_buffer_layout = VertexBufferLayout {
-            array_stride: 80,
+            array_stride: 64,
             step_mode: VertexStepMode::Instance,
             attributes: vec![
                 // @location(0) i_model_transpose_col0: vec4<f32>,
@@ -240,30 +293,23 @@ impl SpecializedRenderPipeline for SpritePipeline {
                     offset: 32,
                     shader_location: 2,
                 },
-                // @location(3) i_color: vec4<f32>,
+                // @location(3) i_uv_offset_scale: vec4<f32>,
                 VertexAttribute {
                     format: VertexFormat::Float32x4,
                     offset: 48,
                     shader_location: 3,
                 },
-                // @location(4) i_uv_offset_scale: vec4<f32>,
-                VertexAttribute {
-                    format: VertexFormat::Float32x4,
-                    offset: 64,
-                    shader_location: 4,
-                },
             ],
         };
-
-        RenderPipelineDescriptor {
+        let mut descriptor = RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: SPRITE_SHADER_HANDLE,
+                shader: SPRITE_MATERIAL_SHADER_HANDLE,
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![instance_rate_vertex_buffer_layout],
             },
             fragment: Some(FragmentState {
-                shader: SPRITE_SHADER_HANDLE,
+                shader: SPRITE_MATERIAL_SHADER_HANDLE,
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {
@@ -272,7 +318,7 @@ impl SpecializedRenderPipeline for SpritePipeline {
                     write_mask: ColorWrites::ALL,
                 })],
             }),
-            layout: vec![self.view_layout.clone(), self.material_layout.clone()],
+            layout: vec![],
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: None,
@@ -284,19 +330,37 @@ impl SpecializedRenderPipeline for SpritePipeline {
             },
             depth_stencil: None,
             multisample: MultisampleState {
-                count: key.msaa_samples(),
+                count: key.pipeline_key.msaa_samples(),
                 mask: !0,
                 alpha_to_coverage_enabled: false,
             },
-            label: Some("sprite_pipeline".into()),
+            label: Some("sprite_material_pipeline".into()),
             push_constant_ranges: Vec::new(),
+        };
+
+        if let Some(vertex_shader) = &self.vertex_shader {
+            descriptor.vertex.shader = vertex_shader.clone();
         }
+
+        if let Some(fragment_shader) = &self.fragment_shader {
+            descriptor.fragment.as_mut().unwrap().shader = fragment_shader.clone();
+        }
+
+        descriptor.layout = vec![
+            self.view_layout.clone(),
+            self.texture_layout.clone(),
+            self.material_layout.clone(),
+        ];
+
+        M::specialize(&mut descriptor, key);
+
+        descriptor
     }
 }
 
-pub struct ExtractedSprite {
+pub struct ExtractedSpriteWithMaterial<M: SpriteMaterial> {
     pub transform: GlobalTransform,
-    pub color: Color,
+    pub material: AssetId<M>,
     /// Select an area of the texture
     pub rect: Option<Rect>,
     /// Change the on-screen size of the sprite
@@ -312,36 +376,27 @@ pub struct ExtractedSprite {
     pub original_entity: Option<Entity>,
 }
 
-#[derive(Resource, Default)]
-pub struct ExtractedSprites {
-    pub sprites: EntityHashMap<Entity, ExtractedSprite>,
+#[derive(Resource)]
+pub struct ExtractedSpriteWithMaterials<M: SpriteMaterial> {
+    pub sprites: EntityHashMap<Entity, ExtractedSpriteWithMaterial<M>>,
 }
 
-#[derive(Resource, Default)]
-pub struct SpriteAssetEvents {
-    pub images: Vec<AssetEvent<Image>>,
-}
-
-pub fn extract_sprite_events(
-    mut events: ResMut<SpriteAssetEvents>,
-    mut image_events: Extract<EventReader<AssetEvent<Image>>>,
-) {
-    let SpriteAssetEvents { ref mut images } = *events;
-    images.clear();
-
-    for event in image_events.read() {
-        images.push(*event);
+impl<M: SpriteMaterial> Default for ExtractedSpriteWithMaterials<M> {
+    fn default() -> Self {
+        Self {
+            sprites: Default::default(),
+        }
     }
 }
 
-pub fn extract_sprites(
-    mut extracted_sprites: ResMut<ExtractedSprites>,
+pub fn extract_sprite_with_materials<M: SpriteMaterial>(
+    mut extracted_sprite_with_materials: ResMut<ExtractedSpriteWithMaterials<M>>,
     texture_atlases: Extract<Res<Assets<TextureAtlas>>>,
-    sprite_query: Extract<
+    sprite_with_material_query: Extract<
         Query<(
             Entity,
             &ViewVisibility,
-            &Sprite,
+            &SpriteWithMaterial<M>,
             &GlobalTransform,
             &Handle<Image>,
         )>,
@@ -350,23 +405,23 @@ pub fn extract_sprites(
         Query<(
             Entity,
             &ViewVisibility,
-            &TextureAtlasSprite,
+            &TextureAtlasSpriteWithMaterial<M>,
             &GlobalTransform,
             &Handle<TextureAtlas>,
         )>,
     >,
 ) {
-    extracted_sprites.sprites.clear();
+    extracted_sprite_with_materials.sprites.clear();
 
-    for (entity, view_visibility, sprite, transform, handle) in sprite_query.iter() {
+    for (entity, view_visibility, sprite, transform, handle) in sprite_with_material_query.iter() {
         if !view_visibility.get() {
             continue;
         }
         // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
-        extracted_sprites.sprites.insert(
+        extracted_sprite_with_materials.sprites.insert(
             entity,
-            ExtractedSprite {
-                color: sprite.color,
+            ExtractedSpriteWithMaterial {
+                material: sprite.material.id(),
                 transform: *transform,
                 rect: sprite.rect,
                 // Pass the custom size
@@ -398,10 +453,10 @@ pub fn extract_sprites(
                         )
                     }),
             );
-            extracted_sprites.sprites.insert(
+            extracted_sprite_with_materials.sprites.insert(
                 entity,
-                ExtractedSprite {
-                    color: atlas_sprite.color,
+                ExtractedSpriteWithMaterial {
+                    material: atlas_sprite.material.id(),
                     transform: *transform,
                     // Select the area in the texture atlas
                     rect,
@@ -423,13 +478,12 @@ pub fn extract_sprites(
 struct SpriteInstance {
     // Affine 4x3 transposed to 3x4
     pub i_model_transpose: [Vec4; 3],
-    pub i_color: [f32; 4],
     pub i_uv_offset_scale: [f32; 4],
 }
 
 impl SpriteInstance {
     #[inline]
-    fn from(transform: &Affine3A, color: &Color, uv_offset_scale: &Vec4) -> Self {
+    fn from(transform: &Affine3A, uv_offset_scale: &Vec4) -> Self {
         let transpose_model_3x3 = transform.matrix3.transpose();
         Self {
             i_model_transpose: [
@@ -437,49 +491,46 @@ impl SpriteInstance {
                 transpose_model_3x3.y_axis.extend(transform.translation.y),
                 transpose_model_3x3.z_axis.extend(transform.translation.z),
             ],
-            i_color: color.as_linear_rgba_f32(),
             i_uv_offset_scale: uv_offset_scale.to_array(),
         }
     }
 }
 
 #[derive(Resource)]
-pub struct SpriteMeta {
+pub struct SpriteMeta<M: SpriteMaterial> {
     view_bind_group: Option<BindGroup>,
     sprite_index_buffer: BufferVec<u32>,
     sprite_instance_buffer: BufferVec<SpriteInstance>,
+    marker: PhantomData<M>,
 }
 
-impl Default for SpriteMeta {
+impl<M: SpriteMaterial> Default for SpriteMeta<M> {
     fn default() -> Self {
         Self {
             view_bind_group: None,
             sprite_index_buffer: BufferVec::<u32>::new(BufferUsages::INDEX),
             sprite_instance_buffer: BufferVec::<SpriteInstance>::new(BufferUsages::VERTEX),
+            marker: PhantomData,
         }
     }
 }
 
 #[derive(Component, PartialEq, Eq, Clone)]
-pub struct SpriteBatch {
+pub struct SpriteBatch<M: SpriteMaterial> {
     image_handle_id: AssetId<Image>,
+    material_handle_id: AssetId<M>,
     range: Range<u32>,
 }
 
-#[derive(Resource, Default)]
-pub struct ImageBindGroups {
-    values: HashMap<AssetId<Image>, BindGroup>,
-}
-
 #[allow(clippy::too_many_arguments)]
-pub fn queue_sprites(
+pub fn queue_sprites<M: SpriteMaterial>(
     mut view_entities: Local<FixedBitSet>,
     draw_functions: Res<DrawFunctions<Transparent2d>>,
-    sprite_pipeline: Res<SpritePipeline>,
-    mut pipelines: ResMut<SpecializedRenderPipelines<SpritePipeline>>,
+    sprite_pipeline: Res<SpriteMaterialPipeline<M>>,
+    mut pipelines: ResMut<SpecializedRenderPipelines<SpriteMaterialPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
     msaa: Res<Msaa>,
-    extracted_sprites: Res<ExtractedSprites>,
+    extracted_sprites: Res<ExtractedSpriteWithMaterials<M>>,
     mut views: Query<(
         &mut RenderPhase<Transparent2d>,
         &VisibleEntities,
@@ -487,10 +538,13 @@ pub fn queue_sprites(
         Option<&Tonemapping>,
         Option<&DebandDither>,
     )>,
-) {
+    render_materials: Res<RenderMaterials<M>>,
+) where
+    M::Data: PartialEq + Eq + Hash + Clone,
+{
     let msaa_key = SpritePipelineKey::from_msaa_samples(msaa.samples());
 
-    let draw_sprite_function = draw_functions.read().id::<DrawSprite>();
+    let draw_sprite_function = draw_functions.read().id::<DrawSprite<M>>();
 
     for (mut transparent_phase, visible_entities, view, tonemapping, dither) in &mut views {
         let mut view_key = SpritePipelineKey::from_hdr(view.hdr) | msaa_key;
@@ -518,17 +572,6 @@ pub fn queue_sprites(
             }
         }
 
-        let pipeline = pipelines.specialize(
-            &pipeline_cache,
-            &sprite_pipeline,
-            view_key | SpritePipelineKey::from_colored(false),
-        );
-        let colored_pipeline = pipelines.specialize(
-            &pipeline_cache,
-            &sprite_pipeline,
-            view_key | SpritePipelineKey::from_colored(true),
-        );
-
         view_entities.clear();
         view_entities.extend(visible_entities.entities.iter().map(|e| e.index() as usize));
 
@@ -537,6 +580,19 @@ pub fn queue_sprites(
             .reserve(extracted_sprites.sprites.len());
 
         for (entity, extracted_sprite) in extracted_sprites.sprites.iter() {
+            let Some(material) = render_materials.get(&extracted_sprite.material) else {
+                continue;
+            };
+
+            let pipeline = pipelines.specialize(
+                &pipeline_cache,
+                &sprite_pipeline,
+                SpriteMaterialKey {
+                    pipeline_key: view_key,
+                    bind_group_data: material.key.clone(),
+                },
+            );
+
             let index = extracted_sprite.original_entity.unwrap_or(*entity).index();
 
             if !view_entities.contains(index as usize) {
@@ -547,45 +603,34 @@ pub fn queue_sprites(
             let sort_key = FloatOrd(extracted_sprite.transform.translation().z);
 
             // Add the item to the render phase
-            if extracted_sprite.color != Color::WHITE {
-                transparent_phase.add(Transparent2d {
-                    draw_function: draw_sprite_function,
-                    pipeline: colored_pipeline,
-                    entity: *entity,
-                    sort_key,
-                    // batch_range and dynamic_offset will be calculated in prepare_sprites
-                    batch_range: 0..0,
-                    dynamic_offset: None,
-                });
-            } else {
-                transparent_phase.add(Transparent2d {
-                    draw_function: draw_sprite_function,
-                    pipeline,
-                    entity: *entity,
-                    sort_key,
-                    // batch_range and dynamic_offset will be calculated in prepare_sprites
-                    batch_range: 0..0,
-                    dynamic_offset: None,
-                });
-            }
+            transparent_phase.add(Transparent2d {
+                draw_function: draw_sprite_function,
+                pipeline,
+                entity: *entity,
+                sort_key,
+                // batch_range and dynamic_offset will be calculated in prepare_sprites
+                batch_range: 0..0,
+                dynamic_offset: None,
+            });
         }
     }
 }
 
 #[allow(clippy::too_many_arguments)]
-pub fn prepare_sprites(
+pub fn prepare_sprites<M: SpriteMaterial>(
     mut commands: Commands,
     mut previous_len: Local<usize>,
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
-    mut sprite_meta: ResMut<SpriteMeta>,
+    mut sprite_meta: ResMut<SpriteMeta<M>>,
     view_uniforms: Res<ViewUniforms>,
-    sprite_pipeline: Res<SpritePipeline>,
+    sprite_material_pipeline: Res<SpriteMaterialPipeline<M>>,
     mut image_bind_groups: ResMut<ImageBindGroups>,
     gpu_images: Res<RenderAssets<Image>>,
-    extracted_sprites: Res<ExtractedSprites>,
+    extracted_sprite_with_materials: Res<ExtractedSpriteWithMaterials<M>>,
     mut phases: Query<&mut RenderPhase<Transparent2d>>,
     events: Res<SpriteAssetEvents>,
+    render_materials: Res<RenderMaterials<M>>,
 ) {
     // If an image has changed, the GpuImage has (probably) changed
     for event in &events.images {
@@ -600,14 +645,14 @@ pub fn prepare_sprites(
     }
 
     if let Some(view_binding) = view_uniforms.uniforms.binding() {
-        let mut batches: Vec<(Entity, SpriteBatch)> = Vec::with_capacity(*previous_len);
+        let mut batches: Vec<(Entity, SpriteBatch<M>)> = Vec::with_capacity(*previous_len);
 
         // Clear the sprite instances
         sprite_meta.sprite_instance_buffer.clear();
 
         sprite_meta.view_bind_group = Some(render_device.create_bind_group(
             "sprite_view_bind_group",
-            &sprite_pipeline.view_layout,
+            &sprite_material_pipeline.view_layout,
             &BindGroupEntries::single(view_binding),
         ));
 
@@ -620,17 +665,20 @@ pub fn prepare_sprites(
             let mut batch_item_index = 0;
             let mut batch_image_size = Vec2::ZERO;
             let mut batch_image_handle = AssetId::invalid();
-
+            let mut batch_material_handle = AssetId::invalid();
             // Iterate through the phase items and detect when successive sprites that can be batched.
             // Spawn an entity with a `SpriteBatch` component for each possible batch.
             // Compatible items share the same entity.
             for item_index in 0..transparent_phase.items.len() {
                 let item = &transparent_phase.items[item_index];
-                let Some(extracted_sprite) = extracted_sprites.sprites.get(&item.entity) else {
+                let Some(extracted_sprite) =
+                    extracted_sprite_with_materials.sprites.get(&item.entity)
+                else {
                     // If there is a phase item that is not a sprite, then we must start a new
                     // batch to draw the other phase item(s) and to respect draw order. This can be
                     // done by invalidating the batch_image_handle
                     batch_image_handle = AssetId::invalid();
+                    batch_material_handle = AssetId::invalid();
                     continue;
                 };
 
@@ -647,14 +695,23 @@ pub fn prepare_sprites(
                         .entry(batch_image_handle)
                         .or_insert_with(|| {
                             render_device.create_bind_group(
-                                "sprite_material_bind_group",
-                                &sprite_pipeline.material_layout,
+                                "sprite_texture_bind_group",
+                                &sprite_material_pipeline.texture_layout,
                                 &BindGroupEntries::sequential((
                                     &gpu_image.texture_view,
                                     &gpu_image.sampler,
                                 )),
                             )
                         });
+                }
+
+                let batch_material_changed = batch_material_handle != extracted_sprite.material;
+                if batch_material_changed {
+                    if render_materials.get(&extracted_sprite.material).is_none() {
+                        continue;
+                    };
+
+                    batch_material_handle = extracted_sprite.material;
                 }
 
                 // By default, the size of the quad is the size of the texture
@@ -700,19 +757,16 @@ pub fn prepare_sprites(
                 // Store the vertex data and add the item to the render phase
                 sprite_meta
                     .sprite_instance_buffer
-                    .push(SpriteInstance::from(
-                        &transform,
-                        &extracted_sprite.color,
-                        &uv_offset_scale,
-                    ));
+                    .push(SpriteInstance::from(&transform, &uv_offset_scale));
 
-                if batch_image_changed {
+                if batch_image_changed || batch_material_changed {
                     batch_item_index = item_index;
 
                     batches.push((
                         item.entity,
                         SpriteBatch {
                             image_handle_id: batch_image_handle,
+                            material_handle_id: batch_material_handle,
                             range: index..index,
                         },
                     ));
@@ -758,16 +812,19 @@ pub fn prepare_sprites(
     }
 }
 
-pub type DrawSprite = (
+pub type DrawSprite<M> = (
     SetItemPipeline,
-    SetSpriteViewBindGroup<0>,
-    SetSpriteTextureBindGroup<1>,
-    DrawSpriteBatch,
+    SetSpriteViewBindGroup<M, 0>,
+    SetSpriteTextureBindGroup<M, 1>,
+    SetSpriteMaterialBindGroup<M, 2>,
+    DrawSpriteBatch<M>,
 );
 
-pub struct SetSpriteViewBindGroup<const I: usize>;
-impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteViewBindGroup<I> {
-    type Param = SRes<SpriteMeta>;
+pub struct SetSpriteViewBindGroup<M: SpriteMaterial, const I: usize>(PhantomData<M>);
+impl<P: PhaseItem, M: SpriteMaterial, const I: usize> RenderCommand<P>
+    for SetSpriteViewBindGroup<M, I>
+{
+    type Param = SRes<SpriteMeta<M>>;
     type ViewWorldQuery = Read<ViewUniformOffset>;
     type ItemWorldQuery = ();
 
@@ -786,16 +843,18 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteViewBindGroup<I
         RenderCommandResult::Success
     }
 }
-pub struct SetSpriteTextureBindGroup<const I: usize>;
-impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGroup<I> {
+pub struct SetSpriteTextureBindGroup<M: SpriteMaterial, const I: usize>(PhantomData<M>);
+impl<P: PhaseItem, M: SpriteMaterial, const I: usize> RenderCommand<P>
+    for SetSpriteTextureBindGroup<M, I>
+{
     type Param = SRes<ImageBindGroups>;
     type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<SpriteBatch>;
+    type ItemWorldQuery = Read<SpriteBatch<M>>;
 
     fn render<'w>(
         _item: &P,
         _view: (),
-        batch: &'_ SpriteBatch,
+        batch: &'_ SpriteBatch<M>,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -813,16 +872,42 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
     }
 }
 
-pub struct DrawSpriteBatch;
-impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
-    type Param = SRes<SpriteMeta>;
+pub struct SetSpriteMaterialBindGroup<M: SpriteMaterial, const I: usize>(PhantomData<M>);
+impl<P: PhaseItem, M: SpriteMaterial, const I: usize> RenderCommand<P>
+    for SetSpriteMaterialBindGroup<M, I>
+{
+    type Param = SRes<RenderMaterials<M>>;
     type ViewWorldQuery = ();
-    type ItemWorldQuery = Read<SpriteBatch>;
+    type ItemWorldQuery = Read<SpriteBatch<M>>;
 
     fn render<'w>(
         _item: &P,
         _view: (),
-        batch: &'_ SpriteBatch,
+        material_handle: ROQueryItem<'_, Self::ItemWorldQuery>,
+        materials: SystemParamItem<'w, '_, Self::Param>,
+        pass: &mut TrackedRenderPass<'w>,
+    ) -> RenderCommandResult {
+        let Some(material) = materials
+            .into_inner()
+            .get(&material_handle.material_handle_id)
+        else {
+            return RenderCommandResult::Failure;
+        };
+        pass.set_bind_group(I, &material.bind_group, &[]);
+        RenderCommandResult::Success
+    }
+}
+
+pub struct DrawSpriteBatch<M: SpriteMaterial>(PhantomData<M>);
+impl<P: PhaseItem, M: SpriteMaterial> RenderCommand<P> for DrawSpriteBatch<M> {
+    type Param = SRes<SpriteMeta<M>>;
+    type ViewWorldQuery = ();
+    type ItemWorldQuery = Read<SpriteBatch<M>>;
+
+    fn render<'w>(
+        _item: &P,
+        _view: (),
+        batch: &'_ SpriteBatch<M>,
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,
         pass: &mut TrackedRenderPass<'w>,
     ) -> RenderCommandResult {
@@ -843,4 +928,150 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
         pass.draw_indexed(0..6, 0, batch.range.clone());
         RenderCommandResult::Success
     }
+}
+
+#[derive(Resource, Deref, DerefMut)]
+pub struct RenderMaterials<T: SpriteMaterial>(HashMap<AssetId<T>, PreparedSpriteMaterial<T>>);
+
+impl<T: SpriteMaterial> Default for RenderMaterials<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+pub struct PreparedSpriteMaterial<T: SpriteMaterial> {
+    pub bindings: Vec<(u32, OwnedBindingResource)>,
+    pub bind_group: BindGroup,
+    pub key: T::Data,
+}
+
+#[derive(Resource)]
+pub struct ExtractedSpriteMaterials<M: SpriteMaterial> {
+    extracted: Vec<(AssetId<M>, M)>,
+    removed: Vec<AssetId<M>>,
+}
+
+impl<M: SpriteMaterial> Default for ExtractedSpriteMaterials<M> {
+    fn default() -> Self {
+        Self {
+            extracted: Default::default(),
+            removed: Default::default(),
+        }
+    }
+}
+
+pub fn extract_sprite_materials<M: SpriteMaterial>(
+    mut commands: Commands,
+    mut events: Extract<EventReader<AssetEvent<M>>>,
+    assets: Extract<Res<Assets<M>>>,
+) {
+    let mut changed_assets = HashSet::default();
+    let mut removed = Vec::new();
+    for event in events.read() {
+        match event {
+            AssetEvent::Added { id } | AssetEvent::Modified { id } => {
+                changed_assets.insert(*id);
+            }
+            AssetEvent::Removed { id } => {
+                changed_assets.remove(id);
+                removed.push(*id);
+            }
+            AssetEvent::LoadedWithDependencies { .. } => {
+                // not implemented
+            }
+        }
+    }
+
+    let mut extracted_assets = Vec::new();
+    for id in changed_assets.drain() {
+        if let Some(asset) = assets.get(id) {
+            extracted_assets.push((id, asset.clone()));
+        }
+    }
+
+    commands.insert_resource(ExtractedSpriteMaterials {
+        extracted: extracted_assets,
+        removed,
+    });
+}
+
+pub struct PrepareNextFrameMaterials<M: SpriteMaterial> {
+    assets: Vec<(AssetId<M>, M)>,
+}
+
+impl<M: SpriteMaterial> Default for PrepareNextFrameMaterials<M> {
+    fn default() -> Self {
+        Self {
+            assets: Default::default(),
+        }
+    }
+}
+
+pub fn prepare_sprite_materials<M: SpriteMaterial>(
+    mut prepare_next_frame: Local<PrepareNextFrameMaterials<M>>,
+    mut extracted_assets: ResMut<ExtractedSpriteMaterials<M>>,
+    mut render_materials: ResMut<RenderMaterials<M>>,
+    render_device: Res<RenderDevice>,
+    images: Res<RenderAssets<Image>>,
+    fallback_image: Res<FallbackImage>,
+    pipeline: Res<SpriteMaterialPipeline<M>>,
+) {
+    let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
+    for (id, material) in queued_assets {
+        match prepare_sprite_material(
+            &material,
+            &render_device,
+            &images,
+            &fallback_image,
+            &pipeline,
+        ) {
+            Ok(prepared_asset) => {
+                render_materials.insert(id, prepared_asset);
+            }
+            Err(AsBindGroupError::RetryNextUpdate) => {
+                prepare_next_frame.assets.push((id, material));
+            }
+        }
+    }
+
+    for removed in std::mem::take(&mut extracted_assets.removed) {
+        render_materials.remove(&removed);
+    }
+
+    for (handle, material) in std::mem::take(&mut extracted_assets.extracted) {
+        match prepare_sprite_material(
+            &material,
+            &render_device,
+            &images,
+            &fallback_image,
+            &pipeline,
+        ) {
+            Ok(prepared_asset) => {
+                render_materials.insert(handle, prepared_asset);
+            }
+            Err(AsBindGroupError::RetryNextUpdate) => {
+                prepare_next_frame.assets.push((handle, material));
+            }
+        }
+    }
+}
+
+fn prepare_sprite_material<M: SpriteMaterial>(
+    material: &M,
+    render_device: &RenderDevice,
+    images: &RenderAssets<Image>,
+    fallback_image: &Res<FallbackImage>,
+    pipeline: &SpriteMaterialPipeline<M>,
+) -> Result<PreparedSpriteMaterial<M>, AsBindGroupError> {
+    let prepared = material.as_bind_group(
+        &pipeline.material_layout,
+        render_device,
+        images,
+        fallback_image,
+    )?;
+    Ok(PreparedSpriteMaterial {
+        bindings: prepared.bindings,
+        bind_group: prepared.bind_group,
+        key: prepared.data,
+    })
 }

--- a/crates/bevy_sprite/src/render/sprite_vertex_output.wgsl
+++ b/crates/bevy_sprite/src/render/sprite_vertex_output.wgsl
@@ -1,0 +1,7 @@
+#define_import_path bevy_sprite::sprite_vertex_output
+
+// The Vertex output of the default vertex shader for the Sprite Material pipeline.
+struct SpriteVertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -1,7 +1,10 @@
+use bevy_asset::Handle;
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::color::Color;
+
+use crate::sprite_material::SpriteMaterial;
 
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default)]
@@ -21,6 +24,39 @@ pub struct Sprite {
     pub rect: Option<Rect>,
     /// [`Anchor`] point of the sprite in the world
     pub anchor: Anchor,
+}
+
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component, Default)]
+#[repr(C)]
+pub struct SpriteWithMaterial<M: SpriteMaterial> {
+    /// The sprite's material tint
+    pub material: Handle<M>,
+    /// Flip the sprite along the `X` axis
+    pub flip_x: bool,
+    /// Flip the sprite along the `Y` axis
+    pub flip_y: bool,
+    /// An optional custom size for the sprite that will be used when rendering, instead of the size
+    /// of the sprite's image
+    pub custom_size: Option<Vec2>,
+    /// An optional rectangle representing the region of the sprite's image to render, instead of
+    /// rendering the full image. This is an easy one-off alternative to using a texture atlas.
+    pub rect: Option<Rect>,
+    /// [`Anchor`] point of the sprite in the world
+    pub anchor: Anchor,
+}
+
+impl<M: SpriteMaterial> Default for SpriteWithMaterial<M> {
+    fn default() -> Self {
+        Self {
+            material: Default::default(),
+            flip_x: Default::default(),
+            flip_y: Default::default(),
+            custom_size: Default::default(),
+            rect: Default::default(),
+            anchor: Default::default(),
+        }
+    }
 }
 
 /// How a sprite is positioned relative to its [`Transform`](bevy_transform::components::Transform).

--- a/crates/bevy_sprite/src/sprite_material.rs
+++ b/crates/bevy_sprite/src/sprite_material.rs
@@ -1,0 +1,148 @@
+use std::hash::Hash;
+
+use bevy_asset::Asset;
+use bevy_render::render_resource::{AsBindGroup, RenderPipelineDescriptor, ShaderRef};
+
+use crate::SpritePipelineKey;
+
+/// Materials are used alongside [`UiMaterialPlugin`](crate::UiMaterialPipeline) and [`MaterialNodeBundle`](crate::prelude::MaterialNodeBundle)
+/// to spawn entities that are rendered with a specific [`UiMaterial`] type. They serve as an easy to use high level
+/// way to render `Node` entities with custom shader logic.
+///
+/// `UiMaterials` must implement [`AsBindGroup`] to define how data will be transferred to the GPU and bound in shaders.
+/// [`AsBindGroup`] can be derived, which makes generating bindings straightforward. See the [`AsBindGroup`] docs for details.
+///
+/// Materials must also implement [`Asset`] so they can be treated as such.
+///
+/// If you are only using the fragment shader, make sure your shader imports the `UiVertexOutput`
+/// from `bevy_ui::ui_vertex_output` and uses it as the input of your fragment shader like the
+/// example below does.
+///
+/// # Example
+///
+/// Here is a simple [`UiMaterial`] implementation. The [`AsBindGroup`] derive has many features. To see what else is available,
+/// check out the [`AsBindGroup`] documentation.
+/// ```
+/// # use bevy_ui::prelude::*;
+/// # use bevy_ecs::prelude::*;
+/// # use bevy_reflect::TypePath;
+/// # use bevy_render::{render_resource::{AsBindGroup, ShaderRef}, texture::Image, color::Color};
+/// # use bevy_asset::{Handle, AssetServer, Assets, Asset};
+///
+/// #[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
+/// pub struct CustomMaterial {
+///     // Uniform bindings must implement `ShaderType`, which will be used to convert the value to
+///     // its shader-compatible equivalent. Most core math types already implement `ShaderType`.
+///     #[uniform(0)]
+///     color: Color,
+///     // Images can be bound as textures in shaders. If the Image's sampler is also needed, just
+///     // add the sampler attribute with a different binding index.
+///     #[texture(1)]
+///     #[sampler(2)]
+///     color_texture: Handle<Image>,
+/// }
+///
+/// // All functions on `UiMaterial` have default impls. You only need to implement the
+/// // functions that are relevant for your material.
+/// impl UiMaterial for CustomMaterial {
+///     fn fragment_shader() -> ShaderRef {
+///         "shaders/custom_material.wgsl".into()
+///     }
+/// }
+///
+/// // Spawn an entity using `CustomMaterial`.
+/// fn setup(mut commands: Commands, mut materials: ResMut<Assets<CustomMaterial>>, asset_server: Res<AssetServer>) {
+///     commands.spawn(MaterialNodeBundle {
+///         style: Style {
+///             width: Val::Percent(100.0),
+///             ..Default::default()
+///         },
+///         material: materials.add(CustomMaterial {
+///             color: Color::RED,
+///             color_texture: asset_server.load("some_image.png"),
+///         }),
+///         ..Default::default()
+///     });
+/// }
+/// ```
+/// In WGSL shaders, the material's binding would look like this:
+///
+/// If you only use the fragment shader make sure to import `UiVertexOutput` from
+/// `bevy_ui::ui_vertex_output` in your wgsl shader.
+/// Also note that bind group 0 is always bound to the [`View Uniform`](bevy_render::view::ViewUniform)
+/// and the [`Globals Uniform`](bevy_render::globals::GlobalsUniform).
+///
+/// ```wgsl
+/// #import bevy_ui::ui_vertex_output UiVertexOutput
+///
+/// struct CustomMaterial {
+///     color: vec4<f32>,
+/// }
+///
+/// @group(1) @binding(0)
+/// var<uniform> material: CustomMaterial;
+/// @group(1) @binding(1)
+/// var color_texture: texture_2d<f32>;
+/// @group(1) @binding(2)
+/// var color_sampler: sampler;
+///
+/// @fragment
+/// fn fragment(in: UiVertexOutput) -> @location(0) vec4<f32> {
+///
+/// }
+/// ```
+pub trait SpriteMaterial: AsBindGroup + Asset + Clone + Sized {
+    /// Returns this materials vertex shader. If [`ShaderRef::Default`] is returned, the default UI
+    /// vertex shader will be used.
+    fn vertex_shader() -> ShaderRef {
+        ShaderRef::Default
+    }
+
+    /// Returns this materials fragment shader. If [`ShaderRef::Default`] is returned, the default
+    /// UI fragment shader will be used.
+    fn fragment_shader() -> ShaderRef {
+        ShaderRef::Default
+    }
+
+    #[allow(unused_variables)]
+    #[inline]
+    fn specialize(descriptor: &mut RenderPipelineDescriptor, key: SpriteMaterialKey<Self>) {}
+}
+
+pub struct SpriteMaterialKey<M: SpriteMaterial> {
+    pub pipeline_key: SpritePipelineKey,
+    pub bind_group_data: M::Data,
+}
+
+impl<M: SpriteMaterial> Eq for SpriteMaterialKey<M> where M::Data: PartialEq {}
+
+impl<M: SpriteMaterial> PartialEq for SpriteMaterialKey<M>
+where
+    M::Data: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.pipeline_key == other.pipeline_key && self.bind_group_data == other.bind_group_data
+    }
+}
+
+impl<M: SpriteMaterial> Clone for SpriteMaterialKey<M>
+where
+    M::Data: Clone,
+{
+    fn clone(&self) -> Self {
+        Self {
+            pipeline_key: self.pipeline_key.clone(),
+            bind_group_data: self.bind_group_data.clone(),
+        }
+    }
+}
+
+impl<M: SpriteMaterial> Hash for SpriteMaterialKey<M>
+where
+    M::Data: Hash,
+{
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.pipeline_key.hash(state);
+        self.bind_group_data.hash(state);
+    }
+}

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -1,4 +1,4 @@
-use crate::Anchor;
+use crate::{sprite_material::SpriteMaterial, Anchor};
 use bevy_asset::{Asset, AssetId, Handle};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::{Rect, Vec2};
@@ -57,6 +57,48 @@ impl TextureAtlasSprite {
     /// Create a new [`TextureAtlasSprite`] with a sprite index,
     /// it should be valid in the corresponding [`TextureAtlas`]
     pub fn new(index: usize) -> TextureAtlasSprite {
+        Self {
+            index,
+            ..Default::default()
+        }
+    }
+}
+
+#[derive(Component, Debug, Clone, Reflect)]
+#[reflect(Component)]
+pub struct TextureAtlasSpriteWithMaterial<M: SpriteMaterial> {
+    /// The tint color used to draw the sprite, defaulting to [`Color::WHITE`]
+    pub material: Handle<M>,
+    /// Texture index in [`TextureAtlas`]
+    pub index: usize,
+    /// Whether to flip the sprite in the X axis
+    pub flip_x: bool,
+    /// Whether to flip the sprite in the Y axis
+    pub flip_y: bool,
+    /// An optional custom size for the sprite that will be used when rendering, instead of the size
+    /// of the sprite's image in the atlas
+    pub custom_size: Option<Vec2>,
+    /// [`Anchor`] point of the sprite in the world
+    pub anchor: Anchor,
+}
+
+impl<M: SpriteMaterial> Default for TextureAtlasSpriteWithMaterial<M> {
+    fn default() -> Self {
+        Self {
+            index: 0,
+            material: Default::default(),
+            flip_x: false,
+            flip_y: false,
+            custom_size: None,
+            anchor: Anchor::default(),
+        }
+    }
+}
+
+impl<M: SpriteMaterial> TextureAtlasSpriteWithMaterial<M> {
+    /// Create a new [`TextureAtlasSprite`] with a sprite index,
+    /// it should be valid in the corresponding [`TextureAtlas`]
+    pub fn new(index: usize) -> Self {
         Self {
             index,
             ..Default::default()

--- a/examples/2d/sprite_material.rs
+++ b/examples/2d/sprite_material.rs
@@ -1,0 +1,40 @@
+//! Displays a single [`Sprite`], created from an image.
+
+use bevy::prelude::*;
+use bevy_internal::{
+    render::render_resource::{AsBindGroup, ShaderRef},
+    sprite::{SpriteMaterial, SpriteMaterialPlugin, SpriteWithMaterial, SpriteWithMaterialBundle},
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(SpriteMaterialPlugin::<GrayScale>::default())
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    mut sprite_materials: ResMut<Assets<GrayScale>>,
+) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(SpriteWithMaterialBundle {
+        sprite: SpriteWithMaterial {
+            material: sprite_materials.add(GrayScale {}),
+            ..default()
+        },
+        texture: asset_server.load("textures/rpg/chars/sensei/sensei.png"),
+        ..default()
+    });
+}
+
+#[derive(AsBindGroup, Asset, TypePath, Debug, Clone)]
+struct GrayScale {}
+
+impl SpriteMaterial for GrayScale {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/grayscale.wgsl".into()
+    }
+}


### PR DESCRIPTION
# Objective

The objective of this PR is to add Material functionality to the existing Sprite component, allowing users to customize the rendering pipeline of sprites by defining their own SpriteMaterial. 

## Solution

Two versions of the implementation are provided:

[1. In this version, a new SpriteWithMaterial component is introduced. It includes a material field to specify the sprite's material tint. The SpriteWithMaterial struct is similar to the existing Sprite struct, with the addition of the material field. However, migrating from the original Sprite to SpriteWithMaterial may be inconvenient.](https://github.com/bevyengine/bevy/pull/10844)

[2. In this version, the original Sprite component is reused, and a SpriteMaterialMarke component is introduced to assist in filtering query results. The changes include adding the material field to the SpriteSheetWithMaterialBundle struct. Migrating from the original Sprite to the SpriteMaterialMarke version requires fewer code changes.](https://github.com/bevyengine/bevy/pull/10845)

## Changelog

TODO:

## Migration Guide

TODO: