### PR TITLE
Substitute `get(0)` with `first()`

### DIFF
--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -644,7 +644,7 @@ fn get_visibility_flag_value(meta_list: &MetaList) -> Result<ShaderStageVisibili
     }
 
     if flags.len() == 1 {
-        if let Some(flag) = flags.get(0) {
+        if let Some(flag) = flags.first() {
             if flag == VISIBILITY_ALL {
                 return Ok(ShaderStageVisibility::All);
             } else if flag == VISIBILITY_NONE {

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -266,7 +266,7 @@ pub fn prepare_windows(
                 // For future HDR output support, we'll need to request a format that supports HDR,
                 // but as of wgpu 0.15 that is not yet supported.
                 // Prefer sRGB formats for surfaces, but fall back to first available format if no sRGB formats are available.
-                let mut format = *formats.get(0).expect("No supported formats for surface");
+                let mut format = *formats.first().expect("No supported formats for surface");
                 for available_format in formats {
                     // Rgba8UnormSrgb and Bgra8UnormSrgb and the only sRGB formats wgpu exposes that we can use for surfaces.
                     if available_format == TextureFormat::Rgba8UnormSrgb

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -561,7 +561,7 @@ fn init_materials(
     let mut materials = Vec::with_capacity(capacity);
     materials.push(assets.add(ColorMaterial {
         color: Color::WHITE,
-        texture: textures.get(0).cloned(),
+        texture: textures.first().cloned(),
     }));
 
     let mut color_rng = StdRng::seed_from_u64(42);

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -221,7 +221,7 @@ fn init_materials(
     let mut materials = Vec::with_capacity(capacity);
     materials.push(assets.add(StandardMaterial {
         base_color: Color::WHITE,
-        base_color_texture: textures.get(0).cloned(),
+        base_color_texture: textures.first().cloned(),
         ..default()
     }));
 


### PR DESCRIPTION
Substitute calls to `get(0)` with `first()`, improving readability.