### PR TITLE
Rename `TextAlignment` to `JustifyText`.

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -12,7 +12,7 @@ use glyph_brush_layout::{
 
 use crate::{
     error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasSets, FontAtlasWarning,
-    GlyphAtlasInfo, TextJustification, TextSettings, YAxisOrientation,
+    GlyphAtlasInfo, JustifyText, TextSettings, YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -36,7 +36,7 @@ impl GlyphBrush {
         &self,
         sections: &[S],
         bounds: Vec2,
-        text_alignment: TextJustification,
+        text_alignment: JustifyText,
         linebreak_behavior: BreakLineOn,
     ) -> Result<Vec<SectionGlyph>, TextError> {
         let geom = SectionGeometry {

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -12,7 +12,7 @@ use glyph_brush_layout::{
 
 use crate::{
     error::TextError, BreakLineOn, Font, FontAtlasSet, FontAtlasSets, FontAtlasWarning,
-    GlyphAtlasInfo, TextAlignment, TextSettings, YAxisOrientation,
+    GlyphAtlasInfo, TextJustification, TextSettings, YAxisOrientation,
 };
 
 pub struct GlyphBrush {
@@ -36,7 +36,7 @@ impl GlyphBrush {
         &self,
         sections: &[S],
         bounds: Vec2,
-        text_alignment: TextAlignment,
+        text_alignment: TextJustification,
         linebreak_behavior: BreakLineOn,
     ) -> Result<Vec<SectionGlyph>, TextError> {
         let geom = SectionGeometry {

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -20,9 +20,7 @@ pub use text2d::*;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{
-        Font, Text, Text2dBundle, TextError, TextJustification, TextSection, TextStyle,
-    };
+    pub use crate::{Font, JustifyText, Text, Text2dBundle, TextError, TextSection, TextStyle};
 }
 
 use bevy_app::prelude::*;
@@ -85,7 +83,7 @@ impl Plugin for TextPlugin {
             .register_type::<TextSection>()
             .register_type::<Vec<TextSection>>()
             .register_type::<TextStyle>()
-            .register_type::<TextJustification>()
+            .register_type::<JustifyText>()
             .register_type::<BreakLineOn>()
             .init_asset_loader::<FontLoader>()
             .init_resource::<TextSettings>()

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -20,7 +20,9 @@ pub use text2d::*;
 
 pub mod prelude {
     #[doc(hidden)]
-    pub use crate::{Font, Text, Text2dBundle, TextAlignment, TextError, TextSection, TextStyle};
+    pub use crate::{
+        Font, Text, Text2dBundle, TextError, TextJustification, TextSection, TextStyle,
+    };
 }
 
 use bevy_app::prelude::*;
@@ -83,7 +85,7 @@ impl Plugin for TextPlugin {
             .register_type::<TextSection>()
             .register_type::<Vec<TextSection>>()
             .register_type::<TextStyle>()
-            .register_type::<TextAlignment>()
+            .register_type::<TextJustification>()
             .register_type::<BreakLineOn>()
             .init_asset_loader::<FontLoader>()
             .init_resource::<TextSettings>()

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -119,7 +119,7 @@ pub struct TextMeasureSection {
 pub struct TextMeasureInfo {
     pub fonts: Box<[ab_glyph::FontArc]>,
     pub sections: Box<[TextMeasureSection]>,
-    pub text_alignment: TextJustification,
+    pub text_justification: TextJustification,
     pub linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     pub min: Vec2,
     pub max: Vec2,
@@ -171,7 +171,7 @@ impl TextMeasureInfo {
         let mut info = Self {
             fonts: fonts.into_boxed_slice(),
             sections: sections.into_boxed_slice(),
-            text_alignment,
+            text_justification: text_alignment,
             linebreak_behavior,
             min: Vec2::ZERO,
             max: Vec2::ZERO,
@@ -191,7 +191,7 @@ impl TextMeasureInfo {
             ..Default::default()
         };
         let section_glyphs = glyph_brush_layout::Layout::default()
-            .h_align(self.text_alignment.into())
+            .h_align(self.text_justification.into())
             .line_breaker(self.linebreak_behavior)
             .calculate_glyphs(&self.fonts, &geom, sections);
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -119,7 +119,7 @@ pub struct TextMeasureSection {
 pub struct TextMeasureInfo {
     pub fonts: Box<[ab_glyph::FontArc]>,
     pub sections: Box<[TextMeasureSection]>,
-    pub text_justification: JustifyText,
+    pub justification: JustifyText,
     pub linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     pub min: Vec2,
     pub max: Vec2,
@@ -165,13 +165,13 @@ impl TextMeasureInfo {
     fn new(
         fonts: Vec<ab_glyph::FontArc>,
         sections: Vec<TextMeasureSection>,
-        text_alignment: JustifyText,
+        justification: JustifyText,
         linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     ) -> Self {
         let mut info = Self {
             fonts: fonts.into_boxed_slice(),
             sections: sections.into_boxed_slice(),
-            text_justification: text_alignment,
+            justification,
             linebreak_behavior,
             min: Vec2::ZERO,
             max: Vec2::ZERO,
@@ -191,7 +191,7 @@ impl TextMeasureInfo {
             ..Default::default()
         };
         let section_glyphs = glyph_brush_layout::Layout::default()
-            .h_align(self.text_justification.into())
+            .h_align(self.justification.into())
             .line_breaker(self.linebreak_behavior)
             .calculate_glyphs(&self.fonts, &geom, sections);
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,7 +1,7 @@
 use crate::{
     compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
-    FontAtlasSets, FontAtlasWarning, PositionedGlyph, Text, TextJustification, TextSection,
-    TextSettings, YAxisOrientation,
+    FontAtlasSets, FontAtlasWarning, JustifyText, PositionedGlyph, Text, TextSection, TextSettings,
+    YAxisOrientation,
 };
 use ab_glyph::PxScale;
 use bevy_asset::{AssetId, Assets, Handle};
@@ -47,7 +47,7 @@ impl TextPipeline {
         fonts: &Assets<Font>,
         sections: &[TextSection],
         scale_factor: f64,
-        text_alignment: TextJustification,
+        text_alignment: JustifyText,
         linebreak_behavior: BreakLineOn,
         bounds: Vec2,
         font_atlas_sets: &mut FontAtlasSets,
@@ -119,7 +119,7 @@ pub struct TextMeasureSection {
 pub struct TextMeasureInfo {
     pub fonts: Box<[ab_glyph::FontArc]>,
     pub sections: Box<[TextMeasureSection]>,
-    pub text_justification: TextJustification,
+    pub text_justification: JustifyText,
     pub linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     pub min: Vec2,
     pub max: Vec2,
@@ -158,14 +158,14 @@ impl TextMeasureInfo {
         Ok(Self::new(
             auto_fonts,
             sections,
-            text.justification,
+            text.justify,
             text.linebreak_behavior.into(),
         ))
     }
     fn new(
         fonts: Vec<ab_glyph::FontArc>,
         sections: Vec<TextMeasureSection>,
-        text_alignment: TextJustification,
+        text_alignment: JustifyText,
         linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     ) -> Self {
         let mut info = Self {

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -1,6 +1,6 @@
 use crate::{
     compute_text_bounds, error::TextError, glyph_brush::GlyphBrush, scale_value, BreakLineOn, Font,
-    FontAtlasSets, FontAtlasWarning, PositionedGlyph, Text, TextAlignment, TextSection,
+    FontAtlasSets, FontAtlasWarning, PositionedGlyph, Text, TextJustification, TextSection,
     TextSettings, YAxisOrientation,
 };
 use ab_glyph::PxScale;
@@ -47,7 +47,7 @@ impl TextPipeline {
         fonts: &Assets<Font>,
         sections: &[TextSection],
         scale_factor: f64,
-        text_alignment: TextAlignment,
+        text_alignment: TextJustification,
         linebreak_behavior: BreakLineOn,
         bounds: Vec2,
         font_atlas_sets: &mut FontAtlasSets,
@@ -119,7 +119,7 @@ pub struct TextMeasureSection {
 pub struct TextMeasureInfo {
     pub fonts: Box<[ab_glyph::FontArc]>,
     pub sections: Box<[TextMeasureSection]>,
-    pub text_alignment: TextAlignment,
+    pub text_alignment: TextJustification,
     pub linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     pub min: Vec2,
     pub max: Vec2,
@@ -158,14 +158,14 @@ impl TextMeasureInfo {
         Ok(Self::new(
             auto_fonts,
             sections,
-            text.alignment,
+            text.justification,
             text.linebreak_behavior.into(),
         ))
     }
     fn new(
         fonts: Vec<ab_glyph::FontArc>,
         sections: Vec<TextMeasureSection>,
-        text_alignment: TextAlignment,
+        text_alignment: TextJustification,
         linebreak_behavior: glyph_brush_layout::BuiltInLineBreaker,
     ) -> Self {
         let mut info = Self {

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -13,7 +13,7 @@ pub struct Text {
     pub sections: Vec<TextSection>,
     /// The text's internal alignment.
     /// Should not affect its position within a container.
-    pub justification: TextJustification,
+    pub justify: JustifyText,
     /// How the text should linebreak when running out of the bounds determined by max_size
     pub linebreak_behavior: BreakLineOn,
 }
@@ -22,7 +22,7 @@ impl Default for Text {
     fn default() -> Self {
         Self {
             sections: Default::default(),
-            justification: TextJustification::Left,
+            justify: JustifyText::Left,
             linebreak_behavior: BreakLineOn::WordBoundary,
         }
     }
@@ -34,7 +34,7 @@ impl Text {
     /// ```
     /// # use bevy_asset::Handle;
     /// # use bevy_render::color::Color;
-    /// # use bevy_text::{Font, Text, TextStyle, TextJustification};
+    /// # use bevy_text::{Font, Text, TextStyle, JustifyText};
     /// #
     /// # let font_handle: Handle<Font> = Default::default();
     /// #
@@ -57,7 +57,7 @@ impl Text {
     ///         color: Color::WHITE,
     ///     },
     /// ) // You can still add text justifaction.
-    /// .with_justification(TextJustification::Center);
+    /// .with_justify(JustifyText::Center);
     /// ```
     pub fn from_section(value: impl Into<String>, style: TextStyle) -> Self {
         Self {
@@ -101,9 +101,9 @@ impl Text {
         }
     }
 
-    /// Returns this [`Text`] with a new [`TextJustification`].
-    pub const fn with_justification(mut self, justification: TextJustification) -> Self {
-        self.justification = justification;
+    /// Returns this [`Text`] with a new [`JustifyText`].
+    pub const fn with_justify(mut self, justify: JustifyText) -> Self {
+        self.justify = justify;
         self
     }
 
@@ -166,7 +166,7 @@ impl From<String> for TextSection {
 /// _Has no affect on a single line text entity._
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
-pub enum TextJustification {
+pub enum JustifyText {
     /// Leftmost character is immediately to the right of the render position.
     /// Bounds start from the render position and advance rightwards.
     #[default]
@@ -179,12 +179,12 @@ pub enum TextJustification {
     Right,
 }
 
-impl From<TextJustification> for glyph_brush_layout::HorizontalAlign {
-    fn from(val: TextJustification) -> Self {
+impl From<JustifyText> for glyph_brush_layout::HorizontalAlign {
+    fn from(val: JustifyText) -> Self {
         match val {
-            TextJustification::Left => glyph_brush_layout::HorizontalAlign::Left,
-            TextJustification::Center => glyph_brush_layout::HorizontalAlign::Center,
-            TextJustification::Right => glyph_brush_layout::HorizontalAlign::Right,
+            JustifyText::Left => glyph_brush_layout::HorizontalAlign::Left,
+            JustifyText::Center => glyph_brush_layout::HorizontalAlign::Center,
+            JustifyText::Right => glyph_brush_layout::HorizontalAlign::Right,
         }
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -102,7 +102,7 @@ impl Text {
     }
 
     /// Returns this [`Text`] with a new [`TextJustification`].
-    pub const fn with_alignment(mut self, justification: TextJustification) -> Self {
+    pub const fn with_justification(mut self, justification: TextJustification) -> Self {
         self.justification = justification;
         self
     }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -13,7 +13,7 @@ pub struct Text {
     pub sections: Vec<TextSection>,
     /// The text's internal alignment.
     /// Should not affect its position within a container.
-    pub alignment: TextAlignment,
+    pub justification: TextJustification,
     /// How the text should linebreak when running out of the bounds determined by max_size
     pub linebreak_behavior: BreakLineOn,
 }
@@ -22,7 +22,7 @@ impl Default for Text {
     fn default() -> Self {
         Self {
             sections: Default::default(),
-            alignment: TextAlignment::Left,
+            justification: TextJustification::Left,
             linebreak_behavior: BreakLineOn::WordBoundary,
         }
     }
@@ -50,14 +50,14 @@ impl Text {
     /// );
     ///
     /// let hello_bevy = Text::from_section(
-    ///     "hello bevy!",
+    ///     "hello world\nand bevy!",
     ///     TextStyle {
     ///         font: font_handle,
     ///         font_size: 60.0,
     ///         color: Color::WHITE,
     ///     },
-    /// ) // You can still add an alignment.
-    /// .with_alignment(TextAlignment::Center);
+    /// ) // You can still add text justifaction.
+    /// .with_justification(TextJustification::Center);
     /// ```
     pub fn from_section(value: impl Into<String>, style: TextStyle) -> Self {
         Self {
@@ -101,9 +101,9 @@ impl Text {
         }
     }
 
-    /// Returns this [`Text`] with a new [`TextAlignment`].
-    pub const fn with_alignment(mut self, alignment: TextAlignment) -> Self {
-        self.alignment = alignment;
+    /// Returns this [`Text`] with a new [`TextJustification`].
+    pub const fn with_alignment(mut self, justification: TextJustification) -> Self {
+        self.justification = justification;
         self
     }
 
@@ -159,28 +159,32 @@ impl From<String> for TextSection {
     }
 }
 
-/// Describes horizontal alignment preference for positioning & bounds.
+/// Describes the horizontal alignment of multiple lines of text relative to each other.
+/// This only affects the internal positioning of the lines of text within a text entity and
+/// does not affect the text entity's position.
+///
+/// _Has no affect on a single line text entity._
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
-pub enum TextAlignment {
-    /// Leftmost character is immediately to the right of the render position.<br/>
+pub enum TextJustification {
+    /// Leftmost character is immediately to the right of the render position.
     /// Bounds start from the render position and advance rightwards.
     #[default]
     Left,
-    /// Leftmost & rightmost characters are equidistant to the render position.<br/>
+    /// Leftmost & rightmost characters are equidistant to the render position.
     /// Bounds start from the render position and advance equally left & right.
     Center,
-    /// Rightmost character is immediately to the left of the render position.<br/>
+    /// Rightmost character is immediately to the left of the render position.
     /// Bounds start from the render position and advance leftwards.
     Right,
 }
 
-impl From<TextAlignment> for glyph_brush_layout::HorizontalAlign {
-    fn from(val: TextAlignment) -> Self {
+impl From<TextJustification> for glyph_brush_layout::HorizontalAlign {
+    fn from(val: TextJustification) -> Self {
         match val {
-            TextAlignment::Left => glyph_brush_layout::HorizontalAlign::Left,
-            TextAlignment::Center => glyph_brush_layout::HorizontalAlign::Center,
-            TextAlignment::Right => glyph_brush_layout::HorizontalAlign::Right,
+            TextJustification::Left => glyph_brush_layout::HorizontalAlign::Left,
+            TextJustification::Center => glyph_brush_layout::HorizontalAlign::Center,
+            TextJustification::Right => glyph_brush_layout::HorizontalAlign::Right,
         }
     }
 }

--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -34,7 +34,7 @@ impl Text {
     /// ```
     /// # use bevy_asset::Handle;
     /// # use bevy_render::color::Color;
-    /// # use bevy_text::{Font, Text, TextStyle, TextAlignment};
+    /// # use bevy_text::{Font, Text, TextStyle, TextJustification};
     /// #
     /// # let font_handle: Handle<Font> = Default::default();
     /// #

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -28,7 +28,7 @@ use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 
 /// The maximum width and height of text. The text will wrap according to the specified size.
 /// Characters out of the bounds after wrapping will be truncated. Text is aligned according to the
-/// specified [`TextAlignment`](crate::text::TextAlignment).
+/// specified [`TextJustification`](crate::text::TextJustification).
 ///
 /// Note: only characters that are completely out of the bounds will be truncated, so this is not a
 /// reliable limit if it is necessary to contain the text strictly in the bounds. Currently this

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -196,7 +196,7 @@ pub fn update_text2d_layout(
                 &fonts,
                 &text.sections,
                 scale_factor,
-                text.alignment,
+                text.justification,
                 text.linebreak_behavior,
                 text_bounds,
                 &mut font_atlas_sets,

--- a/crates/bevy_text/src/text2d.rs
+++ b/crates/bevy_text/src/text2d.rs
@@ -28,7 +28,7 @@ use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 
 /// The maximum width and height of text. The text will wrap according to the specified size.
 /// Characters out of the bounds after wrapping will be truncated. Text is aligned according to the
-/// specified [`TextJustification`](crate::text::TextJustification).
+/// specified [`JustifyText`](crate::text::JustifyText).
 ///
 /// Note: only characters that are completely out of the bounds will be truncated, so this is not a
 /// reliable limit if it is necessary to contain the text strictly in the bounds. Currently this
@@ -196,7 +196,7 @@ pub fn update_text2d_layout(
                 &fonts,
                 &text.sections,
                 scale_factor,
-                text.justification,
+                text.justify,
                 text.linebreak_behavior,
                 text_bounds,
                 &mut font_atlas_sets,

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -15,7 +15,7 @@ use bevy_render::{
 };
 use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
-use bevy_text::{BreakLineOn, Text, TextAlignment, TextLayoutInfo, TextSection, TextStyle};
+use bevy_text::{BreakLineOn, Text, TextJustification, TextLayoutInfo, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// The basic UI node
@@ -245,9 +245,9 @@ impl TextBundle {
         }
     }
 
-    /// Returns this [`TextBundle`] with a new [`TextAlignment`] on [`Text`].
-    pub const fn with_text_alignment(mut self, alignment: TextAlignment) -> Self {
-        self.text.alignment = alignment;
+    /// Returns this [`TextBundle`] with a new [`TextJustification`] on [`Text`].
+    pub const fn with_text_justification(mut self, justification: TextJustification) -> Self {
+        self.text.justification = justification;
         self
     }
 

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -245,9 +245,9 @@ impl TextBundle {
         }
     }
 
-    /// Returns this [`TextBundle`] with a new [`TextJustification`] on [`Text`].
-    pub const fn with_text_justify(mut self, justification: JustifyText) -> Self {
-        self.text.justify = justification;
+    /// Returns this [`TextBundle`] with a new [`JustifyText`] on [`Text`].
+    pub const fn with_text_justify(mut self, justify: JustifyText) -> Self {
+        self.text.justify = justify;
         self
     }
 

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -15,7 +15,7 @@ use bevy_render::{
 };
 use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
-use bevy_text::{BreakLineOn, Text, TextJustification, TextLayoutInfo, TextSection, TextStyle};
+use bevy_text::{BreakLineOn, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// The basic UI node
@@ -246,8 +246,8 @@ impl TextBundle {
     }
 
     /// Returns this [`TextBundle`] with a new [`TextJustification`] on [`Text`].
-    pub const fn with_text_justification(mut self, justification: TextJustification) -> Self {
-        self.text.justification = justification;
+    pub const fn with_text_justify(mut self, justification: JustifyText) -> Self {
+        self.text.justify = justification;
         self
     }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -182,7 +182,7 @@ fn queue_text(
             fonts,
             &text.sections,
             scale_factor,
-            text.justification,
+            text.justify,
             text.linebreak_behavior,
             physical_node_size,
             font_atlas_sets,

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -182,7 +182,7 @@ fn queue_text(
             fonts,
             &text.sections,
             scale_factor,
-            text.alignment,
+            text.justification,
             text.linebreak_behavior,
             physical_node_size,
             font_atlas_sets,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -38,14 +38,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 60.0,
         color: Color::WHITE,
     };
-    let text_alignment = TextJustification::Center;
+    let text_justification = TextJustification::Center;
     // 2d camera
     commands.spawn(Camera2dBundle::default());
     // Demonstrate changing translation
     commands.spawn((
         Text2dBundle {
             text: Text::from_section("translation", text_style.clone())
-                .with_alignment(text_alignment),
+                .with_justification(text_justification),
             ..default()
         },
         AnimateTranslation,
@@ -53,7 +53,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing rotation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("rotation", text_style.clone()).with_alignment(text_alignment),
+            text: Text::from_section("rotation", text_style.clone()).with_justification(text_justification),
             ..default()
         },
         AnimateRotation,
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing scale
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("scale", text_style).with_alignment(text_alignment),
+            text: Text::from_section("scale", text_style).with_justification(text_justification),
             ..default()
         },
         AnimateScale,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -53,7 +53,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing rotation
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("rotation", text_style.clone()).with_justification(text_justification),
+            text: Text::from_section("rotation", text_style.clone())
+                .with_justification(text_justification),
             ..default()
         },
         AnimateRotation,

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -38,7 +38,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 60.0,
         color: Color::WHITE,
     };
-    let text_alignment = TextAlignment::Center;
+    let text_alignment = TextJustification::Center;
     // 2d camera
     commands.spawn(Camera2dBundle::default());
     // Demonstrate changing translation
@@ -91,7 +91,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "this text wraps in the box\n(Unicode linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
-                    alignment: TextAlignment::Left,
+                    justification: TextJustification::Left,
                     linebreak_behavior: BreakLineOn::WordBoundary,
                 },
                 text_2d_bounds: Text2dBounds {
@@ -123,7 +123,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "this text wraps in the box\n(AnyCharacter linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
-                    alignment: TextAlignment::Left,
+                    justification: TextJustification::Left,
                     linebreak_behavior: BreakLineOn::AnyCharacter,
                 },
                 text_2d_bounds: Text2dBounds {

--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -38,14 +38,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         font_size: 60.0,
         color: Color::WHITE,
     };
-    let text_justification = TextJustification::Center;
+    let text_justification = JustifyText::Center;
     // 2d camera
     commands.spawn(Camera2dBundle::default());
     // Demonstrate changing translation
     commands.spawn((
         Text2dBundle {
             text: Text::from_section("translation", text_style.clone())
-                .with_justification(text_justification),
+                .with_justify(text_justification),
             ..default()
         },
         AnimateTranslation,
@@ -54,7 +54,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Text2dBundle {
             text: Text::from_section("rotation", text_style.clone())
-                .with_justification(text_justification),
+                .with_justify(text_justification),
             ..default()
         },
         AnimateRotation,
@@ -62,7 +62,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Demonstrate changing scale
     commands.spawn((
         Text2dBundle {
-            text: Text::from_section("scale", text_style).with_justification(text_justification),
+            text: Text::from_section("scale", text_style).with_justify(text_justification),
             ..default()
         },
         AnimateScale,
@@ -92,7 +92,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "this text wraps in the box\n(Unicode linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
-                    justification: TextJustification::Left,
+                    justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::WordBoundary,
                 },
                 text_2d_bounds: Text2dBounds {
@@ -124,7 +124,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                         "this text wraps in the box\n(AnyCharacter linebreaks)",
                         slightly_smaller_text_style.clone(),
                     )],
-                    justification: TextJustification::Left,
+                    justify: JustifyText::Left,
                     linebreak_behavior: BreakLineOn::AnyCharacter,
                 },
                 text_2d_bounds: Text2dBounds {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -277,7 +277,7 @@ fn setup_image_viewer_scene(
                     ..default()
                 },
             )
-            .with_text_justification(TextJustification::Center)
+            .with_text_justify(JustifyText::Center)
             .with_style(Style {
                 align_self: AlignSelf::Center,
                 margin: UiRect::all(Val::Auto),

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -277,7 +277,7 @@ fn setup_image_viewer_scene(
                     ..default()
                 },
             )
-            .with_text_alignment(TextAlignment::Center)
+            .with_text_justification(TextJustification::Center)
             .with_style(Style {
                 align_self: AlignSelf::Center,
                 margin: UiRect::all(Val::Auto),

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -60,7 +60,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
     for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {
             text: Text::from_section(event.0.to_string(), text_style.clone())
-                .with_alignment(TextAlignment::Center),
+                .with_alignment(TextJustification::Center),
             transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
             ..default()
         });

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -60,7 +60,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
     for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {
             text: Text::from_section(event.0.to_string(), text_style.clone())
-                .with_alignment(TextJustification::Center),
+                .with_justification(TextJustification::Center),
             transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
             ..default()
         });

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -60,7 +60,7 @@ fn spawn_text(mut commands: Commands, mut reader: EventReader<StreamEvent>) {
     for (per_frame, event) in reader.read().enumerate() {
         commands.spawn(Text2dBundle {
             text: Text::from_section(event.0.to_string(), text_style.clone())
-                .with_justification(TextJustification::Center),
+                .with_justify(JustifyText::Center),
             transform: Transform::from_xyz(per_frame as f32 * 100.0, 300.0, 0.0),
             ..default()
         });

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -129,7 +129,7 @@ fn setup_scene(
                         ..default()
                     },
                 )
-                .with_text_justification(TextJustification::Center),
+                .with_text_justify(JustifyText::Center),
             );
         });
 }

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -129,7 +129,7 @@ fn setup_scene(
                         ..default()
                     },
                 )
-                .with_text_alignment(TextAlignment::Center),
+                .with_text_justification(TextJustification::Center),
             );
         });
 }

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -47,7 +47,7 @@ fn setup(mut commands: Commands) {
                 ..default()
             },
         }],
-        alignment: TextAlignment::Left,
+        justification: TextJustification::Left,
         linebreak_behavior: BreakLineOn::AnyCharacter,
     };
 

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -47,7 +47,7 @@ fn setup(mut commands: Commands) {
                 ..default()
             },
         }],
-        justification: TextJustification::Left,
+        justify: JustifyText::Left,
         linebreak_behavior: BreakLineOn::AnyCharacter,
     };
 

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -58,7 +58,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Text2dBundle {
         text: Text {
             sections,
-            justification: TextJustification::Center,
+            justify: JustifyText::Center,
             linebreak_behavior: BreakLineOn::AnyCharacter,
         },
         ..Default::default()

--- a/examples/stress_tests/text_pipeline.rs
+++ b/examples/stress_tests/text_pipeline.rs
@@ -58,7 +58,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Text2dBundle {
         text: Text {
             sections,
-            alignment: TextAlignment::Center,
+            justification: TextJustification::Center,
             linebreak_behavior: BreakLineOn::AnyCharacter,
         },
         ..Default::default()

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -118,7 +118,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                         ..default()
                     },
                 )
-                .with_text_justification(TextJustification::Center),
+                .with_text_justify(JustifyText::Center),
             );
 
             // virtual time info
@@ -131,7 +131,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                         ..default()
                     },
                 )
-                .with_text_justification(TextJustification::Right),
+                .with_text_justify(JustifyText::Right),
                 VirtualTime,
             ));
         });

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -118,7 +118,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                         ..default()
                     },
                 )
-                .with_text_alignment(TextAlignment::Center),
+                .with_text_justification(TextJustification::Center),
             );
 
             // virtual time info
@@ -131,7 +131,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut time: ResMu
                         ..default()
                     },
                 )
-                .with_text_alignment(TextAlignment::Right),
+                .with_text_justification(TextJustification::Right),
                 VirtualTime,
             ));
         });

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text: Text::from_section(
                 "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",                
                 text_style.clone(),
-            ).with_alignment(TextJustification::Center),
+            ).with_justification(TextJustification::Center),
             style: Style {
                 margin: UiRect::bottom(Val::Px(10.)),
                 ..Default::default()
@@ -158,14 +158,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     text: Text::from_section(
                         "Display::None\nVisibility::Hidden\nVisibility::Inherited",
                         TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
-                        ).with_alignment(TextJustification::Center),
+                        ).with_justification(TextJustification::Center),
                     ..Default::default()
                     });
                     builder.spawn(TextBundle {
                         text: Text::from_section(
                             "-\n-\n-",
                             TextStyle { color: Color::DARK_GRAY, ..text_style.clone() }
-                            ).with_alignment(TextJustification::Center),
+                            ).with_justification(TextJustification::Center),
                         ..Default::default()
                         });
                     builder.spawn(TextBundle::from_section(

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text: Text::from_section(
                 "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",                
                 text_style.clone(),
-            ).with_alignment(TextAlignment::Center),
+            ).with_alignment(TextJustification::Center),
             style: Style {
                 margin: UiRect::bottom(Val::Px(10.)),
                 ..Default::default()
@@ -158,14 +158,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     text: Text::from_section(
                         "Display::None\nVisibility::Hidden\nVisibility::Inherited",
                         TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
-                        ).with_alignment(TextAlignment::Center),
+                        ).with_alignment(TextJustification::Center),
                     ..Default::default()
                     });
                     builder.spawn(TextBundle {
                         text: Text::from_section(
                             "-\n-\n-",
                             TextStyle { color: Color::DARK_GRAY, ..text_style.clone() }
-                            ).with_alignment(TextAlignment::Center),
+                            ).with_alignment(TextJustification::Center),
                         ..Default::default()
                         });
                     builder.spawn(TextBundle::from_section(
@@ -425,7 +425,7 @@ where
                     format!("{}::{:?}", Target::<T>::NAME, T::default()),
                     text_style,
                 )
-                .with_text_alignment(TextAlignment::Center),
+                .with_text_justification(TextJustification::Center),
             );
         });
 }

--- a/examples/ui/display_and_visibility.rs
+++ b/examples/ui/display_and_visibility.rs
@@ -96,7 +96,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
             text: Text::from_section(
                 "Use the panel on the right to change the Display and Visibility properties for the respective nodes of the panel on the left",                
                 text_style.clone(),
-            ).with_justification(TextJustification::Center),
+            ).with_justify(JustifyText::Center),
             style: Style {
                 margin: UiRect::bottom(Val::Px(10.)),
                 ..Default::default()
@@ -158,14 +158,14 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                     text: Text::from_section(
                         "Display::None\nVisibility::Hidden\nVisibility::Inherited",
                         TextStyle { color: HIDDEN_COLOR, ..text_style.clone() }
-                        ).with_justification(TextJustification::Center),
+                        ).with_justify(JustifyText::Center),
                     ..Default::default()
                     });
                     builder.spawn(TextBundle {
                         text: Text::from_section(
                             "-\n-\n-",
                             TextStyle { color: Color::DARK_GRAY, ..text_style.clone() }
-                            ).with_justification(TextJustification::Center),
+                            ).with_justify(JustifyText::Center),
                         ..Default::default()
                         });
                     builder.spawn(TextBundle::from_section(
@@ -425,7 +425,7 @@ where
                     format!("{}::{:?}", Target::<T>::NAME, T::default()),
                     text_style,
                 )
-                .with_text_justification(TextJustification::Center),
+                .with_text_justify(JustifyText::Center),
             );
         });
 }

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -287,7 +287,7 @@ fn spawn_button(
                                 ..text_style
                             },
                         )
-                        .with_alignment(TextAlignment::Center),
+                        .with_alignment(TextJustification::Center),
                         ..Default::default()
                     });
                 });

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -287,7 +287,7 @@ fn spawn_button(
                                 ..text_style
                             },
                         )
-                        .with_justification(TextJustification::Center),
+                        .with_justify(JustifyText::Center),
                         ..Default::default()
                     });
                 });

--- a/examples/ui/size_constraints.rs
+++ b/examples/ui/size_constraints.rs
@@ -287,7 +287,7 @@ fn spawn_button(
                                 ..text_style
                             },
                         )
-                        .with_alignment(TextJustification::Center),
+                        .with_justification(TextJustification::Center),
                         ..Default::default()
                     });
                 });

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -40,7 +40,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 ..default()
             },
         ) // Set the justification of the Text
-        .with_text_justification(TextJustification::Center)
+        .with_text_justify(JustifyText::Center)
         // Set the style of the TextBundle itself.
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/ui/text.rs
+++ b/examples/ui/text.rs
@@ -39,8 +39,8 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                 font_size: 100.0,
                 ..default()
             },
-        ) // Set the alignment of the Text
-        .with_text_alignment(TextAlignment::Center)
+        ) // Set the justification of the Text
+        .with_text_justification(TextJustification::Center)
         // Set the style of the TextBundle itself.
         .with_style(Style {
             position_type: PositionType::Absolute,

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -64,13 +64,13 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             )
         );
         builder.spawn(TextBundle::from_section(
-                "This text is right-justified. The `TextJustication` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
+                "This text is right-justified. The `JustifyText` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
                     font: font.clone(),
                     font_size: 30.0,
                     color: Color::YELLOW,
                 },
             )
-            .with_text_justification(TextJustification::Right)
+            .with_text_justify(JustifyText::Right)
             .with_style(Style {
                 max_width: Val::Px(300.),
                 ..default()
@@ -112,7 +112,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     color: Color::rgb(0.8, 0.2, 0.7),
                 },
             )
-            .with_text_justification(TextJustification::Center)
+            .with_text_justify(JustifyText::Center)
             .with_style(Style {
                 max_width: Val::Px(400.),
                 ..default()
@@ -128,7 +128,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
                     color: Color::YELLOW,
                 },
             )
-            .with_text_justification(TextJustification::Left)
+            .with_text_justify(JustifyText::Left)
             .with_style(Style {
                 max_width: Val::Px(300.),
                 ..default()

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -29,110 +29,165 @@ struct TextChanges;
 fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     let font = asset_server.load("fonts/FiraSans-Bold.ttf");
     commands.spawn(Camera2dBundle::default());
-    commands.spawn(
-        TextBundle::from_section(
-            "This is\ntext with\nline breaks\nin the top left",
-            TextStyle {
-                font: font.clone(),
-                font_size: 50.0,
+    let root_uinode = commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.),
+                height: Val::Percent(100.),
+                justify_content: JustifyContent::SpaceBetween,
+
                 ..default()
             },
-        )
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(5.0),
-            left: Val::Px(15.0),
-            ..default()
-        }),
-    );
-    commands.spawn(TextBundle::from_section(
-            "This text is very long, has a limited width, is centered, is positioned in the top right and is also colored pink.",
-            TextStyle {
-                font: font.clone(),
-                font_size: 50.0,
-                color: Color::rgb(0.8, 0.2, 0.7),
-            },
-        )
-        .with_text_alignment(TextAlignment::Center)
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            top: Val::Px(5.0),
-            right: Val::Px(15.0),
-            max_width: Val::Px(400.),
             ..default()
         })
-    );
-    commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new(
-                "This text changes in the bottom right",
+        .id();
+
+    let left_column = commands.spawn(NodeBundle {
+        style: Style {
+            flex_direction: FlexDirection::Column,
+            justify_content: JustifyContent::SpaceBetween,
+            align_items: AlignItems::Start,
+            flex_grow: 1.,
+            margin: UiRect::axes(Val::Px(15.), Val::Px(5.)),
+            ..default()
+        },
+        ..default()
+    }).with_children(|builder| {
+        builder.spawn(
+            TextBundle::from_section(
+                "This is\ntext with\nline breaks\nin the top left.",
+                TextStyle {
+                    font: font.clone(),
+                    font_size: 30.0,
+                    ..default()
+                },
+            )
+        );
+        builder.spawn(TextBundle::from_section(
+                "This text is right-justified and positioned center-left. The `TextJustication` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
+                    font: font.clone(),
+                    font_size: 30.0,
+                    color: Color::YELLOW,
+                },
+            )
+            .with_text_justification(TextJustification::Right)
+            .with_style(Style {
+                max_width: Val::Px(300.),
+                ..default()
+            })
+        );
+        builder.spawn(
+            TextBundle::from_section(
+                "This\ntext has\nline breaks and also a set width in the bottom left.",
                 TextStyle {
                     font: font.clone(),
                     font_size: 30.0,
                     color: Color::WHITE,
                 },
-            ),
-            TextSection::new(
-                "\nThis text changes in the bottom right - ",
+            )
+            .with_style(Style {
+                max_width: Val::Px(300.),
+                ..default()
+            })
+        );
+    }).id();
+
+    let right_column = commands.spawn(NodeBundle {
+        style: Style {
+            flex_direction: FlexDirection::Column,
+            justify_content: JustifyContent::SpaceBetween,
+            align_items: AlignItems::End,
+            flex_grow: 1.,
+            margin: UiRect::axes(Val::Px(15.), Val::Px(5.)),
+            ..default()
+        },
+        ..default()
+    }).with_children(|builder| {
+
+        builder.spawn(TextBundle::from_section(
+                "This text is very long, has a limited width, is center-justified, is positioned in the top right and is also colored pink.",
                 TextStyle {
                     font: font.clone(),
-                    font_size: 30.0,
-                    color: Color::RED,
+                    font_size: 40.0,
+                    color: Color::rgb(0.8, 0.2, 0.7),
                 },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font.clone(),
-                font_size: 30.0,
-                color: Color::ORANGE_RED,
-            }),
-            TextSection::new(
-                " fps, ",
+            )
+            .with_text_justification(TextJustification::Center)
+            .with_style(Style {
+                max_width: Val::Px(400.),
+                ..default()
+            })
+        );
+
+        builder.spawn(
+            TextBundle::from_section(
+                "This text is left-justified and positioned center-right.",
                 TextStyle {
                     font: font.clone(),
-                    font_size: 30.0,
+                    font_size: 40.0,
                     color: Color::YELLOW,
                 },
-            ),
-            TextSection::from_style(TextStyle {
-                font: font.clone(),
-                font_size: 30.0,
-                color: Color::GREEN,
+            )
+            .with_text_justification(TextJustification::Left)
+            .with_style(Style {
+                max_width: Val::Px(300.),
+                ..default()
             }),
-            TextSection::new(
-                " ms/frame",
-                TextStyle {
+        );
+
+        builder.spawn((
+            TextBundle::from_sections([
+                TextSection::new(
+                    "This text changes in the bottom right",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 25.0,
+                        color: Color::WHITE,
+                    },
+                ),
+                TextSection::new(
+                    "\nThis text changes in the bottom right - ",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 25.0,
+                        color: Color::RED,
+                    },
+                ),
+                TextSection::from_style(TextStyle {
                     font: font.clone(),
-                    font_size: 30.0,
-                    color: Color::BLUE,
-                },
-            ),
-        ])
-        .with_style(Style {
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            right: Val::Px(15.0),
-            ..default()
-        }),
-        TextChanges,
-    ));
-    commands.spawn(
-        TextBundle::from_section(
-            "This\ntext has\nline breaks and also a set width in the bottom left",
-            TextStyle {
-                font,
-                font_size: 50.0,
-                color: Color::WHITE,
-            },
-        )
-        .with_style(Style {
-            align_self: AlignSelf::FlexEnd,
-            position_type: PositionType::Absolute,
-            bottom: Val::Px(5.0),
-            left: Val::Px(15.0),
-            width: Val::Px(200.0),
-            ..default()
-        }),
-    );
+                    font_size: 25.0,
+                    color: Color::ORANGE_RED,
+                }),
+                TextSection::new(
+                    " fps, ",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 25.0,
+                        color: Color::YELLOW,
+                    },
+                ),
+                TextSection::from_style(TextStyle {
+                    font: font.clone(),
+                    font_size: 25.0,
+                    color: Color::GREEN,
+                }),
+                TextSection::new(
+                    " ms/frame",
+                    TextStyle {
+                        font: font.clone(),
+                        font_size: 25.0,
+                        color: Color::BLUE,
+                    },
+                ),
+            ]),
+            TextChanges,
+        ));
+    })
+    .id();
+
+    commands
+        .entity(root_uinode)
+        .push_children(&[left_column, right_column]);
 }
 
 fn change_text_system(

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -64,7 +64,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
             )
         );
         builder.spawn(TextBundle::from_section(
-                "This text is right-justified and positioned center-left. The `TextJustication` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
+                "This text is right-justified. The `TextJustication` component controls the horizontal alignment of the lines of multi-line text relative to each other, and does not affect the text node's position in the UI layout.",                TextStyle {
                     font: font.clone(),
                     font_size: 30.0,
                     color: Color::YELLOW,
@@ -121,7 +121,7 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
 
         builder.spawn(
             TextBundle::from_section(
-                "This text is left-justified and positioned center-right.",
+                "This text is left-justified. The text is vertically positioned to distribute the empty space equally above and below.",
                 TextStyle {
                     font: font.clone(),
                     font_size: 40.0,

--- a/examples/ui/text_debug.rs
+++ b/examples/ui/text_debug.rs
@@ -121,10 +121,10 @@ fn infotext_system(mut commands: Commands, asset_server: Res<AssetServer>) {
 
         builder.spawn(
             TextBundle::from_section(
-                "This text is left-justified. The text is vertically positioned to distribute the empty space equally above and below.",
+                "This text is left-justified and is vertically positioned to distribute the empty space equally above and below it.",
                 TextStyle {
                     font: font.clone(),
-                    font_size: 40.0,
+                    font_size: 35.0,
                     color: Color::YELLOW,
                 },
             )

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -120,7 +120,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                         value: message.clone(),
                         style: text_style.clone(),
                     }],
-                    alignment: TextAlignment::Left,
+                    justification: TextJustification::Left,
                     linebreak_behavior,
                 };
                 let text_id = commands

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -120,7 +120,7 @@ fn spawn(mut commands: Commands, asset_server: Res<AssetServer>) {
                         value: message.clone(),
                         style: text_style.clone(),
                     }],
-                    justification: TextJustification::Left,
+                    justify: JustifyText::Left,
                     linebreak_behavior,
                 };
                 let text_id = commands


### PR DESCRIPTION
# Objective

The name `TextAlignment` is really deceptive and almost every new user gets confused about the differences between aligning text with `TextAlignment`, aligning text with `Style` and aligning text with anchor (when using `Text2d`).

## Solution

* Rename `TextAlignment` to `JustifyText`.  The associated helper methods are also renamed.
* Improve the doc comments for text explaining explicitly how the `JustifyText` component affects the arrangement of text.
* Add some extra cases to the `text_debug` example that demonstate the differences between alignment using `JustifyText` and alignment using `Style`.
   <img width="757" alt="text_debug_2" src="https://github.com/bevyengine/bevy/assets/27962798/9d53e647-93f9-4bc7-8a20-0d9f783304d2">

---

## Changelog
* `TextAlignment` has been renamed to `JustifyText`
* `TextBundle::with_text_alignment` has been renamed to `TextBundle::with_text_justify`
* `Text::with_alignment` has been renamed to `Text::with_justify`
* The `text_alignment` field of `TextMeasureInfo` has been renamed to `justification`

## Migration Guide
* `TextAlignment` has been renamed to `JustifyText`
* `TextBundle::with_text_alignment` has been renamed to `TextBundle::with_text_justify`
* `Text::with_alignment` has been renamed to `Text::with_justify`
*  The `text_alignment` field of `TextMeasureInfo` has been renamed to `justification`
