### PR TITLE
Split `Ray` into `Ray2d` and `Ray3d` and simplify plane construction

### DIFF
--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -13,7 +13,7 @@ mod ray;
 mod rects;
 
 pub use affine3::*;
-pub use ray::Ray;
+pub use ray::{Ray2d, Ray3d};
 pub use rects::*;
 
 /// The `bevy_math` prelude.
@@ -25,8 +25,8 @@ pub mod prelude {
             CubicSegment,
         },
         primitives, BVec2, BVec3, BVec4, EulerRot, IRect, IVec2, IVec3, IVec4, Mat2, Mat3, Mat4,
-        Quat, Ray, Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3, Vec3Swizzles, Vec4,
-        Vec4Swizzles,
+        Quat, Ray2d, Ray3d, Rect, URect, UVec2, UVec3, UVec4, Vec2, Vec2Swizzles, Vec3,
+        Vec3Swizzles, Vec4, Vec4Swizzles,
     };
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -64,10 +64,12 @@ pub struct Plane2d {
 }
 impl Primitive2d for Plane2d {}
 
-impl From<Vec2> for Plane2d {
-    fn from(normal: Vec2) -> Self {
+impl Plane2d {
+    /// Create a new `Plane2d` from a normal
+    #[inline]
+    pub fn new(normal: Vec2) -> Self {
         Self {
-            normal: normal.into(),
+            normal: Direction2d::from(normal),
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -64,14 +64,6 @@ pub struct Plane2d {
 }
 impl Primitive2d for Plane2d {}
 
-impl Plane2d {
-    /// Create a new `Plane2d` from a normal
-    #[inline]
-    pub fn new(normal: Vec2) -> Self {
-        Self::from(normal)
-    }
-}
-
 impl From<Vec2> for Plane2d {
     fn from(normal: Vec2) -> Self {
         Self {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -2,7 +2,7 @@ use super::{Primitive2d, WindingOrder};
 use crate::Vec2;
 
 /// A normalized vector pointing in a direction in 2D space
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Direction2d(Vec2);
 
 impl From<Vec2> for Direction2d {
@@ -62,6 +62,32 @@ pub struct Plane2d {
     pub normal: Direction2d,
 }
 impl Primitive2d for Plane2d {}
+
+/// An infinite half-line starting at `origin` and going in `direction` in 2D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ray2d {
+    /// The origin of the ray.
+    pub origin: Vec2,
+    /// The direction of the ray.
+    pub direction: Direction2d,
+}
+
+impl Ray2d {
+    /// Create a new `Ray2d` from a given origin and direction
+    #[inline]
+    pub fn new(origin: Vec2, direction: Vec2) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
+    #[inline]
+    pub fn get_point(&self, distance: f32) -> Vec2 {
+        self.origin + *self.direction * distance
+    }
+}
 
 /// An infinite line along a direction in 2D space.
 ///
@@ -322,6 +348,13 @@ impl RegularPolygon {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ray_math() {
+        let ray = Ray2d::new(Vec2::ZERO, Vec2::Y * 10.0);
+        assert_eq!(*ray.direction, Vec2::Y, "ray direction is not normalized");
+        assert_eq!(ray.get_point(2.0), Vec2::Y * 2.0);
+    }
 
     #[test]
     fn triangle_winding_order() {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -3,6 +3,7 @@ use crate::Vec2;
 
 /// A normalized vector pointing in a direction in 2D space
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Direction2d(Vec2);
 
 impl From<Vec2> for Direction2d {
@@ -63,29 +64,19 @@ pub struct Plane2d {
 }
 impl Primitive2d for Plane2d {}
 
-/// An infinite half-line starting at `origin` and going in `direction` in 2D space.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Ray2d {
-    /// The origin of the ray.
-    pub origin: Vec2,
-    /// The direction of the ray.
-    pub direction: Direction2d,
-}
-
-impl Ray2d {
-    /// Create a new `Ray2d` from a given origin and direction
+impl Plane2d {
+    /// Create a new `Plane2d` from a normal
     #[inline]
-    pub fn new(origin: Vec2, direction: Vec2) -> Self {
+    pub fn new(normal: Vec2) -> Self {
         Self {
-            origin,
-            direction: direction.into(),
+            normal: normal.into(),
         }
     }
+}
 
-    /// Get a point at a given distance along the ray
-    #[inline]
-    pub fn get_point(&self, distance: f32) -> Vec2 {
-        self.origin + *self.direction * distance
+impl From<Vec2> for Plane2d {
+    fn from(vec: Vec2) -> Self {
+        Self { normal: vec.into() }
     }
 }
 
@@ -348,13 +339,6 @@ impl RegularPolygon {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn ray_math() {
-        let ray = Ray2d::new(Vec2::ZERO, Vec2::Y * 10.0);
-        assert_eq!(*ray.direction, Vec2::Y, "ray direction is not normalized");
-        assert_eq!(ray.get_point(2.0), Vec2::Y * 2.0);
-    }
 
     #[test]
     fn triangle_winding_order() {

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -68,15 +68,15 @@ impl Plane2d {
     /// Create a new `Plane2d` from a normal
     #[inline]
     pub fn new(normal: Vec2) -> Self {
-        Self {
-            normal: normal.into(),
-        }
+        Self::from(normal)
     }
 }
 
 impl From<Vec2> for Plane2d {
-    fn from(vec: Vec2) -> Self {
-        Self { normal: vec.into() }
+    fn from(normal: Vec2) -> Self {
+        Self {
+            normal: normal.into(),
+        }
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -67,10 +67,14 @@ impl Primitive2d for Plane2d {}
 
 impl Plane2d {
     /// Create a new `Plane2d` from a normal
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given `normal` is zero (or very close to zero), or non-finite.
     #[inline]
     pub fn new(normal: Vec2) -> Self {
         Self {
-            normal: Direction2d::from(normal),
+            normal: Direction2d::new(normal).expect("normal must be nonzero and finite"),
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -2,7 +2,7 @@ use super::Primitive3d;
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Direction3d(Vec3);
 
 impl From<Vec3> for Direction3d {
@@ -42,6 +42,32 @@ pub struct Plane3d {
     pub normal: Direction3d,
 }
 impl Primitive3d for Plane3d {}
+
+/// An infinite half-line starting at `origin` and going in `direction` in 3D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Ray3d {
+    /// The origin of the ray.
+    pub origin: Vec3,
+    /// The direction of the ray.
+    pub direction: Direction3d,
+}
+
+impl Ray3d {
+    /// Create a new `Ray3d` from a given origin and direction
+    #[inline]
+    pub fn new(origin: Vec3, direction: Vec3) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
+    #[inline]
+    pub fn get_point(&self, distance: f32) -> Vec3 {
+        self.origin + *self.direction * distance
+    }
+}
 
 /// An infinite line along a direction in 3D space.
 ///
@@ -329,5 +355,17 @@ impl Torus {
             std::cmp::Ordering::Equal => TorusKind::Horn,
             std::cmp::Ordering::Less => TorusKind::Spindle,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ray_math() {
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::Z * 10.0);
+        assert_eq!(*ray.direction, Vec3::Z, "ray direction is not normalized");
+        assert_eq!(ray.get_point(2.0), Vec3::Z * 2.0);
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -48,15 +48,15 @@ impl Plane3d {
     /// Create a new `Plane3d` from a normal
     #[inline]
     pub fn new(normal: Vec3) -> Self {
-        Self {
-            normal: normal.into(),
-        }
+        Self::from(normal)
     }
 }
 
 impl From<Vec3> for Plane3d {
-    fn from(vec: Vec3) -> Self {
-        Self { normal: vec.into() }
+    fn from(normal: Vec3) -> Self {
+        Self {
+            normal: normal.into(),
+        }
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -44,10 +44,12 @@ pub struct Plane3d {
 }
 impl Primitive3d for Plane3d {}
 
-impl From<Vec3> for Plane3d {
-    fn from(normal: Vec3) -> Self {
+impl Plane3d {
+    /// Create a new `Plane3d` from a normal
+    #[inline]
+    pub fn new(normal: Vec3) -> Self {
         Self {
-            normal: normal.into(),
+            normal: Direction3d::from(normal),
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -44,14 +44,6 @@ pub struct Plane3d {
 }
 impl Primitive3d for Plane3d {}
 
-impl Plane3d {
-    /// Create a new `Plane3d` from a normal
-    #[inline]
-    pub fn new(normal: Vec3) -> Self {
-        Self::from(normal)
-    }
-}
-
 impl From<Vec3> for Plane3d {
     fn from(normal: Vec3) -> Self {
         Self {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -47,10 +47,14 @@ impl Primitive3d for Plane3d {}
 
 impl Plane3d {
     /// Create a new `Plane3d` from a normal
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given `normal` is zero (or very close to zero), or non-finite.
     #[inline]
     pub fn new(normal: Vec3) -> Self {
         Self {
-            normal: Direction3d::from(normal),
+            normal: Direction3d::new(normal).expect("normal must be nonzero and finite"),
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -3,6 +3,7 @@ use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
 #[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Direction3d(Vec3);
 
 impl From<Vec3> for Direction3d {
@@ -43,29 +44,19 @@ pub struct Plane3d {
 }
 impl Primitive3d for Plane3d {}
 
-/// An infinite half-line starting at `origin` and going in `direction` in 3D space.
-#[derive(Clone, Copy, Debug, PartialEq)]
-pub struct Ray3d {
-    /// The origin of the ray.
-    pub origin: Vec3,
-    /// The direction of the ray.
-    pub direction: Direction3d,
-}
-
-impl Ray3d {
-    /// Create a new `Ray3d` from a given origin and direction
+impl Plane3d {
+    /// Create a new `Plane3d` from a normal
     #[inline]
-    pub fn new(origin: Vec3, direction: Vec3) -> Self {
+    pub fn new(normal: Vec3) -> Self {
         Self {
-            origin,
-            direction: direction.into(),
+            normal: normal.into(),
         }
     }
+}
 
-    /// Get a point at a given distance along the ray
-    #[inline]
-    pub fn get_point(&self, distance: f32) -> Vec3 {
-        self.origin + *self.direction * distance
+impl From<Vec3> for Plane3d {
+    fn from(vec: Vec3) -> Self {
+        Self { normal: vec.into() }
     }
 }
 
@@ -355,17 +346,5 @@ impl Torus {
             std::cmp::Ordering::Equal => TorusKind::Horn,
             std::cmp::Ordering::Less => TorusKind::Spindle,
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn ray_math() {
-        let ray = Ray3d::new(Vec3::ZERO, Vec3::Z * 10.0);
-        assert_eq!(*ray.direction, Vec3::Z, "ray direction is not normalized");
-        assert_eq!(ray.get_point(2.0), Vec3::Z * 2.0);
     }
 }

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -31,8 +31,7 @@ impl Ray2d {
 
     /// Get the distance to a plane if the ray intersects it
     #[inline]
-    pub fn intersect_plane(&self, plane_origin: Vec2, plane: impl Into<Plane2d>) -> Option<f32> {
-        let plane = plane.into();
+    pub fn intersect_plane(&self, plane_origin: Vec2, plane: Plane2d) -> Option<f32> {
         let denominator = plane.normal.dot(*self.direction);
         if denominator.abs() > f32::EPSILON {
             let distance = (plane_origin - self.origin).dot(*plane.normal) / denominator;
@@ -72,8 +71,7 @@ impl Ray3d {
 
     /// Get the distance to a plane if the ray intersects it
     #[inline]
-    pub fn intersect_plane(&self, plane_origin: Vec3, plane: impl Into<Plane3d>) -> Option<f32> {
-        let plane = plane.into();
+    pub fn intersect_plane(&self, plane_origin: Vec3, plane: Plane3d) -> Option<f32> {
         let denominator = plane.normal.dot(*self.direction);
         if denominator.abs() > f32::EPSILON {
             let distance = (plane_origin - self.origin).dot(*plane.normal) / denominator;
@@ -94,21 +92,38 @@ mod tests {
         let ray = Ray2d::new(Vec2::ZERO, Vec2::Y);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::Y), Some(1.0));
-        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::NEG_Y), Some(1.0));
-        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::Y).is_none());
-        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::NEG_Y).is_none());
+        assert_eq!(
+            ray.intersect_plane(Vec2::Y, Plane2d::new(Vec2::Y)),
+            Some(1.0)
+        );
+        assert_eq!(
+            ray.intersect_plane(Vec2::Y, Plane2d::new(Vec2::NEG_Y)),
+            Some(1.0)
+        );
+        assert!(ray
+            .intersect_plane(Vec2::NEG_Y, Plane2d::new(Vec2::Y))
+            .is_none());
+        assert!(ray
+            .intersect_plane(Vec2::NEG_Y, Plane2d::new(Vec2::NEG_Y))
+            .is_none());
 
         // Diagonal
-        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::ONE), Some(1.0));
-        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::ONE).is_none());
+        assert_eq!(
+            ray.intersect_plane(Vec2::Y, Plane2d::new(Vec2::ONE)),
+            Some(1.0)
+        );
+        assert!(ray
+            .intersect_plane(Vec2::NEG_Y, Plane2d::new(Vec2::ONE))
+            .is_none());
 
         // Parallel
-        assert!(ray.intersect_plane(Vec2::X, Vec2::X).is_none());
+        assert!(ray
+            .intersect_plane(Vec2::X, Plane2d::new(Vec2::X))
+            .is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Vec2::X, Vec2::X + Vec2::Y * f32::EPSILON)
+            .intersect_plane(Vec2::X, Plane2d::new(Vec2::X + Vec2::Y * f32::EPSILON))
             .is_none());
     }
 
@@ -117,21 +132,38 @@ mod tests {
         let ray = Ray3d::new(Vec3::ZERO, Vec3::Z);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::Z), Some(1.0));
-        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::NEG_Z), Some(1.0));
-        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::Z).is_none());
-        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::NEG_Z).is_none());
+        assert_eq!(
+            ray.intersect_plane(Vec3::Z, Plane3d::new(Vec3::Z)),
+            Some(1.0)
+        );
+        assert_eq!(
+            ray.intersect_plane(Vec3::Z, Plane3d::new(Vec3::NEG_Z)),
+            Some(1.0)
+        );
+        assert!(ray
+            .intersect_plane(Vec3::NEG_Z, Plane3d::new(Vec3::Z))
+            .is_none());
+        assert!(ray
+            .intersect_plane(Vec3::NEG_Z, Plane3d::new(Vec3::NEG_Z))
+            .is_none());
 
         // Diagonal
-        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::ONE), Some(1.0));
-        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::ONE).is_none());
+        assert_eq!(
+            ray.intersect_plane(Vec3::Z, Plane3d::new(Vec3::ONE)),
+            Some(1.0)
+        );
+        assert!(ray
+            .intersect_plane(Vec3::NEG_Z, Plane3d::new(Vec3::ONE))
+            .is_none());
 
         // Parallel
-        assert!(ray.intersect_plane(Vec3::X, Vec3::X).is_none());
+        assert!(ray
+            .intersect_plane(Vec3::X, Plane3d::new(Vec3::X))
+            .is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Vec3::X, Vec3::X + Vec3::Z * f32::EPSILON)
+            .intersect_plane(Vec3::X, Plane3d::new(Vec3::X + Vec3::Z * f32::EPSILON))
             .is_none());
     }
 }

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -31,7 +31,7 @@ impl Ray2d {
 
     /// Get the distance to a plane if the ray intersects it
     #[inline]
-    pub fn intersect_plane(&self, plane: impl Into<Plane2d>, plane_origin: Vec2) -> Option<f32> {
+    pub fn intersect_plane(&self, plane_origin: Vec2, plane: impl Into<Plane2d>) -> Option<f32> {
         let plane = plane.into();
         let denominator = plane.normal.dot(*self.direction);
         if denominator.abs() > f32::EPSILON {
@@ -72,7 +72,7 @@ impl Ray3d {
 
     /// Get the distance to a plane if the ray intersects it
     #[inline]
-    pub fn intersect_plane(&self, plane: impl Into<Plane3d>, plane_origin: Vec3) -> Option<f32> {
+    pub fn intersect_plane(&self, plane_origin: Vec3, plane: impl Into<Plane3d>) -> Option<f32> {
         let plane = plane.into();
         let denominator = plane.normal.dot(*self.direction);
         if denominator.abs() > f32::EPSILON {

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -1,33 +1,87 @@
-use crate::Vec3;
+use crate::{
+    primitives::{Direction2d, Direction3d, Plane2d, Plane3d},
+    Vec2, Vec3,
+};
 
-/// A ray is an infinite line starting at `origin`, going in `direction`.
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
+/// An infinite half-line starting at `origin` and going in `direction` in 2D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
-pub struct Ray {
+pub struct Ray2d {
     /// The origin of the ray.
-    pub origin: Vec3,
-    /// A normalized vector representing the direction of the ray.
-    pub direction: Vec3,
+    pub origin: Vec2,
+    /// The direction of the ray.
+    pub direction: Direction2d,
 }
 
-impl Ray {
-    /// Returns the distance to the plane if the ray intersects it.
+impl Ray2d {
+    /// Create a new `Ray2d` from a given origin and direction
     #[inline]
-    pub fn intersect_plane(&self, plane_origin: Vec3, plane_normal: Vec3) -> Option<f32> {
-        let denominator = plane_normal.dot(self.direction);
+    pub fn new(origin: Vec2, direction: Vec2) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
+    #[inline]
+    pub fn get_point(&self, distance: f32) -> Vec2 {
+        self.origin + *self.direction * distance
+    }
+
+    /// Get the distance to a plane if the ray intersects it
+    #[inline]
+    pub fn intersect_plane(&self, plane: impl Into<Plane2d>, plane_origin: Vec2) -> Option<f32> {
+        let plane = plane.into();
+        let denominator = plane.normal.dot(*self.direction);
         if denominator.abs() > f32::EPSILON {
-            let distance = (plane_origin - self.origin).dot(plane_normal) / denominator;
+            let distance = (plane_origin - self.origin).dot(*plane.normal) / denominator;
             if distance > f32::EPSILON {
                 return Some(distance);
             }
         }
         None
     }
+}
 
-    /// Retrieve a point at the given distance along the ray.
+/// An infinite half-line starting at `origin` and going in `direction` in 3D space.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct Ray3d {
+    /// The origin of the ray.
+    pub origin: Vec3,
+    /// The direction of the ray.
+    pub direction: Direction3d,
+}
+
+impl Ray3d {
+    /// Create a new `Ray3d` from a given origin and direction
+    #[inline]
+    pub fn new(origin: Vec3, direction: Vec3) -> Self {
+        Self {
+            origin,
+            direction: direction.into(),
+        }
+    }
+
+    /// Get a point at a given distance along the ray
     #[inline]
     pub fn get_point(&self, distance: f32) -> Vec3 {
-        self.origin + self.direction * distance
+        self.origin + *self.direction * distance
+    }
+
+    /// Get the distance to a plane if the ray intersects it
+    #[inline]
+    pub fn intersect_plane(&self, plane: impl Into<Plane3d>, plane_origin: Vec3) -> Option<f32> {
+        let plane = plane.into();
+        let denominator = plane.normal.dot(*self.direction);
+        if denominator.abs() > f32::EPSILON {
+            let distance = (plane_origin - self.origin).dot(*plane.normal) / denominator;
+            if distance > f32::EPSILON {
+                return Some(distance);
+            }
+        }
+        None
     }
 }
 
@@ -36,29 +90,82 @@ mod tests {
     use super::*;
 
     #[test]
-    fn intersect_plane() {
-        let ray = Ray {
-            origin: Vec3::ZERO,
-            direction: Vec3::Z,
-        };
+    fn intersect_plane_2d() {
+        let ray = Ray2d::new(Vec2::ZERO, Vec2::Y);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(Some(1.), ray.intersect_plane(Vec3::Z, Vec3::Z));
-        assert_eq!(Some(1.), ray.intersect_plane(Vec3::Z, Vec3::NEG_Z));
-        assert_eq!(None, ray.intersect_plane(Vec3::NEG_Z, Vec3::Z));
-        assert_eq!(None, ray.intersect_plane(Vec3::NEG_Z, Vec3::NEG_Z));
+        assert_eq!(
+            ray.intersect_plane(Plane2d::new(Vec2::Y), Vec2::Y),
+            Some(1.0),
+        );
+        assert_eq!(
+            ray.intersect_plane(Plane2d::new(Vec2::NEG_Y), Vec2::Y),
+            Some(1.0),
+        );
+        assert!(ray
+            .intersect_plane(Plane2d::new(Vec2::Y), Vec2::NEG_Y)
+            .is_none());
+        assert!(ray
+            .intersect_plane(Plane2d::new(Vec2::NEG_Y), Vec2::NEG_Y)
+            .is_none());
 
         // Diagonal
-        assert_eq!(Some(1.), ray.intersect_plane(Vec3::Z, Vec3::ONE));
-        assert_eq!(None, ray.intersect_plane(Vec3::NEG_Z, Vec3::ONE));
+        assert_eq!(
+            ray.intersect_plane(Plane2d::new(Vec2::ONE), Vec2::Y),
+            Some(1.0),
+        );
+        assert!(ray
+            .intersect_plane(Plane2d::new(Vec2::ONE), Vec2::NEG_Y)
+            .is_none());
 
         // Parallel
-        assert_eq!(None, ray.intersect_plane(Vec3::X, Vec3::X));
+        assert!(ray
+            .intersect_plane(Plane2d::new(Vec2::X), Vec2::X)
+            .is_none());
 
         // Parallel with simulated rounding error
+        assert!(ray
+            .intersect_plane(Plane2d::new(Vec2::X + Vec2::Y * f32::EPSILON), Vec2::X)
+            .is_none());
+    }
+
+    #[test]
+    fn intersect_plane_3d() {
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::Y);
+
+        // Orthogonal, and test that an inverse plane_normal has the same result
         assert_eq!(
-            None,
-            ray.intersect_plane(Vec3::X, Vec3::X + Vec3::Z * f32::EPSILON)
+            ray.intersect_plane(Plane3d::new(Vec3::Y), Vec3::Y),
+            Some(1.0),
         );
+        assert_eq!(
+            ray.intersect_plane(Plane3d::new(Vec3::NEG_Y), Vec3::Y),
+            Some(1.0),
+        );
+        assert!(ray
+            .intersect_plane(Plane3d::new(Vec3::Y), Vec3::NEG_Y)
+            .is_none());
+        assert!(ray
+            .intersect_plane(Plane3d::new(Vec3::NEG_Y), Vec3::NEG_Y)
+            .is_none());
+
+        // Diagonal
+        assert_eq!(
+            ray.intersect_plane(Plane3d::new(Vec3::ONE), Vec3::Y),
+            Some(1.0),
+        );
+        assert!(ray
+            .intersect_plane(Plane3d::new(Vec3::ONE), Vec3::NEG_Y)
+            .is_none());
+
+        // Parallel
+        assert!(ray
+            .intersect_plane(Plane3d::new(Vec3::X), Vec3::X)
+            .is_none());
+
+        // Parallel with simulated rounding error
+        assert!(ray
+            .intersect_plane(Plane3d::new(Vec3::X + Vec3::Y * f32::EPSILON), Vec3::X)
+            .is_none());
     }
 }

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -114,16 +114,16 @@ mod tests {
 
     #[test]
     fn intersect_plane_3d() {
-        let ray = Ray3d::new(Vec3::ZERO, Vec3::Y);
+        let ray = Ray3d::new(Vec3::ZERO, Vec3::Z);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(ray.intersect_plane(Vec3::Y, Vec3::Y), Some(1.0),);
-        assert_eq!(ray.intersect_plane(Vec3::NEG_Y, Vec3::Y), Some(1.0),);
-        assert!(ray.intersect_plane(Vec3::Y, Vec3::NEG_Y).is_none());
+        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::Z), Some(1.0),);
+        assert_eq!(ray.intersect_plane(Vec3::NEG_Y, Vec3::Z), Some(1.0),);
+        assert!(ray.intersect_plane(Vec3::Z, Vec3::NEG_Y).is_none());
         assert!(ray.intersect_plane(Vec3::NEG_Y, Vec3::NEG_Y).is_none());
 
         // Diagonal
-        assert_eq!(ray.intersect_plane(Vec3::ONE, Vec3::Y), Some(1.0),);
+        assert_eq!(ray.intersect_plane(Vec3::ONE, Vec3::Z), Some(1.0),);
         assert!(ray.intersect_plane(Vec3::ONE, Vec3::NEG_Y).is_none());
 
         // Parallel
@@ -131,7 +131,7 @@ mod tests {
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Vec3::X + Vec3::Y * f32::EPSILON, Vec3::X)
+            .intersect_plane(Vec3::X + Vec3::Z * f32::EPSILON, Vec3::X)
             .is_none());
     }
 }

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -15,11 +15,16 @@ pub struct Ray2d {
 
 impl Ray2d {
     /// Create a new `Ray2d` from a given origin and direction
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given `direction` is zero (or very close to zero), or non-finite.
     #[inline]
     pub fn new(origin: Vec2, direction: Vec2) -> Self {
         Self {
             origin,
-            direction: direction.into(),
+            direction: Direction2d::new(direction)
+                .expect("ray direction must be nonzero and finite"),
         }
     }
 
@@ -55,11 +60,16 @@ pub struct Ray3d {
 
 impl Ray3d {
     /// Create a new `Ray3d` from a given origin and direction
+    ///
+    /// # Panics
+    ///
+    /// Panics if the given `direction` is zero (or very close to zero), or non-finite.
     #[inline]
     pub fn new(origin: Vec3, direction: Vec3) -> Self {
         Self {
             origin,
-            direction: direction.into(),
+            direction: Direction3d::new(direction)
+                .expect("ray direction must be nonzero and finite"),
         }
     }
 

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -94,21 +94,21 @@ mod tests {
         let ray = Ray2d::new(Vec2::ZERO, Vec2::Y);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::Y), Some(1.0),);
-        assert_eq!(ray.intersect_plane(Vec2::NEG_Y, Vec2::Y), Some(1.0),);
-        assert!(ray.intersect_plane(Vec2::Y, Vec2::NEG_Y).is_none());
+        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::Y), Some(1.0));
+        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::NEG_Y), Some(1.0));
+        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::Y).is_none());
         assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::NEG_Y).is_none());
 
         // Diagonal
-        assert_eq!(ray.intersect_plane(Vec2::ONE, Vec2::Y), Some(1.0),);
-        assert!(ray.intersect_plane(Vec2::ONE, Vec2::NEG_Y).is_none());
+        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::ONE), Some(1.0));
+        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::ONE).is_none());
 
         // Parallel
         assert!(ray.intersect_plane(Vec2::X, Vec2::X).is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Vec2::X + Vec2::Y * f32::EPSILON, Vec2::X)
+            .intersect_plane(Vec2::X, Vec2::X + Vec2::Y * f32::EPSILON)
             .is_none());
     }
 
@@ -117,21 +117,21 @@ mod tests {
         let ray = Ray3d::new(Vec3::ZERO, Vec3::Z);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::Z), Some(1.0),);
-        assert_eq!(ray.intersect_plane(Vec3::NEG_Y, Vec3::Z), Some(1.0),);
-        assert!(ray.intersect_plane(Vec3::Z, Vec3::NEG_Y).is_none());
-        assert!(ray.intersect_plane(Vec3::NEG_Y, Vec3::NEG_Y).is_none());
+        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::Z), Some(1.0));
+        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::NEG_Z), Some(1.0));
+        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::Z).is_none());
+        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::NEG_Z).is_none());
 
         // Diagonal
-        assert_eq!(ray.intersect_plane(Vec3::ONE, Vec3::Z), Some(1.0),);
-        assert!(ray.intersect_plane(Vec3::ONE, Vec3::NEG_Y).is_none());
+        assert_eq!(ray.intersect_plane(Vec3::Z, Vec3::ONE), Some(1.0));
+        assert!(ray.intersect_plane(Vec3::NEG_Z, Vec3::ONE).is_none());
 
         // Parallel
         assert!(ray.intersect_plane(Vec3::X, Vec3::X).is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Vec3::X + Vec3::Z * f32::EPSILON, Vec3::X)
+            .intersect_plane(Vec3::X, Vec3::X + Vec3::Z * f32::EPSILON)
             .is_none());
     }
 }

--- a/crates/bevy_math/src/ray.rs
+++ b/crates/bevy_math/src/ray.rs
@@ -94,38 +94,21 @@ mod tests {
         let ray = Ray2d::new(Vec2::ZERO, Vec2::Y);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(
-            ray.intersect_plane(Plane2d::new(Vec2::Y), Vec2::Y),
-            Some(1.0),
-        );
-        assert_eq!(
-            ray.intersect_plane(Plane2d::new(Vec2::NEG_Y), Vec2::Y),
-            Some(1.0),
-        );
-        assert!(ray
-            .intersect_plane(Plane2d::new(Vec2::Y), Vec2::NEG_Y)
-            .is_none());
-        assert!(ray
-            .intersect_plane(Plane2d::new(Vec2::NEG_Y), Vec2::NEG_Y)
-            .is_none());
+        assert_eq!(ray.intersect_plane(Vec2::Y, Vec2::Y), Some(1.0),);
+        assert_eq!(ray.intersect_plane(Vec2::NEG_Y, Vec2::Y), Some(1.0),);
+        assert!(ray.intersect_plane(Vec2::Y, Vec2::NEG_Y).is_none());
+        assert!(ray.intersect_plane(Vec2::NEG_Y, Vec2::NEG_Y).is_none());
 
         // Diagonal
-        assert_eq!(
-            ray.intersect_plane(Plane2d::new(Vec2::ONE), Vec2::Y),
-            Some(1.0),
-        );
-        assert!(ray
-            .intersect_plane(Plane2d::new(Vec2::ONE), Vec2::NEG_Y)
-            .is_none());
+        assert_eq!(ray.intersect_plane(Vec2::ONE, Vec2::Y), Some(1.0),);
+        assert!(ray.intersect_plane(Vec2::ONE, Vec2::NEG_Y).is_none());
 
         // Parallel
-        assert!(ray
-            .intersect_plane(Plane2d::new(Vec2::X), Vec2::X)
-            .is_none());
+        assert!(ray.intersect_plane(Vec2::X, Vec2::X).is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Plane2d::new(Vec2::X + Vec2::Y * f32::EPSILON), Vec2::X)
+            .intersect_plane(Vec2::X + Vec2::Y * f32::EPSILON, Vec2::X)
             .is_none());
     }
 
@@ -134,38 +117,21 @@ mod tests {
         let ray = Ray3d::new(Vec3::ZERO, Vec3::Y);
 
         // Orthogonal, and test that an inverse plane_normal has the same result
-        assert_eq!(
-            ray.intersect_plane(Plane3d::new(Vec3::Y), Vec3::Y),
-            Some(1.0),
-        );
-        assert_eq!(
-            ray.intersect_plane(Plane3d::new(Vec3::NEG_Y), Vec3::Y),
-            Some(1.0),
-        );
-        assert!(ray
-            .intersect_plane(Plane3d::new(Vec3::Y), Vec3::NEG_Y)
-            .is_none());
-        assert!(ray
-            .intersect_plane(Plane3d::new(Vec3::NEG_Y), Vec3::NEG_Y)
-            .is_none());
+        assert_eq!(ray.intersect_plane(Vec3::Y, Vec3::Y), Some(1.0),);
+        assert_eq!(ray.intersect_plane(Vec3::NEG_Y, Vec3::Y), Some(1.0),);
+        assert!(ray.intersect_plane(Vec3::Y, Vec3::NEG_Y).is_none());
+        assert!(ray.intersect_plane(Vec3::NEG_Y, Vec3::NEG_Y).is_none());
 
         // Diagonal
-        assert_eq!(
-            ray.intersect_plane(Plane3d::new(Vec3::ONE), Vec3::Y),
-            Some(1.0),
-        );
-        assert!(ray
-            .intersect_plane(Plane3d::new(Vec3::ONE), Vec3::NEG_Y)
-            .is_none());
+        assert_eq!(ray.intersect_plane(Vec3::ONE, Vec3::Y), Some(1.0),);
+        assert!(ray.intersect_plane(Vec3::ONE, Vec3::NEG_Y).is_none());
 
         // Parallel
-        assert!(ray
-            .intersect_plane(Plane3d::new(Vec3::X), Vec3::X)
-            .is_none());
+        assert!(ray.intersect_plane(Vec3::X, Vec3::X).is_none());
 
         // Parallel with simulated rounding error
         assert!(ray
-            .intersect_plane(Plane3d::new(Vec3::X + Vec3::Y * f32::EPSILON), Vec3::X)
+            .intersect_plane(Vec3::X + Vec3::Y * f32::EPSILON, Vec3::X)
             .is_none());
     }
 }

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -287,9 +287,11 @@ impl Camera {
         let world_far_plane = ndc_to_world.project_point3(ndc.extend(f32::EPSILON));
 
         // The fallible direction constructor ensures that world_near_plane and world_far_plane aren't NaN.
-        Direction3d::new(world_far_plane - world_near_plane).map(|direction| Ray3d {
-            origin: world_near_plane,
-            direction,
+        Direction3d::new(world_far_plane - world_near_plane).map_or(None, |direction| {
+            Some(Ray3d {
+                origin: world_near_plane,
+                direction,
+            })
         })
     }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -20,7 +20,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut, Resource},
 };
 use bevy_log::warn;
-use bevy_math::{vec2, Mat4, Ray, Rect, URect, UVec2, UVec4, Vec2, Vec3};
+use bevy_math::{vec2, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{HashMap, HashSet};
@@ -272,7 +272,7 @@ impl Camera {
         &self,
         camera_transform: &GlobalTransform,
         mut viewport_position: Vec2,
-    ) -> Option<Ray> {
+    ) -> Option<Ray3d> {
         let target_size = self.logical_viewport_size()?;
         // Flip the Y co-ordinate origin from the top to the bottom.
         viewport_position.y = target_size.y - viewport_position.y;
@@ -284,9 +284,9 @@ impl Camera {
         // Using EPSILON because an ndc with Z = 0 returns NaNs.
         let world_far_plane = ndc_to_world.project_point3(ndc.extend(f32::EPSILON));
 
-        (!world_near_plane.is_nan() && !world_far_plane.is_nan()).then_some(Ray {
+        (!world_near_plane.is_nan() && !world_far_plane.is_nan()).then_some(Ray3d {
             origin: world_near_plane,
-            direction: (world_far_plane - world_near_plane).normalize(),
+            direction: (world_far_plane - world_near_plane).into(),
         })
     }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -20,7 +20,9 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut, Resource},
 };
 use bevy_log::warn;
-use bevy_math::{vec2, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
+use bevy_math::{
+    primitives::Direction3d, vec2, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3,
+};
 use bevy_reflect::prelude::*;
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{HashMap, HashSet};
@@ -284,9 +286,10 @@ impl Camera {
         // Using EPSILON because an ndc with Z = 0 returns NaNs.
         let world_far_plane = ndc_to_world.project_point3(ndc.extend(f32::EPSILON));
 
-        (!world_near_plane.is_nan() && !world_far_plane.is_nan()).then_some(Ray3d {
+        // The fallible direction constructor ensures that world_near_plane and world_far_plane aren't NaN.
+        Direction3d::new(world_far_plane - world_near_plane).map(|direction| Ray3d {
             origin: world_near_plane,
-            direction: (world_far_plane - world_near_plane).into(),
+            direction,
         })
     }
 

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -29,7 +29,9 @@ fn draw_cursor(
     };
 
     // Calculate if and where the ray is hitting the ground plane.
-    let Some(distance) = ray.intersect_plane(ground.translation(), ground.up()) else {
+    let Some(distance) =
+        ray.intersect_plane(ground.translation(), primitives::Plane3d::new(ground.up()))
+    else {
         return;
     };
     let point = ray.get_point(distance);


### PR DESCRIPTION
# Objective

A better alternative version of #10843.

Currently, Bevy has a single `Ray` struct for 3D. To allow better interoperability with Bevy's primitive shapes (#10572) and some third party crates (that handle e.g. spatial queries), it would be very useful to have separate versions for 2D and 3D respectively.

## Solution

Separate `Ray` into `Ray2d` and `Ray3d`. These new structs also take advantage of the new primitives by using `Direction2d`/`Direction3d` for the direction:

```rust
pub struct Ray2d {
    pub origin: Vec2,
    pub direction: Direction2d,
}

pub struct Ray3d {
    pub origin: Vec3,
    pub direction: Direction3d,
}
```

and by using `Plane2d`/`Plane3d` in `intersect_plane`:

```rust
impl Ray2d {
    // ...
    pub fn intersect_plane(&self, plane_origin: Vec2, plane: Plane2d) -> Option<f32> {
        // ...
    }
}
```

---

## Changelog

### Added

- `Ray2d` and `Ray3d`
- `Ray2d::new` and `Ray3d::new` constructors
- `Plane2d::new` and `Plane3d::new` constructors

### Removed

- Removed `Ray` in favor of `Ray3d`

### Changed

- `direction` is now a `Direction2d`/`Direction3d` instead of a vector, which provides guaranteed normalization
- `intersect_plane` now takes a `Plane2d`/`Plane3d` instead of just a vector for the plane normal
- `Direction2d` and `Direction3d` now derive `Serialize` and `Deserialize` to preserve ray (de)serialization

## Migration Guide

`Ray` has been renamed to `Ray3d`.

### Ray creation

Before:

```rust
Ray {
    origin: Vec3::ZERO,
    direction: Vec3::new(0.5, 0.6, 0.2).normalize(),
}
```

After:

```rust
// Option 1:
Ray3d {
    origin: Vec3::ZERO,
    direction: Direction3d::new(Vec3::new(0.5, 0.6, 0.2)).unwrap(),
}

// Option 2:
Ray3d::new(Vec3::ZERO, Vec3::new(0.5, 0.6, 0.2))
```

### Plane intersections

Before:

```rust
let result = ray.intersect_plane(Vec2::X, Vec2::Y);
```

After:

```rust
let result = ray.intersect_plane(Vec2::X, Plane2d::new(Vec2::Y));
```