### PR TITLE
Remove `From` implementations from the direction types

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -5,13 +5,15 @@ use crate::Vec2;
 #[derive(Clone, Copy, Debug)]
 pub struct Direction2d(Vec2);
 
-impl From<Vec2> for Direction2d {
-    fn from(value: Vec2) -> Self {
-        Self(value.normalize())
-    }
-}
-
 impl Direction2d {
+    /// Create a direction from a finite, nonzero [`Vec2`].
+    ///
+    /// If the input is zero (or very close to zero), or non-finite,
+    /// the result of this operation will be `None`.
+    pub fn new(value: Vec2) -> Option<Self> {
+        value.try_normalize().map(|value| Self(value)) 
+    }
+
     /// Create a direction from a [`Vec2`] that is already normalized
     pub fn from_normalized(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -11,7 +11,7 @@ impl Direction2d {
     /// If the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     pub fn new(value: Vec2) -> Option<Self> {
-        value.try_normalize().map(|value| Self(value))
+        value.try_normalize().map(Self)
     }
 
     /// Create a direction from a [`Vec2`] that is already normalized

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -8,8 +8,7 @@ pub struct Direction2d(Vec2);
 impl Direction2d {
     /// Create a direction from a finite, nonzero [`Vec2`].
     ///
-    /// If the input is zero (or very close to zero), or non-finite,
-    /// the result of this operation will be `None`.
+    /// Returns `None` if the input is zero (or very close to zero), or non-finite.
     pub fn new(value: Vec2) -> Option<Self> {
         value.try_normalize().map(Self)
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -11,7 +11,7 @@ impl Direction2d {
     /// If the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     pub fn new(value: Vec2) -> Option<Self> {
-        value.try_normalize().map(|value| Self(value)) 
+        value.try_normalize().map(|value| Self(value))
     }
 
     /// Create a direction from a [`Vec2`] that is already normalized

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -11,7 +11,7 @@ impl Direction3d {
     /// If the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     pub fn new(value: Vec3) -> Option<Self> {
-        value.try_normalize().map(|value| Self(value))
+        value.try_normalize().map(Self)
     }
 
     /// Create a direction from a [`Vec3`] that is already normalized

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -11,7 +11,7 @@ impl Direction3d {
     /// If the input is zero (or very close to zero), or non-finite,
     /// the result of this operation will be `None`.
     pub fn new(value: Vec3) -> Option<Self> {
-        value.try_normalize().map(|value| Self(value)) 
+        value.try_normalize().map(|value| Self(value))
     }
 
     /// Create a direction from a [`Vec3`] that is already normalized

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -5,13 +5,15 @@ use crate::Vec3;
 #[derive(Clone, Copy, Debug)]
 pub struct Direction3d(Vec3);
 
-impl From<Vec3> for Direction3d {
-    fn from(value: Vec3) -> Self {
-        Self(value.normalize())
-    }
-}
-
 impl Direction3d {
+    /// Create a direction from a finite, nonzero [`Vec3`].
+    ///
+    /// If the input is zero (or very close to zero), or non-finite,
+    /// the result of this operation will be `None`.
+    pub fn new(value: Vec3) -> Option<Self> {
+        value.try_normalize().map(|value| Self(value)) 
+    }
+
     /// Create a direction from a [`Vec3`] that is already normalized
     pub fn from_normalized(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -8,8 +8,7 @@ pub struct Direction3d(Vec3);
 impl Direction3d {
     /// Create a direction from a finite, nonzero [`Vec3`].
     ///
-    /// If the input is zero (or very close to zero), or non-finite,
-    /// the result of this operation will be `None`.
+    /// Returns `None` if the input is zero (or very close to zero), or non-finite.
     pub fn new(value: Vec3) -> Option<Self> {
         value.try_normalize().map(Self)
     }


### PR DESCRIPTION
This removes the `From<Vec2/3>` implementations for the direction types.
It doesn't seem right to have when it only works if the vector is nonzero and finite and produces NaN otherwise.

Added `Direction2d/3d::new` which uses `Vec2/3::try_normalize` to guarantee it returns either a valid direction or `None`.

This should make it impossible to create an invalid direction, which I think was the intention with these types.