### PR TITLE
Unify `SystemSetConfigs` with `SystemConfigs`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,8 +4,8 @@ use bevy_ecs::{
     prelude::*,
     schedule::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
-        run_enter_schedule, InternedScheduleLabel, IntoSystemConfigs,
-        ScheduleBuildSettings, ScheduleLabel,
+        run_enter_schedule, InternedScheduleLabel, IntoSystemConfigs, ScheduleBuildSettings,
+        ScheduleLabel,
     },
 };
 use bevy_utils::{intern::Interned, thiserror::Error, tracing::debug, HashMap, HashSet};

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -4,7 +4,7 @@ use bevy_ecs::{
     prelude::*,
     schedule::{
         apply_state_transition, common_conditions::run_once as run_once_condition,
-        run_enter_schedule, InternedScheduleLabel, IntoSystemConfigs, IntoSystemSetConfigs,
+        run_enter_schedule, InternedScheduleLabel, IntoSystemConfigs,
         ScheduleBuildSettings, ScheduleLabel,
     },
 };
@@ -424,21 +424,13 @@ impl App {
 
     /// Configures a collection of system sets in the default schedule, adding any sets that do not exist.
     #[track_caller]
-    pub fn configure_sets(
+    #[deprecated = "use `.add_systems()` instead"]
+    pub fn configure_sets<M>(
         &mut self,
         schedule: impl ScheduleLabel,
-        sets: impl IntoSystemSetConfigs,
+        sets: impl IntoSystemConfigs<M>,
     ) -> &mut Self {
-        let schedule = schedule.intern();
-        let mut schedules = self.world.resource_mut::<Schedules>();
-        if let Some(schedule) = schedules.get_mut(schedule) {
-            schedule.configure_sets(sets);
-        } else {
-            let mut new_schedule = Schedule::new(schedule);
-            new_schedule.configure_sets(sets);
-            schedules.insert(new_schedule);
-        }
-        self
+        self.add_systems(schedule, sets)
     }
 
     /// Setup the application to manage events of type `T`.

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -45,7 +45,7 @@ use crate::{
 use bevy_app::{App, First, MainScheduleOrder, Plugin, PostUpdate};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
-    schedule::{IntoSystemConfigs, IntoSystemSetConfigs, ScheduleLabel, SystemSet},
+    schedule::{IntoSystemConfigs, ScheduleLabel, SystemSet},
     system::Resource,
     world::FromWorld,
 };
@@ -213,11 +213,10 @@ impl Plugin for AssetPlugin {
             .init_asset::<LoadedFolder>()
             .init_asset::<LoadedUntypedAsset>()
             .init_asset::<()>()
-            .configure_sets(
+            .add_systems(
                 UpdateAssets,
-                TrackAssets.after(handle_internal_asset_events),
-            )
-            .add_systems(UpdateAssets, handle_internal_asset_events);
+                (handle_internal_asset_events, TrackAssets).chain(),
+            );
 
         let mut order = app.world.resource_mut::<MainScheduleOrder>();
         order.insert_after(First, UpdateAssets);

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -81,7 +81,7 @@ impl Plugin for AudioPlugin {
             .register_type::<PlaybackSettings>()
             .insert_resource(self.global_volume)
             .insert_resource(self.spatial_scale)
-            .configure_sets(
+            .add_systems(
                 PostUpdate,
                 AudioPlaySet
                     .run_if(audio_output_available)

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -39,8 +39,8 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, apply_state_transition, common_conditions::*, Condition,
-            IntoSystemConfigs, IntoSystemSet, NextState, OnEnter, OnExit, OnTransition, Schedule,
-            Schedules, State, States, SystemSet,
+            IntoSystemConfigs, IntoSystemSet, NextState, OnEnter, OnExit,
+            OnTransition, Schedule, Schedules, State, States, SystemSet,
         },
         system::{
             Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -39,8 +39,8 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, apply_state_transition, common_conditions::*, Condition,
-            IntoSystemConfigs, IntoSystemSet, NextState, OnEnter, OnExit,
-            OnTransition, Schedule, Schedules, State, States, SystemSet,
+            IntoSystemConfigs, IntoSystemSet, NextState, OnEnter, OnExit, OnTransition, Schedule,
+            Schedules, State, States, SystemSet,
         },
         system::{
             Commands, Deferred, In, IntoSystem, Local, NonSend, NonSendMut, ParallelCommands,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -39,7 +39,7 @@ pub mod prelude {
         removal_detection::RemovedComponents,
         schedule::{
             apply_deferred, apply_state_transition, common_conditions::*, Condition,
-            IntoSystemConfigs, IntoSystemSet, IntoSystemSetConfigs, NextState, OnEnter, OnExit,
+            IntoSystemConfigs, IntoSystemSet, NextState, OnEnter, OnExit,
             OnTransition, Schedule, Schedules, State, States, SystemSet,
         },
         system::{

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -276,6 +276,20 @@ where
         self.into_configs().in_set(set)
     }
 
+    /// Add these systems to the provided `set`.
+    ///
+    /// Any configuration applied to the returned `SystemConfigs` will be applied to `set`.
+    #[track_caller]
+    fn into_set(self, set: impl SystemSet) -> SystemConfigs {
+        let set = set.intern();
+
+        let configs = self.into_configs().in_set(set);
+
+        // We wrap the configs in a single-tuple to prevent a circular depdency
+        // if `.chain()` is called on the `SystemConfigs` returned from this function.
+        ((configs, set),).into_configs()
+    }
+
     /// Run before all systems in `set`.
     ///
     /// Note: The given set is not implicitly added to the schedule when this system set is added.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -32,7 +32,7 @@ fn ambiguous_with(graph_info: &mut GraphInfo, set: InternedSystemSet) {
     }
 }
 
-impl<Marker, F> IntoSystemConfigs<(F, Marker)> for F
+impl<Marker, F> IntoSystemConfigs<(Marker,)> for F
 where
     F: IntoSystem<(), (), Marker>,
 {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -319,7 +319,7 @@ where
     /// that all evaluations in a single schedule run will yield the same result. If another
     /// system is run inbetween two evaluations it could cause the result of the condition to change.
     ///
-    /// Use [`run_if`](IntoSystemSetConfigs::run_if) on a [`SystemSet`] if you want to make sure
+    /// Use [`run_if`](IntoSystemConfigs::run_if) on a [`SystemSet`] if you want to make sure
     /// that either all or none of the systems are run, or you don't want to evaluate the run
     /// condition for each contained system separately.
     fn distributive_run_if<M>(self, condition: impl Condition<M> + Clone) -> SystemConfigs {

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -276,20 +276,6 @@ where
         self.into_configs().in_set(set)
     }
 
-    /// Add these systems to the provided `set`.
-    ///
-    /// Any configuration applied to the returned `SystemConfigs` will be applied to `set`.
-    #[track_caller]
-    fn into_set(self, set: impl SystemSet) -> SystemConfigs {
-        let set = set.intern();
-
-        let configs = self.into_configs().in_set(set);
-
-        // We wrap the configs in a single-tuple to prevent a circular depdency
-        // if `.chain()` is called on the `SystemConfigs` returned from this function.
-        ((configs, set),).into_configs()
-    }
-
     /// Run before all systems in `set`.
     ///
     /// Note: The given set is not implicitly added to the schedule when this system set is added.

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -345,7 +345,7 @@ where
     /// # #[derive(SystemSet, Debug, Eq, PartialEq, Hash, Clone, Copy)]
     /// # struct C;
     /// schedule.add_systems((a, b).run_if(condition));
-    /// schedule.add_systems((a, b).in_set(C)).configure_sets(C.run_if(condition));
+    /// schedule.add_systems(((a, b).in_set(C), C.run_if(condition)));
     /// ```
     ///
     /// # Note

--- a/crates/bevy_ecs/src/schedule/config.rs
+++ b/crates/bevy_ecs/src/schedule/config.rs
@@ -87,7 +87,7 @@ impl SystemConfigs {
             conditions: Vec::new(),
         })
     }
-    
+
     /// Adds a new boxed system set to the systems.
     pub fn in_set_inner(&mut self, set: InternedSystemSet) {
         match self {

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -25,7 +25,7 @@ mod tests {
     use std::sync::atomic::{AtomicU32, Ordering};
 
     pub use crate as bevy_ecs;
-    pub use crate::schedule::{IntoSystemSetConfigs, Schedule, SystemSet};
+    pub use crate::schedule::{Schedule, SystemSet};
     pub use crate::system::{Res, ResMut};
     pub use crate::{prelude::World, system::Resource};
 
@@ -145,11 +145,11 @@ mod tests {
             assert_eq!(world.resource::<SystemOrder>().0, vec![]);
 
             // modify the schedule after it's been initialized and test ordering with sets
-            schedule.configure_sets(TestSet::A.after(named_system));
             schedule.add_systems((
                 make_function_system(3)
                     .before(TestSet::A)
                     .after(named_system),
+                TestSet::A.after(named_system),
                 make_function_system(4).after(TestSet::A),
             ));
             schedule.run(&mut world);
@@ -339,13 +339,13 @@ mod tests {
 
             world.init_resource::<Counter>();
 
-            schedule.configure_sets(TestSet::A.run_if(|| false).run_if(|| false));
+            schedule.add_systems(TestSet::A.run_if(|| false).run_if(|| false));
             schedule.add_systems(counting_system.in_set(TestSet::A));
-            schedule.configure_sets(TestSet::B.run_if(|| true).run_if(|| false));
+            schedule.add_systems(TestSet::B.run_if(|| true).run_if(|| false));
             schedule.add_systems(counting_system.in_set(TestSet::B));
-            schedule.configure_sets(TestSet::C.run_if(|| false).run_if(|| true));
+            schedule.add_systems(TestSet::C.run_if(|| false).run_if(|| true));
             schedule.add_systems(counting_system.in_set(TestSet::C));
-            schedule.configure_sets(TestSet::D.run_if(|| true).run_if(|| true));
+            schedule.add_systems(TestSet::D.run_if(|| true).run_if(|| true));
             schedule.add_systems(counting_system.in_set(TestSet::D));
 
             schedule.run(&mut world);
@@ -359,13 +359,13 @@ mod tests {
 
             world.init_resource::<Counter>();
 
-            schedule.configure_sets(TestSet::A.run_if(|| false));
+            schedule.add_systems(TestSet::A.run_if(|| false));
             schedule.add_systems(counting_system.in_set(TestSet::A).run_if(|| false));
-            schedule.configure_sets(TestSet::B.run_if(|| true));
+            schedule.add_systems(TestSet::B.run_if(|| true));
             schedule.add_systems(counting_system.in_set(TestSet::B).run_if(|| false));
-            schedule.configure_sets(TestSet::C.run_if(|| false));
+            schedule.add_systems(TestSet::C.run_if(|| false));
             schedule.add_systems(counting_system.in_set(TestSet::C).run_if(|| true));
-            schedule.configure_sets(TestSet::D.run_if(|| true));
+            schedule.add_systems(TestSet::D.run_if(|| true));
             schedule.add_systems(counting_system.in_set(TestSet::D).run_if(|| true));
 
             schedule.run(&mut world);
@@ -431,7 +431,7 @@ mod tests {
             world.init_resource::<Bool2>();
             let mut schedule = Schedule::default();
 
-            schedule.configure_sets(
+            schedule.add_systems(
                 TestSet::A
                     .run_if(|res1: Res<RunConditionBool>| res1.is_changed())
                     .run_if(|res2: Res<Bool2>| res2.is_changed()),
@@ -482,7 +482,7 @@ mod tests {
             let mut schedule = Schedule::default();
 
             schedule
-                .configure_sets(TestSet::A.run_if(|res1: Res<RunConditionBool>| res1.is_changed()));
+                .add_systems(TestSet::A.run_if(|res1: Res<RunConditionBool>| res1.is_changed()));
 
             schedule.add_systems(
                 counting_system
@@ -529,7 +529,7 @@ mod tests {
         #[should_panic]
         fn dependency_loop() {
             let mut schedule = Schedule::default();
-            schedule.configure_sets(TestSet::X.after(TestSet::X));
+            schedule.add_systems(TestSet::X.after(TestSet::X));
         }
 
         #[test]
@@ -537,8 +537,8 @@ mod tests {
             let mut world = World::new();
             let mut schedule = Schedule::default();
 
-            schedule.configure_sets(TestSet::A.after(TestSet::B));
-            schedule.configure_sets(TestSet::B.after(TestSet::A));
+            schedule.add_systems(TestSet::A.after(TestSet::B));
+            schedule.add_systems(TestSet::B.after(TestSet::A));
 
             let result = schedule.initialize(&mut world);
             assert!(matches!(
@@ -564,7 +564,7 @@ mod tests {
         #[should_panic]
         fn hierarchy_loop() {
             let mut schedule = Schedule::default();
-            schedule.configure_sets(TestSet::X.in_set(TestSet::X));
+            schedule.add_systems(TestSet::X.in_set(TestSet::X));
         }
 
         #[test]
@@ -572,8 +572,8 @@ mod tests {
             let mut world = World::new();
             let mut schedule = Schedule::default();
 
-            schedule.configure_sets(TestSet::A.in_set(TestSet::B));
-            schedule.configure_sets(TestSet::B.in_set(TestSet::A));
+            schedule.add_systems(TestSet::A.in_set(TestSet::B));
+            schedule.add_systems(TestSet::B.in_set(TestSet::A));
 
             let result = schedule.initialize(&mut world);
             assert!(matches!(result, Err(ScheduleBuildError::HierarchyCycle(_))));
@@ -625,7 +625,7 @@ mod tests {
         fn configure_system_type_set() {
             fn foo() {}
             let mut schedule = Schedule::default();
-            schedule.configure_sets(foo.into_system_set());
+            schedule.add_systems(foo.into_system_set());
         }
 
         #[test]
@@ -639,13 +639,13 @@ mod tests {
             });
 
             // Add `A`.
-            schedule.configure_sets(TestSet::A);
+            schedule.add_systems(TestSet::A);
 
             // Add `B` as child of `A`.
-            schedule.configure_sets(TestSet::B.in_set(TestSet::A));
+            schedule.add_systems(TestSet::B.in_set(TestSet::A));
 
             // Add `X` as child of both `A` and `B`.
-            schedule.configure_sets(TestSet::X.in_set(TestSet::A).in_set(TestSet::B));
+            schedule.add_systems(TestSet::X.in_set(TestSet::A).in_set(TestSet::B));
 
             // `X` cannot be the `A`'s child and grandchild at the same time.
             let result = schedule.initialize(&mut world);
@@ -661,8 +661,8 @@ mod tests {
             let mut schedule = Schedule::default();
 
             // Add `B` and give it both kinds of relationships with `A`.
-            schedule.configure_sets(TestSet::B.in_set(TestSet::A));
-            schedule.configure_sets(TestSet::B.after(TestSet::A));
+            schedule.add_systems(TestSet::B.in_set(TestSet::A));
+            schedule.add_systems(TestSet::B.after(TestSet::A));
             let result = schedule.initialize(&mut world);
             assert!(matches!(
                 result,
@@ -681,7 +681,7 @@ mod tests {
             schedule.add_systems(foo.in_set(TestSet::A).in_set(TestSet::C));
 
             // Order `A -> B -> C`.
-            schedule.configure_sets((
+            schedule.add_systems((
                 TestSet::A,
                 TestSet::B.after(TestSet::A),
                 TestSet::C.after(TestSet::B),

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -579,7 +579,7 @@ impl ScheduleGraph {
     ) -> ProcessConfigsResult {
         match configs {
             SystemConfigs::SystemConfig(config) => {
-                let node_id = BoxedSystem::process_config(self, config);
+                let node_id = self.add_system_inner(config).unwrap();
                 if collect_nodes {
                     ProcessConfigsResult {
                         densely_chained: true,
@@ -593,7 +593,7 @@ impl ScheduleGraph {
                 }
             }
             SystemConfigs::SystemSetConfig(config) => {
-                let node_id = InternedSystemSet::process_config(self, config);
+                let node_id = self.configure_set_inner(config).unwrap();
                 if collect_nodes {
                     ProcessConfigsResult {
                         densely_chained: true,
@@ -1289,24 +1289,6 @@ struct ProcessConfigsResult {
     /// are linearly chained (as if `after` system ordering had been applied between each node)
     /// in the order they are defined
     densely_chained: bool,
-}
-
-/// Trait used by [`ScheduleGraph::process_configs`] to process a single [`NodeConfig`].
-trait ProcessNodeConfig: Sized {
-    /// Process a single [`NodeConfig`].
-    fn process_config(schedule_graph: &mut ScheduleGraph, config: NodeConfig<Self>) -> NodeId;
-}
-
-impl ProcessNodeConfig for BoxedSystem {
-    fn process_config(schedule_graph: &mut ScheduleGraph, config: NodeConfig<Self>) -> NodeId {
-        schedule_graph.add_system_inner(config).unwrap()
-    }
-}
-
-impl ProcessNodeConfig for InternedSystemSet {
-    fn process_config(schedule_graph: &mut ScheduleGraph, config: NodeConfig<Self>) -> NodeId {
-        schedule_graph.configure_set_inner(config).unwrap()
-    }
 }
 
 /// Used to select the appropriate reporting function.

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -569,7 +569,7 @@ impl ScheduleGraph {
     /// `process_config` is the function which processes each individual config node and returns a corresponding `NodeId`.
     ///
     /// The fields on the returned [`ProcessConfigsResult`] are:
-    /// - `nodes`: a vector of all node ids contained in the nested `NodeConfigs`
+    /// - `nodes`: a vector of all node ids contained in the nested `SystemConfigs`
     /// - `densely_chained`: a boolean that is true if all nested nodes are linearly chained (with successive `after` orderings) in the order they are defined
     #[track_caller]
     fn process_configs(
@@ -1282,7 +1282,7 @@ impl ScheduleGraph {
 
 /// Values returned by [`ScheduleGraph::process_configs`]
 struct ProcessConfigsResult {
-    /// All nodes contained inside this process_configs call's [`NodeConfigs`] hierarchy,
+    /// All nodes contained inside this process_configs call's [`SystemConfigs`] hierarchy,
     /// if `ancestor_chained` is true
     nodes: Vec<NodeId>,
     /// True if and only if all nodes are "densely chained", meaning that all nested nodes

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1755,7 +1755,7 @@ impl ScheduleBuildSettings {
 mod tests {
     use crate::{
         self as bevy_ecs,
-        schedule::{IntoSystemConfigs, IntoSystemSetConfigs, Schedule, SystemSet},
+        schedule::{IntoSystemConfigs, Schedule, SystemSet},
         world::World,
     };
 
@@ -1768,7 +1768,7 @@ mod tests {
         let mut world = World::new();
         let mut schedule = Schedule::default();
 
-        schedule.configure_sets(Set.run_if(|| false));
+        schedule.add_systems(Set.run_if(|| false));
         schedule.add_systems(
             (|| panic!("This system must not run"))
                 .ambiguous_with(|| ())

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -115,8 +115,7 @@ impl<T> SystemSet for SystemTypeSet<T> {
 }
 
 /// A [`SystemSet`] implicitly created when using
-/// [`Schedule::add_systems`](super::Schedule::add_systems) or
-/// [`Schedule::configure_sets`](super::Schedule::configure_sets).
+/// [`Schedule::add_systems`](super::Schedule::add_systems).
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub struct AnonymousSet(usize);
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -46,7 +46,7 @@
 //! You can **explicitly order** systems:
 //!
 //! - by calling the `.before(this_system)` or `.after(that_system)` methods when adding them to your schedule
-//! - by adding them to a [`SystemSet`], and then using `.configure_sets(ThisSet.before(ThatSet))` syntax to configure many systems at once
+//! - by adding them to a [`SystemSet`], and then using `.add_systems(ThisSet.before(ThatSet))` syntax to configure many systems at once
 //! - through the use of `.add_systems((system_a, system_b, system_c).chain())`
 //!
 //! [`SystemSet`]: crate::schedule::SystemSet

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -263,18 +263,15 @@ impl Plugin for PbrPlugin {
                 PostUpdate,
                 (
                     (
-                        SimulationLightSystems::AddClusters,
-                        SimulationLightSystems::AddClustersFlush,
-                        SimulationLightSystems::AssignLightsToClusters,
+                        add_clusters.into_set(SimulationLightSystems::AddClusters),
+                        apply_deferred.into_set(SimulationLightSystems::AddClustersFlush),
+                        assign_lights_to_clusters
+                            .into_set(SimulationLightSystems::AssignLightsToClusters)
+                            .after(TransformSystem::TransformPropagate)
+                            .after(VisibilitySystems::CheckVisibility)
+                            .after(CameraUpdateSystem),
                     )
                         .chain(),
-                    add_clusters.in_set(SimulationLightSystems::AddClusters),
-                    apply_deferred.in_set(SimulationLightSystems::AddClustersFlush),
-                    assign_lights_to_clusters
-                        .in_set(SimulationLightSystems::AssignLightsToClusters)
-                        .after(TransformSystem::TransformPropagate)
-                        .after(VisibilitySystems::CheckVisibility)
-                        .after(CameraUpdateSystem),
                     (
                         clear_directional_light_cascades,
                         build_directional_light_cascades::<Projection>,

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -259,18 +259,15 @@ impl Plugin for PbrPlugin {
                 ExtractResourcePlugin::<DefaultOpaqueRendererMethod>::default(),
                 ExtractComponentPlugin::<ShadowFilteringMethod>::default(),
             ))
-            .configure_sets(
-                PostUpdate,
-                (
-                    SimulationLightSystems::AddClusters,
-                    SimulationLightSystems::AddClustersFlush,
-                    SimulationLightSystems::AssignLightsToClusters,
-                )
-                    .chain(),
-            )
             .add_systems(
                 PostUpdate,
                 (
+                    (
+                        SimulationLightSystems::AddClusters,
+                        SimulationLightSystems::AddClustersFlush,
+                        SimulationLightSystems::AssignLightsToClusters,
+                    )
+                        .chain(),
                     add_clusters.in_set(SimulationLightSystems::AddClusters),
                     apply_deferred.in_set(SimulationLightSystems::AddClustersFlush),
                     assign_lights_to_clusters

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -263,15 +263,18 @@ impl Plugin for PbrPlugin {
                 PostUpdate,
                 (
                     (
-                        add_clusters.into_set(SimulationLightSystems::AddClusters),
-                        apply_deferred.into_set(SimulationLightSystems::AddClustersFlush),
-                        assign_lights_to_clusters
-                            .into_set(SimulationLightSystems::AssignLightsToClusters)
-                            .after(TransformSystem::TransformPropagate)
-                            .after(VisibilitySystems::CheckVisibility)
-                            .after(CameraUpdateSystem),
+                        SimulationLightSystems::AddClusters,
+                        SimulationLightSystems::AddClustersFlush,
+                        SimulationLightSystems::AssignLightsToClusters,
                     )
                         .chain(),
+                    add_clusters.in_set(SimulationLightSystems::AddClusters),
+                    apply_deferred.in_set(SimulationLightSystems::AddClustersFlush),
+                    assign_lights_to_clusters
+                        .in_set(SimulationLightSystems::AssignLightsToClusters)
+                        .after(TransformSystem::TransformPropagate)
+                        .after(VisibilitySystems::CheckVisibility)
+                        .after(CameraUpdateSystem),
                     (
                         clear_directional_light_cascades,
                         build_directional_light_cascades::<Projection>,

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -138,9 +138,6 @@ impl Render {
             apply_deferred.in_set(RenderFlush),
             apply_deferred.in_set(PrepareFlush),
             apply_deferred.in_set(CleanupFlush),
-        ));
-
-        schedule.configure_sets(
             (
                 ExtractCommands,
                 ManageViews,
@@ -155,11 +152,11 @@ impl Render {
                 CleanupFlush,
             )
                 .chain(),
-        );
+        ));
 
-        schedule.configure_sets((ExtractCommands, PrepareAssets, Prepare).chain());
-        schedule.configure_sets(QueueMeshes.in_set(Queue).after(prepare_assets::<Mesh>));
-        schedule.configure_sets(
+        schedule.add_systems((ExtractCommands, PrepareAssets, Prepare).chain());
+        schedule.add_systems(QueueMeshes.in_set(Queue).after(prepare_assets::<Mesh>));
+        schedule.add_systems(
             (PrepareResources, PrepareResourcesFlush, PrepareBindGroups)
                 .chain()
                 .in_set(Prepare),

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -132,22 +132,26 @@ impl Render {
         let mut schedule = Schedule::new(Self);
 
         // Create "stage-like" structure using buffer flushes + ordering
-        schedule.add_systems(
+        schedule.add_systems((
             (
                 ExtractCommands,
                 ManageViews,
-                apply_deferred.into_set(ManageViewsFlush),
+                ManageViewsFlush,
                 Queue,
                 PhaseSort,
                 Prepare,
-                apply_deferred.into_set(PrepareFlush),
+                PrepareFlush,
                 Render,
-                apply_deferred.into_set(RenderFlush),
+                RenderFlush,
                 Cleanup,
-                apply_deferred.into_set(CleanupFlush),
+                CleanupFlush,
             )
                 .chain(),
-        );
+            apply_deferred.in_set(ManageViewsFlush),
+            apply_deferred.in_set(PrepareFlush),
+            apply_deferred.in_set(RenderFlush),
+            apply_deferred.in_set(CleanupFlush),
+        ));
 
         schedule.add_systems((ExtractCommands, PrepareAssets, Prepare).chain());
         schedule.add_systems(QueueMeshes.in_set(Queue).after(prepare_assets::<Mesh>));

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -222,7 +222,7 @@ impl Plugin for VisibilityPlugin {
                         // We add an AABB component in CalculateBounds,
                         // which must be ready on the same frame.
                         calculate_bounds.into_set(CalculateBounds),
-                        CalculateBoundsFlush,
+                        apply_deferred.into_set(CalculateBoundsFlush),
                     )
                         .chain(),
                     update_frusta::<OrthographicProjection>

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -214,13 +214,17 @@ impl Plugin for VisibilityPlugin {
         use VisibilitySystems::*;
 
         app
-            // We add an AABB component in CalculateBounds, which must be ready on the same frame.
-            .add_systems(PostUpdate, apply_deferred.in_set(CalculateBoundsFlush))
-            .configure_sets(PostUpdate, CalculateBoundsFlush.after(CalculateBounds))
+            // rustfmt
             .add_systems(
                 PostUpdate,
                 (
-                    calculate_bounds.in_set(CalculateBounds),
+                    (
+                        // We add an AABB component in CalculateBounds,
+                        // which must be ready on the same frame.
+                        calculate_bounds.into_set(CalculateBounds),
+                        CalculateBoundsFlush,
+                    )
+                        .chain(),
                     update_frusta::<OrthographicProjection>
                         .in_set(UpdateOrthographicFrusta)
                         .after(camera_system::<OrthographicProjection>)

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -218,13 +218,11 @@ impl Plugin for VisibilityPlugin {
             .add_systems(
                 PostUpdate,
                 (
-                    (
-                        // We add an AABB component in CalculateBounds,
-                        // which must be ready on the same frame.
-                        calculate_bounds.into_set(CalculateBounds),
-                        apply_deferred.into_set(CalculateBoundsFlush),
-                    )
-                        .chain(),
+                    calculate_bounds.in_set(CalculateBounds),
+                    apply_deferred.in_set(CalculateBoundsFlush),
+                    // We add an AABB component in CalculateBounds,
+                    // which must be ready on the same frame.
+                    (CalculateBounds, CalculateBoundsFlush).chain(),
                     update_frusta::<OrthographicProjection>
                         .in_set(UpdateOrthographicFrusta)
                         .after(camera_system::<OrthographicProjection>)

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -101,10 +101,6 @@ impl Plugin for TransformPlugin {
         app.register_type::<Transform>()
             .register_type::<GlobalTransform>()
             .add_plugins(ValidParentCheckPlugin::<GlobalTransform>::default())
-            .configure_sets(
-                PostStartup,
-                PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
-            )
             // add transform systems to startup so the first update is "correct"
             .add_systems(
                 PostStartup,
@@ -116,11 +112,8 @@ impl Plugin for TransformPlugin {
                         // due to subtle query filtering that is not yet correctly computed in the ambiguity detector
                         .ambiguous_with(PropagateTransformsSet),
                     propagate_transforms.in_set(PropagateTransformsSet),
+                    PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
                 ),
-            )
-            .configure_sets(
-                PostUpdate,
-                PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
             )
             .add_systems(
                 PostUpdate,
@@ -129,6 +122,7 @@ impl Plugin for TransformPlugin {
                         .in_set(TransformSystem::TransformPropagate)
                         .ambiguous_with(PropagateTransformsSet),
                     propagate_transforms.in_set(PropagateTransformsSet),
+                    PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
                 ),
             );
     }

--- a/examples/ecs/ecs_guide.rs
+++ b/examples/ecs/ecs_guide.rs
@@ -284,7 +284,7 @@ fn main() {
         // "before_round": new_player_system, new_round_system
         // "round": print_message_system, score_system
         // "after_round": score_check_system, game_over_system
-        .configure_sets(
+        .add_systems(
             Update,
             // chain() will ensure sets run in the order they are listed
             (MySet::BeforeRound, MySet::Round, MySet::AfterRound).chain(),


### PR DESCRIPTION
# Objective

`SystemSetConfigs` and `SystemConfigs` are nearly identical. Let's just merge them.

This allows users to expressively add configuration to systems and system sets at the same time, and order them alongside each other using `.chain()`.

```rust
.add_systems(
    UpdateAssets,
    (handle_internal_asset_events, TrackAssets).chain(),
);
```

Another benefit of expanding the capabilities of `SystemConfigs` is that it now acts like an anonymous micro-plugin. You can use it to encapsulate some systems, their sets, and ordering between them, and allow them to be freely added to any schedule in an `App`. One example of where this would be beneficial is #10753. That PR splits `apply_state_transitions` into five systems with subtle dependencies. It uses `SystemConfigs` to encapsulate these systems, however extra ordering needs to be applied after inserting those systems, since the configuration does not include ordering for system sets. Using this PR, all of that ordering could be contained in a single instance of `SystemConfigs`.

## Solution

The `SystemConfigs` enum now has a `SystemSetConfig` variant, which stores the configuration for a single system set.

---

## Changelog

* `SystemSet` configuration has been merged with system configuration. Any usage of `configure_sets` should be replaced with `add_systems`.

## Migration Guide

`App::configure_sets` and `Schedule::configure_sets` has been removed. You should use `add_systems` instead, which now allows you to specify configuration for system sets.

The trait `IntoSystemSetConfigs` has been removed. `IntoSystemConfigs` should now be used for both systems and system sets.