### PR TITLE
Add comment about scale factor in `WindowMode`

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -989,6 +989,11 @@ pub enum WindowMode {
     /// When setting this, the window's physical size will be modified to match the size
     /// of the current monitor resolution, and the logical size will follow based
     /// on the scale factor, see [`WindowResolution`].
+    ///
+    /// Note: As this mode respects the scale factor provided by the operating system,
+    /// the window's logical size may be different from its physical size.
+    /// If you want to avoid that behavior, you can use the [`WindowResolution::set_scale_factor_override`]
+    /// function to set the scale factor to 1.0.
     BorderlessFullscreen,
     /// The window should be in "true"/"legacy" Fullscreen mode.
     ///
@@ -1006,6 +1011,11 @@ pub enum WindowMode {
     /// After that, the window's physical size will be modified to match
     /// that monitor resolution, and the logical size will follow based on the
     /// scale factor, see [`WindowResolution`].
+    ///
+    /// Note: As this mode respects the scale factor provided by the operating system,
+    /// the window's logical size may be different from its physical size.
+    /// If you want to avoid that behavior, you can use the [`WindowResolution::set_scale_factor_override`]
+    /// function to set the scale factor to 1.0.
     Fullscreen,
 }
 


### PR DESCRIPTION
# Objective

- Resolves #10784 

## Solution

- As @ickshonpe mentioned in #10784, this is intended behavior but could benefit from mentioning it in docs. 
- I'm also thinking about adding a helper function to disable os scaling such as `disable_os_scaling()`, but not sure if it's needed. 

---

## Changelog

> Add a comment about scaling behavior that happens, and point user to how he can avoid that behavior.