### PR TITLE
Use `impl Into<A>` for `Assets::add`

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -359,9 +359,9 @@ impl<A: Asset> Assets<A> {
 
     /// Adds the given `asset` and allocates a new strong [`Handle`] for it.
     #[inline]
-    pub fn add(&mut self, asset: A) -> Handle<A> {
+    pub fn add(&mut self, asset: impl Into<A>) -> Handle<A> {
         let index = self.dense_storage.allocator.reserve();
-        self.insert_with_index(index, asset).unwrap();
+        self.insert_with_index(index, asset.into()).unwrap();
         Handle::Strong(
             self.handle_provider
                 .get_handle(index.into(), false, None, None),

--- a/errors/B0004.md
+++ b/errors/B0004.md
@@ -33,8 +33,8 @@ fn setup_cube(
         .with_children(|parent| {
             // cube
             parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                mesh: meshes.add(shape::Cube { size: 1.0 }),
+                material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
                 transform: Transform::from_xyz(0.0, 0.5, 0.0),
                 ..default()
             });
@@ -80,8 +80,8 @@ fn setup_cube(
         .with_children(|parent| {
             // cube
             parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                mesh: meshes.add(shape::Cube { size: 1.0 }),
+                material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
                 transform: Transform::from_xyz(0.0, 0.5, 0.0),
                 ..default()
             });

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -18,7 +18,7 @@ fn setup(
 
     // Circle
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(shape::Circle::new(50.).into()).into(),
+        mesh: meshes.add(shape::Circle::new(50.)).into(),
         material: materials.add(ColorMaterial::from(Color::PURPLE)),
         transform: Transform::from_translation(Vec3::new(-150., 0., 0.)),
         ..default()
@@ -37,9 +37,7 @@ fn setup(
 
     // Quad
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes
-            .add(shape::Quad::new(Vec2::new(50., 100.)).into())
-            .into(),
+        mesh: meshes.add(shape::Quad::new(Vec2::new(50., 100.))).into(),
         material: materials.add(ColorMaterial::from(Color::LIME_GREEN)),
         transform: Transform::from_translation(Vec3::new(50., 0., 0.)),
         ..default()
@@ -47,7 +45,7 @@ fn setup(
 
     // Hexagon
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(shape::RegularPolygon::new(50., 6).into()).into(),
+        mesh: meshes.add(shape::RegularPolygon::new(50., 6)).into(),
         material: materials.add(ColorMaterial::from(Color::TURQUOISE)),
         transform: Transform::from_translation(Vec3::new(150., 0., 0.)),
         ..default()

--- a/examples/2d/bloom_2d.rs
+++ b/examples/2d/bloom_2d.rs
@@ -48,7 +48,7 @@ fn setup(
 
     // Circle mesh
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(shape::Circle::new(100.).into()).into(),
+        mesh: meshes.add(shape::Circle::new(100.)).into(),
         // 4. Put something bright in a dark environment to see the effect
         material: materials.add(ColorMaterial::from(Color::rgb(7.5, 0.0, 7.5))),
         transform: Transform::from_translation(Vec3::new(-200., 0., 0.)),
@@ -57,9 +57,7 @@ fn setup(
 
     // Hexagon mesh
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes
-            .add(shape::RegularPolygon::new(100., 6).into())
-            .into(),
+        mesh: meshes.add(shape::RegularPolygon::new(100., 6)).into(),
         // 4. Put something bright in a dark environment to see the effect
         material: materials.add(ColorMaterial::from(Color::rgb(6.25, 9.4, 9.1))),
         transform: Transform::from_translation(Vec3::new(200., 0., 0.)),

--- a/examples/2d/mesh2d.rs
+++ b/examples/2d/mesh2d.rs
@@ -18,7 +18,7 @@ fn setup(
 ) {
     commands.spawn(Camera2dBundle::default());
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Mesh::from(shape::Quad::default())).into(),
+        mesh: meshes.add(shape::Quad::default()).into(),
         transform: Transform::default().with_scale(Vec3::splat(128.)),
         material: materials.add(ColorMaterial::from(Color::PURPLE)),
         ..default()

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -23,14 +23,14 @@ fn setup(
     });
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -17,15 +17,15 @@ fn setup(
 ) {
     // circular base
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Circle::new(4.0).into()),
-        material: materials.add(Color::WHITE.into()),
+        mesh: meshes.add(shape::Circle::new(4.0)),
+        material: materials.add(Color::WHITE),
         transform: Transform::from_rotation(Quat::from_rotation_x(-std::f32::consts::FRAC_PI_2)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb_u8(124, 144, 255).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb_u8(124, 144, 255)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -34,13 +34,13 @@ fn setup(
     });
 
     let shapes = [
-        meshes.add(shape::Cube::default().into()),
-        meshes.add(shape::Box::default().into()),
-        meshes.add(shape::Capsule::default().into()),
-        meshes.add(shape::Torus::default().into()),
-        meshes.add(shape::Cylinder::default().into()),
-        meshes.add(shape::Icosphere::default().try_into().unwrap()),
-        meshes.add(shape::UVSphere::default().into()),
+        meshes.add(shape::Cube::default()),
+        meshes.add(shape::Box::default()),
+        meshes.add(shape::Capsule::default()),
+        meshes.add(shape::Torus::default()),
+        meshes.add(shape::Cylinder::default()),
+        meshes.add(Mesh::try_from(shape::Icosphere::default()).unwrap()),
+        meshes.add(shape::UVSphere::default()),
     ];
 
     let num_shapes = shapes.len();
@@ -75,8 +75,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(shape::Plane::from_size(50.0)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -49,8 +49,8 @@ fn setup(
     // plane
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Plane::from_size(20.).into()),
-            material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+            mesh: meshes.add(shape::Plane::from_size(20.)),
+            material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
             ..default()
         },
         Ground,

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -259,8 +259,8 @@ fn setup(
 ) {
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-        material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
+        mesh: meshes.add(shape::Plane::from_size(50.0)),
+        material: materials.add(Color::rgb(0.1, 0.2, 0.1)),
         ..default()
     });
 
@@ -272,7 +272,7 @@ fn setup(
     // Cubes
     for i in 0..5 {
         commands.spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 0.25 })),
+            mesh: meshes.add(shape::Cube { size: 0.25 }),
             material: cube_material.clone(),
             transform: Transform::from_xyz(i as f32 * 0.25 - 1.0, 0.125, -i as f32 * 0.5),
             ..default()

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -79,7 +79,7 @@ fn setup_terrain_scene(
     // Sky
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Box::default())),
+            mesh: meshes.add(shape::Box::default()),
             material: materials.add(StandardMaterial {
                 base_color: Color::hex("888888").unwrap(),
                 unlit: true,

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -146,10 +146,10 @@ fn setup(
         .id();
 
     // Chessboard Plane
-    let black_material = materials.add(Color::BLACK.into());
-    let white_material = materials.add(Color::WHITE.into());
+    let black_material = materials.add(Color::BLACK);
+    let white_material = materials.add(Color::WHITE);
 
-    let plane_mesh = meshes.add(shape::Plane::from_size(2.0).into());
+    let plane_mesh = meshes.add(shape::Plane::from_size(2.0));
 
     for x in -3..4 {
         for z in -3..4 {

--- a/examples/3d/bloom_3d.rs
+++ b/examples/3d/bloom_3d.rs
@@ -56,11 +56,10 @@ fn setup_scene(
     });
 
     let mesh = meshes.add(
-        shape::Icosphere {
+        Mesh::try_from(shape::Icosphere {
             radius: 0.5,
             subdivisions: 5,
-        }
-        .try_into()
+        })
         .unwrap(),
     );
 

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -103,16 +103,16 @@ fn setup(
 
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.0).into()),
+        mesh: meshes.add(shape::Plane::from_size(50.0)),
         material: forward_mat_h.clone(),
         ..default()
     });
 
-    let cube_h = meshes.add(Mesh::from(shape::Cube { size: 0.1 }));
-    let sphere_h = meshes.add(Mesh::from(shape::UVSphere {
+    let cube_h = meshes.add(shape::Cube { size: 0.1 });
+    let sphere_h = meshes.add(shape::UVSphere {
         radius: 0.125,
         ..default()
-    }));
+    });
 
     // Cubes
     commands.spawn(PbrBundle {
@@ -196,7 +196,7 @@ fn setup(
     // sky
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Box::default())),
+            mesh: meshes.add(shape::Box::default()),
             material: materials.add(StandardMaterial {
                 base_color: Color::hex("888888").unwrap(),
                 unlit: true,

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -58,14 +58,14 @@ fn setup_pyramid_scene(
     // pillars
     for (x, z) in &[(-1.5, -1.5), (1.5, -1.5), (1.5, 1.5), (-1.5, 1.5)] {
         commands.spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Box {
+            mesh: meshes.add(shape::Box {
                 min_x: -0.5,
                 max_x: 0.5,
                 min_z: -0.5,
                 max_z: 0.5,
                 min_y: 0.0,
                 max_y: 3.0,
-            })),
+            }),
             material: stone.clone(),
             transform: Transform::from_xyz(*x, 0.0, *z),
             ..default()
@@ -97,14 +97,14 @@ fn setup_pyramid_scene(
         let size = i as f32 / 2.0 + 3.0;
         let y = -i as f32 / 2.0;
         commands.spawn(PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Box {
+            mesh: meshes.add(shape::Box {
                 min_x: -size,
                 max_x: size,
                 min_z: -size,
                 max_z: size,
                 min_y: 0.0,
                 max_y: 0.5,
-            })),
+            }),
             material: stone.clone(),
             transform: Transform::from_xyz(0.0, y, 0.0),
             ..default()
@@ -113,7 +113,7 @@ fn setup_pyramid_scene(
 
     // sky
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Box::default())),
+        mesh: meshes.add(shape::Box::default()),
         material: materials.add(StandardMaterial {
             base_color: Color::hex("888888").unwrap(),
             unlit: true,

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -25,7 +25,7 @@ fn setup(
 ) {
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(10.0).into()),
+        mesh: meshes.add(shape::Plane::from_size(10.0)),
         material: materials.add(StandardMaterial {
             base_color: Color::WHITE,
             perceptual_roughness: 1.0,
@@ -38,7 +38,7 @@ fn setup(
     let mut transform = Transform::from_xyz(2.5, 2.5, 0.0);
     transform.rotate_z(PI / 2.);
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
+        mesh: meshes.add(shape::Box::new(5.0, 0.15, 5.0)),
         transform,
         material: materials.add(StandardMaterial {
             base_color: Color::INDIGO,
@@ -51,7 +51,7 @@ fn setup(
     let mut transform = Transform::from_xyz(0.0, 2.5, -2.5);
     transform.rotate_x(PI / 2.);
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Box::new(5.0, 0.15, 5.0))),
+        mesh: meshes.add(shape::Box::new(5.0, 0.15, 5.0)),
         transform,
         material: materials.add(StandardMaterial {
             base_color: Color::INDIGO,
@@ -66,7 +66,7 @@ fn setup(
     transform.rotate_y(PI / 8.);
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Quad::new(Vec2::new(2.0, 0.5)))),
+            mesh: meshes.add(shape::Quad::new(Vec2::new(2.0, 0.5))),
             transform,
             material: materials.add(StandardMaterial {
                 base_color_texture: Some(asset_server.load("branding/bevy_logo_light.png")),
@@ -83,7 +83,7 @@ fn setup(
     // cube
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
             material: materials.add(StandardMaterial {
                 base_color: Color::PINK,
                 ..default()
@@ -96,10 +96,10 @@ fn setup(
     // sphere
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::UVSphere {
+            mesh: meshes.add(shape::UVSphere {
                 radius: 0.5,
                 ..default()
-            })),
+            }),
             material: materials.add(StandardMaterial {
                 base_color: Color::LIME_GREEN,
                 ..default()
@@ -131,10 +131,10 @@ fn setup(
         })
         .with_children(|builder| {
             builder.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::UVSphere {
+                mesh: meshes.add(shape::UVSphere {
                     radius: 0.1,
                     ..default()
-                })),
+                }),
                 material: materials.add(StandardMaterial {
                     base_color: Color::RED,
                     emissive: Color::rgba_linear(7.13, 0.0, 0.0, 0.0),
@@ -162,11 +162,11 @@ fn setup(
         .with_children(|builder| {
             builder.spawn(PbrBundle {
                 transform: Transform::from_rotation(Quat::from_rotation_x(PI / 2.0)),
-                mesh: meshes.add(Mesh::from(shape::Capsule {
+                mesh: meshes.add(shape::Capsule {
                     depth: 0.125,
                     radius: 0.1,
                     ..default()
-                })),
+                }),
                 material: materials.add(StandardMaterial {
                     base_color: Color::GREEN,
                     emissive: Color::rgba_linear(0.0, 7.13, 0.0, 0.0),
@@ -191,10 +191,10 @@ fn setup(
         })
         .with_children(|builder| {
             builder.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::UVSphere {
+                mesh: meshes.add(shape::UVSphere {
                     radius: 0.1,
                     ..default()
-                })),
+                }),
                 material: materials.add(StandardMaterial {
                     base_color: Color::BLUE,
                     emissive: Color::rgba_linear(0.0, 0.0, 7.13, 0.0),

--- a/examples/3d/lines.rs
+++ b/examples/3d/lines.rs
@@ -27,12 +27,12 @@ fn setup(
 ) {
     // Spawn a list of lines with start and end points for each lines
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(LineList {
+        mesh: meshes.add(LineList {
             lines: vec![
                 (Vec3::ZERO, Vec3::new(1.0, 1.0, 0.0)),
                 (Vec3::new(1.0, 1.0, 0.0), Vec3::new(1.0, 0.0, 0.0)),
             ],
-        })),
+        }),
         transform: Transform::from_xyz(-1.5, 0.0, 0.0),
         material: materials.add(LineMaterial {
             color: Color::GREEN,
@@ -42,13 +42,13 @@ fn setup(
 
     // Spawn a line strip that goes from point to point
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(LineStrip {
+        mesh: meshes.add(LineStrip {
             points: vec![
                 Vec3::ZERO,
                 Vec3::new(1.0, 1.0, 0.0),
                 Vec3::new(1.0, 0.0, 0.0),
             ],
-        })),
+        }),
         transform: Transform::from_xyz(0.5, 0.0, 0.0),
         material: materials.add(LineMaterial { color: Color::BLUE }),
         ..default()

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -29,32 +29,32 @@ fn setup(
 
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cubes
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(1.5, 0.5, 1.5),
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(1.5, 0.5, -1.5),
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(-1.5, 0.5, 1.5),
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(-1.5, 0.5, -1.5),
         ..default()
     });

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -234,11 +234,10 @@ fn setup(
         .with_children(|commands| {
             // represent the light source as a sphere
             let mesh = meshes.add(
-                shape::Icosphere {
+                Mesh::try_from(shape::Icosphere {
                     radius: 0.05,
                     subdivisions: 3,
-                }
-                .try_into()
+                })
                 .unwrap(),
             );
             commands.spawn(PbrBundle { mesh, ..default() });
@@ -246,13 +245,10 @@ fn setup(
 
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(
-            shape::Plane {
-                size: 10.0,
-                subdivisions: 0,
-            }
-            .into(),
-        ),
+        mesh: meshes.add(shape::Plane {
+            size: 10.0,
+            subdivisions: 0,
+        }),
         material: materials.add(StandardMaterial {
             // standard material derived from dark green, but
             // with roughness and reflectance set.

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -28,7 +28,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 2.0 }));
+    let cube_handle = meshes.add(shape::Cube { size: 2.0 });
     let cube_material_handle = materials.add(StandardMaterial {
         base_color: Color::rgb(0.8, 0.7, 0.6),
         ..default()

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -63,7 +63,7 @@ fn setup(
 
     let image_handle = images.add(image);
 
-    let cube_handle = meshes.add(Mesh::from(shape::Cube { size: 4.0 }));
+    let cube_handle = meshes.add(shape::Cube { size: 4.0 });
     let cube_material_handle = materials.add(StandardMaterial {
         base_color: Color::rgb(0.8, 0.7, 0.6),
         reflectance: 0.02,
@@ -113,7 +113,7 @@ fn setup(
     ));
 
     let cube_size = 4.0;
-    let cube_handle = meshes.add(Mesh::from(shape::Box::new(cube_size, cube_size, cube_size)));
+    let cube_handle = meshes.add(shape::Box::new(cube_size, cube_size, cube_size));
 
     // This material has the texture that has been rendered.
     let material_handle = materials.add(StandardMaterial {

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -112,7 +112,7 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(2.0 * spawn_plane_depth).into()),
+        mesh: meshes.add(shape::Plane::from_size(2.0 * spawn_plane_depth)),
         material: white_handle,
         ..default()
     });

--- a/examples/3d/shadow_caster_receiver.rs
+++ b/examples/3d/shadow_caster_receiver.rs
@@ -47,7 +47,7 @@ fn setup(
     // sphere - initially a caster
     commands.spawn(PbrBundle {
         mesh: sphere_handle.clone(),
-        material: materials.add(Color::RED.into()),
+        material: materials.add(Color::RED),
         transform: Transform::from_xyz(-1.0, spawn_height, 0.0),
         ..default()
     });
@@ -56,7 +56,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: sphere_handle,
-            material: materials.add(Color::BLUE.into()),
+            material: materials.add(Color::BLUE),
             transform: Transform::from_xyz(1.0, spawn_height, 0.0),
             ..default()
         },
@@ -66,8 +66,8 @@ fn setup(
     // floating plane - initially not a shadow receiver and not a caster
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Plane::from_size(20.0).into()),
-            material: materials.add(Color::GREEN.into()),
+            mesh: meshes.add(shape::Plane::from_size(20.0)),
+            material: materials.add(Color::GREEN),
             transform: Transform::from_xyz(0.0, 1.0, -10.0),
             ..default()
         },
@@ -77,7 +77,7 @@ fn setup(
 
     // lower ground plane - initially a shadow receiver
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(20.0).into()),
+        mesh: meshes.add(shape::Plane::from_size(20.0)),
         material: white_handle,
         ..default()
     });

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -22,7 +22,7 @@ fn setup(
 
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(100.0).into()),
+        mesh: meshes.add(shape::Plane::from_size(100.0)),
         material: materials.add(StandardMaterial {
             base_color: Color::rgb(0.2, 0.2, 0.2),
             perceptual_roughness: 0.08,
@@ -36,11 +36,11 @@ fn setup(
     let radius_range = 0.0..0.8;
     let pos_len = position_range.end - position_range.start;
     let radius_len = radius_range.end - radius_range.start;
-    let mesh = meshes.add(Mesh::from(shape::UVSphere {
+    let mesh = meshes.add(shape::UVSphere {
         sectors: 128,
         stacks: 64,
         ..default()
-    }));
+    });
 
     for i in 0..COUNT {
         let percent = i as f32 / COUNT as f32;

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -24,8 +24,8 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(100.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(100.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
 

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -35,15 +35,15 @@ fn setup(
 ) {
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(100.0).into()),
-        material: materials.add(Color::WHITE.into()),
+        mesh: meshes.add(shape::Plane::from_size(100.0)),
+        material: materials.add(Color::WHITE),
         ..default()
     });
 
     // cubes
     let mut rng = StdRng::seed_from_u64(19878367467713);
-    let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 0.5 }));
-    let blue = materials.add(Color::rgb_u8(124, 144, 255).into());
+    let cube_mesh = meshes.add(shape::Cube { size: 0.5 });
+    let blue = materials.add(Color::rgb_u8(124, 144, 255));
     for _ in 0..40 {
         let x = rng.gen_range(-5.0..5.0);
         let y = rng.gen_range(0.0..3.0);
@@ -59,14 +59,14 @@ fn setup(
         ));
     }
 
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere {
+    let sphere_mesh = meshes.add(shape::UVSphere {
         radius: 0.05,
         ..default()
-    }));
-    let sphere_mesh_direction = meshes.add(Mesh::from(shape::UVSphere {
+    });
+    let sphere_mesh_direction = meshes.add(shape::UVSphere {
         radius: 0.1,
         ..default()
-    }));
+    });
     let red_emissive = materials.add(StandardMaterial {
         base_color: Color::RED,
         emissive: Color::rgba_linear(1.0, 0.0, 0.0, 0.0),

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -48,30 +48,30 @@ fn setup(
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: material.clone(),
         transform: Transform::from_xyz(0.0, 0.0, 1.0),
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: material.clone(),
         transform: Transform::from_xyz(0.0, -1.0, 0.0),
         ..default()
     });
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material,
         transform: Transform::from_xyz(1.0, 0.0, 0.0),
         ..default()
     });
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::UVSphere {
+            mesh: meshes.add(shape::UVSphere {
                 radius: 0.4,
                 sectors: 72,
                 stacks: 36,
-            })),
+            }),
             material: materials.add(StandardMaterial {
                 base_color: Color::rgb(0.4, 0.4, 0.4),
                 perceptual_roughness: 1.0,

--- a/examples/3d/texture.rs
+++ b/examples/3d/texture.rs
@@ -24,10 +24,7 @@ fn setup(
 
     // create a new quad mesh. this is what we will apply the texture to
     let quad_width = 8.0;
-    let quad_handle = meshes.add(Mesh::from(shape::Quad::new(Vec2::new(
-        quad_width,
-        quad_width * aspect,
-    ))));
+    let quad_handle = meshes.add(shape::Quad::new(Vec2::new(quad_width, quad_width * aspect)));
 
     // this material renders the texture normally
     let material_handle = materials.add(StandardMaterial {

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -106,8 +106,8 @@ fn setup_basic_scene(
     // plane
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Plane::from_size(50.0).into()),
-            material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
+            mesh: meshes.add(shape::Plane::from_size(50.0)),
+            material: materials.add(Color::rgb(0.1, 0.2, 0.1)),
             ..default()
         },
         SceneNumber(1),
@@ -119,7 +119,7 @@ fn setup_basic_scene(
         ..default()
     });
 
-    let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 0.25 }));
+    let cube_mesh = meshes.add(shape::Cube { size: 0.25 });
     for i in 0..5 {
         commands.spawn((
             PbrBundle {
@@ -133,10 +133,10 @@ fn setup_basic_scene(
     }
 
     // spheres
-    let sphere_mesh = meshes.add(Mesh::from(shape::UVSphere {
+    let sphere_mesh = meshes.add(shape::UVSphere {
         radius: 0.125,
         ..default()
-    }));
+    });
     for i in 0..6 {
         let j = i % 3;
         let s_val = if i < 3 { 0.0 } else { 0.2 };
@@ -225,10 +225,10 @@ fn setup_color_gradient_scene(
 
     commands.spawn((
         MaterialMeshBundle {
-            mesh: meshes.add(Mesh::from(shape::Quad {
+            mesh: meshes.add(shape::Quad {
                 size: vec2(1.0, 1.0) * 0.7,
                 flip: false,
-            })),
+            }),
             material: materials.add(ColorGradientMaterial {}),
             transform,
             visibility: Visibility::Hidden,
@@ -250,10 +250,10 @@ fn setup_image_viewer_scene(
     // exr/hdr viewer (exr requires enabling bevy feature)
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Quad {
+            mesh: meshes.add(shape::Quad {
                 size: vec2(1.0, 1.0),
                 flip: false,
-            })),
+            }),
             material: materials.add(StandardMaterial {
                 base_color_texture: None,
                 unlit: true,

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -76,9 +76,9 @@ fn setup(
         .unwrap(),
     );
 
-    let cube_mesh = meshes.add(Mesh::from(shape::Cube { size: 0.7 }));
+    let cube_mesh = meshes.add(shape::Cube { size: 0.7 });
 
-    let plane_mesh = meshes.add(shape::Plane::from_size(2.0).into());
+    let plane_mesh = meshes.add(shape::Plane::from_size(2.0));
 
     let cylinder_mesh = meshes.add(
         Mesh::try_from(shape::Cylinder {
@@ -94,7 +94,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: cube_mesh.clone(),
-            material: materials.add(StandardMaterial { ..default() }),
+            material: materials.add(StandardMaterial::default()),
             transform: Transform::from_xyz(0.25, 0.5, -2.0).with_rotation(Quat::from_euler(
                 EulerRot::XYZ,
                 1.4,
@@ -114,7 +114,7 @@ fn setup(
     commands.spawn((
         PbrBundle {
             mesh: cube_mesh,
-            material: materials.add(StandardMaterial { ..default() }),
+            material: materials.add(StandardMaterial::default()),
             transform: Transform::from_xyz(-0.75, 0.7, -2.0).with_rotation(Quat::from_euler(
                 EulerRot::XYZ,
                 0.4,

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -20,8 +20,8 @@ fn setup(
 ) {
     // opaque plane, uses `alpha_mode: Opaque` by default
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(6.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(6.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // transparent sphere, uses `alpha_mode: Mask(f32)`
@@ -67,11 +67,11 @@ fn setup(
     });
     // transparent cube, uses `alpha_mode: Blend`
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         // Notice how there is no need to set the `alpha_mode` explicitly here.
         // When converting a color to a material using `into()`, the alpha mode is
         // automatically set to `Blend` if the alpha channel is anything lower than 1.0.
-        material: materials.add(Color::rgba(0.5, 0.5, 1.0, 0.0).into()),
+        material: materials.add(Color::rgba(0.5, 0.5, 1.0, 0.0)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
@@ -84,7 +84,7 @@ fn setup(
             })
             .unwrap(),
         ),
-        material: materials.add(Color::rgb(0.7, 0.2, 0.1).into()),
+        material: materials.add(Color::rgb(0.7, 0.2, 0.1)),
         transform: Transform::from_xyz(0.0, 0.5, -1.5),
         ..default()
     });

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -17,14 +17,14 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -17,8 +17,8 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
@@ -38,7 +38,7 @@ fn setup(
         // This is the default color, but note that vertex colors are
         // multiplied by the base color, so you'll likely want this to be
         // white if using vertex colors.
-        material: materials.add(Color::rgb(1., 1., 1.).into()),
+        material: materials.add(Color::rgb(1., 1., 1.)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -54,16 +54,16 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane::from_size(5.0))),
-        material: materials.add(Color::BLUE.into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::BLUE),
         ..default()
     });
 
     // Red cube: Never renders a wireframe
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::RED.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::RED),
             transform: Transform::from_xyz(-1.0, 0.5, -1.0),
             ..default()
         },
@@ -71,16 +71,16 @@ fn setup(
     ));
     // Orange cube: Follows global wireframe setting
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::ORANGE.into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::ORANGE),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
     // Green cube: Always renders a wireframe
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::GREEN.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::GREEN),
             transform: Transform::from_xyz(1.0, 0.5, 1.0),
             ..default()
         },

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -45,8 +45,8 @@ fn setup(
 
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(500000.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(500000.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
 

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -119,7 +119,7 @@ fn setup(
         .spawn((
             PbrBundle {
                 mesh: meshes.add(Mesh::try_from(shape::Icosphere::default()).unwrap()),
-                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
                 ..default()
             },
             // Add the Name component, and the animation player
@@ -138,8 +138,8 @@ fn setup(
                 p.spawn((
                     PbrBundle {
                         transform: Transform::from_xyz(1.5, 0.0, 0.0),
-                        mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-                        material: materials.add(Color::rgb(0.3, 0.9, 0.3).into()),
+                        mesh: meshes.add(shape::Cube { size: 0.5 }),
+                        material: materials.add(Color::rgb(0.3, 0.9, 0.3)),
                         ..default()
                     },
                     // Add the Name component

--- a/examples/animation/cubic_curve.rs
+++ b/examples/animation/cubic_curve.rs
@@ -38,8 +38,8 @@ fn setup(
     // Spawning a cube to experiment on
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(shape::Cube::default().into()),
-            material: materials.add(Color::ORANGE.into()),
+            mesh: meshes.add(shape::Cube::default()),
+            material: materials.add(Color::ORANGE),
             transform: Transform::from_translation(points[0][0]),
             ..default()
         },
@@ -60,8 +60,8 @@ fn setup(
 
     // ground plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(50.).into()),
-        material: materials.add(Color::SILVER.into()),
+        mesh: meshes.add(shape::Plane::from_size(50.)),
+        material: materials.add(Color::SILVER),
         ..default()
     });
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -45,11 +45,10 @@ fn setup(
     });
 
     // Create inverse bindpose matrices for a skeleton consists of 2 joints
-    let inverse_bindposes =
-        skinned_mesh_inverse_bindposes_assets.add(SkinnedMeshInverseBindposes::from(vec![
-            Mat4::from_translation(Vec3::new(-0.5, -1.0, 0.0)),
-            Mat4::from_translation(Vec3::new(-0.5, -1.0, 0.0)),
-        ]));
+    let inverse_bindposes = skinned_mesh_inverse_bindposes_assets.add(vec![
+        Mat4::from_translation(Vec3::new(-0.5, -1.0, 0.0)),
+        Mat4::from_translation(Vec3::new(-0.5, -1.0, 0.0)),
+    ]);
 
     // Create a mesh
     let mesh = Mesh::new(PrimitiveTopology::TriangleList)
@@ -142,14 +141,11 @@ fn setup(
         commands.spawn((
             PbrBundle {
                 mesh: mesh.clone(),
-                material: materials.add(
-                    Color::rgb(
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                        rng.gen_range(0.0..1.0),
-                    )
-                    .into(),
-                ),
+                material: materials.add(Color::rgb(
+                    rng.gen_range(0.0..1.0),
+                    rng.gen_range(0.0..1.0),
+                    rng.gen_range(0.0..1.0),
+                )),
                 ..default()
             },
             SkinnedMesh {

--- a/examples/async_tasks/async_compute.rs
+++ b/examples/async_tasks/async_compute.rs
@@ -35,10 +35,10 @@ fn add_assets(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    let box_mesh_handle = meshes.add(Mesh::from(shape::Cube { size: 0.25 }));
+    let box_mesh_handle = meshes.add(shape::Cube { size: 0.25 });
     commands.insert_resource(BoxMeshHandle(box_mesh_handle));
 
-    let box_material_handle = materials.add(Color::rgb(1.0, 0.2, 0.3).into());
+    let box_material_handle = materials.add(Color::rgb(1.0, 0.2, 0.3));
     commands.insert_resource(BoxMaterialHandle(box_material_handle));
 }
 

--- a/examples/audio/spatial_audio_2d.rs
+++ b/examples/audio/spatial_audio_2d.rs
@@ -34,8 +34,8 @@ fn setup(
     // sound emitter
     commands.spawn((
         MaterialMesh2dBundle {
-            mesh: meshes.add(shape::Circle::new(15.0).into()).into(),
-            material: materials.add(ColorMaterial::from(Color::BLUE)),
+            mesh: meshes.add(shape::Circle::new(15.0)).into(),
+            material: materials.add(Color::BLUE),
             transform: Transform::from_translation(Vec3::new(0.0, 50.0, 0.0)),
             ..default()
         },

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -22,11 +22,11 @@ fn setup(
     // sound emitter
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::UVSphere {
+            mesh: meshes.add(shape::UVSphere {
                 radius: 0.2,
                 ..default()
-            })),
-            material: materials.add(Color::BLUE.into()),
+            }),
+            material: materials.add(Color::BLUE),
             transform: Transform::from_xyz(0.0, 0.0, 0.0),
             ..default()
         },
@@ -43,16 +43,16 @@ fn setup(
         .with_children(|parent| {
             // left ear indicator
             parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 0.2 })),
-                material: materials.add(Color::RED.into()),
+                mesh: meshes.add(shape::Cube { size: 0.2 }),
+                material: materials.add(Color::RED),
                 transform: Transform::from_translation(listener.left_ear_offset),
                 ..default()
             });
 
             // right ear indicator
             parent.spawn(PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 0.2 })),
-                material: materials.add(Color::GREEN.into()),
+                mesh: meshes.add(shape::Cube { size: 0.2 }),
+                material: materials.add(Color::GREEN),
                 transform: Transform::from_translation(listener.right_ear_offset),
                 ..default()
             });

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -76,14 +76,11 @@ fn generate_bodies(
                     ..default()
                 },
                 mesh: mesh.clone(),
-                material: materials.add(
-                    Color::rgb(
-                        rng.gen_range(color_range.clone()),
-                        rng.gen_range(color_range.clone()),
-                        rng.gen_range(color_range.clone()),
-                    )
-                    .into(),
-                ),
+                material: materials.add(Color::rgb(
+                    rng.gen_range(color_range.clone()),
+                    rng.gen_range(color_range.clone()),
+                    rng.gen_range(color_range.clone()),
+                )),
                 ..default()
             },
             mass: Mass(mass_value),

--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -207,8 +207,8 @@ fn setup(
     // Ball
     commands.spawn((
         MaterialMesh2dBundle {
-            mesh: meshes.add(shape::Circle::default().into()).into(),
-            material: materials.add(ColorMaterial::from(BALL_COLOR)),
+            mesh: meshes.add(shape::Circle::default()).into(),
+            material: materials.add(BALL_COLOR),
             transform: Transform::from_translation(BALL_STARTING_POSITION).with_scale(BALL_SIZE),
             ..default()
         },

--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -62,14 +62,14 @@ fn setup_scene(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.1, 0.2, 0.1).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.1, 0.2, 0.1)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.5, 0.4, 0.3).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.5, 0.4, 0.3)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });
@@ -82,7 +82,7 @@ fn setup_scene(
             })
             .unwrap(),
         ),
-        material: materials.add(Color::rgb(0.1, 0.4, 0.8).into()),
+        material: materials.add(Color::rgb(0.1, 0.4, 0.8)),
         transform: Transform::from_xyz(1.5, 1.5, 1.5),
         ..default()
     });

--- a/examples/shader/animate_shader.rs
+++ b/examples/shader/animate_shader.rs
@@ -21,7 +21,7 @@ fn setup(
 ) {
     // cube
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {}),
         ..default()

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -77,7 +77,7 @@ fn create_array_texture(
     image.reinterpret_stacked_2d_as_array(array_layers);
 
     // Spawn some cubes using the array texture
-    let mesh_handle = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
+    let mesh_handle = meshes.add(shape::Cube { size: 1.0 });
     let material_handle = materials.add(ArrayTextureMaterial {
         array_texture: loading_texture.handle.clone(),
     });

--- a/examples/shader/fallback_image.rs
+++ b/examples/shader/fallback_image.rs
@@ -27,7 +27,7 @@ fn setup(
     mut materials: ResMut<Assets<FallbackTestMaterial>>,
 ) {
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: materials.add(FallbackTestMaterial {
             image_1d: None,
             image_2d: None,
@@ -36,11 +36,11 @@ fn setup(
             image_cube_array: None,
             image_3d: None,
         }),
-        ..Default::default()
+        ..default()
     });
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(5.0, 5.0, 5.0).looking_at(Vec3::new(1.5, 0.0, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -320,8 +320,8 @@ fn setup(
     // cube
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),
             ..default()
         },

--- a/examples/shader/shader_defs.rs
+++ b/examples/shader/shader_defs.rs
@@ -27,7 +27,7 @@ fn setup(
 ) {
     // blue cube
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(-1.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
             color: Color::BLUE,
@@ -38,7 +38,7 @@ fn setup(
 
     // red cube (with green color overridden by the IS_RED "shader def")
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(1.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
             color: Color::GREEN,

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -35,7 +35,7 @@ fn main() {
 
 fn setup(mut commands: Commands, mut meshes: ResMut<Assets<Mesh>>) {
     commands.spawn((
-        meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
+        meshes.add(shape::Cube { size: 0.5 }),
         SpatialBundle::INHERITED_IDENTITY,
         InstanceMaterialData(
             (1..=10)

--- a/examples/shader/shader_material.rs
+++ b/examples/shader/shader_material.rs
@@ -22,7 +22,7 @@ fn setup(
 ) {
     // cube
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
             color: Color::BLUE,

--- a/examples/shader/shader_material_2d.rs
+++ b/examples/shader/shader_material_2d.rs
@@ -29,7 +29,7 @@ fn setup(
 
     // quad
     commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Mesh::from(shape::Quad::default())).into(),
+        mesh: meshes.add(shape::Quad::default()).into(),
         transform: Transform::default().with_scale(Vec3::splat(128.)),
         material: materials.add(CustomMaterial {
             color: Color::BLUE,

--- a/examples/shader/shader_material_glsl.rs
+++ b/examples/shader/shader_material_glsl.rs
@@ -28,7 +28,7 @@ fn setup(
 ) {
     // cube
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: materials.add(CustomMaterial {
             color: Color::BLUE,

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -25,8 +25,8 @@ fn setup(
     mut standard_materials: ResMut<Assets<StandardMaterial>>,
 ) {
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     commands.spawn(PointLightBundle {
@@ -35,7 +35,7 @@ fn setup(
     });
 
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         material: custom_materials.add(CustomMaterial {
             texture: asset_server.load(

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -61,8 +61,8 @@ fn setup(
 
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: std_materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: std_materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
 
@@ -71,7 +71,7 @@ fn setup(
     // For a real application, this isn't ideal.
     commands.spawn((
         MaterialMeshBundle {
-            mesh: meshes.add(shape::Quad::new(Vec2::new(20.0, 20.0)).into()),
+            mesh: meshes.add(shape::Quad::new(Vec2::new(20.0, 20.0))),
             material: depth_materials.add(PrepassOutputMaterial {
                 settings: ShowPrepassSettings::default(),
             }),
@@ -85,7 +85,7 @@ fn setup(
     // Opaque cube
     commands.spawn((
         MaterialMeshBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
             material: materials.add(CustomMaterial {
                 color: Color::WHITE,
                 color_texture: Some(asset_server.load("branding/icon.png")),
@@ -99,7 +99,7 @@ fn setup(
 
     // Cube with alpha mask
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: std_materials.add(StandardMaterial {
             alpha_mode: AlphaMode::Mask(1.0),
             base_color_texture: Some(asset_server.load("branding/icon.png")),
@@ -112,7 +112,7 @@ fn setup(
     // Cube with alpha blending.
     // Transparent materials are ignored by the prepass
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: materials.add(CustomMaterial {
             color: Color::WHITE,
             color_texture: Some(asset_server.load("branding/icon.png")),

--- a/examples/shader/texture_binding_array.rs
+++ b/examples/shader/texture_binding_array.rs
@@ -63,7 +63,7 @@ fn setup(
 ) {
     commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(2.0, 2.0, 2.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-        ..Default::default()
+        ..default()
     });
 
     // load 16 textures
@@ -74,9 +74,9 @@ fn setup(
 
     // a cube with multiple textures
     commands.spawn(MaterialMeshBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
         material: materials.add(BindlessMaterial { textures }),
-        ..Default::default()
+        ..default()
     });
 }
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -206,9 +206,7 @@ fn setup(
         textures,
         materials,
         quad: meshes
-            .add(Mesh::from(shape::Quad::new(Vec2::splat(
-                BIRD_TEXTURE_SIZE as f32,
-            ))))
+            .add(shape::Quad::new(Vec2::splat(BIRD_TEXTURE_SIZE as f32)))
             .into(),
         color_rng: StdRng::seed_from_u64(42),
         material_rng: StdRng::seed_from_u64(42),

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -101,7 +101,7 @@ fn setup(
     let images = images.into_inner();
     let material_assets = material_assets.into_inner();
 
-    let mesh = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
+    let mesh = meshes.add(shape::Cube { size: 1.0 });
 
     let material_textures = init_textures(args, images);
     let materials = init_materials(args, &material_textures, material_assets);

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -185,8 +185,8 @@ fn setup(
 
     // Plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5000.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5000.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -55,12 +55,12 @@ fn setup(
             })
             .unwrap(),
         ),
-        material: materials.add(StandardMaterial::from(Color::WHITE)),
+        material: materials.add(Color::WHITE),
         transform: Transform::from_scale(Vec3::NEG_ONE),
         ..default()
     });
 
-    let mesh = meshes.add(Mesh::from(shape::Cube { size: 1.0 }));
+    let mesh = meshes.add(shape::Cube { size: 1.0 });
     let material = materials.add(StandardMaterial {
         base_color: Color::PINK,
         ..default()

--- a/examples/tools/gamepad_viewer.rs
+++ b/examples/tools/gamepad_viewer.rs
@@ -56,8 +56,8 @@ impl FromWorld for ButtonMaterials {
     fn from_world(world: &mut World) -> Self {
         let mut materials = world.resource_mut::<Assets<ColorMaterial>>();
         Self {
-            normal: materials.add(ColorMaterial::from(NORMAL_BUTTON_COLOR)),
-            active: materials.add(ColorMaterial::from(ACTIVE_BUTTON_COLOR)),
+            normal: materials.add(NORMAL_BUTTON_COLOR),
+            active: materials.add(ACTIVE_BUTTON_COLOR),
         }
     }
 }
@@ -72,12 +72,12 @@ impl FromWorld for ButtonMeshes {
     fn from_world(world: &mut World) -> Self {
         let mut meshes = world.resource_mut::<Assets<Mesh>>();
         Self {
-            circle: meshes.add(shape::Circle::new(BUTTON_RADIUS).into()).into(),
+            circle: meshes.add(shape::Circle::new(BUTTON_RADIUS)).into(),
             triangle: meshes
-                .add(shape::RegularPolygon::new(BUTTON_RADIUS, 3).into())
+                .add(shape::RegularPolygon::new(BUTTON_RADIUS, 3))
                 .into(),
-            start_pause: meshes.add(shape::Quad::new(START_SIZE).into()).into(),
-            trigger: meshes.add(shape::Quad::new(TRIGGER_SIZE).into()).into(),
+            start_pause: meshes.add(shape::Quad::new(START_SIZE)).into(),
+            trigger: meshes.add(shape::Quad::new(TRIGGER_SIZE)).into(),
         }
     }
 }

--- a/examples/transforms/3d_rotation.rs
+++ b/examples/transforms/3d_rotation.rs
@@ -26,8 +26,8 @@ fn setup(
     // Spawn a cube to rotate.
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::WHITE.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::WHITE),
             transform: Transform::from_translation(Vec3::ZERO),
             ..default()
         },

--- a/examples/transforms/scale.rs
+++ b/examples/transforms/scale.rs
@@ -42,8 +42,8 @@ fn setup(
     // Spawn a cube to scale.
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::WHITE.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::WHITE),
             transform: Transform::from_rotation(Quat::from_rotation_y(PI / 4.0)),
             ..default()
         },

--- a/examples/transforms/transform.rs
+++ b/examples/transforms/transform.rs
@@ -53,7 +53,7 @@ fn setup(
                 })
                 .unwrap(),
             ),
-            material: materials.add(Color::YELLOW.into()),
+            material: materials.add(Color::YELLOW),
             transform: Transform::from_translation(Vec3::ZERO),
             ..default()
         },
@@ -73,8 +73,8 @@ fn setup(
         Transform::from_translation(Vec3::Z * -10.0).with_rotation(Quat::from_rotation_y(PI / 2.));
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::WHITE.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::WHITE),
             transform: cube_spawn,
             ..default()
         },

--- a/examples/transforms/translation.rs
+++ b/examples/transforms/translation.rs
@@ -40,8 +40,8 @@ fn setup(
     let entity_spawn = Vec3::ZERO;
     commands.spawn((
         PbrBundle {
-            mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-            material: materials.add(Color::WHITE.into()),
+            mesh: meshes.add(shape::Cube { size: 1.0 }),
+            material: materials.add(Color::WHITE),
             transform: Transform::from_translation(entity_spawn),
             ..default()
         },

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -151,8 +151,8 @@ pub(crate) mod test_setup {
     ) {
         commands.spawn((
             PbrBundle {
-                mesh: meshes.add(Mesh::from(shape::Cube { size: 0.5 })),
-                material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+                mesh: meshes.add(shape::Cube { size: 0.5 }),
+                material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
                 ..default()
             },
             Rotator,

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -35,14 +35,14 @@ fn setup(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(shape::Plane::from_size(5.0).into()),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        mesh: meshes.add(shape::Plane::from_size(5.0)),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -35,17 +35,17 @@ fn setup_3d(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane {
+        mesh: meshes.add(shape::Plane {
             size: 5.0,
             subdivisions: 0,
-        })),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        }),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -118,17 +118,17 @@ fn setup_3d(
 ) {
     // plane
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Plane {
+        mesh: meshes.add(shape::Plane {
             size: 5.0,
             subdivisions: 0,
-        })),
-        material: materials.add(Color::rgb(0.3, 0.5, 0.3).into()),
+        }),
+        material: materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
     // cube
     commands.spawn(PbrBundle {
-        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
-        material: materials.add(Color::rgb(0.8, 0.7, 0.6).into()),
+        mesh: meshes.add(shape::Cube { size: 1.0 }),
+        material: materials.add(Color::rgb(0.8, 0.7, 0.6)),
         transform: Transform::from_xyz(0.0, 0.5, 0.0),
         ..default()
     });


### PR DESCRIPTION
# Motivation

When spawning entities into a scene, it is very common to create assets like meshes and materials and to add them via asset handles. A common setup might look like this:

```rust
fn setup(
    mut commands: Commands,
    mut meshes: ResMut<Assets<Mesh>>,
    mut materials: ResMut<Assets<StandardMaterial>>,
) {
    commands.spawn(PbrBundle {
        mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
        material: materials.add(StandardMaterial::from(Color::RED)),
        ..default()
    });
}
```

Let's take a closer look at the part that adds the assets using `add`.

```rust
mesh: meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
material: materials.add(StandardMaterial::from(Color::RED)),
```

Here, "mesh" and "material" are both repeated three times. It's very explicit, but I find it to be a bit verbose. In addition to being more code to read and write, the extra characters can sometimes also lead to the code being formatted to span multiple lines even though the core task, adding e.g. a primitive mesh, is extremely simple.

A way to address this is by using `.into()`:

```rust
mesh: meshes.add(shape::Cube { size: 1.0 }.into()),
material: materials.add(Color::RED.into()),
```

This is fine, but from the names and the type of `meshes`, we already know what the type should be. It's very clear that `Cube` should be turned into a `Mesh` because of the context it's used in. `.into()` is just seven characters, but it's so common that it quickly adds up and gets annoying.

It would be nice if you could skip all of the conversion and let Bevy handle it for you:

```rust
mesh: meshes.add(shape::Cube { size: 1.0 }),
material: materials.add(Color::RED),
```

# Objective

Make adding assets more ergonomic by making `Assets::add` take an `impl Into<A>` instead of `A`.

## Solution

`Assets::add` now takes an `impl Into<A>` instead of `A`, so e.g. this works:

```rust
    commands.spawn(PbrBundle {
        mesh: meshes.add(shape::Cube { size: 1.0 }),
        material: materials.add(Color::RED),
        ..default()
    });
```

I also changed all examples to use this API, which increases consistency as well because `Mesh::from` and `into` were being used arbitrarily even in the same file. This also gets rid of some lines of code because formatting is nicer.

---

## Changelog

- `Assets::add` now takes an `impl Into<A>` instead of `A`
- Examples don't use `T::from(K)` or `K.into()` when adding assets

## Migration Guide

Some `into` calls that worked previously might now be broken because of the new trait bounds. You need to either remove `into` or perform the conversion explicitly with `from`:

```rust
// Doesn't compile
let mesh_handle = meshes.add(shape::Cube { size: 1.0 }.into()),

// These compile
let mesh_handle = meshes.add(shape::Cube { size: 1.0 }),
let mesh_handle = meshes.add(Mesh::from(shape::Cube { size: 1.0 })),
```

## Concerns

I believe the primary concerns might be:

1. Is this too implicit?
2. Does this increase codegen bloat?

Previously, the two APIs were using `into` or `from`, and now it's "nothing" or `from`. You could argue that `into` is slightly more explicit than "nothing" in cases like the earlier examples where a `Color` gets converted to e.g. a `StandardMaterial`, but I personally don't think `into` adds much value even in this case, and you could still see the actual type from the asset type.

As for codegen bloat, I doubt it adds that much, but I'm not very familiar with the details of codegen. I personally value the user-facing code reduction and ergonomics improvements that these changes would provide, but it might be worth checking the other effects in more detail.

Another slight concern is migration pain; apps might have a ton of `into` calls that would need to be removed, and it did take me a while to do so for Bevy itself (maybe around 20-40 minutes). However, I think the fact that there *are* so many `into` calls just highlights that the API could be made nicer, and I'd gladly migrate my own projects for it.