### PR TITLE
Remove unnecessary ResMut in examples

### DIFF
--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -30,7 +30,7 @@ fn load_textures(mut commands: Commands, asset_server: Res<AssetServer>) {
 
 fn check_textures(
     mut next_state: ResMut<NextState<AppState>>,
-    rpg_sprite_folder: ResMut<RpgSpriteFolder>,
+    rpg_sprite_folder: Res<RpgSpriteFolder>,
     mut events: EventReader<AssetEvent<LoadedFolder>>,
 ) {
     // Advance the `AppState` once all sprite handles have been loaded by the `AssetServer`

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -21,7 +21,7 @@ fn main() {
 
 fn setup(
     mut commands: Commands,
-    asset_server: ResMut<AssetServer>,
+    asset_server: Res<AssetServer>,
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut meshes: ResMut<Assets<Mesh>>,
 ) {

--- a/examples/asset/custom_asset.rs
+++ b/examples/asset/custom_asset.rs
@@ -74,7 +74,7 @@ fn setup(mut state: ResMut<State>, asset_server: Res<AssetServer>) {
     state.handle = asset_server.load("data/asset.custom");
 }
 
-fn print_on_load(mut state: ResMut<State>, custom_assets: ResMut<Assets<CustomAsset>>) {
+fn print_on_load(mut state: ResMut<State>, custom_assets: Res<Assets<CustomAsset>>) {
     let custom_asset = custom_assets.get(&state.handle);
     if state.printed || custom_asset.is_none() {
         return;

--- a/examples/ui/ui_scaling.rs
+++ b/examples/ui/ui_scaling.rs
@@ -24,7 +24,7 @@ fn main() {
         .run();
 }
 
-fn setup(mut commands: Commands, asset_server: ResMut<AssetServer>) {
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
     let text_style = TextStyle {


### PR DESCRIPTION
# Objective

- Examples containing `ResMut`s that are never mutated can be confusing for readers.

## Solution

- Changes them to `Res`.

