### PR TITLE
Add `Direction2d::from_xy` and `Direction3d::from_xyz`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -29,9 +29,9 @@ impl Direction2d {
 
     /// Create a direction from its `x` and `y` components.
     ///
-    /// Returns `None` if the vector formed by the components
-    /// is zero (or very close to zero), or non-finite.
-    pub fn from_xy(x: f32, y: f32) -> Option<Self> {
+    /// Returns [`Err(InvalidDirectionError)`](InvalidDirectionError) if the length
+    /// of the vector formed by the components is zero (or very close to zero), infinite, or `NaN`.
+    pub fn from_xy(x: f32, y: f32) -> Result<Self, InvalidDirectionError> {
         Self::new(Vec2::new(x, y))
     }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -13,7 +13,15 @@ impl Direction2d {
         value.try_normalize().map(Self)
     }
 
-    /// Create a direction from a [`Vec2`] that is already normalized
+    /// Create a direction from its `x` and `y` components.
+    ///
+    /// Returns `None` if the vector formed by the components
+    /// is zero (or very close to zero), or non-finite.
+    pub fn from_xy(x: f32, y: f32) -> Option<Self> {
+        Self::new(Vec2::new(x, y))
+    }
+
+    /// Create a direction from a [`Vec2`] that is already normalized.
     pub fn from_normalized(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -29,9 +29,9 @@ impl Direction3d {
 
     /// Create a direction from its `x`, `y`, and `z` components.
     ///
-    /// Returns `None` if the vector formed by the components
-    /// is zero (or very close to zero), or non-finite.
-    pub fn from_xyz(x: f32, y: f32, z: f32) -> Option<Self> {
+    /// Returns [`Err(InvalidDirectionError)`](InvalidDirectionError) if the length
+    /// of the vector formed by the components is zero (or very close to zero), infinite, or `NaN`.
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Result<Self, InvalidDirectionError> {
         Self::new(Vec3::new(x, y, z))
     }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -13,7 +13,15 @@ impl Direction3d {
         value.try_normalize().map(Self)
     }
 
-    /// Create a direction from a [`Vec3`] that is already normalized
+    /// Create a direction from its `x`, `y`, and `z` components.
+    ///
+    /// Returns `None` if the vector formed by the components
+    /// is zero (or very close to zero), or non-finite.
+    pub fn from_xyz(x: f32, y: f32, z: f32) -> Option<Self> {
+        Self::new(Vec3::new(x, y, z))
+    }
+
+    /// Create a direction from a [`Vec3`] that is already normalized.
     pub fn from_normalized(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)


### PR DESCRIPTION
# Objective

Make direction construction a bit more ergonomic.

## Solution

Add `Direction2d::from_xy` and `Direction3d::from_xyz`, similar to `Transform::from_xyz`:

```rust
let dir2 = Direction2d::from_xy(0.5, 0.5).unwrap();
let dir3 = Direction3d::from_xyz(0.5, 0.5, 0.5).unwrap();
```

This can be a bit cleaner than using `new`:

```rust
let dir2 = Direction2d::new(Vec2::new(0.5, 0.5)).unwrap();
let dir3 = Direction3d::new(Vec3::new(0.5, 0.5, 0.5)).unwrap();
```