### PR TITLE
Impl `TryFrom` vector for directions and add `InvalidDirectionError`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -1,4 +1,4 @@
-use super::{Primitive2d, WindingOrder};
+use super::{InvalidDirectionError, Primitive2d, WindingOrder};
 use crate::Vec2;
 
 /// A normalized vector pointing in a direction in 2D space
@@ -17,6 +17,14 @@ impl Direction2d {
     pub fn from_normalized(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)
+    }
+}
+
+impl TryFrom<Vec2> for Direction2d {
+    type Error = InvalidDirectionError;
+
+    fn try_from(value: Vec2) -> Result<Self, Self::Error> {
+        Self::new(value).map_or(Err(InvalidDirectionError), Ok)
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1,4 +1,4 @@
-use super::Primitive3d;
+use super::{InvalidDirectionError, Primitive3d};
 use crate::Vec3;
 
 /// A normalized vector pointing in a direction in 3D space
@@ -17,6 +17,14 @@ impl Direction3d {
     pub fn from_normalized(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());
         Self(value)
+    }
+}
+
+impl TryFrom<Vec3> for Direction3d {
+    type Error = InvalidDirectionError;
+
+    fn try_from(value: Vec3) -> Result<Self, Self::Error> {
+        Self::new(value).map_or(Err(InvalidDirectionError), Ok)
     }
 }
 

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -13,9 +13,16 @@ pub trait Primitive2d {}
 /// A marker trait for 3D primitives
 pub trait Primitive3d {}
 
-/// An error indicating that a direction is invalid because it is zero or not finite.
-#[derive(Debug)]
-pub struct InvalidDirectionError;
+/// An error indicating that a direction is invalid.
+#[derive(Debug, PartialEq)]
+pub enum InvalidDirectionError {
+    /// The direction has a length that is zero or very close to zero.
+    Zero,
+    /// The length of the vector is equal to `std::f32::INFINITY`.
+    Infinite,
+    /// One or more components of the direction vector have a `NaN` value.
+    NaN,
+}
 
 impl std::fmt::Display for InvalidDirectionError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -13,6 +13,19 @@ pub trait Primitive2d {}
 /// A marker trait for 3D primitives
 pub trait Primitive3d {}
 
+/// An error indicating that a direction is invalid because it is zero or not finite.
+#[derive(Debug)]
+pub struct InvalidDirectionError;
+
+impl std::fmt::Display for InvalidDirectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Direction can not be zero (or very close to zero), or non-finite."
+        )
+    }
+}
+
 /// The winding order for a set of points
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum WindingOrder {

--- a/crates/bevy_math/src/primitives/mod.rs
+++ b/crates/bevy_math/src/primitives/mod.rs
@@ -16,11 +16,11 @@ pub trait Primitive3d {}
 /// An error indicating that a direction is invalid.
 #[derive(Debug, PartialEq)]
 pub enum InvalidDirectionError {
-    /// The direction has a length that is zero or very close to zero.
+    /// The length of the direction vector is zero or very close to zero.
     Zero,
-    /// The length of the vector is equal to `std::f32::INFINITY`.
+    /// The length of the direction vector is `std::f32::INFINITY`.
     Infinite,
-    /// One or more components of the direction vector have a `NaN` value.
+    /// The length of the direction vector is `NaN`.
     NaN,
 }
 


### PR DESCRIPTION
# Objective

Implement `TryFrom<Vec2>`/`TryFrom<Vec3>` for direction primitives as considered in #10857.

## Solution

Implement `TryFrom` for the direction primitives.

These are all equivalent:

```rust
let dir2d = Direction2d::try_from(Vec2::new(0.5, 0.5)).unwrap();
let dir2d = Vec2::new(0.5, 0.5).try_into().unwrap(); // (assumes that the type is inferred)
let dir2d = Direction2d::new(Vec2::new(0.5, 0.5)).unwrap();
```

For error cases, an `Err(InvalidDirectionError)` is returned. It contains the type of failure:

```rust
/// An error indicating that a direction is invalid.
#[derive(Debug, PartialEq)]
pub enum InvalidDirectionError {
    /// The length of the direction vector is zero or very close to zero.
    Zero,
    /// The length of the direction vector is `std::f32::INFINITY`.
    Infinite,
    /// The length of the direction vector is `NaN`.
    NaN,
}
```