### PR TITLE
Publish docs with Github Pages artifacts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,26 @@ on:
     branches:
       - 'main'
 
+  # Allows running the action manually.
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: --html-in-header header.html
 
+# Sets the permissions to allow deploying to Github pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only allow one deployment to run at a time, however it will not cancel in-progress runs.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,19 +51,24 @@ jobs:
       #   - A top level redirect to the bevy crate documentation
       #   - A CNAME file for redirecting the docs domain to the API reference
       #   - A robots.txt file to forbid any crawling of the site (to defer to the docs.rs site on search engines).
-      #   - A .nojekyll file to disable Jekyll GitHub Pages builds.
       - name: Finalize documentation
         run: |
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bevy/index.html\">" > target/doc/index.html
           echo "dev-docs.bevyengine.org" > target/doc/CNAME
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
-          touch target/doc/.nojekyll
 
-      - name: Deploy
-        if: github.repository == 'bevyengine/bevy'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          branch: gh-pages
-          folder: target/doc
-          single-commit: true
-          force: true
+          path: target/doc
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to Github Pages
+        id: deployment
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
# Objective

Closes #10821

## Solution

- Replaced [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) with [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact) and [actions/deploy-pages](https://github.com/actions/deploy-pages).

## Notes

- I made this workflow possible to run through dispatch (`workflow_dispatch`), in case something goes wrong.
- I restricted the permissions to just the things Github Pages needs.
- I made it so that only one deployments can happen at a time, the other deployment requests will be queued up and the latest one will be run.
- My local fork got borked by a glitch, so it builds perfectly fine but fails during the [deployment job](https://github.com/BD103/bevy/actions/runs/7109591903/job/19354812203). It shouldn't happen to you, but I want to test before this gets merged.