### PR TITLE
Publish dev-docs with Github Pages artifacts (2nd attempt)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -58,7 +58,7 @@ jobs:
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v1
         with:
           path: target/doc
 
@@ -71,4 +71,4 @@ jobs:
     steps:
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v3
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -62,13 +65,6 @@ jobs:
         with:
           path: target/doc
 
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
       - name: Deploy to Github Pages
         id: deployment
         uses: actions/deploy-pages@v2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,12 +5,26 @@ on:
     branches:
       - 'main'
 
+  # Allows running the action manually.
+  workflow_dispatch:
+
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: --html-in-header header.html
 
+# Sets the permissions to allow deploying to Github pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only allow one deployment to run at a time, however it will not cancel in-progress runs.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -37,19 +51,24 @@ jobs:
       #   - A top level redirect to the bevy crate documentation
       #   - A CNAME file for redirecting the docs domain to the API reference
       #   - A robots.txt file to forbid any crawling of the site (to defer to the docs.rs site on search engines).
-      #   - A .nojekyll file to disable Jekyll GitHub Pages builds.
       - name: Finalize documentation
         run: |
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bevy/index.html\">" > target/doc/index.html
-          echo "dev-docs.bevyengine.org" > target/doc/CNAME
+          # echo "dev-docs.bevyengine.org" > target/doc/CNAME
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
-          touch target/doc/.nojekyll
 
-      - name: Deploy
-        if: github.repository == 'bevyengine/bevy'
-        uses: JamesIves/github-pages-deploy-action@v4
+      - name: Upload site artifact
+        uses: actions/upload-pages-artifact@v2
         with:
-          branch: gh-pages
-          folder: target/doc
-          single-commit: true
-          force: true
+          path: target/doc
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to Github Pages
+        id: deployment
+        uses: actions/deploy-pages@v3

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Finalize documentation
         run: |
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bevy/index.html\">" > target/doc/index.html
-          # echo "dev-docs.bevyengine.org" > target/doc/CNAME
+          echo "dev-docs.bevyengine.org" > target/doc/CNAME
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
 
       - name: Upload site artifact


### PR DESCRIPTION
Supersedes #10888.

# Objective

Closes #10821

## Solution

- Replaced [JamesIves/github-pages-deploy-action](https://github.com/JamesIves/github-pages-deploy-action) with [actions/upload-pages-artifact](https://github.com/actions/upload-pages-artifact) and [actions/deploy-pages](https://github.com/actions/deploy-pages).

## Notes

- I made this workflow possible to run through dispatch (`workflow_dispatch`), in case something goes wrong.
- I restricted the permissions to just the things Github Pages needs.
- I made it so that only one deployments can happen at a time, the other deployment requests will be queued up and the latest one will be run.