### PR TITLE
Enable Clippy nesting limit

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,1 +1,2 @@
 doc-valid-idents = ["GilRs", "glTF", "sRGB", "VSync", "WebGL2", "WebGPU", ".."]
+excessive-nesting-threshold = 9


### PR DESCRIPTION
# Objective

Some areas of the codebase are excessively nested. I think we should at least put a limit to it to prevent exacerbating the already critical situation.

## Solution

Update `clippy.toml` to set the `excessive-nesting-threshold` option to `9`, which is the highest level of nesting so far.

Tested by doing `cargo +stable clippy --all-features --all-targets`