### PR TITLE
Deduplicate systems in bevy_audio

### DIFF
--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -87,6 +87,10 @@ impl Plugin for AudioPlugin {
                     .run_if(audio_output_available)
                     .after(TransformSystem::TransformPropagate), // For spatial audio transforms
             )
+            .add_systems(
+                PostUpdate,
+                (update_emitter_positions, update_listener_positions).in_set(AudioPlaySet),
+            )
             .init_resource::<AudioOutput>();
 
         #[cfg(any(feature = "mp3", feature = "flac", feature = "wav", feature = "vorbis"))]
@@ -107,11 +111,8 @@ impl AddAudioSource for App {
     {
         self.init_asset::<T>().add_systems(
             PostUpdate,
-            play_queued_audio_system::<T>.in_set(AudioPlaySet),
+            (play_queued_audio_system::<T>, cleanup_finished_audio::<T>).in_set(AudioPlaySet),
         );
-        self.add_systems(PostUpdate, cleanup_finished_audio::<T>.in_set(AudioPlaySet));
-        self.add_systems(PostUpdate, update_emitter_positions.in_set(AudioPlaySet));
-        self.add_systems(PostUpdate, update_listener_positions.in_set(AudioPlaySet));
         self
     }
 }


### PR DESCRIPTION
# Objective
The `update_emitter_positions`, and `update_listener_positions` systems are added for every call to `add_audio_source`.
Instead, add them once in the `AudioPlugin` directly.

Also merged the calls to `add_systems`.


Caught while working on my schedule visualizer c: