### PR TITLE
Refactor function `update_accessibility_nodes`

### DIFF
--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -96,9 +96,6 @@ fn update_accessibility_nodes(
         // TODO: Extract into function
         adapter.update_if_active(|| {
             let mut to_update = vec![];
-            // TODO: Inline variable
-            // TODO: Remove redundant dereference
-            let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
             // TODO: Rename to `window_children`
             let mut root_children = vec![];
             for (entity, node, children, parent) in &nodes {
@@ -141,7 +138,7 @@ fn update_accessibility_nodes(
             TreeUpdate {
                 nodes: to_update,
                 tree: None,
-                focus: NodeId(focus_id),
+                focus: NodeId(focus.unwrap_or(primary_window_id).to_bits()),
             }
         });
     }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -157,7 +157,7 @@ fn queue_node_for_update(
         true
     };
     if should_push {
-        window_children.push(NodeId(node_entity.to_bits()))
+        window_children.push(NodeId(node_entity.to_bits()));
     }
 }
 

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -96,8 +96,6 @@ fn update_accessibility_nodes(
         // TODO: Extract into function
         adapter.update_if_active(|| {
             let mut to_update = vec![];
-            // TODO: Remove `name` variable
-            let mut name = None;
             // TODO: Inline variable
             // TODO: Remove redundant dereference
             let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
@@ -133,10 +131,7 @@ fn update_accessibility_nodes(
             let mut root = NodeBuilder::new(Role::Window);
             if primary_window.focused {
                 let title = primary_window.title.clone();
-                name = Some(title.into_boxed_str());
-            }
-            if let Some(name) = name {
-                root.set_name(name);
+                root.set_name(title.into_boxed_str());
             }
             root.set_children(root_children);
             let root = root.build(&mut NodeClassSet::lock_global());

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -86,72 +86,72 @@ fn update_accessibility_nodes(
     )>,
     node_entities: Query<Entity, With<AccessibilityNode>>,
 ) {
-    // TODO: Invert CF
-    if let Ok((primary_window_id, primary_window)) = primary_window.get_single() {
-        // TODO: Invert CF
-        if let Some(adapter) = adapters.get(&primary_window_id) {
-            // TODO: Inline variable
-            let should_run = focus.is_changed() || !nodes.is_empty();
-            if should_run {
-                // TODO: Extract into function
-                adapter.update_if_active(|| {
-                    let mut to_update = vec![];
-                    // TODO: Remove `name` variable
-                    let mut name = None;
-                    // TODO: Move after loop
-                    if primary_window.focused {
-                        let title = primary_window.title.clone();
-                        name = Some(title.into_boxed_str());
-                    }
-                    // TODO: Inline variable
-                    // TODO: Remove redundant dereference
-                    let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
-                    // TODO: Rename to `window_children`
-                    let mut root_children = vec![];
-                    for (entity, node, children, parent) in &nodes {
-                        let mut node = (**node).clone();
-                        // TODO: Extract function
-                        if let Some(parent) = parent {
-                            if !node_entities.contains(**parent) {
-                                root_children.push(NodeId(entity.to_bits()));
-                            }
-                        } else {
-                            root_children.push(NodeId(entity.to_bits()));
-                        }
-                        // TODO: Extract function
-                        // TODO: Invert CF
-                        if let Some(children) = children {
-                            for child in children {
-                                if node_entities.contains(*child) {
-                                    node.push_child(NodeId(child.to_bits()));
-                                }
-                            }
-                        }
-                        to_update.push((
-                            // TODO: Extract variable
-                            NodeId(entity.to_bits()),
-                            // TODO: extract variable
-                            node.build(&mut NodeClassSet::lock_global()),
-                        ));
-                    }
-                    // TODO: Rename to window_node
-                    let mut root = NodeBuilder::new(Role::Window);
-                    if let Some(name) = name {
-                        root.set_name(name);
-                    }
-                    root.set_children(root_children);
-                    let root = root.build(&mut NodeClassSet::lock_global());
-                    // TODO: Extract `window_node_id`
-                    let window_update = (NodeId(primary_window_id.to_bits()), root);
-                    to_update.insert(0, window_update);
-                    TreeUpdate {
-                        nodes: to_update,
-                        tree: None,
-                        focus: NodeId(focus_id),
-                    }
-                });
+    let Ok((primary_window_id, primary_window)) = primary_window.get_single() else {
+        return;
+    };
+    let Some(adapter) = adapters.get(&primary_window_id) else {
+        return;
+    };
+    // TODO: Inline variable
+    let should_run = focus.is_changed() || !nodes.is_empty();
+    if should_run {
+        // TODO: Extract into function
+        adapter.update_if_active(|| {
+            let mut to_update = vec![];
+            // TODO: Remove `name` variable
+            let mut name = None;
+            // TODO: Move after loop
+            if primary_window.focused {
+                let title = primary_window.title.clone();
+                name = Some(title.into_boxed_str());
             }
-        }
+            // TODO: Inline variable
+            // TODO: Remove redundant dereference
+            let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
+            // TODO: Rename to `window_children`
+            let mut root_children = vec![];
+            for (entity, node, children, parent) in &nodes {
+                let mut node = (**node).clone();
+                // TODO: Extract function
+                if let Some(parent) = parent {
+                    if !node_entities.contains(**parent) {
+                        root_children.push(NodeId(entity.to_bits()));
+                    }
+                } else {
+                    root_children.push(NodeId(entity.to_bits()));
+                }
+                // TODO: Extract function
+                // TODO: Invert CF
+                if let Some(children) = children {
+                    for child in children {
+                        if node_entities.contains(*child) {
+                            node.push_child(NodeId(child.to_bits()));
+                        }
+                    }
+                }
+                to_update.push((
+                    // TODO: Extract variable
+                    NodeId(entity.to_bits()),
+                    // TODO: extract variable
+                    node.build(&mut NodeClassSet::lock_global()),
+                ));
+            }
+            // TODO: Rename to window_node
+            let mut root = NodeBuilder::new(Role::Window);
+            if let Some(name) = name {
+                root.set_name(name);
+            }
+            root.set_children(root_children);
+            let root = root.build(&mut NodeClassSet::lock_global());
+            // TODO: Extract `window_node_id`
+            let window_update = (NodeId(primary_window_id.to_bits()), root);
+            to_update.insert(0, window_update);
+            TreeUpdate {
+                nodes: to_update,
+                tree: None,
+                focus: NodeId(focus_id),
+            }
+        });
     }
 }
 

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -96,17 +96,16 @@ fn update_accessibility_nodes(
         // TODO: Extract into function
         adapter.update_if_active(|| {
             let mut to_update = vec![];
-            // TODO: Rename to `window_children`
-            let mut root_children = vec![];
+            let mut window_children = vec![];
             for (entity, node, children, parent) in &nodes {
                 let mut node = (**node).clone();
                 // TODO: Extract function
                 if let Some(parent) = parent {
                     if !node_entities.contains(**parent) {
-                        root_children.push(NodeId(entity.to_bits()));
+                        window_children.push(NodeId(entity.to_bits()));
                     }
                 } else {
-                    root_children.push(NodeId(entity.to_bits()));
+                    window_children.push(NodeId(entity.to_bits()));
                 }
                 // TODO: Extract function
                 // TODO: Invert CF
@@ -124,16 +123,15 @@ fn update_accessibility_nodes(
                     node.build(&mut NodeClassSet::lock_global()),
                 ));
             }
-            // TODO: Rename to window_node
-            let mut root = NodeBuilder::new(Role::Window);
+            let mut window_node = NodeBuilder::new(Role::Window);
             if primary_window.focused {
                 let title = primary_window.title.clone();
-                root.set_name(title.into_boxed_str());
+                window_node.set_name(title.into_boxed_str());
             }
-            root.set_children(root_children);
-            let root = root.build(&mut NodeClassSet::lock_global());
+            window_node.set_children(window_children);
+            let window_node = window_node.build(&mut NodeClassSet::lock_global());
             // TODO: Extract `window_node_id`
-            let window_update = (NodeId(primary_window_id.to_bits()), root);
+            let window_update = (NodeId(primary_window_id.to_bits()), window_node);
             to_update.insert(0, window_update);
             TreeUpdate {
                 nodes: to_update,

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -92,9 +92,7 @@ fn update_accessibility_nodes(
     let Some(adapter) = adapters.get(&primary_window_id) else {
         return;
     };
-    // TODO: Inline variable
-    let should_run = focus.is_changed() || !nodes.is_empty();
-    if should_run {
+    if focus.is_changed() || !nodes.is_empty() {
         // TODO: Extract into function
         adapter.update_if_active(|| {
             let mut to_update = vec![];

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -151,12 +151,13 @@ fn queue_node_for_update(
     node_entities: &Query<Entity, With<AccessibilityNode>>,
     window_children: &mut Vec<NodeId>,
 ) {
-    if let Some(parent) = parent {
-        if !node_entities.contains(parent.get()) {
-            window_children.push(NodeId(node_entity.to_bits()));
-        }
+    let should_push = if let Some(parent) = parent {
+        node_entities.contains(parent.get())
     } else {
-        window_children.push(NodeId(node_entity.to_bits()));
+        true
+    };
+    if should_push {
+        window_children.push(NodeId(node_entity.to_bits()))
     }
 }
 

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -86,21 +86,31 @@ fn update_accessibility_nodes(
     )>,
     node_entities: Query<Entity, With<AccessibilityNode>>,
 ) {
+    // TODO: Invert CF
     if let Ok((primary_window_id, primary_window)) = primary_window.get_single() {
+        // TODO: Invert CF
         if let Some(adapter) = adapters.get(&primary_window_id) {
+            // TODO: Inline variable
             let should_run = focus.is_changed() || !nodes.is_empty();
             if should_run {
+                // TODO: Extract into function
                 adapter.update_if_active(|| {
                     let mut to_update = vec![];
+                    // TODO: Remove `name` variable
                     let mut name = None;
+                    // TODO: Move after loop
                     if primary_window.focused {
                         let title = primary_window.title.clone();
                         name = Some(title.into_boxed_str());
                     }
+                    // TODO: Inline variable
+                    // TODO: Remove redundant dereference
                     let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
+                    // TODO: Rename to `window_children`
                     let mut root_children = vec![];
                     for (entity, node, children, parent) in &nodes {
                         let mut node = (**node).clone();
+                        // TODO: Extract function
                         if let Some(parent) = parent {
                             if !node_entities.contains(**parent) {
                                 root_children.push(NodeId(entity.to_bits()));
@@ -108,6 +118,8 @@ fn update_accessibility_nodes(
                         } else {
                             root_children.push(NodeId(entity.to_bits()));
                         }
+                        // TODO: Extract function
+                        // TODO: Invert CF
                         if let Some(children) = children {
                             for child in children {
                                 if node_entities.contains(*child) {
@@ -116,16 +128,20 @@ fn update_accessibility_nodes(
                             }
                         }
                         to_update.push((
+                            // TODO: Extract variable
                             NodeId(entity.to_bits()),
+                            // TODO: extract variable
                             node.build(&mut NodeClassSet::lock_global()),
                         ));
                     }
+                    // TODO: Rename to window_node
                     let mut root = NodeBuilder::new(Role::Window);
                     if let Some(name) = name {
                         root.set_name(name);
                     }
                     root.set_children(root_children);
                     let root = root.build(&mut NodeClassSet::lock_global());
+                    // TODO: Extract `window_node_id`
                     let window_update = (NodeId(primary_window_id.to_bits()), root);
                     to_update.insert(0, window_update);
                     TreeUpdate {

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -98,11 +98,6 @@ fn update_accessibility_nodes(
             let mut to_update = vec![];
             // TODO: Remove `name` variable
             let mut name = None;
-            // TODO: Move after loop
-            if primary_window.focused {
-                let title = primary_window.title.clone();
-                name = Some(title.into_boxed_str());
-            }
             // TODO: Inline variable
             // TODO: Remove redundant dereference
             let focus_id = (*focus).unwrap_or_else(|| primary_window_id).to_bits();
@@ -136,6 +131,10 @@ fn update_accessibility_nodes(
             }
             // TODO: Rename to window_node
             let mut root = NodeBuilder::new(Role::Window);
+            if primary_window.focused {
+                let title = primary_window.title.clone();
+                name = Some(title.into_boxed_str());
+            }
             if let Some(name) = name {
                 root.set_name(name);
             }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -116,12 +116,9 @@ fn update_accessibility_nodes(
                         }
                     }
                 }
-                to_update.push((
-                    // TODO: Extract variable
-                    NodeId(entity.to_bits()),
-                    // TODO: extract variable
-                    node.build(&mut NodeClassSet::lock_global()),
-                ));
+                let node_id = NodeId(entity.to_bits());
+                let node = node.build(&mut NodeClassSet::lock_global());
+                to_update.push((node_id, node));
             }
             let mut window_node = NodeBuilder::new(Role::Window);
             if primary_window.focused {
@@ -130,8 +127,8 @@ fn update_accessibility_nodes(
             }
             window_node.set_children(window_children);
             let window_node = window_node.build(&mut NodeClassSet::lock_global());
-            // TODO: Extract `window_node_id`
-            let window_update = (NodeId(primary_window_id.to_bits()), window_node);
+            let node_id = NodeId(primary_window_id.to_bits());
+            let window_update = (node_id, window_node);
             to_update.insert(0, window_update);
             TreeUpdate {
                 nodes: to_update,


### PR DESCRIPTION
# Objective

`update_accessibility_nodes` is one of the most nested functions in the entire Bevy repository, with a maximum of 9 levels of indentations. This PR refactors it down to 3 levels of indentations, while improving readability on other fronts. The result is a function that is actually understandable at a first glance.

- This is a proof of concept to demonstrate that it is possible to gradually lower the nesting limit proposed by #10896.

PS: I read AccessKit's documentation, but I don't have experience with it. Therefore, naming of variables and subroutines may be a bit off.

PS2: I don't know if the test suite covers the functionality of this system, but since I've spent quite some time on it and the changes were simple, I'm pretty confident the refactor is functionally equivalent to the original.

## Solution

I documented each change with a commit, but as a summary I did the following to reduce nesting:

- I moved from `if-let` blocks to `let-else` statements where appropriate to reduce rightward shift
- I extracted the closure body to a new function `update_adapter`
- I factored out parts of `update_adapter` into new functions `queue_node_for_update` and `add_children_nodes`

**Note for reviewers:** GitHub's diff viewer is not the greatest in showing horizontal code shifts, therefore you may want to use a different tool like VSCode to review some commits, especially the second one (anyway, that commit is very straightforward, despite changing many lines).