### PR TITLE
Remove reference to default schedule

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -418,7 +418,7 @@ impl App {
         self
     }
 
-    /// Configures a collection of system sets in the default schedule, adding any sets that do not exist.
+    /// Configures a collection of system sets in the provided schedule, adding any sets that do not exist.
     #[track_caller]
     pub fn configure_sets(
         &mut self,


### PR DESCRIPTION
Simple doc change since there is no more a default schedule after #8079.