### PR TITLE
Refactor `process_handle_drop_internal()` in bevy_asset

### DIFF
--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -608,9 +608,6 @@ impl AssetInfos {
         true
     }
 
-    // Either the asset was already dropped, it doesn't exist, or it isn't managed by the asset server
-    // None of these cases should result in a removal from the Assets collection
-
     /// Consumes all current handle drop events. This will update information in [`AssetInfos`], but it
     /// will not affect [`Assets`] storages. For normal use cases, prefer `Assets::track_assets()`
     /// This should only be called if `Assets` storage isn't being used (such as in [`AssetProcessor`](crate::processor::AssetProcessor))

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -562,11 +562,10 @@ impl AssetInfos {
         watching_for_changes: bool,
         id: UntypedAssetId,
     ) -> bool {
-        let mut entry = match infos.entry(id) {
-            Entry::Occupied(entry) => entry,
+        let Entry::Occupied(mut entry) = infos.entry(id) else {
             // Either the asset was already dropped, it doesn't exist, or it isn't managed by the asset server
             // None of these cases should result in a removal from the Assets collection
-            Entry::Vacant(_) => return false,
+            return false;
         };
 
         if entry.get_mut().handle_drops_to_skip > 0 {


### PR DESCRIPTION
# Objective

- Reduce nesting in `process_handle_drop_internal()`.
- Related to #10896.

## Solution

- Use early returns when possible.
- Reduced from 9 levels of indents to 4.