### PR TITLE
Add `RectifiedCurve`

### DIFF
--- a/crates/bevy_animation/src/curve_path.rs
+++ b/crates/bevy_animation/src/curve_path.rs
@@ -1,0 +1,76 @@
+use bevy_math::cubic_splines::{CubicCurve, Point};
+
+/// A curve that has been divided into straight line segments.
+#[derive(Clone, Debug)]
+pub struct CurvePath<P: Point> {
+    curve: CubicCurve<P>,
+    arc_lengths: Vec<f32>,
+}
+
+impl<P: Point> CurvePath<P> {
+    /// Splits the curve into subdivisions of straight line segments that can be used for computing
+    /// spatial length.
+    pub fn from_cubic_curve(curve: CubicCurve<P>, subdivisions: usize) -> CurvePath<P> {
+        let arc_lengths: Vec<f32> = curve
+            .iter_positions(subdivisions)
+            .scan((0.0, curve.position(0.0)), |state, x| {
+                state.0 += x.distance(state.1);
+                state.1 = x;
+
+                Some(state.0)
+            })
+            .collect();
+
+        CurvePath { curve, arc_lengths }
+    }
+
+    /// Total length of the curve.
+    pub fn length(&self) -> f32 {
+        self.arc_lengths[self.arc_lengths.len() - 1]
+    }
+
+    /// Returns a 't' value between 0..=1 based on the distance along the curve.
+    fn sample(&self, distance: f32) -> f32 {
+        // Get index with greatest value that is less than or equal to target distance.
+        let closest = self.arc_lengths.partition_point(|&x| x <= distance) - 1;
+
+        // Check if index's distance perfectly matches target distance, otherwise lerp between the
+        // index and its next neighbor.
+        if self.arc_lengths[closest] == distance {
+            (closest + 1) as f32 / (self.arc_lengths.len() + 1) as f32
+        } else {
+            let length_before = self.arc_lengths[closest];
+            let length_after = self.arc_lengths[closest + 1];
+            let segment_length = length_after - length_before;
+
+            let segment_fraction = (distance - length_before) / segment_length;
+
+            (closest as f32 + segment_fraction) / (self.arc_lengths.len() - 1) as f32
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bevy_math::cubic_splines::{CubicBezier, CubicGenerator};
+
+    use crate::curve_path::CurvePath;
+
+    #[test]
+    fn sample() {
+        const SUBDIVISIONS: usize = 1000;
+        let points = [[0.0, 0.2, 0.8, 1.0]];
+        let bezier = CubicBezier::new(points).to_curve();
+        let curve_path = CurvePath::from_cubic_curve(bezier, SUBDIVISIONS);
+
+        assert_eq!(curve_path.length(), 1.0);
+
+        // Check with exact point.
+        assert_eq!(curve_path.sample(0.5), 0.5);
+
+        // Check with value between two points.
+        let t = curve_path.sample(0.25);
+        let position = curve_path.curve.position(t);
+        assert!(0.24998 < position && position < 0.25001);
+    }
+}

--- a/crates/bevy_animation/src/curve_path.rs
+++ b/crates/bevy_animation/src/curve_path.rs
@@ -1,7 +1,9 @@
+//! A curve through space.
+
 use bevy_math::cubic_splines::{CubicCurve, Point};
 
-/// A curve that can be sampled by distance instead of t. Can be used for linearly animating along
-/// a curve.
+/// A curve representing a path through space. Unlike [`CubicCurve`], it is sampled based on distance
+/// along the path. Can be used for linearly animating along a curve.
 ///
 /// Note: Values are approximated using a series of line segments. Accuracy is based on the
 /// subdivisions specified when creating the path.
@@ -12,7 +14,7 @@ pub struct CurvePath<P: Point> {
 }
 
 impl<P: Point> CurvePath<P> {
-    /// Creates a new `CurvePath` from a curve. Subdivisions will determine how many line segments
+    /// Creates a new [`CurvePath`] from a curve. Subdivisions will determine how many line segments
     /// are used, and therefore the accuracy.
     pub fn from_cubic_curve(curve: CubicCurve<P>, subdivisions: usize) -> CurvePath<P> {
         let arc_lengths: Vec<f32> = curve
@@ -26,6 +28,11 @@ impl<P: Point> CurvePath<P> {
             .collect();
 
         CurvePath { curve, arc_lengths }
+    }
+
+    /// Returns the [`CubicCurve`] this path is based on.
+    pub fn curve(&self) -> &CubicCurve<P> {
+        &self.curve
     }
 
     /// Total length of the curve.

--- a/crates/bevy_animation/src/curve_path.rs
+++ b/crates/bevy_animation/src/curve_path.rs
@@ -80,6 +80,8 @@ impl<P: Point> CurvePath<P> {
 
 #[cfg(test)]
 mod tests {
+    use std::f32::consts::{PI, TAU};
+
     use bevy_math::{
         cubic_splines::{CubicBezier, CubicGenerator},
         vec2, Vec2,
@@ -87,6 +89,7 @@ mod tests {
 
     use crate::curve_path::CurvePath;
 
+    const ERROR: f32 = 0.001;
     const SUBDIVISIONS: usize = 256;
     // The 0.551915 is taken from https://www.mechanicalexpressions.com/explore/geometric-modeling/circle-spline-approximation.pdf
     const CIRCLE_POINTS: [[Vec2; 4]; 4] = [
@@ -99,7 +102,7 @@ mod tests {
         [
             vec2(0., 1.),
             vec2(-0.551915, 1.),
-            vec2(-1., 0.55228475),
+            vec2(-1., 0.551915),
             vec2(-1., 0.),
         ],
         [
@@ -123,8 +126,8 @@ mod tests {
 
         let length = path.length();
 
-        // Length should be 2 PI
-        assert!(6.283 < length && length < 6.284);
+        // Length should be 2 PI or TAU
+        assert!(TAU - ERROR < length && length < TAU + ERROR);
     }
 
     #[test]
@@ -140,7 +143,7 @@ mod tests {
 
         // Check with value between two points.
         let position = curve_path.position(0.25);
-        assert!(0.24998 < position && position < 0.25001);
+        assert!(0.25 - ERROR < position && position < 0.25 + ERROR);
     }
 
     #[test]
@@ -149,8 +152,8 @@ mod tests {
             CurvePath::from_cubic_curve(CubicBezier::new(CIRCLE_POINTS).to_curve(), SUBDIVISIONS);
 
         // Circle starts at (1, 0) and goes counter-clockwise so PI should be (-1, 0)
-        let position = path.position(std::f32::consts::PI);
+        let position = path.position(PI);
 
-        assert!(position.distance(vec2(-1., 0.)) < 0.001);
+        assert!(position.distance(vec2(-1., 0.)) < ERROR);
     }
 }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -17,11 +17,14 @@ use bevy_time::Time;
 use bevy_transform::{prelude::Transform, TransformSystem};
 use bevy_utils::{tracing::warn, HashMap};
 
+pub mod curve_path;
+
 #[allow(missing_docs)]
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        AnimationClip, AnimationPlayer, AnimationPlugin, EntityPath, Keyframes, VariableCurve,
+        curve_path::CurvePath, AnimationClip, AnimationPlayer, AnimationPlugin, EntityPath,
+        Keyframes, VariableCurve,
     };
 }
 

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -609,7 +609,7 @@ impl RectifiedCurve {
 
             let segment_fraction = (distance - length_before) / segment_length;
 
-            (closest as f32 + segment_fraction + 1.) / (self.arc_lengths.len() + 1) as f32
+            (closest as f32 + segment_fraction) / (self.arc_lengths.len() - 1) as f32
         }
     }
 }
@@ -647,6 +647,24 @@ mod tests {
             + 3.0 * p[1] * t * (1.0 - t).powi(2)
             + 3.0 * p[2] * t.powi(2) * (1.0 - t)
             + p[3] * t.powi(3)
+    }
+
+    #[test]
+    fn rectified_curve() {
+        const SUBDIVISIONS: usize = 1000;
+        let points = [[0.0, 0.2, 0.8, 1.0]];
+        let bezier = CubicBezier::new(points).to_curve();
+        let rectified = bezier.rectify(SUBDIVISIONS);
+
+        assert_eq!(rectified.length(), 1.0);
+
+        // Check with exact point.
+        assert_eq!(rectified.distance_to_parameter(0.5), 0.5);
+
+        // Check with value between two points.
+        let t = rectified.distance_to_parameter(0.25);
+        let position = bezier.position(t);
+        assert!(0.24998 < position && position < 0.25001);
     }
 
     /// Basic cubic Bezier easing test to verify the shape of the curve.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -483,20 +483,21 @@ impl<P: Point> CubicCurve<P> {
         let (segment, t) = self.segment(t);
         segment.acceleration(t)
     }
-    
+
     /// Splits the curve into subdivisions of straight line segments that can be used for computing
     /// spatial length.
     pub fn rectify(&self, subdivisions: usize) -> RectifiedCurve {
-        let arc_lengths: Vec<f32> = self.iter_positions(subdivisions).scan((0.0, self.position(0.0)), |state, x| {
-            state.0 += x.distance(state.1);
-            state.1 = x;
+        let arc_lengths: Vec<f32> = self
+            .iter_positions(subdivisions)
+            .scan((0.0, self.position(0.0)), |state, x| {
+                state.0 += x.distance(state.1);
+                state.1 = x;
 
-            Some(state.0)
-        }).collect();
+                Some(state.0)
+            })
+            .collect();
 
-        RectifiedCurve{
-            arc_lengths
-        }
+        RectifiedCurve { arc_lengths }
     }
 
     /// A flexible iterator used to sample curves with arbitrary functions.
@@ -583,7 +584,7 @@ impl<P: Point> CubicCurve<P> {
 #[derive(Clone, Debug)]
 pub struct RectifiedCurve {
     // Each index stores the distance from the start of the curve to that point.
-    arc_lengths: Vec<f32>
+    arc_lengths: Vec<f32>,
 }
 
 impl RectifiedCurve {
@@ -600,7 +601,7 @@ impl RectifiedCurve {
         // Check if index's distance perfectly matches target distance, otherwise lerp between the
         // index and its next neighbor.
         if self.arc_lengths[closest] == distance {
-            return (closest + 1) as f32 / (self.arc_lengths.len() + 1) as f32;
+            (closest + 1) as f32 / (self.arc_lengths.len() + 1) as f32
         } else {
             let length_before = self.arc_lengths[closest];
             let length_after = self.arc_lengths[closest + 1];
@@ -608,7 +609,7 @@ impl RectifiedCurve {
 
             let segment_fraction = (distance - length_before) / segment_length;
 
-            return (closest as f32 + segment_fraction + 1.) / (self.arc_lengths.len() + 1) as f32;
+            (closest as f32 + segment_fraction + 1.) / (self.arc_lengths.len() + 1) as f32
         }
     }
 }


### PR DESCRIPTION
# Objective

When working with curves, it's sometimes helpful to work with spatial distances instead of `t` values.

`CubicCurve::iter_samples` provides uniformly spaced points by `t`, but they are not guaranteed to be spatially uniform. This means you can't animate something linearly along a curve, it will accelerate and decelerate based on how the control points are arranged. Another example of when this would be useful is generating UV coordinates for procedural meshes based on a curve. Using the basic `CubicCurve::iter_samples` can cause stretching of the UV map.

## Solution

Add a `RectifiedCurve` struct that can be created from a `CubicCurve` that contains an array of arc lengths. This can then be used to get the total length of the curve, or sample it based on distance to get the corresponding `t` value which can then be used on the original curve.

## Potential Issues
- `RectifiedCurve::distance_to_parameter` may not be the best name, `distance_to_x` or `sample` are some other ideas.
- `RectifiedCurve::distance_to_parameter` returns a `t` value from `0..=1`, while `CubicCurve::position` uses `t` from `0..=(n_points - 3)`. This is noted in the documentation, but could be somewhat confusing for the user. Alternatively, the segment count could be stored in `RectifiedCurve` and take this into account when calculating `t`.

## Next Steps
Please let me know what I can do to improve this PR. I'd be happy to add an example, but would it be better to update the existing `animation/cubic_curve.rs`, or make a new one such as `animation/rectified_curve.rs` showcasing the same path as the original but animated linearly?