### PR TITLE
Give UI nodes with `Display::None` an empty clipping rect

### DIFF
--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -1,6 +1,6 @@
 //! This module contains systems that update the UI when something changes
 
-use crate::{CalculatedClip, OverflowAxis, Style};
+use crate::{CalculatedClip, OverflowAxis, Style, Display};
 
 use super::Node;
 use bevy_ecs::{
@@ -35,7 +35,7 @@ fn update_clipping(
     children_query: &Query<&Children>,
     node_query: &mut Query<(&Node, &GlobalTransform, &Style, Option<&mut CalculatedClip>)>,
     entity: Entity,
-    maybe_inherited_clip: Option<Rect>,
+    mut maybe_inherited_clip: Option<Rect>,
 ) {
     let Ok((node, global_transform, style, maybe_calculated_clip)) = node_query.get_mut(entity)
     else {

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -42,6 +42,11 @@ fn update_clipping(
         return;
     };
 
+    // If `display` is None, clip the entire node and all its descendants by replacing the inherited clip with a default rect (which is empty)
+    if style.display == Display::None {
+        maybe_inherited_clip = Some(Rect::default());
+    }
+
     // Update this node's CalculatedClip component
     if let Some(mut calculated_clip) = maybe_calculated_clip {
         if let Some(inherited_clip) = maybe_inherited_clip {

--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -1,6 +1,6 @@
 //! This module contains systems that update the UI when something changes
 
-use crate::{CalculatedClip, OverflowAxis, Style, Display};
+use crate::{CalculatedClip, Display, OverflowAxis, Style};
 
 use super::Node;
 use bevy_ecs::{


### PR DESCRIPTION
# Objective
Outlines are drawn for UI nodes with `Display::None` set and their descendants. They should not be visible.

## Solution

Make all Nodes with `Display::None` inherit an empty clipping rect, ensuring that the outlines are not visible.

Fixes #10940

---

## Changelog
* In `update_clipping_system` if a node has `Display::None` set, clip the entire node and all its descendants by replacing the inherited clip with a default rect (which is empty)