### PR TITLE
Improve `EntityWorldMut.remove`, `retain` and `despawn` docs by linking to more detail

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -812,9 +812,6 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
 
     /// Removes a [`Bundle`] of components from the entity.
     ///
-    /// See [`EntityWorldMut::remove`](EntityWorldMut::remove) for more
-    /// details.
-    ///
     /// # Example
     ///
     /// ```
@@ -911,9 +908,6 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     /// Removes all components except the given [`Bundle`] from the entity.
     ///
     /// This can also be used to remove all the components from the entity by passing it an empty Bundle.
-    ///
-    /// See [`EntityWorldMut::retain`](EntityWorldMut::retain) for more
-    /// details.
     ///
     /// # Example
     ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -961,6 +961,8 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Despawns the current entity.
+    ///
+    /// See [`World::despawn`] for more details.
     pub fn despawn(self) {
         debug!("Despawning entity {:?}", self.entity);
         let world = self.world;

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -889,6 +889,8 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Removes any components in the [`Bundle`] from the entity.
+    ///
+    /// See [`EntityCommands::remove`](crate::system::EntityCommands::remove) for more details.
     // TODO: BundleRemover?
     pub fn remove<T: Bundle>(&mut self) -> &mut Self {
         let archetypes = &mut self.world.archetypes;
@@ -920,6 +922,8 @@ impl<'w> EntityWorldMut<'w> {
     }
 
     /// Removes any components except those in the [`Bundle`] from the entity.
+    ///
+    /// See [`EntityCommands::retain`](crate::system::EntityCommands::retain) for more details.
     pub fn retain<T: Bundle>(&mut self) -> &mut Self {
         let archetypes = &mut self.world.archetypes;
         let storages = &mut self.world.storages;


### PR DESCRIPTION
## Solution

`Commands.remove` and `.retain` (because I copied `remove`s doc) referenced `EntityWorldMut.remove` and `retain` for more detail but the `Commands` docs are much more detailed (which makes sense because it is the most common api), so I have instead inverted this so that `EntityWorldMut` docs link to `Commands`.

I also made `EntityWorldMut.despawn` reference `World.despawn` for more details, like `Commands.despawn` does.