### PR TITLE
Add docs to bevy_sprite a little

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -10,11 +10,15 @@ use bevy_render::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
+/// A Bundle of components for drawing a single sprite from an image.
 #[derive(Bundle, Clone, Default)]
 pub struct SpriteBundle {
+    /// Specifies the rendering properties of the sprite, such as color tint and flip
     pub sprite: Sprite,
+    /// The transform of the sprite
     pub transform: Transform,
     pub global_transform: GlobalTransform,
+    /// A handle to the image to be drawn
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -29,7 +29,7 @@ pub struct SpriteBundle {
     pub view_visibility: ViewVisibility,
 }
 
-/// A Bundle of components for drawing a single sprite from a sprite sheet (also referred
+/// A [`Bundle`] of components for drawing a single sprite from a sprite sheet (also referred
 /// to as a `TextureAtlas`)
 #[derive(Bundle, Clone, Default)]
 pub struct SpriteSheetBundle {

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -10,15 +10,16 @@ use bevy_render::{
 };
 use bevy_transform::components::{GlobalTransform, Transform};
 
-/// A Bundle of components for drawing a single sprite from an image.
+/// A [`Bundle`] of components for drawing a single sprite from an image.
 #[derive(Bundle, Clone, Default)]
 pub struct SpriteBundle {
     /// Specifies the rendering properties of the sprite, such as color tint and flip
     pub sprite: Sprite,
-    /// The transform of the sprite
+    /// The local transform of the sprite, relative to its parent
     pub transform: Transform,
+    /// The absolute transform of the sprite. This should generally not be written to directly.
     pub global_transform: GlobalTransform,
-    /// A handle to the image to be drawn
+    /// A reference-counted handle to the image asset to be drawn
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,

--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -13,13 +13,13 @@ use bevy_transform::components::{GlobalTransform, Transform};
 /// A [`Bundle`] of components for drawing a single sprite from an image.
 #[derive(Bundle, Clone, Default)]
 pub struct SpriteBundle {
-    /// Specifies the rendering properties of the sprite, such as color tint and flip
+    /// Specifies the rendering properties of the sprite, such as color tint and flip.
     pub sprite: Sprite,
-    /// The local transform of the sprite, relative to its parent
+    /// The local transform of the sprite, relative to its parent.
     pub transform: Transform,
     /// The absolute transform of the sprite. This should generally not be written to directly.
     pub global_transform: GlobalTransform,
-    /// A reference-counted handle to the image asset to be drawn
+    /// A reference-counted handle to the image asset to be drawn.
     pub texture: Handle<Image>,
     /// User indication of whether an entity is visible
     pub visibility: Visibility,
@@ -30,7 +30,7 @@ pub struct SpriteBundle {
 }
 
 /// A [`Bundle`] of components for drawing a single sprite from a sprite sheet (also referred
-/// to as a `TextureAtlas`)
+/// to as a `TextureAtlas`).
 #[derive(Bundle, Clone, Default)]
 pub struct SpriteSheetBundle {
     /// The specific sprite from the texture atlas to be drawn, defaulting to the sprite at index 0.

--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -2,6 +2,7 @@
 
 use bevy_math::{Vec2, Vec3};
 
+/// Collision side returned by [`collide`]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Collision {
     Left,

--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -2,7 +2,7 @@
 
 use bevy_math::{Vec2, Vec3};
 
-/// The side where a collision occurred, as returned by [`collide`]
+/// The side where a collision occurred, as returned by [`collide`].
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Collision {
     Left,

--- a/crates/bevy_sprite/src/collide_aabb.rs
+++ b/crates/bevy_sprite/src/collide_aabb.rs
@@ -2,7 +2,7 @@
 
 use bevy_math::{Vec2, Vec3};
 
-/// Collision side returned by [`collide`]
+/// The side where a collision occurred, as returned by [`collide`]
 #[derive(Debug, PartialEq, Eq, Copy, Clone)]
 pub enum Collision {
     Left,

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,3 +1,4 @@
+//! Provides 2D sprite rendering functionality.
 mod bundle;
 mod dynamic_texture_atlas_builder;
 mod mesh2d;
@@ -40,11 +41,13 @@ use bevy_render::{
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
 
+/// Adds support for 2D sprite rendering.
 #[derive(Default)]
 pub struct SpritePlugin;
 
 pub const SPRITE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2763343953151597127);
 
+/// Set system for the systems relating to sprite rendering.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum SpriteSystem {
     ExtractSprites,

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -47,7 +47,7 @@ pub struct SpritePlugin;
 
 pub const SPRITE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2763343953151597127);
 
-/// Set system for the systems relating to sprite rendering.
+/// System set for sprite rendering.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum SpriteSystem {
     ExtractSprites,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -756,6 +756,7 @@ pub fn prepare_sprites(
     }
 }
 
+/// [`RenderCommand`](bevy_render::render_phase::RenderCommand) for sprite rendering.
 pub type DrawSprite = (
     SetItemPipeline,
     SetSpriteViewBindGroup<0>,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -756,7 +756,7 @@ pub fn prepare_sprites(
     }
 }
 
-/// [`RenderCommand`](bevy_render::render_phase::RenderCommand) for sprite rendering.
+/// [`RenderCommand`] for sprite rendering.
 pub type DrawSprite = (
     SetItemPipeline,
     SetSpriteViewBindGroup<0>,

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -5,7 +5,7 @@ use bevy_render::color::Color;
 
 /// Specifies the rendering properties of a sprite.
 ///
-/// [`SpriteBundle`](crate::bundle::SpriteBundle) is a bundle for common sprite rendering use cases.
+/// This is commonly used as a component within [`SpriteBundle`](crate::bundle::SpriteBundle).
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default)]
 #[repr(C)]

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -3,6 +3,9 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::color::Color;
 
+/// Specifies the rendering properties of a sprite.
+///
+/// [`SpriteBundle`](crate::bundle::SpriteBundle) is a bundle for common sprite rendering use cases.
 #[derive(Component, Debug, Default, Clone, Reflect)]
 #[reflect(Component, Default)]
 #[repr(C)]

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -22,6 +22,9 @@ pub struct TextureAtlas {
     pub(crate) texture_handles: Option<HashMap<AssetId<Image>, usize>>,
 }
 
+/// Specifies the rendering properties of a sprite from a sprite sheet.
+///
+/// [`SpriteSheetBundle`](crate::bundle::SpriteSheetBundle) is a bundle for common sprite rendering use cases.
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component)]
 pub struct TextureAtlasSprite {

--- a/crates/bevy_sprite/src/texture_atlas.rs
+++ b/crates/bevy_sprite/src/texture_atlas.rs
@@ -24,7 +24,7 @@ pub struct TextureAtlas {
 
 /// Specifies the rendering properties of a sprite from a sprite sheet.
 ///
-/// [`SpriteSheetBundle`](crate::bundle::SpriteSheetBundle) is a bundle for common sprite rendering use cases.
+/// This is commonly used as a component within [`SpriteSheetBundle`](crate::bundle::SpriteSheetBundle).
 #[derive(Component, Debug, Clone, Reflect)]
 #[reflect(Component)]
 pub struct TextureAtlasSprite {


### PR DESCRIPTION
# Objective

- bevy_sprite crate is missing docs for important types. `Sprite` being undocumented was especially confusing for me even though it is one of the first types I need to learn.
 
## Solution

- Improves the situation a little by adding some documentations.
I'm unsure about my understanding of functionality and writing. I'm happy to be pointed out any mistakes.