### PR TITLE
Improve `Parent` and `Children` API docs

### DIFF
--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -10,19 +10,22 @@ use core::slice;
 use smallvec::SmallVec;
 use std::ops::Deref;
 
-/// Contains references to the child entities of this entity.
+/// Component referencing children entities.
 ///
-/// Each child must contain a [`Parent`] component that points back to this entity.
-/// This component rarely needs to be created manually,
-/// consider using higher level utilities like [`BuildChildren::with_children`]
-/// which are safer and easier to use.
+/// You can access children entities like an array,
+/// by calling iterator methods (e.g. `children.iter()`),
+/// or by index (e.g. `children[3]`).
 ///
-/// See [`HierarchyQueryExt`] for hierarchy related methods on [`Query`].
+/// Unless otherwise stated,
+/// children are always added at the last position.
 ///
-/// [`HierarchyQueryExt`]: crate::query_extension::HierarchyQueryExt
-/// [`Query`]: bevy_ecs::system::Query
-/// [`Parent`]: crate::components::parent::Parent
-/// [`BuildChildren::with_children`]: crate::child_builder::BuildChildren::with_children
+/// This component is automatically removed
+/// once the entity loses all of its children.
+///
+/// Check the [crate-level documentation]
+/// to learn how to correctly use this component.
+///
+/// [crate-level documentation]: crate
 #[derive(Component, Debug)]
 #[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(feature = "reflect", reflect(Component, MapEntities))]

--- a/crates/bevy_hierarchy/src/components/parent.rs
+++ b/crates/bevy_hierarchy/src/components/parent.rs
@@ -7,34 +7,32 @@ use bevy_ecs::{
 };
 use std::ops::Deref;
 
-/// Holds a reference to the parent entity of this entity.
-/// This component should only be present on entities that actually have a parent entity.
+/// Component referencing the parent entity.
 ///
-/// Parent entity must have this entity stored in its [`Children`] component.
-/// It is hard to set up parent/child relationships manually,
-/// consider using higher level utilities like [`BuildChildren::with_children`].
+/// To get the parent [`Entity`], call the [`get`] method.
 ///
-/// See [`HierarchyQueryExt`] for hierarchy related methods on [`Query`].
+/// This component is automatically removed once the entity loses its parent.
 ///
-/// [`HierarchyQueryExt`]: crate::query_extension::HierarchyQueryExt
-/// [`Query`]: bevy_ecs::system::Query
-/// [`Children`]: super::children::Children
-/// [`BuildChildren::with_children`]: crate::child_builder::BuildChildren::with_children
+/// Check the [crate-level documentation]
+/// to learn how to correctly use this component.
+///
+/// [crate-level documentation]: crate
+/// [`get`]: Self::get
 #[derive(Component, Debug, Eq, PartialEq)]
 #[cfg_attr(feature = "reflect", derive(bevy_reflect::Reflect))]
 #[cfg_attr(feature = "reflect", reflect(Component, MapEntities, PartialEq))]
 pub struct Parent(pub(crate) Entity);
 
 impl Parent {
-    /// Gets the [`Entity`] ID of the parent.
+    /// Returns the parent [`Entity`].
     pub fn get(&self) -> Entity {
         self.0
     }
 
-    /// Gets the parent [`Entity`] as a slice of length 1.
+    /// Returns the parent [`Entity`] as a slice of length `1`.
     ///
     /// Useful for making APIs that require a type or homogeneous storage
-    /// for both [`Children`] & [`Parent`] that is agnostic to edge direction.
+    /// for both [`Children`] and [`Parent`] that is agnostic to edge direction.
     ///
     /// [`Children`]: super::children::Children
     pub fn as_slice(&self) -> &[Entity] {

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,8 +1,49 @@
 #![warn(missing_docs)]
-//! `bevy_hierarchy` can be used to define hierarchies of entities.
+//! Parent-child relationships for Bevy entities.
 //!
-//! Most commonly, these hierarchies are used for inheriting `Transform` values
-//! from the [`Parent`] to its [`Children`].
+//! You should use the tools in this crate
+//! whenever you want to organize your entities in a hierarchical fashion,
+//! to make groups of entities more manageable,
+//! or to propagate properties throughout the entity hierarchy.
+//!
+//! This crate introduces various tools, including a [plugin]
+//! for managing parent-child relationships between entities.
+//! It provides two components, [`Parent`] and [`Children`],
+//! to store references to related entities.
+//! It also provides [command] and [world] API extensions
+//! to set and clear those relationships.
+//!
+//! More advanced users may also appreciate
+//! [query extension methods] to traverse hierarchies,
+//! and [events] to notify hiearchical changes.
+//! There is also a [diagnostic plugin] to validate property propagation.
+//!
+//! # Hierarchy management
+//!
+//! The methods defined in this crate fully manage
+//! the components responsible for defining the entity hierarchy.
+//! Mutating these components manually may result in hierarchy invalidation.
+//!
+//! Hierarchical relationships are always managed symmetrically.
+//! For example, assigning a child to an entity
+//! will always set the parent in the other,
+//! and vice versa.
+//! Similarly, unassigning a child in the parent
+//! will always unassign the parent in the child.
+//!
+//! ## Despawning entities
+//!
+//! The commands and methods provided by `bevy_ecs` to despawn entities
+//! are not capable of despawning hierarchies of entities, invalidating them.
+//! Instead, you should use the provided [hierarchical despawn extension methods].
+//!
+//! [command]: BuildChildren
+//! [diagnostic plugin]: ValidParentCheckPlugin
+//! [events]: HierarchyEvent
+//! [hierarchical despawn extension methods]: DespawnRecursiveExt
+//! [plugin]: HierarchyPlugin
+//! [query extension methods]: HierarchyQueryExt
+//! [world]: BuildWorldChildren
 
 mod components;
 pub use components::*;
@@ -35,7 +76,11 @@ pub mod prelude {
 #[cfg(feature = "bevy_app")]
 use bevy_app::prelude::*;
 
-/// The base plugin for handling [`Parent`] and [`Children`] components
+/// Provides hierarchy functionality to a Bevy app.
+///
+/// Check the [crate-level documentation] for all the features.
+///
+/// [crate-level documentation]: crate
 #[derive(Default)]
 pub struct HierarchyPlugin;
 


### PR DESCRIPTION
> This PR is based on #10951, therefore it will stay in a draft state until the other is resolved.

I added information about how to access parent and children entities, and about the component lifecycle.

I removed redundant information about holding invariants, which is automatically taken care by the crate's methods, and is already addressed by the base PR.