### PR TITLE
Fix broken link between files

### DIFF
--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -2,7 +2,7 @@
 
 ## Contributing
 
-For more advice on contributing to the engine, see the [relevant section](../../CONTRIBUTING.md#Contributing-your-own-ideas) of `CONTRIBUTING.md`.
+For more advice on contributing to the engine, see the [relevant section](../../CONTRIBUTING.md#Contributing-code) of `CONTRIBUTING.md`.
 
 ## General guidelines
 


### PR DESCRIPTION
# Objective

- Fix a link to a non-existent section of a document.

## Solution

- Change the link to a more likely source.