### PR TITLE
Allow the editing of startup schedules

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -118,7 +118,7 @@ pub struct Last;
 /// their order.
 #[derive(Resource, Debug)]
 pub struct MainScheduleOrder {
-    /// The labels to run for the [`Main`] schedule (in the order they will be run).
+    /// The labels to run for the main phase of the [`Main`] schedule (in the order they will be run).
     pub labels: Vec<InternedScheduleLabel>,
     /// The labels to run for the startup phase of the [`Main`] schedule (in the order they will be run).
     pub startup_labels: Vec<InternedScheduleLabel>,
@@ -143,7 +143,7 @@ impl Default for MainScheduleOrder {
 }
 
 impl MainScheduleOrder {
-    /// Adds the given `schedule` after the `after` schedule
+    /// Adds the given `schedule` after the `after` schedule in the main list of schedules.
     pub fn insert_after(&mut self, after: impl ScheduleLabel, schedule: impl ScheduleLabel) {
         let index = self
             .labels
@@ -151,6 +151,20 @@ impl MainScheduleOrder {
             .position(|current| (**current).eq(&after))
             .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
         self.labels.insert(index + 1, schedule.intern());
+    }
+
+    /// Adds the given `schedule` after the `after` schedule in the list of startup schedules.
+    pub fn insert_startup_after(
+        &mut self,
+        after: impl ScheduleLabel,
+        schedule: impl ScheduleLabel,
+    ) {
+        let index = self
+            .startup_labels
+            .iter()
+            .position(|current| (**current).eq(&after))
+            .unwrap_or_else(|| panic!("Expected {after:?} to exist"));
+        self.startup_labels.insert(index + 1, schedule.intern());
     }
 }
 


### PR DESCRIPTION
# Objective

Fixes #10968 

## Solution

Pull startup schedules from a list of `ScheduleLabel`s in the same way the update schedules are handled.

---

## Changelog

- Added `MainScheduleOrder::startup_labels` to allow the editing of the startup schedule order.

## Migration Guide

- Added a new field to `MainScheduleOrder`, `startup_labels`, for editing the startup schedule order.
