### PR TITLE
docs: AnimationPlayer::play doesn't have transition_duration arg

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -285,8 +285,6 @@ impl AnimationPlayer {
     }
 
     /// Start playing an animation, resetting state of the player, unless the requested animation is already playing.
-    /// If `transition_duration` is set, this will use a linear blending
-    /// between the previous and the new animation to make a smooth transition
     pub fn play(&mut self, handle: Handle<AnimationClip>) -> &mut Self {
         if !self.is_playing_clip(&handle) || self.is_paused() {
             self.start(handle);


### PR DESCRIPTION
# Objective

The documentation for `AnimationPlayer::play` mentions a non-existent `transition_duration` argument from an old iteration of the API. It's confusing.

## Solution

Remove the offending sentence.