### PR TITLE
Simplify equality assertions

### DIFF
--- a/crates/bevy_derive/src/bevy_main.rs
+++ b/crates/bevy_derive/src/bevy_main.rs
@@ -4,9 +4,9 @@ use syn::{parse_macro_input, ItemFn};
 
 pub fn bevy_main(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as ItemFn);
-    assert!(
-        input.sig.ident == "main",
-        "`bevy_main` can only be used on a function called 'main'.",
+    assert_eq!(
+        input.sig.ident, "main",
+        "`bevy_main` can only be used on a function called 'main'."
     );
 
     TokenStream::from(quote! {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1051,8 +1051,8 @@ mod tests {
         for tracker in query.iter(&world) {
             let ticks_since_insert = change_tick.relative_to(*tracker.ticks.added).get();
             let ticks_since_change = change_tick.relative_to(*tracker.ticks.changed).get();
-            assert!(ticks_since_insert == MAX_CHANGE_AGE);
-            assert!(ticks_since_change == MAX_CHANGE_AGE);
+            assert_eq!(ticks_since_insert, MAX_CHANGE_AGE);
+            assert_eq!(ticks_since_change, MAX_CHANGE_AGE);
         }
     }
 

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -977,10 +977,10 @@ mod tests {
         // This is intentionally testing `lt` and `ge` as separate functions.
         #![allow(clippy::nonminimal_bool)]
 
-        assert!(Entity::new(123, 456) == Entity::new(123, 456));
-        assert!(Entity::new(123, 789) != Entity::new(123, 456));
-        assert!(Entity::new(123, 456) != Entity::new(123, 789));
-        assert!(Entity::new(123, 456) != Entity::new(456, 123));
+        assert_eq!(Entity::new(123, 456), Entity::new(123, 456));
+        assert_ne!(Entity::new(123, 789), Entity::new(123, 456));
+        assert_ne!(Entity::new(123, 456), Entity::new(123, 789));
+        assert_ne!(Entity::new(123, 456), Entity::new(456, 123));
 
         // ordering is by generation then by index
 

--- a/crates/bevy_ecs/src/schedule/mod.rs
+++ b/crates/bevy_ecs/src/schedule/mod.rs
@@ -239,7 +239,7 @@ mod tests {
                 partially_ordered == [8, 9, 10] || partially_ordered == [10, 8, 9],
                 "partially_ordered must be [8, 9, 10] or [10, 8, 9]"
             );
-            assert!(order.len() == 11, "must have exactly 11 order entries");
+            assert_eq!(order.len(), 11, "must have exactly 11 order entries");
         }
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1297,7 +1297,7 @@ mod tests {
             .spawn((W(1u32), W(2u64)))
             .id();
         command_queue.apply(&mut world);
-        assert!(world.entities().len() == 1);
+        assert_eq!(world.entities().len(), 1);
         let results = world
             .query::<(&W<u32>, &W<u64>)>()
             .iter(&world)

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -520,7 +520,7 @@ where
     }
 
     fn update_archetype_component_access(&mut self, world: UnsafeWorldCell) {
-        assert!(self.world_id == Some(world.id()), "Encountered a mismatched World. A System cannot be used with Worlds other than the one it was initialized with.");
+        assert_eq!(self.world_id, Some(world.id()), "Encountered a mismatched World. A System cannot be used with Worlds other than the one it was initialized with.");
         let archetypes = world.archetypes();
         let old_generation =
             std::mem::replace(&mut self.archetype_generation, archetypes.generation());

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1812,7 +1812,7 @@ mod tests {
         assert!(res.is_err());
 
         // Ensure that the location has been properly updated.
-        assert!(entity.location() != old_location);
+        assert_ne!(entity.location(), old_location);
     }
 
     // regression test for https://github.com/bevyengine/bevy/pull/7805

--- a/crates/bevy_hierarchy/src/hierarchy.rs
+++ b/crates/bevy_hierarchy/src/hierarchy.rs
@@ -272,7 +272,7 @@ mod tests {
         // The parent's Children component should still have two children.
         let children = world.entity(parent).get::<Children>();
         assert!(children.is_some());
-        assert!(children.unwrap().len() == 2_usize);
+        assert_eq!(children.unwrap().len(), 2_usize);
         // The original child should be despawned.
         assert!(world.get_entity(child).is_none());
     }

--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -481,7 +481,7 @@ mod test {
         assert!(touches.pressed.get(&touch_event.id).is_none());
         let touch = touches.just_released.get(&touch_event.id).unwrap();
         // Make sure the position is updated from TouchPhase::Moved and TouchPhase::Ended
-        assert!(touch.previous_position != touch.position);
+        assert_ne!(touch.previous_position, touch.position);
     }
 
     #[test]

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -464,12 +464,13 @@ impl<T: Sized> DebugEnsureAligned for *mut T {
         // ptr.is_aligned_to.
         //
         // Replace once https://github.com/rust-lang/rust/issues/96284 is stable.
-        assert!(
-            self as usize & (align - 1) == 0,
+        assert_eq!(
+            self as usize & (align - 1),
+            0,
             "pointer is not aligned. Address {:p} does not have alignment {} for type {}",
             self,
             align,
-            core::any::type_name::<T>(),
+            core::any::type_name::<T>()
         );
         self
     }

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -755,28 +755,33 @@ mod tests {
         graph.add_slot_edge("C", 0, "D", 0);
 
         assert!(input_nodes("A", &graph).is_empty(), "A has no inputs");
-        assert!(
-            output_nodes("A", &graph) == HashSet::from_iter(vec![c_id]),
+        assert_eq!(
+            output_nodes("A", &graph),
+            HashSet::from_iter(vec![c_id]),
             "A outputs to C"
         );
 
         assert!(input_nodes("B", &graph).is_empty(), "B has no inputs");
-        assert!(
-            output_nodes("B", &graph) == HashSet::from_iter(vec![c_id]),
+        assert_eq!(
+            output_nodes("B", &graph),
+            HashSet::from_iter(vec![c_id]),
             "B outputs to C"
         );
 
-        assert!(
-            input_nodes("C", &graph) == HashSet::from_iter(vec![a_id, b_id]),
+        assert_eq!(
+            input_nodes("C", &graph),
+            HashSet::from_iter(vec![a_id, b_id]),
             "A and B input to C"
         );
-        assert!(
-            output_nodes("C", &graph) == HashSet::from_iter(vec![d_id]),
+        assert_eq!(
+            output_nodes("C", &graph),
+            HashSet::from_iter(vec![d_id]),
             "C outputs to D"
         );
 
-        assert!(
-            input_nodes("D", &graph) == HashSet::from_iter(vec![c_id]),
+        assert_eq!(
+            input_nodes("D", &graph),
+            HashSet::from_iter(vec![c_id]),
             "C inputs to D"
         );
         assert!(output_nodes("D", &graph).is_empty(), "D has no outputs");
@@ -880,20 +885,24 @@ mod tests {
 
         graph.add_node_edges(&["A", "B", "C"]);
 
-        assert!(
-            output_nodes("A", &graph) == HashSet::from_iter(vec![b_id]),
+        assert_eq!(
+            output_nodes("A", &graph),
+            HashSet::from_iter(vec![b_id]),
             "A -> B"
         );
-        assert!(
-            input_nodes("B", &graph) == HashSet::from_iter(vec![a_id]),
+        assert_eq!(
+            input_nodes("B", &graph),
+            HashSet::from_iter(vec![a_id]),
             "A -> B"
         );
-        assert!(
-            output_nodes("B", &graph) == HashSet::from_iter(vec![c_id]),
+        assert_eq!(
+            output_nodes("B", &graph),
+            HashSet::from_iter(vec![c_id]),
             "B -> C"
         );
-        assert!(
-            input_nodes("C", &graph) == HashSet::from_iter(vec![b_id]),
+        assert_eq!(
+            input_nodes("C", &graph),
+            HashSet::from_iter(vec![b_id]),
             "B -> C"
         );
     }

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -573,8 +573,9 @@ impl Image {
     /// # Panics
     /// Panics if the `new_size` does not have the same volume as to old one.
     pub fn reinterpret_size(&mut self, new_size: Extent3d) {
-        assert!(
-            new_size.volume() == self.texture_descriptor.size.volume(),
+        assert_eq!(
+            new_size.volume(),
+            self.texture_descriptor.size.volume(),
             "Incompatible sizes: old = {:?} new = {:?}",
             self.texture_descriptor.size,
             new_size
@@ -592,8 +593,8 @@ impl Image {
     /// the `layers`.
     pub fn reinterpret_stacked_2d_as_array(&mut self, layers: u32) {
         // Must be a stacked image, and the height must be divisible by layers.
-        assert!(self.texture_descriptor.dimension == TextureDimension::D2);
-        assert!(self.texture_descriptor.size.depth_or_array_layers == 1);
+        assert_eq!(self.texture_descriptor.dimension, TextureDimension::D2);
+        assert_eq!(self.texture_descriptor.size.depth_or_array_layers, 1);
         assert_eq!(self.height() % layers, 0);
 
         self.reinterpret_size(Extent3d {


### PR DESCRIPTION
# Objective

- Shorten assertions.

## Solution

- Replace '==' assertions with 'assert_eq()' and '!=' assertions with 'assert_ne()' .