### PR TITLE
Add docs link to root `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["game", "engine", "gamedev", "graphics", "bevy"]
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
+documentation = "https://docs.rs/bevy"
 rust-version = "1.74.0"
 
 [workspace]


### PR DESCRIPTION
The `documentation` key was missing from the root `Cargo.toml`, which means crates.io doesn't display a documentation link from the search page.

<img width="523" alt="image" src="https://github.com/bevyengine/bevy/assets/6706944/96247a72-168f-47f4-ab35-287c06bb9b30">



