### PR TITLE
Replace deprecated elements

### DIFF
--- a/crates/bevy_core/src/task_pool_options.rs
+++ b/crates/bevy_core/src/task_pool_options.rs
@@ -54,7 +54,7 @@ impl Default for TaskPoolOptions {
         TaskPoolOptions {
             // By default, use however many cores are available on the system
             min_total_threads: 1,
-            max_total_threads: std::usize::MAX,
+            max_total_threads: usize::MAX,
 
             // Use 25% of cores for IO, at least 1, no more than 4
             io: TaskPoolThreadAssignmentPolicy {
@@ -73,7 +73,7 @@ impl Default for TaskPoolOptions {
             // Use all remaining cores for compute (at least 1)
             compute: TaskPoolThreadAssignmentPolicy {
                 min_threads: 1,
-                max_threads: std::usize::MAX,
+                max_threads: usize::MAX,
                 percent: 1.0, // This 1.0 here means "whatever is left over"
             },
         }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -380,15 +380,15 @@ mod tests {
             Err(InvalidDirectionError::Zero)
         );
         assert_eq!(
-            Direction2d::new(Vec2::new(std::f32::INFINITY, 0.0)),
+            Direction2d::new(Vec2::new(f32::INFINITY, 0.0)),
             Err(InvalidDirectionError::Infinite)
         );
         assert_eq!(
-            Direction2d::new(Vec2::new(std::f32::NEG_INFINITY, 0.0)),
+            Direction2d::new(Vec2::new(f32::NEG_INFINITY, 0.0)),
             Err(InvalidDirectionError::Infinite)
         );
         assert_eq!(
-            Direction2d::new(Vec2::new(std::f32::NAN, 0.0)),
+            Direction2d::new(Vec2::new(f32::NAN, 0.0)),
             Err(InvalidDirectionError::NaN)
         );
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -393,15 +393,15 @@ mod test {
             Err(InvalidDirectionError::Zero)
         );
         assert_eq!(
-            Direction3d::new(Vec3::new(std::f32::INFINITY, 0.0, 0.0)),
+            Direction3d::new(Vec3::new(f32::INFINITY, 0.0, 0.0)),
             Err(InvalidDirectionError::Infinite)
         );
         assert_eq!(
-            Direction3d::new(Vec3::new(std::f32::NEG_INFINITY, 0.0, 0.0)),
+            Direction3d::new(Vec3::new(f32::NEG_INFINITY, 0.0, 0.0)),
             Err(InvalidDirectionError::Infinite)
         );
         assert_eq!(
-            Direction3d::new(Vec3::new(std::f32::NAN, 0.0, 0.0)),
+            Direction3d::new(Vec3::new(f32::NAN, 0.0, 0.0)),
             Err(InvalidDirectionError::NaN)
         );
     }

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -213,8 +213,8 @@ where
     T: ab_glyph::Font,
 {
     let mut text_bounds = Rect {
-        min: Vec2::splat(std::f32::MAX),
-        max: Vec2::splat(std::f32::MIN),
+        min: Vec2::splat(f32::MAX),
+        max: Vec2::splat(f32::MIN),
     };
 
     for sg in section_glyphs {


### PR DESCRIPTION
# Objective

- Replace deprecated elements.

## Solution

- Remove 'std::' from constants.