### PR TITLE
Expose stable gamepad UUID

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -1,14 +1,13 @@
 //! The gamepad input functionality.
 
 use crate::{Axis, ButtonInput, ButtonState};
-use bevy_ecs::event::{Event, EventReader, EventWriter};
 use bevy_ecs::{
     change_detection::DetectChangesMut,
+    event::{Event, EventReader, EventWriter},
     system::{Res, ResMut, Resource},
 };
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_utils::Duration;
-use bevy_utils::{tracing::info, HashMap};
+use bevy_utils::{tracing::info, Duration, HashMap, Uuid};
 use thiserror::Error;
 
 /// Errors that occur when setting axis settings for gamepad input.
@@ -108,12 +107,27 @@ impl Gamepad {
     reflect(Serialize, Deserialize)
 )]
 pub struct GamepadInfo {
-    /// The name of the gamepad.
+    /// The display name of the gamepad.
     ///
-    /// This name is generally defined by the OS.
-    ///
-    /// For example on Windows the name may be "HID-compliant game controller".
+    /// This name is generally defined by the OS. For example on Windows the
+    /// name may be "HID-compliant game controller". This is a display name,
+    /// with no guarantee of unicity; if a user has two devices from the same
+    /// make and model, chances are this name will be the same. For a unique
+    /// identifier stable across runs, see [`uuid`] instead.
     pub name: String,
+
+    /// The unique identifier of the gamepad.
+    ///
+    /// This UUID is computed by `gilrs` and is guaranteed to be unique for each
+    /// device, even if they're the same make and model. The ID is also stable
+    /// across runs, so can be used to identify a gamepad in serialized data for
+    /// example.
+    ///
+    /// # Warning
+    ///
+    /// The value is extracted from `gilrs`. At the moment, this is not
+    /// implemented on all platforms. See <https://gitlab.com/gilrs-project/gilrs/-/issues/153>.
+    pub uuid: Uuid,
 }
 
 /// A collection of connected [`Gamepad`]s.
@@ -146,6 +160,16 @@ impl Gamepads {
     /// The name of the gamepad if this one is connected.
     pub fn name(&self, gamepad: Gamepad) -> Option<&str> {
         self.gamepads.get(&gamepad).map(|g| g.name.as_str())
+    }
+
+    /// The UUID of the gamepad if this one is connected.
+    ///
+    /// # Warning
+    ///
+    /// The value is extracted from `gilrs`. At the moment, this is not
+    /// implemented on all platforms. See <https://gitlab.com/gilrs-project/gilrs/-/issues/153>.
+    pub fn uuid(&self, gamepad: Gamepad) -> Option<Uuid> {
+        self.gamepads.get(&gamepad).map(|g| g.uuid)
     }
 
     /// Registers the `gamepad`, marking it as connected.


### PR DESCRIPTION
# Objective

Expose a stable gameped identifier trackable across app restarts. This is particularly useful with serialization, to save user preferences related to a particular gamepad for example.

## Solution

Expose the stable gamepad UUID from `gilrs`.

Unfortunately it's somewhat unusable at the minute due to the limited platform implementations.
https://gitlab.com/gilrs-project/gilrs/-/issues/153
However I already wrote the change by the time I realized this, so might as well open a PR for it to not lose the work.

---

## Changelog

### Added

- Added `GamepadInfo::uuid`, a unique gamepad identifier stable across application restarts.
