### PR TITLE
Implement Std traits for `SceneInstanceReady`

### DIFF
--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 /// Emitted when [`crate::SceneInstance`] becomes ready to use.
 ///
 /// See also [`SceneSpawner::instance_is_ready`].
-#[derive(Event)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Event)]
 pub struct SceneInstanceReady {
     /// Entity to which the scene was spawned as a child.
     pub parent: Entity,


### PR DESCRIPTION
# Objective

Being able to do:
```rust
ev_scene_ready.read().next().unwrap();
```
Which currently isn't possible because `SceneInstanceReady` doesn't implement `Debug`.

## Solution

Implement `Debug` for `SceneInstanceReady`.

---

## Changelog

### Added
- Implement Std traits for `SceneInstanceReady`.