### PR TITLE
Re-export smallvec crate from bevy_utils

### DIFF
--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -25,8 +25,5 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
 ], optional = true }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 
-# other
-smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }
-
 [lints]
 workspace = true

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -6,7 +6,7 @@ use bevy_ecs::{
     system::{Command, Commands, EntityCommands},
     world::{EntityWorldMut, World},
 };
-use smallvec::SmallVec;
+use bevy_utils::smallvec::{smallvec, SmallVec};
 
 // Do not use `world.send_event_batch` as it prints error message when the Events are not available in the world,
 // even though it's a valid use case to execute commands on a world without events. Loading a GLTF file for example
@@ -24,7 +24,7 @@ fn push_child_unchecked(world: &mut World, parent: Entity, child: Entity) {
     if let Some(mut children) = parent.get_mut::<Children>() {
         children.0.push(child);
     } else {
-        parent.insert(Children(smallvec::smallvec![child]));
+        parent.insert(Children(smallvec![child]));
     }
 }
 
@@ -696,7 +696,7 @@ mod tests {
         components::{Children, Parent},
         HierarchyEvent::{self, ChildAdded, ChildMoved, ChildRemoved},
     };
-    use smallvec::{smallvec, SmallVec};
+    use bevy_utils::smallvec::{smallvec, SmallVec};
 
     use bevy_ecs::{
         component::Component,

--- a/crates/bevy_hierarchy/src/components/children.rs
+++ b/crates/bevy_hierarchy/src/components/children.rs
@@ -6,8 +6,8 @@ use bevy_ecs::{
     prelude::FromWorld,
     world::World,
 };
+use bevy_utils::smallvec::SmallVec;
 use core::slice;
-use smallvec::SmallVec;
 use std::ops::Deref;
 
 /// Contains references to the child entities of this entity.

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -40,11 +40,12 @@ use bevy_app::prelude::*;
 pub struct HierarchyPlugin;
 
 #[cfg(feature = "bevy_app")]
+use bevy_utils::smallvec::SmallVec;
 impl Plugin for HierarchyPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Children>()
             .register_type::<Parent>()
-            .register_type::<smallvec::SmallVec<[bevy_ecs::entity::Entity; 8]>>()
+            .register_type::<SmallVec<[bevy_ecs::entity::Entity; 8]>>()
             .add_event::<HierarchyEvent>();
     }
 }

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -35,7 +35,6 @@ fixedbitset = "0.4"
 bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
 naga_oil = "0.11"
-smallvec = "1.6"
 thread_local = "1.0"
 
 [lints]

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 default = []
 # When enabled, provides Bevy-related reflection implementations
 bevy = ["glam", "smallvec", "bevy_math", "smol_str"]
+smallvec = []
 # When enabled, allows documentation comments to be accessed via reflection
 documentation = ["bevy_reflect_derive/documentation"]
 
@@ -30,11 +31,7 @@ erased-serde = "0.3"
 downcast-rs = "1.2"
 thiserror = "1.0"
 serde = "1"
-smallvec = { version = "1.6", features = [
-  "serde",
-  "union",
-  "const_generics",
-], optional = true }
+
 glam = { version = "0.24.1", features = ["serde"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -30,7 +30,11 @@ erased-serde = "0.3"
 downcast-rs = "1.2"
 thiserror = "1.0"
 serde = "1"
-smallvec = { optional = true }
+smallvec = { version = "1.6", features = [
+  "serde",
+  "union",
+  "const_generics",
+], optional = true }
 glam = { version = "0.24.1", features = ["serde"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -30,11 +30,7 @@ erased-serde = "0.3"
 downcast-rs = "1.2"
 thiserror = "1.0"
 serde = "1"
-smallvec = { version = "1.6", features = [
-  "serde",
-  "union",
-  "const_generics",
-], optional = true }
+smallvec = { optional = true }
 glam = { version = "0.24.1", features = ["serde"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -1,5 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
+use bevy_utils::smallvec;
 use smallvec::SmallVec;
+
 use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
@@ -148,7 +150,7 @@ where
     }
 }
 
-impl_type_path!(::smallvec::SmallVec<T: smallvec::Array>);
+impl_type_path!(::bevy_utils::smallvec::SmallVec<T: smallvec::Array>);
 
 impl<T: smallvec::Array + TypePath + Send + Sync> FromReflect for SmallVec<T>
 where

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1383,6 +1383,7 @@ mod tests {
         // List (SmallVec)
         #[cfg(feature = "smallvec")]
         {
+            use bevy_utils::smallvec;
             type MySmallVec = smallvec::SmallVec<[String; 2]>;
 
             let info = MySmallVec::type_info();

--- a/crates/bevy_reflect/src/type_uuid_impl.rs
+++ b/crates/bevy_reflect/src/type_uuid_impl.rs
@@ -4,8 +4,7 @@ use bevy_reflect_derive::impl_type_uuid;
 use bevy_utils::{all_tuples, Duration, HashMap, HashSet, Instant, Uuid};
 
 #[cfg(feature = "smallvec")]
-use bevy_utils::smallvec;
-use smallvec::SmallVec;
+use bevy_utils::{smallvec, smallvec::SmallVec};
 
 #[cfg(any(unix, windows))]
 use std::ffi::OsString;

--- a/crates/bevy_reflect/src/type_uuid_impl.rs
+++ b/crates/bevy_reflect/src/type_uuid_impl.rs
@@ -2,8 +2,11 @@ use crate::TypeUuid;
 use crate::{self as bevy_reflect, __macro_exports::generate_composite_uuid};
 use bevy_reflect_derive::impl_type_uuid;
 use bevy_utils::{all_tuples, Duration, HashMap, HashSet, Instant, Uuid};
+
 #[cfg(feature = "smallvec")]
+use bevy_utils::smallvec;
 use smallvec::SmallVec;
+
 #[cfg(any(unix, windows))]
 use std::ffi::OsString;
 use std::{

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -71,7 +71,6 @@ naga_oil = "0.11"
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }
-smallvec = { version = "1.6", features = ["union", "const_generics"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"
 thiserror = "1.0"

--- a/crates/bevy_render/src/renderer/graph_runner.rs
+++ b/crates/bevy_render/src/renderer/graph_runner.rs
@@ -1,8 +1,11 @@
 use bevy_ecs::{prelude::Entity, world::World};
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
-use bevy_utils::HashMap;
-use smallvec::{smallvec, SmallVec};
+use bevy_utils::{
+    smallvec::{smallvec, SmallVec},
+    HashMap,
+};
+
 #[cfg(feature = "trace")]
 use std::ops::Deref;
 use std::{borrow::Cow, collections::VecDeque};

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -33,7 +33,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 # other
 taffy = { version = "0.3.10" }
 serde = { version = "1", features = ["derive"] }
-smallvec = { version = "1.6", features = ["union", "const_generics"] }
 bytemuck = { version = "1.5", features = ["derive"] }
 thiserror = "1.0.0"
 

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -13,9 +13,9 @@ use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{camera::NormalizedRenderTarget, prelude::Camera, view::ViewVisibility};
 use bevy_transform::components::GlobalTransform;
 
+use bevy_utils::smallvec::SmallVec;
 use bevy_window::{PrimaryWindow, Window};
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 
 /// Describes what type of input interaction has occurred for a UI node.
 ///

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -5,8 +5,8 @@ use bevy_math::{Rect, Vec2};
 use bevy_reflect::prelude::*;
 use bevy_render::{color::Color, texture::Image};
 use bevy_transform::prelude::GlobalTransform;
+use bevy_utils::smallvec::SmallVec;
 use serde::{Deserialize, Serialize};
-use smallvec::SmallVec;
 use std::num::{NonZeroI16, NonZeroU16};
 use thiserror::Error;
 

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -21,7 +21,7 @@ bevy_utils_proc_macros = { version = "0.12.0", path = "macros" }
 petgraph = "0.6"
 thiserror = "1.0"
 nonmax = "0.5"
-smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }
+smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -21,6 +21,7 @@ bevy_utils_proc_macros = { version = "0.12.0", path = "macros" }
 petgraph = "0.6"
 thiserror = "1.0"
 nonmax = "0.5"
+smallvec = { version = "1.6", features = ["serde", "union", "const_generics"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -33,9 +33,9 @@ pub use float_ord::*;
 pub use hashbrown;
 pub use instant::{Duration, Instant, SystemTime};
 pub use petgraph;
+pub use smallvec;
 pub use thiserror;
 pub use tracing;
-pub use smallvec;
 
 #[allow(missing_docs)]
 pub mod nonmax {

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -35,6 +35,7 @@ pub use instant::{Duration, Instant, SystemTime};
 pub use petgraph;
 pub use thiserror;
 pub use tracing;
+pub use smallvec;
 
 #[allow(missing_docs)]
 pub mod nonmax {


### PR DESCRIPTION
Matches versioning & features from other Cargo.toml files in the project.

# Objective
Resolves #10932 

## Solution
Added smallvec to the bevy_utils cargo.toml and added a line to re-export the crate. Target version and features set to match what's used in the other bevy crates.
