### PR TITLE
Remove OrthographicProjection.scale

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -935,8 +935,7 @@ fn load_node(
                     let orthographic_projection = OrthographicProjection {
                         near: orthographic.znear(),
                         far: orthographic.zfar(),
-                        scaling_mode: ScalingMode::FixedHorizontal(1.0),
-                        scale: xmag,
+                        scaling_mode: ScalingMode::FixedHorizontal(xmag),
                         ..Default::default()
                     };
 

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -255,12 +255,6 @@ pub struct OrthographicProjection {
     ///
     /// Defaults to `ScalingMode::WindowSize(1.0)`
     pub scaling_mode: ScalingMode,
-    /// Scales the projection in world units.
-    ///
-    /// As scale increases, the apparent size of objects decreases, and vice versa.
-    ///
-    /// Defaults to `1.0`
-    pub scale: f32,
     /// The area that the projection covers relative to `viewport_origin`.
     ///
     /// Bevy's [`camera_system`](crate::camera::camera_system) automatically
@@ -325,10 +319,10 @@ impl CameraProjection for OrthographicProjection {
         let origin_y = projection_height * self.viewport_origin.y;
 
         self.area = Rect::new(
-            self.scale * -origin_x,
-            self.scale * -origin_y,
-            self.scale * (projection_width - origin_x),
-            self.scale * (projection_height - origin_y),
+            -origin_x,
+            -origin_y,
+            projection_width - origin_x,
+            projection_height - origin_y,
         );
     }
 
@@ -355,7 +349,6 @@ impl CameraProjection for OrthographicProjection {
 impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
-            scale: 1.0,
             near: 0.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -18,8 +18,7 @@ fn setup(
     // camera
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
-            scale: 3.0,
-            scaling_mode: ScalingMode::FixedVertical(2.0),
+            scaling_mode: ScalingMode::FixedVertical(6.0),
             ..default()
         }
         .into(),

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,5 +1,6 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
+use bevy::render::camera::ScalingMode;
 use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
@@ -129,7 +130,7 @@ fn setup(
         Camera3dBundle {
             transform: Transform::from_xyz(0.0, 0.0, 8.0).looking_at(Vec3::default(), Vec3::Y),
             projection: OrthographicProjection {
-                scale: 0.01,
+                scaling_mode: ScalingMode::WindowSize(100.0),
                 ..default()
             }
             .into(),

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -90,8 +90,7 @@ fn setup(
     match std::env::args().nth(1).as_deref() {
         Some("orthographic") => commands.spawn(Camera3dBundle {
             projection: OrthographicProjection {
-                scale: 20.0,
-                scaling_mode: ScalingMode::FixedHorizontal(1.0),
+                scaling_mode: ScalingMode::FixedHorizontal(20.0),
                 ..default()
             }
             .into(),


### PR DESCRIPTION
While trying to set up orthographic projection, I spent some time figuring out what these parameters do. Examples like this:

https://github.com/bevyengine/bevy/blob/05b00267c60fb563ad5fbc64152b1108b24b2d34/examples/3d/orthographic.rs#L20-L24

do not help much.

Apparently `OrthographicProjection.scale` and `ScalingMode.xxx` are redundant: one is multiplied by the other. So having to learn about them is overhead.

Not sure why `.scale` exists. Is it useful?

I have three alternatives:
- Remove `.scale` field (implemented by this PR)
- Remove some fields of `ScalingMode`, e.g. remove parameter from `ScalingMode::FixedVertical`, but keep `ScalingMode::Fixed`

https://github.com/bevyengine/bevy/blob/05b00267c60fb563ad5fbc64152b1108b24b2d34/crates/bevy_render/src/camera/projection.rs#L210-L215

- Keep as is, but write a comment explaining `.scale` parameter is redundant (https://github.com/bevyengine/bevy/pull/11023)

Three modified examples look the same after this PR.