### PR TITLE
Add non-existent entity behavior to Has doc

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1114,6 +1114,16 @@ unsafe impl<T: ReadOnlyQueryData> ReadOnlyQueryData for Option<T> {}
 /// This can be used in a [`Query`](crate::system::Query) if you want to know whether or not entities
 /// have the component `T`  but don't actually care about the component's value.
 ///
+/// # Footguns
+///
+/// Note that a `Query<Has<T>>` will match all existing entities.
+/// Beware! Even if it matches all entites, it doesn't mean that `query.get(entity)`
+/// will always return `Ok(bool)`.
+///
+/// In the case of a non-existent entity, such as a despawned one, it will return `Err`.
+/// A workaround is to replace `query.get(entity).unwrap()` by
+/// `query.get(entity).unwrap_or_default()`.
+///
 /// # Examples
 ///
 /// ```


### PR DESCRIPTION
# Objective

`Has<T>` in some niche cases may behave in an unexpected way.

Specifically, when using `Query::get` on a `Has<T>` with a despawned entity.

## Solution

Add precision about cases wehre `Query::get` could return an `Err`.
