### PR TITLE
Add the ability to manually create ParsedPaths (+ cleanup)

### DIFF
--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -1,56 +1,74 @@
+//! Representation for individual element accesses within a path.
+
 use std::{borrow::Cow, fmt};
 
-use super::{AccessError, ReflectPathError};
+use super::ReflectPathError;
 use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
 use thiserror::Error;
 
-type InnerResult<T> = Result<Option<T>, Error<'static>>;
+type InnerResult<'a, T> = Result<Option<T>, Error<'a>>;
 
+/// An error originating from an access of a reflected type.
 #[derive(Debug, PartialEq, Eq, Error)]
-pub(super) enum Error<'a> {
+pub enum Error<'a> {
+    /// An error that occurs when a certain type doesn't
+    /// contain the value contained in the [`Access`].
     #[error(
         "the current {ty} doesn't have the {} {}",
         access.kind(),
         access.display_value(),
     )]
-    Access { ty: TypeShape, access: Access<'a> },
-
-    #[error("invalid type shape: expected {expected} but found a reflect {actual}")]
-    Type {
-        expected: TypeShape,
-        actual: TypeShape,
+    MissingAccess {
+        /// The type of the object being accessed.
+        ty: TypeKind,
+        /// The [`Access`] used on the object.
+        access: Access<'a>,
     },
 
-    #[error("invalid enum access: expected {expected} variant but found {actual} variant")]
-    Enum {
-        expected: TypeShape,
-        actual: TypeShape,
+    /// An error that occurs when using an [`Access`] on the wrong type.
+    /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct, or a [`TupleIndex`](Access::TupleIndex) on a list)
+    #[error(
+        "invalid type: expected {} access to use a type of {expected} but found a reflect {actual}",
+        access.kind()
+    )]
+    InvalidType {
+        /// The [`TypeKind`] that was expected based on the [`Access`].
+        expected: TypeKind,
+        /// The actual [`TypeKind`] that was found.
+        actual: TypeKind,
+        /// The [`Access`] used.
+        access: Access<'a>,
+    },
+
+    /// An error that occurs when using an [`Access`] on the wrong enum variant.
+    /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct variant, or a [`TupleIndex`](Access::TupleIndex) on a unit variant)
+    #[error(
+        "invalid enum variant: expected {} access to use a type of {expected:?} variant but found {actual:?} variant",
+        access.kind()
+    )]
+    InvalidEnumVariant {
+        /// The [`VariantType`] that was expected based on the [`Access`].
+        expected: VariantType,
+        /// The actual [`VariantType`] that was found.
+        actual: VariantType,
+        /// The [`Access`] used.
+        access: Access<'a>,
     },
 }
 
 impl<'a> Error<'a> {
     fn with_offset(self, offset: usize) -> ReflectPathError<'a> {
-        let error = AccessError(self);
-        ReflectPathError::InvalidAccess { offset, error }
-    }
-
-    fn access(ty: TypeShape, access: Access<'a>) -> Self {
-        Self::Access { ty, access }
-    }
-}
-impl Error<'static> {
-    fn bad_enum_variant(expected: TypeShape, actual: impl Into<TypeShape>) -> Self {
-        let actual = actual.into();
-        Error::Enum { expected, actual }
-    }
-    fn bad_type(expected: TypeShape, actual: impl Into<TypeShape>) -> Self {
-        let actual = actual.into();
-        Error::Type { expected, actual }
+        ReflectPathError::InvalidAccess {
+            offset,
+            error: self,
+        }
     }
 }
 
+/// The kind of the type trying to be accessed.
+#[allow(missing_docs /* Variants are self-explanatory */)]
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub(super) enum TypeShape {
+pub enum TypeKind {
     Struct,
     TupleStruct,
     Tuple,
@@ -62,54 +80,72 @@ pub(super) enum TypeShape {
     Unit,
 }
 
-impl fmt::Display for TypeShape {
+impl fmt::Display for TypeKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
-            TypeShape::Struct => "struct",
-            TypeShape::TupleStruct => "tuple struct",
-            TypeShape::Tuple => "tuple",
-            TypeShape::List => "list",
-            TypeShape::Array => "array",
-            TypeShape::Map => "map",
-            TypeShape::Enum => "enum",
-            TypeShape::Value => "value",
-            TypeShape::Unit => "unit",
+            TypeKind::Struct => "struct",
+            TypeKind::TupleStruct => "tuple struct",
+            TypeKind::Tuple => "tuple",
+            TypeKind::List => "list",
+            TypeKind::Array => "array",
+            TypeKind::Map => "map",
+            TypeKind::Enum => "enum",
+            TypeKind::Value => "value",
+            TypeKind::Unit => "unit",
         };
         write!(f, "{name}")
     }
 }
-impl<'a> From<ReflectRef<'a>> for TypeShape {
+impl<'a> From<ReflectRef<'a>> for TypeKind {
     fn from(value: ReflectRef<'a>) -> Self {
         match value {
-            ReflectRef::Struct(_) => TypeShape::Struct,
-            ReflectRef::TupleStruct(_) => TypeShape::TupleStruct,
-            ReflectRef::Tuple(_) => TypeShape::Tuple,
-            ReflectRef::List(_) => TypeShape::List,
-            ReflectRef::Array(_) => TypeShape::Array,
-            ReflectRef::Map(_) => TypeShape::Map,
-            ReflectRef::Enum(_) => TypeShape::Enum,
-            ReflectRef::Value(_) => TypeShape::Value,
+            ReflectRef::Struct(_) => TypeKind::Struct,
+            ReflectRef::TupleStruct(_) => TypeKind::TupleStruct,
+            ReflectRef::Tuple(_) => TypeKind::Tuple,
+            ReflectRef::List(_) => TypeKind::List,
+            ReflectRef::Array(_) => TypeKind::Array,
+            ReflectRef::Map(_) => TypeKind::Map,
+            ReflectRef::Enum(_) => TypeKind::Enum,
+            ReflectRef::Value(_) => TypeKind::Value,
         }
     }
 }
-impl From<VariantType> for TypeShape {
+impl<'a> From<ReflectMut<'a>> for TypeKind {
+    fn from(value: ReflectMut<'a>) -> Self {
+        match value {
+            ReflectMut::Struct(_) => TypeKind::Struct,
+            ReflectMut::TupleStruct(_) => TypeKind::TupleStruct,
+            ReflectMut::Tuple(_) => TypeKind::Tuple,
+            ReflectMut::List(_) => TypeKind::List,
+            ReflectMut::Array(_) => TypeKind::Array,
+            ReflectMut::Map(_) => TypeKind::Map,
+            ReflectMut::Enum(_) => TypeKind::Enum,
+            ReflectMut::Value(_) => TypeKind::Value,
+        }
+    }
+}
+impl From<VariantType> for TypeKind {
     fn from(value: VariantType) -> Self {
         match value {
-            VariantType::Struct => TypeShape::Struct,
-            VariantType::Tuple => TypeShape::Tuple,
-            VariantType::Unit => TypeShape::Unit,
+            VariantType::Struct => TypeKind::Struct,
+            VariantType::Tuple => TypeKind::Tuple,
+            VariantType::Unit => TypeKind::Unit,
         }
     }
 }
 
 /// A singular element access within a path.
 ///
-/// Can be applied to a `dyn Reflect` to get a reference to the targeted element.
+/// Can be applied to a [`dyn Reflect`](Reflect) to get a reference to the targeted element.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(super) enum Access<'a> {
+pub enum Access<'a> {
+    /// A name-based field access on a struct.
     Field(Cow<'a, str>),
+    /// A index-based field access on a struct.
     FieldIndex(usize),
+    /// An index-based access on a tuple.
     TupleIndex(usize),
+    /// An index-based access on a list.
     ListIndex(usize),
 }
 
@@ -125,9 +161,14 @@ impl fmt::Display for Access<'_> {
 }
 
 impl<'a> Access<'a> {
-    pub(super) fn into_owned(self) -> Access<'static> {
+    /// If the [`Access`] is of variant [`Field`](Access::Field),
+    /// the field's [`Cow<str>`] will be converted to it's owned
+    /// counterpart, which doesn't require a lifetime.
+    ///
+    /// Otherwise does nothing.
+    pub fn as_static(self) -> Access<'static> {
         match self {
-            Self::Field(value) => Access::Field(value.to_string().into()),
+            Self::Field(value) => Access::Field(Cow::Owned(value.to_string())),
             Self::FieldIndex(value) => Access::FieldIndex(value),
             Self::TupleIndex(value) => Access::TupleIndex(value),
             Self::ListIndex(value) => Access::ListIndex(value),
@@ -140,6 +181,7 @@ impl<'a> Access<'a> {
             Self::FieldIndex(value) | Self::TupleIndex(value) | Self::ListIndex(value) => value,
         }
     }
+
     fn kind(&self) -> &'static str {
         match self {
             Self::Field(_) => "field",
@@ -155,33 +197,59 @@ impl<'a> Access<'a> {
     ) -> Result<&'r dyn Reflect, ReflectPathError<'a>> {
         let ty = base.reflect_ref().into();
         self.element_inner(base)
-            .and_then(|maybe| maybe.ok_or(Error::access(ty, self.clone())))
+            .and_then(|maybe| {
+                maybe.ok_or(Error::MissingAccess {
+                    ty,
+                    access: self.clone(),
+                })
+            })
             .map_err(|err| err.with_offset(offset))
     }
 
-    fn element_inner<'r>(&self, base: &'r dyn Reflect) -> InnerResult<&'r dyn Reflect> {
+    fn element_inner<'r>(&self, base: &'r dyn Reflect) -> InnerResult<'a, &'r dyn Reflect> {
         use ReflectRef::*;
+
         match (self, base.reflect_ref()) {
             (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref())),
             (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
-                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Struct,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
             (&Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field_at(index)),
-                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Struct,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Tuple => Ok(enum_ref.field_at(index)),
-                actual => Err(Error::bad_enum_variant(TypeShape::Tuple, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Tuple,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::ListIndex(index), List(list)) => Ok(list.get(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
-            (&Self::ListIndex(_), actual) => Err(Error::bad_type(TypeShape::List, actual)),
-            (_, actual) => Err(Error::bad_type(TypeShape::Struct, actual)),
+            (&Self::ListIndex(_), actual) => Err(Error::InvalidType {
+                expected: TypeKind::List,
+                actual: actual.into(),
+                access: self.clone(),
+            }),
+            (_, actual) => Err(Error::InvalidType {
+                expected: TypeKind::Struct,
+                actual: actual.into(),
+                access: self.clone(),
+            }),
         }
     }
 
@@ -192,34 +260,62 @@ impl<'a> Access<'a> {
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'a>> {
         let ty = base.reflect_ref().into();
         self.element_inner_mut(base)
-            .and_then(|maybe| maybe.ok_or(Error::access(ty, self.clone())))
+            .and_then(|maybe| {
+                maybe.ok_or(Error::MissingAccess {
+                    ty,
+                    access: self.clone(),
+                })
+            })
             .map_err(|err| err.with_offset(offset))
     }
 
-    fn element_inner_mut<'r>(&self, base: &'r mut dyn Reflect) -> InnerResult<&'r mut dyn Reflect> {
+    fn element_inner_mut<'r>(
+        &self,
+        base: &'r mut dyn Reflect,
+    ) -> InnerResult<'a, &'r mut dyn Reflect> {
         use ReflectMut::*;
-        let base_shape: TypeShape = base.reflect_ref().into();
+
         match (self, base.reflect_mut()) {
             (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field.as_ref())),
             (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref())),
-                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Struct,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
             (&Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(Error::bad_enum_variant(TypeShape::Struct, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Struct,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(Error::bad_enum_variant(TypeShape::Tuple, actual)),
+                actual => Err(Error::InvalidEnumVariant {
+                    expected: VariantType::Tuple,
+                    actual,
+                    access: self.clone(),
+                }),
             },
             (&Self::ListIndex(index), List(list)) => Ok(list.get_mut(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get_mut(index)),
-            (&Self::ListIndex(_), _) => Err(Error::bad_type(TypeShape::List, base_shape)),
-            (_, _) => Err(Error::bad_type(TypeShape::Struct, base_shape)),
+            (&Self::ListIndex(_), actual) => Err(Error::InvalidType {
+                expected: TypeKind::List,
+                actual: actual.into(),
+                access: self.clone(),
+            }),
+            (_, actual) => Err(Error::InvalidType {
+                expected: TypeKind::Struct,
+                actual: actual.into(),
+                access: self.clone(),
+            }),
         }
     }
 }

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -168,7 +168,7 @@ impl<'a> Access<'a> {
     /// counterpart, which doesn't require a reference.
     pub fn into_owned(self) -> Access<'static> {
         match self {
-            Self::Field(value) => Access::Field(Cow::Owned(value.to_string())),
+            Self::Field(value) => Access::Field(Cow::Owned(value.into_owned())),
             Self::FieldIndex(value) => Access::FieldIndex(value),
             Self::TupleIndex(value) => Access::TupleIndex(value),
             Self::ListIndex(value) => Access::ListIndex(value),

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 type InnerResult<'a, T> = Result<Option<T>, Error<'a>>;
 
-/// An error originating from an [`Access`] of a reflected type.
+/// An error originating from an [`Access`] of an element within a type.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum Error<'a> {
     /// An error that occurs when a certain type doesn't
@@ -135,6 +135,7 @@ impl From<VariantType> for TypeKind {
 }
 
 /// A singular element access within a path.
+/// Multiple accesses can be combined into a [`ParsedPath`](super::ParsedPath).
 ///
 /// Can be applied to a [`dyn Reflect`](Reflect) to get a reference to the targeted element.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -14,7 +14,7 @@ pub enum AccessError<'a> {
     /// An error that occurs when a certain type doesn't
     /// contain the value contained in the [`Access`].
     #[error(
-        "the current {kind} doesn't have the {} {}",
+        "The current {kind} doesn't have the {} {}",
         access.kind(),
         access.display_value(),
     )]
@@ -28,7 +28,7 @@ pub enum AccessError<'a> {
     /// An error that occurs when using an [`Access`] on the wrong type.
     /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct, or a [`TupleIndex`](Access::TupleIndex) on a list)
     #[error(
-        "invalid type: expected {} access to use a type of {expected} but found a reflect {actual}",
+        "Expected {} access to be of type {expected}, got {actual} instead.",
         access.kind()
     )]
     InvalidType {
@@ -43,7 +43,7 @@ pub enum AccessError<'a> {
     /// An error that occurs when using an [`Access`] on the wrong enum variant.
     /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct variant, or a [`TupleIndex`](Access::TupleIndex) on a unit variant)
     #[error(
-        "invalid enum variant: expected {} access to use a type of {expected:?} variant but found {actual:?} variant",
+        "Expected variant {} access to be a {expected:?} variant, got a {actual:?} variant instead.",
         access.kind()
     )]
     InvalidEnumVariant {

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 type InnerResult<'a, T> = Result<Option<T>, Error<'a>>;
 
-/// An error originating from an access of a reflected type.
+/// An error originating from an [`Access`] of a reflected type.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum Error<'a> {
     /// An error that occurs when a certain type doesn't
@@ -57,7 +57,7 @@ pub enum Error<'a> {
 }
 
 impl<'a> Error<'a> {
-    fn with_offset(self, offset: usize) -> ReflectPathError<'a> {
+    fn with_offset(self, offset: Option<usize>) -> ReflectPathError<'a> {
         ReflectPathError::InvalidAccess {
             offset,
             error: self,
@@ -193,7 +193,7 @@ impl<'a> Access<'a> {
     pub(super) fn element<'r>(
         &self,
         base: &'r dyn Reflect,
-        offset: usize,
+        offset: Option<usize>,
     ) -> Result<&'r dyn Reflect, ReflectPathError<'a>> {
         let ty = base.reflect_ref().into();
         self.element_inner(base)
@@ -256,7 +256,7 @@ impl<'a> Access<'a> {
     pub(super) fn element_mut<'r>(
         &self,
         base: &'r mut dyn Reflect,
-        offset: usize,
+        offset: Option<usize>,
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'a>> {
         let ty = base.reflect_ref().into();
         self.element_inner_mut(base)

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -2,137 +2,11 @@
 
 use std::{borrow::Cow, fmt};
 
-use super::ReflectPathError;
+use super::error::{AccessErrorKind, TypeKind};
+use super::{Offset, ReflectPathError};
 use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
-use thiserror::Error;
 
-type InnerResult<'a, T> = Result<Option<T>, AccessError<'a>>;
-
-/// An error originating from an [`Access`] of an element within a type.
-#[derive(Debug, PartialEq, Eq, Error)]
-pub enum AccessError<'a> {
-    /// An error that occurs when a certain type doesn't
-    /// contain the value contained in the [`Access`].
-    #[error(
-        "The current {kind} doesn't have the {} {}",
-        access.kind(),
-        access.display_value(),
-    )]
-    MissingAccess {
-        /// The kind of the type being accessed.
-        kind: TypeKind,
-        /// The [`Access`] used on the type.
-        access: Access<'a>,
-    },
-
-    /// An error that occurs when using an [`Access`] on the wrong type.
-    /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct, or a [`TupleIndex`](Access::TupleIndex) on a list)
-    #[error(
-        "Expected {} access to be of type {expected}, got {actual} instead.",
-        access.kind()
-    )]
-    InvalidType {
-        /// The [`TypeKind`] that was expected based on the [`Access`].
-        expected: TypeKind,
-        /// The actual [`TypeKind`] that was found.
-        actual: TypeKind,
-        /// The [`Access`] used.
-        access: Access<'a>,
-    },
-
-    /// An error that occurs when using an [`Access`] on the wrong enum variant.
-    /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct variant, or a [`TupleIndex`](Access::TupleIndex) on a unit variant)
-    #[error(
-        "Expected variant {} access to be a {expected:?} variant, got a {actual:?} variant instead.",
-        access.kind()
-    )]
-    InvalidEnumVariant {
-        /// The [`VariantType`] that was expected based on the [`Access`].
-        expected: VariantType,
-        /// The actual [`VariantType`] that was found.
-        actual: VariantType,
-        /// The [`Access`] used.
-        access: Access<'a>,
-    },
-}
-
-impl<'a> AccessError<'a> {
-    fn with_offset(self, offset: Option<usize>) -> ReflectPathError<'a> {
-        ReflectPathError::InvalidAccess {
-            offset,
-            error: self,
-        }
-    }
-}
-
-/// The kind of the type trying to be accessed.
-#[allow(missing_docs /* Variants are self-explanatory */)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub enum TypeKind {
-    Struct,
-    TupleStruct,
-    Tuple,
-    List,
-    Array,
-    Map,
-    Enum,
-    Value,
-    Unit,
-}
-
-impl fmt::Display for TypeKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let name = match self {
-            TypeKind::Struct => "struct",
-            TypeKind::TupleStruct => "tuple struct",
-            TypeKind::Tuple => "tuple",
-            TypeKind::List => "list",
-            TypeKind::Array => "array",
-            TypeKind::Map => "map",
-            TypeKind::Enum => "enum",
-            TypeKind::Value => "value",
-            TypeKind::Unit => "unit",
-        };
-        write!(f, "{name}")
-    }
-}
-impl<'a> From<ReflectRef<'a>> for TypeKind {
-    fn from(value: ReflectRef<'a>) -> Self {
-        match value {
-            ReflectRef::Struct(_) => TypeKind::Struct,
-            ReflectRef::TupleStruct(_) => TypeKind::TupleStruct,
-            ReflectRef::Tuple(_) => TypeKind::Tuple,
-            ReflectRef::List(_) => TypeKind::List,
-            ReflectRef::Array(_) => TypeKind::Array,
-            ReflectRef::Map(_) => TypeKind::Map,
-            ReflectRef::Enum(_) => TypeKind::Enum,
-            ReflectRef::Value(_) => TypeKind::Value,
-        }
-    }
-}
-impl<'a> From<ReflectMut<'a>> for TypeKind {
-    fn from(value: ReflectMut<'a>) -> Self {
-        match value {
-            ReflectMut::Struct(_) => TypeKind::Struct,
-            ReflectMut::TupleStruct(_) => TypeKind::TupleStruct,
-            ReflectMut::Tuple(_) => TypeKind::Tuple,
-            ReflectMut::List(_) => TypeKind::List,
-            ReflectMut::Array(_) => TypeKind::Array,
-            ReflectMut::Map(_) => TypeKind::Map,
-            ReflectMut::Enum(_) => TypeKind::Enum,
-            ReflectMut::Value(_) => TypeKind::Value,
-        }
-    }
-}
-impl From<VariantType> for TypeKind {
-    fn from(value: VariantType) -> Self {
-        match value {
-            VariantType::Struct => TypeKind::Struct,
-            VariantType::Tuple => TypeKind::Tuple,
-            VariantType::Unit => TypeKind::Unit,
-        }
-    }
-}
+type InnerResult<T> = Result<Option<T>, AccessErrorKind>;
 
 /// A singular element access within a path.
 /// Multiple accesses can be combined into a [`ParsedPath`](super::ParsedPath).
@@ -176,147 +50,89 @@ impl<'a> Access<'a> {
         }
     }
 
-    fn display_value(&self) -> &dyn fmt::Display {
-        match self {
-            Self::Field(value) => value,
-            Self::FieldIndex(value) | Self::TupleIndex(value) | Self::ListIndex(value) => value,
-        }
-    }
-
-    fn kind(&self) -> &'static str {
-        match self {
-            Self::Field(_) => "field",
-            Self::FieldIndex(_) => "field index",
-            Self::TupleIndex(_) | Self::ListIndex(_) => "index",
-        }
-    }
-
     pub(super) fn element<'r>(
         &self,
         base: &'r dyn Reflect,
-        offset: Option<usize>,
+        offset: Offset,
     ) -> Result<&'r dyn Reflect, ReflectPathError<'a>> {
         let kind = base.reflect_ref().into();
         self.element_inner(base)
-            .and_then(|maybe| {
-                maybe.ok_or(AccessError::MissingAccess {
-                    kind,
-                    access: self.clone(),
-                })
-            })
-            .map_err(|err| err.with_offset(offset))
+            .and_then(|maybe| maybe.ok_or(AccessErrorKind::MissingAccess(kind)))
+            .map_err(|err| err.with_access(self, offset))
     }
 
-    fn element_inner<'r>(&self, base: &'r dyn Reflect) -> InnerResult<'a, &'r dyn Reflect> {
+    fn element_inner<'r>(&self, base: &'r dyn Reflect) -> InnerResult<&'r dyn Reflect> {
         use ReflectRef::*;
+
+        let invalid_variant =
+            |expected, actual| AccessErrorKind::InvalidEnumVariant { expected, actual };
 
         match (self, base.reflect_ref()) {
             (Self::Field(field), Struct(struct_ref)) => Ok(struct_ref.field(field.as_ref())),
             (Self::Field(field), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field(field.as_ref())),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Struct,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::FieldIndex(index), Struct(struct_ref)) => Ok(struct_ref.field_at(index)),
             (&Self::FieldIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Struct => Ok(enum_ref.field_at(index)),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Struct,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field(index)),
             (&Self::TupleIndex(index), Enum(enum_ref)) => match enum_ref.variant_type() {
                 VariantType::Tuple => Ok(enum_ref.field_at(index)),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Tuple,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (&Self::ListIndex(index), List(list)) => Ok(list.get(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
-            (&Self::ListIndex(_), actual) => Err(AccessError::InvalidType {
-                expected: TypeKind::List,
-                actual: actual.into(),
-                access: self.clone(),
-            }),
-            (_, actual) => Err(AccessError::InvalidType {
-                expected: TypeKind::Struct,
-                actual: actual.into(),
-                access: self.clone(),
-            }),
+            (&Self::ListIndex(_), actual) => {
+                Err(AccessErrorKind::invalid_type(TypeKind::List, actual))
+            }
+            (_, actual) => Err(AccessErrorKind::invalid_type(TypeKind::Struct, actual)),
         }
     }
 
     pub(super) fn element_mut<'r>(
         &self,
         base: &'r mut dyn Reflect,
-        offset: Option<usize>,
+        offset: Offset,
     ) -> Result<&'r mut dyn Reflect, ReflectPathError<'a>> {
         let kind = base.reflect_ref().into();
         self.element_inner_mut(base)
-            .and_then(|maybe| {
-                maybe.ok_or(AccessError::MissingAccess {
-                    kind,
-                    access: self.clone(),
-                })
-            })
-            .map_err(|err| err.with_offset(offset))
+            .and_then(|maybe| maybe.ok_or(AccessErrorKind::MissingAccess(kind)))
+            .map_err(|err| err.with_access(self, offset))
     }
 
-    fn element_inner_mut<'r>(
-        &self,
-        base: &'r mut dyn Reflect,
-    ) -> InnerResult<'a, &'r mut dyn Reflect> {
+    fn element_inner_mut<'r>(&self, base: &'r mut dyn Reflect) -> InnerResult<&'r mut dyn Reflect> {
         use ReflectMut::*;
+
+        let invalid_variant =
+            |expected, actual| AccessErrorKind::InvalidEnumVariant { expected, actual };
 
         match (self, base.reflect_mut()) {
             (Self::Field(field), Struct(struct_mut)) => Ok(struct_mut.field_mut(field.as_ref())),
             (Self::Field(field), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_mut(field.as_ref())),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Struct,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::FieldIndex(index), Struct(struct_mut)) => Ok(struct_mut.field_at_mut(index)),
             (&Self::FieldIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Struct => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Struct,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Struct, actual)),
             },
             (&Self::TupleIndex(index), TupleStruct(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Tuple(tuple)) => Ok(tuple.field_mut(index)),
             (&Self::TupleIndex(index), Enum(enum_mut)) => match enum_mut.variant_type() {
                 VariantType::Tuple => Ok(enum_mut.field_at_mut(index)),
-                actual => Err(AccessError::InvalidEnumVariant {
-                    expected: VariantType::Tuple,
-                    actual,
-                    access: self.clone(),
-                }),
+                actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (&Self::ListIndex(index), List(list)) => Ok(list.get_mut(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get_mut(index)),
-            (&Self::ListIndex(_), actual) => Err(AccessError::InvalidType {
-                expected: TypeKind::List,
-                actual: actual.into(),
-                access: self.clone(),
-            }),
-            (_, actual) => Err(AccessError::InvalidType {
-                expected: TypeKind::Struct,
-                actual: actual.into(),
-                access: self.clone(),
-            }),
+            (&Self::ListIndex(_), actual) => {
+                Err(AccessErrorKind::invalid_type(TypeKind::List, actual))
+            }
+            (_, actual) => Err(AccessErrorKind::invalid_type(TypeKind::Struct, actual)),
         }
     }
 }

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -1,0 +1,145 @@
+use std::fmt;
+
+use thiserror::Error;
+
+use super::{Access, Offset};
+use crate::{ReflectMut, ReflectRef, VariantType};
+
+#[derive(Debug, PartialEq, Eq, Error, Clone, Copy)]
+pub(super) enum AccessErrorKind {
+    #[error("Invalid access for {0} type")]
+    MissingAccess(TypeKind),
+
+    #[error("Invalid type kind, expected {expected} type, got {actual} type")]
+    InvalidType {
+        expected: TypeKind,
+        actual: TypeKind,
+    },
+    #[error("Invalid variant kind, expected {expected:?} variant, got {actual:?} variant")]
+    InvalidEnumVariant {
+        expected: VariantType,
+        actual: VariantType,
+    },
+}
+
+impl AccessErrorKind {
+    pub(super) fn with_access<'a>(
+        self,
+        access: &Access<'a>,
+        offset: Offset,
+    ) -> crate::ReflectPathError<'a> {
+        crate::ReflectPathError::InvalidAccess(AccessError::new(self, access.clone(), offset))
+    }
+
+    pub(super) fn invalid_type(expected: impl Into<TypeKind>, actual: impl Into<TypeKind>) -> Self {
+        Self::InvalidType {
+            expected: expected.into(),
+            actual: actual.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct AccessOffsetDisplay(Offset);
+
+impl fmt::Display for AccessOffsetDisplay {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(index) = self.0.get() {
+            write!(f, " at offset {index} in path")?;
+        }
+        Ok(())
+    }
+}
+
+/// An error originating from an [`Access`] of an element within a type.
+///
+/// Use the `Display` impl of this type to get informations on the error.
+/// Some sample messages:
+/// ```text
+/// Error accessing element at offset 10 in path with '.x': Invalid access for tuple type.
+/// Error accessing element with '[0]': Invalid type kind, expected list type, got struct type.
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("Error accessing element{offset} with '{access}': {error}.")]
+pub struct AccessError<'a> {
+    error: AccessErrorKind,
+    access: Access<'a>,
+    offset: AccessOffsetDisplay,
+}
+
+impl<'a> AccessError<'a> {
+    pub(super) fn new(error: AccessErrorKind, access: Access<'a>, offset: Offset) -> Self {
+        Self {
+            error,
+            access,
+            offset: AccessOffsetDisplay(offset),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub(super) enum TypeKind {
+    Struct,
+    TupleStruct,
+    Tuple,
+    List,
+    Array,
+    Map,
+    Enum,
+    Value,
+    Unit,
+}
+
+impl fmt::Display for TypeKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            TypeKind::Struct => "struct",
+            TypeKind::TupleStruct => "tuple struct",
+            TypeKind::Tuple => "tuple",
+            TypeKind::List => "list",
+            TypeKind::Array => "array",
+            TypeKind::Map => "map",
+            TypeKind::Enum => "enum",
+            TypeKind::Value => "value",
+            TypeKind::Unit => "unit",
+        };
+        write!(f, "{name}")
+    }
+}
+impl<'a> From<ReflectRef<'a>> for TypeKind {
+    fn from(value: ReflectRef<'a>) -> Self {
+        match value {
+            ReflectRef::Struct(_) => TypeKind::Struct,
+            ReflectRef::TupleStruct(_) => TypeKind::TupleStruct,
+            ReflectRef::Tuple(_) => TypeKind::Tuple,
+            ReflectRef::List(_) => TypeKind::List,
+            ReflectRef::Array(_) => TypeKind::Array,
+            ReflectRef::Map(_) => TypeKind::Map,
+            ReflectRef::Enum(_) => TypeKind::Enum,
+            ReflectRef::Value(_) => TypeKind::Value,
+        }
+    }
+}
+impl<'a> From<ReflectMut<'a>> for TypeKind {
+    fn from(value: ReflectMut<'a>) -> Self {
+        match value {
+            ReflectMut::Struct(_) => TypeKind::Struct,
+            ReflectMut::TupleStruct(_) => TypeKind::TupleStruct,
+            ReflectMut::Tuple(_) => TypeKind::Tuple,
+            ReflectMut::List(_) => TypeKind::List,
+            ReflectMut::Array(_) => TypeKind::Array,
+            ReflectMut::Map(_) => TypeKind::Map,
+            ReflectMut::Enum(_) => TypeKind::Enum,
+            ReflectMut::Value(_) => TypeKind::Value,
+        }
+    }
+}
+impl From<VariantType> for TypeKind {
+    fn from(value: VariantType) -> Self {
+        match value {
+            VariantType::Struct => TypeKind::Struct,
+            VariantType::Tuple => TypeKind::Tuple,
+            VariantType::Unit => TypeKind::Unit,
+        }
+    }
+}

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -410,12 +410,28 @@ impl<const N: usize> From<[OffsetAccess; N]> for ParsedPath {
 }
 impl From<Vec<Access<'static>>> for ParsedPath {
     fn from(value: Vec<Access<'static>>) -> Self {
-        ParsedPath(value.into_iter().map(|access| OffsetAccess { access, offset: None }).collect())
+        ParsedPath(
+            value
+                .into_iter()
+                .map(|access| OffsetAccess {
+                    access,
+                    offset: None,
+                })
+                .collect(),
+        )
     }
 }
 impl<const N: usize> From<[Access<'static>; N]> for ParsedPath {
     fn from(value: [Access<'static>; N]) -> Self {
-        ParsedPath(value.into_iter().map(|access| OffsetAccess { access, offset: None }).collect())
+        ParsedPath(
+            value
+                .into_iter()
+                .map(|access| OffsetAccess {
+                    access,
+                    offset: None,
+                })
+                .collect(),
+        )
     }
 }
 

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -24,7 +24,7 @@ pub enum ReflectPathError<'a> {
         /// Position in the path string.
         offset: Option<usize>,
         /// The underlying error.
-        error: access::Error<'a>,
+        error: access::AccessError<'a>,
     },
 
     /// An error that occurs when a type cannot downcast to a given type.
@@ -573,7 +573,7 @@ mod tests {
         expected: TypeKind,
         access: &'static str,
     ) -> StaticError {
-        let error = access::Error::InvalidType {
+        let error = access::AccessError::InvalidType {
             actual,
             expected,
             access: ParsedPath::parse_static(access).unwrap()[1].access.clone(),
@@ -745,7 +745,7 @@ mod tests {
             a.reflect_path("x.notreal").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: Some(2),
-                error: access::Error::MissingAccess {
+                error: access::AccessError::MissingAccess {
                     kind: TypeKind::Struct,
                     access: access_field("notreal"),
                 },
@@ -756,7 +756,7 @@ mod tests {
             a.reflect_path("unit_variant.0").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: Some(13),
-                error: access::Error::InvalidEnumVariant {
+                error: access::AccessError::InvalidEnumVariant {
                     actual: VariantType::Unit,
                     expected: VariantType::Tuple,
                     access: ParsedPath::parse_static("unit_variant.0").unwrap()[1]

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -364,7 +364,7 @@ impl ParsedPath {
         let mut parts = Vec::new();
         for (access, offset) in PathParser::new(string) {
             parts.push(OffsetAccess {
-                access: access?.as_static(),
+                access: access?.into_owned(),
                 offset: Some(offset),
             });
         }
@@ -709,7 +709,7 @@ mod tests {
             ReflectPathError::InvalidAccess {
                 offset: Some(2),
                 error: access::Error::MissingAccess {
-                    ty: TypeKind::Struct,
+                    kind: TypeKind::Struct,
                     access: access_field("notreal"),
                 },
             }

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -12,27 +12,29 @@ use thiserror::Error;
 
 pub use parse::ParseError;
 
+use access::AccessError;
+
 type PathResult<'a, T> = Result<T, ReflectPathError<'a>>;
 
 /// An error returned from a failed path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ReflectPathError<'a> {
     /// An error caused by trying to access a path that's not able to be accessed,
-    /// see [access::Error] for details.
-    #[error("at {} in path specification: {error}", offset.map(|v| v.to_string()).unwrap_or("{unknown}".to_string()))]
+    /// see [AccessError] for details.
+    #[error("Error accessing element in path (index {}): {error}", offset.map(|v| v.to_string()).unwrap_or("{unknown}".to_string()))]
     InvalidAccess {
         /// Position in the path string.
         offset: Option<usize>,
         /// The underlying error.
-        error: access::AccessError<'a>,
+        error: AccessError<'a>,
     },
 
     /// An error that occurs when a type cannot downcast to a given type.
-    #[error("failed to downcast to the path result to the given type")]
+    #[error("Can't downcast result of access to the given type")]
     InvalidDowncast,
 
     /// An error caused by an invalid path string that couldn't be parsed.
-    #[error("at {offset} in '{path}': {error}")]
+    #[error("Encounted an error at offset {offset} while parsing `{path}`: {error}")]
     ParseError {
         /// Position in `path`.
         offset: usize,

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -1,4 +1,6 @@
-mod access;
+#![warn(missing_docs)]
+
+pub mod access;
 mod parse;
 
 use std::fmt;
@@ -12,29 +14,31 @@ pub use parse::ParseError;
 
 type PathResult<'a, T> = Result<T, ReflectPathError<'a>>;
 
-/// An error specific to accessing a field/index on a `Reflect`.
-#[derive(Debug, PartialEq, Eq, Error)]
-#[error(transparent)]
-pub struct AccessError<'a>(access::Error<'a>);
-
 /// An error returned from a failed path string query.
 #[derive(Debug, PartialEq, Eq, Error)]
 pub enum ReflectPathError<'a> {
+    /// An error caused by trying to access a path that's not able to be accessed,
+    /// see [access::Error] for details.
     #[error("at {offset} in path specification: {error}")]
     InvalidAccess {
         /// Position in the path string.
         offset: usize,
-        error: AccessError<'a>,
+        /// The underlying error.
+        error: access::Error<'a>,
     },
 
+    /// An error that occurs when a type cannot downcast to a given type.
     #[error("failed to downcast to the path result to the given type")]
     InvalidDowncast,
 
+    /// An error caused by an invalid path string that couldn't be parsed.
     #[error("at {offset} in '{path}': {error}")]
     ParseError {
         /// Position in `path`.
         offset: usize,
+        /// The path that the error occured in.
         path: &'a str,
+        /// The underlying error.
         error: ParseError<'a>,
     },
 }
@@ -271,7 +275,17 @@ pub trait GetPath: Reflect {
 // Implement `GetPath` for `dyn Reflect`
 impl<T: Reflect + ?Sized> GetPath for T {}
 
+/// An [`Access`] combined with an `offset` for extra context.
+#[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct OffsetAccess {
+    access: Access<'static>,
+    offset: usize,
+}
+
 /// A pre-parsed path to an element within a type.
+///
+/// This struct can be constructed manually from its [`Access`]es or with
+/// the [parse](ParsedPath::parse) method.
 ///
 /// This struct may be used like [`GetPath`] but removes the cost of parsing the path
 /// string at each element access.
@@ -280,13 +294,13 @@ impl<T: Reflect + ?Sized> GetPath for T {}
 /// unlikely to be changed and will be accessed repeatedly.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct ParsedPath(
-    /// This is the boxed slice of pre-parsed accesses.
+    /// This is a vector of pre-parsed accesses.
     ///
     /// Each item in the slice contains the access along with the character
     /// index of the start of the access within the parsed path string.
     ///
     /// The index is mainly used for more helpful error reporting.
-    Box<[(Access<'static>, usize)]>,
+    pub Vec<OffsetAccess>,
 );
 
 impl ParsedPath {
@@ -338,9 +352,12 @@ impl ParsedPath {
     pub fn parse(string: &str) -> PathResult<Self> {
         let mut parts = Vec::new();
         for (access, offset) in PathParser::new(string) {
-            parts.push((access?.into_owned(), offset));
+            parts.push(OffsetAccess {
+                access: access?.as_static(),
+                offset,
+            });
         }
-        Ok(Self(parts.into_boxed_slice()))
+        Ok(Self(parts))
     }
 
     /// Similar to [`Self::parse`] but only works on `&'static str`
@@ -348,41 +365,61 @@ impl ParsedPath {
     pub fn parse_static(string: &'static str) -> PathResult<Self> {
         let mut parts = Vec::new();
         for (access, offset) in PathParser::new(string) {
-            parts.push((access?, offset));
+            parts.push(OffsetAccess {
+                access: access?,
+                offset,
+            });
         }
-        Ok(Self(parts.into_boxed_slice()))
+        Ok(Self(parts))
     }
 }
 impl<'a> ReflectPath<'a> for &'a ParsedPath {
     fn reflect_element(self, mut root: &dyn Reflect) -> PathResult<'a, &dyn Reflect> {
-        for (access, offset) in &*self.0 {
+        for OffsetAccess { access, offset } in &self.0 {
             root = access.element(root, *offset)?;
         }
         Ok(root)
     }
     fn reflect_element_mut(self, mut root: &mut dyn Reflect) -> PathResult<'a, &mut dyn Reflect> {
-        for (access, offset) in &*self.0 {
+        for OffsetAccess { access, offset } in &self.0 {
             root = access.element_mut(root, *offset)?;
         }
         Ok(root)
     }
 }
+impl<I: Into<Vec<OffsetAccess>>> From<I> for ParsedPath {
+    fn from(value: I) -> Self {
+        ParsedPath(value.into())
+    }
+}
 
 impl fmt::Display for ParsedPath {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for (access, _) in self.0.iter() {
+        for OffsetAccess { access, .. } in &self.0 {
             write!(f, "{access}")?;
         }
         Ok(())
     }
 }
+impl std::ops::Index<usize> for ParsedPath {
+    type Output = OffsetAccess;
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+impl std::ops::IndexMut<usize> for ParsedPath {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::float_cmp, clippy::approx_constant)]
 mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::*;
-    use access::TypeShape;
+    use access::TypeKind;
 
     #[derive(Reflect)]
     struct A {
@@ -438,61 +475,77 @@ mod tests {
         }
     }
 
+    fn offset(access: Access<'static>, offset: usize) -> OffsetAccess {
+        OffsetAccess { access, offset }
+    }
+
     fn access_field(field: &'static str) -> Access {
         Access::Field(field.into())
     }
 
     type StaticError = ReflectPathError<'static>;
 
-    fn invalid_access(offset: usize, actual: TypeShape, expected: TypeShape) -> StaticError {
-        let error = AccessError(access::Error::Type { actual, expected });
+    fn invalid_access(
+        offset: usize,
+        actual: TypeKind,
+        expected: TypeKind,
+        access: &'static str,
+    ) -> StaticError {
+        let error = access::Error::InvalidType {
+            actual,
+            expected,
+            access: ParsedPath::parse_static(access).unwrap()[1].access.clone(),
+        };
         ReflectPathError::InvalidAccess { offset, error }
     }
 
     #[test]
     fn parsed_path_parse() {
         assert_eq!(
-            &*ParsedPath::parse("w").unwrap().0,
-            &[(access_field("w"), 1)]
+            ParsedPath::parse("w").unwrap().0,
+            &[offset(access_field("w"), 1)]
         );
         assert_eq!(
-            &*ParsedPath::parse("x.foo").unwrap().0,
-            &[(access_field("x"), 1), (access_field("foo"), 2)]
+            ParsedPath::parse("x.foo").unwrap().0,
+            &[offset(access_field("x"), 1), offset(access_field("foo"), 2)]
         );
         assert_eq!(
-            &*ParsedPath::parse("x.łørđ.mосква").unwrap().0,
+            ParsedPath::parse("x.łørđ.mосква").unwrap().0,
             &[
-                (access_field("x"), 1),
-                (access_field("łørđ"), 2),
-                (access_field("mосква"), 10)
+                offset(access_field("x"), 1),
+                offset(access_field("łørđ"), 2),
+                offset(access_field("mосква"), 10)
             ]
         );
         assert_eq!(
-            &*ParsedPath::parse("y[1].mосква").unwrap().0,
+            ParsedPath::parse("y[1].mосква").unwrap().0,
             &[
-                (access_field("y"), 1),
-                (Access::ListIndex(1), 2),
-                (access_field("mосква"), 5)
+                offset(access_field("y"), 1),
+                offset(Access::ListIndex(1), 2),
+                offset(access_field("mосква"), 5)
             ]
         );
         assert_eq!(
-            &*ParsedPath::parse("z.0.1").unwrap().0,
+            ParsedPath::parse("z.0.1").unwrap().0,
             &[
-                (access_field("z"), 1),
-                (Access::TupleIndex(0), 2),
-                (Access::TupleIndex(1), 4),
+                offset(access_field("z"), 1),
+                offset(Access::TupleIndex(0), 2),
+                offset(Access::TupleIndex(1), 4),
             ]
         );
         assert_eq!(
-            &*ParsedPath::parse("x#0").unwrap().0,
-            &[(access_field("x"), 1), (Access::FieldIndex(0), 2)]
+            ParsedPath::parse("x#0").unwrap().0,
+            &[
+                offset(access_field("x"), 1),
+                offset(Access::FieldIndex(0), 2)
+            ]
         );
         assert_eq!(
-            &*ParsedPath::parse("x#0#1").unwrap().0,
+            ParsedPath::parse("x#0#1").unwrap().0,
             &[
-                (access_field("x"), 1),
-                (Access::FieldIndex(0), 2),
-                (Access::FieldIndex(1), 4)
+                offset(access_field("x"), 1),
+                offset(Access::FieldIndex(0), 2),
+                offset(Access::FieldIndex(1), 4)
             ]
         );
     }
@@ -607,10 +660,10 @@ mod tests {
             a.reflect_path("x.notreal").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 2,
-                error: AccessError(access::Error::Access {
-                    ty: TypeShape::Struct,
+                error: access::Error::MissingAccess {
+                    ty: TypeKind::Struct,
                     access: access_field("notreal"),
-                }),
+                },
             }
         );
 
@@ -618,39 +671,48 @@ mod tests {
             a.reflect_path("unit_variant.0").err().unwrap(),
             ReflectPathError::InvalidAccess {
                 offset: 13,
-                error: AccessError(access::Error::Enum {
-                    actual: TypeShape::Unit,
-                    expected: TypeShape::Tuple
-                }),
+                error: access::Error::InvalidEnumVariant {
+                    actual: VariantType::Unit,
+                    expected: VariantType::Tuple,
+                    access: ParsedPath::parse_static("unit_variant.0").unwrap()[1]
+                        .access
+                        .clone()
+                },
             }
         );
         assert_eq!(
             a.reflect_path("x[0]").err().unwrap(),
-            invalid_access(2, TypeShape::Struct, TypeShape::List)
+            invalid_access(2, TypeKind::Struct, TypeKind::List, "x[0]")
         );
         assert_eq!(
             a.reflect_path("y.x").err().unwrap(),
-            invalid_access(2, TypeShape::List, TypeShape::Struct)
+            invalid_access(2, TypeKind::List, TypeKind::Struct, "y.x")
         );
     }
 
     #[test]
     fn accept_leading_tokens() {
         assert_eq!(
-            &*ParsedPath::parse(".w").unwrap().0,
-            &[(access_field("w"), 1)]
+            ParsedPath::parse(".w").unwrap().0,
+            &[offset(access_field("w"), 1)]
         );
         assert_eq!(
-            &*ParsedPath::parse("#0.foo").unwrap().0,
-            &[(Access::FieldIndex(0), 1), (access_field("foo"), 3)]
+            ParsedPath::parse("#0.foo").unwrap().0,
+            &[
+                offset(Access::FieldIndex(0), 1),
+                offset(access_field("foo"), 3)
+            ]
         );
         assert_eq!(
-            &*ParsedPath::parse(".5").unwrap().0,
-            &[(Access::TupleIndex(5), 1)]
+            ParsedPath::parse(".5").unwrap().0,
+            &[offset(Access::TupleIndex(5), 1)]
         );
         assert_eq!(
-            &*ParsedPath::parse("[0].łørđ").unwrap().0,
-            &[(Access::ListIndex(0), 1), (access_field("łørđ"), 4)]
+            ParsedPath::parse("[0].łørđ").unwrap().0,
+            &[
+                offset(Access::ListIndex(0), 1),
+                offset(access_field("łørđ"), 4)
+            ]
         );
     }
 }

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -275,7 +275,7 @@ pub trait GetPath: Reflect {
 // Implement `GetPath` for `dyn Reflect`
 impl<T: Reflect + ?Sized> GetPath for T {}
 
-/// An [`Access`] combined with an `offset` for improved error reporting.
+/// An [`Access`] combined with an `offset` for more helpful error reporting.
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct OffsetAccess {
     /// The [`Access`] itself.
@@ -301,16 +301,53 @@ impl From<Access<'static>> for OffsetAccess {
 /// This struct may be used like [`GetPath`] but removes the cost of parsing the path
 /// string at each element access.
 ///
-/// It's recommended to use this in place of `GetPath` when the path string is
+/// It's recommended to use this in place of [`GetPath`] when the path string is
 /// unlikely to be changed and will be accessed repeatedly.
+///
+/// ## Examples
+///
+/// Parsing a [`&'static str`](str):
+/// ```
+/// # use bevy_reflect::ParsedPath;
+/// let my_static_string: &'static str = "bar#0.1[2].0";
+/// // Breakdown:
+/// //   "bar" - Access struct field named "bar"
+/// //   "#0" - Access struct field at index 0
+/// //   ".1" - Access tuple struct field at index 1
+/// //   "[2]" - Access list element at index 2
+/// //   ".0" - Access tuple variant field at index 0
+/// let my_path = ParsedPath::parse_static(my_static_string);
+/// ```
+/// Parsing a non-static [`&str`](str):
+/// ```
+/// # use bevy_reflect::ParsedPath;
+/// let my_string = String::from("bar#0.1[2].0");
+/// // Breakdown:
+/// //   "bar" - Access struct field named "bar"
+/// //   "#0" - Access struct field at index 0
+/// //   ".1" - Access tuple struct field at index 1
+/// //   "[2]" - Access list element at index 2
+/// //   ".0" - Access tuple variant field at index 0
+/// let my_path = ParsedPath::parse(&my_string);
+/// ```
+/// Manually constructing a [`ParsedPath`]:
+/// ```
+/// # use std::borrow::Cow;
+/// # use bevy_reflect::access::Access;
+/// # use bevy_reflect::ParsedPath;
+/// let path_elements = [
+///     Access::Field(Cow::Borrowed("bar")),
+///     Access::FieldIndex(0),
+///     Access::TupleIndex(1),
+///     Access::ListIndex(2),
+///     Access::TupleIndex(1),
+/// ];
+/// let my_path = ParsedPath::from(path_elements);
+/// ```
+///
 #[derive(Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct ParsedPath(
-    /// This is a vector of pre-parsed accesses.
-    ///
-    /// Each item in the slice contains the access along with the character
-    /// index of the start of the access within the parsed path string.
-    ///
-    /// The index is mainly used for more helpful error reporting.
+    /// This is a vector of pre-parsed [`OffsetAccess`]es.
     pub Vec<OffsetAccess>,
 );
 


### PR DESCRIPTION
# Objective

I'm working on a developer console plugin, and I wanted to get a field/index of a struct/list/tuple. My command parser already parses member expressions and all that, so I wanted to construct a `ParsedPath` manually, but it's all private.

## Solution

Make the internals of `ParsedPath` public and add documentation for everything, and I changed the boxed slice inside `ParsedPath` to a vector for more flexibility.

I also did a bunch of code cleanup. Improving documentation, error messages, code, type names, etc.

---

## Changelog

- Added the ability to manually create `ParsedPath`s from their elements, without the need of string parsing.
- Improved `ReflectPath` error handling.

## Migration Guide

-  `bevy::reflect::AccessError` has been refactored.

That should be it I think, everything else that was changed was private before this PR.
