### PR TITLE
Relax ordering of the first two parameters of exclusive systems

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1602,7 +1602,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn exclusive_in_out_2<A, B>( _: &mut World, _: In<A>) -> B {
+        fn exclusive_in_out_2<A, B>(_: &mut World, _: In<A>) -> B {
             unimplemented!()
         }
 
@@ -1628,7 +1628,9 @@ mod tests {
         assert_is_system(returning::<&str>.map(u64::from_str).map(Result::unwrap));
         assert_is_system(static_system_param);
         assert_is_system(exclusive_in_out::<(), Result<(), std::io::Error>>.map(bevy_utils::error));
-        assert_is_system(exclusive_in_out_2::<(), Result<(), std::io::Error>>.map(bevy_utils::error));
+        assert_is_system(
+            exclusive_in_out_2::<(), Result<(), std::io::Error>>.map(bevy_utils::error),
+        );
         assert_is_system(exclusive_with_state);
         assert_is_system(returning::<bool>.pipe(exclusive_in_out::<bool, ()>));
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -1602,6 +1602,10 @@ mod tests {
             unimplemented!()
         }
 
+        fn exclusive_in_out_2<A, B>( _: &mut World, _: In<A>) -> B {
+            unimplemented!()
+        }
+
         fn static_system_param(_: StaticSystemParam<Query<'static, 'static, &W<u32>>>) {
             unimplemented!()
         }
@@ -1624,6 +1628,7 @@ mod tests {
         assert_is_system(returning::<&str>.map(u64::from_str).map(Result::unwrap));
         assert_is_system(static_system_param);
         assert_is_system(exclusive_in_out::<(), Result<(), std::io::Error>>.map(bevy_utils::error));
+        assert_is_system(exclusive_in_out_2::<(), Result<(), std::io::Error>>.map(bevy_utils::error));
         assert_is_system(exclusive_with_state);
         assert_is_system(returning::<bool>.pipe(exclusive_in_out::<bool, ()>));
 


### PR DESCRIPTION
# Objective

When an exclusive system takes an input, its first two parameters must be `In<T>, &mut World`. Trying to write an exclusive system that take `&mut World, In<T>` causes an inscrutable compile error that unhelpfully suggests users turn the system into an iterator.

This is arbitrary, confusing, and impossible to debug. And it just looks weird to see an exclusive system whose first parameter isn't `&mut World`.

## Solution

Allow the two parameters to occur in any order. Note that `&mut World` and `In<T>` still must occur before other `ExclusiveSystemParams`, this PR only relaxes the ordering between the two parameters.

---

## Changelog

For exclusive systems that take inputs, the parameters `&mut World` and `In<T>` can now be specified in either order.