### PR TITLE
reflect: maximally relax `TypePath` bounds

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -83,7 +83,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
         },
     );
 
-    let type_path_impl = impl_type_path(reflect_enum.meta(), &where_clause_options);
+    let type_path_impl = impl_type_path(reflect_enum.meta());
 
     let get_type_registration_impl = reflect_enum
         .meta()

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -89,7 +89,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         },
     );
 
-    let type_path_impl = impl_type_path(reflect_struct.meta(), &where_clause_options);
+    let type_path_impl = impl_type_path(reflect_struct.meta());
 
     let get_type_registration_impl = reflect_struct.get_type_registration(&where_clause_options);
 

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -82,7 +82,7 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
         },
     );
 
-    let type_path_impl = impl_type_path(reflect_struct.meta(), &where_clause_options);
+    let type_path_impl = impl_type_path(reflect_struct.meta());
 
     let (impl_generics, ty_generics, where_clause) = reflect_struct
         .meta()

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/typed.rs
@@ -1,5 +1,3 @@
-use std::iter;
-
 use crate::utility::{extend_where_clause, StringExpr, WhereClauseOptions};
 use quote::{quote, ToTokens};
 
@@ -51,7 +49,9 @@ pub(crate) enum TypedProperty {
 }
 
 pub(crate) fn impl_type_path(meta: &ReflectMeta) -> proc_macro2::TokenStream {
-    let where_clause_options = &WhereClauseOptions::new(meta, iter::empty(), iter::empty());
+    // Use `WhereClauseOptions::new_value` here so we don't enforce reflection bounds,
+    // ensuring the impl applies in the most cases possible.
+    let where_clause_options = &WhereClauseOptions::new_value(meta);
 
     if !meta.traits().type_path_attrs().should_auto_derive() {
         return proc_macro2::TokenStream::new();

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/typed.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/typed.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use crate::utility::{extend_where_clause, StringExpr, WhereClauseOptions};
 use quote::{quote, ToTokens};
 
@@ -48,10 +50,9 @@ pub(crate) enum TypedProperty {
     TypePath,
 }
 
-pub(crate) fn impl_type_path(
-    meta: &ReflectMeta,
-    where_clause_options: &WhereClauseOptions,
-) -> proc_macro2::TokenStream {
+pub(crate) fn impl_type_path(meta: &ReflectMeta) -> proc_macro2::TokenStream {
+    let where_clause_options = &WhereClauseOptions::new(meta, iter::empty(), iter::empty());
+
     if !meta.traits().type_path_attrs().should_auto_derive() {
         return proc_macro2::TokenStream::new();
     }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -31,7 +31,7 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
         },
     );
 
-    let type_path_impl = impl_type_path(meta, &where_clause_options);
+    let type_path_impl = impl_type_path(meta);
 
     let (impl_generics, ty_generics, where_clause) = type_path.generics().split_for_impl();
     let where_reflect_clause = extend_where_clause(where_clause, &where_clause_options);

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -39,7 +39,6 @@ use reflect_value::ReflectValueDef;
 use syn::spanned::Spanned;
 use syn::{parse_macro_input, DeriveInput};
 use type_path::NamedTypePathDef;
-use utility::WhereClauseOptions;
 
 pub(crate) static REFLECT_ATTRIBUTE_NAME: &str = "reflect";
 pub(crate) static REFLECT_VALUE_ATTRIBUTE_NAME: &str = "reflect_value";
@@ -286,7 +285,7 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
     let type_path_impl = impls::impl_type_path(
         derive_data.meta(),
         // Use `WhereClauseOptions::new_value` here so we don't enforce reflection bounds
-        &WhereClauseOptions::new_value(derive_data.meta()),
+        // &WhereClauseOptions::new_value(derive_data.meta()),
     );
 
     TokenStream::from(quote! {
@@ -613,7 +612,7 @@ pub fn impl_type_path(input: TokenStream) -> TokenStream {
 
     let meta = ReflectMeta::new(type_path, ReflectTraits::default());
 
-    let type_path_impl = impls::impl_type_path(&meta, &WhereClauseOptions::new_value(&meta));
+    let type_path_impl = impls::impl_type_path(&meta);
 
     TokenStream::from(quote! {
         const _: () = {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -282,11 +282,7 @@ pub fn derive_type_path(input: TokenStream) -> TokenStream {
         Err(err) => return err.into_compile_error().into(),
     };
 
-    let type_path_impl = impls::impl_type_path(
-        derive_data.meta(),
-        // Use `WhereClauseOptions::new_value` here so we don't enforce reflection bounds
-        // &WhereClauseOptions::new_value(derive_data.meta()),
-    );
+    let type_path_impl = impls::impl_type_path(derive_data.meta());
 
     TokenStream::from(quote! {
         const _: () = {

--- a/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/utility.rs
@@ -132,9 +132,9 @@ impl WhereClauseOptions {
                 let custom_bounds = active_bounds(field).map(|bounds| quote!(+ #bounds));
 
                 let bounds = if is_from_reflect {
-                    quote!(#bevy_reflect_path::FromReflect + #bevy_reflect_path::TypePath #custom_bounds)
+                    quote!(#bevy_reflect_path::FromReflect #custom_bounds)
                 } else {
-                    quote!(#bevy_reflect_path::Reflect + #bevy_reflect_path::TypePath #custom_bounds)
+                    quote!(#bevy_reflect_path::Reflect #custom_bounds)
                 };
 
                 (ty, bounds)


### PR DESCRIPTION
# Objective

- Provides an alternate solution to the one implemented in #10791 without breaking changes.

## Solution

- Changes the bounds of macro-generated `TypePath` implementations to universally ignore the types of fields, rather than use the same bounds as other implementations. I think this is a more holistic solution than #10791 because it totally erases the finicky bounds we currently generate, helping to untangle the reflection trait system.