### PR TITLE
Derive `Debug` for `BloomCompositeMode`

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/settings.rs
+++ b/crates/bevy_core_pipeline/src/bloom/settings.rs
@@ -175,7 +175,7 @@ pub struct BloomPrefilterSettings {
     pub threshold_softness: f32,
 }
 
-#[derive(Clone, Reflect, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, Reflect, PartialEq, Eq, Hash, Copy)]
 pub enum BloomCompositeMode {
     EnergyConserving,
     Additive,


### PR DESCRIPTION
# Objective

- API guidelines recommend that every type should implement `Debug` where possible.

## Solution

- Do that.