### PR TITLE
Derive `Eq` and `Ord` for `Msaa`

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -84,7 +84,7 @@ impl Plugin for ViewPlugin {
 ///     .run();
 /// ```
 #[derive(
-    Resource, Default, Clone, Copy, ExtractResource, Reflect, PartialEq, PartialOrd, Debug,
+    Resource, Default, Clone, Copy, ExtractResource, Reflect, PartialEq, Eq, PartialOrd, Ord, Debug,
 )]
 #[reflect(Resource)]
 pub enum Msaa {


### PR DESCRIPTION
# Objective

- `Msaa` already implements the partial relation traits, but there isn't much of a reason to not implement the total ones.

## Solution

- Add `Eq` and `Ord` to the derive list.
