### PR TITLE
Simplify examples/3d/orthographic

### DIFF
--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -18,8 +18,8 @@ fn setup(
     // camera
     commands.spawn(Camera3dBundle {
         projection: OrthographicProjection {
-            scale: 3.0,
-            scaling_mode: ScalingMode::FixedVertical(2.0),
+            // 6 world units per window height.
+            scaling_mode: ScalingMode::FixedVertical(6.0),
             ..default()
         }
         .into(),


### PR DESCRIPTION
Current example may mislead into thinking both parameters are mandatory to make orthographic projection work.