### PR TITLE
Document None conditions on compute_aabb

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -568,7 +568,7 @@ impl Mesh {
     /// Compute the Axis-Aligned Bounding Box of the mesh vertices in model space
     ///
     /// Returns `None` if `self` doesn't have [`Mesh::ATTRIBUTE_POSITION`] of
-    /// type [`VertexAttributeValues::Float32x3`], or if `self` doesn't have any vertex.
+    /// type [`VertexAttributeValues::Float32x3`], or if `self` doesn't have any vertices.
     pub fn compute_aabb(&self) -> Option<Aabb> {
         let Some(VertexAttributeValues::Float32x3(values)) =
             self.attribute(Mesh::ATTRIBUTE_POSITION)

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -566,6 +566,9 @@ impl Mesh {
     }
 
     /// Compute the Axis-Aligned Bounding Box of the mesh vertices in model space
+    ///
+    /// Returns `None` if `self` doesn't have [`Mesh::ATTRIBUTE_POSITION`] of
+    /// type [`VertexAttributeValues::Float32x3`], or if `self` doesn't have any vertex.
     pub fn compute_aabb(&self) -> Option<Aabb> {
         let Some(VertexAttributeValues::Float32x3(values)) =
             self.attribute(Mesh::ATTRIBUTE_POSITION)


### PR DESCRIPTION
The error conditions were not documented, this requires the user to inspect the source code to know when to expect a `None`.

Error conditions should always be documented, so we document them.