### PR TITLE
fix base64 padding when loading a gltf file

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1448,7 +1448,7 @@ impl<'a> DataUri<'a> {
 
     fn decode(&self) -> Result<Vec<u8>, base64::DecodeError> {
         if self.base64 {
-            base64::Engine::decode(&base64::engine::general_purpose::STANDARD_NO_PAD, self.data)
+            base64::Engine::decode(&base64::engine::general_purpose::STANDARD, self.data)
         } else {
             Ok(self.data.as_bytes().to_owned())
         }


### PR DESCRIPTION
# Objective

- After #10336, some gltf files fail to load (examples custom_gltf_vertex_attribute, gltf_skinned_mesh, ...)
- Fix them

## Solution

- Allow padding in base 64 decoder
