### PR TITLE
add libxkbcommon-x11-0 to the default linux dependencies

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -70,7 +70,7 @@ jobs:
         run: |
           sudo apt-get update;
           DEBIAN_FRONTEND=noninteractive sudo apt-get install --no-install-recommends -yq \
-            libasound2-dev libudev-dev;
+            libasound2-dev libudev-dev libxkbcommon-x11-0;
       - name: install xvfb, llvmpipe and lavapipe
         run: |
           sudo apt-get update -y -qq

--- a/docs/linux_dependencies.md
+++ b/docs/linux_dependencies.md
@@ -7,7 +7,7 @@ If you don't see your distro present in the list, feel free to add the instructi
 ## [Ubuntu](https://ubuntu.com/)
 
 ```bash
-sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev
+sudo apt-get install g++ pkg-config libx11-dev libasound2-dev libudev-dev libxkbcommon-x11-0
 ```
 
 if using Wayland, you will also need to install


### PR DESCRIPTION
# Objective

- After #10702, it seems `libxkbcommon-x11-0` is now a default dependency
```
2023-12-21T14:13:14.876926Z  INFO log: Failed loading `libxkbcommon-x11.so.0`. Error: CantOpen(DlOpen { desc: "libxkbcommon-x11.so.0: cannot open shared object file: No such file or directory" })   
```

## Solution

- Add the new dependency on linux
