### PR TITLE
Use `WindowBuilder::with_append()` to append canvas

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -140,7 +140,8 @@ impl WinitWindows {
             }
 
             winit_window_builder =
-                winit_window_builder.with_prevent_default(window.prevent_default_event_handling)
+                winit_window_builder.with_prevent_default(window.prevent_default_event_handling);
+            winit_window_builder = winit_window_builder.with_append(true);
         }
 
         let winit_window = winit_window_builder.build(event_loop).unwrap();
@@ -188,22 +189,6 @@ impl WinitWindows {
 
         self.entity_to_winit.insert(entity, winit_window.id());
         self.winit_to_entity.insert(winit_window.id(), entity);
-
-        #[cfg(target_arch = "wasm32")]
-        {
-            use winit::platform::web::WindowExtWebSys;
-
-            if window.canvas.is_none() {
-                let canvas = winit_window.canvas().expect("Failed to retrieve canvas.");
-
-                let window = web_sys::window().unwrap();
-                let document = window.document().unwrap();
-                let body = document.body().unwrap();
-
-                body.append_child(&canvas)
-                    .expect("Append canvas to HTML body.");
-            }
-        }
 
         self.windows
             .entry(winit_window.id())


### PR DESCRIPTION
# Objective

Replace the canvas appending code with a simpler version provided by Winit v0.29.

Related: #11052.

## Solution

Use [`WindowBuilder::with_append()`](https://docs.rs/winit/0.29.5/wasm32-unknown-unknown/winit/platform/web/trait.WindowBuilderExtWebSys.html#tymethod.with_append).