### PR TITLE
Register Camera types.

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -64,7 +64,8 @@ impl Default for Camera3d {
     }
 }
 
-#[derive(Clone, Copy, Reflect)]
+#[derive(Clone, Copy, Reflect, Serialize, Deserialize)]
+#[reflect(Serialize, Deserialize)]
 pub struct Camera3dDepthTextureUsage(u32);
 
 impl From<TextureUsages> for Camera3dDepthTextureUsage {

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -83,6 +83,8 @@ impl Plugin for Core3dPlugin {
     fn build(&self, app: &mut App) {
         app.register_type::<Camera3d>()
             .register_type::<Camera3dDepthLoadOp>()
+            .register_type::<Camera3dDepthTextureUsage>()
+            .register_type::<ScreenSpaceTransmissionQuality>()
             .add_plugins((SkyboxPlugin, ExtractComponentPlugin::<Camera3d>::default()))
             .add_systems(PostUpdate, check_msaa);
 


### PR DESCRIPTION
# Objective

Register and Serialize `Camera3dDepthTextureUsage` and `ScreenSpaceTransmissionQuality`.

Fixes: #11036

## Solution

Added the relevant derives for reflection and serialization and type registrations.