### PR TITLE
Specify which corners are defined by min/max

### DIFF
--- a/crates/bevy_math/src/rects/rect.rs
+++ b/crates/bevy_math/src/rects/rect.rs
@@ -12,9 +12,9 @@ use crate::{IRect, URect, Vec2};
 #[derive(Default, Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Rect {
-    /// The minimum corner point of the rect.
+    /// The minimum (bottom-left) corner point of the rect.
     pub min: Vec2,
-    /// The maximum corner point of the rect.
+    /// The maximum (top-right) corner point of the rect.
     pub max: Vec2,
 }
 


### PR DESCRIPTION
# Objective
Clarifies which corners of the rectangle are described by the `Rect::min` and `Rect::max` properties.

## Solution
Currently unclear which corners of the rectangle are `Rect::min` and `Rect::max`. `Rect::from_corners` and `Rect::from_center_half_size` confirm the behavior that `Rect::min` is the bottom-left corner and `Rect::max` is the top-right corner. I updated the docs on those properties to explain.