### PR TITLE
Add run conditions for executing a system after a delay

### DIFF
--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,4 +1,4 @@
-use crate::{Real, Time, Timer};
+use crate::{Real, Time, Timer, TimerMode};
 use bevy_ecs::system::Res;
 use bevy_utils::Duration;
 
@@ -34,7 +34,7 @@ use bevy_utils::Duration;
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
 pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
+    let mut timer = Timer::new(duration, TimerMode::Repeating);
     move |time: Res<Time>| {
         timer.tick(time.delta());
         timer.just_finished()
@@ -74,7 +74,7 @@ pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
 pub fn on_real_timer(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
+    let mut timer = Timer::new(duration, TimerMode::Repeating);
     move |time: Res<Time<Real>>| {
         timer.tick(time.delta());
         timer.just_finished()
@@ -100,11 +100,11 @@ pub fn on_real_timer(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool 
 ///     .run();
 /// }
 /// fn tick() {
-///     // ran once a second
+///     // ran once, after a second
 /// }
 /// ```
 pub fn once_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    let mut timer = Timer::new(duration, TimerMode::Once);
     move |time: Res<Time>| {
         timer.tick(time.delta());
         timer.just_finished()
@@ -130,7 +130,7 @@ pub fn once_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + C
 ///     .run();
 /// }
 /// fn tick() {
-///     // ran once a second
+///     // ran once, after a second
 /// }
 /// ```
 pub fn once_after_real_delay(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
@@ -160,11 +160,11 @@ pub fn once_after_real_delay(duration: Duration) -> impl FnMut(Res<Time<Real>>) 
 ///     .run();
 /// }
 /// fn tick() {
-///     // ran once a second
+///     // ran every frame, after a second
 /// }
 /// ```
 pub fn repeating_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    let mut timer = Timer::new(duration, TimerMode::Once);
     move |time: Res<Time>| {
         timer.tick(time.delta());
         timer.finished()
@@ -190,13 +190,13 @@ pub fn repeating_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> boo
 ///     .run();
 /// }
 /// fn tick() {
-///     // ran once a second
+///     // ran every frame, after a second
 /// }
 /// ```
 pub fn repeating_after_real_delay(
     duration: Duration,
 ) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    let mut timer = Timer::new(duration, TimerMode::Once);
     move |time: Res<Time<Real>>| {
         timer.tick(time.delta());
         timer.finished()

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -33,9 +33,12 @@ use bevy_utils::Duration;
 /// For more accurate timers, use the [`Timer`] class directly (see
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
-#[deprecated = "Renamed to `on_time_interval`."]
 pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
-    on_time_interval(duration)
+    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
+    move |time: Res<Time>| {
+        timer.tick(time.delta());
+        timer.just_finished()
+    }
 }
 
 /// Run condition that is active on a regular time interval,
@@ -70,84 +73,7 @@ pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
 /// For more accurate timers, use the [`Timer`] class directly (see
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
-#[deprecated = "Renamed to `on_real_time_interval`."]
 pub fn on_real_timer(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
-    on_real_time_interval(duration)
-}
-
-/// Run condition that is active on a regular time interval,
-/// using [`Time`] to advance the timer.
-/// The timer ticks at the rate of [`Time::relative_speed`].
-///
-/// ```rust,no_run
-/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
-/// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
-/// # use bevy_time::common_conditions::on_time_interval;
-/// fn main() {
-///     App::new()
-///         .add_plugins(DefaultPlugins)
-///         .add_systems(
-///             Update,
-///             tick.run_if(on_time_interval(Duration::from_secs(1))),
-///         )
-///     .run();
-/// }
-/// fn tick() {
-///     // ran once a second
-/// }
-/// ```
-///
-/// Note that this does **not** guarantee that systems will run at exactly the
-/// specified interval. If delta time is larger than the specified `duration` then
-/// the system will only run once even though the timer may have completed multiple
-/// times. This condition should only be used with large time durations (relative to
-/// delta time).
-///
-/// For more accurate timers, use the [`Timer`] class directly (see
-/// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
-/// use fixed timesteps that allow systems to run multiple times per frame.
-pub fn on_time_interval(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
-    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
-    move |time: Res<Time>| {
-        timer.tick(time.delta());
-        timer.just_finished()
-    }
-}
-
-/// Run condition that is active on a regular time interval,
-/// using [`Time<Real>`] to advance the timer.
-/// The timer ticks are not scaled.
-///
-/// ```rust,no_run
-/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
-/// # use bevy_ecs::schedule::IntoSystemConfigs;
-/// # use bevy_utils::Duration;
-/// # use bevy_time::common_conditions::on_real_time_interval;
-/// fn main() {
-///     App::new()
-///         .add_plugins(DefaultPlugins)
-///         .add_systems(
-///             Update,
-///             tick.run_if(on_real_time_interval(Duration::from_secs(1))),
-///         )
-///         .run();
-/// }
-/// fn tick() {
-///     // ran once a second
-/// }
-/// ```
-///
-/// Note that this does **not** guarantee that systems will run at exactly the
-/// specified interval. If delta time is larger than the specified `duration` then
-/// the system will only run once even though the timer may have completed multiple
-/// times. This condition should only be used with large time durations (relative to
-/// delta time).
-///
-/// For more accurate timers, use the [`Timer`] class directly (see
-/// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
-/// use fixed timesteps that allow systems to run multiple times per frame.
-pub fn on_real_time_interval(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
     let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
     move |time: Res<Time<Real>>| {
         timer.tick(time.delta());
@@ -289,7 +215,7 @@ mod tests {
     #[test]
     fn distributive_run_if_compiles() {
         Schedule::default().add_systems(
-            (test_system, test_system).distributive_run_if(on_time_interval(Duration::new(1, 0))),
+            (test_system, test_system).distributive_run_if(on_timer(Duration::new(1, 0))),
         );
     }
 }

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -288,8 +288,8 @@ mod tests {
     // Ensure distributive_run_if compiles with the common conditions.
     #[test]
     fn distributive_run_if_compiles() {
-        Schedule::default().add_systems((test_system, test_system).distributive_run_if(on_timer(
-            Timer::new(Duration::new(1, 0), crate::TimerMode::Repeating),
-        )));
+        Schedule::default().add_systems(
+            (test_system, test_system).distributive_run_if(on_time_interval(Duration::new(1, 0))),
+        );
     }
 }

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,5 +1,6 @@
 use crate::{Real, Time, Timer};
 use bevy_ecs::system::Res;
+use bevy_utils::Duration;
 
 /// Run condition that is active on a regular time interval, using [`Time`] to advance
 /// the timer. The timer ticks at the rate of [`Time::relative_speed`].
@@ -8,17 +9,13 @@ use bevy_ecs::system::Res;
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
 /// # use bevy_utils::Duration;
-/// # use bevy_time::{Timer, TimerMode};
 /// # use bevy_time::common_conditions::on_timer;
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
 ///         .add_systems(
 ///             Update,
-///             tick.run_if(on_timer(Timer::new(
-///                 Duration::from_secs(1),
-///                 TimerMode::Repeating,
-///             ))),
+///             tick.run_if(on_timer(Duration::from_secs(1))),
 ///         )
 ///     .run();
 /// }
@@ -36,31 +33,26 @@ use bevy_ecs::system::Res;
 /// For more accurate timers, use the [`Timer`] class directly (see
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
-pub fn on_timer(mut timer: Timer) -> impl FnMut(Res<Time>) -> bool + Clone {
-    move |time: Res<Time>| {
-        timer.tick(time.delta());
-        timer.just_finished()
-    }
+#[deprecated = "Renamed to `on_time_interval`."]
+pub fn on_timer(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
+    on_time_interval(duration)
 }
 
-/// Run condition that is active on a regular time interval, using [`Time<Real>`] to advance
-/// the timer. The timer ticks are not scaled.
+/// Run condition that is active on a regular time interval,
+/// using [`Time<Real>`] to advance the timer.
+/// The timer ticks are not scaled.
 ///
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
 /// # use bevy_ecs::schedule::IntoSystemConfigs;
 /// # use bevy_utils::Duration;
-/// # use bevy_time::{Timer, TimerMode};
 /// # use bevy_time::common_conditions::on_real_timer;
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
 ///         .add_systems(
 ///             Update,
-///             tick.run_if(on_real_timer(Timer::new(
-///                 Duration::from_secs(1),
-///                 TimerMode::Repeating,
-///             ))),
+///             tick.run_if(on_real_timer(Duration::from_secs(1))),
 ///         )
 ///         .run();
 /// }
@@ -78,10 +70,210 @@ pub fn on_timer(mut timer: Timer) -> impl FnMut(Res<Time>) -> bool + Clone {
 /// For more accurate timers, use the [`Timer`] class directly (see
 /// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
 /// use fixed timesteps that allow systems to run multiple times per frame.
-pub fn on_real_timer(mut timer: Timer) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
+#[deprecated = "Renamed to `on_real_time_interval`."]
+pub fn on_real_timer(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
+    on_real_time_interval(duration)
+}
+
+/// Run condition that is active on a regular time interval,
+/// using [`Time`] to advance the timer.
+/// The timer ticks at the rate of [`Time::relative_speed`].
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::on_time_interval;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(on_time_interval(Duration::from_secs(1))),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+///
+/// Note that this does **not** guarantee that systems will run at exactly the
+/// specified interval. If delta time is larger than the specified `duration` then
+/// the system will only run once even though the timer may have completed multiple
+/// times. This condition should only be used with large time durations (relative to
+/// delta time).
+///
+/// For more accurate timers, use the [`Timer`] class directly (see
+/// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
+/// use fixed timesteps that allow systems to run multiple times per frame.
+pub fn on_time_interval(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
+    move |time: Res<Time>| {
+        timer.tick(time.delta());
+        timer.just_finished()
+    }
+}
+
+/// Run condition that is active on a regular time interval,
+/// using [`Time<Real>`] to advance the timer.
+/// The timer ticks are not scaled.
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::on_real_time_interval;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(on_real_time_interval(Duration::from_secs(1))),
+///         )
+///         .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+///
+/// Note that this does **not** guarantee that systems will run at exactly the
+/// specified interval. If delta time is larger than the specified `duration` then
+/// the system will only run once even though the timer may have completed multiple
+/// times. This condition should only be used with large time durations (relative to
+/// delta time).
+///
+/// For more accurate timers, use the [`Timer`] class directly (see
+/// [`Timer::times_finished_this_tick`] to address the problem mentioned above), or
+/// use fixed timesteps that allow systems to run multiple times per frame.
+pub fn on_real_time_interval(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Repeating);
     move |time: Res<Time<Real>>| {
         timer.tick(time.delta());
         timer.just_finished()
+    }
+}
+
+/// Run condition that is active *once* after the specified delay,
+/// using [`Time`] to advance the timer.
+/// The timer ticks at the rate of [`Time::relative_speed`].
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::once_after_delay;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(once_after_delay(Duration::from_secs(1))),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+pub fn once_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    move |time: Res<Time>| {
+        timer.tick(time.delta());
+        timer.just_finished()
+    }
+}
+
+/// Run condition that is active *once* after the specified delay,
+/// using [`Time<Real>`] to advance the timer.
+/// The timer ticks are not scaled.
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::once_after_delay;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(once_after_delay(Duration::from_secs(1))),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+pub fn once_after_real_delay(duration: Duration) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    move |time: Res<Time<Real>>| {
+        timer.tick(time.delta());
+        timer.just_finished()
+    }
+}
+
+/// Run condition that is active *indefinitely* after the specified delay,
+/// using [`Time`] to advance the timer.
+/// The timer ticks at the rate of [`Time::relative_speed`].
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::repeating_after_delay;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(repeating_after_delay(Duration::from_secs(1))),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+pub fn repeating_after_delay(duration: Duration) -> impl FnMut(Res<Time>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    move |time: Res<Time>| {
+        timer.tick(time.delta());
+        timer.finished()
+    }
+}
+
+/// Run condition that is active *indefinitely* after the specified delay,
+/// using [`Time<Real>`] to advance the timer.
+/// The timer ticks are not scaled.
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_utils::Duration;
+/// # use bevy_time::common_conditions::repeating_after_real_delay;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(repeating_after_real_delay(Duration::from_secs(1))),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran once a second
+/// }
+/// ```
+pub fn repeating_after_real_delay(
+    duration: Duration,
+) -> impl FnMut(Res<Time<Real>>) -> bool + Clone {
+    let mut timer = Timer::new(duration, crate::TimerMode::Once);
+    move |time: Res<Time<Real>>| {
+        timer.tick(time.delta());
+        timer.finished()
     }
 }
 

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -25,7 +25,10 @@ fn main() {
                     // `on_timer` run condition uses `Virtual` time meaning it's scaled
                     // and would result in the UI updating at different intervals based
                     // on `Time<Virtual>::relative_speed` and `Time<Virtual>::is_paused()`
-                    .run_if(on_real_timer(Duration::from_millis(250))),
+                    .run_if(on_real_timer(Timer::new(
+                        Duration::from_millis(250),
+                        TimerMode::Repeating,
+                    ))),
             ),
         )
         .run();

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use bevy::{
     input::common_conditions::input_just_pressed, prelude::*,
-    time::common_conditions::on_real_timer,
+    time::common_conditions::on_real_time_interval,
 };
 
 fn main() {
@@ -22,13 +22,10 @@ fn main() {
                 change_time_speed::<-1>.run_if(input_just_pressed(KeyCode::ArrowDown)),
                 (update_virtual_time_info_text, update_real_time_info_text)
                     // update the texts on a timer to make them more readable
-                    // `on_timer` run condition uses `Virtual` time meaning it's scaled
+                    // `on_time_interval` run condition uses `Virtual` time meaning it's scaled
                     // and would result in the UI updating at different intervals based
                     // on `Time<Virtual>::relative_speed` and `Time<Virtual>::is_paused()`
-                    .run_if(on_real_timer(Timer::new(
-                        Duration::from_millis(250),
-                        TimerMode::Repeating,
-                    ))),
+                    .run_if(on_real_time_interval(Duration::from_millis(250))),
             ),
         )
         .run();

--- a/examples/time/virtual_time.rs
+++ b/examples/time/virtual_time.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 use bevy::{
     input::common_conditions::input_just_pressed, prelude::*,
-    time::common_conditions::on_real_time_interval,
+    time::common_conditions::on_real_timer,
 };
 
 fn main() {
@@ -22,10 +22,10 @@ fn main() {
                 change_time_speed::<-1>.run_if(input_just_pressed(KeyCode::ArrowDown)),
                 (update_virtual_time_info_text, update_real_time_info_text)
                     // update the texts on a timer to make them more readable
-                    // `on_time_interval` run condition uses `Virtual` time meaning it's scaled
+                    // `on_timer` run condition uses `Virtual` time meaning it's scaled
                     // and would result in the UI updating at different intervals based
                     // on `Time<Virtual>::relative_speed` and `Time<Virtual>::is_paused()`
-                    .run_if(on_real_time_interval(Duration::from_millis(250))),
+                    .run_if(on_real_timer(Duration::from_millis(250))),
             ),
         )
         .run();


### PR DESCRIPTION
# Objective

I want to run a system once after a given delay.

- First, I tried using the `on_timer` run condition, but it uses a repeating timer, causing the system to run multiple times.
- Next, I tried combining the `on_timer` with the `run_once` run condition. However, this causes the timer to *tick* only once, so the system is never executed.

## Solution

- ~~Replace `on_timer` by `on_time_interval` and `on_real_timer` by `on_real_time_interval` to clarify the meaning (the old ones are deprecated to avoid a breaking change).~~ (Reverted according to feedback)
- Add `once_after_delay` and `once_after_real_delay` to run the system exactly once after the delay, using `TimerMode::Once`.
- Add `repeating_after_delay` and `repeating_after_real_delay` to run the system indefinitely after the delay, using `Timer::finished` instead of `Timer::just_finished`.

---

## Changelog

### Added

- `once_after_delay` and `once_after_real_delay` run conditions to run the system exactly once after the delay, using `TimerMode::Once`.
- `repeating_after_delay` and `repeating_after_real_delay` run conditions to run the system indefinitely after the delay, using `Timer::finished` instead of `Timer::just_finished`.