### PR TITLE
Fixed Typo in the description of EntityMut

### DIFF
--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -190,7 +190,7 @@ impl<'a> From<&'a EntityMut<'_>> for EntityRef<'a> {
 
 /// Provides mutable access to a single entity and all of its components.
 ///
-/// Contrast with [`EntityWorldMut`], with allows adding and removing components,
+/// Contrast with [`EntityWorldMut`], wich allows adding and removing components,
 /// despawning the entity, and provides mutable access to the entire world.
 /// Because of this, `EntityWorldMut` cannot coexist with any other world accesses.
 ///

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -190,7 +190,7 @@ impl<'a> From<&'a EntityMut<'_>> for EntityRef<'a> {
 
 /// Provides mutable access to a single entity and all of its components.
 ///
-/// Contrast with [`EntityWorldMut`], wich allows adding and removing components,
+/// Contrast with [`EntityWorldMut`], which allows adding and removing components,
 /// despawning the entity, and provides mutable access to the entire world.
 /// Because of this, `EntityWorldMut` cannot coexist with any other world accesses.
 ///


### PR DESCRIPTION
# Objective
Fix a typo in the description of the  `EntityMut` struct