### PR TITLE
Implement Deref and DerefMut for In

### DIFF
--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -113,7 +113,7 @@ mod system;
 mod system_param;
 mod system_registry;
 
-use std::borrow::Cow;
+use std::{borrow::Cow, ops::DerefMut};
 
 pub use adapter_system::*;
 pub use combinator::*;
@@ -306,6 +306,20 @@ pub fn assert_system_does_not_conflict<Out, Params, S: IntoSystem<(), Out, Param
     let mut system = IntoSystem::into_system(sys);
     system.initialize(&mut world);
     system.run((), &mut world);
+}
+
+impl<T> std::ops::Deref for In<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T> std::ops::DerefMut for In<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -113,7 +113,7 @@ mod system;
 mod system_param;
 mod system_registry;
 
-use std::{borrow::Cow, ops::DerefMut};
+use std::borrow::Cow;
 
 pub use adapter_system::*;
 pub use combinator::*;


### PR DESCRIPTION
# Objective

Implement Deref and DerefMut for In<T>

makes it so the user doesn't have to add ".0" in most cases