### PR TITLE
Fix Mesh::ATTRIBUTE_UV_0 documentation

### DIFF
--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -139,12 +139,15 @@ impl Mesh {
     /// Texture coordinates for the vertex. Use in conjunction with [`Mesh::insert_attribute`]
     /// or [`Mesh::with_inserted_attribute`].
     ///
-    /// Values are generally between 0. and 1., with `StandardMaterial` and `ColorMaterial`
-    /// `[0.,0.]` is the top left of the texture, and [1.,1.] the bottom-right.
-    /// You usually want to only use values in that range, values outside will be
-    /// clamped per pixel not for the vertex, "stretching" the borders of the texture.
+    /// Generally `[0.,0.]` is mapped to the top left of the texture, and `[1.,1.]` to the bottom-right.
+    ///
+    /// By default values outside will be clamped per pixel not for the vertex,
+    /// "stretching" the borders of the texture.
     /// This behavior can be useful in some cases, usually when the borders have only
     /// one color, for example a logo, and you want to "extend" those borders.
+    ///
+    /// For different mapping outside of `0..=1` range,
+    /// see [`ImageAddressMode`](crate::texture::ImageAddressMode).
     pub const ATTRIBUTE_UV_0: MeshVertexAttribute =
         MeshVertexAttribute::new("Vertex_Uv", 2, VertexFormat::Float32x2);
 

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -148,6 +148,8 @@ pub struct DefaultImageSampler(pub(crate) Sampler);
 
 /// How edges should be handled in texture addressing.
 ///
+/// See [`ImageSamplerDescriptor`] for information how to configure this.
+///
 /// This type mirrors [`wgpu::AddressMode`].
 #[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
 pub enum ImageAddressMode {


### PR DESCRIPTION
Comment incorrect suggests that texture is clamped outside of `0..=1` range, while it can actually be configured.

CC https://github.com/bevyengine/bevy/pull/11109