### PR TITLE
ImageSampler::init_descriptor

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -136,6 +136,23 @@ impl ImageSampler {
     pub fn nearest() -> ImageSampler {
         ImageSampler::Descriptor(ImageSamplerDescriptor::nearest())
     }
+
+    /// Initialize the descriptor if it is not already initialized.
+    ///
+    /// Descriptor is typically initialized by Bevy when the image is loaded,
+    /// so this is convenient shortcut for updating the descriptor.
+    pub fn init_descriptor(&mut self) -> &mut ImageSamplerDescriptor {
+        match self {
+            ImageSampler::Default => {
+                *self = ImageSampler::Descriptor(ImageSamplerDescriptor::default());
+                match self {
+                    ImageSampler::Descriptor(descriptor) => descriptor,
+                    _ => unreachable!(),
+                }
+            }
+            ImageSampler::Descriptor(descriptor) => descriptor,
+        }
+    }
 }
 
 /// A rendering resource for the default image sampler which is set during renderer

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -141,7 +141,7 @@ impl ImageSampler {
     ///
     /// Descriptor is typically initialized by Bevy when the image is loaded,
     /// so this is convenient shortcut for updating the descriptor.
-    pub fn init_descriptor(&mut self) -> &mut ImageSamplerDescriptor {
+    pub fn get_or_init_descriptor(&mut self) -> &mut ImageSamplerDescriptor {
         match self {
             ImageSampler::Default => {
                 *self = ImageSampler::Descriptor(ImageSamplerDescriptor::default());


### PR DESCRIPTION
Shortcut to avoid repetition in code like https://github.com/bevyengine/bevy/pull/11109.