### PR TITLE
Add a limited `Not` query filter

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1941,9 +1941,16 @@ mod tests {
     #[test]
     fn query_filter_not_mixed_archetypal() {
         let mut world = World::default();
-        fn query_mixed(world: &mut World) -> Vec<Entity> {
+        fn query_mixed_and(world: &mut World) -> Vec<Entity> {
             world
                 .query_filtered::<Entity, Not<(With<A>, Changed<B>)>>()
+                .iter(&world)
+                .collect::<Vec<_>>()
+        }
+
+        fn query_mixed_or(world: &mut World) -> Vec<Entity> {
+            world
+                .query_filtered::<Entity, Not<Or<(With<B>, Changed<B>)>>>()
                 .iter(&world)
                 .collect::<Vec<_>>()
         }
@@ -1951,9 +1958,15 @@ mod tests {
         let e1 = world.spawn(A(0)).id();
         let e2 = world.spawn(B(0)).id();
         let e3 = world.spawn((A(0), B(0))).id();
-        assert_eq!(query_mixed(&mut world), vec![]);
+        let e4 = world.spawn(B(0)).id();
+        assert_eq!(query_mixed_and(&mut world), vec![]);
+        assert_eq!(query_mixed_or(&mut world), vec![e1]);
 
         world.clear_trackers();
-        assert_eq!(query_mixed(&mut world), vec![e2]);
+        assert_eq!(query_mixed_and(&mut world), vec![e2, e3]);
+        assert_eq!(query_mixed_or(&mut world), vec![e1, e2, e4]);
+
+        *world.get_mut(e2).unwrap() = B(0);
+        assert_eq!(query_mixed_or(&mut world), vec![e1, e4]);
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1912,6 +1912,8 @@ mod tests {
         type Filter = (Or<(With<A>, Without<B>)>, Or<(Without<C>, With<D>)>);
 
         type Inverted = Or<((Without<A>, With<B>), (With<C>, Without<D>))>;
+
+        /// SAFETY: only consists of archetypal filters
         unsafe impl InvertibleFilter for Filter {}
 
         let mut world = World::default();

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1908,40 +1908,33 @@ mod tests {
         struct C;
         #[derive(Component)]
         struct D;
+        #[derive(Component)]
+        struct E;
+        #[derive(Component)]
+        struct F;
 
-        type Filter = (Or<(With<A>, Without<B>)>, Or<(Without<C>, With<D>)>);
+        #[derive(Component)]
+        struct G;
 
-        type Inverted = Or<((Without<A>, With<B>), (With<C>, Without<D>))>;
+        type Filter = Or<(
+            (Without<A>, Without<B>),
+            (Without<C>, Without<D>),
+            (Without<E>, Without<F>),
+        )>;
 
         /// SAFETY: only consists of archetypal filters
         unsafe impl InvertibleFilter for Filter {}
 
         let mut world = World::default();
-        world.spawn(A);
-        world.spawn(B);
-        world.spawn(C);
-        world.spawn(D);
-        world.spawn((A, B));
-        world.spawn((A, C));
-        world.spawn((A, D));
-        world.spawn((B, C));
-        world.spawn((B, D));
-        world.spawn((C, D));
-        world.spawn((A, B, C));
-        world.spawn((B, C, D));
-        world.spawn((A, B, C, D));
-        world.spawn_empty();
 
-        let q1 = world
-            .query_filtered::<Entity, Not<Filter>>()
-            .iter(&world)
-            .collect::<Vec<_>>();
+        use crate::prelude::Query;
+        fn system(
+            _q1: Query<(Entity, &mut G), Not<Filter>>,
+            _q2: Query<(Entity, &mut G), (Without<E>, Without<F>)>,
+        ) {
+        }
 
-        let q2 = world
-            .query_filtered::<Entity, Inverted>()
-            .iter(&world)
-            .collect::<Vec<_>>();
-
-        assert_eq!(q1, q2);
+        let system_id = world.register_system(system);
+        _ = world.run_system(system_id);
     }
 }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1890,8 +1890,8 @@ mod tests {
 
         use crate::prelude::Query;
         fn system(
-            _q1: Query<(Entity, &mut C), (With<A>, Not<Without<B>>)>,
-            _q2: Query<(Entity, &mut C), With<A>>,
+            _q1: Query<(Entity, &mut C), (Changed<A>, Not<Without<B>>)>,
+            _q2: Query<(Entity, &mut C), Changed<A>>,
         ) {
         }
 
@@ -1936,5 +1936,6 @@ mod tests {
 
         let system_id = world.register_system(system);
         _ = world.run_system(system_id);
+        panic!();
     }
 }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -270,7 +270,7 @@ pub struct FilteredAccess<T: SparseSetIndex> {
     access: Access<T>,
     // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
     // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
-    pub(crate)filter_sets: Vec<AccessFilters<T>>,
+    pub(crate) filter_sets: Vec<AccessFilters<T>>,
 }
 
 impl<T: SparseSetIndex> Default for FilteredAccess<T> {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -270,7 +270,7 @@ pub struct FilteredAccess<T: SparseSetIndex> {
     access: Access<T>,
     // An array of filter sets to express `With` or `Without` clauses in disjunctive normal form, for example: `Or<(With<A>, With<B>)>`.
     // Filters like `(With<A>, Or<(With<B>, Without<C>)>` are expanded into `Or<((With<A>, With<B>), (With<A>, Without<C>))>`.
-    filter_sets: Vec<AccessFilters<T>>,
+    pub(crate)filter_sets: Vec<AccessFilters<T>>,
 }
 
 impl<T: SparseSetIndex> Default for FilteredAccess<T> {
@@ -426,9 +426,9 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
 }
 
 #[derive(Clone, Eq, PartialEq)]
-struct AccessFilters<T> {
-    with: FixedBitSet,
-    without: FixedBitSet,
+pub(crate) struct AccessFilters<T> {
+    pub(crate) with: FixedBitSet,
+    pub(crate) without: FixedBitSet,
     _index_type: PhantomData<T>,
 }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -514,10 +514,12 @@ all_tuples!(impl_query_filter_tuple, 0, 15, F, S);
 
 /// A filter that tests if the given filter does not apply.
 ///
-/// This filter does not compose with the `Or` filter or with tuples of filters. Instead,
-/// distribute it within the filters. For example, `Not<Or<(Changed<A>, Changed<B>)>>` should become
-/// `(Not<Changed<A>>, Not<Changed<B>>)` and `Not<(Changed<A>, Changed<B>)>` should become
-/// `Or<(Not<Changed<A>>, Not<Changed<B>>)>`.
+/// This filter does not compose with the [`Or`] filter or with tuples of filters. Instead, [`Not`]
+/// should be distributed within according to de Morgan's laws.
+///
+/// For example, `Not<Or<(Changed<A>, Changed<B>)>>` should become `(Not<Changed<A>>, Not<Changed<B>>)`.
+///
+/// `Not<(Changed<A>, Changed<B>)>` should become `Or<(Not<Changed<A>>, Not<Changed<B>>)>`.
 ///
 /// # Examples
 ///

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -542,6 +542,13 @@ all_tuples!(impl_query_filter_tuple, 0, 15, F, S);
 /// # bevy_ecs::system::assert_is_system(print_still_entity_system);
 pub struct Not<T>(PhantomData<T>);
 
+/// SAFETY:
+///
+/// For archetypal filters, this inverts the access in `update_component_access` as well as in
+/// `matches_component_set`, ensuring that they match.
+///
+/// For non-archetypal filters, this maintains the same read accesses as the original filter in
+/// both instances.
 unsafe impl<T> WorldQuery for Not<T>
 where
     T: QueryFilter + InvertibleFilter,
@@ -575,12 +582,12 @@ where
         archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        T::set_archetype(fetch, state, archetype, table)
+        T::set_archetype(fetch, state, archetype, table);
     }
 
     #[inline]
     unsafe fn set_table<'w>(fetch: &mut Self::Fetch<'w>, state: &Self::State, table: &'w Table) {
-        T::set_table(fetch, state, table)
+        T::set_table(fetch, state, table);
     }
 
     #[inline(always)]

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -636,8 +636,7 @@ where
     ) -> bool {
         if T::IS_ARCHETYPAL {
             true
-        }
-        else {
+        } else {
             !T::filter_fetch(fetch, entity, table_row)
         }
     }


### PR DESCRIPTION
# Objective
Resolve #7265.

## Solution
Create a `Not` query filter, inverting primitive query filters.

### Implementation note and future work

This implementation only allows for inversions of `Added<T>`, `Changed<T>`, `With<T>` and `Without<T>`. The implementation without the added `InvertibleFilter` trait produces the correct result for tuples (and `Or` tuples) of only archetypal filters and only non-archetypal filters, but not tuples that mix the two. I was unable to figure out how to distinguish these cases, and chose to omit tuples altogether for correctness since it does not affect the possible filters that can be expressed.

---

## Changelog

Add a `Not` query filter, inverting the condition of primitive query filters.
