### PR TITLE
Rename `ArchetypeEntity::entity` into `ArchetypeEntity::id`

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -269,6 +269,7 @@ pub struct ArchetypeEntity {
     table_row: TableRow,
 }
 
+// REMOVE THIS meaningless commit to test CI
 impl ArchetypeEntity {
     /// The ID of the entity.
     #[inline]

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -269,11 +269,10 @@ pub struct ArchetypeEntity {
     table_row: TableRow,
 }
 
-// REMOVE THIS meaningless commit to test CI
 impl ArchetypeEntity {
     /// The ID of the entity.
     #[inline]
-    pub const fn entity(&self) -> Entity {
+    pub const fn id(&self) -> Entity {
         self.entity
     }
 

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -178,7 +178,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
             // Caller assures `index` in range of the current archetype.
             if !F::filter_fetch(
                 &mut self.cursor.filter,
-                archetype_entity.entity(),
+                archetype_entity.id(),
                 archetype_entity.table_row(),
             ) {
                 continue;
@@ -188,7 +188,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
             // Caller assures `index` in range of the current archetype.
             let item = D::fetch(
                 &mut self.cursor.fetch,
-                archetype_entity.entity(),
+                archetype_entity.id(),
                 archetype_entity.table_row(),
             );
 
@@ -719,7 +719,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 let archetype_entity = self.archetype_entities.get_unchecked(index);
                 Some(D::fetch(
                     &mut self.fetch,
-                    archetype_entity.entity(),
+                    archetype_entity.id(),
                     archetype_entity.table_row(),
                 ))
             }
@@ -817,7 +817,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 let archetype_entity = self.archetype_entities.get_unchecked(self.current_row);
                 if !F::filter_fetch(
                     &mut self.filter,
-                    archetype_entity.entity(),
+                    archetype_entity.id(),
                     archetype_entity.table_row(),
                 ) {
                     self.current_row += 1;
@@ -831,7 +831,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIterationCursor<'w, 's, D, F> {
                 // - fetch is only called once for each `archetype_entity`.
                 let item = D::fetch(
                     &mut self.fetch,
-                    archetype_entity.entity(),
+                    archetype_entity.id(),
                     archetype_entity.table_row(),
                 );
                 self.current_row += 1;

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -507,7 +507,7 @@ impl World {
                 .iter()
                 .enumerate()
                 .map(|(archetype_row, archetype_entity)| {
-                    let entity = archetype_entity.entity();
+                    let entity = archetype_entity.id();
                     let location = EntityLocation {
                         archetype_id: archetype.id(),
                         archetype_row: ArchetypeRow::new(archetype_row),
@@ -536,7 +536,7 @@ impl World {
                 .iter()
                 .enumerate()
                 .map(move |(archetype_row, archetype_entity)| {
-                    let entity = archetype_entity.entity();
+                    let entity = archetype_entity.id();
                     let location = EntityLocation {
                         archetype_id: archetype.id(),
                         archetype_row: ArchetypeRow::new(archetype_row),

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -96,7 +96,7 @@ impl Scene {
             for scene_entity in archetype.entities() {
                 let entity = *instance_info
                     .entity_map
-                    .entry(scene_entity.entity())
+                    .entry(scene_entity.id())
                     .or_insert_with(|| world.spawn_empty().id());
                 for component_id in archetype.components() {
                     let component_info = self
@@ -117,7 +117,7 @@ impl Scene {
                                 }
                             })
                         })?;
-                    reflect_component.copy(&self.world, world, scene_entity.entity(), entity);
+                    reflect_component.copy(&self.world, world, scene_entity.id(), entity);
                 }
             }
         }


### PR DESCRIPTION
# Objective

Fixes #11050

Rename ArchetypeEntity::entity to ArchetypeEntity::id to be consistent with `EntityWorldMut`, `EntityMut` and `EntityRef`.

## Migration Guide

The method `ArchetypeEntity::entity` has been renamed to `ArchetypeEntity::id`
