### PR TITLE
column/table level change detection

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -458,6 +458,7 @@ impl BundleInfo {
         // NOTE: get_components calls this closure on each component in "bundle order".
         // bundle_info.component_ids are also in "bundle order"
         let mut bundle_component = 0;
+        table.update_last_mutable_access_tick(change_tick);
         bundle.get_components(&mut |storage_type, component_ptr| {
             let component_id = *self.component_ids.get_unchecked(bundle_component);
             match storage_type {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -899,6 +899,11 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
     ) {
         if Self::IS_DENSE {
             Self::set_table(fetch, component_id, table);
+        } else {
+            fetch
+                .sparse_set
+                .debug_checked_unwrap()
+                .set_last_mutable_access_tick(fetch.this_run)
         }
     }
 
@@ -909,6 +914,8 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         table: &'w Table,
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
+        table.set_last_mutable_access_tick(fetch.this_run);
+        column.set_last_mutable_access_tick(fetch.this_run);
         fetch.table_data = Some((
             column.get_data_slice().into(),
             column.get_added_ticks_slice().into(),

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -903,7 +903,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
             fetch
                 .sparse_set
                 .debug_checked_unwrap()
-                .set_last_mutable_access_tick(fetch.this_run)
+                .update_last_mutable_access_tick(fetch.this_run)
         }
     }
 
@@ -914,8 +914,7 @@ unsafe impl<'__w, T: Component> WorldQuery for &'__w mut T {
         table: &'w Table,
     ) {
         let column = table.get_column(component_id).debug_checked_unwrap();
-        table.set_last_mutable_access_tick(fetch.this_run);
-        column.set_last_mutable_access_tick(fetch.this_run);
+        table.update_table_and_component_access_tick(component_id, fetch.this_run);
         fetch.table_data = Some((
             column.get_data_slice().into(),
             column.get_added_ticks_slice().into(),

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -331,8 +331,8 @@ impl ComponentSparseSet {
         self.dense.read_last_mutable_access_tick()
     }
 
-    pub fn set_last_mutable_access_tick(&self, tick: Tick) {
-        self.dense.set_last_mutable_access_tick(tick);
+    pub fn update_last_mutable_access_tick(&self, tick: Tick) {
+        self.dense.update_last_mutable_access_tick(tick);
     }
 }
 

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -326,6 +326,14 @@ impl ComponentSparseSet {
     pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
         self.dense.check_change_ticks(change_tick);
     }
+
+    pub fn read_last_mutable_access_tick(&self) -> Tick {
+        self.dense.read_last_mutable_access_tick()
+    }
+
+    pub fn set_last_mutable_access_tick(&self, tick: Tick) {
+        self.dense.set_last_mutable_access_tick(tick);
+    }
 }
 
 /// A data structure that blends dense and sparse storage


### PR DESCRIPTION
# Objective

- currently, bevy's change detection will check all matched archtype entities ,leading to unnecessary overhead  in certain scenarios.
- try to fix #5097 

## Solution

- Introducing an `AtomicU32 `type to track the last mutable access for tables and columns.
- Assigning the responsibility of updating this information to the `set_table `and `set_archetype `methods.
- Implementing the `archetype_filter_fetch `method on `QueryFilter `to filter out tables or columns that have not been subject to mutable access since system last run.

## Notes
I !!!express reservations about the current implementation due to its involvement in multiple data flows, potentially increasing code vulnerability and expensive . I would highly appreciate it if someone could propose an alternative implementation details with fewer complexities and improved security considerations.

## Performance
 Intel 13400kf NV4070ti

![image](https://github.com/bevyengine/bevy/assets/45868716/d8f394d6-65ca-4ef3-9b85-69a7e70bd9b9)
to comprehensively evaluate the change detection mechanism, additional benchmarking across various scenarios is deemed necessary

regression:
![image](https://github.com/bevyengine/bevy/assets/45868716/a1946ae6-caee-42f7-b000-7ecf747520b2)
The regression in spawn/insert is attributed to the introduction of an atomic operation for each table per component. 
`iter_fragmented_* `method appears to only iterate over few entities, making the maintenance of tick costly.
`query.get_mut_compoent/unchecked(entity)` is expensive becase it set the archetype for each entity retrieved. 

It is worth mentioning that many_foxes frame_time dropped from 3.06ms to 4.21ms
yellow is main ,red is the pr
![image](https://github.com/bevyengine/bevy/assets/45868716/35d68db4-4a87-4b85-aadb-6022781aa0a6)

the hotspot is `animation_player `,`propagate_transform ` which parallel use of get_unchecked for each entity seems leading to numerous invalid cache instances across CPU cores.
![image](https://github.com/bevyengine/bevy/assets/45868716/376d90e3-d9c9-4a3a-bb32-a7cda4635bc8)
![image](https://github.com/bevyengine/bevy/assets/45868716/628ec3d9-4291-4cb1-a7c6-0d4e761225f7)


## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
