### PR TITLE
Add testing to Commands run_system functions

### DIFF
--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1267,6 +1267,9 @@ mod tests {
     #[component(storage = "SparseSet")]
     struct SparseDropCk(DropCk);
 
+    #[derive(Resource)]
+    struct Counter(i32);
+
     #[derive(Component)]
     struct DropCk(Arc<AtomicUsize>);
     impl DropCk {
@@ -1287,6 +1290,14 @@ mod tests {
 
     fn simple_command(world: &mut World) {
         world.spawn((W(0u32), W(42u64)));
+    }
+
+    fn add_to_counter(mut counter: ResMut<Counter>) {
+        counter.0 += 1;
+    }
+
+    fn add_to_counter_with_input(In(val): In<i32>,mut counter: ResMut<Counter>) {
+        counter.0 += val;
     }
 
     #[test]

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1255,7 +1255,7 @@ mod tests {
     use crate::{
         self as bevy_ecs,
         component::Component,
-        system::{CommandQueue, Commands, Resource, ResMut, In },
+        system::{CommandQueue, Commands, In, ResMut, Resource},
         world::World,
     };
     use std::sync::{
@@ -1296,7 +1296,7 @@ mod tests {
         counter.0 += 1;
     }
 
-    fn add_to_counter_with_input(In(val): In<i32>,mut counter: ResMut<Counter>) {
+    fn add_to_counter_with_input(In(val): In<i32>, mut counter: ResMut<Counter>) {
         counter.0 += val;
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1255,7 +1255,7 @@ mod tests {
     use crate::{
         self as bevy_ecs,
         component::Component,
-        system::{CommandQueue, Commands, Resource},
+        system::{CommandQueue, Commands, Resource, ResMut, In },
         world::World,
     };
     use std::sync::{
@@ -1427,5 +1427,29 @@ mod tests {
         queue_1.apply(&mut world);
         assert!(world.contains_resource::<W<i32>>());
         assert!(world.contains_resource::<W<f64>>());
+    }
+
+    #[test]
+    fn run_one_shot_systems() {
+        let mut world = World::default();
+        world.insert_resource(Counter(0));
+        let add_simple = world.register_system(add_to_counter);
+        let add_with_input = world.register_system(add_to_counter_with_input);
+
+        let mut queue_1 = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue_1, &world);
+            commands.run_system(add_simple)
+        }
+        queue_1.apply(&mut world);
+        assert_eq!(1, world.resource::<Counter>().0);
+
+        let mut queue_2 = CommandQueue::default();
+        {
+            let mut commands = Commands::new(&mut queue_2, &world);
+            commands.run_system_with_input(add_with_input, 2);
+        }
+        queue_2.apply(&mut world);
+        assert_eq!(3, world.resource::<Counter>().0);
     }
 }


### PR DESCRIPTION
# Objective

- It was mentioned on #11019 the possibility to add a test to `Commands::run_system` and `Commands::run_system_with_input`, this is a follow up of the possibility
## Solution

- Adding the test to the common `Commands` tests

---

