### PR TITLE
Add window entity to TouchInput events

### DIFF
--- a/crates/bevy_input/src/touch.rs
+++ b/crates/bevy_input/src/touch.rs
@@ -1,5 +1,6 @@
 //! The touch input functionality.
 
+use bevy_ecs::entity::Entity;
 use bevy_ecs::event::{Event, EventReader};
 use bevy_ecs::system::{ResMut, Resource};
 use bevy_math::Vec2;
@@ -44,6 +45,8 @@ pub struct TouchInput {
     pub phase: TouchPhase,
     /// The position of the finger on the touchscreen.
     pub position: Vec2,
+    /// The window entity registering the touch.
+    pub window: Entity,
     /// Describes how hard the screen was pressed.
     ///
     /// May be [`None`] if the platform does not support pressure sensitivity.
@@ -408,6 +411,7 @@ mod test {
     #[test]
     fn touch_process() {
         use crate::{touch::TouchPhase, TouchInput, Touches};
+        use bevy_ecs::entity::Entity;
         use bevy_math::Vec2;
 
         let mut touches = Touches::default();
@@ -417,6 +421,7 @@ mod test {
         let touch_event = TouchInput {
             phase: TouchPhase::Started,
             position: Vec2::splat(4.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: 4,
         };
@@ -432,6 +437,7 @@ mod test {
         let moved_touch_event = TouchInput {
             phase: TouchPhase::Moved,
             position: Vec2::splat(5.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: touch_event.id,
         };
@@ -453,6 +459,7 @@ mod test {
         let cancel_touch_event = TouchInput {
             phase: TouchPhase::Canceled,
             position: Vec2::ONE,
+            window: Entity::PLACEHOLDER,
             force: None,
             id: touch_event.id,
         };
@@ -468,6 +475,7 @@ mod test {
         let end_touch_event = TouchInput {
             phase: TouchPhase::Ended,
             position: Vec2::splat(4.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: touch_event.id,
         };
@@ -487,6 +495,7 @@ mod test {
     #[test]
     fn touch_pressed() {
         use crate::{touch::TouchPhase, TouchInput, Touches};
+        use bevy_ecs::entity::Entity;
         use bevy_math::Vec2;
 
         let mut touches = Touches::default();
@@ -494,6 +503,7 @@ mod test {
         let touch_event = TouchInput {
             phase: TouchPhase::Started,
             position: Vec2::splat(4.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: 4,
         };
@@ -509,6 +519,7 @@ mod test {
     #[test]
     fn touch_released() {
         use crate::{touch::TouchPhase, TouchInput, Touches};
+        use bevy_ecs::entity::Entity;
         use bevy_math::Vec2;
 
         let mut touches = Touches::default();
@@ -516,6 +527,7 @@ mod test {
         let touch_event = TouchInput {
             phase: TouchPhase::Ended,
             position: Vec2::splat(4.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: 4,
         };
@@ -531,6 +543,7 @@ mod test {
     #[test]
     fn touch_canceled() {
         use crate::{touch::TouchPhase, TouchInput, Touches};
+        use bevy_ecs::entity::Entity;
         use bevy_math::Vec2;
 
         let mut touches = Touches::default();
@@ -538,6 +551,7 @@ mod test {
         let touch_event = TouchInput {
             phase: TouchPhase::Canceled,
             position: Vec2::splat(4.0),
+            window: Entity::PLACEHOLDER,
             force: None,
             id: 4,
         };

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -40,6 +40,7 @@ pub fn convert_mouse_button(mouse_button: winit::event::MouseButton) -> MouseBut
 pub fn convert_touch_input(
     touch_input: winit::event::Touch,
     location: winit::dpi::LogicalPosition<f64>,
+    window_entity: Entity,
 ) -> TouchInput {
     TouchInput {
         phase: match touch_input.phase {
@@ -49,6 +50,7 @@ pub fn convert_touch_input(
             winit::event::TouchPhase::Cancelled => TouchPhase::Canceled,
         },
         position: Vec2::new(location.x as f32, location.y as f32),
+        window: window_entity,
         force: touch_input.force.map(|f| match f {
             winit::event::Force::Calibrated {
                 force,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -515,7 +515,11 @@ pub fn winit_runner(mut app: App) {
                             .to_logical(window.resolution.scale_factor() as f64);
                         event_writers
                             .touch_input
-                            .send(converters::convert_touch_input(touch, location));
+                            .send(converters::convert_touch_input(
+                                touch,
+                                location,
+                                window_entity,
+                            ));
                     }
                     WindowEvent::ScaleFactorChanged {
                         scale_factor,


### PR DESCRIPTION
# Objective

If you have multiple windows, there is no way to determine which window a `TouchInput` event applies to. This fixes that.

## Solution

- Add the window entity directly to `TouchInput`, just like the other input events.
- Fixes #6011.

## Migration Guide

+ Add a `window` field when constructing or destructuring a `TouchInput` struct.
