### PR TITLE
add cancel in progress support to automated CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ env:
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,6 +12,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - 'main'
 
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: --html-in-header header.html

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+
+concurrency:
+  group: ${{github.workflow}}-${{github.ref}}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   NIGHTLY_TOOLCHAIN: nightly


### PR DESCRIPTION
# Objective

When working on PRs, I'll often find that one of the early CI checks fails, and work on fixing the result, but when I push the earlier commits are still being processed by the CI. This would mean that if a new commit is pushed while another CI process is already running on that branch, the first set of jobs will be cancelled - reducing wasted resources and wait time for  CI on the latest commits.

## Solution

The solution is simply adding Github's concurrency groups to every relevant workflow.