### PR TITLE
Use previous ubuntu version in validation jobs

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -63,7 +63,8 @@ jobs:
 
   run-examples-linux-vulkan:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
+    # TODO: switch to ubuntu-latest once xvfb starts working again there
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Install Bevy dependencies
@@ -125,7 +126,9 @@ jobs:
 
   run-examples-on-wasm:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: ubuntu-latest
+    # TODO: switch to ubuntu-latest once xvfb starts working again there
+    # runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -436,6 +436,7 @@ impl Entities {
     /// Reserve entity IDs concurrently.
     ///
     /// Storage for entity generation and location is lazily allocated by calling [`flush`](Entities::flush).
+    #[allow(clippy::unnecessary_fallible_conversions)] // Because `IdCursor::try_from` may fail on 32-bit platforms.
     pub fn reserve_entities(&self, count: u32) -> ReserveEntitiesIterator {
         // Use one atomic subtract to grab a range of new IDs. The range might be
         // entirely nonnegative, meaning all IDs come from the freelist, or entirely
@@ -627,6 +628,7 @@ impl Entities {
     }
 
     /// Ensure at least `n` allocations can succeed without reallocating.
+    #[allow(clippy::unnecessary_fallible_conversions)] // Because `IdCursor::try_from` may fail on 32-bit platforms.
     pub fn reserve(&mut self, additional: u32) {
         self.verify_flushed();
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -996,7 +996,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
-    /// iter() method, but cannot be chained like a normal [`Iterator`].
+    /// `iter()` method, but cannot be chained like a normal [`Iterator`].
     ///
     /// This can only be called for read-only queries, see [`Self::for_each_mut`] for write-queries.
     ///
@@ -1024,7 +1024,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Runs `func` on each query result for the given [`World`]. This is faster than the equivalent
-    /// iter() method, but cannot be chained like a normal [`Iterator`].
+    /// `iter()` method, but cannot be chained like a normal [`Iterator`].
     ///
     /// # Safety
     ///
@@ -1086,7 +1086,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
 
     /// Runs `func` on each query result in parallel for the given [`World`], where the last change and
     /// the current change tick are given. This is faster than the equivalent
-    /// iter() method, but cannot be chained like a normal [`Iterator`].
+    /// `iter()` method, but cannot be chained like a normal [`Iterator`].
     ///
     /// # Panics
     /// The [`ComputeTaskPool`] is not initialized. If using this from a query that is being

--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -306,7 +306,7 @@ impl BlobVec {
     /// The removed element is replaced by the last element of the `BlobVec`.
     ///
     /// # Safety
-    /// It is the caller's responsibility to ensure that `index` is < self.len()
+    /// It is the caller's responsibility to ensure that `index` is `< self.len()`.
     #[inline]
     pub unsafe fn swap_remove_and_drop_unchecked(&mut self, index: usize) {
         debug_assert!(index < self.len());

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -893,7 +893,7 @@ fn load_material(
 }
 
 /// Loads a glTF node.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::result_large_err)]
 fn load_node(
     gltf_node: &Node,
     world_builder: &mut WorldChildBuilder,
@@ -1291,6 +1291,7 @@ fn texture_address_mode(gltf_address_mode: &WrappingMode) -> ImageAddressMode {
 }
 
 /// Maps the `primitive_topology` form glTF to `wgpu`.
+#[allow(clippy::result_large_err)]
 fn get_primitive_topology(mode: Mode) -> Result<PrimitiveTopology, GltfError> {
     match mode {
         Mode::Points => Ok(PrimitiveTopology::PointList),

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1295,7 +1295,7 @@ impl<T: FromReflect + Clone + TypePath> FromReflect for Cow<'static, [T]> {
             for field in ref_list.iter() {
                 temp_vec.push(T::from_reflect(field)?);
             }
-            temp_vec.try_into().ok()
+            Some(temp_vec.into())
         } else {
             None
         }

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -1035,7 +1035,7 @@ impl GridTrack {
         .into()
     }
 
-    /// Create a fit-content() grid track with fixed pixel limit
+    /// Create a `fit-content()` grid track with fixed pixel limit.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function>
     pub fn fit_content_px<T: From<Self>>(limit: f32) -> T {
@@ -1046,7 +1046,7 @@ impl GridTrack {
         .into()
     }
 
-    /// Create a fit-content() grid track with percentage limit
+    /// Create a `fit-content()` grid track with percentage limit.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function>
     pub fn fit_content_percent<T: From<Self>>(limit: f32) -> T {
@@ -1057,7 +1057,7 @@ impl GridTrack {
         .into()
     }
 
-    /// Create a minmax() grid track
+    /// Create a `minmax()` grid track.
     ///
     /// <https://developer.mozilla.org/en-US/docs/Web/CSS/minmax>
     pub fn minmax<T: From<Self>>(min: MinTrackSizingFunction, max: MaxTrackSizingFunction) -> T {
@@ -1198,7 +1198,7 @@ impl RepeatedGridTrack {
         .into()
     }
 
-    /// Create a repeating set of fit-content() grid tracks with fixed pixel limit
+    /// Create a repeating set of `fit-content()` grid tracks with fixed pixel limit
     pub fn fit_content_px<T: From<Self>>(repetition: u16, limit: f32) -> T {
         Self {
             repetition: GridTrackRepetition::Count(repetition),
@@ -1207,7 +1207,7 @@ impl RepeatedGridTrack {
         .into()
     }
 
-    /// Create a repeating set of fit-content() grid tracks with percentage limit
+    /// Create a repeating set of `fit-content()` grid tracks with percentage limit
     pub fn fit_content_percent<T: From<Self>>(repetition: u16, limit: f32) -> T {
         Self {
             repetition: GridTrackRepetition::Count(repetition),
@@ -1216,7 +1216,7 @@ impl RepeatedGridTrack {
         .into()
     }
 
-    /// Create a repeating set of minmax() grid track
+    /// Create a repeating set of `minmax()` grid track
     pub fn minmax<T: From<Self>>(
         repetition: impl Into<GridTrackRepetition>,
         min: MinTrackSizingFunction,

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -127,11 +127,8 @@ pub struct Hashed<V, H = FixedState> {
 impl<V: Hash, H: BuildHasher + Default> Hashed<V, H> {
     /// Pre-hashes the given value using the [`BuildHasher`] configured in the [`Hashed`] type.
     pub fn new(value: V) -> Self {
-        let builder = H::default();
-        let mut hasher = builder.build_hasher();
-        value.hash(&mut hasher);
         Self {
-            hash: hasher.finish(),
+            hash: H::default().hash_one(&value),
             value,
             marker: PhantomData,
         }

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -80,15 +80,12 @@ fn setup(
 
     let plane_mesh = meshes.add(shape::Plane::from_size(2.0).into());
 
-    let cylinder_mesh = meshes.add(
-        Mesh::try_from(shape::Cylinder {
-            radius: 0.5,
-            height: 2.0,
-            resolution: 50,
-            segments: 1,
-        })
-        .unwrap(),
-    );
+    let cylinder_mesh = meshes.add(Mesh::from(shape::Cylinder {
+        radius: 0.5,
+        height: 2.0,
+        resolution: 50,
+        segments: 1,
+    }));
 
     // Cube #1
     commands.spawn((


### PR DESCRIPTION
# Objective

xvfb is failing to start, likely due to a Mesa update. This has happened before: https://github.com/bevyengine/bevy/pull/6810

https://github.com/bevyengine/bevy/actions/runs/7359665469/job/20034758381

## Solution

Swap ubuntu-latest for ubuntu-20.04 (the previous ubuntu version) for the failing jobs. Lets hope this works!

We should revert this once ubuntu-latest is working again.
