### PR TITLE
NoAsset, NoAssetLoader, NoProcess

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -521,8 +521,10 @@ pub enum UntypedAssetConversionError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as bevy_asset; // required for derive macros
 
-    type TestAsset = ();
+    #[derive(Asset, TypePath)]
+    struct TestAsset;
 
     const UUID_1: Uuid = Uuid::from_u128(123);
     const UUID_2: Uuid = Uuid::from_u128(456);

--- a/crates/bevy_asset/src/id.rs
+++ b/crates/bevy_asset/src/id.rs
@@ -420,8 +420,11 @@ pub enum UntypedAssetIdConversionError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate as bevy_asset;
+    use bevy_reflect::TypePath; // required for derive macros
 
-    type TestAsset = ();
+    #[derive(Asset, TypePath)]
+    struct TestAsset;
 
     const UUID_1: Uuid = Uuid::from_u128(123);
     const UUID_2: Uuid = Uuid::from_u128(456);

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -38,6 +38,7 @@ pub use bevy_utils::BoxedFuture;
 /// Rusty Object Notation, a crate used to serialize and deserialize bevy assets.
 pub use ron;
 
+use crate::meta::NoAsset;
 use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
     processor::{AssetProcessor, Process},
@@ -212,7 +213,7 @@ impl Plugin for AssetPlugin {
         app.insert_resource(embedded)
             .init_asset::<LoadedFolder>()
             .init_asset::<LoadedUntypedAsset>()
-            .init_asset::<()>()
+            .init_asset::<NoAsset>()
             .configure_sets(
                 UpdateAssets,
                 TrackAssets.after(handle_internal_asset_events),

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,3 +1,4 @@
+use crate::meta::NoProcess;
 use crate::{
     io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
     meta::{
@@ -102,15 +103,17 @@ where
     }
 
     fn deserialize_meta(&self, meta: &[u8]) -> Result<Box<dyn AssetMetaDyn>, DeserializeMetaError> {
-        let meta = AssetMeta::<L, ()>::deserialize(meta)?;
+        let meta = AssetMeta::<L, NoProcess>::deserialize(meta)?;
         Ok(Box::new(meta))
     }
 
     fn default_meta(&self) -> Box<dyn AssetMetaDyn> {
-        Box::new(AssetMeta::<L, ()>::new(crate::meta::AssetAction::Load {
-            loader: self.type_name().to_string(),
-            settings: L::Settings::default(),
-        }))
+        Box::new(AssetMeta::<L, NoProcess>::new(
+            crate::meta::AssetAction::Load {
+                loader: self.type_name().to_string(),
+                settings: L::Settings::default(),
+            },
+        ))
     }
 
     fn type_name(&self) -> &'static str {

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,6 +1,7 @@
-use crate::{self as bevy_asset, DeserializeMetaError, VisitAssetDependencies};
+use crate::{self as bevy_asset, DeserializeMetaError};
 use crate::{loader::AssetLoader, processor::Process, Asset, AssetPath};
 use bevy_log::error;
+use bevy_reflect::TypePath;
 use downcast_rs::{impl_downcast, Downcast};
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};
@@ -166,32 +167,31 @@ impl<T: 'static> Settings for T where T: Send + Sync {}
 
 impl_downcast!(Settings);
 
-/// The () processor should never be called. This implementation exists to make the meta format nicer to work with.
-impl Process for () {
+/// `NoProcess` processor is never called. This implementation exists to make the meta format nicer to work with.
+pub enum NoProcess {}
+
+impl Process for NoProcess {
     type Settings = ();
-    type OutputLoader = ();
+    type OutputLoader = NoAssetLoader;
 
     fn process<'a>(
         &'a self,
         _context: &'a mut bevy_asset::processor::ProcessContext,
-        _meta: AssetMeta<(), Self>,
+        _meta: AssetMeta<NoAssetLoader, Self>,
         _writer: &'a mut bevy_asset::io::Writer,
     ) -> bevy_utils::BoxedFuture<'a, Result<(), bevy_asset::processor::ProcessError>> {
-        unreachable!()
+        match *self {}
     }
 }
 
-impl Asset for () {}
+#[derive(Asset, TypePath)]
+pub enum NoAsset {}
 
-impl VisitAssetDependencies for () {
-    fn visit_dependencies(&self, _visit: &mut impl FnMut(bevy_asset::UntypedAssetId)) {
-        unreachable!()
-    }
-}
+/// `NoAssetLoader` is never called. This implementation exists to make the meta format nicer to work with.
+pub enum NoAssetLoader {}
 
-/// The () loader should never be called. This implementation exists to make the meta format nicer to work with.
-impl AssetLoader for () {
-    type Asset = ();
+impl AssetLoader for NoAssetLoader {
+    type Asset = NoAsset;
     type Settings = ();
     type Error = std::io::Error;
     fn load<'a>(
@@ -200,11 +200,11 @@ impl AssetLoader for () {
         _settings: &'a Self::Settings,
         _load_context: &'a mut crate::LoadContext,
     ) -> bevy_utils::BoxedFuture<'a, Result<Self::Asset, Self::Error>> {
-        unreachable!();
+        match *self {}
     }
 
     fn extensions(&self) -> &[&str] {
-        unreachable!();
+        match *self {}
     }
 }
 

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -4,6 +4,7 @@ mod process;
 pub use log::*;
 pub use process::*;
 
+use crate::meta::{NoAssetLoader, NoProcess};
 use crate::{
     io::{
         AssetReader, AssetReaderError, AssetSource, AssetSourceBuilders, AssetSourceEvent,
@@ -704,7 +705,9 @@ impl AssetProcessor {
                     }
                     AssetActionMinimal::Ignore => {
                         let meta: Box<dyn AssetMetaDyn> =
-                            Box::new(AssetMeta::<(), ()>::deserialize(&meta_bytes)?);
+                            Box::new(AssetMeta::<NoAssetLoader, NoProcess>::deserialize(
+                                &meta_bytes,
+                            )?);
                         (meta, None)
                     }
                 };
@@ -722,7 +725,9 @@ impl AssetProcessor {
                         Ok(loader) => (loader.default_meta(), None),
                         Err(MissingAssetLoaderForExtensionError { .. }) => {
                             let meta: Box<dyn AssetMetaDyn> =
-                                Box::new(AssetMeta::<(), ()>::new(AssetAction::Ignore));
+                                Box::new(AssetMeta::<NoAssetLoader, NoProcess>::new(
+                                    AssetAction::Ignore,
+                                ));
                             (meta, None)
                         }
                     }


### PR DESCRIPTION
# Objective

- empty enum instead of `()` make clear types are never instantiated
  - `match *self` instead of `unreachable!` converts runtime errors to compile time errors
- arguably named types are easier to read than `()` in code like this:

https://github.com/bevyengine/bevy/blob/8067e46049f222d37ac394745805bad98979980f/crates/bevy_asset/src/processor/mod.rs#L707

- code navigation is easier, for example, find all usages of `NoAssetLoader`

## Solution

Replace implementations for `()` with implementation for `NoAsset`, `NoAssetLoader`, `NoProcess`.

## Migration guide

`bevy::asset` trait `Asset`, `AssetLoader`, `Process` implementations removed for `()`. If you use these implementations, consider using `NoAsset`, `NoAssetLoader`, `NoProcess` instead.