### PR TITLE
CameraProjection::compute_frustum

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -41,14 +41,7 @@ impl Default for Camera2dBundle {
             ..Default::default()
         };
         let transform = Transform::default();
-        let view_projection =
-            projection.get_projection_matrix() * transform.compute_matrix().inverse();
-        let frustum = Frustum::from_view_projection_custom_far(
-            &view_projection,
-            &transform.translation,
-            &transform.back(),
-            projection.far(),
-        );
+        let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
             camera_render_graph: CameraRenderGraph::new(crate::core_2d::graph::NAME),
             projection,
@@ -79,14 +72,7 @@ impl Camera2dBundle {
             ..Default::default()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
-        let view_projection =
-            projection.get_projection_matrix() * transform.compute_matrix().inverse();
-        let frustum = Frustum::from_view_projection_custom_far(
-            &view_projection,
-            &transform.translation,
-            &transform.back(),
-            projection.far(),
-        );
+        let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
             camera_render_graph: CameraRenderGraph::new(crate::core_2d::graph::NAME),
             projection,

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -62,8 +62,6 @@ pub trait CameraProjection {
     fn far(&self) -> f32;
     fn get_frustum_corners(&self, z_near: f32, z_far: f32) -> [Vec3A; 8];
 
-    // Provided.
-
     /// Compute camera frustum for camera with given projection and transform.
     ///
     /// This code is called by [`update_frusta`](crate::view::visibility::update_frusta) system

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -280,14 +280,7 @@ pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
     >,
 ) {
     for (transform, projection, mut frustum) in &mut views {
-        let view_projection =
-            projection.get_projection_matrix() * transform.compute_matrix().inverse();
-        *frustum = Frustum::from_view_projection_custom_far(
-            &view_projection,
-            &transform.translation(),
-            &transform.back(),
-            projection.far(),
-        );
+        *frustum = projection.compute_frustum(transform);
     }
 }
 


### PR DESCRIPTION
Frustum computation is nontrivial amount of code private in `update_frusta` system.

Make it public.

This is needed to decide which entities to spawn/despawn in `Update` based on camera changes. But if `Update` also changed camera, frustum is not yet recomputed.

Technically it is probably possible to run an iteration of `update_frusta` system by a user in `Update` schedule after propagating `GlobalTransform` to the cameras, but it is easier to just compute frustum manually using API added in this PR.

Also replace two places where this code is used.