### PR TITLE
Make SystemMeta::new public

### DIFF
--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -34,7 +34,10 @@ pub struct SystemMeta {
 }
 
 impl SystemMeta {
-    pub(crate) fn new<T>() -> Self {
+    /// Creates a new empty system meta with `T` type name as its system name.
+    ///
+    /// This function rarely needed to be called directly.
+    pub fn new<T>() -> Self {
         let name = std::any::type_name::<T>();
         Self {
             name: name.into(),


### PR DESCRIPTION
# Objective

Without public `SystemMeta::new` it is hard to construct `ExclusiveSystemParam`.

While technically it is possible (probably accidentally): by calling `SystemState::<PhantomData<T>>::new().meta().clone()`. So this new function being public does not allow anything was not possible before. Just makes it work naturally and more efficient.

Context. Trying to implement custom systems. For non-exclusive systems, there's convenient `SystemState` utility.

There's no such utility for `ExclusiveFunctionSystem`.

~~Alternatively we can kick `SystemState` from `ExclusiveSystemParam` signatures: it is not used in any implementations, and cannot do a lot of useful things.~~ https://github.com/bevyengine/bevy/pull/11163

## Solution

Make `SystemMeta::new` public.

## Changelog

- `SystemMeta::new` is made public