### PR TITLE
Allow same-state transitions and add `ChangeState` system param

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -38,7 +38,7 @@ pub mod prelude {
         query::{Added, AnyOf, Changed, Has, Or, QueryState, With, Without},
         removal_detection::RemovedComponents,
         schedule::{
-            apply_deferred, apply_state_transition, common_conditions::*, Condition,
+            apply_deferred, apply_state_transition, common_conditions::*, ChangeState, Condition,
             IntoSystemConfigs, IntoSystemSet, IntoSystemSetConfigs, NextState, OnEnter, OnExit,
             OnTransition, Schedule, Schedules, State, States, SystemSet,
         },

--- a/examples/2d/texture_atlas.rs
+++ b/examples/2d/texture_atlas.rs
@@ -35,7 +35,7 @@ fn load_textures(mut commands: Commands, asset_server: Res<AssetServer>) {
 }
 
 fn check_textures(
-    mut next_state: ResMut<NextState<AppState>>,
+    mut state: ChangeState<AppState>,
     rpg_sprite_folder: Res<RpgSpriteFolder>,
     mut events: EventReader<AssetEvent<LoadedFolder>>,
 ) {
@@ -43,7 +43,7 @@ fn check_textures(
     // and that the the font has been loaded by the `FontSystem`.
     for event in events.read() {
         if event.is_loaded_with_dependencies(&rpg_sprite_folder.0) {
-            next_state.set(AppState::Finished);
+            state.change(AppState::Finished);
         }
     }
 }

--- a/examples/ecs/generic_system.rs
+++ b/examples/ecs/generic_system.rs
@@ -72,11 +72,11 @@ fn print_text_system(time: Res<Time>, mut query: Query<(&mut PrinterTick, &TextT
 }
 
 fn transition_to_in_game_system(
-    mut next_state: ResMut<NextState<AppState>>,
+    mut state: ChangeState<AppState>,
     keyboard_input: Res<ButtonInput<KeyCode>>,
 ) {
     if keyboard_input.pressed(KeyCode::Space) {
-        next_state.set(AppState::InGame);
+        state.change(AppState::InGame);
     }
 }
 

--- a/examples/ecs/state.rs
+++ b/examples/ecs/state.rs
@@ -92,7 +92,7 @@ fn setup_menu(mut commands: Commands) {
 }
 
 fn menu(
-    mut next_state: ResMut<NextState<AppState>>,
+    mut state: ChangeState<AppState>,
     mut interaction_query: Query<
         (&Interaction, &mut BackgroundColor),
         (Changed<Interaction>, With<Button>),
@@ -102,7 +102,7 @@ fn menu(
         match *interaction {
             Interaction::Pressed => {
                 *color = PRESSED_BUTTON.into();
-                next_state.set(AppState::InGame);
+                state.change(AppState::InGame);
             }
             Interaction::Hovered => {
                 *color = HOVERED_BUTTON.into();

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -34,6 +34,7 @@ fn main() {
                 rotate_bonus,
                 scoreboard_system,
                 spawn_bonus,
+                restart_keyboard,
             )
                 .run_if(in_state(GameState::Playing)),
         )
@@ -111,6 +112,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     game.player.i = BOARD_SIZE_I / 2;
     game.player.j = BOARD_SIZE_J / 2;
     game.player.move_cooldown = Timer::from_seconds(0.3, TimerMode::Once);
+    game.bonus.entity = None;
 
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 10.0, 4.0),
@@ -302,7 +304,7 @@ fn focus_camera(
 fn spawn_bonus(
     time: Res<Time>,
     mut timer: ResMut<BonusSpawnTimer>,
-    mut next_state: ResMut<NextState<GameState>>,
+    mut state: ChangeState<GameState>,
     mut commands: Commands,
     mut game: ResMut<Game>,
 ) {
@@ -316,7 +318,7 @@ fn spawn_bonus(
         commands.entity(entity).despawn_recursive();
         game.bonus.entity = None;
         if game.score <= -5 {
-            next_state.set(GameState::GameOver);
+            state.change(GameState::GameOver);
             return;
         }
     }
@@ -373,13 +375,17 @@ fn scoreboard_system(game: Res<Game>, mut query: Query<&mut Text>) {
     text.sections[0].value = format!("Sugar Rush: {}", game.score);
 }
 
-// restart the game when pressing spacebar
-fn gameover_keyboard(
-    mut next_state: ResMut<NextState<GameState>>,
-    keyboard_input: Res<ButtonInput<KeyCode>>,
-) {
+// restart the game on R press
+fn restart_keyboard(mut state: ChangeState<GameState>, keyboard_input: Res<ButtonInput<KeyCode>>) {
+    if keyboard_input.just_pressed(KeyCode::KeyR) {
+        state.reload();
+    }
+}
+
+// start a new game on spacebar press
+fn gameover_keyboard(mut state: ChangeState<GameState>, keyboard_input: Res<ButtonInput<KeyCode>>) {
     if keyboard_input.just_pressed(KeyCode::Space) {
-        next_state.set(GameState::Playing);
+        state.change(GameState::Playing);
     }
 }
 

--- a/examples/games/game_menu.rs
+++ b/examples/games/game_menu.rs
@@ -108,12 +108,12 @@ mod splash {
 
     // Tick the timer, and change state when finished
     fn countdown(
-        mut game_state: ResMut<NextState<GameState>>,
+        mut game_state: ChangeState<GameState>,
         time: Res<Time>,
         mut timer: ResMut<SplashTimer>,
     ) {
         if timer.tick(time.delta()).finished() {
-            game_state.set(GameState::Menu);
+            game_state.change(GameState::Menu);
         }
     }
 }
@@ -233,13 +233,9 @@ mod game {
     }
 
     // Tick the timer, and change state when finished
-    fn game(
-        time: Res<Time>,
-        mut game_state: ResMut<NextState<GameState>>,
-        mut timer: ResMut<GameTimer>,
-    ) {
+    fn game(time: Res<Time>, mut game_state: ChangeState<GameState>, mut timer: ResMut<GameTimer>) {
         if timer.tick(time.delta()).finished() {
-            game_state.set(GameState::Menu);
+            game_state.change(GameState::Menu);
         }
     }
 }
@@ -390,8 +386,8 @@ mod menu {
         }
     }
 
-    fn menu_setup(mut menu_state: ResMut<NextState<MenuState>>) {
-        menu_state.set(MenuState::Main);
+    fn menu_setup(mut menu_state: ChangeState<MenuState>) {
+        menu_state.change(MenuState::Main);
     }
 
     fn main_menu_setup(mut commands: Commands, asset_server: Res<AssetServer>) {
@@ -794,8 +790,8 @@ mod menu {
             (Changed<Interaction>, With<Button>),
         >,
         mut app_exit_events: EventWriter<AppExit>,
-        mut menu_state: ResMut<NextState<MenuState>>,
-        mut game_state: ResMut<NextState<GameState>>,
+        mut menu_state: ChangeState<MenuState>,
+        mut game_state: ChangeState<GameState>,
     ) {
         for (interaction, menu_button_action) in &interaction_query {
             if *interaction == Interaction::Pressed {
@@ -804,19 +800,19 @@ mod menu {
                         app_exit_events.send(AppExit);
                     }
                     MenuButtonAction::Play => {
-                        game_state.set(GameState::Game);
-                        menu_state.set(MenuState::Disabled);
+                        game_state.change(GameState::Game);
+                        menu_state.change(MenuState::Disabled);
                     }
-                    MenuButtonAction::Settings => menu_state.set(MenuState::Settings),
+                    MenuButtonAction::Settings => menu_state.change(MenuState::Settings),
                     MenuButtonAction::SettingsDisplay => {
-                        menu_state.set(MenuState::SettingsDisplay);
+                        menu_state.change(MenuState::SettingsDisplay);
                     }
                     MenuButtonAction::SettingsSound => {
-                        menu_state.set(MenuState::SettingsSound);
+                        menu_state.change(MenuState::SettingsSound);
                     }
-                    MenuButtonAction::BackToMainMenu => menu_state.set(MenuState::Main),
+                    MenuButtonAction::BackToMainMenu => menu_state.change(MenuState::Main),
                     MenuButtonAction::BackToSettings => {
-                        menu_state.set(MenuState::Settings);
+                        menu_state.change(MenuState::Settings);
                     }
                 }
             }


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/9130.

## Solution

Add a system param `ChangeState<S>` to set the next state depending on the current state. Remove the same-state check from `apply_state_transition`.

See https://github.com/bevyengine/bevy/pull/11158 for an alternative approach.

---

## Changelog

- Added a system param `ChangeState<S>` to set the next state depending on the current state.
- Removed the check preventing state transitions from the current state to itself.

## Migration Guide

`NextState` can now trigger state transitions from `current_state` to itself.

To preserve the old behavior, replace instances of `next_state: ResMut<NextState<S>>` with `state: ChangeState<S>`, and replace `next_state.set(Foo)` with `state.change(Foo)`.