### PR TITLE
Print to stderr from panic handler in LogPlugin

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -118,7 +118,7 @@ impl Plugin for LogPlugin {
         {
             let old_handler = panic::take_hook();
             panic::set_hook(Box::new(move |infos| {
-                println!("{}", tracing_error::SpanTrace::capture());
+                eprintln!("{}", tracing_error::SpanTrace::capture());
                 old_handler(infos);
             }));
         }


### PR DESCRIPTION
# Objective

When panic handler prints to stdout instead of stderr, I've observed two outcomes with this PR test #11169:
- Sometimes output is mixed up, so it is not clear where one record ends and another stards
- Sometimes output is lost

## Solution

Print to stderr.

## Changelog

- Panic handler in `LogPlugin` writes to stderr instead of stdin.