### PR TITLE
Add ability to panic to logs example

### DIFF
--- a/examples/app/logs.rs
+++ b/examples/app/logs.rs
@@ -11,9 +11,31 @@ fn main() {
             // filter: "wgpu=warn,bevy_ecs=info".to_string(),
             ..default()
         }))
+        .add_systems(Startup, setup)
         .add_systems(Update, log_system)
         .add_systems(Update, log_once_system)
+        .add_systems(Update, panic_on_p)
         .run();
+}
+
+fn setup(mut commands: Commands) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(TextBundle {
+        text: Text::from_section(
+            "Press P to panic",
+            TextStyle {
+                font_size: 60.0,
+                ..default()
+            },
+        ),
+        ..default()
+    });
+}
+
+fn panic_on_p(keys: Res<ButtonInput<KeyCode>>) {
+    if keys.just_pressed(KeyCode::KeyP) {
+        panic!("P pressed, panicking");
+    }
 }
 
 fn log_system() {


### PR DESCRIPTION
# Objective

To debug issues like https://github.com/bevyengine/bevy/pull/11169.

## Solution

When P is pressed in logs example, call `panic!()`.

<img width="1392" alt="Screenshot 2024-01-02 at 01 10 16" src="https://github.com/bevyengine/bevy/assets/28969/a788737e-d23c-43a3-bc68-d6c5b0ab88ad">
