### PR TITLE
 Fair Change Detection Benchmarking

### DIFF
--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -270,7 +270,8 @@ fn insert_if_bit_enabled<const B: u16>(entity: &mut EntityWorldMut, i: u16) {
         entity.insert(Data::<B>(1.0));
     }
 }
-fn add_archetypes_entites<T: Component + Default>(
+
+fn add_archetypes_entities<T: Component + Default>(
     world: &mut World,
     archetype_count: u16,
     entity_count: u32,
@@ -313,7 +314,7 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
             bencher.iter_batched_ref(
                 || {
                     let mut world = World::new();
-                    add_archetypes_entites::<T>(&mut world, archetype_count, entity_count);
+                    add_archetypes_entities::<T>(&mut world, archetype_count, entity_count);
                     world.clear_trackers();
                     let mut query = world.query::<(
                         Option<&mut Data<0>>,
@@ -333,6 +334,7 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
                         Option<&mut Data<14>>,
                     )>();
                     for components in query.iter_mut(&mut world) {
+                        // change Data<X> while keeping T unchanged
                         modify!(components;0,1,2,3,4,5,6,7,8,9,10,11,12,13,14);
                     }
                     let query = generic_filter_query::<Changed<T>>(&mut world);

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -14,7 +14,7 @@ criterion_group!(
     all_changed_detection,
     few_changed_detection,
     none_changed_detection,
-    multiple_archetype_changed_detection
+    multiple_archetype_none_changed_detection
 );
 criterion_main!(benches);
 
@@ -252,12 +252,12 @@ fn insert_if_bit_enabled<const B: u16>(entity: &mut EntityWorldMut, i: u16) {
         entity.insert(Data::<B>(1.0));
     }
 }
-fn add_archetypes_entites<T: Component+Default>(
+fn add_archetypes_entites<T: Component + Default>(
     world: &mut World,
     archetype_count: u16,
     entity_count: u32,
 ) {
-    for i in 0..archetype_count  {
+    for i in 0..archetype_count {
         for j in 0..entity_count {
             let mut e = world.spawn(T::default());
             insert_if_bit_enabled::<0>(&mut e, i);
@@ -279,7 +279,7 @@ fn add_archetypes_entites<T: Component+Default>(
         }
     }
 }
-fn multiple_archetype_changed_detection_generic<T: Component + Default + BenchModify>(
+fn multiple_archetype_none_changed_detection_generic<T: Component + Default + BenchModify>(
     group: &mut BenchGroup,
     archetype_count: u16,
     entity_count: u32,
@@ -297,9 +297,9 @@ fn multiple_archetype_changed_detection_generic<T: Component + Default + BenchMo
                     let mut world = World::new();
                     add_archetypes_entites::<T>(&mut world, archetype_count, entity_count);
                     world.clear_trackers();
-                    let mut query = world.query::<&mut T>();
+                    let mut query = world.query::<(&mut Data<1>)>();
                     for mut component in query.iter_mut(&mut world) {
-                        component.bench_modify();
+                        component.0 = 2.
                     }
                     world
                 },
@@ -315,18 +315,18 @@ fn multiple_archetype_changed_detection_generic<T: Component + Default + BenchMo
     );
 }
 
-fn multiple_archetype_changed_detection(criterion: &mut Criterion) {
+fn multiple_archetype_none_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("multiple_archetype_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(800));
     group.measurement_time(std::time::Duration::from_secs(8));
-    for archetype_count in [5,20,100] {
-        for entity_count in [10,100,1000,10000] {
-            multiple_archetype_changed_detection_generic::<Table>(
+    for archetype_count in [5, 20, 100] {
+        for entity_count in [10, 100, 1000, 10000] {
+            multiple_archetype_none_changed_detection_generic::<Table>(
                 &mut group,
                 archetype_count,
                 entity_count,
             );
-            multiple_archetype_changed_detection_generic::<Sparse>(
+            multiple_archetype_none_changed_detection_generic::<Sparse>(
                 &mut group,
                 archetype_count,
                 entity_count,

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -54,7 +54,7 @@ impl BenchModify for Sparse {
     }
 }
 
-const ENTITIES_TO_BENCH_COUT: [u32; 2] = [5000, 50000];
+const ENTITIES_TO_BENCH_COUNT: [u32; 2] = [5000, 50000];
 
 type BenchGroup<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
 
@@ -106,7 +106,7 @@ fn all_added_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("all_added_detection");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
-    for entity_count in ENTITIES_TO_BENCH_COUT {
+    for entity_count in ENTITIES_TO_BENCH_COUNT {
         generic_bench(
             &mut group,
             vec![
@@ -154,7 +154,7 @@ fn all_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("all_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
-    for entity_count in ENTITIES_TO_BENCH_COUT {
+    for entity_count in ENTITIES_TO_BENCH_COUNT {
         generic_bench(
             &mut group,
             vec![
@@ -204,7 +204,7 @@ fn few_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("few_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
-    for entity_count in ENTITIES_TO_BENCH_COUT {
+    for entity_count in ENTITIES_TO_BENCH_COUNT {
         generic_bench(
             &mut group,
             vec![
@@ -248,7 +248,7 @@ fn none_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("none_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(500));
     group.measurement_time(std::time::Duration::from_secs(4));
-    for entity_count in ENTITIES_TO_BENCH_COUT {
+    for entity_count in ENTITIES_TO_BENCH_COUNT {
         generic_bench(
             &mut group,
             vec![

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -82,13 +82,13 @@ fn all_added_detection_generic<T: Component + Default>(group: &mut BenchGroup, e
     group.bench_function(
         format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
         |bencher| {
-            bencher.iter_batched(
+            bencher.iter_batched_ref(
                 || {
                     let mut world = setup::<T>(entity_count);
-                    let mut query = world.query_filtered::<Entity, Added<T>>();
+                    let query = world.query_filtered::<Entity, Added<T>>();
                     (world, query)
                 },
-                |(mut world, mut query)| {
+                |(ref mut world, ref mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);
@@ -125,7 +125,7 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
     group.bench_function(
         format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
         |bencher| {
-            bencher.iter_batched(
+            bencher.iter_batched_ref(
                 || {
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
@@ -133,10 +133,10 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
                     for mut component in query.iter_mut(&mut world) {
                         black_box(component.bench_modify());
                     }
-                    let mut query = world.query_filtered::<Entity, Changed<T>>();
+                    let query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |(mut world, mut query)| {
+                |(ref mut world, ref mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);
@@ -175,7 +175,7 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
     group.bench_function(
         format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
         |bencher| {
-            bencher.iter_batched(
+            bencher.iter_batched_ref(
                 || {
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
@@ -186,10 +186,10 @@ fn few_changed_detection_generic<T: Component + Default + BenchModify>(
                     for component in to_modify[0..amount_to_modify].iter_mut() {
                         black_box(component.bench_modify());
                     }
-                    let mut query = world.query_filtered::<Entity, Changed<T>>();
+                    let query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |(mut world, mut query)| {
+                |(ref mut world, ref mut query)| {
                     for entity in query.iter(&world) {
                         black_box(entity);
                     }
@@ -223,14 +223,14 @@ fn none_changed_detection_generic<T: Component + Default>(
     group.bench_function(
         format!("{}_entities_{}", entity_count, std::any::type_name::<T>()),
         |bencher| {
-            bencher.iter_batched(
+            bencher.iter_batched_ref(
                 || {
                     let mut world = setup::<T>(entity_count);
                     world.clear_trackers();
-                    let mut query = world.query_filtered::<Entity, Changed<T>>();
+                    let query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |(mut world, mut query)| {
+                |(ref mut world, ref mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);
@@ -270,7 +270,7 @@ fn add_archetypes_entites<T: Component + Default>(
     entity_count: u32,
 ) {
     for i in 0..archetype_count {
-        for j in 0..entity_count {
+        for _j in 0..entity_count {
             let mut e = world.spawn(T::default());
             insert_if_bit_enabled::<0>(&mut e, i);
             insert_if_bit_enabled::<1>(&mut e, i);
@@ -304,7 +304,7 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
             std::any::type_name::<T>()
         ),
         |bencher| {
-            bencher.iter_batched(
+            bencher.iter_batched_ref(
                 || {
                     let mut world = World::new();
                     add_archetypes_entites::<T>(&mut world, archetype_count, entity_count);
@@ -329,10 +329,10 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
                     for components in query.iter_mut(&mut world) {
                         modify!(components;0,1,2,3,4,5,6,7,8,9,10,11,12,13,14);
                     }
-                    let mut query = world.query_filtered::<Entity, Changed<T>>();
+                    let query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |(mut world, mut query)| {
+                |(ref mut world, ref mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -46,7 +46,6 @@ impl BenchModify for Sparse {
 }
 
 const ENTITIES_TO_BENCH_COUT: [u32; 2] = [5000, 50000];
-const ARCHETYPES_TO_BENCH_COUT: [u16; 3] = [5, 50, 100];
 
 type BenchGroup<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
 
@@ -320,8 +319,8 @@ fn multiple_archetype_changed_detection(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("multiple_archetype_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(800));
     group.measurement_time(std::time::Duration::from_secs(8));
-    for archetype_count in ARCHETYPES_TO_BENCH_COUT {
-        for entity_count in ENTITIES_TO_BENCH_COUT {
+    for archetype_count in [5,20,100] {
+        for entity_count in [10,100,1000,10000] {
             multiple_archetype_changed_detection_generic::<Table>(
                 &mut group,
                 archetype_count,

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -88,7 +88,7 @@ fn all_added_detection_generic<T: Component + Default>(group: &mut BenchGroup, e
                     let mut query = world.query_filtered::<Entity, Added<T>>();
                     (world, query)
                 },
-                |(mut world, query)| {
+                |(mut world, mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);
@@ -136,7 +136,7 @@ fn all_changed_detection_generic<T: Component + Default + BenchModify>(
                     let mut query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |(mut world, query)| {
+                |(mut world, mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);
@@ -230,7 +230,7 @@ fn none_changed_detection_generic<T: Component + Default>(
                     let mut query = world.query_filtered::<Entity, Changed<T>>();
                     (world, query)
                 },
-                |mut world| {
+                |(mut world, mut query)| {
                     let mut count = 0;
                     for entity in query.iter(&world) {
                         black_box(entity);

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -299,15 +299,18 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
                     world.clear_trackers();
                     let mut query = world.query::<(&mut Data<1>)>();
                     for mut component in query.iter_mut(&mut world) {
-                        component.0 = 2.
+                        component.0 += 2.
                     }
                     world
                 },
                 |mut world| {
+                    let mut count = 0;
                     let mut query = world.query_filtered::<Entity, Changed<T>>();
                     for entity in query.iter(&world) {
                         black_box(entity);
+                        count+=1;
                     }
+                    assert_eq!(0, count);
                 },
                 criterion::BatchSize::LargeInput,
             )
@@ -316,7 +319,7 @@ fn multiple_archetype_none_changed_detection_generic<T: Component + Default + Be
 }
 
 fn multiple_archetype_none_changed_detection(criterion: &mut Criterion) {
-    let mut group = criterion.benchmark_group("multiple_archetype_changed_detection");
+    let mut group = criterion.benchmark_group("multiple_archetypes_none_changed_detection");
     group.warm_up_time(std::time::Duration::from_millis(800));
     group.measurement_time(std::time::Duration::from_secs(8));
     for archetype_count in [5, 20, 100] {

--- a/benches/benches/bevy_ecs/change_detection.rs
+++ b/benches/benches/bevy_ecs/change_detection.rs
@@ -46,7 +46,7 @@ impl BenchModify for Sparse {
 }
 
 const ENTITIES_TO_BENCH_COUT: [u32; 2] = [5000, 50000];
-const ARCHETYPES_TO_BENCH_COUT: [u16; 3] = [5, 10, 100];
+const ARCHETYPES_TO_BENCH_COUT: [u16; 3] = [5, 50, 100];
 
 type BenchGroup<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;
 


### PR DESCRIPTION
# Objective

- #4972 introduce a benchmark to measure chang detection performance
- However,it uses `iter_batch ` cause a lot of overhead in clone data to each routine closure(it feels like a bug in`iter_batch `) and constructs  new query in every iter.This overhead masks the real change detection throughput we want to measure. Instead of evaluating raw change detection, the benchmark ends up dominated by data cloning and allocation costs.


## Solution

- Use iter_batch_ref to reduce the benchmark overload 
- Use cached query to better reflect real-world usage scenarios.
- Add more benmark

---

## Changelog


