### PR TITLE
Add `Cursor.grab_mode` docs for X11

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -474,6 +474,7 @@ pub struct Cursor {
     /// - **`Windows`** doesn't support [`CursorGrabMode::Locked`]
     /// - **`macOS`** doesn't support [`CursorGrabMode::Confined`]
     /// - **`iOS/Android`** don't have cursors.
+    /// - **`X11`**: The grab mode should be set in a startup system. See: <https://github.com/bevyengine/bevy/issues/10084>.
     ///
     /// Since `Windows` and `macOS` have different [`CursorGrabMode`] support, we first try to set the grab mode that was asked for. If it doesn't work then use the alternate grab mode.
     pub grab_mode: CursorGrabMode,


### PR DESCRIPTION
# Objective

- Documents workaround for bug on X11 with cursor grab on window initialization.
- Fixes #10084 

## Solution

- Add an entry to the platform-specific documentation for `bevy::window::Cursor.grab_mode` ([link](https://docs.rs/bevy/latest/bevy/window/struct.Cursor.html#structfield.grab_mode)), providing a link to the above issue where the workaround is described. I believe this is the cleanest solution.
