### PR TITLE
Add `approx` feature to `bevy_math`

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 serialize = ["dep:serde", "glam/serde"]
+# Enable approx for glam types to approximate floating point equality comparisons and assertions
 approx = ["glam/approx"]
 # Enable interoperation of glam types with mint-compatible libraries
 mint = ["glam/mint"]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"], optional = true }
 
 [features]
 serialize = ["dep:serde", "glam/serde"]
+approx = ["glam/approx"]
 # Enable interoperation of glam types with mint-compatible libraries
 mint = ["glam/mint"]
 # Enable assertions to check the validity of parameters passed to glam

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -24,8 +24,8 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
+bevy_math = { path = "../bevy_math", version = "0.12.0", features = ["approx"] }
 approx = "0.5.1"
-glam = { version = "0.24", features = ["approx"] }
 
 [features]
 serialize = ["dep:serde", "bevy_math/serialize"]


### PR DESCRIPTION
# Objective

`bevy_math` re-exports Glam, but doesn't have a feature for enabling `approx` for it. Many projects (including some of Bevy's own crates) need `approx`, and it'd be nice if you didn't have to manually add Glam to specify the feature for it.

## Solution

Add an `approx` feature to `bevy_math`.