### PR TITLE
Enable cloning EntityHashMap and PreHashMap

### DIFF
--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -189,7 +189,7 @@ impl<V: Clone, H> Clone for Hashed<V, H> {
 impl<V: Eq, H> Eq for Hashed<V, H> {}
 
 /// A [`BuildHasher`] that results in a [`PassHasher`].
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PassHash;
 
 impl BuildHasher for PassHash {
@@ -251,7 +251,7 @@ impl<K: Hash + Eq + PartialEq + Clone, V> PreHashMapExt<K, V> for PreHashMap<K, 
 }
 
 /// A [`BuildHasher`] that results in a [`EntityHasher`].
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct EntityHash;
 
 impl BuildHasher for EntityHash {
@@ -413,5 +413,25 @@ macro_rules! detailed_trace {
         if cfg!(detailed_trace) {
             bevy_utils::tracing::trace!($($tts)*);
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone_entity_hash_map() {
+        let map = EntityHashMap::<u64, usize>::default();
+        // This should compile
+        let _ = map.clone();
+    }
+
+    #[test]
+    fn test_clone_pre_hash_map() {
+        let map = PreHashMap::<u64, usize>::default();
+        // This should compile
+        let _ = map.clone();
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -416,7 +416,6 @@ macro_rules! detailed_trace {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# Objective

- `EntityHashMap`, `EntityHashSet` and `PreHashMap` are currently not Cloneable because of a missing trivial `Clone` bound for `EntityHash` and `PreHash`. This PR makes them Cloneable.

(the parent struct `hashbrown::HashMap` requires the `HashBuilder` to be `Clone` for the `HashMap` to be `Clone`, see: https://github.com/rust-lang/hashbrown/blob/master/src/map.rs#L195)


## Solution

- Add a `Clone` bound to `PreHash` and `EntityHash`
