### PR TITLE
Implement `Neg` for `Direction2d` and `Direction3d`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -58,6 +58,13 @@ impl std::ops::Deref for Direction2d {
     }
 }
 
+impl std::ops::Neg for Direction2d {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
 /// A circle primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Circle {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -58,6 +58,13 @@ impl std::ops::Deref for Direction3d {
     }
 }
 
+impl std::ops::Neg for Direction3d {
+    type Output = Self;
+    fn neg(self) -> Self::Output {
+        Self(-self.0)
+    }
+}
+
 /// A sphere primitive
 #[derive(Clone, Copy, Debug)]
 pub struct Sphere {


### PR DESCRIPTION
# Objective

I frequently encounter cases where I need to get the opposite direction. This currently requires something like `Direction2d::from_normalized(-*direction)`, which is very inconvenient.

## Solution

Implement `Neg` for `Direction2d` and `Direction3d`.