### PR TITLE
Add static assertions to bevy_utils for compile-time checks

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -23,6 +23,9 @@ thiserror = "1.0"
 nonmax = "0.5"
 smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 
+[dev-dependencies]
+static_assertions = "1.1.0"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.0", features = ["js"] }
 

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -189,7 +189,7 @@ impl<V: Clone, H> Clone for Hashed<V, H> {
 impl<V: Eq, H> Eq for Hashed<V, H> {}
 
 /// A [`BuildHasher`] that results in a [`PassHasher`].
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct PassHash;
 
 impl BuildHasher for PassHash {
@@ -251,7 +251,7 @@ impl<K: Hash + Eq + PartialEq + Clone, V> PreHashMapExt<K, V> for PreHashMap<K, 
 }
 
 /// A [`BuildHasher`] that results in a [`EntityHasher`].
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct EntityHash;
 
 impl BuildHasher for EntityHash {
@@ -413,5 +413,25 @@ macro_rules! detailed_trace {
         if cfg!(detailed_trace) {
             bevy_utils::tracing::trace!($($tts)*);
         }
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clone_entity_hash_map() {
+        let map = EntityHashMap::<u64, usize>::default();
+        // This should compile
+        let _ = map.clone();
+    }
+
+    #[test]
+    fn test_clone_pre_hash_map() {
+        let map = PreHashMap::<u64, usize>::default();
+        // This should compile
+        let _ = map.clone();
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -419,18 +419,11 @@ macro_rules! detailed_trace {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use static_assertions::assert_impl_all;
 
     #[test]
-    fn test_clone_entity_hash_map() {
-        let map = EntityHashMap::<u64, usize>::default();
-        // This should compile
-        let _ = map.clone();
-    }
-
-    #[test]
-    fn test_clone_pre_hash_map() {
-        let map = PreHashMap::<u64, usize>::default();
-        // This should compile
-        let _ = map.clone();
+    fn test_clone_bounds() {
+        assert_impl_all!(EntityHashMap::<u64, usize>: Clone);
+        assert_impl_all!(PreHashMap::<u64, usize>: Clone);
     }
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -421,9 +421,7 @@ mod tests {
     use super::*;
     use static_assertions::assert_impl_all;
 
-    #[test]
-    fn test_clone_bounds() {
-        assert_impl_all!(EntityHashMap::<u64, usize>: Clone);
-        assert_impl_all!(PreHashMap::<u64, usize>: Clone);
-    }
+    // Check that the HashMaps are Clone if the key/values are Clone
+    assert_impl_all!(EntityHashMap::<u64, usize>: Clone);
+    assert_impl_all!(PreHashMap::<u64, usize>: Clone);
 }

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -416,7 +416,6 @@ macro_rules! detailed_trace {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
# Objective

- We want to use `static_assertions` to perform precise compile time checks at testing time. In this PR, we add those checks to make sure that `EntityHashMap` and `PreHashMap` are `Clone` (and we replace the more clumsy previous tests)
- Fixes #11181 

(will need to be rebased once https://github.com/bevyengine/bevy/pull/11178 is merged)