### PR TITLE
Bump the vertex attribute index for prepass joints.

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -421,7 +421,7 @@ where
         let bind_group = setup_morph_and_skinning_defs(
             &self.mesh_layouts,
             layout,
-            4,
+            5,
             &key.mesh_key,
             &mut shader_defs,
             &mut vertex_attributes,


### PR DESCRIPTION
This was missed in #10231.

Fixes #11190.