### PR TITLE
Fix: Gizmos crash due to the persistence policy being set to `Unload`. Change it to `Keep`

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -372,7 +372,7 @@ impl RenderAsset for LineGizmo {
     type Param = SRes<RenderDevice>;
 
     fn persistence_policy(&self) -> RenderAssetPersistencePolicy {
-        RenderAssetPersistencePolicy::Unload
+        RenderAssetPersistencePolicy::Keep
     }
 
     fn prepare_asset(


### PR DESCRIPTION
# Objective

Fixes Gizmos crash due to the persistence policy being set to `Unload`

## Solution

Change it to `Keep`

