### PR TITLE
Implement TypePath for EntityHash

### DIFF
--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -80,6 +80,7 @@ impl_reflect_value!(isize(
 impl_reflect_value!(f32(Debug, PartialEq, Serialize, Deserialize, Default));
 impl_reflect_value!(f64(Debug, PartialEq, Serialize, Deserialize, Default));
 impl_type_path!(str);
+impl_type_path!(::bevy_utils::EntityHash);
 impl_reflect_value!(::alloc::string::String(
     Debug,
     Hash,

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1514,8 +1514,8 @@ mod tests {
         Enum, FromReflect, Reflect, ReflectSerialize, TypeInfo, TypeRegistry, Typed, VariantInfo,
         VariantType,
     };
-    use bevy_utils::HashMap;
     use bevy_utils::{Duration, Instant};
+    use bevy_utils::{EntityHashMap, HashMap};
     use std::f32::consts::{PI, TAU};
     use std::path::Path;
 
@@ -1723,5 +1723,13 @@ mod tests {
         let path = Path::new("hello_world.rs");
         let output = <&'static Path as FromReflect>::from_reflect(&path).unwrap();
         assert_eq!(path, output);
+    }
+
+    #[test]
+    fn entity_hashmap_should_impl_reflect() {
+        let entity_map = bevy_utils::EntityHashMap::<i32, i32>::default();
+        let entity_map_type_info =
+            <EntityHashMap<_, _> as Reflect>::get_represented_type_info(&entity_map);
+        assert!(entity_map_type_info.is_some());
     }
 }


### PR DESCRIPTION
# Objective

- Fix #11117 by implementing `Reflect` for `EntityHashMap`

## Solution

- By implementing `TypePath` for `EntityHash`, Bevy will automatically implement `Reflect` for `EntityHashMap`

---

## Changelog

- `TypePath` is implemented for `EntityHash`
- A test called `entity_hashmap_should_impl_reflect` was created to verify that #11117 was solved.
