### PR TITLE
Support unchecked pipelines

### DIFF
--- a/crates/bevy_render/src/renderer/render_device.rs
+++ b/crates/bevy_render/src/renderer/render_device.rs
@@ -51,6 +51,19 @@ impl RenderDevice {
         self.device.create_shader_module(desc)
     }
 
+    /// Creates a [`ShaderModule`](wgpu::ShaderModule) from either SPIR-V or WGSL source code without runtime checks.
+    ///
+    /// # Safety
+    ///
+    /// See: [`wgpu::Device::create_shader_module_unchecked()`].
+    #[inline]
+    pub unsafe fn create_shader_module_unchecked(
+        &self,
+        desc: wgpu::ShaderModuleDescriptor,
+    ) -> wgpu::ShaderModule {
+        self.device.create_shader_module_unchecked(desc)
+    }
+
     /// Check for resource cleanups and mapping callbacks.
     ///
     /// Return `true` if the queue is empty, or `false` if there are more queue


### PR DESCRIPTION
`device.create_shader_module()` has a (somewhat evil) cousin `device.create_shader_module_unchecked()` which allows to instantiate a shader without extra runtime checks (e.g. for array bounds).

This comes very handy for memory-intensive shaders, for instance yielding an extra 25% boost for my ray tracing thingie.

This commit introduces the concept of unchecked pipelines for Bevy abstractions as well.