### PR TITLE
Ensure CubicCurves with the default value have at least one CubicSegment

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -431,9 +431,17 @@ impl CubicSegment<Vec2> {
 }
 
 /// A collection of [`CubicSegment`]s chained into a curve.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CubicCurve<P: Point> {
     segments: Vec<CubicSegment<P>>,
+}
+
+impl<P: Point> Default for CubicCurve<P> {
+    fn default() -> Self {
+        Self {
+            segments: vec![CubicSegment::default()],
+        }
+    }
 }
 
 impl<P: Point> CubicCurve<P> {


### PR DESCRIPTION
# Objective

- Fixes #11209 .

## Solution

- The `CubicCurve::position` function assumes the given `CubicCurve` has at least one `CubicSegment`. However, a `CubicCurve` with the default value does not have any `CubicSegment`.
- Implement the `default` function for `CubicCurve` which returns a `CubicCurve` with one default `CubicSegment`.
