### PR TITLE
ignore files starting with . when loading folders

### DIFF
--- a/crates/bevy_asset/src/io/file/file_asset.rs
+++ b/crates/bevy_asset/src/io/file/file_asset.rs
@@ -74,6 +74,15 @@ impl AssetReader for FileAssetReader {
                                 return None;
                             }
                         }
+                        // filter out hidden files. they are not listed by default but are directly targetable
+                        if path
+                            .file_name()
+                            .and_then(|file_name| file_name.to_str())
+                            .map(|file_name| file_name.starts_with('.'))
+                            .unwrap_or_default()
+                        {
+                            return None;
+                        }
                         let relative_path = path.strip_prefix(&root_path).unwrap();
                         Some(relative_path.to_owned())
                     })

--- a/crates/bevy_asset/src/io/file/sync_file_asset.rs
+++ b/crates/bevy_asset/src/io/file/sync_file_asset.rs
@@ -145,6 +145,16 @@ impl AssetReader for FileAssetReader {
                                 return None;
                             }
                         }
+                        // filter out hidden files. they are not listed by default but are directly targetable
+                        if path
+                            .file_name()
+                            .and_then(|file_name| file_name.to_str())
+                            .map(|file_name| file_name.starts_with('.'))
+                            .unwrap_or_default()
+                        {
+                            return None;
+                        }
+
                         let relative_path = path.strip_prefix(&root_path).unwrap();
                         Some(relative_path.to_owned())
                     })

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -982,6 +982,14 @@ impl AssetServer {
             if is_dir {
                 let mut path_stream = reader.read_directory(path.as_ref()).await?;
                 while let Some(child_path) = path_stream.next().await {
+                    if child_path
+                        .file_name()
+                        .and_then(|file_name| file_name.to_str())
+                        .map(|file_name| file_name.starts_with('.'))
+                        .unwrap_or_default()
+                    {
+                        continue;
+                    }
                     if reader.is_directory(&child_path).await? {
                         Box::pin(load_folder(
                             source.clone(),

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -982,14 +982,6 @@ impl AssetServer {
             if is_dir {
                 let mut path_stream = reader.read_directory(path.as_ref()).await?;
                 while let Some(child_path) = path_stream.next().await {
-                    if child_path
-                        .file_name()
-                        .and_then(|file_name| file_name.to_str())
-                        .map(|file_name| file_name.starts_with('.'))
-                        .unwrap_or_default()
-                    {
-                        continue;
-                    }
                     if reader.is_directory(&child_path).await? {
                         Box::pin(load_folder(
                             source.clone(),


### PR DESCRIPTION
# Objective

- When loading a folder with dot files inside, Bevy crashes:
```
thread 'IO Task Pool (1)' panicked at crates/bevy_asset/src/io/mod.rs:260:10:
asset paths must have extensions
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
- those files are common for other tools to store their settings/metadata

## Solution

- Ignore files starting with a dot when loading folders
