### PR TITLE
Don't auto create assets folder

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -6,7 +6,6 @@ mod file_asset;
 #[cfg(not(feature = "multi-threaded"))]
 mod sync_file_asset;
 
-use bevy_log::warn;
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
 
@@ -45,12 +44,6 @@ impl FileAssetReader {
     /// See `get_base_path` below.
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         let root_path = Self::get_base_path().join(path.as_ref());
-        if let Err(e) = std::fs::create_dir_all(&root_path) {
-            warn!(
-                "Failed to create root directory {:?} for file asset reader: {:?}",
-                root_path, e
-            );
-        }
         Self { root_path }
     }
 

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -43,7 +43,7 @@ impl<'a> AssetSourceId<'a> {
     }
 
     /// Returns [`None`] if this is [`AssetSourceId::Default`] and [`Some`] containing the
-    /// the name if this is [`AssetSourceId::Name`].
+    /// name if this is [`AssetSourceId::Name`].
     pub fn as_str(&self) -> Option<&str> {
         match self {
             AssetSourceId::Default => None,

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -43,7 +43,7 @@ impl<'a> AssetSourceId<'a> {
     }
 
     /// Returns [`None`] if this is [`AssetSourceId::Default`] and [`Some`] containing the
-    /// the name if this is [`AssetSourceId::Name`].  
+    /// the name if this is [`AssetSourceId::Name`].
     pub fn as_str(&self) -> Option<&str> {
         match self {
             AssetSourceId::Default => None,
@@ -486,7 +486,7 @@ impl AssetSource {
                     sender,
                     file_debounce_wait_time,
                 )
-                .unwrap(),
+                .unwrap_or_else(|e| panic!("Failed to create file watcher: {}", e)),
             ));
             #[cfg(any(
                 not(feature = "file_watcher"),

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -486,7 +486,7 @@ impl AssetSource {
                     sender,
                     file_debounce_wait_time,
                 )
-                .unwrap_or_else(|e| panic!("Failed to create file watcher: {}", e)),
+                .expect("Failed to create file watcher"),
             ));
             #[cfg(any(
                 not(feature = "file_watcher"),


### PR DESCRIPTION
# Objective

- Don't automatically create an assets folder
- resolves #11208

## Solution

- Removes directory creation from file reader.
- Clearer panic when using file watcher and asset folder doesn't exist