### PR TITLE
Add `libm` feature to `bevy_math`

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -18,6 +18,9 @@ serialize = ["dep:serde", "glam/serde"]
 approx = ["glam/approx"]
 # Enable interoperation of glam types with mint-compatible libraries
 mint = ["glam/mint"]
+# Enable libm mathematical functions for glam types to ensure consistent outputs
+# across platforms at the cost of losing hardware-level optimization using intrinsics
+libm = ["glam/libm"]
 # Enable assertions to check the validity of parameters passed to glam
 glam_assert = ["glam/glam-assert"]
 # Enable assertions in debug builds to check the validity of parameters passed to glam


### PR DESCRIPTION
# Objective

Different platforms use their own implementations of several mathematical functions (especially transcendental functions like sin, cos, tan, atan, and so on) to provide hardware-level optimization using intrinsics. This is good for performance, but bad when you expect consistent outputs across machines.

[`libm`](https://github.com/rust-lang/libm) is a widely used crate that provides mathematical functions that don't use intrinsics like `std` functions. This allows bit-for-bit deterministic math across hardware, which is crucial for things like cross-platform deterministic physics simulation.

Glam has the `libm` feature for using [`libm` for the math](https://github.com/bitshifter/glam-rs/blob/d2871a151bb1ecc91bb160e1c1cce336d8a52d9d/src/f32/math.rs#L35) in its own types. This would be nice to expose as a feature in `bevy_math`.

## Solution

Add `libm` feature to `bevy_math`. We could name it something like `enhanced-determinism`, but this wouldn't be accurate for the rest of Bevy, so I think just `libm` is more fitting and explicit.