### PR TITLE
mobile and webgpu: trigger redraw request when needed and improve window creation

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -682,7 +682,6 @@ pub fn winit_runner(mut app: App) {
                 event: DeviceEvent::MouseMotion { delta: (x, y) },
                 ..
             } => {
-                runner_state.redraw_requested = true;
                 let (mut event_writers, ..) = event_writer_system_state.get_mut(&mut app.world);
                 event_writers.mouse_motion.send(MouseMotion {
                     delta: Vec2::new(x as f32, y as f32),

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -743,6 +743,7 @@ pub fn winit_runner(mut app: App) {
                     }
                 }
                 runner_state.active = ActiveState::Active;
+                runner_state.redraw_requested = true;
                 #[cfg(target_os = "android")]
                 {
                     // Get windows that are cached but without raw handles. Those window were already created, but got their

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -352,6 +352,7 @@ pub fn winit_runner(mut app: App) {
                 app.finish();
                 app.cleanup();
             }
+            runner_state.redraw_requested = true;
 
             if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
                 if app_exit_event_reader.read(app_exit_events).last().is_some() {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -858,8 +858,7 @@ fn run_app_update_if_should(
         app.update();
 
         // decide when to run the next update
-        let (config, windows) = focused_windows_state.get(&app.world);
-        let focused = windows.iter().any(|window| window.focused);
+        let (config, _) = focused_windows_state.get(&app.world);
         match config.update_mode(focused) {
             UpdateMode::Continuous => {
                 runner_state.redraw_requested = true;

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -361,9 +361,18 @@ pub fn winit_runner(mut app: App) {
                 }
             }
         }
-        runner_state.redraw_requested = false;
 
         match event {
+            Event::AboutToWait => {
+                if runner_state.redraw_requested {
+                    let (_, winit_windows, _, _) =
+                        event_writer_system_state.get_mut(&mut app.world);
+                    for window in winit_windows.windows.values() {
+                        window.request_redraw();
+                    }
+                }
+                runner_state.redraw_requested = false;
+            }
             Event::NewEvents(_) => {
                 if let Some(t) = runner_state.scheduled_update {
                     let now = Instant::now();
@@ -757,12 +766,6 @@ pub fn winit_runner(mut app: App) {
                 }
             }
             _ => (),
-        }
-        if runner_state.redraw_requested {
-            let (_, winit_windows, _, _) = event_writer_system_state.get_mut(&mut app.world);
-            for window in winit_windows.windows.values() {
-                window.request_redraw();
-            }
         }
     };
 


### PR DESCRIPTION
# Objective

- Since #11227, Bevy doesn't work on mobile anymore. Windows are not created.

## Solution

- Create initial window on mobile after the initial `Resume` event. macOS is included because it's excluded from the other initial window creation and I didn't want it to feel alone. Also, it makes sense. this is needed for Android
https://github.com/bevyengine/bevy/blob/cfcb6885e3b475a93ec0fe7e88023ac0f354bbbf/crates/bevy_winit/src/lib.rs#L152
- request redraw during plugin initialisation (needed for WebGPU)
- request redraw when receiving `AboutToWait` instead of at the end of the event handler. request to redraw during a `RedrawRequested` event are ignored on iOS