### PR TITLE
example showcase patches: use default instead of game mode for desktop

### DIFF
--- a/tools/example-showcase/remove-desktop-app-mode.patch
+++ b/tools/example-showcase/remove-desktop-app-mode.patch
@@ -14,7 +14,7 @@ index b91e25d34..48f19b708 100644
 -                wait: Duration::from_secs(60),
 -            },
 -        }
-+        Self::game()
++        Self::default()
      }
  
      /// Returns the current [`UpdateMode`].


### PR DESCRIPTION
# Objective

- After https://github.com/bevyengine/bevy/pull/11227, example showcase timeouts
- `ReactiveLowPower` now can wait indefinitely depending on "platform specifics"

## Solution

- Patch desktop mode in example showcase to use default mode which is always `Continuous`
