### PR TITLE
Better error message on incorrect asset label

### DIFF
--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -487,9 +487,16 @@ impl AssetServer {
                     match loaded_asset.labeled_assets.get(&label) {
                         Some(labeled_asset) => labeled_asset.handle.clone(),
                         None => {
+                            let mut all_labels: Vec<String> = loaded_asset
+                                .labeled_assets
+                                .keys()
+                                .map(|s| (**s).to_owned())
+                                .collect();
+                            all_labels.sort_unstable();
                             return Err(AssetLoadError::MissingLabel {
                                 base_path,
                                 label: label.to_string(),
+                                all_labels,
                             });
                         }
                     }
@@ -1138,10 +1145,15 @@ pub enum AssetLoadError {
         loader_name: &'static str,
         error: Box<dyn std::error::Error + Send + Sync + 'static>,
     },
-    #[error("The file at '{base_path}' does not contain the labeled asset '{label}'.")]
+    #[error("The file at '{}' does not contain the labeled asset '{}'; it contains the following {} assets: {}",
+            base_path,
+            label,
+            all_labels.len(),
+            all_labels.iter().map(|l| format!("'{}'", l)).collect::<Vec<_>>().join(", "))]
     MissingLabel {
         base_path: AssetPath<'static>,
         label: String,
+        all_labels: Vec<String>,
     },
 }
 


### PR DESCRIPTION
# Objective

When you have no idea what to put after `#` when loading an asset, error message may help.

## Solution

Add all labels to the error message.

## Test plan

Modified `anti_alias` example to put incorrect label, the error is:

```
2024-01-08T07:41:25.462287Z ERROR bevy_asset::server: The file at 'models/FlightHelmet/FlightHelmet.gltf' does not contain the labeled asset 'Rrrr'; it contains the following 25 assets: 'Material0', 'Material1', 'Material2', 'Material3', 'Material4', 'Material5', 'Mesh0', 'Mesh0/Primitive0', 'Mesh1', 'Mesh1/Primitive0', 'Mesh2', 'Mesh2/Primitive0', 'Mesh3', 'Mesh3/Primitive0', 'Mesh4', 'Mesh4/Primitive0', 'Mesh5', 'Mesh5/Primitive0', 'Node0', 'Node1', 'Node2', 'Node3', 'Node4', 'Node5', 'Scene0'
```