### PR TITLE
Cleanup bevy_winit

### DIFF
--- a/crates/bevy_window/src/event.rs
+++ b/crates/bevy_window/src/event.rs
@@ -332,7 +332,7 @@ pub enum FileDragAndDrop {
 )]
 pub struct WindowMoved {
     /// Window that moved.
-    pub entity: Entity,
+    pub window: Entity,
     /// Where the window moved to in physical pixels.
     pub position: IVec2,
 }

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -1,11 +1,10 @@
-use bevy_a11y::AccessibilityRequested;
 use bevy_ecs::{
     entity::Entity,
     event::EventWriter,
     prelude::{Changed, Component, Resource},
+    query::QueryFilter,
     removal_detection::RemovedComponents,
-    system::{Commands, NonSendMut, Query, ResMut},
-    world::Mut,
+    system::{NonSendMut, Query, SystemParamItem},
 };
 use bevy_utils::{
     tracing::{error, info, warn},
@@ -20,12 +19,11 @@ use winit::{
 };
 
 use crate::{
-    accessibility::{AccessKitAdapters, WinitActionHandlers},
     converters::{
         self, convert_enabled_buttons, convert_window_level, convert_window_theme,
         convert_winit_theme,
     },
-    get_best_videomode, get_fitting_videomode, WindowAndInputEventWriters, WinitWindows,
+    get_best_videomode, get_fitting_videomode, CreateWindowParams, WinitWindows,
 };
 
 /// Creates new windows on the [`winit`] backend for each entity with a newly-added
@@ -34,17 +32,19 @@ use crate::{
 /// If any of these entities are missing required components, those will be added with their
 /// default values.
 #[allow(clippy::too_many_arguments)]
-pub(crate) fn create_windows<'a>(
+pub(crate) fn create_windows<F: QueryFilter + 'static>(
     event_loop: &EventLoopWindowTarget<()>,
-    mut commands: Commands,
-    created_windows: impl Iterator<Item = (Entity, Mut<'a, Window>)>,
-    mut event_writer: EventWriter<WindowCreated>,
-    mut winit_windows: NonSendMut<WinitWindows>,
-    mut adapters: NonSendMut<AccessKitAdapters>,
-    mut handlers: ResMut<WinitActionHandlers>,
-    accessibility_requested: ResMut<AccessibilityRequested>,
+    (
+        mut commands,
+        mut created_windows,
+        mut window_created_events,
+        mut winit_windows,
+        mut adapters,
+        mut handlers,
+        accessibility_requested,
+    ): SystemParamItem<CreateWindowParams<F>>,
 ) {
-    for (entity, mut window) in created_windows {
+    for (entity, mut window) in &mut created_windows {
         if winit_windows.get_window(entity).is_some() {
             continue;
         }
@@ -81,7 +81,7 @@ pub(crate) fn create_windows<'a>(
                 window: window.clone(),
             });
 
-        event_writer.send(WindowCreated { window: entity });
+        window_created_events.send(WindowCreated { window: entity });
     }
 }
 
@@ -123,7 +123,7 @@ pub struct CachedWindow {
 pub(crate) fn changed_windows(
     mut changed_windows: Query<(Entity, &mut Window, &mut CachedWindow), Changed<Window>>,
     winit_windows: NonSendMut<WinitWindows>,
-    mut event_writers: WindowAndInputEventWriters<'_>,
+    mut window_resized: EventWriter<bevy_window::WindowResized>,
 ) {
     for (entity, mut window, mut cache) in &mut changed_windows {
         if let Some(winit_window) = winit_windows.get_window(entity) {
@@ -161,7 +161,7 @@ pub(crate) fn changed_windows(
                     window.resolution.physical_height(),
                 );
                 if let Some(size_now) = winit_window.request_inner_size(physical_size) {
-                    crate::react_to_resize(&mut window, size_now, &mut event_writers, entity);
+                    crate::react_to_resize(&mut window, size_now, &mut window_resized, entity);
                 }
             }
 


### PR DESCRIPTION
## Objective

The `bevy_winit` crate has a very large `lib.rs`, the size is daunting and discourages both contributors and reviewers. Beside, more code implies more ways to accidentally introduce bugs.

## Solution

This PR does a few things to reduce the line count, without changing logic:

- Move the winit event handler to a standalone function. This reduces the amount of indentation, and isolates relevant code.
- Replace the `WindowAndInputEventWriters` struct with direct calls to `World::send_event`. This is done through a new private extension trait called `AppSendEvent`. Now, instead of using `event_writers.specific_events.send(SpecificEvent { … })`, it directly does `app.send_event(SpecificEvent { … })`. Looking at the `send_event` implementation, I didn't see anything that would lead me to believe this is more costly or leads to different behaviors. With this change, we both reduce boilerplate on event sending and delete the `WindowAndInputEventWriters` struct
- Rename `window_entity` to `window`. This allows constructing most `bevy_window` events in a single line, rather than being split on several lines by `rustfmt`. This is also more consistent, since the `Entity` field of `bevy_window` events is called `window`, it makes sense to re-use the same name to designate the same thing. This removes a lot of boilerplate.
- Explicitly name the `CreateWindowParams` as a type alias instead of copy/pasting it about everywhere. In `create_windows`, instead of accepting each param field, accept the whole param. This removes a lot of boilerplate as well.

The combination of all those changes leads to a reduction of 200 lines.

### Notes to reviewers

You should really use the "Hide whitespaces" diff display mode.

The trickiest bit is probably the scale factor handling. Because we now directly access the world, I had to move event-sending code around, to avoid breaking mutual exclusion rules. I'm fairly confident it's the same behavior.

Another thing that deserves looking-at is non-linux plateform handling. I've only compiled this for linux targets, hence it might fail to compile on other plateforms.

---

## Changelog

- `bevy::window::WindowMoved`'s `entity` field has been renamed to `window`

## Migration Guide

`bevy::window::WindowMoved`'s `entity` field has been renamed to `window`. This is to be more consistent with other windowing events.

Consider changing usage:
```diff
-window_moved.entity
+window_moved.window
```
