### PR TITLE
AssetSaver and AssetTransformer split

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -2,6 +2,7 @@ pub mod io;
 pub mod meta;
 pub mod processor;
 pub mod saver;
+pub mod transformer;
 
 pub mod prelude {
     #[doc(hidden)]

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -527,11 +527,11 @@ impl<'a> LoadContext<'a> {
     /// deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
     /// "load dependency".
     ///
-    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadAndSave`] preprocessor,
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
     /// changing a "load dependency" will result in re-processing of the asset.
     ///
     /// [`Process`]: crate::processor::Process
-    /// [`LoadAndSave`]: crate::processor::LoadAndSave
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
     pub async fn load_direct<'b>(
         &mut self,
         path: impl Into<AssetPath<'b>>,
@@ -575,11 +575,11 @@ impl<'a> LoadContext<'a> {
     /// For example, if you are deriving a new asset from the referenced asset, or you are building a collection of assets. This will add the `path` as a
     /// "load dependency".
     ///
-    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadAndSave`] preprocessor,
+    /// If the current loader is used in a [`Process`] "asset preprocessor", such as a [`LoadTransformAndSave`] preprocessor,
     /// changing a "load dependency" will result in re-processing of the asset.
     ///
     /// [`Process`]: crate::processor::Process
-    /// [`LoadAndSave`]: crate::processor::LoadAndSave
+    /// [`LoadTransformAndSave`]: crate::processor::LoadTransformAndSave
     pub async fn load_direct_with_reader<'b>(
         &mut self,
         reader: &mut Reader<'_>,

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -18,7 +18,7 @@ use thiserror::Error;
 /// Asset "processor" logic that reads input asset bytes (stored on [`ProcessContext`]), processes the value in some way,
 /// and then writes the final processed bytes with [`Writer`]. The resulting bytes must be loadable with the given [`Process::OutputLoader`].
 ///
-/// This is a "low level", maximally flexible interface. Most use cases are better served by the [`LoadAndSave`] implementation
+/// This is a "low level", maximally flexible interface. Most use cases are better served by the [`LoadTransformAndSave`] implementation
 /// of [`Process`].
 pub trait Process: Send + Sync + Sized + 'static {
     /// The configuration / settings used to process the asset. This will be stored in the [`AssetMeta`] and is user-configurable per-asset.

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -54,7 +54,7 @@ pub struct LoadTransformAndSave<
 > {
     transformer: T,
     saver: S,
-    marker: PhantomData<PhantomData<fn() -> L>>,
+    marker: PhantomData<fn() -> L>,
 }
 
 #[derive(Serialize, Deserialize, Default)]

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,0 +1,20 @@
+use crate::{meta::Settings, Asset};
+use serde::{Deserialize, Serialize};
+
+/// Transforms an [`Asset`] of a given [`AssetTransformer::AssetInput`] type to an [`Asset`] of [`AssetTransformer::AssetOutput`] type.
+pub trait AssetTransformer: Send + Sync + 'static {
+    /// The [`Asset`] type which this [`AssetTransformer`] takes as and input.
+    type AssetInput: Asset;
+    /// The [`Asset`] type which this [`AssetTransformer`] outputs.
+    type AssetOutput: Asset;
+    /// The settings type used by this [`AssetTransformer`].
+    type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
+    /// The type of [error](`std::error::Error`) which could be encountered by this saver.
+    type Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    fn transform<'a>(
+        &'a self,
+        asset: Self::AssetInput,
+        settings: &'a Self::Settings,
+    ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>>;
+}

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,6 +1,5 @@
 use crate::{meta::Settings, Asset};
 use serde::{Deserialize, Serialize};
-use std::{convert::Infallible, marker::PhantomData};
 
 /// Transforms an [`Asset`] of a given [`AssetTransformer::AssetInput`] type to an [`Asset`] of [`AssetTransformer::AssetOutput`] type.
 pub trait AssetTransformer: Send + Sync + 'static {
@@ -18,33 +17,4 @@ pub trait AssetTransformer: Send + Sync + 'static {
         asset: Self::AssetInput,
         settings: &'a Self::Settings,
     ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>>;
-}
-
-/// An [`AssetTransformer`] implementation which returns the original [`Asset`] unchanged.
-/// This is useful when
-pub struct NoopAssetTransformer<A: Asset> {
-    marker: PhantomData<fn() -> A>,
-}
-
-impl<A: Asset> AssetTransformer for NoopAssetTransformer<A> {
-    type AssetInput = A;
-    type AssetOutput = A;
-    type Settings = ();
-    type Error = Infallible;
-
-    fn transform<'a>(
-        &'a self,
-        asset: Self::AssetInput,
-        _settings: &'a Self::Settings,
-    ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        Ok(asset)
-    }
-}
-
-impl<A: Asset> Default for NoopAssetTransformer<A> {
-    fn default() -> Self {
-        NoopAssetTransformer {
-            marker: Default::default(),
-        }
-    }
 }

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,5 +1,6 @@
 use crate::{meta::Settings, Asset};
 use serde::{Deserialize, Serialize};
+use std::{convert::Infallible, marker::PhantomData};
 
 /// Transforms an [`Asset`] of a given [`AssetTransformer::AssetInput`] type to an [`Asset`] of [`AssetTransformer::AssetOutput`] type.
 pub trait AssetTransformer: Send + Sync + 'static {
@@ -17,4 +18,33 @@ pub trait AssetTransformer: Send + Sync + 'static {
         asset: Self::AssetInput,
         settings: &'a Self::Settings,
     ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>>;
+}
+
+/// An [`AssetTransformer`] implementation which returns the original [`Asset`] unchanged.
+/// This is useful when
+pub struct NoopAssetTransformer<A: Asset> {
+    marker: PhantomData<fn() -> A>,
+}
+
+impl<A: Asset> AssetTransformer for NoopAssetTransformer<A> {
+    type AssetInput = A;
+    type AssetOutput = A;
+    type Settings = ();
+    type Error = Infallible;
+
+    fn transform<'a>(
+        &'a self,
+        asset: Self::AssetInput,
+        _settings: &'a Self::Settings,
+    ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        Ok(asset)
+    }
+}
+
+impl<A: Asset> Default for NoopAssetTransformer<A> {
+    fn default() -> Self {
+        NoopAssetTransformer {
+            marker: Default::default(),
+        }
+    }
 }

--- a/examples/asset/processing/asset_processing.rs
+++ b/examples/asset/processing/asset_processing.rs
@@ -1,5 +1,4 @@
 //! This example illustrates how to define custom `AssetLoader`s, `AssetTransfomers`, and `AssetSaver`s, how to configure them, and how to register asset processors.
-//! In this example we have two asset types, Text and CoolText.
 
 use bevy::{
     asset::{
@@ -209,7 +208,7 @@ impl AssetSaver for CoolTextSaver {
         &'a self,
         writer: &'a mut Writer,
         asset: SavedAsset<'a, Self::Asset>,
-        settings: &'a Self::Settings,
+        _settings: &'a Self::Settings,
     ) -> BoxedFuture<'a, Result<TextSettings, Self::Error>> {
         Box::pin(async move {
             writer.write_all(asset.text.as_bytes()).await?;

--- a/examples/asset/processing/assets/a.cool.ron.meta
+++ b/examples/asset/processing/assets/a.cool.ron.meta
@@ -1,12 +1,13 @@
 (
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextTransformer, asset_processing::CoolTextSaver>",
         settings: (
             loader_settings: (),
-            saver_settings: (
+            transformer_settings: (
                 appended: "X",
             ),
+            saver_settings: (),
         ),
     ),
 )

--- a/examples/asset/processing/assets/d.cool.ron
+++ b/examples/asset/processing/assets/d.cool.ron
@@ -3,6 +3,7 @@
     dependencies: [
     ],
     embedded_dependencies: [
-        "foo/c.cool.ron"
+        "foo/c.cool.ron",
+        "embedded://asset_processing/e.txt"
     ],
 )

--- a/examples/asset/processing/assets/d.cool.ron.meta
+++ b/examples/asset/processing/assets/d.cool.ron.meta
@@ -1,12 +1,13 @@
 (
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextTransformer, asset_processing::CoolTextSaver>",
         settings: (
             loader_settings: (),
-            saver_settings: (
+            transformer_settings: (
                 appended: "",
             ),
+            saver_settings: (),
         ),
     ),
 )

--- a/examples/asset/processing/assets/foo/b.cool.ron.meta
+++ b/examples/asset/processing/assets/foo/b.cool.ron.meta
@@ -1,12 +1,13 @@
 (
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextTransformer, asset_processing::CoolTextSaver>",
         settings: (
             loader_settings: (),
-            saver_settings: (
+            transformer_settings: (
                 appended: "",
             ),
+            saver_settings: (),
         ),
     ),
 )

--- a/examples/asset/processing/assets/foo/c.cool.ron.meta
+++ b/examples/asset/processing/assets/foo/c.cool.ron.meta
@@ -1,12 +1,13 @@
 (
     meta_format_version: "1.0",
     asset: Process(
-        processor: "bevy_asset::processor::process::LoadAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextSaver>",
+        processor: "bevy_asset::processor::process::LoadTransformAndSave<asset_processing::CoolTextLoader, asset_processing::CoolTextTransformer, asset_processing::CoolTextSaver>",
         settings: (
             loader_settings: (),
-            saver_settings: (
+            transformer_settings: (
                 appended: "",
             ),
+            saver_settings: (),
         ),
     ),
 )


### PR DESCRIPTION
# Objective
One of a few Bevy Asset improvements I would like to make: #11216.

Currently asset processing and asset saving are handled by the same trait, `AssetSaver`. This makes it difficult to reuse saving implementations and impossible to have a single "universal" saver for a given asset type.

## Solution
This PR splits off the processing portion of `AssetSaver` into `AssetTransformer`, which is responsible for transforming assets. This change involves adding the `LoadTransformAndSave` processor, which utilizes the new API. The `LoadAndSave` still exists since it remains useful in situations where no "transformation" of the asset is done, such as when compressing assets.

## Notes:
As an aside, Bikeshedding is welcome on the names. I'm not entirely convinced by `AssetTransformer`, which was chosen mostly because `AssetProcessor` is taken. Additionally, `LoadTransformSave` may be sufficient instead of `LoadTransformAndSave`.


---

## Changelog
### Added 
- `AssetTransformer` which is responsible for transforming Assets.
- `LoadTransformAndSave`, a `Process` implementation.
### Changed
- Changed `AssetSaver`'s responsibilities from processing and saving to just saving.
- Updated `asset_processing` example to use new API.
- Old asset .meta files regenerated with new processor.
