### PR TITLE
Confidence intervals for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ bytemuck = "1.7"
 futures-lite = "2.0.1"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
+bevy_test_utils = { path = "crates/bevy_test_utils", version = "0.0.0" }
 
 [[example]]
 name = "hello_world"

--- a/crates/bevy_test_utils/Cargo.toml
+++ b/crates/bevy_test_utils/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "bevy_test_utils"
+version = "0.0.0"
+edition = "2021"
+publish = false
+description = "Utilities for self-testing Bevy"
+
+[dependencies]
+bevy_app = { path = "../bevy_app" }
+bevy_ecs = { path = "../bevy_ecs" }
+bevy_log = { path = "../bevy_log" }
+bevy_time = { path = "../bevy_time" }
+
+[lints]
+workspace = true

--- a/crates/bevy_test_utils/src/fbs_benchmark.rs
+++ b/crates/bevy_test_utils/src/fbs_benchmark.rs
@@ -1,0 +1,120 @@
+use std::time::{Duration, Instant};
+
+use bevy_ecs::system::Local;
+use bevy_log::{info, warn};
+
+/// Welford's method for computing variance.
+#[derive(Default, Debug)]
+struct Welford {
+    n: u64,
+    x: f64,
+    s2: f64,
+}
+
+impl Welford {
+    /// Add a new sample.
+    fn add(&mut self, x: f64) {
+        let new_n = self.n + 1;
+        let new_x = self.x + (x - self.x) / (new_n as f64);
+        let new_s2 = self.s2 + (x - self.x) * (x - new_x);
+
+        self.n = new_n;
+        self.x = new_x;
+        self.s2 = new_s2;
+    }
+
+    /// Compute standard deviation.
+    fn std(&self) -> f64 {
+        let var = self.s2 / ((self.n - 1) as f64);
+        var.sqrt()
+    }
+
+    /// Compute mean.
+    fn mean(&self) -> f64 {
+        self.x
+    }
+}
+
+/// Welford's method.
+#[derive(Default, Debug)]
+pub(crate) struct FpsBenchmarkState {
+    last_run: Option<Instant>,
+    started: Option<Instant>,
+    frames: u64,
+    welford: Welford,
+}
+
+pub(crate) fn fps_benchmark_system(
+    mut state: Local<FpsBenchmarkState>,
+    mut local_last_print: Local<Option<Instant>>,
+) {
+    if local_last_print.is_none() {
+        warn!(
+            "Benchmark outputs need to be dealt with carefully!\n\
+            First, algorithm assumes normal distribution of frame times, which is not true.\n\"\
+            Second, program performance varies a lot depending on the environment, for example:\n\
+            - CPU frequency is throttled when the CPU is too hot or battery is too low\n\
+            - other processes running on the system, like a browser, slow down this application\n\
+            - render iteration is faster when window is not visible\n\
+            - random program state like heap fragmentation or hash collisions\n\
+              systematically affect performance and this is not corrected\n\
+              by running the benchmark for a long time"
+        );
+    }
+
+    state.frames += 1;
+    let now = Instant::now();
+    if let (Some(last_run), Some(started)) = (state.last_run, state.started) {
+        // Do not update statistics while the application is warming up.
+        // Output would be converge if we did, but it would take longer to converge,
+        // and statistics would be less accurate.
+        if now - started >= Duration::from_secs(1) && state.frames >= 100 {
+            let x = (now - last_run).as_secs_f64();
+            state.welford.add(x);
+        }
+    }
+    state.last_run = Some(now);
+    if state.started.is_none() {
+        state.started = Some(now);
+    }
+
+    if let Some(last_print) = *local_last_print {
+        if (now - last_print).as_secs_f64() >= 1.0 && state.welford.n >= 2 {
+            let n = state.welford.n;
+
+            info!("frame count: {}", n);
+
+            let frame_time_mean = state.welford.mean();
+            let frame_time_std = state.welford.std();
+            let frame_time_error = frame_time_std / (n as f64).sqrt();
+            // Multiply by 3 to get 99.7% confidence interval.
+            // But careful, this is assuming normal distribution of frame times,
+            // which is not true.
+            info!(
+                "frame time : {:>5}us +- {:>4}us",
+                (frame_time_mean * 1_000_000.0) as u64,
+                (frame_time_error * 1_000_000.0 * 3.0) as u64
+            );
+
+            // Now computing error of FPS.
+            // We can reasonably assume than mean of FPS is inverse of mean of frame duration.
+            // (Which is, again, not true, because frame time distribution is skewed.)
+            let fps_mean = 1.0 / frame_time_mean;
+
+            // Standard deviation of f(x) is approximately f'(mean(x)) * std(x).
+            // f(x) = 1 / x
+            // f'(x) = -1 / x^2
+            // std(f) = (1 / mean(x)^2) * std(x)
+            let fps_std = frame_time_std / frame_time_mean.powi(2);
+
+            // And now compute the error of FPS.
+            let fps_error = fps_std / (n as f64).sqrt();
+
+            // See above about multiplying by 3.
+            info!("fps        : {:7.3} +- {:.3}", fps_mean, fps_error * 3.0);
+            *local_last_print = Some(now);
+        }
+    } else {
+        *local_last_print = Some(now);
+    }
+}

--- a/crates/bevy_test_utils/src/lib.rs
+++ b/crates/bevy_test_utils/src/lib.rs
@@ -1,0 +1,14 @@
+use bevy_app::{App, Plugin, Update};
+
+use crate::fbs_benchmark::fps_benchmark_system;
+
+mod fbs_benchmark;
+
+/// Output frame rate in Bevy benchmarks.
+pub struct BenchmarkPlugin;
+
+impl Plugin for BenchmarkPlugin {
+    fn build(&self, app: &mut App) {
+        app.add_systems(Update, fps_benchmark_system);
+    }
+}

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -5,15 +5,16 @@
 
 use std::time::Duration;
 
+use rand::Rng;
+
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::LogDiagnosticsPlugin,
     math::Quat,
     prelude::*,
     render::camera::Camera,
     window::{PresentMode, WindowResolution},
 };
-
-use rand::Rng;
+use bevy_test_utils::BenchmarkPlugin;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
@@ -22,7 +23,7 @@ fn main() {
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugins((
             LogDiagnosticsPlugin::default(),
-            FrameTimeDiagnosticsPlugin,
+            BenchmarkPlugin,
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     present_mode: PresentMode::AutoNoVsync,

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -1,10 +1,12 @@
 /// General UI benchmark that stress tests layouting, text, interaction and rendering
 use argh::FromArgs;
+
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     prelude::*,
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_internal::diagnostic::LogDiagnosticsPlugin;
+use bevy_test_utils::BenchmarkPlugin;
 
 const FONT_SIZE: f32 = 7.0;
 
@@ -54,8 +56,8 @@ fn main() {
             }),
             ..default()
         }),
-        FrameTimeDiagnosticsPlugin,
         LogDiagnosticsPlugin::default(),
+        BenchmarkPlugin,
     ))
     .add_systems(Update, button_system);
 

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -21,6 +21,7 @@ use bevy::{
     },
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
 #[derive(FromArgs, Resource)]
@@ -79,7 +80,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            FrameTimeDiagnosticsPlugin,
+            BenchmarkPlugin,
             LogDiagnosticsPlugin::default(),
         ))
         .insert_resource(args)

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -5,12 +5,14 @@ use std::f32::consts::PI;
 use std::time::Duration;
 
 use argh::FromArgs;
+
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::LogDiagnosticsPlugin,
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 #[derive(FromArgs, Resource)]
 /// `many_foxes` stress test
@@ -47,7 +49,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            FrameTimeDiagnosticsPlugin,
+            BenchmarkPlugin,
             LogDiagnosticsPlugin::default(),
         ))
         .insert_resource(Foxes {

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -6,11 +6,12 @@
 //! To recompute all text each frame run
 //! `cargo run --example many_glyphs --release recompute-text`
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::LogDiagnosticsPlugin,
     prelude::*,
     text::{BreakLineOn, Text2dBounds},
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 fn main() {
     let mut app = App::new();
@@ -23,7 +24,7 @@ fn main() {
             }),
             ..default()
         }),
-        FrameTimeDiagnosticsPlugin,
+        BenchmarkPlugin,
         LogDiagnosticsPlugin::default(),
     ))
     .add_systems(Startup, setup);

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -3,15 +3,17 @@
 
 use std::f64::consts::PI;
 
+use rand::{thread_rng, Rng};
+
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::LogDiagnosticsPlugin,
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
     prelude::*,
     render::{camera::ScalingMode, Render, RenderApp, RenderSet},
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
-use rand::{thread_rng, Rng};
+use bevy_test_utils::BenchmarkPlugin;
 
 fn main() {
     App::new()
@@ -26,7 +28,7 @@ fn main() {
                 }),
                 ..default()
             }),
-            FrameTimeDiagnosticsPlugin,
+            BenchmarkPlugin,
             LogDiagnosticsPlugin::default(),
             LogVisibleLights,
         ))

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -7,13 +7,14 @@
 //! Add the `--colored` arg to run with color tinted sprites. This will cause the sprites to be rendered
 //! in multiple batches, reducing performance but useful for testing.
 
+use rand::Rng;
+
 use bevy::{
-    diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
+    diagnostic::LogDiagnosticsPlugin,
     prelude::*,
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
-
-use rand::Rng;
+use bevy_test_utils::BenchmarkPlugin;
 
 const CAMERA_SPEED: f32 = 1000.0;
 
@@ -30,7 +31,7 @@ fn main() {
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugins((
             LogDiagnosticsPlugin::default(),
-            FrameTimeDiagnosticsPlugin,
+            BenchmarkPlugin,
             DefaultPlugins.set(WindowPlugin {
                 primary_window: Some(Window {
                     present_mode: PresentMode::AutoNoVsync,


### PR DESCRIPTION
# Objective

Benchmarks output some numbers to the console which are hard to interpret, and even harder to make decisions based on.

When I submit PRs, I sometimes get comment like "we need a benchmark", I don't see a good benchmarking solution to answer to these comments.

For microbenchmarking I complained about usefulness of criterion before, and this is my complaint about macro scale benchmarking.

## Solution

Compute mean and error for frame time and FPS, output it to the console instead.

Add `BenchmarkPlugin`, available only to examples.

Unlike `FrameTimeDiagnosticPlugin`
- computes total statistics (from program start, not discounted with time)
- computes error

Error of frame time is computed assuming standard distribution. This is incorrect, but good approximation.

"Mean" of FPS and error of FPS are computed from mean and errors of frame time.

Numbers are somewhat useful, but not 100% reliable. I tried running this command:

```
cargo run --example many_animated_sprites --release
```

7 times up to 30000 frames. The output was:

```
frame count: 31046
frame time :  0.002000 +- 0.000023
fps        : 500.072 +- 5.778

frame count: 30504
frame time :  0.002003 +- 0.000023
fps        : 499.346 +- 5.647

frame count: 30336
frame time :  0.001981 +- 0.000023
fps        : 504.750 +- 5.777

frame count: 30062
frame time :  0.002000 +- 0.000024
fps        : 500.113 +- 6.062

frame count: 30283
frame time :  0.001984 +- 0.000022
fps        : 503.990 +- 5.588

frame count: 30176
frame time :  0.001958 +- 0.000020
fps        : 510.627 +- 5.255

frame count: 30314
frame time :  0.001983 +- 0.000020
fps        : 504.403 +- 5.177

frame count: 30572
frame time :  0.001999 +- 0.000022
fps        : 500.207 +- 5.515
```

Which means some values (like 5th run) is outside of confidence interval. Which probably means:
- my statistics is too much incorrect
- something happened on my machine or in the process why this test was running

Anyway, I added a big warning to the console to not misinterpret output.

This solution is not perfect. Because it is not fully automated, and outputs needs to be carefully inspected.

Proper solution might be this:
- patch benchmarking apps to be able to optionally run the fixed number of iterations (like 10000)
- compile two binaries of the example, before/after the change
- use a tool like mine [absh](https://github.com/stepancheg/absh) to run A/B/A/B/... in loop until it converges

Maybe I should do that instead, I don't know.