### PR TITLE
Stop after BEVY_BENCHMARK_ITER_COUNT iterations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,6 +303,7 @@ bytemuck = "1.7"
 futures-lite = "2.0.1"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
+bevy_test_utils = { path = "crates/bevy_test_utils", version = "0.0.0" }
 
 [[example]]
 name = "hello_world"

--- a/crates/bevy_test_utils/Cargo.toml
+++ b/crates/bevy_test_utils/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "bevy_test_utils"
+version = "0.0.0"
+edition = "2021"
+description = "Utilities for self-testing Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+publish = false
+
+[dependencies]
+bevy_app = { path = "../bevy_app", version = "0.12.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
+bevy_log = { path = "../bevy_log", version = "0.12.0" }
+bevy_time = { path = "../bevy_time", version = "0.12.0" }
+
+[lints]
+workspace = true

--- a/crates/bevy_test_utils/src/lib.rs
+++ b/crates/bevy_test_utils/src/lib.rs
@@ -1,0 +1,26 @@
+use bevy_app::{App, AppExit, Plugin, Update};
+use bevy_ecs::event::EventWriter;
+use bevy_log::info;
+use std::env;
+
+/// Output frame rate in Bevy benchmarks.
+pub struct BenchmarkPlugin;
+
+impl Plugin for BenchmarkPlugin {
+    fn build(&self, app: &mut App) {
+        if let Ok(arg) = env::var("BEVY_BENCHMARK_ITER_COUNT") {
+            let mut iter_count = arg
+                .parse::<u64>()
+                .expect("BEVY_BENCHMARK_ITER_COUNT must be a number");
+            info!("Will stop after {} iterations", iter_count);
+            app.add_systems(Update, move |mut app_exit_events: EventWriter<AppExit>| {
+                match iter_count.checked_sub(1) {
+                    Some(count) => iter_count = count,
+                    None => {
+                        app_exit_events.send(AppExit);
+                    }
+                }
+            });
+        }
+    }
+}

--- a/examples/stress_tests/many_animated_sprites.rs
+++ b/examples/stress_tests/many_animated_sprites.rs
@@ -13,6 +13,7 @@ use bevy::{
     window::{PresentMode, WindowResolution},
 };
 
+use bevy_test_utils::BenchmarkPlugin;
 use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
@@ -21,6 +22,7 @@ fn main() {
     App::new()
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugins((
+            BenchmarkPlugin,
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin,
             DefaultPlugins.set(WindowPlugin {

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -5,6 +5,7 @@ use bevy::{
     prelude::*,
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 const FONT_SIZE: f32 = 7.0;
 
@@ -54,6 +55,7 @@ fn main() {
             }),
             ..default()
         }),
+        BenchmarkPlugin,
         FrameTimeDiagnosticsPlugin,
         LogDiagnosticsPlugin::default(),
     ))

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -21,6 +21,7 @@ use bevy::{
     },
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 use rand::{rngs::StdRng, seq::SliceRandom, Rng, SeedableRng};
 
 #[derive(FromArgs, Resource)]
@@ -79,6 +80,7 @@ fn main() {
                 }),
                 ..default()
             }),
+            BenchmarkPlugin,
             FrameTimeDiagnosticsPlugin,
             LogDiagnosticsPlugin::default(),
         ))

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -11,6 +11,7 @@ use bevy::{
     prelude::*,
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 #[derive(FromArgs, Resource)]
 /// `many_foxes` stress test
@@ -47,6 +48,7 @@ fn main() {
                 }),
                 ..default()
             }),
+            BenchmarkPlugin,
             FrameTimeDiagnosticsPlugin,
             LogDiagnosticsPlugin::default(),
         ))

--- a/examples/stress_tests/many_gizmos.rs
+++ b/examples/stress_tests/many_gizmos.rs
@@ -5,6 +5,7 @@ use bevy::{
     prelude::*,
     window::{PresentMode, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 const SYSTEM_COUNT: u32 = 10;
 
@@ -20,6 +21,7 @@ fn main() {
             }),
             ..default()
         }),
+        BenchmarkPlugin,
         FrameTimeDiagnosticsPlugin,
     ))
     .insert_resource(Config {

--- a/examples/stress_tests/many_glyphs.rs
+++ b/examples/stress_tests/many_glyphs.rs
@@ -11,6 +11,7 @@ use bevy::{
     text::{BreakLineOn, Text2dBounds},
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 
 fn main() {
     let mut app = App::new();
@@ -23,6 +24,7 @@ fn main() {
             }),
             ..default()
         }),
+        BenchmarkPlugin,
         FrameTimeDiagnosticsPlugin,
         LogDiagnosticsPlugin::default(),
     ))

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -11,6 +11,7 @@ use bevy::{
     render::{camera::ScalingMode, Render, RenderApp, RenderSet},
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
+use bevy_test_utils::BenchmarkPlugin;
 use rand::{thread_rng, Rng};
 
 fn main() {
@@ -26,6 +27,7 @@ fn main() {
                 }),
                 ..default()
             }),
+            BenchmarkPlugin,
             FrameTimeDiagnosticsPlugin,
             LogDiagnosticsPlugin::default(),
             LogVisibleLights,

--- a/examples/stress_tests/many_sprites.rs
+++ b/examples/stress_tests/many_sprites.rs
@@ -13,6 +13,7 @@ use bevy::{
     window::{PresentMode, WindowPlugin, WindowResolution},
 };
 
+use bevy_test_utils::BenchmarkPlugin;
 use rand::Rng;
 
 const CAMERA_SPEED: f32 = 1000.0;
@@ -29,6 +30,7 @@ fn main() {
         ))
         // Since this is also used as a benchmark, we want it to display performance data.
         .add_plugins((
+            BenchmarkPlugin,
             LogDiagnosticsPlugin::default(),
             FrameTimeDiagnosticsPlugin,
             DefaultPlugins.set(WindowPlugin {


### PR DESCRIPTION
# Objective

When submitting a PR, it is not always clear how to measure whether it makes code slower or faster.

## Solution

Add `BEVY_BENCHMARK_ITER_COUNT` env variable for stress test benchmarks.

Benchmark exits after given number of iteration. So external program can be used to measure performance difference.

## Test plan

Compile `many_cubes` example with command

```sh
cargo build --release --example many_cubes
```

Before is `main`, after is with patch which disabled parallel iteration:

```diff
--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -126,7 +126,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
         #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
         {
             let thread_count = bevy_tasks::ComputeTaskPool::get().thread_num();
-            if thread_count <= 1 {
+            if thread_count <= 1 || true {
                 // SAFETY: See the safety comment above.
                 unsafe {
                     self.state
```

Test with [absh](https://github.com/stepancheg/absh) utility

```sh
absh \
    -a 'BEVY_BENCHMARK_ITER_COUNT=1000 ~/many_cubes-a' \
    -b 'BEVY_BENCHMARK_ITER_COUNT=1000 ~/many_cubes-b' \
    -im
```

Command output statistics like this:

<img width="475" alt="image" src="https://github.com/bevyengine/bevy/assets/28969/2b7bbd9a-3a80-4225-a26d-52b6839d4839">

In this case it means, disabling parallel iteration costs about 6% performance, and no memory usage change. Exactly as expected.