### PR TITLE
Replace `console_error_panic_hook` and throw the panic instead

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -31,8 +31,8 @@ tracy-client = { version = "0.16", optional = true }
 android_log-sys = "0.3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2.1"
+wasm-bindgen = "0.2.89"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

By throwing the panic instead of `console.error`ing it, it has practically the same effect, but the main difference is that you can actually handle it by using `window.onerror`.

As an example, I have this error screen: 
![image](https://github.com/bevyengine/bevy/assets/142252300/9ef17c67-af10-4fc9-8fc3-c0f095c32737)

This is easily achieved with this change by having a function like this:
```js
window.onerror = (_ev, _source, _line, _col, e) => {
    error.innerText = e;
    stack.innerText = e?.stack;
    fatal.hidden = false;
};
```

And the panic is still nicely logged
![image](https://github.com/bevyengine/bevy/assets/142252300/95416d2b-fe0f-40b1-8ee3-30e70a5ec73a)


---

## Changelog

- Changed `bevy_log` to throw panics in WASM instead of just logging them.