### PR TITLE
Skip rehashing TypeIds

### DIFF
--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -66,13 +66,11 @@ impl std::hash::Hasher for NoOpTypeIdHasher {
         self.0
     }
 
-    fn write(&mut self, bytes: &[u8]) {
+    fn write(&mut self, _bytes: &[u8]) {
         // This will never be called: TypeId always just calls write_u64 once!
         // This is unlikely to ever change, but as it isn't officially guaranteed,
-        // here's a fallback (which can be very low quality).
-        self.0 = bytes.iter().fold(self.0, |hash, b| {
-            hash.rotate_left(8).wrapping_add(*b as u64)
-        });
+        // panicking will let us detect this as fast as possible.
+        unimplemented!("Hashing of std::any::TypeId changed");
     }
 
     fn write_u64(&mut self, i: u64) {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -58,7 +58,7 @@ type TypeIdMap<V> =
 
 #[doc(hidden)]
 #[derive(Default)]
-pub struct NoOpTypeIdHasher(u64);
+struct NoOpTypeIdHasher(u64);
 
 // TypeId already contains a high-quality hash, so skip re-hashing that hash.
 impl std::hash::Hasher for NoOpTypeIdHasher {

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -76,7 +76,7 @@ impl std::hash::Hasher for NoOpTypeIdHasher {
     }
 
     fn write_u64(&mut self, i: u64) {
-        self.0 = i
+        self.0 = i;
     }
 }
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -53,7 +53,32 @@ pub mod prelude {
 pub use bevy_utils::all_tuples;
 
 /// A specialized hashmap type with Key of [`TypeId`]
-type TypeIdMap<V> = rustc_hash::FxHashMap<TypeId, V>;
+type TypeIdMap<V> =
+    std::collections::HashMap<TypeId, V, std::hash::BuildHasherDefault<NoOpTypeIdHasher>>;
+
+#[doc(hidden)]
+#[derive(Default)]
+pub struct NoOpTypeIdHasher(u64);
+
+// TypeId already contains a high-quality hash, so skip re-hashing that hash.
+impl std::hash::Hasher for NoOpTypeIdHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        // This will never be called: TypeId always just calls write_u64 once!
+        // This is unlikely to ever change, but as it isn't officially guaranteed,
+        // here's a fallback (which can be very low quality).
+        self.0 = bytes.iter().fold(self.0, |hash, b| {
+            hash.rotate_left(8).wrapping_add(*b as u64)
+        });
+    }
+
+    fn write_u64(&mut self, i: u64) {
+        self.0 = i
+    }
+}
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Objective

`TypeId` contains a high-quality hash. Whenever a lookup based on a `TypeId` is performed (e.g. to insert/remove components), the hash is run through a second hash function. This is unnecessary.

## Solution

Skip re-hashing `TypeId`s.

In my [testing](https://gist.github.com/SpecificProtagonist/4b49ad74c6b82b0aedd3b4ea35121be8), this improves lookup performance consistently by 10%-15% (of course, the lookup is only a small part of e.g. a bundle insertion).