### PR TITLE
Remove unused event-listener dependency

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -22,7 +22,6 @@ bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 bevy_ecs_macros = { path = "macros", version = "0.12.0" }
 
 async-channel = "1.4"
-event-listener = "2.5"
 thread_local = "1.1.4"
 fixedbitset = "0.4.2"
 rustc-hash = "1.1"


### PR DESCRIPTION
# Objective

This dependency is seemingly no longer used directly after #7267.

Unfortunately, this doesn't fix us having versions of `event-listener` in our tree.

Closes #10654

## Solution

Remove it, see if anything breaks.