### PR TITLE
Remove unnecessary unsafe impls for WinitWindows on Wasm

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -356,9 +356,3 @@ pub fn winit_window_position(
         }
     }
 }
-
-// WARNING: this only works under the assumption that wasm runtime is single threaded
-#[cfg(target_arch = "wasm32")]
-unsafe impl Send for WinitWindows {}
-#[cfg(target_arch = "wasm32")]
-unsafe impl Sync for WinitWindows {}


### PR DESCRIPTION
# Objective

In the past `winit::window::Window` was not Send + Sync on web. https://github.com/rust-windowing/winit/pull/2834 made `winit::window::Window` Sync + Send so Bevy's `unsafe impl` is no longer necessary.

## Solution

Remove the unsafe impls.