### PR TITLE
auto create imported asset folder if needed

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -74,8 +74,8 @@ impl FileAssetWriter {
     /// watching for changes.
     ///
     /// See `get_base_path` below.
-    pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P, should_create: bool) -> Self {
-        if should_create {
+    pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P, create_root: bool) -> Self {
+        if create_root {
             if let Err(e) = std::fs::create_dir_all(&path) {
                 error!(
                     "Failed to create root directory {:?} for file asset writer: {:?}",

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -6,6 +6,7 @@ mod file_asset;
 #[cfg(not(feature = "multi-threaded"))]
 mod sync_file_asset;
 
+use bevy_log::warn;
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
 
@@ -73,7 +74,15 @@ impl FileAssetWriter {
     /// watching for changes.
     ///
     /// See `get_base_path` below.
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P, should_create: bool) -> Self {
+        if should_create {
+            if let Err(e) = std::fs::create_dir_all(&path) {
+                warn!(
+                    "Failed to create root directory {:?} for file asset reader: {:?}",
+                    path, e
+                );
+            }
+        }
         Self {
             root_path: get_base_path().join(path.as_ref()),
         }

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -6,7 +6,7 @@ mod file_asset;
 #[cfg(not(feature = "multi-threaded"))]
 mod sync_file_asset;
 
-use bevy_log::warn;
+use bevy_log::error;
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
 
@@ -77,8 +77,8 @@ impl FileAssetWriter {
     pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P, should_create: bool) -> Self {
         if should_create {
             if let Err(e) = std::fs::create_dir_all(&path) {
-                warn!(
-                    "Failed to create root directory {:?} for file asset reader: {:?}",
+                error!(
+                    "Failed to create root directory {:?} for file asset writer: {:?}",
                     path, e
                 );
             }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -111,7 +111,7 @@ impl<'a> PartialEq for AssetSourceId<'a> {
 #[derive(Default)]
 pub struct AssetSourceBuilder {
     pub reader: Option<Box<dyn FnMut() -> Box<dyn AssetReader> + Send + Sync>>,
-    pub writer: Option<Box<dyn FnMut() -> Option<Box<dyn AssetWriter>> + Send + Sync>>,
+    pub writer: Option<Box<dyn FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync>>,
     pub watcher: Option<
         Box<
             dyn FnMut(crossbeam_channel::Sender<AssetSourceEvent>) -> Option<Box<dyn AssetWatcher>>
@@ -120,7 +120,8 @@ pub struct AssetSourceBuilder {
         >,
     >,
     pub processed_reader: Option<Box<dyn FnMut() -> Box<dyn AssetReader> + Send + Sync>>,
-    pub processed_writer: Option<Box<dyn FnMut() -> Option<Box<dyn AssetWriter>> + Send + Sync>>,
+    pub processed_writer:
+        Option<Box<dyn FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync>>,
     pub processed_watcher: Option<
         Box<
             dyn FnMut(crossbeam_channel::Sender<AssetSourceEvent>) -> Option<Box<dyn AssetWatcher>>
@@ -142,8 +143,8 @@ impl AssetSourceBuilder {
         watch_processed: bool,
     ) -> Option<AssetSource> {
         let reader = self.reader.as_mut()?();
-        let writer = self.writer.as_mut().and_then(|w| w());
-        let processed_writer = self.processed_writer.as_mut().and_then(|w| w());
+        let writer = self.writer.as_mut().and_then(|w| w(false));
+        let processed_writer = self.processed_writer.as_mut().and_then(|w| w(true));
         let mut source = AssetSource {
             id: id.clone(),
             reader,
@@ -200,7 +201,7 @@ impl AssetSourceBuilder {
     /// Will use the given `writer` function to construct unprocessed [`AssetWriter`] instances.
     pub fn with_writer(
         mut self,
-        writer: impl FnMut() -> Option<Box<dyn AssetWriter>> + Send + Sync + 'static,
+        writer: impl FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync + 'static,
     ) -> Self {
         self.writer = Some(Box::new(writer));
         self
@@ -230,7 +231,7 @@ impl AssetSourceBuilder {
     /// Will use the given `writer` function to construct processed [`AssetWriter`] instances.
     pub fn with_processed_writer(
         mut self,
-        writer: impl FnMut() -> Option<Box<dyn AssetWriter>> + Send + Sync + 'static,
+        writer: impl FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync + 'static,
     ) -> Self {
         self.processed_writer = Some(Box::new(writer));
         self
@@ -443,10 +444,13 @@ impl AssetSource {
     /// the asset root. This will return [`None`] if this platform does not support writing assets by default.
     pub fn get_default_writer(
         _path: String,
-    ) -> impl FnMut() -> Option<Box<dyn AssetWriter>> + Send + Sync {
-        move || {
+    ) -> impl FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync {
+        move |_should_create: bool| {
             #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
-            return Some(Box::new(super::file::FileAssetWriter::new(&_path)));
+            return Some(Box::new(super::file::FileAssetWriter::new(
+                &_path,
+                _should_create,
+            )));
             #[cfg(any(target_arch = "wasm32", target_os = "android"))]
             return None;
         }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -445,11 +445,11 @@ impl AssetSource {
     pub fn get_default_writer(
         _path: String,
     ) -> impl FnMut(bool) -> Option<Box<dyn AssetWriter>> + Send + Sync {
-        move |_should_create: bool| {
+        move |_create_root: bool| {
             #[cfg(all(not(target_arch = "wasm32"), not(target_os = "android")))]
             return Some(Box::new(super::file::FileAssetWriter::new(
                 &_path,
-                _should_create,
+                _create_root,
             )));
             #[cfg(any(target_arch = "wasm32", target_os = "android"))]
             return None;


### PR DESCRIPTION
# Objective

- Since #11218, example `asset_processing` fails:
```
thread 'main' panicked at crates/bevy_asset/src/io/source.rs:489:18:
Failed to create file watcher: Error { kind: PathNotFound, paths: ["examples/asset/processing/imported_assets/Default"] }
```

start from a fresh git clone or delete the folder before running to reproduce, it is in gitignore and should not be present on a fresh run
https://github.com/bevyengine/bevy/blob/a6574786757c0a0a7ddffb99fdc40ce90980fc82/.gitignore#L18

## Solution

- Auto create the `imported_assets` folder if it is configured
