### PR TITLE
Fix scene example

### DIFF
--- a/assets/scenes/load_scene_example.scn.ron
+++ b/assets/scenes/load_scene_example.scn.ron
@@ -5,7 +5,7 @@
     ),
   },
   entities: {
-    0: (
+    4294967296: (
       components: {
         "bevy_transform::components::transform::Transform": (
           translation: (
@@ -34,7 +34,7 @@
         ),
       },
     ),
-    1: (
+    4294967297: (
       components: {
         "scene::ComponentA": (
           x: 3.0,


### PR DESCRIPTION
Since #9907 the generation starts at `1` instead of `0` so `Entity::to_bits` now returns `4294967296` (ie. `u32::MAX + 1`) as the lowest number instead of `0`.

Without this change scene loading fails with this error message:
`ERROR bevy_asset::server: Failed to load asset 'scenes/load_scene_example.scn.ron' with asset loader 'bevy_scene::scene_loader::SceneLoader': Could not parse RON: 8:6: Invalid generation bits`