### PR TITLE
avoid realloc memory across frame in GpuArrayBuffer

### DIFF
--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -72,6 +72,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
             GpuArrayBuffer::Uniform(buffer) => buffer.write_buffer(device, queue),
             GpuArrayBuffer::Storage((buffer, vec)) => {
                 std::mem::swap(vec, buffer.get_mut());
+                // TODO: shrink vector size to save memory when it's not needed
                 vec.clear();
                 buffer.write_buffer(device, queue);
             }

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -71,7 +71,8 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
         match self {
             GpuArrayBuffer::Uniform(buffer) => buffer.write_buffer(device, queue),
             GpuArrayBuffer::Storage((buffer, vec)) => {
-                buffer.set(mem::take(vec));
+                std::mem::swap(vec, buffer.get_mut());
+                vec.clear();
                 buffer.write_buffer(device, queue);
             }
         }

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy_ecs::{prelude::Component, system::Resource};
 use bevy_utils::nonmax::NonMaxU32;
 use encase::{private::WriteInto, ShaderSize, ShaderType};
-use std::{marker::PhantomData, mem};
+use std::marker::PhantomData;
 use wgpu::BindingResource;
 
 /// Trait for types able to go in a [`GpuArrayBuffer`].


### PR DESCRIPTION
# Objective

- currently,bevy use GputArrayBuffer for meshUniform,however ,in GpuArrayBuffer::StorageBuffer keeps a buffer will pass to Gpu everyframe that will be drop across frame which is not necessary.

## Solution
- keep the buffer to avoid realloc 


## Peformance
Window 11 ,Intel 13400kf, NV 4070Ti
(Only the platform which support StorageBuffer will benefit from this pr)

many cubes
yellow is main   ,    red is pr 
![1](https://github.com/bevyengine/bevy/assets/45868716/873672d7-8cd1-435d-b63c-d5a80e36f4b3)
frame meantime from 3.85ms to 3.23ms,~16% reduction 

hot-spot function : batch_and_prepare_render_phase
![2](https://github.com/bevyengine/bevy/assets/45868716/295ffd15-9dc7-4cad-98b5-dbd2b44b9e72)
meantime from 1.01ms to 0.567ms,almost 100% gain

