### PR TITLE
Fix ssao only sampling mip 0

### DIFF
--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -139,7 +139,8 @@ fn gtao(@builtin(global_invocation_id) global_id: vec3<u32>) {
             s *= s; // https://github.com/GameTechDev/XeGTAO#sample-distribution
             let sample = s * sample_mul;
 
-            let sample_mip_level = clamp(log2(length(sample)) - 3.3, 0.0, 5.0); // https://github.com/GameTechDev/XeGTAO#memory-bandwidth-bottleneck
+            // * view.viewport.zw gets us from [0, 1] to [0, viewport_size], which is needed for this to get the correct mip levels
+            let sample_mip_level = clamp((log2(length(sample * view.viewport.zw)) - 3.3), 0.0, 5.0); // https://github.com/GameTechDev/XeGTAO#memory-bandwidth-bottleneck
             let sample_position_1 = load_and_reconstruct_view_space_position(uv + sample, sample_mip_level);
             let sample_position_2 = load_and_reconstruct_view_space_position(uv - sample, sample_mip_level);
 

--- a/crates/bevy_pbr/src/ssao/gtao.wgsl
+++ b/crates/bevy_pbr/src/ssao/gtao.wgsl
@@ -140,7 +140,7 @@ fn gtao(@builtin(global_invocation_id) global_id: vec3<u32>) {
             let sample = s * sample_mul;
 
             // * view.viewport.zw gets us from [0, 1] to [0, viewport_size], which is needed for this to get the correct mip levels
-            let sample_mip_level = clamp((log2(length(sample * view.viewport.zw)) - 3.3), 0.0, 5.0); // https://github.com/GameTechDev/XeGTAO#memory-bandwidth-bottleneck
+            let sample_mip_level = clamp(log2(length(sample * view.viewport.zw)) - 3.3, 0.0, 5.0); // https://github.com/GameTechDev/XeGTAO#memory-bandwidth-bottleneck
             let sample_position_1 = load_and_reconstruct_view_space_position(uv + sample, sample_mip_level);
             let sample_position_2 = load_and_reconstruct_view_space_position(uv - sample, sample_mip_level);
 


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/11222

## Solution

SSAO's sample_mip_level was always giving negative values because it was in UV space (0..1) when it needed to be in pixel units (0..resolution).

Fixing it so it properly samples lower mip levels when appropriate is a pretty large speedup (~3.2ms -> ~1ms at 4k, ~507us-> 256us at 1080p on a 6800xt), and I didn't notice any obvious visual quality differences.