### PR TITLE
Warn when bevy_sprite and bevy_pbr are not enabled with bevy_gizmos

### DIFF
--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -25,6 +25,7 @@ bevy_core = { path = "../bevy_core", version = "0.12.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
 bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
+bevy_log = { path = "../bevy_log", version = "0.12.0" }
 
 [lints]
 workspace = true

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -92,7 +92,7 @@ impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         // Gizmos cannot work without either a 3D or 2D renderer.
         #[cfg(all(not(feature = "bevy_pbr"), not(feature = "bevy_sprite")))]
-        bevy_log::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one as an optional dependency.");
+        bevy_log::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one.");
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -90,6 +90,10 @@ pub struct GizmoPlugin;
 
 impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut bevy_app::App) {
+        // Gizmos cannot work without either a 3D or 2D renderer.
+        #[cfg(all(not(feature = "bevy_pbr"), not(feature = "bevy_sprite")))]
+        bevy_utils::tracing::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one as an optional dependency.");
+
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 
         app.register_type::<GizmoConfig>()

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -92,7 +92,7 @@ impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         // Gizmos cannot work without either a 3D or 2D renderer.
         #[cfg(all(not(feature = "bevy_pbr"), not(feature = "bevy_sprite")))]
-        bevy_utils::tracing::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one as an optional dependency.");
+        bevy_log::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one as an optional dependency.");
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 


### PR DESCRIPTION
# Objective

- `bevy_gizmos` cannot work if both `bevy_sprite` and `bevy_pbr` are disabled.
- It silently fails to render, making it difficult to debug.
- Fixes #10984

## Solution

- Log an error message when `GizmoPlugin` is registered.

## Alternatives

I chose to log an error message, since it seemed the least intrusive of potential solutions. Some alternatives include:

- Choosing one dependency as the default, neglecting the other. (#11035)
- Raising a compile error when neither dependency is enabled. ([See my original comment](https://github.com/bevyengine/bevy/issues/10984#issuecomment-1873420426))
- Raising a compile warning using a macro hack. ([Pre-RFC - Add compile_warning! macro](https://internals.rust-lang.org/t/pre-rfc-add-compile-warning-macro/9370/7?u=bd103))
- Logging a warning instead of an error.
  - _This might be the better option. Let me know if I should change it._

---

## Changelog

- `bevy_gizmos` will now log an error if neither `bevy_pbr` nor `bevy_sprite` are enabled.

