### PR TITLE
Ensure animations do not overshoot their final keyframe

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -639,39 +639,6 @@ fn apply_animation(
     parents: &Query<(Has<AnimationPlayer>, Option<&Parent>)>,
     children: &Query<&Children>,
 ) {
-    /// Sets the [`Transform`] value to exactly the value it has at the provided keyframe.
-    fn set_transform_to_keyframe(
-        curve: &VariableCurve,
-        transform: &mut Mut<'_, Transform>,
-        weight: f32,
-        morphs: &mut Option<Mut<'_, MorphWeights>>,
-        keyframe: usize,
-    ) {
-        match &curve.keyframes {
-            Keyframes::Rotation(keyframes) => {
-                transform.rotation = transform.rotation.slerp(keyframes[keyframe], weight);
-            }
-            Keyframes::Translation(keyframes) => {
-                transform.translation = transform.translation.lerp(keyframes[keyframe], weight);
-            }
-            Keyframes::Scale(keyframes) => {
-                transform.scale = transform.scale.lerp(keyframes[keyframe], weight);
-            }
-            Keyframes::Weights(keyframes) => {
-                if let Some(morphs) = morphs {
-                    let target_count = morphs.weights().len();
-                    lerp_morph_weights(
-                        morphs.weights_mut(),
-                        get_keyframe(target_count, keyframes, keyframe)
-                            .iter()
-                            .copied(),
-                        weight,
-                    );
-                }
-            }
-        }
-    }
-
     if let Some(animation_clip) = animations.get(&animation.animation_clip) {
         // We don't return early because seek_to() may have been called on the animation player.
         animation.update(
@@ -790,6 +757,39 @@ fn apply_animation(
 
         if !any_path_found {
             warn!("Animation player on {root:?} did not match any entity paths.");
+        }
+    }
+}
+
+/// Sets the [`Transform`] value to exactly the value it has at the provided keyframe.
+fn set_transform_to_keyframe(
+    curve: &VariableCurve,
+    transform: &mut Mut<'_, Transform>,
+    weight: f32,
+    morphs: &mut Option<Mut<'_, MorphWeights>>,
+    keyframe: usize,
+) {
+    match &curve.keyframes {
+        Keyframes::Rotation(keyframes) => {
+            transform.rotation = transform.rotation.slerp(keyframes[keyframe], weight);
+        }
+        Keyframes::Translation(keyframes) => {
+            transform.translation = transform.translation.lerp(keyframes[keyframe], weight);
+        }
+        Keyframes::Scale(keyframes) => {
+            transform.scale = transform.scale.lerp(keyframes[keyframe], weight);
+        }
+        Keyframes::Weights(keyframes) => {
+            if let Some(morphs) = morphs {
+                let target_count = morphs.weights().len();
+                lerp_morph_weights(
+                    morphs.weights_mut(),
+                    get_keyframe(target_count, keyframes, keyframe)
+                        .iter()
+                        .copied(),
+                    weight,
+                );
+            }
         }
     }
 }

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -639,8 +639,8 @@ fn apply_animation(
     parents: &Query<(Has<AnimationPlayer>, Option<&Parent>)>,
     children: &Query<&Children>,
 ) {
-    /// Set transform to exactly the value of some keyframe.
-    fn set_keyframe(
+    /// Sets the [`Transform`] value to exactly the value it has at the provided keyframe.
+    fn set_transform_to_keyframe(
         curve: &VariableCurve,
         transform: &mut Mut<'_, Transform>,
         weight: f32,
@@ -749,13 +749,25 @@ fn apply_animation(
                     .binary_search_by(|probe| probe.partial_cmp(&animation.seek_time).unwrap())
                 {
                     Ok(n) if n >= curve.keyframe_timestamps.len() - 1 => {
-                        set_keyframe(curve, &mut transform, weight, &mut morphs, len - 1);
+                        set_transform_to_keyframe(
+                            curve,
+                            &mut transform,
+                            weight,
+                            &mut morphs,
+                            len - 1,
+                        );
                         continue;
                     } // this curve is finished
                     Ok(i) => i,
                     Err(0) => continue, // this curve isn't started yet
                     Err(n) if n > curve.keyframe_timestamps.len() - 1 => {
-                        set_keyframe(curve, &mut transform, weight, &mut morphs, len - 1);
+                        set_transform_to_keyframe(
+                            curve,
+                            &mut transform,
+                            weight,
+                            &mut morphs,
+                            len - 1,
+                        );
                         continue;
                     } // this curve is finished
                     Err(i) => i - 1,

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -644,7 +644,7 @@ fn apply_animation(
         curve: &VariableCurve,
         transform: &mut Mut<'_, Transform>,
         weight: f32,
-        morphs: &mut Result<Mut<'_, MorphWeights>, bevy_ecs::query::QueryEntityError>,
+        morphs: &mut Option<Mut<'_, MorphWeights>>,
         keyframe: usize,
     ) {
         match &curve.keyframes {
@@ -658,7 +658,7 @@ fn apply_animation(
                 transform.scale = transform.scale.lerp(keyframes[keyframe], weight);
             }
             Keyframes::Weights(keyframes) => {
-                if let Ok(morphs) = morphs {
+                if let Some(morphs) = morphs {
                     let target_count = morphs.weights().len();
                     lerp_morph_weights(
                         morphs.weights_mut(),


### PR DESCRIPTION
# Objective

- Animations can overshoot their last keyframe.
- Fixes #10832

## Solution

- If the animation exceeds the final keyframe, clamp to the final value.

## Additional context

This is an adoption of https://github.com/bevyengine/bevy/pull/10842 by @A-Walrus <3