### PR TITLE
 Change `WinitPlugin` defaults to limit game update rate when window is not visible (for real this time)

### DIFF
--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -52,10 +52,7 @@ impl WinitSettings {
 
 impl Default for WinitSettings {
     fn default() -> Self {
-        WinitSettings {
-            focused_mode: UpdateMode::Continuous,
-            unfocused_mode: UpdateMode::Continuous,
-        }
+        WinitSettings::game()
     }
 }
 


### PR DESCRIPTION
# Objective

I goofed. #7611 forgot to change the default update modes set by the `WinitPlugin`.

<https://github.com/bevyengine/bevy/blob/ce5bae55f64bb095e1516427a706a2622ccf2d23/crates/bevy_winit/src/winit_config.rs#L53-L60>

<https://github.com/bevyengine/bevy/blob/ce5bae55f64bb095e1516427a706a2622ccf2d23/crates/bevy_winit/src/lib.rs#L127>

## Solution

Change `Default` impl for `WinitSettings` to return the `game` settings that limit FPS when the app runs in the background.
