### PR TITLE
Clean up code to find the current keyframe

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -956,6 +956,7 @@ impl Plugin for AnimationPlugin {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::VariableCurve;
     use bevy_math::Vec3;

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -738,6 +738,8 @@ fn apply_animation(
                 Err(i) => i - 1,
             };
 
+            assert!(step_start + 1 <= curve.keyframe_timestamps.len());
+
             let timestamp_start = curve.keyframe_timestamps[step_start];
             let timestamp_end = curve.keyframe_timestamps[step_start + 1];
             let lerp = f32::inverse_lerp(timestamp_start, timestamp_end, animation.seek_time);

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -709,10 +709,14 @@ fn apply_animation(
 
                 // Find the current keyframe
                 // PERF: finding the current keyframe can be optimised
-                let step_start = match curve
+                // Attempt to find the keyframe at or before the current time
+                // An Ok(keyframe_index) result means an exact result was found by binary search
+                // An Err result means the keyframe was not found, and the index is the keyframe
+                let index = curve
                     .keyframe_timestamps
-                    .binary_search_by(|probe| probe.partial_cmp(&animation.seek_time).unwrap())
-                {
+                    .binary_search_by(|probe| probe.partial_cmp(&animation.seek_time).unwrap());
+
+                let step_start = match index {
                     Ok(n) if n >= curve.keyframe_timestamps.len() - 1 => continue, // this curve is finished
                     Ok(i) => i,
                     Err(0) => continue, // this curve isn't started yet

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -742,6 +742,7 @@ fn apply_animation(
 
             let timestamp_start = curve.keyframe_timestamps[step_start];
             let timestamp_end = curve.keyframe_timestamps[step_start + 1];
+            // Compute how far we are through the keyframe, normalized to [0, 1]
             let lerp = f32::inverse_lerp(timestamp_start, timestamp_end, animation.seek_time);
 
             apply_keyframe(

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -735,16 +735,16 @@ fn apply_animation(
                 Err(i) => i - 1,
             };
 
-            let ts_start = curve.keyframe_timestamps[step_start];
-            let ts_end = curve.keyframe_timestamps[step_start + 1];
-            let lerp = f32::inverse_lerp(ts_start, ts_end, animation.seek_time);
+            let timestamp_start = curve.keyframe_timestamps[step_start];
+            let timestamp_end = curve.keyframe_timestamps[step_start + 1];
+            let lerp = f32::inverse_lerp(timestamp_start, timestamp_end, animation.seek_time);
 
             apply_keyframe(
                 curve,
                 step_start,
                 weight,
                 lerp,
-                ts_end - ts_start,
+                timestamp_end - timestamp_start,
                 &mut transform,
                 &mut morphs,
             );

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -96,7 +96,8 @@ impl VariableCurve {
             Err(i) => i - 1,
         };
 
-        assert!(step_start + 1 <= self.keyframe_timestamps.len());
+        // Consumers need to be able to interpolate between the return keyframe and the next
+        assert!(step_start < self.keyframe_timestamps.len());
 
         Some(step_start)
     }
@@ -747,9 +748,8 @@ fn apply_animation(
             }
 
             // Find the current keyframe
-            let step_start = match curve.find_current_keyframe(animation.seek_time) {
-                Some(keyframe) => keyframe,
-                None => continue,
+            let Some(step_start) = curve.find_current_keyframe(animation.seek_time) else {
+                continue;
             };
 
             let timestamp_start = curve.keyframe_timestamps[step_start];

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -710,15 +710,18 @@ fn apply_animation(
             }
 
             // Find the current keyframe
-            // PERF: finding the current keyframe can be optimised
+
             // Attempt to find the keyframe at or before the current time
             // An Ok(keyframe_index) result means an exact result was found by binary search
             // An Err result means the keyframe was not found, and the index is the keyframe
-            let index = curve
+            // PERF: finding the current keyframe can be optimised
+            let search_result = curve
                 .keyframe_timestamps
                 .binary_search_by(|probe| probe.partial_cmp(&animation.seek_time).unwrap());
 
-            let step_start = match index {
+            // We want to find the index of the keyframe before the current time
+            // If the keyframe is past the second-to-last keyframe, the animation cannot be interpolated.
+            let step_start = match search_result {
                 // An exact match was found, and it is the last or second last keyframe.
                 // This means that the curve is finished.
                 Ok(n) if n >= curve.keyframe_timestamps.len() - 1 => continue,

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -88,16 +88,40 @@ impl VariableCurve {
     /// To be more precise, this returns [`None`] if the frame is at or past the last keyframe:
     /// we cannot get the *next* keyframe to interpolate to in that case.
     pub fn find_current_keyframe(&self, seek_time: f32) -> Option<usize> {
-        match self
+        // An Ok(keyframe_index) result means an exact result was found by binary search
+        // An Err result means the keyframe was not found, and the index is the keyframe
+        // PERF: finding the current keyframe can be optimised
+        let search_result = self
             .keyframe_timestamps
-            .binary_search_by(|probe| probe.partial_cmp(&seek_time).unwrap())
-        {
-            Ok(n) if n >= self.keyframe_timestamps.len() - 1 => None, // this curve is finished
-            Ok(i) => Some(i),
-            Err(0) => None, // this curve isn't started yet
-            Err(n) if n > self.keyframe_timestamps.len() - 1 => None, // this curve is finished
-            Err(i) => Some(i - 1),
-        }
+            .binary_search_by(|probe| probe.partial_cmp(&seek_time).unwrap());
+
+        // Subtract one for zero indexing!
+        let last_keyframe = self.keyframes.len() - 1;
+
+        // We want to find the index of the keyframe before the current time
+        // If the keyframe is past the second-to-last keyframe, the animation cannot be interpolated.
+        let step_start = match search_result {
+            // An exact match was found, and it is the last keyframe (or something has gone terribly wrong).
+            // This means that the curve is finished.
+            Ok(n) if n >= last_keyframe => return None,
+            // An exact match was found, and it is not the last keyframe.
+            Ok(i) => i,
+            // No exact match was found, and the seek_time is before the start of the animation.
+            // This occurs because the binary search returns the index of where we could insert a value
+            // without disrupting the order of the vector.
+            // If the value is less than the first element, the index will be 0.
+            Err(0) => return None,
+            // No exact match was found, and it was after the last keyframe.
+            // The curve is finished.
+            Err(n) if n > last_keyframe => return None,
+            // No exact match was found, so return the previous keyframe to interpolate from.
+            Err(i) => i - 1,
+        };
+
+        // Consumers need to be able to interpolate between the return keyframe and the next
+        assert!(step_start < self.keyframe_timestamps.len());
+
+        Some(step_start)
     }
 }
 


### PR DESCRIPTION
# Objective

While working on #10832, I found this code very dense and hard to understand.

I was not confident in my fix (or the correctness of the existing code).

## Solution

Clean up, test and document the code used in the `apply_animation` system.

I also added a pair of length-related utility methods to `Keyframes` for easier testing. They seemed generically useful, so I made them pub.

## Changelog

- Added `VariableCurve::find_current_keyframe` method.
- Added `Keyframes::len` and `is_empty` methods.
