### PR TITLE
Add paused run condition

### DIFF
--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -231,8 +231,8 @@ pub fn repeating_after_real_delay(
 ///     // ran when time is not paused
 /// }
 /// ```
-pub fn paused() -> impl FnMut(Res<Time<Virtual>>) -> bool + Clone {
-    move |time: Res<Time<Virtual>>| time.is_paused()
+pub fn paused(time: Res<Time<Virtual>>) -> bool {
+    time.is_paused()
 }
 
 #[cfg(test)]

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -204,9 +204,27 @@ pub fn repeating_after_real_delay(
 }
 
 /// Run condition that is active when the [`Time<Virtual>`] clock is paused.
-/// Use [`bevy::ecs::schedule::common_conditions::not'] to make it active when
+/// Use [`bevy_ecs::schedule::common_conditions::not`] to make it active when
 /// it's not paused.
-pub fn on_paused() -> impl FnMut(Res<Time<Virtual>>) -> bool + Clone {
+///
+/// ```rust,no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
+/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_time::common_conditions::paused;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins)
+///         .add_systems(
+///             Update,
+///             tick.run_if(paused()),
+///         )
+///     .run();
+/// }
+/// fn tick() {
+///     // ran when time is paused
+/// }
+/// ```
+pub fn paused() -> impl FnMut(Res<Time<Virtual>>) -> bool + Clone {
     move |time: Res<Time<Virtual>>| time.is_paused()
 }
 

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -1,4 +1,4 @@
-use crate::{Real, Time, Timer, TimerMode};
+use crate::{Real, Time, Timer, TimerMode, Virtual};
 use bevy_ecs::system::Res;
 use bevy_utils::Duration;
 
@@ -201,6 +201,13 @@ pub fn repeating_after_real_delay(
         timer.tick(time.delta());
         timer.finished()
     }
+}
+
+/// Run condition that is active when the [`Time<Virtual>`] clock is paused.
+/// Use [`bevy::ecs::schedule::common_conditions::not'] to make it active when
+/// it's not paused.
+pub fn on_paused() -> impl FnMut(Res<Time<Virtual>>) -> bool + Clone {
+    move |time: Res<Time<Virtual>>| time.is_paused()
 }
 
 #[cfg(test)]

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -209,19 +209,26 @@ pub fn repeating_after_real_delay(
 ///
 /// ```rust,no_run
 /// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup, Update};
-/// # use bevy_ecs::schedule::IntoSystemConfigs;
+/// # use bevy_ecs::schedule::{common_conditions::not, IntoSystemConfigs};
 /// # use bevy_time::common_conditions::paused;
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)
 ///         .add_systems(
 ///             Update,
-///             tick.run_if(paused()),
+///             (
+///                 is_paused.run_if(paused()),
+///                 not_paused.run_if(not(paused())),
+///             )
 ///         )
 ///     .run();
 /// }
-/// fn tick() {
+/// fn is_paused() {
 ///     // ran when time is paused
+/// }
+///
+/// fn not_paused() {
+///     // ran when time is not paused
 /// }
 /// ```
 pub fn paused() -> impl FnMut(Res<Time<Virtual>>) -> bool + Clone {

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -217,8 +217,8 @@ pub fn repeating_after_real_delay(
 ///         .add_systems(
 ///             Update,
 ///             (
-///                 is_paused.run_if(paused()),
-///                 not_paused.run_if(not(paused())),
+///                 is_paused.run_if(paused),
+///                 not_paused.run_if(not(paused)),
 ///             )
 ///         )
 ///     .run();
@@ -249,7 +249,7 @@ mod tests {
         Schedule::default().add_systems(
             (test_system, test_system)
                 .distributive_run_if(on_timer(Duration::new(1, 0)))
-                .distributive_run_if(paused()),
+                .distributive_run_if(paused),
         );
     }
 }

--- a/crates/bevy_time/src/common_conditions.rs
+++ b/crates/bevy_time/src/common_conditions.rs
@@ -240,7 +240,9 @@ mod tests {
     #[test]
     fn distributive_run_if_compiles() {
         Schedule::default().add_systems(
-            (test_system, test_system).distributive_run_if(on_timer(Duration::new(1, 0))),
+            (test_system, test_system)
+                .distributive_run_if(on_timer(Duration::new(1, 0)))
+                .distributive_run_if(paused()),
         );
     }
 }


### PR DESCRIPTION
# Objective

- It is common to run a system only when the clock is paused or not paused, but this run condition doesn't exist.

## Solution

- Add the "paused" run condition.

---

## Changelog

- Systems can now be scheduled to run only if the clock is paused or not using `.run_if(paused())` or `.run_if(not(paused()))`.