### PR TITLE
Add example using `State` in docs

### DIFF
--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -74,6 +74,27 @@ pub struct OnTransition<S: States> {
 /// [`apply_state_transition::<S>`] system.
 ///
 /// The starting state is defined via the [`Default`] implementation for `S`.
+/// 
+/// ```
+/// use bevy_ecs::prelude::*;
+/// 
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+/// 
+/// fn game_logic(game_state: Res<State<GameState>>) {
+///     match game_state.get() {
+///         GameState::InGame => {
+///             // Run game logic here...
+///         },
+///         _ => {},
+///     }
+/// }
+/// ```
 #[derive(Resource, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
 pub struct State<S: States>(S);

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -74,10 +74,10 @@ pub struct OnTransition<S: States> {
 /// [`apply_state_transition::<S>`] system.
 ///
 /// The starting state is defined via the [`Default`] implementation for `S`.
-/// 
+///
 /// ```
 /// use bevy_ecs::prelude::*;
-/// 
+///
 /// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
 /// enum GameState {
 ///     #[default]
@@ -85,7 +85,7 @@ pub struct OnTransition<S: States> {
 ///     SettingsMenu,
 ///     InGame,
 /// }
-/// 
+///
 /// fn game_logic(game_state: Res<State<GameState>>) {
 ///     match game_state.get() {
 ///         GameState::InGame => {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -138,6 +138,22 @@ impl<S: States> Deref for State<S> {
 /// To queue a transition, just set the contained value to `Some(next_state)`.
 /// Note that these transitions can be overridden by other systems:
 /// only the actual value of this resource at the time of [`apply_state_transition`] matters.
+///
+/// ```
+/// use bevy_ecs::prelude::*;
+///
+/// #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug, Default, States)]
+/// enum GameState {
+///     #[default]
+///     MainMenu,
+///     SettingsMenu,
+///     InGame,
+/// }
+///
+/// fn start_game(mut next_game_state: ResMut<NextState<GameState>>) {
+///     next_game_state.set(GameState::InGame);
+/// }
+/// ```
 #[derive(Resource, Debug)]
 #[cfg_attr(
     feature = "bevy_reflect",


### PR DESCRIPTION
# Objective

- It may be confusing whether [`State`](https://docs.rs/bevy_ecs/latest/bevy_ecs/schedule/struct.State.html) is a `Resource` or a `SystemParam`.
- Fixes #11312.

## Solution

- Add an example using `State` in a system in the docs, to clarify that it is a `Resource`.

---

I basically copied the example from [`States`](https://docs.rs/bevy_ecs/latest/bevy_ecs/schedule/trait.States.html) and added a system beside it. I don't have a strong opinion on what the example should look like, so please comment if you have a better idea. :)