### PR TITLE
Make sure tracy deps conform to compatibility table

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -22,10 +22,13 @@ tracing-subscriber = { version = "0.3.1", features = [
   "env-filter",
 ] }
 tracing-chrome = { version = "0.7.0", optional = true }
-tracing-tracy = { version = "0.10.0", optional = true }
 tracing-log = "0.1.2"
 tracing-error = { version = "0.2.0", optional = true }
-tracy-client = { version = "0.16", optional = true }
+
+# Tracy dependency compatibility table:
+# https://github.com/nagisa/rust_tracy_client
+tracing-tracy = { version = "0.10.4", optional = true }
+tracy-client = { version = "0.16.4", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.0"


### PR DESCRIPTION
# Objective

The table  [here](https://github.com/nagisa/rust_tracy_client) shows which versions of [Tracy](https://github.com/wolfpld/tracy) should be used combined with which Rust deps.

Reading `bevy_log`'s `Cargo.toml` can be slightly confusing since the exact versions are not picked from the same row.

Reading the produced `Cargo.lock` when building a Bevy example shows that it's the most recent row that is resolved, but this should be more clearly understood without needing to check the lock file.


## Solution

- Specify versions from the compatibility table including patch version
