### PR TITLE
Remove `Default` impl for `CubicCurve`

### DIFF
--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -431,6 +431,9 @@ impl CubicSegment<Vec2> {
 }
 
 /// A collection of [`CubicSegment`]s chained into a curve.
+///
+/// Use any struct that implements the [`CubicGenerator`] trait to create a new curve, such as
+/// [`CubicBezier`].
 #[derive(Clone, Debug, PartialEq)]
 pub struct CubicCurve<P: Point> {
     segments: Vec<CubicSegment<P>>,

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -431,7 +431,7 @@ impl CubicSegment<Vec2> {
 }
 
 /// A collection of [`CubicSegment`]s chained into a curve.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct CubicCurve<P: Point> {
     segments: Vec<CubicSegment<P>>,
 }


### PR DESCRIPTION
# Objective

- Implementing `Default` for [`CubicCurve`](https://docs.rs/bevy/latest/bevy/math/cubic_splines/struct.CubicCurve.html) does not make sense because it cannot be mutated after creation.
- Closes #11209.
- Alternative to #11211.

## Solution

- Remove `Default` from `CubicCurve`'s derive statement.

Based off of @mockersf comment (https://github.com/bevyengine/bevy/pull/11211#issuecomment-1880088036):

> CubicCurve can't be updated once created... I would prefer to remove the Default impl as it doesn't make sense

---

## Changelog

- Removed the `Default` implementation for `CubicCurve`.

## Migration Guide

- Remove `CubicCurve` from any structs that implement `Default`.
- Wrap `CubicCurve` in a new type and provide your own default.

```rust
#[derive(Deref)]
struct MyCubicCurve<P: Point>(pub CubicCurve<P>);

impl Default for MyCubicCurve<Vec2> {
    fn default() -> Self {
        let points = [[
            vec2(-1.0, -20.0),
            vec2(3.0, 2.0),
            vec2(5.0, 3.0),
            vec2(9.0, 8.0),
        ]];

        Self(CubicBezier::new(points).to_curve())
    }
}
```