### PR TITLE
Implement bounding volumes for primitive shapes

### DIFF
--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -1,3 +1,5 @@
+mod primitive_impls;
+
 use super::BoundingVolume;
 use crate::prelude::Vec2;
 

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -293,7 +293,7 @@ impl BoundingCircle {
 
     /// Computes the smallest [`Aabb2d`] containing this [`BoundingCircle`].
     #[inline(always)]
-    pub fn bounding_circle(&self) -> Aabb2d {
+    pub fn aabb_2d(&self) -> Aabb2d {
         Aabb2d {
             min: self.center - Vec2::splat(self.radius()),
             max: self.center + Vec2::splat(self.radius()),

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -1,1 +1,201 @@
 //! Contains [`Bounded2d`](super::Bounded2d) implementations for [geometric primitives](crate::primitives).
+
+use glam::{Mat2, Vec2};
+
+use crate::primitives::{
+    BoxedPolygon, BoxedPolyline2d, Circle, Direction2d, Ellipse, Line2d, Plane2d, Polygon,
+    Polyline2d, Rectangle, RegularPolygon, Segment2d, Triangle2d,
+};
+
+use super::{rotate_vec2, Aabb2d, Bounded2d, BoundingCircle};
+
+impl Bounded2d for Circle {
+    fn aabb_2d(&self, translation: Vec2, _rotation: f32) -> Aabb2d {
+        Aabb2d {
+            min: translation - Vec2::splat(self.radius),
+            max: translation + Vec2::splat(self.radius),
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, self.radius)
+    }
+}
+
+impl Bounded2d for Ellipse {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        //           V = (hh * cos(beta), hh * sin(beta))
+        //      #####*#####
+        //   ###     |     ###
+        //  #     hh |        #
+        // #         *---------* U = (hw * cos(alpha), hw * sin(alpha))
+        //  #            hw   #
+        //   ###           ###
+        //      ###########
+
+        let (alpha, beta) = (rotation, rotation + std::f32::consts::FRAC_PI_2);
+        let (hw, hh) = (self.half_width, self.half_height);
+
+        let (ux, uy) = (hw * alpha.cos(), hw * alpha.sin());
+        let (vx, vy) = (hh * beta.cos(), hh * beta.sin());
+
+        let half_extents = Vec2::new(ux.hypot(vx), uy.hypot(vy));
+
+        Aabb2d {
+            min: translation - half_extents,
+            max: translation + half_extents,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, self.half_width.max(self.half_height))
+    }
+}
+
+impl Bounded2d for Plane2d {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        // Add or subtract pi/2 from the rotation to get a direction in the right side of the plane
+        let direction = rotate_vec2(
+            *self.normal,
+            rotation - std::f32::consts::FRAC_PI_2 * self.normal.y.signum(),
+        );
+        let x_parallel = direction == Vec2::X || direction == Vec2::NEG_X;
+        let y_parallel = direction == Vec2::Y || direction == Vec2::NEG_Y;
+
+        // Dividing `f32::MAX` by 2.0 can actually be good so that we can do operations
+        // like growing or shrinking the AABB without breaking things.
+        let half_width = if y_parallel { 0.0 } else { f32::MAX / 2.0 };
+        let half_height = if x_parallel { 0.0 } else { f32::MAX / 2.0 };
+        let half_size = Vec2::new(half_width, half_height);
+
+        Aabb2d {
+            min: translation - half_size,
+            max: translation + half_size,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, f32::MAX / 2.0)
+    }
+}
+
+impl Bounded2d for Line2d {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        let direction = rotate_vec2(*self.direction, rotation);
+        let x_parallel = direction == Vec2::X || direction == Vec2::NEG_X;
+        let y_parallel = direction == Vec2::Y || direction == Vec2::NEG_Y;
+
+        // Dividing `f32::MAX` by 2.0 can actually be good so that we can do operations
+        // like growing or shrinking the AABB without breaking things.
+        let half_width = if y_parallel { 0.0 } else { f32::MAX / 2.0 };
+        let half_height = if x_parallel { 0.0 } else { f32::MAX / 2.0 };
+        let half_size = Vec2::new(half_width, half_height);
+
+        Aabb2d {
+            min: translation - half_size,
+            max: translation + half_size,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, f32::MAX / 2.0)
+    }
+}
+
+impl Bounded2d for Segment2d {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        // Rotate the segment by `rotation`
+        let direction = Direction2d::from_normalized(rotate_vec2(*self.direction, rotation));
+        let segment = Self { direction, ..*self };
+        let (point1, point2) = (segment.point1(), segment.point2());
+
+        Aabb2d {
+            min: translation + point1.min(point2),
+            max: translation + point1.max(point2),
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, self.half_length)
+    }
+}
+
+impl<const N: usize> Bounded2d for Polyline2d<N> {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        Aabb2d::from_point_cloud(translation, rotation, self.vertices)
+    }
+
+    fn bounding_circle(&self, translation: Vec2, rotation: f32) -> BoundingCircle {
+        BoundingCircle::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}
+
+impl Bounded2d for BoxedPolyline2d {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        Aabb2d::from_point_cloud(translation, rotation, self.vertices.to_vec())
+    }
+
+    fn bounding_circle(&self, translation: Vec2, rotation: f32) -> BoundingCircle {
+        BoundingCircle::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}
+
+impl Bounded2d for Triangle2d {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        let [a, b, c] = self.vertices.map(|vtx| rotate_vec2(vtx, rotation));
+
+        let min = Vec2::new(a.x.min(b.x).min(c.x), a.y.min(b.y).min(c.y));
+        let max = Vec2::new(a.x.max(b.x).max(c.x), a.y.max(b.y).max(c.y));
+
+        Aabb2d {
+            min: min + translation,
+            max: max + translation,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, rotation: f32) -> BoundingCircle {
+        self.aabb_2d(translation, rotation).bounding_circle()
+    }
+}
+
+impl Bounded2d for Rectangle {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        let half_size = Vec2::new(self.half_width, self.half_height);
+
+        // Compute the AABB of the rotated rectangle by transforming the half-extents
+        // by an absolute rotation matrix.
+        let (sin, cos) = rotation.sin_cos();
+        let abs_rot_mat = Mat2::from_cols_array(&[cos.abs(), sin.abs(), sin.abs(), cos.abs()]);
+        let half_extents = abs_rot_mat * half_size;
+
+        Aabb2d {
+            min: translation - half_extents,
+            max: translation + half_extents,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        let radius = self.half_width.hypot(self.half_height);
+        BoundingCircle::new(translation, radius)
+    }
+}
+
+impl<const N: usize> Bounded2d for Polygon<N> {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        Aabb2d::from_point_cloud(translation, rotation, self.vertices)
+    }
+
+    fn bounding_circle(&self, translation: Vec2, rotation: f32) -> BoundingCircle {
+        BoundingCircle::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}
+
+impl Bounded2d for BoxedPolygon {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        Aabb2d::from_point_cloud(translation, rotation, self.vertices.to_vec())
+    }
+
+    fn bounding_circle(&self, translation: Vec2, rotation: f32) -> BoundingCircle {
+        BoundingCircle::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -199,3 +199,24 @@ impl Bounded2d for BoxedPolygon {
         BoundingCircle::from_point_cloud(translation, rotation, &self.vertices)
     }
 }
+
+impl Bounded2d for RegularPolygon {
+    fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
+        let mut min = Vec2::ZERO;
+        let mut max = Vec2::ZERO;
+
+        for vertex in self.vertices(rotation) {
+            min = min.min(vertex);
+            max = max.max(vertex);
+        }
+
+        Aabb2d {
+            min: min + translation,
+            max: max + translation,
+        }
+    }
+
+    fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
+        BoundingCircle::new(translation, self.circumcircle.radius)
+    }
+}

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -1,0 +1,1 @@
+//! Contains [`Bounded2d`](super::Bounded2d) implementations for [geometric primitives](crate::primitives).

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -1,3 +1,5 @@
+mod primitive_impls;
+
 use super::BoundingVolume;
 use crate::prelude::{Quat, Vec3};
 

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -1,0 +1,1 @@
+//! Contains [`Bounded3d`](super::Bounded3d) implementations for [geometric primitives](crate::primitives).

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -1,1 +1,334 @@
 //! Contains [`Bounded3d`](super::Bounded3d) implementations for [geometric primitives](crate::primitives).
+
+use glam::{Mat3, Quat, Vec2, Vec3};
+
+use crate::primitives::{
+    BoxedPolyline3d, Capsule, Cone, ConicalFrustum, Cuboid, Cylinder, Direction3d, Line3d, Plane3d,
+    Polyline3d, Segment3d, Sphere, Torus,
+};
+
+use super::{Aabb3d, Bounded3d, BoundingSphere};
+
+impl Bounded3d for Sphere {
+    fn aabb_3d(&self, translation: Vec3, _rotation: Quat) -> Aabb3d {
+        Aabb3d {
+            min: translation - Vec3::splat(self.radius),
+            max: translation + Vec3::splat(self.radius),
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, self.radius)
+    }
+}
+
+impl Bounded3d for Plane3d {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Get a direction along the plane rotated by `rotation`
+        let direction = (rotation * *self.normal).any_orthonormal_vector();
+        let facing_x = direction == Vec3::X || direction == Vec3::NEG_X;
+        let facing_y = direction == Vec3::Y || direction == Vec3::NEG_Y;
+        let facing_z = direction == Vec3::Z || direction == Vec3::NEG_Z;
+
+        // Dividing `f32::MAX` by 2.0 can actually be good so that we can do operations
+        // like growing or shrinking the AABB without breaking things.
+        let max = f32::MAX / 2.0;
+        let half_width = if facing_y && facing_z { 0.0 } else { max };
+        let half_height = if facing_x && facing_z { 0.0 } else { max };
+        let half_depth = if facing_x && facing_y { 0.0 } else { max };
+        let half_size = Vec3::new(half_width, half_height, half_depth);
+
+        Aabb3d {
+            min: translation - half_size,
+            max: translation + half_size,
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, f32::MAX / 2.0)
+    }
+}
+
+impl Bounded3d for Line3d {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Get the line direction along the plane rotated by `rotation`
+        let direction = rotation * *self.direction;
+        let x_parallel = direction == Vec3::X || direction == Vec3::NEG_X;
+        let y_parallel = direction == Vec3::Y || direction == Vec3::NEG_Y;
+        let z_parallel = direction == Vec3::Z || direction == Vec3::NEG_Z;
+
+        // Dividing `f32::MAX` by 2.0 can actually be good so that we can do operations
+        // like growing or shrinking the AABB without breaking things.
+        let max = f32::MAX / 2.0;
+        let half_width = if y_parallel && z_parallel { 0.0 } else { max };
+        let half_height = if x_parallel && z_parallel { 0.0 } else { max };
+        let half_depth = if x_parallel && y_parallel { 0.0 } else { max };
+        let half_size = Vec3::new(half_width, half_height, half_depth);
+
+        Aabb3d {
+            min: translation - half_size,
+            max: translation + half_size,
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, f32::MAX / 2.0)
+    }
+}
+
+impl Bounded3d for Segment3d {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Rotate the segment by `rotation`
+        let direction = Direction3d::from_normalized(rotation * *self.direction);
+        let segment = Self { direction, ..*self };
+        let (point1, point2) = (segment.point1(), segment.point2());
+
+        Aabb3d {
+            min: translation + point1.min(point2),
+            max: translation + point1.max(point2),
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, self.half_length)
+    }
+}
+
+impl<const N: usize> Bounded3d for Polyline3d<N> {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        Aabb3d::from_point_cloud(translation, rotation, self.vertices)
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
+        BoundingSphere::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}
+
+impl Bounded3d for BoxedPolyline3d {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        Aabb3d::from_point_cloud(translation, rotation, self.vertices.to_vec())
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
+        BoundingSphere::from_point_cloud(translation, rotation, &self.vertices)
+    }
+}
+
+impl Bounded3d for Cuboid {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Compute the AABB of the rotated cuboid by transforming the half-extents
+        // by an absolute rotation matrix.
+        let rot_mat = Mat3::from_quat(rotation);
+        let abs_rot_mat = Mat3::from_cols(
+            rot_mat.x_axis.abs(),
+            rot_mat.y_axis.abs(),
+            rot_mat.z_axis.abs(),
+        );
+
+        let half_extents = abs_rot_mat * self.half_extents;
+
+        Aabb3d {
+            min: translation - half_extents,
+            max: translation + half_extents,
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere {
+            center: translation,
+            sphere: Sphere {
+                radius: self.half_extents.length(),
+            },
+        }
+    }
+}
+
+impl Bounded3d for Cylinder {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Reference: http://iquilezles.org/articles/diskbbox/
+
+        let top = rotation * Vec3::Y * self.half_height;
+        let bottom = -top;
+        let segment = bottom - top;
+
+        let e = 1.0 - segment * segment / segment.length_squared();
+        let half_extents = self.radius * Vec3::new(e.x.sqrt(), e.y.sqrt(), e.z.sqrt());
+
+        Aabb3d {
+            min: translation + (top - half_extents).min(bottom - half_extents),
+            max: translation + (top + half_extents).max(bottom + half_extents),
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        let radius = (self.radius.powi(2) + self.half_height.powi(2)).sqrt();
+        BoundingSphere::new(translation, radius)
+    }
+}
+
+impl Bounded3d for Capsule {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Get the line segment between the hemispheres of the rotated capsule
+        let segment = Segment3d {
+            direction: Direction3d::from_normalized(rotation * Vec3::Y),
+            half_length: self.half_length,
+        };
+        let (a, b) = (segment.point1(), segment.point2());
+
+        // Expand the line segment by the capsule radius to get the capsule half-extents
+        let min = a.min(b) - Vec3::splat(self.radius);
+        let max = a.max(b) + Vec3::splat(self.radius);
+
+        Aabb3d {
+            min: min + translation,
+            max: max + translation,
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, self.radius + self.half_length)
+    }
+}
+
+impl Bounded3d for Cone {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Reference: http://iquilezles.org/articles/diskbbox/
+
+        let top = rotation * Vec3::Y * 0.5 * self.height;
+        let bottom = -top;
+        let segment = bottom - top;
+
+        let e = 1.0 - segment * segment / segment.length_squared();
+        let half_extents = Vec3::new(e.x.sqrt(), e.y.sqrt(), e.z.sqrt());
+
+        Aabb3d {
+            min: translation + top.min(bottom - self.radius * half_extents),
+            max: translation + top.max(bottom + self.radius * half_extents),
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
+        // To compute the bounding sphere, we'll get the circumcenter U and circumradius R
+        // of the circumcircle passing through all three vertices of the triangular
+        // cross-section of the cone.
+        //
+        // Here, we assume the tip A is translated to the origin, which simplifies calculations.
+        //
+        //     A = (0, 0)
+        //         *
+        //        / \
+        //       /   \
+        //      /     \
+        //     /       \
+        //    /         \
+        //   /     U     \
+        //  /             \
+        // *---------------*
+        // B                C
+
+        let b = Vec2::new(-self.radius, -self.height);
+        let c = Vec2::new(self.radius, -self.height);
+        let b_length_sq = b.length_squared();
+        let c_length_sq = c.length_squared();
+
+        // Reference: https://en.wikipedia.org/wiki/Circumcircle#Cartesian_coordinates_2
+        let inv_d = (2.0 * (b.x * c.y - b.y * c.x)).recip();
+        let ux = inv_d * (c.y * b_length_sq - b.y * c_length_sq);
+        let uy = inv_d * (b.x * c_length_sq - c.x * b_length_sq);
+        let u = Vec2::new(ux, uy);
+
+        // Compute true circumcenter and circumradius, adding the tip coordinate so that
+        // A is translated back to its actual coordinate.
+        let circumcenter = u + 0.5 * self.height * Vec2::Y;
+        let circumradius = u.length();
+
+        BoundingSphere::new(
+            translation + rotation * circumcenter.extend(0.0),
+            circumradius,
+        )
+    }
+}
+
+impl Bounded3d for ConicalFrustum {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Reference: http://iquilezles.org/articles/diskbbox/
+
+        let top = rotation * Vec3::Y * 0.5 * self.height;
+        let bottom = -top;
+        let segment = bottom - top;
+
+        let e = 1.0 - segment * segment / segment.length_squared();
+        let half_extents = Vec3::new(e.x.sqrt(), e.y.sqrt(), e.z.sqrt());
+
+        Aabb3d {
+            min: translation
+                + (top - self.radius_top * half_extents)
+                    .min(bottom - self.radius_bottom * half_extents),
+            max: translation
+                + (top + self.radius_top * half_extents)
+                    .max(bottom + self.radius_bottom * half_extents),
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
+        let half_height = 0.5 * self.height;
+
+        // To compute the bounding sphere, we'll get the center and radius of the circumcircle
+        // passing through all four vertices of the trapezoidal cross-section of the conical frustum.
+        //
+        // The circumcenter is at the intersection of the bisectors perpendicular to the sides.
+        // For the isosceles trapezoid, the X coordinate is zero at the center, so a single bisector is enough.
+        //
+        //       A
+        //       *-------*
+        //      /    |    \
+        //     /     |     \
+        // AB / \    |    / \
+        //   /     \ | /     \
+        //  /        C        \
+        // *-------------------*
+        // B
+
+        let a = Vec2::new(-self.radius_top, half_height);
+        let b = Vec2::new(-self.radius_bottom, -half_height);
+        let ab = a - b;
+        let ab_midpoint = b + 0.5 * ab;
+
+        // The direction towards the circumcenter is the bisector perpendicular to the side
+        let bisector = -ab.perp().normalize_or_zero();
+
+        // Here we divide the bisector by its X coordinate so that its X becomes 1
+        // and we can reach the center by multiplying by the X distance to the midpoint of AB.
+        let circumcenter = ab_midpoint + ab_midpoint.x.abs() * bisector / bisector.x.abs();
+
+        // The circumcircle passes through all four vertices, so we can pick any of them
+        let circumradius = a.distance(circumcenter);
+
+        BoundingSphere::new(
+            translation + rotation * circumcenter.extend(0.0),
+            circumradius,
+        )
+    }
+}
+
+impl Bounded3d for Torus {
+    fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
+        // Compute the AABB of a flat disc with the major radius of the torus.
+        // Reference: http://iquilezles.org/articles/diskbbox/
+        let normal = rotation * Vec3::Y;
+        let e = 1.0 - normal * normal;
+        let disc_half_extents = self.major_radius * Vec3::new(e.x.sqrt(), e.y.sqrt(), e.z.sqrt());
+
+        // Expand the disc by the minor radius to get the torus half extents
+        let half_extents = disc_half_extents + Vec3::splat(self.minor_radius);
+
+        Aabb3d {
+            min: translation - half_extents,
+            max: translation + half_extents,
+        }
+    }
+
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
+        BoundingSphere::new(translation, self.outer_radius())
+    }
+}


### PR DESCRIPTION
# Objective

#10946 added bounding volume types and traits, but didn't use them for anything yet. This PR implements `Bounded2d` and `Bounded3d` for Bevy's primitive shapes.

## Solution

Implement `Bounded2d` and `Bounded3d` for primitive shapes. This allows computing AABBs and bounding circles/spheres for them.

For most shapes, there are several ways of implementing bounding volumes. I took inspiration from [Parry's bounding volumes](https://github.com/dimforge/parry/tree/master/src/bounding_volume), [Inigo Quilez](http://iquilezles.org/articles/diskbbox/), and figured out the rest myself using geometry. I tried to comment all slightly non-trivial or unclear math to make it understandable.

Parry uses support mapping (finding the farthest point in some direction for convex shapes) for some AABBs like cones, cylinders, and line segments. This involves several quat operations and normalizations, so I opted for the simpler and more efficient geometric approaches shown in [Quilez's article](http://iquilezles.org/articles/diskbbox/).

Below you can see some of the bounding volumes working in 2D and 3D. Note that I can't conveniently add these examples yet because they use primitive shape meshing, which is still WIP.

https://github.com/bevyengine/bevy/assets/57632562/4465cbc6-285b-4c71-b62d-a2b3ee16f8b4

https://github.com/bevyengine/bevy/assets/57632562/94b4ac84-a092-46d7-b438-ce2e971496a4

---

## Changelog

- Implemented `Bounded2d`/`Bounded3d` for primitive shapes
- Added `from_point_cloud` method for bounding volumes (used by many bounding implementations)
- Added `point_cloud_2d/3d_center` and `rotate_vec2` utility functions
- Added `RegularPolygon::vertices` method (used in regular polygon AABB construction)
- Added bounding circle/sphere creation from AABBs and vice versa

## Todo

- [ ] Add tests for `Bounded2d`/`Bounded3d` implementations

## Extra

Do we want to implement `Bounded2d` for some "3D-ish" shapes too? For example, capsules are sort of dimension-agnostic and useful for 2D, so I think that would be good to implement. But a cylinder in 2D is just a rectangle, and a cone is a triangle, so they wouldn't make as much sense to me. A conical frustum would be an isosceles trapezoid, which could be useful, but I'm not sure if computing the 2D AABB of a 3D frustum makes semantic sense.