### PR TITLE
Better error reporting for embedded_path macro

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -255,3 +255,32 @@ macro_rules! load_internal_binary_asset {
         );
     }};
 }
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_embedded_path_no_panics() {
+       assert_eq!(file!(), "crates/bevy_asset/src/io/embedded/mod.rs");
+       assert_eq!(embedded_path!("/src/", "a"), PathBuf::from("bevy_asset/io/embedded/a"));
+       assert_eq!(embedded_path!("/src", "a"), PathBuf::from("/io/embedded/a"));
+       assert_eq!(embedded_path!("src", "a"), PathBuf::from("/io/embedded/a"));
+    }
+
+    #[test]
+    // Panic message prior to change.
+    #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
+    // #[should_panic(expected = "Expected source path `NOT-IN-PATH` in file path `crates/bevy_asset/src/io/embedded/mod.rs`")]
+    fn test_embedded_path_panic0() {
+       assert_eq!(embedded_path!("NOT-IN-PATH", "b"), PathBuf::from("bevy_asset/tes/b"));
+    }
+
+
+    #[test]
+    #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
+    // #[should_panic(expected = "Expected source path `/a/` in file path `crates/bevy_asset/src/io/embedded/mod.rs`")]
+    fn test_embedded_path_panic1() {
+       assert_eq!(embedded_path!("/a/", "b"), PathBuf::from("bevy_asset/tes/b"));
+    }
+}


### PR DESCRIPTION
# Objective

Better error reporting for embedded_path macro.  

A number of cases will cause a panic, which is fine. The issue is there are two or three different possible panics that all report an unwrap on a None value, so they're hard to differentiate for the user, and they were difficult for me to diagnose as a user.

## Solution

This refactor does not change `embedded_path!`'s functional behavior. All cases that caused a panic before, will still cause a panic. However, this change will provide the user diagnostic information that will hopefully help them right whatever issue is causing the panic.

The original behavior that caught me up was this:

```
    #[test]
    #[should_panic(expected = "called `Option::unwrap()` on a `None` value")]
    fn test_embedded_path_original_behavior() {
        embedded_path!("NOT-IN-PATH", "embed.png"),
    }
```

The changed behavior is this:

```
    #[test]
    #[should_panic(
        expected = "Expected source path `NOT-IN-PATH` in file path `crates/bevy_asset/src/io/embedded/mod.rs`"
    )]
    fn test_embedded_path_original_behavior() {
        embedded_path!("NOT-IN-PATH", "embed.png")
    }
```
---

## Changelog

> Added error reporting for embedded_path macro
