### PR TITLE
Do not preprocess gLTF transform on gLTF load

### DIFF
--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -101,7 +101,7 @@ pub struct Gltf {
 }
 
 /// A glTF node with all of its child nodes, its [`GltfMesh`],
-/// [`Transform`](bevy_transform::prelude::Transform) and an optional [`GltfExtras`].
+/// [`GltfTransform`] and an optional [`GltfExtras`].
 ///
 /// See [the relevant glTF specification section](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-node).
 #[derive(Asset, Debug, Clone, TypePath)]
@@ -111,9 +111,21 @@ pub struct GltfNode {
     /// Mesh of the node.
     pub mesh: Option<Handle<GltfMesh>>,
     /// Local transform.
-    pub transform: bevy_transform::prelude::Transform,
+    pub transform: GltfTransform,
     /// Additional data.
     pub extras: Option<GltfExtras>,
+}
+
+/// A glTF transform which may consist of either Matrix - [`Mat4`](bevy_math::Mat4)
+/// or Decomposed Translation, Rotation and Scale - [`Transform`](bevy_transform::prelude::Transform).
+///
+/// See [the relevant glTF specification section on node properties](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#reference-node).
+#[derive(Debug, Clone, TypePath)]
+pub enum GltfTransform {
+    /// A 4x4 column major matrix.
+    Matrix(bevy_math::Mat4),
+    /// Decomposed Translation, Rotation and Scale
+    Decomposed(bevy_transform::prelude::Transform),
 }
 
 /// A glTF mesh, which may consist of multiple [`GltfPrimitives`](GltfPrimitive)

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -1,4 +1,4 @@
-use crate::{vertex_attributes::convert_attribute, Gltf, GltfExtras, GltfNode};
+use crate::{vertex_attributes::convert_attribute, Gltf, GltfExtras, GltfNode, GltfTransform};
 use bevy_asset::{
     io::Reader, AssetLoadError, AssetLoader, AsyncReadExt, Handle, LoadContext, ReadAssetBytesError,
 };
@@ -524,17 +524,17 @@ async fn load_gltf<'a, 'b, 'c>(
                     .and_then(|i| meshes.get(i).cloned()),
                 transform: match node.transform() {
                     gltf::scene::Transform::Matrix { matrix } => {
-                        Transform::from_matrix(Mat4::from_cols_array_2d(&matrix))
+                        GltfTransform::Matrix(Mat4::from_cols_array_2d(&matrix))
                     }
                     gltf::scene::Transform::Decomposed {
                         translation,
                         rotation,
                         scale,
-                    } => Transform {
+                    } => GltfTransform::Decomposed(Transform {
                         translation: bevy_math::Vec3::from(translation),
                         rotation: bevy_math::Quat::from_array(rotation),
                         scale: bevy_math::Vec3::from(scale),
-                    },
+                    }),
                 },
                 extras: get_gltf_extras(node.extras()),
             },
@@ -1496,14 +1496,14 @@ mod test {
     use std::path::PathBuf;
 
     use super::resolve_node_hierarchy;
-    use crate::GltfNode;
+    use crate::{GltfNode, GltfTransform};
 
     impl GltfNode {
         fn empty() -> Self {
             GltfNode {
                 children: vec![],
                 mesh: None,
-                transform: bevy_transform::prelude::Transform::IDENTITY,
+                transform: GltfTransform::Decomposed(bevy_transform::prelude::Transform::IDENTITY),
                 extras: None,
             }
         }


### PR DESCRIPTION
# Objective

Allow user to access raw loaded gLTF transform, so it can be used in deterministic way. Bevy preprocesses this transform into one single type, doing conversions from matrix into Bevy's Transform which does multiple float operations that can result in different results on different architectures due to floating point inaccuracies.

## Solution

- Keep the loaded gLTF transform unchanged, just convert it to corresponding bevy types that don't do any calculations to prevent floating point inaccuracies.

As unintended side-effect, this this speeds up gLTF file loading times slightly, as there are less calculations.

---

## Changelog

- Changed GltfMesh to contain raw unprocessed transform that matches what was loaded from gLTF file

## Migration Guide

If you previously did any calculations on GltfMesh::transform you now need to convert it to whatever you need, to get transform that was available previously you can do:
```rust
let gltf_mesh: GltfMesh = ...;
let transform = match gltf_mesh.transform {
    GltfTransform::Matrix(matrix) => Transform::from_matrix(matrix),
    GltfTransform::Transform(transform) => transform, 
};
```