### PR TITLE
Use EntityHashMap whenever possible

### DIFF
--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -33,7 +33,7 @@ use bevy_scene::Scene;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::IoTaskPool;
 use bevy_transform::components::Transform;
-use bevy_utils::{HashMap, HashSet};
+use bevy_utils::{EntityHashMap, HashMap, HashSet};
 use gltf::{
     accessor::Iter,
     mesh::{util::ReadIndices, Mode},
@@ -583,7 +583,7 @@ async fn load_gltf<'a, 'b, 'c>(
         let mut err = None;
         let mut world = World::default();
         let mut node_index_to_entity_map = HashMap::new();
-        let mut entity_to_skin_index_map = HashMap::new();
+        let mut entity_to_skin_index_map = EntityHashMap::default();
         let mut scene_load_context = load_context.begin_labeled_asset();
         world
             .spawn(SpatialBundle::INHERITED_IDENTITY)
@@ -904,7 +904,7 @@ fn load_node(
     load_context: &mut LoadContext,
     settings: &GltfLoaderSettings,
     node_index_to_entity_map: &mut HashMap<usize, Entity>,
-    entity_to_skin_index_map: &mut HashMap<Entity, usize>,
+    entity_to_skin_index_map: &mut EntityHashMap<Entity, usize>,
     active_camera_found: &mut bool,
     parent_transform: &Transform,
 ) -> Result<(), GltfError> {

--- a/crates/bevy_pbr/src/bundle.rs
+++ b/crates/bevy_pbr/src/bundle.rs
@@ -11,7 +11,7 @@ use bevy_render::{
     view::{InheritedVisibility, ViewVisibility, Visibility, VisibleEntities},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::HashMap;
+use bevy_utils::EntityHashMap;
 
 /// A component bundle for PBR entities with a [`Mesh`] and a [`StandardMaterial`].
 pub type PbrBundle = MaterialMeshBundle<StandardMaterial>;
@@ -75,7 +75,7 @@ impl CubemapVisibleEntities {
 pub struct CascadesVisibleEntities {
     /// Map of view entity to the visible entities for each cascade frustum.
     #[reflect(ignore)]
-    pub entities: HashMap<Entity, Vec<VisibleEntities>>,
+    pub entities: EntityHashMap<Entity, Vec<VisibleEntities>>,
 }
 
 /// A component bundle for [`PointLight`] entities.

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -16,7 +16,7 @@ use bevy_render::{
     view::{InheritedVisibility, RenderLayers, ViewVisibility, VisibleEntities},
 };
 use bevy_transform::components::{GlobalTransform, Transform};
-use bevy_utils::{tracing::warn, HashMap};
+use bevy_utils::{tracing::warn, EntityHashMap};
 
 use crate::*;
 
@@ -381,7 +381,7 @@ impl From<CascadeShadowConfigBuilder> for CascadeShadowConfig {
 #[reflect(Component)]
 pub struct Cascades {
     /// Map from a view to the configuration of each of its [`Cascade`]s.
-    pub(crate) cascades: HashMap<Entity, Vec<Cascade>>,
+    pub(crate) cascades: EntityHashMap<Entity, Vec<Cascade>>,
 }
 
 #[derive(Clone, Debug, Default, Reflect)]

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -18,7 +18,7 @@ use bevy_transform::{components::GlobalTransform, prelude::Transform};
 use bevy_utils::{
     nonmax::NonMaxU32,
     tracing::{error, warn},
-    HashMap,
+    EntityHashMap,
 };
 use std::{hash::Hash, num::NonZeroU64, ops::Range};
 
@@ -47,7 +47,7 @@ pub struct ExtractedDirectionalLight {
     shadow_depth_bias: f32,
     shadow_normal_bias: f32,
     cascade_shadow_config: CascadeShadowConfig,
-    cascades: HashMap<Entity, Vec<Cascade>>,
+    cascades: EntityHashMap<Entity, Vec<Cascade>>,
     render_layers: RenderLayers,
 }
 
@@ -550,7 +550,7 @@ pub const CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT: u32 = 3;
 #[derive(Resource)]
 pub struct GlobalLightMeta {
     pub gpu_point_lights: GpuPointLights,
-    pub entity_to_index: HashMap<Entity, usize>,
+    pub entity_to_index: EntityHashMap<Entity, usize>,
 }
 
 impl FromWorld for GlobalLightMeta {
@@ -567,7 +567,7 @@ impl GlobalLightMeta {
     pub fn new(buffer_binding_type: BufferBindingType) -> Self {
         Self {
             gpu_point_lights: GpuPointLights::new(buffer_binding_type),
-            entity_to_index: HashMap::default(),
+            entity_to_index: EntityHashMap::default(),
         }
     }
 }

--- a/crates/bevy_render/src/primitives/mod.rs
+++ b/crates/bevy_render/src/primitives/mod.rs
@@ -3,7 +3,7 @@ use std::borrow::Borrow;
 use bevy_ecs::{component::Component, prelude::Entity, reflect::ReflectComponent};
 use bevy_math::{Affine3A, Mat3A, Mat4, Vec3, Vec3A, Vec4, Vec4Swizzles};
 use bevy_reflect::Reflect;
-use bevy_utils::HashMap;
+use bevy_utils::EntityHashMap;
 
 /// An axis-aligned bounding box, defined by:
 /// - a center,
@@ -323,7 +323,7 @@ impl CubemapFrusta {
 #[reflect(Component)]
 pub struct CascadesFrusta {
     #[reflect(ignore)]
-    pub frusta: HashMap<Entity, Vec<Frustum>>,
+    pub frusta: EntityHashMap<Entity, Vec<Frustum>>,
 }
 
 #[cfg(test)]

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
-use bevy_utils::{default, tracing::debug, HashMap, HashSet};
+use bevy_utils::{default, tracing::debug, EntityHashMap, HashSet};
 use bevy_window::{
     CompositeAlphaMode, PresentMode, PrimaryWindow, RawHandleWrapper, Window, WindowClosed,
 };
@@ -89,11 +89,11 @@ impl ExtractedWindow {
 #[derive(Default, Resource)]
 pub struct ExtractedWindows {
     pub primary: Option<Entity>,
-    pub windows: HashMap<Entity, ExtractedWindow>,
+    pub windows: EntityHashMap<Entity, ExtractedWindow>,
 }
 
 impl Deref for ExtractedWindows {
-    type Target = HashMap<Entity, ExtractedWindow>;
+    type Target = EntityHashMap<Entity, ExtractedWindow>;
 
     fn deref(&self) -> &Self::Target {
         &self.windows
@@ -199,7 +199,7 @@ struct SurfaceData {
 
 #[derive(Resource, Default)]
 pub struct WindowSurfaces {
-    surfaces: HashMap<Entity, SurfaceData>,
+    surfaces: EntityHashMap<Entity, SurfaceData>,
     /// List of windows that we have already called the initial `configure_surface` for
     configured_windows: HashSet<Entity>,
 }

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -5,7 +5,7 @@ use bevy_asset::{load_internal_asset, Handle};
 use bevy_ecs::prelude::*;
 use bevy_log::{error, info, info_span};
 use bevy_tasks::AsyncComputeTaskPool;
-use bevy_utils::HashMap;
+use bevy_utils::EntityHashMap;
 use std::sync::Mutex;
 use thiserror::Error;
 use wgpu::{
@@ -33,7 +33,7 @@ pub type ScreenshotFn = Box<dyn FnOnce(Image) + Send + Sync>;
 #[derive(Resource, Default)]
 pub struct ScreenshotManager {
     // this is in a mutex to enable extraction with only an immutable reference
-    pub(crate) callbacks: Mutex<HashMap<Entity, ScreenshotFn>>,
+    pub(crate) callbacks: Mutex<EntityHashMap<Entity, ScreenshotFn>>,
 }
 
 #[derive(Error, Debug)]

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -15,7 +15,7 @@ use bevy_hierarchy::{Children, Parent};
 use bevy_log::warn;
 use bevy_math::Vec2;
 use bevy_transform::components::Transform;
-use bevy_utils::{default, HashMap};
+use bevy_utils::{default, EntityHashMap};
 use bevy_window::{PrimaryWindow, Window, WindowResolution, WindowScaleFactorChanged};
 use std::fmt;
 use taffy::Taffy;
@@ -50,14 +50,14 @@ struct RootNodePair {
 
 #[derive(Resource)]
 pub struct UiSurface {
-    entity_to_taffy: HashMap<Entity, taffy::node::Node>,
-    window_roots: HashMap<Entity, Vec<RootNodePair>>,
+    entity_to_taffy: EntityHashMap<Entity, taffy::node::Node>,
+    window_roots: EntityHashMap<Entity, Vec<RootNodePair>>,
     taffy: Taffy,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
-    _assert_send_sync::<HashMap<Entity, taffy::node::Node>>();
+    _assert_send_sync::<EntityHashMap<Entity, taffy::node::Node>>();
     _assert_send_sync::<Taffy>();
     _assert_send_sync::<UiSurface>();
 }

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -22,16 +22,16 @@ use bevy_ecs::{
     system::{NonSend, NonSendMut, Query, Res, ResMut, Resource},
 };
 use bevy_hierarchy::{Children, Parent};
-use bevy_utils::HashMap;
+use bevy_utils::EntityHashMap;
 use bevy_window::{PrimaryWindow, Window, WindowClosed};
 
 /// Maps window entities to their `AccessKit` [`Adapter`]s.
 #[derive(Default, Deref, DerefMut)]
-pub struct AccessKitAdapters(pub HashMap<Entity, Adapter>);
+pub struct AccessKitAdapters(pub EntityHashMap<Entity, Adapter>);
 
 /// Maps window entities to their respective [`WinitActionHandler`]s.
 #[derive(Resource, Default, Deref, DerefMut)]
-pub struct WinitActionHandlers(pub HashMap<Entity, WinitActionHandler>);
+pub struct WinitActionHandlers(pub EntityHashMap<Entity, WinitActionHandler>);
 
 /// Forwards `AccessKit` [`ActionRequest`]s from winit to an event channel.
 #[derive(Clone, Default, Deref, DerefMut)]

--- a/crates/bevy_winit/src/system.rs
+++ b/crates/bevy_winit/src/system.rs
@@ -9,7 +9,7 @@ use bevy_ecs::{
 };
 use bevy_utils::{
     tracing::{error, info, warn},
-    HashMap,
+    EntityHashMap,
 };
 use bevy_window::{RawHandleWrapper, Window, WindowClosed, WindowCreated};
 use raw_window_handle::{HasRawDisplayHandle, HasRawWindowHandle};
@@ -87,7 +87,7 @@ pub(crate) fn create_windows<'a>(
 
 /// Cache for closing windows so we can get better debug information.
 #[derive(Debug, Clone, Resource)]
-pub struct WindowTitleCache(HashMap<Entity, String>);
+pub struct WindowTitleCache(EntityHashMap<Entity, String>);
 
 pub(crate) fn despawn_windows(
     mut closed: RemovedComponents<Window>,

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -7,7 +7,7 @@ use bevy_a11y::{
 };
 use bevy_ecs::entity::Entity;
 
-use bevy_utils::{tracing::warn, HashMap};
+use bevy_utils::{tracing::warn, EntityHashMap, HashMap};
 use bevy_window::{CursorGrabMode, Window, WindowMode, WindowPosition, WindowResolution};
 
 use winit::{
@@ -27,7 +27,7 @@ pub struct WinitWindows {
     /// Stores [`winit`] windows by window identifier.
     pub windows: HashMap<winit::window::WindowId, winit::window::Window>,
     /// Maps entities to `winit` window identifiers.
-    pub entity_to_winit: HashMap<Entity, winit::window::WindowId>,
+    pub entity_to_winit: EntityHashMap<Entity, winit::window::WindowId>,
     /// Maps `winit` window identifiers to entities.
     pub winit_to_entity: HashMap<winit::window::WindowId, Entity>,
     // Many `winit` window functions (e.g. `set_window_icon`) can only be called on the main thread.


### PR DESCRIPTION
# Objective

Fixes #11352

## Solution

- Use `EntityHashMap<Entity, T>` instead of `HashMap<Entity, T>`

---

## Changelog

Changed
- Use `EntityHashMap<Entity, T>` instead of `HashMap<Entity, T>` whenever possible

## Migration Guide

TODO