### PR TITLE
Fix doc of [`Schedules`] to mention exclusion of current schedule.

### DIFF
--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -25,7 +25,7 @@ use crate::{
     world::World,
 };
 
-/// Resource that stores [`Schedule`]s mapped to [`ScheduleLabel`]s.
+/// Resource that stores [`Schedule`]s mapped to [`ScheduleLabel`]s excluding the current running [`Schedule`].
 #[derive(Default, Resource)]
 pub struct Schedules {
     inner: HashMap<InternedScheduleLabel, Schedule>,


### PR DESCRIPTION
Document that [`Schedules`] resource does not include the current schedule.