### PR TITLE
Feature: Component composition.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/bevyengine/bevy"
 documentation = "https://docs.rs/bevy"
-rust-version = "1.74.0"
+rust-version = "1.75.0"
 
 [workspace]
 exclude = [

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -151,7 +151,7 @@ pub unsafe trait Bundle: DynamicBundle + Sized + Send + Sync + 'static {
         (self, tail)
     }
 
-    /// Apply duplicate items in a bundle to an EntityMut and remove them.
+    /// Apply duplicate items in a bundle to an [`EntityWorldMut`] and remove them.
     fn spawn_compose(self, entity: &mut EntityWorldMut, parent: impl Bundle) {
         let (head, tail) = self.split_head();
         match entity.get_mut::<Self::Head>() {
@@ -209,10 +209,13 @@ mod sealed {
     }
 }
 
+/// SAFETY:
+/// Safe since this implementation explicitly does nothing.
 unsafe impl Bundle for () {
     type Head = sealed::DummyComponent;
 
     fn spawn_compose(self, entity: &mut EntityWorldMut, parent: impl Bundle) {
+        // This ends recursion by inserting the remaining bundle.
         entity.insert(parent);
     }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -282,7 +282,6 @@ impl<C: Component> DynamicBundle for C {
 macro_rules! tuple_impl {
     () => {};
     ($first: ident $(, $rest: ident)*) => {
-        tuple_impl!($($rest),*);
         // SAFETY:
         // - `Bundle::component_ids` calls `ids` for each component type in the
         // bundle, in the exact order that `DynamicBundle::get_components` is called.
@@ -307,9 +306,9 @@ macro_rules! tuple_impl {
 
             #[allow(unused_variables, unused_mut)]
             #[allow(clippy::unused_unit)]
-            unsafe fn from_components<T, FN>(ctx: &mut T, func: &mut FN) -> Self
+            unsafe fn from_components<T, F>(ctx: &mut T, func: &mut F) -> Self
             where
-                FN: FnMut(&mut T) -> OwningPtr<'_>
+                F: FnMut(&mut T) -> OwningPtr<'_>
             {
                 // Rust guarantees that tuple calls are evaluated 'left to right'.
                 // https://doc.rust-lang.org/reference/expressions.html#evaluation-order-of-operands
@@ -332,7 +331,20 @@ macro_rules! tuple_impl {
     }
 }
 
-tuple_impl!(A, B, C, D, E, F, G, H, I, J, K, L, M, N, O);
+macro_rules! tuple_impl_pretty {
+    ({}{}) => {};
+
+    ({$($head: ident),*} {$tail: ident}) => {
+        tuple_impl_pretty!({} {$($head),*});
+        tuple_impl!($($head,)* $tail);
+    };
+
+    ({$($head: ident),*} {$mid: ident $(, $tail: ident)*}) => {
+        tuple_impl_pretty!({$($head,)* $mid} {$($tail),*});
+    };
+}
+
+tuple_impl_pretty!({} {B0, B1, B2, B3, B4, B5, B6, B7, B8, B9, B10, B11, B12, B13, B14});
 
 /// For a specific [`World`], this stores a unique value identifying a type of a registered [`Bundle`].
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -89,6 +89,26 @@ use std::{
 /// [`Table`]: crate::storage::Table
 /// [`SparseSet`]: crate::storage::SparseSet
 ///
+/// # Composing components
+///
+/// Components can be composed using the `compose` function.
+///
+/// ```
+/// # use bevy_ecs::component::Component;
+/// #
+/// #[derive(Component)]
+/// #[component(compose = "ComponentA::compose")]
+/// struct ComponentA(usize);
+///
+/// impl ComponentA {
+///     fn compose(&mut self, incoming: Self) {
+///         self.0 |= incoming.0;
+///     }
+/// }
+/// # let mut component = ComponentA(1);
+/// # component.compose(ComponentA(2));
+/// # assert_eq!(component.0, 3);
+/// ```
 /// # Implementing the trait for foreign types
 ///
 /// As a consequence of the [orphan rule], it is not possible to separate into two different crates the implementation of `Component` from the definition of a type.
@@ -146,10 +166,17 @@ use std::{
 ///
 /// [`SyncCell`]: bevy_utils::synccell::SyncCell
 /// [`Exclusive`]: https://doc.rust-lang.org/nightly/std/sync/struct.Exclusive.html
-pub trait Component: Send + Sync + 'static {
+pub trait Component: Send + Sync + Sized + 'static {
     /// A marker type indicating the storage type used for this component.
     /// This must be either [`TableStorage`] or [`SparseStorage`].
     type Storage: ComponentStorage;
+
+    /// Compose an existing component with an incoming one.
+    /// The default implementation is replacing the current
+    /// component with the incoming one.
+    fn compose(&mut self, incoming: Self) {
+        *self = incoming;
+    }
 }
 
 /// Marker type for components stored in a [`Table`](crate::storage::Table).

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     self as bevy_ecs,
     bundle::Bundle,
     entity::{Entities, Entity},
-    prelude::Component,
     system::{RunSystemWithInput, SystemId},
     world::{EntityWorldMut, FromWorld, World},
 };
@@ -1239,7 +1238,7 @@ mod tests {
 
     impl ComposeCkVec {
         fn compose(&mut self, incoming: Self) {
-            self.0.extend(incoming.0)
+            self.0.extend(incoming.0);
         }
     }
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -784,11 +784,11 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///
     /// fn add_flags_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///   commands.entity(player.entity)
-    ///    // You can use try_insert to insert components:
-    ///     .try_compose(Flags::IS_ACTIVE)
+    ///    // You can use compose to insert components:
+    ///     .compose(Flags::IS_ACTIVE)
     ///     
-    ///    // You can also use try_insert to compose to existing components:
-    ///     .try_compose(Flags::DEAD);
+    ///    // You can also use compose to compose to existing components:
+    ///     .compose(Flags::DEAD);
     /// }
     /// # bevy_ecs::system::assert_is_system(add_flags_system);
     /// ```
@@ -876,10 +876,10 @@ impl<'w, 's, 'a> EntityCommands<'w, 's, 'a> {
     ///
     /// fn add_flags_system(mut commands: Commands, player: Res<PlayerEntity>) {
     ///   commands.entity(player.entity)
-    ///    // You can use try_insert to insert components:
+    ///    // You can use try_compose to compose components:
     ///     .try_compose(Flags::IS_ACTIVE)
     ///     
-    ///    // You can also use try_insert to compose to existing components:
+    ///    // You can also use try_compose to compose to existing components:
     ///     .try_compose(Flags::DEAD);
     ///    
     ///    // Suppose this occurs in a parallel adjacent system or process
@@ -1386,10 +1386,19 @@ mod tests {
 
         Commands::new(&mut command_queue, &world)
             .entity(entity)
+            .try_compose(ComposeCk(4))
+            .try_compose(ComposeCk(8))
+            .try_compose(ComposeCk(16));
+        command_queue.apply(&mut world);
+
+        assert_eq!(world.entity(entity).get::<ComposeCk>().unwrap().0, 31);
+
+        Commands::new(&mut command_queue, &world)
+            .entity(entity)
             .try_compose(ComposeCk(1));
         command_queue.apply(&mut world);
 
-        assert_eq!(world.entity(entity).get::<ComposeCk>().unwrap().0, 3);
+        assert_eq!(world.entity(entity).get::<ComposeCk>().unwrap().0, 31);
 
         Commands::new(&mut command_queue, &world)
             .entity(entity)


### PR DESCRIPTION
# Objective

Allow specialized component insertion behavior. The primary objective is allowing inserting a component multiple times between two `apply_deferred` calls for the clear cut case of feature composition. This opens up a lot of freedom for library developers, as  previously it was difficult to modify an already inserted component without race condition or a specialized command.

For example this can be used to build a `bitflags` or a `vec` from multiple `compose` calls, without the need to aggregate data in one place.

## Solution

Added support for specialized insertion behavior for pre-existing components. Added `compose` and `try_compose` to `EntityCommands` as an alternative to `insert` and `try_insert`.

`compose` takes a `&mut Self` and composes it with an incoming `Self`.

---

## Changelog

* Added method `compose` to `Component` with a default implementation identical to `insert`.
* Added type level `(head, tail)` deconstruction support for `Bundle` to support bundle compositions. 
* Added attribute `compose` to derive macro `Component`.
* Added `compose` and `try_compose` to `EntityCommands` as an alternative to `insert` and `try_insert`.
* Bumped MSRV to `1.75.0` for RPITIT support, which is needed to provide default implementations for `Bundle`.

## Migration Guide

`Component` and `Bundle` are now `Sized`, which might be a breaking change.
