### PR TITLE
Added AssetLoadFailedEvent, UntypedAssetLoadFailedEvent

### DIFF
--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -1,8 +1,49 @@
-use crate::{Asset, AssetId};
+use crate::{Asset, AssetId, AssetLoadError, AssetPath, Handle, UntypedAssetId, UntypedHandle};
 use bevy_ecs::event::Event;
 use std::fmt::Debug;
 
-/// Events that occur for a specific [`Asset`], such as "value changed" events and "dependency" events.
+/// An event emitted when a specific [`Asset`] fails to load.
+#[derive(Event, Clone, Debug)]
+pub struct AssetLoadFailedEvent<A: Asset> {
+    pub id: AssetId<A>,
+    /// The original handle returned when the asset load was requested.
+    pub handle: Option<Handle<A>>,
+    /// The asset path that was attempted.
+    pub path: AssetPath<'static>,
+    /// Why the asset failed to load.
+    pub error: AssetLoadError,
+}
+
+impl<A: Asset> AssetLoadFailedEvent<A> {
+    /// Converts this to an "untyped" / "generic-less" asset error event that stores the type information.
+    pub fn untyped(&self) -> UntypedAssetLoadFailedEvent {
+        self.into()
+    }
+}
+
+/// An untyped version of [`AssetLoadFailedEvent`].
+#[derive(Event, Clone, Debug)]
+pub struct UntypedAssetLoadFailedEvent {
+    pub id: UntypedAssetId,
+    pub handle: Option<UntypedHandle>,
+    /// The asset path that was attempted.
+    pub path: AssetPath<'static>,
+    /// Why the asset failed to load.
+    pub error: AssetLoadError,
+}
+
+impl<A: Asset> From<&AssetLoadFailedEvent<A>> for UntypedAssetLoadFailedEvent {
+    fn from(value: &AssetLoadFailedEvent<A>) -> Self {
+        UntypedAssetLoadFailedEvent {
+            id: value.id.untyped(),
+            handle: value.handle.clone().map(|h| h.untyped()),
+            path: value.path.clone(),
+            error: value.error.clone(),
+        }
+    }
+}
+
+/// Events that occur for a specific loaded [`Asset`], such as "value changed" events and "dependency" events.
 #[derive(Event)]
 pub enum AssetEvent<A: Asset> {
     /// Emitted whenever an [`Asset`] is added.

--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -3,6 +3,8 @@ use bevy_ecs::event::Event;
 use std::fmt::Debug;
 
 /// An event emitted when a specific [`Asset`] fails to load.
+///
+/// For an untyped equivalent, see [`UntypedAssetLoadFailedEvent`].
 #[derive(Event, Clone, Debug)]
 pub struct AssetLoadFailedEvent<A: Asset> {
     pub id: AssetId<A>,

--- a/crates/bevy_asset/src/event.rs
+++ b/crates/bevy_asset/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{Asset, AssetId, AssetLoadError, AssetPath, Handle, UntypedAssetId, UntypedHandle};
+use crate::{Asset, AssetId, AssetLoadError, AssetPath, UntypedAssetId};
 use bevy_ecs::event::Event;
 use std::fmt::Debug;
 
@@ -8,8 +8,6 @@ use std::fmt::Debug;
 #[derive(Event, Clone, Debug)]
 pub struct AssetLoadFailedEvent<A: Asset> {
     pub id: AssetId<A>,
-    /// The original handle returned when the asset load was requested.
-    pub handle: Option<Handle<A>>,
     /// The asset path that was attempted.
     pub path: AssetPath<'static>,
     /// Why the asset failed to load.
@@ -27,7 +25,6 @@ impl<A: Asset> AssetLoadFailedEvent<A> {
 #[derive(Event, Clone, Debug)]
 pub struct UntypedAssetLoadFailedEvent {
     pub id: UntypedAssetId,
-    pub handle: Option<UntypedHandle>,
     /// The asset path that was attempted.
     pub path: AssetPath<'static>,
     /// Why the asset failed to load.
@@ -38,7 +35,6 @@ impl<A: Asset> From<&AssetLoadFailedEvent<A>> for UntypedAssetLoadFailedEvent {
     fn from(value: &AssetLoadFailedEvent<A>) -> Self {
         UntypedAssetLoadFailedEvent {
             id: value.id.untyped(),
-            handle: value.handle.clone().map(|h| h.untyped()),
             path: value.path.clone(),
             error: value.error.clone(),
         }

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -569,22 +569,22 @@ impl AssetSources {
 }
 
 /// An error returned when an [`AssetSource`] does not exist for a given id.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Asset Source '{0}' does not exist")]
 pub struct MissingAssetSourceError(AssetSourceId<'static>);
 
 /// An error returned when an [`AssetWriter`] does not exist for a given id.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Asset Source '{0}' does not have an AssetWriter.")]
 pub struct MissingAssetWriterError(AssetSourceId<'static>);
 
 /// An error returned when a processed [`AssetReader`] does not exist for a given id.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Asset Source '{0}' does not have a processed AssetReader.")]
 pub struct MissingProcessedAssetReaderError(AssetSourceId<'static>);
 
 /// An error returned when a processed [`AssetWriter`] does not exist for a given id.
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 #[error("Asset Source '{0}' does not have a processed AssetWriter.")]
 pub struct MissingProcessedAssetWriterError(AssetSourceId<'static>);
 

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -53,10 +53,7 @@ impl HttpWasmAssetReader {
                 Ok(reader)
             }
             404 => Err(AssetReaderError::NotFound(path)),
-            status => Err(AssetReaderError::Io(std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Encountered unexpected HTTP status {status}"),
-            ))),
+            status => Err(AssetReaderError::HttpError(status as u16)),
         }
     }
 }

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -213,6 +213,7 @@ impl Plugin for AssetPlugin {
             .init_asset::<LoadedFolder>()
             .init_asset::<LoadedUntypedAsset>()
             .init_asset::<()>()
+            .add_event::<UntypedAssetLoadFailedEvent>()
             .configure_sets(
                 UpdateAssets,
                 TrackAssets.after(handle_internal_asset_events),
@@ -377,6 +378,7 @@ impl AssetApp for App {
         self.insert_resource(assets)
             .allow_ambiguous_resource::<Assets<A>>()
             .add_event::<AssetEvent<A>>()
+            .add_event::<AssetLoadFailedEvent<A>>()
             .register_type::<Handle<A>>()
             .register_type::<AssetId<A>>()
             .add_systems(AssetEvents, Assets::<A>::asset_events)
@@ -431,11 +433,12 @@ mod tests {
         io::{
             gated::{GateOpener, GatedReader},
             memory::{Dir, MemoryAssetReader},
-            AssetSource, AssetSourceId, Reader,
+            AssetReader, AssetReaderError, AssetSource, AssetSourceId, Reader,
         },
         loader::{AssetLoader, LoadContext},
-        Asset, AssetApp, AssetEvent, AssetId, AssetPath, AssetPlugin, AssetServer, Assets,
-        DependencyLoadState, LoadState, RecursiveDependencyLoadState,
+        Asset, AssetApp, AssetEvent, AssetId, AssetLoadError, AssetLoadFailedEvent, AssetPath,
+        AssetPlugin, AssetServer, Assets, DependencyLoadState, LoadState,
+        RecursiveDependencyLoadState,
     };
     use bevy_app::{App, Update};
     use bevy_core::TaskPoolPlugin;
@@ -446,20 +449,23 @@ mod tests {
     };
     use bevy_log::LogPlugin;
     use bevy_reflect::TypePath;
-    use bevy_utils::BoxedFuture;
+    use bevy_utils::{BoxedFuture, Duration, HashMap};
     use futures_lite::AsyncReadExt;
     use serde::{Deserialize, Serialize};
-    use std::path::Path;
+    use std::{
+        path::{Path, PathBuf},
+        sync::Arc,
+    };
     use thiserror::Error;
 
     #[derive(Asset, TypePath, Debug)]
     pub struct CoolText {
-        text: String,
-        embedded: String,
+        pub text: String,
+        pub embedded: String,
         #[dependency]
-        dependencies: Vec<Handle<CoolText>>,
+        pub dependencies: Vec<Handle<CoolText>>,
         #[dependency]
-        sub_texts: Vec<Handle<SubText>>,
+        pub sub_texts: Vec<Handle<SubText>>,
     }
 
     #[derive(Asset, TypePath, Debug)]
@@ -476,10 +482,10 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct CoolTextLoader;
+    pub struct CoolTextLoader;
 
     #[derive(Error, Debug)]
-    enum CoolTextLoaderError {
+    pub enum CoolTextLoaderError {
         #[error("Could not load dependency: {dependency}")]
         CannotLoadDependency { dependency: AssetPath<'static> },
         #[error("A RON error occurred during loading")]
@@ -537,6 +543,83 @@ mod tests {
         }
     }
 
+    /// A dummy [`CoolText`] asset reader that only succeeds after `failure_count` times it's read from for each asset.
+    #[derive(Default, Clone)]
+    pub struct UnstableMemoryAssetReader {
+        pub attempt_counters: Arc<std::sync::Mutex<HashMap<PathBuf, usize>>>,
+        pub load_delay: Duration,
+        memory_reader: MemoryAssetReader,
+        failure_count: usize,
+    }
+
+    impl UnstableMemoryAssetReader {
+        pub fn new(root: Dir, failure_count: usize) -> Self {
+            Self {
+                load_delay: Duration::from_millis(10),
+                memory_reader: MemoryAssetReader { root },
+                attempt_counters: Default::default(),
+                failure_count,
+            }
+        }
+    }
+
+    impl AssetReader for UnstableMemoryAssetReader {
+        fn is_directory<'a>(
+            &'a self,
+            path: &'a Path,
+        ) -> BoxedFuture<'a, Result<bool, AssetReaderError>> {
+            self.memory_reader.is_directory(path)
+        }
+        fn read_directory<'a>(
+            &'a self,
+            path: &'a Path,
+        ) -> BoxedFuture<'a, Result<Box<bevy_asset::io::PathStream>, AssetReaderError>> {
+            self.memory_reader.read_directory(path)
+        }
+        fn read_meta<'a>(
+            &'a self,
+            path: &'a Path,
+        ) -> BoxedFuture<'a, Result<Box<bevy_asset::io::Reader<'a>>, AssetReaderError>> {
+            self.memory_reader.read_meta(path)
+        }
+        fn read<'a>(
+            &'a self,
+            path: &'a Path,
+        ) -> BoxedFuture<
+            'a,
+            Result<Box<bevy_asset::io::Reader<'a>>, bevy_asset::io::AssetReaderError>,
+        > {
+            let attempt_number = {
+                let key = PathBuf::from(path);
+                let mut attempt_counters = self.attempt_counters.lock().unwrap();
+                if let Some(existing) = attempt_counters.get_mut(&key) {
+                    *existing += 1;
+                    *existing
+                } else {
+                    attempt_counters.insert(key, 1);
+                    1
+                }
+            };
+
+            if attempt_number <= self.failure_count {
+                let io_error = std::io::Error::new(
+                    std::io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "Simulated failure {attempt_number} of {}",
+                        self.failure_count
+                    ),
+                );
+                let wait = self.load_delay;
+                return Box::pin(async move {
+                    std::thread::sleep(wait);
+                    Err(AssetReaderError::Io(io_error.into()))
+                });
+            }
+
+            self.memory_reader.read(path)
+        }
+    }
+
     fn test_app(dir: Dir) -> (App, GateOpener) {
         let mut app = App::new();
         let (gated_memory_reader, gate_opener) = GatedReader::new(MemoryAssetReader { root: dir });
@@ -552,7 +635,7 @@ mod tests {
         (app, gate_opener)
     }
 
-    fn run_app_until(app: &mut App, mut predicate: impl FnMut(&mut World) -> Option<()>) {
+    pub fn run_app_until(app: &mut App, mut predicate: impl FnMut(&mut World) -> Option<()>) {
         for _ in 0..LARGE_ITERATION_COUNT {
             app.update();
             if predicate(&mut app.world).is_some() {
@@ -581,6 +664,10 @@ mod tests {
 
     #[test]
     fn load_dependencies() {
+        // The particular usage of GatedReader in this test will cause deadlocking if running single-threaded
+        #[cfg(not(feature = "multi-threaded"))]
+        panic!("This test requires the \"multi-threaded\" feature, otherwise it will deadlock.\ncargo test --package bevy_asset --features multi-threaded");
+
         let dir = Dir::default();
 
         let a_path = "a.cool.ron";
@@ -898,6 +985,10 @@ mod tests {
 
     #[test]
     fn failure_load_states() {
+        // The particular usage of GatedReader in this test will cause deadlocking if running single-threaded
+        #[cfg(not(feature = "multi-threaded"))]
+        panic!("This test requires the \"multi-threaded\" feature, otherwise it will deadlock.\ncargo test --package bevy_asset --features multi-threaded");
+
         let dir = Dir::default();
 
         let a_path = "a.cool.ron";
@@ -1017,6 +1108,10 @@ mod tests {
 
     #[test]
     fn manual_asset_management() {
+        // The particular usage of GatedReader in this test will cause deadlocking if running single-threaded
+        #[cfg(not(feature = "multi-threaded"))]
+        panic!("This test requires the \"multi-threaded\" feature, otherwise it will deadlock.\ncargo test --package bevy_asset --features multi-threaded");
+
         let dir = Dir::default();
 
         let dep_path = "dep.cool.ron";
@@ -1122,6 +1217,10 @@ mod tests {
 
     #[test]
     fn load_folder() {
+        // The particular usage of GatedReader in this test will cause deadlocking if running single-threaded
+        #[cfg(not(feature = "multi-threaded"))]
+        panic!("This test requires the \"multi-threaded\" feature, otherwise it will deadlock.\ncargo test --package bevy_asset --features multi-threaded");
+
         let dir = Dir::default();
 
         let a_path = "text/a.cool.ron";
@@ -1207,6 +1306,135 @@ mod tests {
                 }
             }
             None
+        });
+    }
+
+    /// Tests that `AssetLoadFailedEvent<A>` events are emitted and can be used to retry failed assets.
+    #[test]
+    fn load_error_events() {
+        #[derive(Resource, Default)]
+        struct ErrorTracker {
+            tick: u64,
+            failures: usize,
+            queued_retries: Vec<(AssetPath<'static>, Handle<CoolText>, u64)>,
+            finished_asset: Option<AssetId<CoolText>>,
+        }
+
+        fn asset_event_handler(
+            mut events: EventReader<AssetEvent<CoolText>>,
+            mut tracker: ResMut<ErrorTracker>,
+        ) {
+            for event in events.read() {
+                if let AssetEvent::LoadedWithDependencies { id } = event {
+                    tracker.finished_asset = Some(*id);
+                }
+            }
+        }
+
+        fn asset_load_error_event_handler(
+            server: Res<AssetServer>,
+            mut errors: EventReader<AssetLoadFailedEvent<CoolText>>,
+            mut tracker: ResMut<ErrorTracker>,
+        ) {
+            // In the real world, this would refer to time (not ticks)
+            tracker.tick += 1;
+
+            // Retry loading past failed items
+            let now = tracker.tick;
+            tracker
+                .queued_retries
+                .retain(|(path, old_handle, retry_after)| {
+                    if now > *retry_after {
+                        let new_handle = server.load::<CoolText>(path);
+                        assert_eq!(new_handle.id(), old_handle.id());
+                        false
+                    } else {
+                        true
+                    }
+                });
+
+            // Check what just failed
+            for error in errors.read() {
+                let (load_state, _, _) = server.get_load_states(error.id).unwrap();
+                assert_eq!(load_state, LoadState::Failed);
+                let original_handle = error.handle.as_ref().unwrap().clone();
+                assert!(original_handle.is_strong());
+                assert_eq!(*error.path.source(), AssetSourceId::Name("unstable".into()));
+                match &error.error {
+                    AssetLoadError::AssetReaderError(read_error) => match read_error {
+                        AssetReaderError::Io(_) => {
+                            tracker.failures += 1;
+                            if tracker.failures <= 2 {
+                                // Retry in 10 ticks
+                                tracker.queued_retries.push((
+                                    error.path.clone(),
+                                    original_handle.clone_weak(),
+                                    now + 10,
+                                ));
+                            } else {
+                                panic!(
+                                    "Unexpected failure #{} (expected only 2)",
+                                    tracker.failures
+                                );
+                            }
+                        }
+                        _ => panic!("Unexpected error type {:?}", read_error),
+                    },
+                    _ => panic!("Unexpected error type {:?}", error.error),
+                }
+            }
+        }
+
+        let a_path = "text/a.cool.ron";
+        let a_ron = r#"
+(
+    text: "a",
+    dependencies: [],
+    embedded_dependencies: [],
+    sub_texts: [],
+)"#;
+
+        let dir = Dir::default();
+        dir.insert_asset_text(Path::new(a_path), a_ron);
+        let unstable_reader = UnstableMemoryAssetReader::new(dir, 2);
+
+        let mut app = App::new();
+        app.register_asset_source(
+            "unstable",
+            AssetSource::build().with_reader(move || Box::new(unstable_reader.clone())),
+        )
+        .add_plugins((
+            TaskPoolPlugin::default(),
+            LogPlugin::default(),
+            AssetPlugin::default(),
+        ))
+        .init_asset::<CoolText>()
+        .register_asset_loader(CoolTextLoader)
+        .init_resource::<ErrorTracker>()
+        .add_systems(
+            Update,
+            (asset_event_handler, asset_load_error_event_handler).chain(),
+        );
+
+        let asset_server = app.world.resource::<AssetServer>().clone();
+        let a_path = format!("unstable://{a_path}");
+        let a_handle: Handle<CoolText> = asset_server.load(a_path);
+        let a_id = a_handle.id();
+
+        app.world.spawn(a_handle);
+
+        run_app_until(&mut app, |world| {
+            let tracker = world.resource::<ErrorTracker>();
+            match tracker.finished_asset {
+                Some(asset_id) => {
+                    assert_eq!(asset_id, a_id);
+                    let assets = world.resource::<Assets<CoolText>>();
+                    let result = assets.get(asset_id).unwrap();
+                    assert_eq!(result.text, "a");
+                    Some(())
+                }
+                None => None,
+            }
         });
     }
 

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -254,7 +254,7 @@ pub struct LoadDirectError {
 }
 
 /// An error that occurs while deserializing [`AssetMeta`].
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum DeserializeMetaError {
     #[error("Failed to deserialize asset meta: {0:?}")]
     DeserializeSettings(#[from] SpannedError),

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -76,7 +76,7 @@ pub(crate) struct AssetInfos {
     pub(crate) dependency_loaded_event_sender: HashMap<TypeId, fn(&mut World, UntypedAssetId)>,
     pub(crate) dependency_failed_event_sender: HashMap<
         TypeId,
-        fn(&mut World, UntypedAssetId, AssetPath<'static>, Option<UntypedHandle>, AssetLoadError),
+        fn(&mut World, UntypedAssetId, AssetPath<'static>, AssetLoadError),
     >,
 }
 

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -74,10 +74,8 @@ pub(crate) struct AssetInfos {
     pub(crate) living_labeled_assets: HashMap<AssetPath<'static>, HashSet<String>>,
     pub(crate) handle_providers: HashMap<TypeId, AssetHandleProvider>,
     pub(crate) dependency_loaded_event_sender: HashMap<TypeId, fn(&mut World, UntypedAssetId)>,
-    pub(crate) dependency_failed_event_sender: HashMap<
-        TypeId,
-        fn(&mut World, UntypedAssetId, AssetPath<'static>, AssetLoadError),
-    >,
+    pub(crate) dependency_failed_event_sender:
+        HashMap<TypeId, fn(&mut World, UntypedAssetId, AssetPath<'static>, AssetLoadError)>,
 }
 
 impl std::fmt::Debug for AssetInfos {

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1011,7 +1011,7 @@ pub fn handle_internal_asset_events(world: &mut World) {
                 } => {
                     infos.process_asset_fail(id);
 
-                    // Send untyped failure event (used by `AssetLoadRetryPlugin`)
+                    // Send untyped failure event
                     untyped_failures.push(UntypedAssetLoadFailedEvent {
                         id,
                         handle: handle.clone(),


### PR DESCRIPTION
# Objective

This adds events for assets that fail to load along with minor utility methods to make them useful. This paves the way for users writing their own error handling and retry systems, plus Bevy including robust retry handling: #11349.

* Addresses #11288
* Needed for #11349

# Solution

```rust
/// An event emitted when a specific [`Asset`] fails to load.
#[derive(Event, Clone, Debug)]
pub struct AssetLoadFailedEvent<A: Asset> {
    pub id: AssetId<A>,
    /// The original handle returned when the asset load was requested.
    pub handle: Option<Handle<A>>,
    /// The asset path that was attempted.
    pub path: AssetPath<'static>,
    /// Why the asset failed to load.
    pub error: AssetLoadError,
}
```

I started implementing `AssetEvent::Failed` like suggested in #11288, but decided it was better as its own type because:

 * I think it makes sense for `AssetEvent` to only refer to assets that actually exist. 
 * In order to return `AssetLoadError` in the event (which is useful information for error handlers that might attempt a retry) we would have to remove `Copy` from `AssetEvent`.
 * There are numerous places in the render app that match against `AssetEvent`, and I don't think it's worth introducing extra noise about assets that don't exist.

I also introduced `UntypedAssetLoadErrorEvent`, which is very useful in places that need to support type flexibility, like an Asset-agnostic retry plugin.

# Changelog

* **Added:** `AssetLoadFailedEvent<A>`
* **Added**: `UntypedAssetLoadFailedEvent`
* **Added:** `AssetReaderError::Http` for status code information on HTTP errors. Before this, status codes were only available by parsing the error message of generic `Io` errors.
* **Added:** `asset_server.get_path_id(path)`. This method simply gets the asset id for the path. Without this, one was left using `get_path_handle(path)`, which has the overhead of returning a strong handle. 
* **Fixed**: Made `AssetServer` loads return the same handle for assets that already exist in a failed state. Now, when you attempt a `load` that's in a `LoadState::Failed` state, it'll re-use the original asset id. The advantage of this is that any dependent assets created using the original handle will "unbreak" if a retry succeeds.
