### PR TITLE
Fix embedded watcher to work with external crates

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -202,7 +202,6 @@ macro_rules! embedded_asset {
         let watched_path = $crate::io::embedded::watched_path(file!(), $path);
         embedded.insert_asset(watched_path, &path, include_bytes!($path));
     }};
-
 }
 
 // Returns the path used by the watcher when the embedded_watcher feature is
@@ -210,7 +209,10 @@ macro_rules! embedded_asset {
 #[doc(hidden)]
 pub fn watched_path(source_file_path: &'static str, asset_path: &'static str) -> PathBuf {
     #[cfg(feature = "embedded_watcher")]
-    let path = PathBuf::from(source_file_path).parent().unwrap().join(asset_path);
+    let path = PathBuf::from(source_file_path)
+        .parent()
+        .unwrap()
+        .join(asset_path);
     #[cfg(not(feature = "embedded_watcher"))]
     let path = PathBuf::from("");
     path

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -204,18 +204,21 @@ macro_rules! embedded_asset {
     }};
 }
 
-// Returns the path used by the watcher when the embedded_watcher feature is
-// enabled. Returns an empty PathBuf otherwise.
+/// Returns the path used by the watcher.
 #[doc(hidden)]
+#[cfg(feature = "embedded_watcher")]
 pub fn watched_path(source_file_path: &'static str, asset_path: &'static str) -> PathBuf {
-    #[cfg(feature = "embedded_watcher")]
-    let path = PathBuf::from(source_file_path)
+    PathBuf::from(source_file_path)
         .parent()
         .unwrap()
-        .join(asset_path);
-    #[cfg(not(feature = "embedded_watcher"))]
-    let path = PathBuf::from("");
-    path
+        .join(asset_path)
+}
+
+/// Returns an empty PathBuf.
+#[doc(hidden)]
+#[cfg(not(feature = "embedded_watcher"))]
+pub fn watched_path(_source_file_path: &'static str, _asset_path: &'static str) -> PathBuf {
+    PathBuf::from("")
 }
 
 /// Loads an "internal" asset by embedding the string stored in the given `path_str` and associates it with the given handle.


### PR DESCRIPTION
# Objective

Tried using "embedded_watcher" feature and `embedded_asset!()` from another crate. The assets embedded fine but were not "watched." The problem appears to be that checking for the feature was done inside the macro, so rather than checking if "embedded_watcher" was enabled for bevy, it would check if it was enabled for the current crate.

## Solution

I extracted the checks for the "embedded_watcher" feature into its own function called `watched_path()`. No external changes.

### Alternative Solution

An alternative fix would be to not do any feature checking in `embedded_asset!()` or an extracted function and always send the full_path to `insert_asset()` where it's promptly dropped when the feature isn't turned on. That would be simpler.

```
    ($app: ident, $source_path: expr, $path: expr) => {{
        let mut embedded = $app
            .world
            .resource_mut::<$crate::io::embedded::EmbeddedAssetRegistry>();
        let path = $crate::embedded_path!($source_path, $path);
        //#[cfg(feature = "embedded_watcher")]
        let full_path = std::path::Path::new(file!()).parent().unwrap().join($path);
        //#[cfg(not(feature = "embedded_watcher"))]
        //let full_path = std::path::PathBuf::new();
        embedded.insert_asset(full_path, &path, include_bytes!($path));
    }};
```

## Changelog

> Fix embedded_watcher feature to work with external crates