### PR TITLE
Make `DynamicUniformBuffer::push` accept an `&T` instead of `T`

### DIFF
--- a/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
@@ -89,7 +89,7 @@ impl<T: GpuArrayBufferable> BatchedUniformBuffer<T> {
     }
 
     pub fn flush(&mut self) {
-        self.uniforms.push(self.temp.clone());
+        self.uniforms.push(&self.temp);
 
         self.current_offset +=
             align_to_next(self.temp.size().get(), self.dynamic_offset_alignment as u64) as u32;

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -227,8 +227,8 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
 
     /// Push data into the `DynamicUniformBuffer`'s internal vector (residing on system RAM).
     #[inline]
-    pub fn push(&mut self, value: T) -> u32 {
-        self.scratch.write(&value).unwrap() as u32
+    pub fn push(&mut self, value: &T) -> u32 {
+        self.scratch.write(value).unwrap() as u32
     }
 
     pub fn set_label(&mut self, label: Option<&str>) {


### PR DESCRIPTION
# Objective

- `DynamicUniformBuffer::push` takes an owned `T` but only uses a shared reference to it
- This in turn requires users of `DynamicUniformBuffer::push` to potentially unecessarily clone data

## Solution

- Have `DynamicUniformBuffer::push` take a shared reference to `T`

---

## Changelog

- `DynamicUniformBuffer::push` now takes a `&T` instead of `T`

## Migration Guide

- Users of `DynamicUniformBuffer::push` now need to pass references to `DynamicUniformBuffer::push` (e.g. existing `uniforms.push(value)` will now become `uniforms.push(&value)`)