### PR TITLE
Fix link to plugin guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -220,7 +220,7 @@ You can improve Bevy's ecosystem by building your own Bevy Plugins and crates.
 Non-trivial, reusable functionality that works well with itself is a good candidate for a plugin.
 If it's closer to a snippet or design pattern, you may want to share it with the community on [Discord], Reddit, or [GitHub Discussions] instead.
 
-Check out our [plugin guidelines](https://github.com/bevyengine/bevy/blob/main/docs/plugins_guidelines.md) for helpful tips and patterns.
+Check out our [plugin guidelines](https://bevyengine.org/learn/book/plugin-development/) for helpful tips and patterns.
 
 ### Fixing bugs
 


### PR DESCRIPTION
# Objective

This document was moved in #11242, so this link is now broken.

## Solution

Swap in a working link.