### PR TITLE
Remove duplicate `#[automatically_derived]` in ECS macro

### DIFF
--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -37,7 +37,6 @@ pub(crate) fn item_struct(
         Fields::Unnamed(_) => quote! {
             #derive_macro_call
             #item_attrs
-            #[automatically_derived]
             #visibility struct #item_struct_name #user_impl_generics_with_world #user_where_clauses_with_world(
                 #( #field_visibilities <#field_types as #path::query::WorldQuery>::Item<'__w>, )*
             );


### PR DESCRIPTION
# Objective

It's already provided by `item_attrs`, so it can be removed.

# Solution

Remove the extra `#[automatically_derived]`.