### PR TITLE
Restore brightness in the remaining three examples after exposure PR

### DIFF
--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -80,6 +80,10 @@ fn setup(
     });
     // light
     commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 150_000.0,
+            ..default()
+        },
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
         ..default()
     });

--- a/examples/asset/hot_asset_reloading.rs
+++ b/examples/asset/hot_asset_reloading.rs
@@ -28,6 +28,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     });
     // light
     commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 150_000.0,
+            ..default()
+        },
         transform: Transform::from_xyz(4.0, 5.0, 4.0),
         ..default()
     });

--- a/examples/ui/render_ui_to_texture.rs
+++ b/examples/ui/render_ui_to_texture.rs
@@ -60,6 +60,10 @@ fn setup(
 
     // Light
     commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 500_000.0,
+            ..default()
+        },
         transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
         ..default()
     });


### PR DESCRIPTION
# Objective

Fixes #11376
During the development of the exposure settings PR (#11347) all examples with lighting had to be adjusted, but three were missed or simply didn't exist yet at the time. This PR restores the brightness in those examples again:

render_ui_to_texture
asset_loading
hot_asset_reloading

All of them are a bit brighter now compared to before the exposure PR, but it looks better IMO.
