### PR TITLE
Feature-gate all references to `bevy_text` in `bevy_ui`

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -186,8 +186,8 @@ impl Plugin for UiPlugin {
 /// A function that should be called from [`UiPlugin::build`] when [`bevy_text`] is enabled.
 #[cfg(feature = "bevy_text")]
 fn build_text_interop(app: &mut App) {
-    use bevy_text::TextLayoutInfo;
     use crate::widget::TextFlags;
+    use bevy_text::TextLayoutInfo;
 
     app.register_type::<TextLayoutInfo>()
         .register_type::<TextFlags>();

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -192,7 +192,6 @@ fn build_text_interop(app: &mut App) {
     app.register_type::<TextLayoutInfo>()
         .register_type::<TextFlags>();
 
-    // add these systems to front because these must run before transform update systems
     app.add_systems(
         PostUpdate,
         (

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -176,8 +176,8 @@ impl Plugin for UiPlugin {
             system
         });
 
-        /// Marks systems that can be ambiguous with [`widget::text_system`], if the `bevy_text` feature is enabled.
-        /// https://github.com/bevyengine/bevy/pull/11391
+        // Marks systems that can be ambiguous with [`widget::text_system`] if the `bevy_text` feature is enabled.
+        // See https://github.com/bevyengine/bevy/pull/11391 for more details.
         #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
         struct AmbiguousWithTextSystem;
 

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -12,8 +12,6 @@ pub mod widget;
 use bevy_derive::{Deref, DerefMut};
 use bevy_reflect::Reflect;
 #[cfg(feature = "bevy_text")]
-use bevy_text::TextLayoutInfo;
-#[cfg(feature = "bevy_text")]
 mod accessibility;
 mod focus;
 mod geometry;
@@ -40,8 +38,6 @@ pub mod prelude {
     };
 }
 
-#[cfg(feature = "bevy_text")]
-use crate::widget::TextFlags;
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
 use bevy_input::InputSystem;
@@ -80,6 +76,14 @@ impl Default for UiScale {
         Self(1.0)
     }
 }
+
+// Marks systems that can be ambiguous with [`widget::text_system`] if the `bevy_text` feature is enabled.
+// See https://github.com/bevyengine/bevy/pull/11391 for more details.
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+struct AmbiguousWithTextSystem;
+
+#[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
+struct AmbiguousWithUpdateText2DLayout;
 
 impl Plugin for UiPlugin {
     fn build(&self, app: &mut App) {
@@ -129,48 +133,6 @@ impl Plugin for UiPlugin {
                 ui_focus_system.in_set(UiSystem::Focus).after(InputSystem),
             );
 
-        #[cfg(feature = "bevy_text")]
-        app.register_type::<TextLayoutInfo>()
-            .register_type::<TextFlags>();
-
-        // add these systems to front because these must run before transform update systems
-        #[cfg(feature = "bevy_text")]
-        app.add_systems(
-            PostUpdate,
-            (
-                widget::measure_text_system
-                    .before(UiSystem::Layout)
-                    // Potential conflict: `Assets<Image>`
-                    // In practice, they run independently since `bevy_render::camera_update_system`
-                    // will only ever observe its own render target, and `widget::measure_text_system`
-                    // will never modify a pre-existing `Image` asset.
-                    .ambiguous_with(bevy_render::camera::CameraUpdateSystem)
-                    // Potential conflict: `Assets<Image>`
-                    // Since both systems will only ever insert new [`Image`] assets,
-                    // they will never observe each other's effects.
-                    .ambiguous_with(bevy_text::update_text2d_layout)
-                    // We assume Text is on disjoint UI entities to UiImage and UiTextureAtlasImage
-                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(widget::update_image_content_size_system),
-                widget::text_system
-                    .after(UiSystem::Layout)
-                    .after(bevy_text::remove_dropped_font_atlas_sets)
-                    // Text2d and bevy_ui text are entirely on separate entities
-                    .ambiguous_with(bevy_text::update_text2d_layout),
-            ),
-        );
-
-        #[cfg(feature = "bevy_text")]
-        app.add_plugins(accessibility::AccessibilityPlugin);
-
-        // Marks systems that can be ambiguous with [`widget::text_system`] if the `bevy_text` feature is enabled.
-        // See https://github.com/bevyengine/bevy/pull/11391 for more details.
-        #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
-        struct AmbiguousWithTextSystem;
-
-        #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
-        struct AmbiguousWithUpdateText2DLayout;
-
         app.add_systems(
             PostUpdate,
             (
@@ -207,16 +169,7 @@ impl Plugin for UiPlugin {
         );
 
         #[cfg(feature = "bevy_text")]
-        app.configure_sets(
-            PostUpdate,
-            AmbiguousWithTextSystem.ambiguous_with(widget::text_system),
-        );
-
-        #[cfg(feature = "bevy_text")]
-        app.configure_sets(
-            PostUpdate,
-            AmbiguousWithUpdateText2DLayout.ambiguous_with(bevy_text::update_text2d_layout),
-        );
+        build_text_interop(app);
 
         build_ui_render(app);
     }
@@ -228,4 +181,52 @@ impl Plugin for UiPlugin {
 
         render_app.init_resource::<UiPipeline>();
     }
+}
+
+/// A function that should be called from [`UiPlugin::build`] when [`bevy_text`] is enabled.
+#[cfg(feature = "bevy_text")]
+fn build_text_interop(app: &mut App) {
+    use bevy_text::TextLayoutInfo;
+    use crate::widget::TextFlags;
+
+    app.register_type::<TextLayoutInfo>()
+        .register_type::<TextFlags>();
+
+    // add these systems to front because these must run before transform update systems
+    app.add_systems(
+        PostUpdate,
+        (
+            widget::measure_text_system
+                .before(UiSystem::Layout)
+                // Potential conflict: `Assets<Image>`
+                // In practice, they run independently since `bevy_render::camera_update_system`
+                // will only ever observe its own render target, and `widget::measure_text_system`
+                // will never modify a pre-existing `Image` asset.
+                .ambiguous_with(bevy_render::camera::CameraUpdateSystem)
+                // Potential conflict: `Assets<Image>`
+                // Since both systems will only ever insert new [`Image`] assets,
+                // they will never observe each other's effects.
+                .ambiguous_with(bevy_text::update_text2d_layout)
+                // We assume Text is on disjoint UI entities to UiImage and UiTextureAtlasImage
+                // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
+                .ambiguous_with(widget::update_image_content_size_system),
+            widget::text_system
+                .after(UiSystem::Layout)
+                .after(bevy_text::remove_dropped_font_atlas_sets)
+                // Text2d and bevy_ui text are entirely on separate entities
+                .ambiguous_with(bevy_text::update_text2d_layout),
+        ),
+    );
+
+    app.add_plugins(accessibility::AccessibilityPlugin);
+
+    app.configure_sets(
+        PostUpdate,
+        AmbiguousWithTextSystem.ambiguous_with(widget::text_system),
+    );
+
+    app.configure_sets(
+        PostUpdate,
+        AmbiguousWithUpdateText2DLayout.ambiguous_with(bevy_text::update_text2d_layout),
+    );
 }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -8,24 +8,18 @@ use bevy_render::{
     render_phase::PhaseItem, render_resource::BindGroupEntries, view::ViewVisibility,
     ExtractSchedule, Render,
 };
-use bevy_sprite::SpriteAssetEvents;
-#[cfg(feature = "bevy_text")]
-use bevy_sprite::TextureAtlas;
+use bevy_sprite::{SpriteAssetEvents, TextureAtlas};
 pub use pipeline::*;
 pub use render_pass::*;
 pub use ui_material_pipeline::*;
 
-#[cfg(feature = "bevy_text")]
-use crate::{BackgroundColor, UiImage};
 use crate::{
-    BorderColor, CalculatedClip, ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera,
-    UiScale, Val,
+    BackgroundColor, BorderColor, CalculatedClip, ContentSize, DefaultUiCamera, Node, Outline,
+    Style, TargetCamera, UiImage, UiScale, Val,
 };
 
 use bevy_app::prelude::*;
-#[cfg(feature = "bevy_text")]
-use bevy_asset::Assets;
-use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Handle};
+use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
 use bevy_render::{
@@ -40,7 +34,6 @@ use bevy_render::{
     view::{ExtractedView, ViewUniforms},
     Extract, RenderApp, RenderSet,
 };
-#[cfg(feature = "bevy_text")]
 use bevy_sprite::TextureAtlasLayout;
 #[cfg(feature = "bevy_text")]
 use bevy_text::{PositionedGlyph, Text, TextLayoutInfo};
@@ -404,7 +397,6 @@ pub fn extract_uinode_outlines(
     }
 }
 
-#[cfg(feature = "bevy_text")]
 pub fn extract_uinodes(
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     images: Extract<Res<Assets<Image>>>,

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -15,16 +15,17 @@ pub use pipeline::*;
 pub use render_pass::*;
 pub use ui_material_pipeline::*;
 
-use crate::{
-    BorderColor, CalculatedClip, ContentSize, Node, Style, UiScale, Val, DefaultUiCamera, Outline, TargetCamera,
-};
 #[cfg(feature = "bevy_text")]
 use crate::{BackgroundColor, UiImage};
+use crate::{
+    BorderColor, CalculatedClip, ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera,
+    UiScale, Val,
+};
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Handle};
 #[cfg(feature = "bevy_text")]
 use bevy_asset::Assets;
+use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Handle};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
 use bevy_render::{

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -81,7 +81,6 @@ pub fn build_ui_render(app: &mut App) {
             (
                 extract_default_ui_camera_view::<Camera2d>,
                 extract_default_ui_camera_view::<Camera3d>,
-                #[cfg(feature = "bevy_text")]
                 extract_uinodes.in_set(RenderUiSystem::ExtractNode),
                 extract_uinode_borders.after(RenderUiSystem::ExtractAtlasNode),
                 #[cfg(feature = "bevy_text")]

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -8,18 +8,23 @@ use bevy_render::{
     render_phase::PhaseItem, render_resource::BindGroupEntries, view::ViewVisibility,
     ExtractSchedule, Render,
 };
-use bevy_sprite::{SpriteAssetEvents, TextureAtlas};
+use bevy_sprite::SpriteAssetEvents;
+#[cfg(feature = "bevy_text")]
+use bevy_sprite::TextureAtlas;
 pub use pipeline::*;
 pub use render_pass::*;
 pub use ui_material_pipeline::*;
 
 use crate::{
-    BackgroundColor, BorderColor, CalculatedClip, ContentSize, Node, Style, UiImage, UiScale, Val,
+    BorderColor, CalculatedClip, ContentSize, Node, Style, UiScale, Val, DefaultUiCamera, Outline, TargetCamera,
 };
-use crate::{DefaultUiCamera, Outline, TargetCamera};
+#[cfg(feature = "bevy_text")]
+use crate::{BackgroundColor, UiImage};
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Handle};
+#[cfg(feature = "bevy_text")]
+use bevy_asset::Assets;
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
 use bevy_render::{
@@ -82,6 +87,7 @@ pub fn build_ui_render(app: &mut App) {
             (
                 extract_default_ui_camera_view::<Camera2d>,
                 extract_default_ui_camera_view::<Camera3d>,
+                #[cfg(feature = "bevy_text")]
                 extract_uinodes.in_set(RenderUiSystem::ExtractNode),
                 extract_uinode_borders.after(RenderUiSystem::ExtractAtlasNode),
                 #[cfg(feature = "bevy_text")]
@@ -397,6 +403,7 @@ pub fn extract_uinode_outlines(
     }
 }
 
+#[cfg(feature = "bevy_text")]
 pub fn extract_uinodes(
     mut extracted_uinodes: ResMut<ExtractedUiNodes>,
     images: Extract<Res<Assets<Image>>>,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -2,6 +2,7 @@ use crate::{measurement::AvailableSpace, ContentSize, Measure, Node, UiImage, Ui
 use bevy_asset::Assets;
 
 use bevy_ecs::change_detection::DetectChanges;
+#[cfg(feature = "bevy_text")]
 use bevy_ecs::query::Without;
 use bevy_ecs::{
     prelude::Component,

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,15 +1,6 @@
 use crate::{measurement::AvailableSpace, ContentSize, Measure, Node, UiImage, UiScale};
 use bevy_asset::Assets;
-
-#[cfg(feature = "bevy_text")]
-use bevy_ecs::query::Without;
-use bevy_ecs::{
-    change_detection::DetectChanges,
-    prelude::Component,
-    query::With,
-    reflect::ReflectComponent,
-    system::{Local, Query, Res},
-};
+use bevy_ecs::prelude::*;
 use bevy_math::Vec2;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::texture::Image;

--- a/crates/bevy_ui/src/widget/image.rs
+++ b/crates/bevy_ui/src/widget/image.rs
@@ -1,10 +1,10 @@
 use crate::{measurement::AvailableSpace, ContentSize, Measure, Node, UiImage, UiScale};
 use bevy_asset::Assets;
 
-use bevy_ecs::change_detection::DetectChanges;
 #[cfg(feature = "bevy_text")]
 use bevy_ecs::query::Without;
 use bevy_ecs::{
+    change_detection::DetectChanges,
     prelude::Component,
     query::With,
     reflect::ReflectComponent,


### PR DESCRIPTION
# Objective

- `bevy_ui` fails to compile without `bevy_text` being enabled.
- Fixes #11363.

## Solution

- Add `#[cfg(feature = "bevy_text")]` to all items that require it.

I think this change is honestly a bit ugly, but I can't see any other way around it. I considered making `bevy_text` required, but we agreed [on Discord](https://discord.com/channels/691052431525675048/743663673393938453/1196868117486379148) that there were some use cases for `bevy_ui` without `bevy_text`. If you have any ideas that decreases the amount of `#[cfg(...)]`s and `#[allow(...)]`s, that would be greatly appreciated.

This was tested by running the following commands:

```shell
$ cargo clippy -p bevy_ui
$ cargo clippy -p bevy_ui -F bevy_text
$ cargo run -p ci
```

---

## Changelog

- Fixed `bevy_ui` not compiling without `bevy_text`.
