### PR TITLE
support `NO_COLOR` env var for disabling ANSI

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -173,7 +173,11 @@ impl Plugin for LogPlugin {
             #[cfg(feature = "tracing-tracy")]
             let tracy_layer = tracing_tracy::TracyLayer::new();
 
-            let fmt_layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
+            let use_color = std::env::var("NO_COLOR").map(|v| v != "1").unwrap_or(true);
+
+            let fmt_layer = tracing_subscriber::fmt::Layer::default()
+                .with_ansi(use_color)
+                .with_writer(std::io::stderr);
 
             // bevy_render::renderer logs a `tracy.frame_mark` event every frame
             // at Level::INFO. Formatted logs should omit it.


### PR DESCRIPTION
# Objective

Allows disabling ANSI codes in log outputs according to https://no-color.org/. Fixes #11351 

## Solution

Instead of using the default tracing subscriber formatting layer, we check if the the env variable `NO_COLOR` equals `"1"`, and if so, set `.with_ansi(false)`.

---

## Changelog

Allows setting the `NO_COLOR` environment variable to disable ANSI codes in log output.

## Migration Guide

N/A (non-breaking, new feature)