### PR TITLE
Get Change Tick methods for Resources

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -18,7 +18,7 @@ use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, ArchetypeRow, Archetypes},
     bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, TicksMut},
-    component::{Component, ComponentDescriptor, ComponentId, ComponentInfo, Components, Tick},
+    component::{Component, ComponentDescriptor, ComponentId, ComponentInfo, Components, Tick, ComponentTicks},
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
     event::{Event, EventId, Events, SendBatchIds},
     query::{DebugCheckedUnwrap, QueryData, QueryEntityError, QueryFilter, QueryState},
@@ -1253,6 +1253,25 @@ impl World {
                     .map(|ticks| ticks.is_changed(self.last_change_tick(), self.read_change_tick()))
             })
             .unwrap_or(false)
+    }
+
+    /// Retrieves the change ticks for the given resource.
+    pub fn get_resource_change_ticks<R: Resource>(&self) -> Option<ComponentTicks> {
+        self.components
+            .get_resource_id(TypeId::of::<R>())
+            .and_then(|component_id| self.get_resource_change_ticks_by_id(component_id))
+    }
+
+    /// Retrieves the change ticks for the given [`ComponentId`].
+    ///
+    /// **You should prefer to use the typed API [`World::get_resource_change_ticks`] where possible.**
+    pub fn get_resource_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
+        self.storages
+            .resources
+            .get(component_id)
+            .and_then(|resource| {
+                resource.get_ticks()
+            })
     }
 
     /// Gets a reference to the resource of the given type

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -18,7 +18,10 @@ use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, ArchetypeRow, Archetypes},
     bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, TicksMut},
-    component::{Component, ComponentDescriptor, ComponentId, ComponentInfo, Components, Tick, ComponentTicks},
+    component::{
+        Component, ComponentDescriptor, ComponentId, ComponentInfo, ComponentTicks, Components,
+        Tick,
+    },
     entity::{AllocAtWithoutReplacement, Entities, Entity, EntityLocation},
     event::{Event, EventId, Events, SendBatchIds},
     query::{DebugCheckedUnwrap, QueryData, QueryEntityError, QueryFilter, QueryState},
@@ -1265,13 +1268,14 @@ impl World {
     /// Retrieves the change ticks for the given [`ComponentId`].
     ///
     /// **You should prefer to use the typed API [`World::get_resource_change_ticks`] where possible.**
-    pub fn get_resource_change_ticks_by_id(&self, component_id: ComponentId) -> Option<ComponentTicks> {
+    pub fn get_resource_change_ticks_by_id(
+        &self,
+        component_id: ComponentId,
+    ) -> Option<ComponentTicks> {
         self.storages
             .resources
             .get(component_id)
-            .and_then(|resource| {
-                resource.get_ticks()
-            })
+            .and_then(|resource| resource.get_ticks())
     }
 
     /// Gets a reference to the resource of the given type


### PR DESCRIPTION
# Objective

- Add methods to get Change Ticks for a given resource by type or ComponentId
- Fixes #11390
The `is_resource_id_changed` requested in the Issue already exists, this adds their request for `get_resource_change_ticks`

## Solution

- Added two methods to get change ticks by Type or ComponentId