### PR TITLE
Use `static_assertions` to check for trait impls

### DIFF
--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -41,6 +41,7 @@ rmp-serde = "1.1"
 bincode = "1.3"
 serde_json = "1.0"
 serde = { version = "1", features = ["derive"] }
+static_assertions = "1.1.0"
 
 [[example]]
 name = "reflect_docs"

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1603,7 +1603,6 @@ mod tests {
 
     #[test]
     fn option_should_impl_enum() {
-        // TODO: Should we keep the other tests?
         assert_impl_all!(Option<()>: Enum);
 
         let mut value = Some(123usize);
@@ -1679,7 +1678,6 @@ mod tests {
 
     #[test]
     fn option_should_impl_typed() {
-        // TODO: Should we keep the other tests?
         assert_impl_all!(Option<()>: Typed);
 
         type MyOption = Option<i32>;

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1516,9 +1516,9 @@ mod tests {
     };
     use bevy_utils::{Duration, Instant};
     use bevy_utils::{EntityHashMap, HashMap};
+    use static_assertions::assert_impl_all;
     use std::f32::consts::{PI, TAU};
     use std::path::Path;
-    use static_assertions::assert_impl_all;
 
     // EntityHashMap should implement Reflect
     assert_impl_all!(EntityHashMap<i32, i32>: Reflect);

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1603,6 +1603,9 @@ mod tests {
 
     #[test]
     fn option_should_impl_enum() {
+        // TODO: Should we keep the other tests?
+        assert_impl_all!(Option<()>: Enum);
+
         let mut value = Some(123usize);
 
         assert!(value
@@ -1676,6 +1679,9 @@ mod tests {
 
     #[test]
     fn option_should_impl_typed() {
+        // TODO: Should we keep the other tests?
+        assert_impl_all!(Option<()>: Typed);
+
         type MyOption = Option<i32>;
         let info = MyOption::type_info();
         if let TypeInfo::Enum(info) = info {
@@ -1706,6 +1712,7 @@ mod tests {
             panic!("Expected `TypeInfo::Enum`");
         }
     }
+
     #[test]
     fn nonzero_usize_impl_reflect_from_reflect() {
         let a: &dyn Reflect = &std::num::NonZeroUsize::new(42).unwrap();

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1518,6 +1518,10 @@ mod tests {
     use bevy_utils::{EntityHashMap, HashMap};
     use std::f32::consts::{PI, TAU};
     use std::path::Path;
+    use static_assertions::assert_impl_all;
+
+    // EntityHashMap should implement Reflect
+    assert_impl_all!(EntityHashMap<i32, i32>: Reflect);
 
     #[test]
     fn can_serialize_duration() {
@@ -1723,13 +1727,5 @@ mod tests {
         let path = Path::new("hello_world.rs");
         let output = <&'static Path as FromReflect>::from_reflect(&path).unwrap();
         assert_eq!(path, output);
-    }
-
-    #[test]
-    fn entity_hashmap_should_impl_reflect() {
-        let entity_map = bevy_utils::EntityHashMap::<i32, i32>::default();
-        let entity_map_type_info =
-            <EntityHashMap<_, _> as Reflect>::get_represented_type_info(&entity_map);
-        assert!(entity_map_type_info.is_some());
     }
 }


### PR DESCRIPTION
# Objective

- Tests are manually checking whether derived types implement certain traits. (Specifically in `bevy_reflect.)
- #11182 introduces [`static_assertions`](https://docs.rs/static_assertions/) to automatically check this.
- Simplifies `Reflect` test in #11195.
- Closes #11196.

## Solution

- Add `static_assertions` and replace current tests.

---

I wasn't sure whether to remove the existing test or not. What do you think?