### PR TITLE
Bump dev-docs pages actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,10 +61,10 @@ jobs:
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: target/doc
 
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
# Objective

- `actions/upload-pages-artifact` and `actions/deploy-pages` are outdated.
- Alternative to #11253 and #11252.

## Solution

- Bump the version of both actions.

---


There appear to be no user-facing changes. They just both need to be updated together. (The `actions: read` permission was a bug that was fixed later.)