### PR TITLE
move once from bevy_log to bevy_utils, to allow for it's use in bevy_ecs

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -11,8 +11,6 @@
 //! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
 //! `DefaultPlugins` during app initialization.
 
-mod once;
-
 #[cfg(feature = "trace")]
 use std::panic;
 
@@ -31,12 +29,17 @@ pub mod prelude {
         debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
     };
 
-    pub use crate::{debug_once, error_once, info_once, trace_once, warn_once};
+    #[doc(hidden)]
+    pub use bevy_utils::{debug_once, error_once, info_once, once, trace_once, warn_once};
 }
 
-pub use bevy_utils::tracing::{
-    debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
-    Level,
+pub use bevy_utils::{
+    debug_once, error_once, info_once, once, trace_once,
+    tracing::{
+        debug, debug_span, error, error_span, info, info_span, trace, trace_span, warn, warn_span,
+        Level,
+    },
+    warn_once,
 };
 pub use tracing_subscriber;
 

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -23,6 +23,7 @@ mod cow_arc;
 mod default;
 mod float_ord;
 pub mod intern;
+mod once;
 
 pub use crate::uuid::Uuid;
 pub use ahash::{AHasher, RandomState};

--- a/crates/bevy_utils/src/once.rs
+++ b/crates/bevy_utils/src/once.rs
@@ -11,7 +11,7 @@ macro_rules! once {
     }};
 }
 
-/// Call [`trace!`](crate::trace) once per call site.
+/// Call [`trace!`](crate::tracing::trace) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
@@ -21,7 +21,7 @@ macro_rules! trace_once {
     });
 }
 
-/// Call [`debug!`](crate::debug) once per call site.
+/// Call [`debug!`](crate::tracing::debug) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
@@ -31,7 +31,7 @@ macro_rules! debug_once {
     });
 }
 
-/// Call [`info!`](crate::info) once per call site.
+/// Call [`info!`](crate::tracing::info) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
@@ -41,7 +41,7 @@ macro_rules! info_once {
     });
 }
 
-/// Call [`warn!`](crate::warn) once per call site.
+/// Call [`warn!`](crate::tracing::warn) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]
@@ -51,7 +51,7 @@ macro_rules! warn_once {
     });
 }
 
-/// Call [`error!`](crate::error) once per call site.
+/// Call [`error!`](crate::tracing::error) once per call site.
 ///
 /// Useful for logging within systems which are called every frame.
 #[macro_export]

--- a/crates/bevy_utils/src/once.rs
+++ b/crates/bevy_utils/src/once.rs
@@ -17,7 +17,7 @@ macro_rules! once {
 #[macro_export]
 macro_rules! trace_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::trace!($($arg)+))
+        $crate::once!($crate::tracing::trace!($($arg)+))
     });
 }
 
@@ -27,7 +27,7 @@ macro_rules! trace_once {
 #[macro_export]
 macro_rules! debug_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::debug!($($arg)+))
+        $crate::once!($crate::tracing::debug!($($arg)+))
     });
 }
 
@@ -37,7 +37,7 @@ macro_rules! debug_once {
 #[macro_export]
 macro_rules! info_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::info!($($arg)+))
+        $crate::once!($crate::tracing::info!($($arg)+))
     });
 }
 
@@ -47,7 +47,7 @@ macro_rules! info_once {
 #[macro_export]
 macro_rules! warn_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::warn!($($arg)+))
+        $crate::once!($crate::tracing::warn!($($arg)+))
     });
 }
 
@@ -57,6 +57,6 @@ macro_rules! warn_once {
 #[macro_export]
 macro_rules! error_once {
     ($($arg:tt)+) => ({
-        $crate::once!($crate::error!($($arg)+))
+        $crate::once!($crate::tracing::error!($($arg)+))
     });
 }


### PR DESCRIPTION
# Objective

When working within `bevy_ecs`, we can't use the `log_once` macros due to their placement in `bevy_log` - which depends on `bevy_ecs`. All this create does is migrate those macros to the `bevy_utils` crate,  while still re-exporting them in `bevy_log`.

created to resolve this: https://github.com/bevyengine/bevy/pull/11417#discussion_r1458100211