### PR TITLE
Fix gizmos app new panic

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -156,8 +156,7 @@ impl AppGizmoBuilder for App {
         self.init_resource::<GizmoStorage<T>>()
             .add_systems(Last, update_gizmo_meshes::<T>);
 
-        self.world
-            .resource_mut::<GizmoConfigStore>()
+        self.world.get_resource_or_insert_with::<GizmoConfigStore>(Default::default)
             .register::<T>();
 
         let Ok(render_app) = self.get_sub_app_mut(RenderApp) else {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -103,6 +103,7 @@ impl Plugin for GizmoPlugin {
             .init_asset::<LineGizmo>()
             .add_plugins(RenderAssetPlugin::<LineGizmo>::default())
             .init_resource::<LineGizmoHandles>()
+            // We insert the Resource GizmoConfigStore into the world implicitly here if it does not exist.
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
             .add_plugins(AabbGizmoPlugin);
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -103,7 +103,6 @@ impl Plugin for GizmoPlugin {
             .init_asset::<LineGizmo>()
             .add_plugins(RenderAssetPlugin::<LineGizmo>::default())
             .init_resource::<LineGizmoHandles>()
-            .init_resource::<GizmoConfigStore>()
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
             .add_plugins(AabbGizmoPlugin);
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -156,7 +156,8 @@ impl AppGizmoBuilder for App {
         self.init_resource::<GizmoStorage<T>>()
             .add_systems(Last, update_gizmo_meshes::<T>);
 
-        self.world.get_resource_or_insert_with::<GizmoConfigStore>(Default::default)
+        self.world
+            .get_resource_or_insert_with::<GizmoConfigStore>(Default::default)
             .register::<T>();
 
         let Ok(render_app) = self.get_sub_app_mut(RenderApp) else {


### PR DESCRIPTION
# Objective

After the Gizmos changes, `App::init_gizmos_group` turned into a important function that for sure mustn't panic. The problem is: the actual implementation causes a panic if somehow the code is runned before `GizmoPlugin` was added to the App
- The error occurs here for example:
```rust
fn main() {
    App::new()
        .init_gizmo_group::<MyGizmoConfig>()
        .add_plugins(DefaultPlugins)
        .run();
}

#[derive(Default, Reflect, GizmoConfigGroup)]
struct MyGizmoConfig;
```
![image](https://github.com/bevyengine/bevy/assets/126117294/35e75608-0946-4320-8035-00a82562e37e)


## Solution

- Instead of panicking when getting `GizmoConfigStore`, insert the store in `App::init_gizmos_group` if needed 

---

## Changelog

### Changed
- Changed App::init_gizmos_group to insert the resource if it don't exist

### Removed
- Removed explicit init of `GizmoConfigStore`

