### PR TITLE
Miri is failing on latest nightly: pin nightly to last known working version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  NIGHTLY_TOOLCHAIN: nightly
+  NIGHTLY_TOOLCHAIN: nightly-2024-01-17
 
 jobs:
   build:


### PR DESCRIPTION
# Objective

- https://github.com/rust-lang/rust/pull/118553 seems to have broken miri test

## Solution

- Pin nightly to before it was merged
