### PR TITLE
Direction: Rename `from_normalized` to `new_unchecked`

### DIFF
--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -166,7 +166,8 @@ impl Bounded3d for Capsule {
     fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
         // Get the line segment between the hemispheres of the rotated capsule
         let segment = Segment3d {
-            direction: Direction3d::from_normalized(rotation * Vec3::Y),
+            // SAFETY: Multipling a normalized vector (Vec3::Y) with a rotation returns a normalized vector.
+            direction: unsafe { Direction3d::new_unchecked(rotation * Vec3::Y) },
             half_length: self.half_length,
         };
         let (a, b) = (segment.point1(), segment.point2());

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -166,7 +166,7 @@ impl Bounded3d for Capsule {
     fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
         // Get the line segment between the hemispheres of the rotated capsule
         let segment = Segment3d {
-            // Multipling a normalized vector (Vec3::Y) with a rotation returns a normalized vector.
+            // Multiplying a normalized vector (Vec3::Y) with a rotation returns a normalized vector.
             direction: Direction3d::new_unchecked(rotation * Vec3::Y),
             half_length: self.half_length,
         };

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -166,8 +166,8 @@ impl Bounded3d for Capsule {
     fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
         // Get the line segment between the hemispheres of the rotated capsule
         let segment = Segment3d {
-            // SAFETY: Multipling a normalized vector (Vec3::Y) with a rotation returns a normalized vector.
-            direction: unsafe { Direction3d::new_unchecked(rotation * Vec3::Y) },
+            // Multipling a normalized vector (Vec3::Y) with a rotation returns a normalized vector.
+            direction: Direction3d::new_unchecked(rotation * Vec3::Y),
             half_length: self.half_length,
         };
         let (a, b) = (segment.point1(), segment.point2());

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -28,8 +28,7 @@ impl Direction2d {
     ///
     /// # Warning
     ///
-    /// This function only checks if `value` is normalized on debug builds,
-    /// release builds can allow the creation of a [`Direction2d`] that is not normalized.
+    /// `value` must be normalized, i.e it's length must be `1.0`.
     pub fn new_unchecked(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -26,7 +26,7 @@ impl Direction2d {
 
     /// Create a [`Direction2d`] from a [`Vec2`] that is already normalized.
     ///
-    /// ## Warning
+    /// # Warning
     ///
     /// This function only checks if `value` is normalized on debug builds,
     /// release builds can allow the creation of a [`Direction2d`] that is not normalized.

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -24,6 +24,18 @@ impl Direction2d {
         Self::new_and_length(value).map(|(dir, _)| dir)
     }
 
+    /// Create a [`Direction2d`] from a [`Vec2`] that is already normalized.
+    ///
+    /// ## Safety
+    ///
+    /// This function only checks if `value` is normalized on debug builds,
+    /// release builds can allow the creation of a [`Direction2d`] that is not normalized.
+    pub unsafe fn new_unchecked(value: Vec2) -> Self {
+        debug_assert!(value.is_normalized());
+
+        Self(value)
+    }
+
     /// Create a direction from a finite, nonzero [`Vec2`], also returning its original length.
     ///
     /// Returns [`Err(InvalidDirectionError)`](InvalidDirectionError) if the length
@@ -34,7 +46,7 @@ impl Direction2d {
 
         direction
             .map(|dir| (Self(dir), length))
-            .map_or(Err(InvalidDirectionError::from_length(length)), Ok)
+            .ok_or(InvalidDirectionError::from_length(length))
     }
 
     /// Create a direction from its `x` and `y` components.
@@ -43,12 +55,6 @@ impl Direction2d {
     /// of the vector formed by the components is zero (or very close to zero), infinite, or `NaN`.
     pub fn from_xy(x: f32, y: f32) -> Result<Self, InvalidDirectionError> {
         Self::new(Vec2::new(x, y))
-    }
-
-    /// Create a direction from a [`Vec2`] that is already normalized.
-    pub fn from_normalized(value: Vec2) -> Self {
-        debug_assert!(value.is_normalized());
-        Self(value)
     }
 }
 
@@ -163,8 +169,10 @@ impl Segment2d {
     pub fn from_points(point1: Vec2, point2: Vec2) -> (Self, Vec2) {
         let diff = point2 - point1;
         let length = diff.length();
+
         (
-            Self::new(Direction2d::from_normalized(diff / length), length),
+            // SAFETY: We are dividing by the length here, so the Vector is normalized.
+            Self::new(unsafe { Direction2d::new_unchecked(diff / length) }, length),
             (point1 + point2) / 2.,
         )
     }
@@ -457,7 +465,7 @@ mod tests {
         );
         assert_eq!(
             Direction2d::new_and_length(Vec2::X * 6.5),
-            Ok((Direction2d::from_normalized(Vec2::X), 6.5))
+            Ok((Direction2d::X, 6.5))
         );
     }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -26,11 +26,11 @@ impl Direction2d {
 
     /// Create a [`Direction2d`] from a [`Vec2`] that is already normalized.
     ///
-    /// ## Safety
+    /// ## Warning
     ///
     /// This function only checks if `value` is normalized on debug builds,
     /// release builds can allow the creation of a [`Direction2d`] that is not normalized.
-    pub unsafe fn new_unchecked(value: Vec2) -> Self {
+    pub fn new_unchecked(value: Vec2) -> Self {
         debug_assert!(value.is_normalized());
 
         Self(value)
@@ -171,8 +171,8 @@ impl Segment2d {
         let length = diff.length();
 
         (
-            // SAFETY: We are dividing by the length here, so the Vector is normalized.
-            Self::new(unsafe { Direction2d::new_unchecked(diff / length) }, length),
+            // We are dividing by the length here, so the vector is normalized.
+            Self::new(Direction2d::new_unchecked(diff / length), length),
             (point1 + point2) / 2.,
         )
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -30,11 +30,11 @@ impl Direction3d {
 
     /// Create a [`Direction3d`] from a [`Vec3`] that is already normalized.
     ///
-    /// ## Safety
+    /// # Warning
     ///
     /// This function only checks if `value` is normalized on debug builds,
     /// release builds can allow the creation of a [`Direction3d`] that is not normalized.
-    pub unsafe fn new_unchecked(value: Vec3) -> Self {
+    pub fn new_unchecked(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());
 
         Self(value)
@@ -50,7 +50,7 @@ impl Direction3d {
 
         direction
             .map(|dir| (Self(dir), length))
-            .map_or(Err(InvalidDirectionError::from_length(length)), Ok)
+            .ok_or(InvalidDirectionError::from_length(length))
     }
 
     /// Create a direction from its `x`, `y`, and `z` components.
@@ -154,8 +154,8 @@ impl Segment3d {
         let length = diff.length();
 
         (
-            // SAFETY: We are dividing by the length here, so the Vector is normalized.
-            Self::new(unsafe { Direction3d::new_unchecked(diff / length) }, length),
+            // We are dividing by the length here, so the Vector is normalized.
+            Self::new(Direction3d::new_unchecked(diff / length), length),
             (point1 + point2) / 2.,
         )
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -153,7 +153,7 @@ impl Segment3d {
         let length = diff.length();
 
         (
-            // We are dividing by the length here, so the Vector is normalized.
+            // We are dividing by the length here, so the vector is normalized.
             Self::new(Direction3d::new_unchecked(diff / length), length),
             (point1 + point2) / 2.,
         )

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -32,8 +32,7 @@ impl Direction3d {
     ///
     /// # Warning
     ///
-    /// This function only checks if `value` is normalized on debug builds,
-    /// release builds can allow the creation of a [`Direction3d`] that is not normalized.
+    /// `value` must be normalized, i.e it's length must be `1.0`.
     pub fn new_unchecked(value: Vec3) -> Self {
         debug_assert!(value.is_normalized());
 


### PR DESCRIPTION
# Objective

`Direction2d::from_normalized` & `Direction3d::from_normalized` don't emphasize that importance of the vector being normalized enough.

## Solution

Rename `from_normalized` to `new_unchecked` and add more documentation.

---

`Direction2d` and `Direction3d` were added somewhat recently in https://github.com/bevyengine/bevy/pull/10466 (after 0.12), so I don't think documenting the changelog and migration guide is necessary (Since there is no major previous version to migrate from).

But here it is anyway in case it's needed:

## Changelog

- Renamed `Direction2d::from_normalized` and `Direction3d::from_normalized` to `new_unchecked`.

## Migration Guide

- Renamed `Direction2d::from_normalized` and `Direction3d::from_normalized` to `new_unchecked`.