### PR TITLE
Improve `Rectangle` and `Cuboid` consistency

### DIFF
--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -193,11 +193,11 @@ impl Bounded2d for Rectangle {
         // by an absolute rotation matrix.
         let (sin, cos) = rotation.sin_cos();
         let abs_rot_mat = Mat2::from_cols_array(&[cos.abs(), sin.abs(), sin.abs(), cos.abs()]);
-        let half_extents = abs_rot_mat * self.half_size;
+        let half_size = abs_rot_mat * self.half_size;
 
         Aabb2d {
-            min: translation - half_extents,
-            max: translation + half_extents,
+            min: translation - half_size,
+            max: translation + half_size,
         }
     }
 

--- a/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/primitive_impls.rs
@@ -189,13 +189,11 @@ impl Bounded2d for Triangle2d {
 
 impl Bounded2d for Rectangle {
     fn aabb_2d(&self, translation: Vec2, rotation: f32) -> Aabb2d {
-        let half_size = Vec2::new(self.half_width, self.half_height);
-
         // Compute the AABB of the rotated rectangle by transforming the half-extents
         // by an absolute rotation matrix.
         let (sin, cos) = rotation.sin_cos();
         let abs_rot_mat = Mat2::from_cols_array(&[cos.abs(), sin.abs(), sin.abs(), cos.abs()]);
-        let half_extents = abs_rot_mat * half_size;
+        let half_extents = abs_rot_mat * self.half_size;
 
         Aabb2d {
             min: translation - half_extents,
@@ -204,7 +202,7 @@ impl Bounded2d for Rectangle {
     }
 
     fn bounding_circle(&self, translation: Vec2, _rotation: f32) -> BoundingCircle {
-        let radius = self.half_width.hypot(self.half_height);
+        let radius = self.half_size.length();
         BoundingCircle::new(translation, radius)
     }
 }

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -120,12 +120,11 @@ impl Bounded3d for Cuboid {
             rot_mat.y_axis.abs(),
             rot_mat.z_axis.abs(),
         );
-
-        let half_extents = abs_rot_mat * self.half_size;
+        let half_size = abs_rot_mat * self.half_size;
 
         Aabb3d {
-            min: translation - half_extents,
-            max: translation + half_extents,
+            min: translation - half_size,
+            max: translation + half_size,
         }
     }
 

--- a/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/primitive_impls.rs
@@ -121,7 +121,7 @@ impl Bounded3d for Cuboid {
             rot_mat.z_axis.abs(),
         );
 
-        let half_extents = abs_rot_mat * self.half_extents;
+        let half_extents = abs_rot_mat * self.half_size;
 
         Aabb3d {
             min: translation - half_extents,
@@ -133,7 +133,7 @@ impl Bounded3d for Cuboid {
         BoundingSphere {
             center: translation,
             sphere: Sphere {
-                radius: self.half_extents.length(),
+                radius: self.half_size.length(),
             },
         }
     }

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -311,12 +311,9 @@ impl Triangle2d {
 #[doc(alias = "Quad")]
 #[derive(Clone, Copy, Debug)]
 pub struct Rectangle {
-    /// The half width of the rectangle
-    pub half_width: f32,
-    /// The half height of the rectangle
-    pub half_height: f32,
+    /// Half of the width and height of the rectangle
+    pub half_size: Vec2,
 }
-impl Primitive2d for Rectangle {}
 
 impl Rectangle {
     /// Create a rectangle from a full width and height
@@ -327,8 +324,7 @@ impl Rectangle {
     /// Create a rectangle from a given full size
     pub fn from_size(size: Vec2) -> Self {
         Self {
-            half_width: size.x / 2.,
-            half_height: size.y / 2.,
+            half_size: size / 2.,
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -222,7 +222,7 @@ impl BoxedPolyline3d {
 #[derive(Clone, Copy, Debug)]
 pub struct Cuboid {
     /// Half of the width, height and depth of the cuboid
-    pub half_extents: Vec3,
+    pub half_size: Vec3,
 }
 impl Primitive3d for Cuboid {}
 
@@ -235,7 +235,7 @@ impl Cuboid {
     /// Create a cuboid from a given full size
     pub fn from_size(size: Vec3) -> Self {
         Self {
-            half_extents: size / 2.,
+            half_size: size / 2.,
         }
     }
 }


### PR DESCRIPTION
# Objective

The `Rectangle` and `Cuboid` primitives currently use different representations:

```rust
pub struct Rectangle {
    /// The half width of the rectangle
    pub half_width: f32,
    /// The half height of the rectangle
    pub half_height: f32,
}

pub struct Cuboid {
    /// Half of the width, height and depth of the cuboid
    pub half_extents: Vec3,
}
```

The property names and helpers are also inconsistent. `Cuboid` has `half_extents`, but it also has a method called `from_size`. Most existing code also uses "size" instead of "extents".

## Solution

Represent both `Rectangle` and `Cuboid` with `half_size` properties.