### PR TITLE
Implement bounding volume intersections

### DIFF
--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -154,7 +154,7 @@ impl IntersectsVolume<BoundingCircle> for Aabb2d {
         let closest_point = self.closest_point(circle.center);
         let distance_squared = circle.center.distance_squared(closest_point);
         let radius_squared = circle.radius().powi(2);
-        distance_squared < radius_squared
+        distance_squared <= radius_squared
     }
 }
 

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -268,6 +268,20 @@ mod aabb2d_tests {
     }
 
     #[test]
+    fn closest_point() {
+        let aabb = Aabb2d {
+            min: Vec2::NEG_ONE,
+            max: Vec2::ONE,
+        };
+        assert_eq!(aabb.closest_point(Vec2::X * 10.0), Vec2::X);
+        assert_eq!(aabb.closest_point(Vec2::NEG_ONE * 10.0), Vec2::NEG_ONE);
+        assert_eq!(
+            aabb.closest_point(Vec2::new(0.25, 0.1)),
+            Vec2::new(0.25, 0.1)
+        );
+    }
+
+    #[test]
     fn intersect_aabb() {
         let aabb = Aabb2d {
             min: Vec2::NEG_ONE,
@@ -536,6 +550,20 @@ mod bounding_circle_tests {
         assert!((shrunk.radius() - 4.5).abs() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn closest_point() {
+        let circle = BoundingCircle::new(Vec2::ZERO, 1.0);
+        assert_eq!(circle.closest_point(Vec2::X * 10.0), Vec2::X);
+        assert_eq!(
+            circle.closest_point(Vec2::NEG_ONE * 10.0),
+            Vec2::NEG_ONE.normalize()
+        );
+        assert_eq!(
+            circle.closest_point(Vec2::new(0.25, 0.1)),
+            Vec2::new(0.25, 0.1)
+        );
     }
 
     #[test]

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -73,7 +73,7 @@ impl Aabb2d {
 
     /// Finds the point on the AABB that is closest to the given `point`.
     ///
-    /// If the point is outside the AABB, the returned point will be on the surface of the AABB.
+    /// If the point is outside the AABB, the returned point will be on the perimeter of the AABB.
     /// Otherwise, it will be inside the AABB and returned as is.
     #[inline(always)]
     pub fn closest_point(&self, point: Vec2) -> Vec2 {
@@ -377,22 +377,11 @@ impl BoundingCircle {
 
     /// Finds the point on the bounding circle that is closest to the given `point`.
     ///
-    /// If the point is outside the circle, the returned point will be on the surface of the circle.
+    /// If the point is outside the circle, the returned point will be on the perimeter of the circle.
     /// Otherwise, it will be inside the circle and returned as is.
     #[inline(always)]
     pub fn closest_point(&self, point: Vec2) -> Vec2 {
-        let offset_from_center = point - self.center;
-        let distance_to_center_squared = offset_from_center.length_squared();
-
-        if distance_to_center_squared <= self.radius().powi(2) {
-            // The point is inside the circle
-            point
-        } else {
-            // The point is outside the circle.
-            // Find the closest point on the surface of the circle.
-            let dir_to_point = offset_from_center / distance_to_center_squared.sqrt();
-            self.center() + self.radius() * dir_to_point
-        }
+        self.circle.closest_point(point - self.center) + self.center
     }
 }
 

--- a/crates/bevy_math/src/bounding/bounded2d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded2d/mod.rs
@@ -161,7 +161,10 @@ impl IntersectsVolume<BoundingCircle> for Aabb2d {
 #[cfg(test)]
 mod aabb2d_tests {
     use super::Aabb2d;
-    use crate::{bounding::BoundingVolume, Vec2};
+    use crate::{
+        bounding::{BoundingCircle, BoundingVolume, IntersectsVolume},
+        Vec2,
+    };
 
     #[test]
     fn center() {
@@ -262,6 +265,39 @@ mod aabb2d_tests {
         assert!((shrunk.max - Vec2::new(1., 1.)).length() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn intersect_aabb() {
+        let aabb = Aabb2d {
+            min: Vec2::NEG_ONE,
+            max: Vec2::ONE,
+        };
+        assert!(aabb.intersects(&aabb));
+        assert!(aabb.intersects(&Aabb2d {
+            min: Vec2::new(0.5, 0.5),
+            max: Vec2::new(2.0, 2.0),
+        }));
+        assert!(aabb.intersects(&Aabb2d {
+            min: Vec2::new(-2.0, -2.0),
+            max: Vec2::new(-0.5, -0.5),
+        }));
+        assert!(!aabb.intersects(&Aabb2d {
+            min: Vec2::new(1.1, 0.0),
+            max: Vec2::new(2.0, 0.5),
+        }));
+    }
+
+    #[test]
+    fn intersect_bounding_circle() {
+        let aabb = Aabb2d {
+            min: Vec2::NEG_ONE,
+            max: Vec2::ONE,
+        };
+        assert!(aabb.intersects(&BoundingCircle::new(Vec2::ZERO, 1.0)));
+        assert!(aabb.intersects(&BoundingCircle::new(Vec2::ONE * 1.5, 1.0)));
+        assert!(aabb.intersects(&BoundingCircle::new(Vec2::NEG_ONE * 1.5, 1.0)));
+        assert!(!aabb.intersects(&BoundingCircle::new(Vec2::ONE * 1.75, 1.0)));
     }
 }
 
@@ -421,7 +457,10 @@ impl IntersectsVolume<Aabb2d> for BoundingCircle {
 #[cfg(test)]
 mod bounding_circle_tests {
     use super::BoundingCircle;
-    use crate::{bounding::BoundingVolume, Vec2};
+    use crate::{
+        bounding::{BoundingVolume, IntersectsVolume},
+        Vec2,
+    };
 
     #[test]
     fn area() {
@@ -497,5 +536,14 @@ mod bounding_circle_tests {
         assert!((shrunk.radius() - 4.5).abs() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn intersect_bounding_circle() {
+        let circle = BoundingCircle::new(Vec2::ZERO, 1.0);
+        assert!(circle.intersects(&BoundingCircle::new(Vec2::ZERO, 1.0)));
+        assert!(circle.intersects(&BoundingCircle::new(Vec2::ONE * 1.25, 1.0)));
+        assert!(circle.intersects(&BoundingCircle::new(Vec2::NEG_ONE * 1.25, 1.0)));
+        assert!(!circle.intersects(&BoundingCircle::new(Vec2::ONE * 1.5, 1.0)));
     }
 }

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -264,6 +264,20 @@ mod aabb3d_tests {
     }
 
     #[test]
+    fn closest_point() {
+        let aabb = Aabb3d {
+            min: Vec3::NEG_ONE,
+            max: Vec3::ONE,
+        };
+        assert_eq!(aabb.closest_point(Vec3::X * 10.0), Vec3::X);
+        assert_eq!(aabb.closest_point(Vec3::NEG_ONE * 10.0), Vec3::NEG_ONE);
+        assert_eq!(
+            aabb.closest_point(Vec3::new(0.25, 0.1, 0.3)),
+            Vec3::new(0.25, 0.1, 0.3)
+        );
+    }
+
+    #[test]
     fn intersect_aabb() {
         let aabb = Aabb3d {
             min: Vec3::NEG_ONE,
@@ -538,6 +552,20 @@ mod bounding_sphere_tests {
         assert!((shrunk.radius() - 4.5).abs() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn closest_point() {
+        let sphere = BoundingSphere::new(Vec3::ZERO, 1.0);
+        assert_eq!(sphere.closest_point(Vec3::X * 10.0), Vec3::X);
+        assert_eq!(
+            sphere.closest_point(Vec3::NEG_ONE * 10.0),
+            Vec3::NEG_ONE.normalize()
+        );
+        assert_eq!(
+            sphere.closest_point(Vec3::new(0.25, 0.1, 0.3)),
+            Vec3::new(0.25, 0.1, 0.3)
+        );
     }
 
     #[test]

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -158,7 +158,10 @@ impl IntersectsVolume<BoundingSphere> for Aabb3d {
 #[cfg(test)]
 mod aabb3d_tests {
     use super::Aabb3d;
-    use crate::{bounding::BoundingVolume, Vec3};
+    use crate::{
+        bounding::{BoundingSphere, BoundingVolume, IntersectsVolume},
+        Vec3,
+    };
 
     #[test]
     fn center() {
@@ -258,6 +261,39 @@ mod aabb3d_tests {
         assert!((shrunk.max - Vec3::new(1., 1., 1.)).length() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn intersect_aabb() {
+        let aabb = Aabb3d {
+            min: Vec3::NEG_ONE,
+            max: Vec3::ONE,
+        };
+        assert!(aabb.intersects(&aabb));
+        assert!(aabb.intersects(&Aabb3d {
+            min: Vec3::splat(0.5),
+            max: Vec3::splat(2.0),
+        }));
+        assert!(aabb.intersects(&Aabb3d {
+            min: Vec3::splat(-2.0),
+            max: Vec3::splat(-0.5),
+        }));
+        assert!(!aabb.intersects(&Aabb3d {
+            min: Vec3::new(1.1, 0.0, 0.0),
+            max: Vec3::new(2.0, 0.5, 0.25),
+        }));
+    }
+
+    #[test]
+    fn intersect_bounding_sphere() {
+        let aabb = Aabb3d {
+            min: Vec3::NEG_ONE,
+            max: Vec3::ONE,
+        };
+        assert!(aabb.intersects(&BoundingSphere::new(Vec3::ZERO, 1.0)));
+        assert!(aabb.intersects(&BoundingSphere::new(Vec3::ONE * 1.5, 1.0)));
+        assert!(aabb.intersects(&BoundingSphere::new(Vec3::NEG_ONE * 1.5, 1.0)));
+        assert!(!aabb.intersects(&BoundingSphere::new(Vec3::ONE * 1.75, 1.0)));
     }
 }
 
@@ -423,7 +459,10 @@ impl IntersectsVolume<Aabb3d> for BoundingSphere {
 #[cfg(test)]
 mod bounding_sphere_tests {
     use super::BoundingSphere;
-    use crate::{bounding::BoundingVolume, Vec3};
+    use crate::{
+        bounding::{BoundingVolume, IntersectsVolume},
+        Vec3,
+    };
 
     #[test]
     fn area() {
@@ -499,5 +538,14 @@ mod bounding_sphere_tests {
         assert!((shrunk.radius() - 4.5).abs() < std::f32::EPSILON);
         assert!(a.contains(&shrunk));
         assert!(!shrunk.contains(&a));
+    }
+
+    #[test]
+    fn intersect_bounding_sphere() {
+        let sphere = BoundingSphere::new(Vec3::ZERO, 1.0);
+        assert!(sphere.intersects(&BoundingSphere::new(Vec3::ZERO, 1.0)));
+        assert!(sphere.intersects(&BoundingSphere::new(Vec3::ONE * 1.1, 1.0)));
+        assert!(sphere.intersects(&BoundingSphere::new(Vec3::NEG_ONE * 1.1, 1.0)));
+        assert!(!sphere.intersects(&BoundingSphere::new(Vec3::ONE * 1.2, 1.0)));
     }
 }

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -373,18 +373,7 @@ impl BoundingSphere {
     /// Otherwise, it will be inside the sphere and returned as is.
     #[inline(always)]
     pub fn closest_point(&self, point: Vec3) -> Vec3 {
-        let offset_from_center = point - self.center;
-        let distance_to_center_squared = offset_from_center.length_squared();
-
-        if distance_to_center_squared <= self.radius().powi(2) {
-            // The point is inside the sphere
-            point
-        } else {
-            // The point is outside the sphere.
-            // Find the closest point on the surface of the sphere.
-            let dir_to_point = offset_from_center / distance_to_center_squared.sqrt();
-            self.center() + self.radius() * dir_to_point
-        }
+        self.sphere.closest_point(point - self.center) + self.center
     }
 }
 

--- a/crates/bevy_math/src/bounding/bounded3d/mod.rs
+++ b/crates/bevy_math/src/bounding/bounded3d/mod.rs
@@ -151,7 +151,7 @@ impl IntersectsVolume<BoundingSphere> for Aabb3d {
         let closest_point = self.closest_point(sphere.center);
         let distance_squared = sphere.center.distance_squared(closest_point);
         let radius_squared = sphere.radius().powi(2);
-        distance_squared < radius_squared
+        distance_squared <= radius_squared
     }
 }
 


### PR DESCRIPTION
# Objective

#10946 added bounding volume types and an `IntersectsVolume` trait, but didn't actually implement intersections between bounding volumes.

This PR implements AABB-AABB, circle-circle / sphere-sphere, and AABB-circle / AABB-sphere intersections.

## Solution

Implement `IntersectsVolume` for bounding volume pairs. I also added `closest_point` methods to return the closest point on the surface / inside of bounding volumes. This is used for AABB-circle / AABB-sphere intersections.