### PR TITLE
add a required feature for shader_material_glsl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1897,6 +1897,7 @@ wasm = true
 name = "shader_material_glsl"
 path = "examples/shader/shader_material_glsl.rs"
 doc-scrape-examples = true
+required-features = ["shader_format_glsl"]
 
 [package.metadata.example.shader_material_glsl]
 name = "Material - GLSL"


### PR DESCRIPTION
# Objective

- Since https://github.com/bevyengine/bevy/pull/11366, feature `glsl` of `naga_oil` is not enabled by default
- It is needed for example `shader_material_glsl`

```
thread 'Compute Task Pool (0)' panicked at crates\bevy_render\src\render_resource\shader.rs:238:35:
GLSL is not supported in this configuration; use the feature `shader_format_glsl`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_render::render_resource::pipeline_cache::PipelineCache::process_pipeline_queue_system`!
thread 'main' panicked at crates\bevy_render\src\pipelined_rendering.rs:145:45:
called `Result::unwrap()` on an `Err` value: RecvError
```

## Solution

- Add feature `shader_format_glsl` as a required feature for example `shader_material_glsl`
