### PR TITLE
Fix reflected serialization/deserialization on `Name` component

### DIFF
--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -24,7 +24,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 #[reflect(Component, Default, Debug)]
 #[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct Name {
-    hash: u64, // TODO: Shouldn't be serialized
+    hash: u64, // Won't be serialized (see: `bevy_core::serde` module)
     name: Cow<'static, str>,
 }
 

--- a/crates/bevy_core/src/name.rs
+++ b/crates/bevy_core/src/name.rs
@@ -10,6 +10,9 @@ use std::{
     ops::Deref,
 };
 
+#[cfg(feature = "serialize")]
+use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
+
 /// Component used to identify an entity. Stores a hash for faster comparisons.
 ///
 /// The hash is eagerly re-computed upon each update to the name.
@@ -19,6 +22,7 @@ use std::{
 /// used instead as the default unique identifier.
 #[derive(Reflect, Component, Clone)]
 #[reflect(Component, Default, Debug)]
+#[cfg_attr(feature = "serialize", reflect(Serialize, Deserialize))]
 pub struct Name {
     hash: u64, // TODO: Shouldn't be serialized
     name: Cow<'static, str>,


### PR DESCRIPTION
# Objective

- This PR makes it so that `ReflectSerialize` and `ReflectDeserialize` traits are properly derived on `Name`. This avoids having the internal hash “leak” into the serialization when using reflection.

## Solution

- Added a conditional derive for `ReflectDeserialize` and `ReflectSerialize` via `#[cfg_attr()]`

---

## Changelog

- `Name` now implements `ReflectDeserialize` and `ReflectSerialize` whenever the `serialize` feature is enabled.

