### PR TITLE
Fix wrong transmuted type in `TaskPool::scope_with_executor_inner`

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -360,7 +360,8 @@ impl TaskPool {
             unsafe { mem::transmute(external_executor) };
         // SAFETY: As above, all futures must complete in this function so we can change the lifetime
         let scope_executor: &'env ThreadExecutor<'env> = unsafe { mem::transmute(scope_executor) };
-        let spawned: ConcurrentQueue<FallibleTask<T>> = ConcurrentQueue::unbounded();
+        let spawned: ConcurrentQueue<FallibleTask<Result<T, Box<(dyn std::any::Any + Send)>>>> =
+            ConcurrentQueue::unbounded();
         // shadow the variable so that the owned value cannot be used for the rest of the function
         // SAFETY: As above, all futures must complete in this function so we can change the lifetime
         let spawned: &'env ConcurrentQueue<


### PR DESCRIPTION
# Objective

#8219 changed the target type of a `transmute` without changing the one transmuting from ([see the relevant diff](https://github.com/bevyengine/bevy/commit/55e9ab7c9206776c997982bc6df4fe150054bddf#diff-11413fb2eeba97978379d325353d32aa76eefd0af0c8e9b50b7f394ddfda7a26R351-R355)), making them incompatible. This PR fixes this by changing the initial type to match the target one (modulo lifetimes).

## Solution

Change the type to be transmuted from to match the one transmuting into (modulo lifetimes)
