### PR TITLE
Fix memory leak in dynamic ECS example

### DIFF
--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -196,7 +196,7 @@ fn to_owned_ptrs(data: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
         // - Data pointed to won't be dropped until `to_insert_data` is dropped
         unsafe {
             let non_null = NonNull::new_unchecked(ptr.cast());
-            ptrs.push(OwningPtr::new(non_null))
+            ptrs.push(OwningPtr::new(non_null));
         }
     }
     ptrs

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -131,7 +131,7 @@ fn main() {
                 let mut entity = world.spawn_empty();
 
                 // Construct an `OwningPtr` for each component in `to_insert_data`
-                let to_insert_ptr = to_owned_ptrs(&mut to_insert_data);
+                let to_insert_ptr = to_owning_ptrs(&mut to_insert_data);
 
                 // SAFETY:
                 // - Component ids have been taken from the same world
@@ -187,7 +187,7 @@ fn main() {
 
 // Constructs `OwningPtr` for each item in `data`
 // By sharing the lifetime of `data` with the resulting ptrs we ensure drop the data before use
-fn to_owned_ptrs(data: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
+fn to_owning_ptrs(data: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
     let mut ptrs = Vec::new();
     for data in data.iter_mut() {
         let ptr = data.as_mut_ptr();

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -186,7 +186,7 @@ fn main() {
 }
 
 // Constructs `OwningPtr` for each item in `data`
-// By sharing the lifetime of `data` with the resulting ptrs we ensure drop the data before use
+// By sharing the lifetime of `data` with the resulting ptrs we ensure we don't drop the data before use
 fn to_owning_ptrs(data: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
     let mut ptrs = Vec::new();
     for data in data.iter_mut() {

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -185,21 +185,22 @@ fn main() {
     }
 }
 
-// Constructs `OwningPtr` for each item in `data`
-// By sharing the lifetime of `data` with the resulting ptrs we ensure we don't drop the data before use
-fn to_owning_ptrs(data: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
-    let mut ptrs = Vec::new();
-    for data in data.iter_mut() {
-        let ptr = data.as_mut_ptr();
-        // SAFETY:
-        // - Pointers are guaranteed to be non-null
-        // - Data pointed to won't be dropped until `to_insert_data` is dropped
-        unsafe {
-            let non_null = NonNull::new_unchecked(ptr.cast());
-            ptrs.push(OwningPtr::new(non_null));
-        }
-    }
-    ptrs
+// Constructs `OwningPtr` for each item in `components`
+// By sharing the lifetime of `components` with the resulting ptrs we ensure we don't drop the data before use
+fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
+    components
+        .iter_mut()
+        .map(|data| {
+            let ptr = data.as_mut_ptr();
+            // SAFETY:
+            // - Pointers are guaranteed to be non-null
+            // - Memory pointed to won't be dropped until `components` is dropped
+            unsafe {
+                let non_null = NonNull::new_unchecked(ptr.cast());
+                OwningPtr::new(non_null)
+            }
+        })
+        .collect()
 }
 
 fn parse_term<Q: QueryData>(

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -117,10 +117,11 @@ fn main() {
                     // Calculate the length for the array based on the layout created for this component id
                     let info = world.components().get_info(id).unwrap();
                     let len = info.layout().size() / std::mem::size_of::<u64>();
-                    let values: Vec<u64> = component
+                    let mut values: Vec<u64> = component
                         .take(len)
                         .filter_map(|value| value.parse::<u64>().ok())
                         .collect();
+                    values.resize(len, 0);
 
                     // Collect the id and array to be inserted onto our entity
                     to_insert_ids.push(id);


### PR DESCRIPTION
# Objective

- Fix a memory leak in the dynamic ECS example mentioned in #11459

## Solution

- Rather than allocate the memory manually instead store a collection of `Vec` that will be dropped after it is used.

---

I must have misinterpreted `OwningPtr`s semantics when initially writing this example. I believe we should be able to provide better APIs here for inserting dynamic components that don't require the user to wrangle so much unsafety. We have no other examples using `insert_by_ids` and our only tests show it being used for 1 or 2 values with nested calls to `OwningPtr::make` despite the function taking an iterator. Rust's type system is quite restrictive here but we could at least let `OwningPtr::new` take non u8 `NonNull`.

I also agree with #11459 that we should generally be trying to simplify and clarify this example.
