### PR TITLE
Togglable bit flag for Identifier

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -23,7 +23,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_ecs_macros = { path = "macros", version = "0.14.0-dev" }
 
 petgraph = "0.6"
-bitflags = "2.3"
+bitflags = "2.4"
 concurrent-queue = "2.4.0"
 fixedbitset = "0.5"
 serde = { version = "1", optional = true, default-features = false }

--- a/crates/bevy_ecs/src/entity/map_entities.rs
+++ b/crates/bevy_ecs/src/entity/map_entities.rs
@@ -86,7 +86,7 @@ impl EntityMapper for SceneEntityMapper<'_> {
         // this new entity reference is specifically designed to never represent any living entity
         let new = Entity::from_raw_and_generation(
             self.dead_start.index(),
-            IdentifierMask::inc_masked_high_by(self.dead_start.generation, self.generations),
+            IdentifierMask::inc_entity_generation_by(self.dead_start.generation, self.generations),
         );
 
         // Prevent generations counter from being a greater value than HIGH_MASK.

--- a/crates/bevy_ecs/src/identifier/bits.rs
+++ b/crates/bevy_ecs/src/identifier/bits.rs
@@ -1,0 +1,64 @@
+//! Module for defining the flag bits present in the [`super::Identifier`] format.
+
+use std::fmt::Debug;
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Flag bits defined for [`super::Identifier`].
+    pub struct IdentifierFlagBits: u32 {
+        /// Flag for determining whether an [`super::Identifier`] is a
+        /// [`super::IdKind::Placeholder`] or [`super::IdKind::Entity`].
+        const IS_PLACEHOLDER = 0b1000_0000_0000_0000_0000_0000_0000_0000;
+        /// Flag for determining whether the [`super::Identifier`] is in a
+        /// `toggeable` state or not.
+        const IS_TOGGLABLE = 0b0100_0000_0000_0000_0000_0000_0000_0000;
+
+        const _ = !0;
+    }
+}
+
+impl PartialEq for IdentifierFlagBits {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Debug for IdentifierFlagBits {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("IdentifierFlagBits").field(&self.0).finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_test() {
+        // Both flag bits are set
+        let bits: u32 = 0xC0FF_EEEE;
+
+        let flags = IdentifierFlagBits::from_bits_retain(bits);
+
+        assert!(flags.contains(IdentifierFlagBits::IS_PLACEHOLDER));
+        assert!(flags.contains(IdentifierFlagBits::IS_TOGGLABLE));
+
+        // Only IS_PLACEHOLDER flag bit set
+        let bits: u32 = 0x80FF_F00F;
+
+        let flags = IdentifierFlagBits::from_bits_retain(bits);
+
+        assert!(flags.contains(IdentifierFlagBits::IS_PLACEHOLDER));
+        assert!(!flags.contains(IdentifierFlagBits::IS_TOGGLABLE));
+
+        // Only IS_TOGGLABLE flag bit set
+        let bits: u32 = 0x40FF_F00F;
+
+        let flags = IdentifierFlagBits::from_bits_retain(bits);
+
+        assert!(!flags.contains(IdentifierFlagBits::IS_PLACEHOLDER));
+        assert!(flags.contains(IdentifierFlagBits::IS_TOGGLABLE));
+    }
+}

--- a/crates/bevy_ecs/src/identifier/bits.rs
+++ b/crates/bevy_ecs/src/identifier/bits.rs
@@ -11,7 +11,7 @@ bitflags! {
         /// [`super::IdKind::Placeholder`] or [`super::IdKind::Entity`].
         const IS_PLACEHOLDER = 0b1000_0000_0000_0000_0000_0000_0000_0000;
         /// Flag for determining whether the [`super::Identifier`] is in a
-        /// `toggeable` state or not.
+        /// `togglable` state or not.
         const IS_TOGGLABLE = 0b0100_0000_0000_0000_0000_0000_0000_0000;
 
         const _ = !0;
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn smoke_test() {
+    fn flag_bits_are_correctly_determined() {
         // Both flag bits are set
         let bits: u32 = 0xC0FF_EEEE;
 

--- a/crates/bevy_ecs/src/identifier/kinds.rs
+++ b/crates/bevy_ecs/src/identifier/kinds.rs
@@ -1,3 +1,6 @@
+//! Module for defining the different [`super::Identifier`] kinds, which
+//! have different semantics with regards to their shared layout.
+
 /// The kinds of ID that [`super::Identifier`] can represent. Each
 /// variant imposes different usages of the low/high segments
 /// of the ID.
@@ -7,5 +10,5 @@ pub enum IdKind {
     /// An ID variant that is compatible with [`crate::entity::Entity`].
     Entity = 0,
     /// A future ID variant.
-    Placeholder = 0b1000_0000,
+    Placeholder = 1,
 }

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -94,7 +94,7 @@ impl IdentifierMask {
         // SAFETY:
         // - The rhs is masked to never be a value greater than the mask, allowing
         //   the overflow to be tracked/accounted for.
-        // - Adding the overflow flag will offet overflows to start at 1 instead of 0
+        // - Adding the overflow flag will offset overflows to start at 1 instead of 0
         // - The sum of 0x3FFF_FFFF + 1 (overflow) == 1
         // - The sum of Ox3FFF_FFFF + 0x3FFF_FFFF == 0x3FFF_FFFF
         // - If the operation doesn't overflow at 30 bits, no offsetting takes place

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -139,7 +139,7 @@ mod tests {
         // Excludes the most significant bit as that is a flag bit.
         assert_eq!(IdentifierMask::extract_value_from_high(high), HIGH_MASK);
 
-        // Start bit and end bit are ones.
+        // Start two bits and end bit are ones.
         let high: u32 = 0xC000_0001;
 
         assert_eq!(IdentifierMask::extract_value_from_high(high), 0x0000_0001);
@@ -152,12 +152,12 @@ mod tests {
 
     #[test]
     fn pack_flag_bits() {
-        // All bits are ones expect the 2 most significant bits, which are zero
+        // All bits are ones except the 2 most significant bits, which are zero
         let high: u32 = 0x7FFF_FFFF;
 
         assert_eq!(
             IdentifierMask::pack_flags_into_high(high, IdentifierFlagBits::IS_PLACEHOLDER),
-            // The IS_HIDDEN flag is cleared and the IS_PLACEHOLDER flag is enabled
+            // The IS_TOGGLABLE flag is cleared and the IS_PLACEHOLDER flag is enabled
             0xBFFF_FFFF
         );
 

--- a/crates/bevy_ecs/src/identifier/masks.rs
+++ b/crates/bevy_ecs/src/identifier/masks.rs
@@ -1,11 +1,11 @@
 use std::num::NonZeroU32;
 
-use super::kinds::IdKind;
+use super::{bits::IdentifierFlagBits, kinds::IdKind};
 
 /// Mask for extracting the value portion of a 32-bit high segment. This
 /// yields 31-bits of total value, as the final bit (the most significant)
 /// is reserved as a flag bit. Can be negated to extract the flag bit.
-pub(crate) const HIGH_MASK: u32 = 0x7FFF_FFFF;
+pub(crate) const HIGH_MASK: u32 = 0x3FFF_FFFF;
 
 /// Abstraction over masks needed to extract values/components of an [`super::Identifier`].
 pub(crate) struct IdentifierMask;
@@ -31,10 +31,12 @@ impl IdentifierMask {
         ((high as u64) << u32::BITS) | (low as u64)
     }
 
-    /// Pack the [`IdKind`] bits into a high segment.
+    /// Packs flag bits into the high value. This will clear any existing
+    /// flags in the high component in order to be able to toggle all bits
+    /// correctly.
     #[inline(always)]
-    pub(crate) const fn pack_kind_into_high(value: u32, kind: IdKind) -> u32 {
-        value | ((kind as u32) << 24)
+    pub(crate) const fn pack_flags_into_high(value: u32, flags: IdentifierFlagBits) -> u32 {
+        (value & HIGH_MASK) | flags.bits()
     }
 
     /// Extract the value component from a high segment of an [`super::Identifier`].
@@ -43,33 +45,59 @@ impl IdentifierMask {
         value & HIGH_MASK
     }
 
+    #[inline(always)]
+    pub(crate) const fn extract_flags_from_high(value: u32) -> IdentifierFlagBits {
+        IdentifierFlagBits::from_bits_retain(value & !HIGH_MASK)
+    }
+
     /// Extract the ID kind component from a high segment of an [`super::Identifier`].
     #[inline(always)]
     pub(crate) const fn extract_kind_from_high(value: u32) -> IdKind {
-        // The negated HIGH_MASK will extract just the bit we need for kind.
-        let kind_mask = !HIGH_MASK;
-        let bit = value & kind_mask;
+        let flags = Self::extract_flags_from_high(value);
 
-        if bit == kind_mask {
+        if flags.contains(IdentifierFlagBits::IS_PLACEHOLDER) {
             IdKind::Placeholder
         } else {
             IdKind::Entity
         }
     }
 
-    /// Offsets a masked generation value by the specified amount, wrapping to 1 instead of 0.
-    /// Will never be greater than [`HIGH_MASK`] or less than `1`, and increments are masked to
-    /// never be greater than [`HIGH_MASK`].
     #[inline(always)]
-    pub(crate) const fn inc_masked_high_by(lhs: NonZeroU32, rhs: u32) -> NonZeroU32 {
-        let lo = (lhs.get() & HIGH_MASK).wrapping_add(rhs & HIGH_MASK);
-        // Checks high 32 bit for whether we have overflowed 31 bits.
-        let overflowed = lo >> 31;
+    pub(crate) const fn set_togglable_flag_in_high(value: u32, flag_state: bool) -> u32 {
+        let bits = IdentifierFlagBits::from_bits_retain(value);
 
+        if flag_state {
+            bits.union(IdentifierFlagBits::IS_TOGGLABLE).bits()
+        } else {
+            bits.difference(IdentifierFlagBits::IS_TOGGLABLE).bits()
+        }
+    }
+
+    /// Offsets a masked generation value by the specified amount, wrapping to 1 instead of 0.
+    /// Will never be greater than [`HIGH_MASK`] or less than `1`, and increments will never be
+    /// greater than [`HIGH_MASK`], as they are masked for safety reasons.
+    ///
+    /// **NOTE**: This method should only be used for `Entity`. Incrementing the high/generation
+    /// value will clear any invalid flags as the generation is always incremented in the case
+    /// of despawned entities that are not allocated as any particular type/kind. Only after they
+    /// are spawned will they then have any flags toggled.
+    #[inline(always)]
+    pub(crate) const fn inc_entity_generation_by(high: NonZeroU32, increment: u32) -> NonZeroU32 {
+        // Increment the masked value portion of the bits
+        let lo = (high.get() & HIGH_MASK).wrapping_add(increment & HIGH_MASK);
+        // Check high bits for whether we have overflowed 30 bits.
+        let overflowed = ((lo & !HIGH_MASK) != 0) as u32;
+
+        // Apply the overflow bit to the incremented value to ensure we will always
+        // get a non-zero overflow. Mask to then remove unwanted high bits for the
+        // final value.
         // SAFETY:
-        // - Adding the overflow flag will offset overflows to start at 1 instead of 0
-        // - The sum of `0x7FFF_FFFF` + `u32::MAX` + 1 (overflow) == `0x7FFF_FFFF`
-        // - If the operation doesn't overflow at 31 bits, no offsetting takes place
+        // - The rhs is masked to never be a value greater than the mask, allowing
+        //   the overflow to be tracked/accounted for.
+        // - Adding the overflow flag will offet overflows to start at 1 instead of 0
+        // - The sum of 0x3FFF_FFFF + 1 (overflow) == 1
+        // - The sum of Ox3FFF_FFFF + 0x3FFF_FFFF == 0x3FFF_FFFF
+        // - If the operation doesn't overflow at 30 bits, no offsetting takes place
         unsafe { NonZeroU32::new_unchecked(lo.wrapping_add(overflowed) & HIGH_MASK) }
     }
 }
@@ -109,43 +137,45 @@ mod tests {
         let high: u32 = 0xFFFF_FFFF;
 
         // Excludes the most significant bit as that is a flag bit.
-        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x7FFF_FFFF);
+        assert_eq!(IdentifierMask::extract_value_from_high(high), HIGH_MASK);
 
         // Start bit and end bit are ones.
-        let high: u32 = 0x8000_0001;
+        let high: u32 = 0xC000_0001;
 
         assert_eq!(IdentifierMask::extract_value_from_high(high), 0x0000_0001);
 
         // Classic bit pattern.
         let high: u32 = 0xDEAD_BEEF;
 
-        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x5EAD_BEEF);
+        assert_eq!(IdentifierMask::extract_value_from_high(high), 0x1EAD_BEEF);
     }
 
     #[test]
-    fn pack_kind_bits() {
-        // All bits are ones expect the most significant bit, which is zero
+    fn pack_flag_bits() {
+        // All bits are ones expect the 2 most significant bits, which are zero
         let high: u32 = 0x7FFF_FFFF;
 
         assert_eq!(
-            IdentifierMask::pack_kind_into_high(high, IdKind::Placeholder),
-            0xFFFF_FFFF
+            IdentifierMask::pack_flags_into_high(high, IdentifierFlagBits::IS_PLACEHOLDER),
+            // The IS_HIDDEN flag is cleared and the IS_PLACEHOLDER flag is enabled
+            0xBFFF_FFFF
         );
 
         // Arbitrary bit pattern
         let high: u32 = 0x00FF_FF00;
 
         assert_eq!(
-            IdentifierMask::pack_kind_into_high(high, IdKind::Entity),
+            IdentifierMask::pack_flags_into_high(high, IdentifierFlagBits::empty()),
             // Remains unchanged as before
             0x00FF_FF00
         );
 
         // Bit pattern that almost spells a word
-        let high: u32 = 0x40FF_EEEE;
+        let high: u32 = 0x00FF_EEEE;
+        let flags_to_set = IdentifierFlagBits::IS_PLACEHOLDER | IdentifierFlagBits::IS_TOGGLABLE;
 
         assert_eq!(
-            IdentifierMask::pack_kind_into_high(high, IdKind::Placeholder),
+            IdentifierMask::pack_flags_into_high(high, flags_to_set),
             0xC0FF_EEEE // Milk and no sugar, please.
         );
     }
@@ -162,72 +192,90 @@ mod tests {
     }
 
     #[test]
-    fn incrementing_masked_nonzero_high_is_safe() {
+    fn incrementing_entity_generation_is_safe() {
         // Adding from lowest value with lowest to highest increment
-        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        // No result should ever be greater than 0x3FFF_FFFF or HIGH_MASK
         assert_eq!(
             NonZeroU32::MIN,
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 0)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, 0)
         );
         assert_eq!(
             NonZeroU32::new(2).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 1)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, 1)
         );
         assert_eq!(
             NonZeroU32::new(3).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, 2)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, 2)
         );
         assert_eq!(
             NonZeroU32::MIN,
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, HIGH_MASK)
-        );
-        assert_eq!(
-            NonZeroU32::MIN,
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MIN, u32::MAX)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, HIGH_MASK)
         );
         // Adding from absolute highest value with lowest to highest increment
-        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        // No result should ever be greater than 0x3FFF_FFFF or HIGH_MASK
         assert_eq!(
             NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 0)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MAX, 0)
         );
         assert_eq!(
             NonZeroU32::MIN,
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 1)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MAX, 1)
         );
         assert_eq!(
             NonZeroU32::new(2).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, 2)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MAX, 2)
         );
         assert_eq!(
             NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, HIGH_MASK)
-        );
-        assert_eq!(
-            NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::MAX, u32::MAX)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MAX, HIGH_MASK)
         );
         // Adding from actual highest value with lowest to highest increment
-        // No result should ever be greater than 0x7FFF_FFFF or HIGH_MASK
+        // No result should ever be greater than 0x3FFF_FFFF or HIGH_MASK
         assert_eq!(
             NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 0)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::new(HIGH_MASK).unwrap(), 0)
         );
         assert_eq!(
             NonZeroU32::MIN,
-            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 1)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::new(HIGH_MASK).unwrap(), 1)
         );
         assert_eq!(
             NonZeroU32::new(2).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), 2)
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::new(HIGH_MASK).unwrap(), 2)
         );
         assert_eq!(
             NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), HIGH_MASK)
+            IdentifierMask::inc_entity_generation_by(
+                NonZeroU32::new(HIGH_MASK).unwrap(),
+                HIGH_MASK
+            )
         );
+    }
+
+    #[test]
+    fn incrementing_generation_by_more_than_mask_size() {
         assert_eq!(
             NonZeroU32::new(HIGH_MASK).unwrap(),
-            IdentifierMask::inc_masked_high_by(NonZeroU32::new(HIGH_MASK).unwrap(), u32::MAX)
+            // This should be equivalent to adding by HIGH_MASK
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::new(HIGH_MASK).unwrap(), u32::MAX)
+        );
+
+        assert_eq!(
+            NonZeroU32::MIN,
+            // This should be equivalent to adding by HIGH_MASK
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, u32::MAX)
+        );
+
+        assert_eq!(
+            NonZeroU32::MIN,
+            // This should be equivalent to adding by 0
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, 0xC000_0000)
+        );
+
+        assert_eq!(
+            NonZeroU32::new(2).unwrap(),
+            // This should be equivalent to adding by 1
+            IdentifierMask::inc_entity_generation_by(NonZeroU32::MIN, 0xC000_0001)
         );
     }
 }

--- a/crates/bevy_ecs/src/identifier/mod.rs
+++ b/crates/bevy_ecs/src/identifier/mod.rs
@@ -31,7 +31,7 @@ pub struct Identifier {
 }
 
 impl Identifier {
-    /// Construct a new [`Identifier`]. The `high` parameter is masked so to pack
+    /// Construct a new [`Identifier`]. The `high` parameter is masked so we can pack
     /// the high value and bit flags into the same field.
     #[inline(always)]
     pub const fn new(
@@ -95,7 +95,7 @@ impl Identifier {
         IdentifierMask::extract_kind_from_high(self.high.get())
     }
 
-    /// Returns with the [`Identifier`] is in a `hidden` state.
+    /// Returns with the [`Identifier`] is in a `togglable` state.
     #[inline(always)]
     pub const fn is_togglable(self) -> bool {
         self.flags().contains(IdentifierFlagBits::IS_TOGGLABLE)
@@ -114,16 +114,16 @@ impl Identifier {
         IdentifierMask::extract_flags_from_high(self.high.get())
     }
 
-    /// Returns a `hidden` [`Identifier`].
+    /// Returns a `togglable` [`Identifier`].
     #[inline(always)]
     #[must_use]
-    pub const fn set_hidden(self, state: bool) -> Identifier {
+    pub const fn set_togglable(self, state: bool) -> Identifier {
         Self {
             low: self.low,
             // SAFETY: the high component will always be non-zero due to either the
             // placeholder flag or the value component not being modified and either
             // one guaranteed to be one due to Identifier being initialised with the
-            // correct invariants checked. As such, modifying the hidden bit will
+            // correct invariants checked. As such, modifying the togglable bit will
             // never result in a zero value.
             high: unsafe {
                 NonZeroU32::new_unchecked(IdentifierMask::set_togglable_flag_in_high(
@@ -275,7 +275,7 @@ mod tests {
 
         assert!(id.is_togglable());
 
-        let id = id.set_hidden(false);
+        let id = id.set_togglable(false);
 
         assert_eq!(id.to_bits(), 0x3FFF_FFFF_0000_000C);
         assert!(!id.is_togglable());


### PR DESCRIPTION
# Objective

- Provide the building block to enable togglable components using IDs. 
- Add another piece to the relations story.

## Solution

This PR focuses on adding to the `Identifier` spec/type the ability to set and modify the `IS_TOGGLABLE` flag bit, for the primary purpose of building out the ability to "toggle" components assigned to a given entity (once they too are back by `Identifier`s/Entities). The PR does NOT include wiring this in as a full feature, but is instead focusing on just the `Identifier` bits.

The ability to toggle components on/off on an `Entity` allows the ability to have "temporary" removals instead of full removal, which would necessitate an archetype move. However, checking whether each component is toggled in a query would kill query perf, so this has to be a strictly opt-in feature. With this, a component that is set to be togglable would exist in an archetype for such, and would have a bitset to check against. And since the ID's are different, plain versions of that component would be distinguishable from togglable versions, so the checking of the bitset only applies to those that have been set to be such.

Note: Adding an additional flag to `Identifier` means that available generation space for `Identifier`/`Entity` is now 2^30 - 1, or 1,073,741,823 generations. The flags occupy the two most significant bits on the `Identifier`'s high component. Due to the increasing complexity of managing the bit flags, I've included `bitflags` crate to wire some of the logic in and also to enable `const`-able operations.

The generation increment method has been modified to account for this, and also incorporates a micro-optimisation that seems only to be triggered for 30-bit values and less, as the same code for a 31-bit value resolves to the same ASM output. The optimisation now allows for one less instruction being emitted: https://rust.godbolt.org/z/vnnhr5cod

```asm
inc_entity_generation_by:
        and     edi, 1073741823
        and     esi, 1073741823
        lea     eax, [rsi + rdi]
        cmp     eax, 1073741824
        sbb     eax, -1
        and     eax, 1073741823
        ret
```

Some other optimisations include removing `panic!` paths from methods that will never panic, and preventing the inlining of panic pathways as a further optimisation for others (if something is panicking, it doesn't matter if that path is "slow").

---

## Changelog

### Added
- Togglable bit flag for `Identifier`.

### Changed
- Micro-optimisations for `Identifier`/`Entity` methods

## Migration Guide

`Entity`/`Identifier` layout has changed, so that the flags occupy 2 bits and the high value is now only 30 bits, so all code/assets relying on specific layout of `Entity` will need to be migrated/updated to the new layout.
