### PR TITLE
Fix bug where Sprite::rect was ignored

### DIFF
--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -361,7 +361,19 @@ pub fn extract_sprites(
                     .map(|e| (commands.spawn_empty().id(), e)),
             );
         } else {
-            let rect = sheet.and_then(|s| s.texture_rect(&texture_atlases));
+            let atlas_rect = sheet.and_then(|s| s.texture_rect(&texture_atlases));
+            let rect = match (atlas_rect, sprite.rect) {
+                (None, None) => None,
+                (None, Some(sprite_rect)) => Some(sprite_rect),
+                (Some(atlas_rect), None) => Some(atlas_rect),
+                (Some(atlas_rect), Some(mut sprite_rect)) => {
+                    sprite_rect.min += atlas_rect.min;
+                    sprite_rect.max += atlas_rect.min;
+
+                    Some(sprite_rect)
+                }
+            };
+            
             // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
             extracted_sprites.sprites.insert(
                 entity,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -373,7 +373,7 @@ pub fn extract_sprites(
                     Some(sprite_rect)
                 }
             };
-            
+
             // PERF: we don't check in this function that the `Image` asset is ready, since it should be in most cases and hashing the handle is expensive
             extracted_sprites.sprites.insert(
                 entity,

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -21,10 +21,11 @@ pub struct Sprite {
     /// An optional custom size for the sprite that will be used when rendering, instead of the size
     /// of the sprite's image
     pub custom_size: Option<Vec2>,
-    /// An optional rectangle representing the region of the sprite's image to render, instead of
-    /// rendering the full image. This is an easy one-off alternative to using a [`TextureAtlas`](crate::TextureAtlas).
+    /// An optional rectangle representing the region of the sprite's image to render, instead of rendering
+    /// the full image. This is an easy one-off alternative to using a [`TextureAtlas`](crate::TextureAtlas).
     ///
-    /// When used with a [`TextureAtlas`](crate::TextureAtlas), the rect is offset by the atlas's starting position.
+    /// When used with a [`TextureAtlas`](crate::TextureAtlas), the rect
+    /// is offset by the atlas's minimal (top-left) corner position.
     pub rect: Option<Rect>,
     /// [`Anchor`] point of the sprite in the world
     pub anchor: Anchor,

--- a/crates/bevy_sprite/src/sprite.rs
+++ b/crates/bevy_sprite/src/sprite.rs
@@ -22,7 +22,9 @@ pub struct Sprite {
     /// of the sprite's image
     pub custom_size: Option<Vec2>,
     /// An optional rectangle representing the region of the sprite's image to render, instead of
-    /// rendering the full image. This is an easy one-off alternative to using a texture atlas.
+    /// rendering the full image. This is an easy one-off alternative to using a [`TextureAtlas`](crate::TextureAtlas).
+    ///
+    /// When used with a [`TextureAtlas`](crate::TextureAtlas), the rect is offset by the atlas's starting position.
     pub rect: Option<Rect>,
     /// [`Anchor`] point of the sprite in the world
     pub anchor: Anchor,


### PR DESCRIPTION
# Objective

https://github.com/bevyengine/bevy/pull/5103 caused a bug where `Sprite::rect` was ignored by the engine. (Did nothing)

## Solution

My solution changes the way how Bevy calculates the rect, based on this table:

| `atlas_rect` | `Sprite::rect` | Result                                               |
|--------------|----------------|------------------------------------------------------|
| `None`       | `None`         | `None`                                               |
| `None`       | `Some`         | `Sprite::rect`                                       |
| `Some`       | `None`         | `atlas_rect`                                         |
| `Some`       | `Some`         | `Sprite::rect` is used, relative to `atlas_rect.min` |