### PR TITLE
Register `AssetPath` as type for reflection

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -218,7 +218,8 @@ impl Plugin for AssetPlugin {
                 UpdateAssets,
                 TrackAssets.after(handle_internal_asset_events),
             )
-            .add_systems(UpdateAssets, handle_internal_asset_events);
+            .add_systems(UpdateAssets, handle_internal_asset_events)
+            .register_type::<AssetPath>();
 
         let mut order = app.world.resource_mut::<MainScheduleOrder>();
         order.insert_after(First, UpdateAssets);


### PR DESCRIPTION
# Objective

- `AssetPath` implements reflection, but is not registered as a type in the plugin.
- Fixes #11481.

## Solution

- Register the `AssetPath` type when `AssetPlugin::build` is called.

---

## Changelog

- Registered `AssetPath` type for use in reflection.
