### PR TITLE
Add backwards compatibility to former (incorrect) `Name` reflect serialization

### DIFF
--- a/crates/bevy_core/src/serde.rs
+++ b/crates/bevy_core/src/serde.rs
@@ -3,6 +3,8 @@ use std::{
     fmt::{self, Formatter},
 };
 
+use bevy_utils::tracing::warn;
+
 use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
@@ -18,7 +20,7 @@ impl Serialize for Name {
 
 impl<'de> Deserialize<'de> for Name {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        deserializer.deserialize_str(EntityVisitor)
+        deserializer.deserialize_any(EntityVisitor)
     }
 }
 
@@ -37,5 +39,42 @@ impl<'de> Visitor<'de> for EntityVisitor {
 
     fn visit_string<E: Error>(self, v: String) -> Result<Self::Value, E> {
         Ok(Name::new(v))
+    }
+
+    /// We accidentally forgot to derive `ReflectSerialize` and `ReflectDeserialize` on `Name` for a while,
+    /// which meant that `Name` components were being serialized as `{ "hash": _, "name" _ }` maps.
+    ///
+    /// We've since fixed this on [#11447](https://github.com/bevyengine/bevy/pull/11447), but in order
+    /// to maintain backwards compatibility with data that might have been serialized with the wrong format,
+    /// we should keep support for deserializing it for a bit. (A couple of releases should be enough.)
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        use ::std::sync::atomic::{AtomicBool, Ordering};
+
+        let mut result = Err(Error::missing_field("name"));
+
+        while let Some(key) = map.next_key::<&str>()? {
+            if key == "hash" {
+                map.next_value::<u64>()?;
+            } else if key == "name" {
+                result = Ok(Name::new(map.next_value::<&str>()?.to_string()));
+            } else {
+                return Err(Error::unknown_field(&key, &["name", "hash"]));
+            }
+        }
+
+        if result.is_ok() {
+            // Doing this “manually” here because we don't have access to `bevy_log`'s `warn_once` macro
+            static DID_WARN_ABOUT_DEPRECATION: AtomicBool = AtomicBool::new(false);
+            if !DID_WARN_ABOUT_DEPRECATION.swap(true, Ordering::Relaxed) {
+                warn!(
+                    "Support for deserializing `Name` from a `{{ \"hash\": _, \"name\" _ }}` map is kept for backwards compatibility, but will be removed in a future version. Please update your serialized data to use a string instead."
+                );
+            }
+        }
+
+        result
     }
 }

--- a/crates/bevy_core/src/serde.rs
+++ b/crates/bevy_core/src/serde.rs
@@ -1,3 +1,4 @@
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::{
     any,
     fmt::{self, Formatter},
@@ -51,7 +52,11 @@ impl<'de> Visitor<'de> for EntityVisitor {
     where
         A: serde::de::MapAccess<'de>,
     {
-        use ::std::sync::atomic::{AtomicBool, Ordering};
+        #[deprecated(
+            since = "0.13.0",
+            note = "Support for deserializing `Name` from a `{{ \"hash\": _, \"name\" _ }}` map is kept for backwards compatibility, but will be removed in a future version."
+        )]
+        fn _i_am_deprecated() {} // Can't use `#[deprecated]` on a trait impl method
 
         let mut result = Err(Error::missing_field("name"));
 


### PR DESCRIPTION
# Objective

@MrGVSV pointed out that #11447 inadvertently caused a breaking change, since existing scenes might have been serialized with the broken `{ "name": _, "hash":  _ }` format for the `Name` component. This PR aims to avoids that breakage.

## Solution

This PR introduces support for deserializing `Name` either from a string or from a `{ "name": _, "hash":  _ }` map. Once enough time has passed and people have re-exported/fixed their files, we can remove this. Added a warning to make sure people are aware of the change.

---

## Changelog

- Added backwards compatibility support for the former (incorrect) reflect serialization format for the `Name` component. This will be removed in a future release, so make sure to update any files that might be using the old format.