### PR TITLE
Workaround for ICE in the DXC shader compiler in debug builds with an `EnvironmentMapLight`

### DIFF
--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -52,7 +52,10 @@ fn compute_radiances(
             cubemap_index = reflection_probe.cubemap_index;
             intensity = reflection_probe.intensity;
             // TODO: Workaround for ICE in DXC https://github.com/microsoft/DirectXShaderCompiler/issues/6183
+            // This works because it's the last thing that happens in the for loop, and will break as soon as it
+            // goes back to the top of the loop.
             // We can't use `break` here because of the ICE.
+            // break;
             reflection_probe_index = light_probes.reflection_probe_count;
         }
     }

--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -51,7 +51,9 @@ fn compute_radiances(
         if (all(abs(probe_space_pos) <= vec3(0.5))) {
             cubemap_index = reflection_probe.cubemap_index;
             intensity = reflection_probe.intensity;
-            break;
+            // TODO: Workaround for ICE in DXC https://github.com/microsoft/DirectXShaderCompiler/issues/6183
+            // We can't use `break` here because of the ICE.
+            reflection_probe_index = light_probes.reflection_probe_count;
         }
     }
 


### PR DESCRIPTION
# Objective

DXC+DX12 debug builds with an environment map have been broken since https://github.com/bevyengine/bevy/pull/11366 merged due to an internal compiler error in DXC. I tracked it down to a single `break` statement and reported it upstream (https://github.com/microsoft/DirectXShaderCompiler/issues/6183)

## Solution

Workaround the ICE by setting the for loop index variable to the max value of the loop to avoid the `break` that's causing the ICE.

This works because it's the last thing in the for loop.

The `reflection_probes` and `pbr` examples both appear to still work correctly.