### PR TITLE
Revert "Bump dev-docs pages actions"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,10 +61,10 @@ jobs:
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v1
         with:
           path: target/doc
 
       - name: Deploy to Github Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v2


### PR DESCRIPTION
This reverts commit 11e43860d8dc89cbdc01afecda26e56d20efabfd.

# Objective

- All Deploy Docs CI builds have failed since [this run](https://github.com/bevyengine/bevy/actions/runs/7593590637).
- The source of the issue is PR #11418.

## Solution

- Revert the commit to allow time for further investigation.

---

This commit was originally my pull request, but I have no idea why it broke. Unlike the error text, the artifact is less than 10 GB large. I don't believe it contains any links, but I'll need to check.

<img width="1045" alt="image" src="https://github.com/bevyengine/bevy/assets/59022059/46479e94-30e2-4652-a1e9-612e752bc7fe">
