### PR TITLE
Include asset path in get_meta_path panic message

### DIFF
--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -269,7 +269,7 @@ pub(crate) fn get_meta_path(path: &Path) -> PathBuf {
     let mut meta_path = path.to_path_buf();
     let mut extension = path
         .extension()
-        .unwrap_or_else(|| panic!("missing expected extension for asset path {path:?}"))
+        .unwrap_or_else(|| panic!("missing extension for asset path {path:?}"))
         .to_os_string();
     extension.push(".meta");
     meta_path.set_extension(extension);

--- a/crates/bevy_asset/src/io/mod.rs
+++ b/crates/bevy_asset/src/io/mod.rs
@@ -269,7 +269,7 @@ pub(crate) fn get_meta_path(path: &Path) -> PathBuf {
     let mut meta_path = path.to_path_buf();
     let mut extension = path
         .extension()
-        .expect("asset paths must have extensions")
+        .unwrap_or_else(|| panic!("missing expected extension for asset path {path:?}"))
         .to_os_string();
     extension.push(".meta");
     meta_path.set_extension(extension);


### PR DESCRIPTION
# Objective

- Fixes a hurdle encountered when debugging a panic caused by the file watcher loading a `.gitignore` file, which was hard to debug because there was no file name in the report, only `asset paths must have extensions`

## Solution

- Panic with a formatted message that includes the asset path, e.g. `missing expected extension for asset path .gitignore`
