### PR TITLE
documentation in CI: remove lock file

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -59,6 +59,7 @@ jobs:
           echo "<meta http-equiv=\"refresh\" content=\"0; url=bevy/index.html\">" > target/doc/index.html
           echo "dev-docs.bevyengine.org" > target/doc/CNAME
           echo "User-Agent: *\nDisallow: /" > target/doc/robots.txt
+          rm target/doc/.lock
 
       - name: Upload site artifact
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
# Objective

- Try to fix replying docs in CI
- Alternative to https://github.com/bevyengine/bevy/pull/11502

## Solution

- The only issue I could find is the lock file with invalid permissions, try to remove it
