### PR TITLE
Add README to benches

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -4,7 +4,7 @@ This is a crate with a collection of benchmarks for Bevy, separate from the rest
 
 ## Running the benchmarks
 
-1. If cargo isn't already installed, [install it](https://www.rust-lang.org/tools/install).
+1. Setup everything you need for Bevy with the [setup guide](https://bevyengine.org/learn/book/getting-started/setup/).
 2. Move into the `benches` directory (where this README is located).
 
     ```sh
@@ -25,4 +25,4 @@ This is a crate with a collection of benchmarks for Bevy, separate from the rest
 
 ## Criterion
 
-Bevy's benchmarks use [Criterion](https://crates.io/crates/criterion) to chart and track benchmarks over time. If you want to learn more about using Criterion for benchmarking, you can read the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
+Bevy's benchmarks use [Criterion](https://crates.io/crates/criterion) to chart and plot the performance of benchmarks. If you want to learn more about using Criterion for benchmarking, you can read the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,28 @@
+# Bevy Benchmarks
+
+This is a crate with a collection of benchmarks for Bevy, separate from the rest of the Bevy crates.
+
+## Running the benchmarks
+
+1. If cargo isn't already installed, [install it](https://www.rust-lang.org/tools/install).
+2. Move into the `benches` directory (where this README is located).
+
+    ```sh
+    bevy $ cd benches
+    ```
+
+3. Run the benchmarks with cargo (This will take a while)
+
+    ```sh
+    bevy/benches $ cargo bench
+    ```
+
+    If you'd like to only compile the benchmarks (without running them), you can do that like this:
+
+    ```sh
+    bevy/benches $ cargo bench --no-run
+    ```
+
+## Criterion
+
+Bevy's benchmarks use [Criterion](https://crates.io/crates/criterion) to chart and track benchmarks over time. If you want to learn more about using Criterion for benchmarking, you can read the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).

--- a/benches/README.md
+++ b/benches/README.md
@@ -25,4 +25,4 @@ This is a crate with a collection of benchmarks for Bevy, separate from the rest
 
 ## Criterion
 
-Bevy's benchmarks use [Criterion](https://crates.io/crates/criterion) to chart and plot the performance of benchmarks. If you want to learn more about using Criterion for benchmarking, you can read the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).
+Bevy's benchmarks use [Criterion](https://crates.io/crates/criterion). If you want to learn more about using Criterion for comparing performance against a baseline or generating detailed reports, you can read the [Criterion.rs documentation](https://bheisler.github.io/criterion.rs/book/criterion_rs.html).


### PR DESCRIPTION
# Objective

It is unclear how to run Bevy's benchmarks

## Solution

Add a README to the benches, with documentation that tells you what the benchmarks are, and how to run them.
