### PR TITLE
Add Accessibility plugin to default plugins docs

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -11,6 +11,7 @@ use bevy_app::{Plugin, PluginGroup, PluginGroupBuilder};
 /// * [`DiagnosticsPlugin`](crate::diagnostic::DiagnosticsPlugin)
 /// * [`InputPlugin`](crate::input::InputPlugin)
 /// * [`WindowPlugin`](crate::window::WindowPlugin)
+/// * [`AccessibilityPlugin`](crate::a11y::AccessibilityPlugin)
 /// * [`AssetPlugin`](crate::asset::AssetPlugin) - with feature `bevy_asset`
 /// * [`ScenePlugin`](crate::scene::ScenePlugin) - with feature `bevy_scene`
 /// * [`WinitPlugin`](crate::winit::WinitPlugin) - with feature `bevy_winit`


### PR DESCRIPTION
# Objective

- Fixes #11453

This is a temporary fix. There is PR fixing it (#11460), but I'm not sure if it's going to be merged before the 0.13 release.
