### PR TITLE
Fix panic in examples using argh on the web

### DIFF
--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -94,7 +94,10 @@ impl FromStr for Mode {
 const FIXED_TIMESTEP: f32 = 0.2;
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
 
     App::new()
         .add_plugins((

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -94,6 +94,7 @@ impl FromStr for Mode {
 const FIXED_TIMESTEP: f32 = 0.2;
 
 fn main() {
+    // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -42,7 +42,11 @@ struct Args {
 
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
     let mut app = App::new();
 
     app.add_plugins((

--- a/examples/stress_tests/many_buttons.rs
+++ b/examples/stress_tests/many_buttons.rs
@@ -42,6 +42,7 @@ struct Args {
 
 /// This example shows what happens when there is a lot of buttons on screen.
 fn main() {
+    // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -66,6 +66,7 @@ impl FromStr for Layout {
 }
 
 fn main() {
+    // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -66,7 +66,10 @@ impl FromStr for Layout {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
 
     App::new()
         .add_plugins((

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -33,7 +33,10 @@ struct Foxes {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
 
     App::new()
         .add_plugins((

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -33,6 +33,7 @@ struct Foxes {
 }
 
 fn main() {
+    // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -19,7 +19,11 @@ struct Args {
 }
 
 fn main() {
+    #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
+    #[cfg(target_arch = "wasm32")]
+    let args = Args::from_args(&[], &[]).unwrap();
+
     let window = if let Some(scale_factor) = args.scale_factor {
         Window {
             resolution: WindowResolution::default().with_scale_factor_override(scale_factor),

--- a/examples/ui/text_wrap_debug.rs
+++ b/examples/ui/text_wrap_debug.rs
@@ -19,6 +19,7 @@ struct Args {
 }
 
 fn main() {
+    // `from_env` panics on the web
     #[cfg(not(target_arch = "wasm32"))]
     let args: Args = argh::from_env();
     #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
# Objective

Fixes #11503

## Solution

Use an empty set of args on the web.

## Discussion

Maybe in the future we could wrap this so that we can use query args on the web or something, but this was the minimum changeset I could think of to keep the functionality and make them not panic on the web.