### PR TITLE
Early out when there's no image to replace in tonemapping example update_image_viewer

### DIFF
--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -318,6 +318,10 @@ fn update_image_viewer(
         }
     }
 
+    if new_image.is_none() && image_events.is_empty() {
+        return;
+    }
+
     for (mat_h, mesh_h) in &image_mesh {
         if let Some(mat) = materials.get_mut(mat_h) {
             if let Some(ref new_image) = new_image {


### PR DESCRIPTION
# Objective

update_image_viewer is iterating over every mesh material in the scene calling get_mut on the material every frame, and not doing anything with it unless theres an image event to replace the image in the material with. this triggers change detection unconditionally every single frame on every single mesh's material, which is obliterating performance.

## Solution

early out when there's no image event

---

Unblocks #10610
