### PR TITLE
Fix cyclic dep

### DIFF
--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -19,7 +19,8 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
 bevy_math = { path = "../bevy_math", version = "0.12.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
-  "glam", "smol_str",
+  "glam",
+  "smol_str",
 ] }
 
 # other

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -19,7 +19,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
 bevy_math = { path = "../bevy_math", version = "0.12.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
-  "glam",
+  "glam", "smol_str",
 ] }
 
 # other

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -27,8 +27,5 @@ serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1.0"
 smol_str = "0.2"
 
-[dev-dependencies]
-bevy = { path = "../../", version = "0.12.0" }
-
 [lints]
 workspace = true

--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -5,8 +5,9 @@ use std::hash::Hash;
 /// Stateful run condition that can be toggled via a input press using [`ButtonInput::just_pressed`].
 ///
 /// ```no_run
-/// use bevy::prelude::*;
-/// use bevy::input::common_conditions::input_toggle_active;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
+/// # use bevy_ecs::prelude::IntoSystemConfigs;
+/// # use bevy_input::{common_conditions::input_toggle_active, prelude::KeyCode};
 ///
 /// fn main() {
 ///     App::new()
@@ -23,8 +24,9 @@ use std::hash::Hash;
 /// If you want other systems to be able to access whether the toggled state is active,
 /// you should use a custom resource or a state for that:
 /// ```no_run
-/// use bevy::prelude::*;
-/// use bevy::input::common_conditions::input_just_pressed;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
+/// # use bevy_ecs::prelude::{IntoSystemConfigs, Res, ResMut, Resource};
+/// # use bevy_input::{common_conditions::input_just_pressed, prelude::KeyCode};
 ///
 /// #[derive(Resource, Default)]
 /// struct Paused(bool);
@@ -72,8 +74,9 @@ where
 /// Run condition that is active if [`ButtonInput::just_pressed`] is true for the given input.
 ///
 /// ```no_run
-/// use bevy::prelude::*;
-/// use bevy::input::common_conditions::input_just_pressed;
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, Update};
+/// # use bevy_ecs::prelude::IntoSystemConfigs;
+/// # use bevy_input::{common_conditions::input_just_pressed, prelude::KeyCode};
 /// fn main() {
 ///     App::new()
 ///         .add_plugins(DefaultPlugins)

--- a/crates/bevy_input/src/common_conditions.rs
+++ b/crates/bevy_input/src/common_conditions.rs
@@ -101,7 +101,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::prelude::{IntoSystemConfigs, KeyCode, Schedule};
+    use crate::prelude::KeyCode;
+    use bevy_ecs::schedule::{IntoSystemConfigs, Schedule};
 
     fn test_system() {}
 


### PR DESCRIPTION
# Objective

Rust analyzer kept complaining about a cyclic dependency due to `bevy_input` having a dev-dependency on `bevy`.

`bevy_input` was also missing `bevy_reflect`'s "smol_str" feature which it needs to compile on its own.

Fixes #10256

## Solution

Remove the dev-dependency on `bevy` from `bevy_input` since it was only used to reduce imports for 1 test and 3 doc examples by 1 line each, as `bevy_input` already has dependencies on everything needed for those tests and doctests to work.

Add `bevy_reflect`'s "smol_str" feature to `bevy_input`'s dependency list as it needs it to actually compile.