### PR TITLE
Add `new` constructors for `Circle` and `Sphere`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -88,6 +88,12 @@ pub struct Circle {
 impl Primitive2d for Circle {}
 
 impl Circle {
+    /// Create a new [`Circle`] from a `radius`
+    #[inline(always)]
+    pub const fn new(radius: f32) -> Self {
+        Self { radius }
+    }
+
     /// Finds the point on the circle that is closest to the given `point`.
     ///
     /// If the point is outside the circle, the returned point will be on the perimeter of the circle.

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -92,6 +92,12 @@ pub struct Sphere {
 impl Primitive3d for Sphere {}
 
 impl Sphere {
+    /// Create a new [`Sphere`] from a `radius`
+    #[inline(always)]
+    pub const fn new(radius: f32) -> Self {
+        Self { radius }
+    }
+
     /// Finds the point on the sphere that is closest to the given `point`.
     ///
     /// If the point is outside the sphere, the returned point will be on the surface of the sphere.


### PR DESCRIPTION
# Objective

Make APIs more consistent and ergonomic by adding a `new` constructor for `Circle` and `Sphere`.

This could be seen as a redundant "trivial constructor", but in practise, it seems valuable to me. I have lots of cases where formatting becomes ugly because of the lack of a constructor, like this:

```rust
Circle {
    radius: self.radius(),
}
.contains_local_point(centered_pt)
```

With `new`, it'd be formatted much nicer:

```rust
Circle::new(self.radius()).contains_local_point(centered_pt)
```

Of course, this is just one example, but my circle/sphere definitions very frequently span three or more lines when they could fit on one.

Adding `new` also increases consistency. `Ellipse` has `new` already, and so does the mesh version of `Circle`.

## Solution

Add a `new` constructor for `Circle` and `Sphere`.