### PR TITLE
Implement Arc3D for Gizmos

### DIFF
--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -5,9 +5,11 @@
 
 use crate::circles::DEFAULT_CIRCLE_SEGMENTS;
 use crate::prelude::{GizmoConfigGroup, Gizmos};
-use bevy_math::Vec2;
+use bevy_math::{Quat, Vec2, Vec3};
 use bevy_render::color::Color;
 use std::f32::consts::TAU;
+
+// === 2D ===
 
 impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     /// Draw an arc, which is a part of the circumference of a circle, in 2D.
@@ -108,4 +110,125 @@ fn arc_inner(
         let angle = start + (i as f32 * (arc_angle / segments as f32));
         Vec2::from(angle.sin_cos()) * radius
     })
+}
+
+// === 3D ===
+
+impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
+    /// Draw an arc, which is a part of the circumference of a circle, in 2D.
+    ///
+    /// This should be called for each frame the arc needs to be rendered.
+    ///
+    /// # Arguments
+    /// - `position` sets the center of this circle.
+    /// - `radius` controls the distance from `position` to this arc, and thus its curvature.
+    /// - `direction_angle` sets the clockwise  angle in radians between `Vec2::Y` and
+    /// the vector from `position` to the midpoint of the arc.
+    /// - `arc_angle` sets the length of this arc, in radians.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_gizmos::prelude::*;
+    /// # use bevy_render::prelude::*;
+    /// # use bevy_math::prelude::*;
+    /// # use std::f32::consts::PI;
+    /// fn system(mut gizmos: Gizmos) {
+    ///     gizmos.arc_2d(Vec2::ZERO, 0., PI / 4., 1., Color::GREEN);
+    ///
+    ///     // Arcs have 32 line-segments by default.
+    ///     // You may want to increase this for larger arcs.
+    ///     gizmos
+    ///         .arc_2d(Vec2::ZERO, 0., PI / 4., 5., Color::RED)
+    ///         .segments(64);
+    /// }
+    /// # bevy_ecs::system::assert_is_system(system);
+    /// ```
+    #[inline]
+    pub fn arc_3d(
+        &mut self,
+        center: Vec3,
+        rotation_axis: Vec3,
+        from: Vec3,
+        angle: f32,
+        radius: f32,
+        color: Color,
+    ) -> Arc3dBuilder<'_, 'w, 's, T> {
+        Arc3dBuilder {
+            gizmos: self,
+            center,
+            rotation_axis,
+            from,
+            angle,
+            radius,
+            color,
+            segments: None,
+        }
+    }
+}
+
+/// A builder returned by [`Gizmos::arc_2d`].
+pub struct Arc3dBuilder<'a, 'w, 's, T: GizmoConfigGroup> {
+    gizmos: &'a mut Gizmos<'w, 's, T>,
+    center: Vec3,
+    rotation_axis: Vec3,
+    from: Vec3,
+    angle: f32,
+    radius: f32,
+    color: Color,
+    segments: Option<usize>,
+}
+
+impl<T: GizmoConfigGroup> Arc3dBuilder<'_, '_, '_, T> {
+    /// Set the number of line-segments for this arc.
+    pub fn segments(mut self, segments: usize) -> Self {
+        self.segments = Some(segments);
+        self
+    }
+}
+
+impl<T: GizmoConfigGroup> Drop for Arc3dBuilder<'_, '_, '_, T> {
+    fn drop(&mut self) {
+        let segments = match self.segments {
+            Some(segments) => segments,
+            // Do a linear interpolation between 1 and `DEFAULT_CIRCLE_SEGMENTS`
+            // using the arc angle as scalar.
+            None => ((self.angle.abs() / TAU) * DEFAULT_CIRCLE_SEGMENTS as f32).ceil() as usize,
+        };
+
+        let positions = arc3d_inner(
+            self.center,
+            self.rotation_axis,
+            self.from,
+            self.angle,
+            self.radius,
+            segments,
+        );
+        self.gizmos.linestrip(positions, self.color);
+    }
+}
+
+fn arc3d_inner(
+    center: Vec3,
+    rotation_axis: Vec3,
+    from: Vec3,
+    angle: f32,
+    radius: f32,
+    segments: usize,
+) -> impl Iterator<Item = Vec3> {
+    // drawing arcs bigger than 360.0 degrees or smaller than -360.0 degrees makes no sense since
+    // we won't see the overlap
+    let angle = angle.clamp(-360.0, 360.0);
+    (from - center)
+        .try_normalize()
+        .into_iter()
+        .flat_map(move |dir| {
+            let start_point = dir * radius;
+
+            (0..=segments)
+                .map(move |frac| frac as f32 / segments as f32)
+                .map(move |percentage| {
+                    Quat::from_axis_angle(rotation_axis, percentage * angle).mul_vec3(start_point)
+                })
+                .map(move |p| p + center)
+        })
 }

--- a/crates/bevy_gizmos/src/arcs.rs
+++ b/crates/bevy_gizmos/src/arcs.rs
@@ -209,7 +209,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     ///
     /// # Notes
     /// - This method assumes that the points `from` and `to` are distinct from the `center`. If
-    /// the points are coincident with the `center`, the behavior is undefined.
+    /// the points are coincident with the `center`, nothing is rendered.
     /// - The arc is drawn as a portion of a circle with a radius equal to the distance from the
     /// `center` to `from`. If the distance from `center` to `to` is not equal to the radius, then
     /// the results will behave as if this were the case
@@ -259,7 +259,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
     ///
     /// # Notes
     /// - This method assumes that the points `from` and `to` are distinct from the `center`. If
-    /// the points are coincident with the `center`, the behavior is undefined.
+    /// the points are coincident with the `center`, nothing is rendered.
     /// - The arc is drawn as a portion of a circle with a radius equal to the distance from the
     /// `center` to `from`. If the distance from `center` to `to` is not equal to the radius, then
     /// the results will behave as if this were the case.

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -96,6 +96,14 @@ fn system(mut gizmos: Gizmos, mut my_gizmos: Gizmos<MyRoundGizmos>, time: Res<Ti
         );
     }
 
+    my_gizmos
+        .arc_3d(180.0_f32.to_radians())
+        .radius(0.2)
+        .center(Vec3::ONE)
+        .rotation(Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()))
+        .segments(10)
+        .color(Color::ORANGE);
+
     // Circles have 32 line-segments by default.
     my_gizmos.circle(Vec3::ZERO, Direction3d::Y, 3., Color::BLACK);
     // You may want to increase this for larger circles or spheres.

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -97,12 +97,14 @@ fn system(mut gizmos: Gizmos, mut my_gizmos: Gizmos<MyRoundGizmos>, time: Res<Ti
     }
 
     my_gizmos
-        .arc_3d(180.0_f32.to_radians())
-        .radius(0.2)
-        .center(Vec3::ONE)
-        .rotation(Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()))
-        .segments(10)
-        .color(Color::ORANGE);
+        .arc_3d(
+            180.0_f32.to_radians(),
+            0.2,
+            Vec3::ONE,
+            Quat::from_rotation_arc(Vec3::Y, Vec3::ONE.normalize()),
+            Color::ORANGE,
+        )
+        .segments(10);
 
     // Circles have 32 line-segments by default.
     my_gizmos.circle(Vec3::ZERO, Direction3d::Y, 3., Color::BLACK);


### PR DESCRIPTION
# Objective

- Implement an arc3d API for gizmos
- Solves #11536

## Solution

### `arc_3d`

- The current `arc3d` method on gizmos only takes an angle
- It draws an "standard arc" by default, this is an arc starting at `Vec3::X`, in the XZ plane, in counter clockwise direction with a normal that is facing up
- The "standard arc" can be customized with the usual gizmo builder pattern. This way you'll be able to draw arbitrary arcs

### `short/long_arc_3d_between`

- Given `center`, `from`, `to` draws an arc between `from` and `to`

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- Added: `Gizmos::arc3d(&mut self, angle)` method
- Added: `Gizmos::long_arc_3d_between(&mut self, center, from, to)` method
- Added: `Gizmos::short_arc_3d_between(&mut self, center, from, to)` method

---

This PR factors out an orthogonal part of another PR as mentioned in [this comment](https://github.com/bevyengine/bevy/pull/11072#issuecomment-1883859573)