### PR TITLE
Use `-Z threads=0` option in `config_fast_builds.toml`

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -8,7 +8,7 @@ linker = "clang"
 rustflags = [
   "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
   "-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
-  "-Zthreads=8",             # (Nightly) Use improved multithreading with 8 threads.
+  "-Zthreads=0",             # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 # NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
@@ -17,20 +17,21 @@ rustflags = [
 rustflags = [
   "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
   "-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
-  "-Zthreads=8",                                          # (Nightly) Use improved multithreading with 8 threads.
+  "-Zthreads=0",                                          # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
   "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
   "-Zshare-generics=y",                                      # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=0",                                             # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe" # Use LLD Linker
 rustflags = [
   "-Zshare-generics=n",
-  "-Zthreads=8",        # (Nightly) Use improved multithreading with 8 threads.
+  "-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'

--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -8,6 +8,7 @@ linker = "clang"
 rustflags = [
   "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
   "-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=8",             # (Nightly) Use improved multithreading with 8 threads.
 ]
 
 # NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
@@ -16,6 +17,7 @@ rustflags = [
 rustflags = [
   "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
   "-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=8",                                          # (Nightly) Use improved multithreading with 8 threads.
 ]
 
 [target.aarch64-apple-darwin]
@@ -25,8 +27,11 @@ rustflags = [
 ]
 
 [target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe"            # Use LLD Linker
-rustflags = ["-Zshare-generics=n"]
+linker = "rust-lld.exe" # Use LLD Linker
+rustflags = [
+  "-Zshare-generics=n",
+  "-Zthreads=8",        # (Nightly) Use improved multithreading with 8 threads.
+]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.


### PR DESCRIPTION
# Objective

Improve compile times.

## Solution

The `-Z threads=0` option has been introduced into nightly rust somewhat recently, and was showcased in this [rust-lang article](https://blog.rust-lang.org/2023/11/09/parallel-rustc.html). This option improves multithreading in rust and speeds up compilation. I added this option to `config_fast_builds.toml` so others can also use this option to improve compile times.

`-Z threads=0` automatically uses the same amount of threads as the amount of threads in your system (See [rustc source code](https://github.com/rust-lang/rust/blob/6b4f1c5e782c72a047a23e922decd33e7d462345/compiler/rustc_session/src/options.rs#L617)). 

### Benchmarks

> **Disclaimer:** This section was written before I knew of `-Z threads=0`, so it uses `-Z threads=8` instead.

I compiled bevy with/without the `-Z threads=8` and saw about a 7% improvement in compliation times on my Kubuntu system with a 13th Gen Intel® Core™ i5-13400.

Also the compile times go down over time, probably because I had other things running in the background.

#### Without `-Z threads=8` 

- 42.33s
- 40.90s
- 38.27s
- 38.07s
- 37.17s
- 37.67s
- 36.63s
- 37.24s

**Average**: 38.535

#### With `-Z threads=8`

- 36.77s
- 39.50s
- 38.86s
- 35.61s
- 34.37s
- 34.32s
- 34.44s
- 33.74s

**Average**: 35.95125
