### PR TITLE
Add `get_ref` methods for Queries

### DIFF
--- a/crates/bevy_ecs/macros/src/query_data.rs
+++ b/crates/bevy_ecs/macros/src/query_data.rs
@@ -179,7 +179,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
         let field_ty = field.ty.clone();
         field_types.push(quote!(#field_ty));
         read_only_field_types.push(quote!(<#field_ty as #path::query::QueryData>::ReadOnly));
-        reffed_field_types.push(quote!(<#field_ty as #path::query::QueryData>::Reffed));
+        reffed_field_types.push(quote!(<#field_ty as #path::query::QueryData>::ReadOnlySmartRef));
     }
 
     let derive_args = &attributes.derive_args;
@@ -336,7 +336,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
                 unsafe impl #user_impl_generics #path::query::QueryData
                 for #read_only_struct_name #user_ty_generics #user_where_clauses {
                     type ReadOnly = #read_only_struct_name #user_ty_generics;
-                    type Reffed = #reffed_struct_name #user_ty_generics;
+                    type ReadOnlySmartRef = #reffed_struct_name #user_ty_generics;
                 }
             }
         } else {
@@ -345,8 +345,8 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
         let reffed_data_impl = quote! {
             unsafe impl #user_impl_generics #path::query::QueryData
             for #reffed_struct_name #user_ty_generics #user_where_clauses {
-                type ReadOnly = Self; // Reffed types are always read-only
-                type Reffed = Self;
+                type ReadOnly = Self;
+                type ReadOnlySmartRef = Self;
             }
         };
 
@@ -355,7 +355,7 @@ pub fn derive_query_data_impl(input: TokenStream) -> TokenStream {
             unsafe impl #user_impl_generics #path::query::QueryData
             for #struct_name #user_ty_generics #user_where_clauses {
                 type ReadOnly = #read_only_struct_name #user_ty_generics;
-                type Reffed = #reffed_struct_name #user_ty_generics;
+                type ReadOnlySmartRef = #reffed_struct_name #user_ty_generics;
             }
 
             #read_only_data_impl

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -285,7 +285,7 @@ pub type QueryItem<'w, Q> = <Q as WorldQuery>::Item<'w>;
 pub type ROQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::ReadOnly>;
 // TODO: Better docs, not sure about using the term "reffed".
 /// The reffed variant of the item type returned when a "reffed access" is requested. For example,
-/// Ref<T> would be "reffed access" of &T.
+/// `Ref<T>` would be "reffed access" of `&T`.
 pub type ReffedQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::Reffed>;
 
 /// SAFETY:

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -263,12 +263,10 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 pub unsafe trait QueryData: WorldQuery {
     /// The read-only variant of this [`QueryData`], which satisfies the [`ReadOnlyQueryData`] trait.
     type ReadOnly: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;
-    /// The "reffed" variant of this [`QueryData`]. As in, the [`Ref`] smart pointer for change
-    /// detection. If this [`QueryData`] doesn't have a "reffed" form (for example, [`Entity`]) -
-    /// this type must be identical to [`Self::ReadOnly`]. If this [`QueryData`] does have a
-    /// "reffed" form (for example, &'w T -> Ref<'w, T>) then that would be this type.
-    ///
-    /// Note that &'w mut T should also be turned into Ref<'w, T>.
+    /// The "reffed" variant of this [`QueryData`] (as in, the [`Ref`] smart pointer for change detection).
+    /// - If this [`QueryData`] doesn't have a "reffed" form (for example, [`Entity`]) - this type must be identical to [`Self::ReadOnly`].
+    /// - If this [`QueryData`] does have a "reffed" form (for example, &'w T -> Ref<'w, T>) then that would be this type.
+    /// - Note that &'w mut T should also be turned into Ref<'w, T>.
     type Reffed: ReadOnlyQueryData<State = <Self as WorldQuery>::State>;
 }
 
@@ -283,9 +281,9 @@ pub unsafe trait ReadOnlyQueryData: QueryData<ReadOnly = Self> {}
 pub type QueryItem<'w, Q> = <Q as WorldQuery>::Item<'w>;
 /// The read-only variant of the item type returned when a [`QueryData`] is iterated over immutably
 pub type ROQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::ReadOnly>;
-// TODO: Better docs, not sure about using the term "reffed".
-/// The reffed variant of the item type returned when a "reffed access" is requested. For example,
-/// `Ref<T>` would be "reffed access" of `&T`.
+/// Change-detection enabled read-only access, almost always by in the form of `Ref<T>`. Or, if `T`
+/// can't (shouldn't) be put in a `Ref` (for example: [`Entity`]) - then this is equivalent to [`ROQueryItem`].
+/// Note that this type should always be read-only.
 pub type ReffedQueryItem<'w, D> = QueryItem<'w, <D as QueryData>::Reffed>;
 
 /// SAFETY:

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -18,7 +18,7 @@ use std::{any::TypeId, borrow::Borrow, fmt, mem::MaybeUninit};
 
 use super::{
     NopWorldQuery, QueryBuilder, QueryComponentError, QueryData, QueryEntityError, QueryFilter,
-    QueryManyIter, QuerySingleError, ROQueryItem,
+    QueryManyIter, QuerySingleError, ROQueryItem, ReffedQueryItem,
 };
 
 /// Provides scoped access to a [`World`] state according to a given [`QueryData`] and [`QueryFilter`].
@@ -65,6 +65,17 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         // SAFETY: invariant on `WorldQuery` trait upholds that `D::ReadOnly` and `F::ReadOnly`
         // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.
         unsafe { self.as_transmuted_state::<D::ReadOnly, F>() }
+    }
+
+    /// Converts this `QueryState` reference to a `QueryState` with "reffed" access (read-only +
+    /// change detection using the [`Ref`] smart pointer)
+    pub fn as_reffed(&self) -> &QueryState<D::Reffed, F> {
+        // SAFETY: invariant on `WorldQuery` trait upholds that `D::Reffed` and `F::ReadOnly`
+        // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.
+        //
+        // ------- WHICH I'M NOT SURE IS TRUE FOR &T and Ref<T> -------- (remove if PR is reviewed and accepted)
+        //
+        unsafe { self.as_transmuted_state::<D::Reffed, F>() }
     }
 
     /// Converts this `QueryState` reference to a `QueryState` that does not return any data
@@ -390,6 +401,29 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         // SAFETY: query is read only
         unsafe {
             self.as_readonly().get_unchecked_manual(
+                world.as_unsafe_world_cell_readonly(),
+                entity,
+                world.last_change_tick(),
+                world.read_change_tick(),
+            )
+        }
+    }
+
+    // TODO: Better explanation, I'm not a fan of the term "reffed".
+    /// Gets the query result in "reffed" form (whatever can go in the [`Ref`] smart pointer - goes into it,
+    /// whatver doesn't - turns into the read-only version) for the given [`World`] and [`Entity`].
+    ///
+    /// This can only be called for read-only queries, see [`Self::get_mut`] for write-queries.
+    #[inline]
+    pub fn get_ref<'w>(
+        &mut self,
+        world: &'w World,
+        entity: Entity,
+    ) -> Result<ReffedQueryItem<'w, D>, QueryEntityError> {
+        self.update_archetypes(world);
+        // SAFETY: query is read only
+        unsafe {
+            self.as_reffed().get_unchecked_manual(
                 world.as_unsafe_world_cell_readonly(),
                 entity,
                 world.last_change_tick(),

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -68,7 +68,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Converts this `QueryState` reference to a change-detection-enabled reference.
-    /// (Most often using the [`Ref`](crate::change_detection::Ref) smart pointer)
+    /// (Most often using the [`Ref`] smart pointer)
     pub fn as_readonly_smart_ref(&self) -> &QueryState<D::ReadOnlySmartRef, F> {
         // SAFETY: invariant on `WorldQuery` trait upholds that `D::ReadOnlySmartRef` and `F::ReadOnly`
         // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -872,8 +872,8 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// This can only be called for read-only queries, see [`Self::iter_mut`] for write-queries.
     #[inline]
     pub fn iter_ref<'w, 's>(
-        &'s mut self, 
-        world: &'w World
+        &'s mut self,
+        world: &'w World,
     ) -> QueryIter<'w, 's, D::ReadOnlySmartRef, F> {
         self.update_archetypes(world);
         // SAFETY: query is read only

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -72,9 +72,6 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     pub fn as_reffed(&self) -> &QueryState<D::Reffed, F> {
         // SAFETY: invariant on `WorldQuery` trait upholds that `D::Reffed` and `F::ReadOnly`
         // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.
-        //
-        // ------- WHICH I'M NOT SURE IS TRUE FOR &T and Ref<T> -------- (remove if PR is reviewed and accepted)
-        //
         unsafe { self.as_transmuted_state::<D::Reffed, F>() }
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -68,7 +68,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Converts this `QueryState` reference to a `QueryState` with "reffed" access (read-only +
-    /// change detection using the [`Ref`] smart pointer)
+    /// change detection using the [`Ref`](crate::change_detection::Ref) smart pointer)
     pub fn as_reffed(&self) -> &QueryState<D::Reffed, F> {
         // SAFETY: invariant on `WorldQuery` trait upholds that `D::Reffed` and `F::ReadOnly`
         // have a subset of the access, and match the exact same archetypes/tables as `D`/`F` respectively.
@@ -410,7 +410,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     // TODO: Better explanation, I'm not a fan of the term "reffed".
-    /// Gets the query result in "reffed" form (whatever can go in the [`Ref`] smart pointer - goes into it,
+    /// Gets the query result in "reffed" form (whatever can go in the [`Ref`](crate::change_detection::Ref) smart pointer - goes into it,
     /// whatver doesn't - turns into the read-only version) for the given [`World`] and [`Entity`].
     ///
     /// This can only be called for read-only queries, see [`Self::get_mut`] for write-queries.

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -406,9 +406,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         }
     }
 
-    // TODO: Better explanation, I'm not a fan of the term "reffed".
-    /// Gets the query result in "reffed" form (whatever can go in the [`Ref`](crate::change_detection::Ref) smart pointer - goes into it,
-    /// whatver doesn't - turns into the read-only version) for the given [`World`] and [`Entity`].
+    /// Gets the query result in "reffed" form (Change-detection enabled read-only access) - most often using the [`Ref`] smart pointer, for the given [`World`] and [`Entity`].
     ///
     /// This can only be called for read-only queries, see [`Self::get_mut`] for write-queries.
     #[inline]

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -871,7 +871,10 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ///
     /// This can only be called for read-only queries, see [`Self::iter_mut`] for write-queries.
     #[inline]
-    pub fn iter_ref<'w, 's>(&'s mut self, world: &'w World) -> QueryIter<'w, 's, D::ReadOnlySmartRef, F> {
+    pub fn iter_ref<'w, 's>(
+        &'s mut self, 
+        world: &'w World
+    ) -> QueryIter<'w, 's, D::ReadOnlySmartRef, F> {
         self.update_archetypes(world);
         // SAFETY: query is read only
         unsafe {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -406,7 +406,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         }
     }
 
-    /// Gets the query result in "reffed" form (Change-detection enabled read-only access) - most often using the [`Ref`] smart pointer, for the given [`World`] and [`Entity`].
+    /// Gets the query result in "reffed" form (Change-detection enabled read-only access) - most often using the `Ref` smart pointer, for the given [`World`] and [`Entity`].
     ///
     /// This can only be called for read-only queries, see [`Self::get_mut`] for write-queries.
     #[inline]

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -481,14 +481,14 @@ mod tests {
         }
 
         fn log1(mut commands: Commands, query: Query<Ref<B>>) {
-            commands.insert_resource(Added1(query.get_single().unwrap().ticks.added.clone()));
-            commands.insert_resource(Changed1(query.get_single().unwrap().ticks.changed.clone()));
+            commands.insert_resource(Added1(*query.get_single().unwrap().ticks.added));
+            commands.insert_resource(Changed1(*query.get_single().unwrap().ticks.changed));
         }
 
         fn log2(mut commands: Commands, query: Query<&B>, te: Res<TargetEntity>) {
             let te = te.0;
-            commands.insert_resource(Added2(query.get_ref(te).unwrap().ticks.added.clone()));
-            commands.insert_resource(Changed2(query.get_ref(te).unwrap().ticks.changed.clone()));
+            commands.insert_resource(Added2(*query.get_ref(te).unwrap().ticks.added));
+            commands.insert_resource(Changed2(*query.get_ref(te).unwrap().ticks.changed));
         }
 
         let mut world = World::default();

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1032,7 +1032,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// # Example
     ///
     /// Here, `get_ref` is used to retrieve the exact query item of the entity specified by the `SelectedCharacter`
-    /// resource, note that the component will be returned inside the [`Ref`](crate::change_detection::Ref) smart pointer that contains
+    /// resource, note that the component will be returned inside the [`Ref`] smart pointer that contains
     /// change detection info (when was the component last changed, and when was it added).
     ///
     /// ```

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -4,7 +4,7 @@ use crate::{
     query::{
         BatchingStrategy, QueryCombinationIter, QueryComponentError, QueryData, QueryEntityError,
         QueryFilter, QueryIter, QueryManyIter, QueryParIter, QuerySingleError, QueryState,
-        ROQueryItem, ReadOnlyQueryData, ReffedQueryItem,
+        ROQueryItem, ROQueryItemRef, ReadOnlyQueryData,
     },
     world::{unsafe_world_cell::UnsafeWorldCell, Mut},
 };
@@ -872,7 +872,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
         }
     }
 
-    /// Returns the "reffed" query item for the given [`Entity`].
+    /// Returns a change-detection-enabled shared-reference to the query data.
     ///
     /// In case of a nonexisting entity or mismatched component, a [`QueryEntityError`] is returned instead.
     ///
@@ -906,11 +906,11 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     ///
     /// - [`get_mut`](Self::get_mut) to get a mutable query item.
     #[inline]
-    pub fn get_ref(&self, entity: Entity) -> Result<ReffedQueryItem<'_, D>, QueryEntityError> {
+    pub fn get_ref(&self, entity: Entity) -> Result<ROQueryItemRef<'_, D>, QueryEntityError> {
         // SAFETY: system runs without conflicts with other systems.
         // same-system queries have runtime borrow checks when they conflict
         unsafe {
-            self.state.as_reffed().get_unchecked_manual(
+            self.state.as_readonly_smart_ref().get_unchecked_manual(
                 self.world,
                 entity,
                 self.last_run,

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -879,7 +879,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// # Example
     ///
     /// Here, `get_ref` is used to retrieve the exact query item of the entity specified by the `SelectedCharacter`
-    /// resource, note that the component will be returned inside the [`Ref`] smart pointer that contains
+    /// resource, note that the component will be returned inside the [`Ref`](crate::change_detection::Ref) smart pointer that contains
     /// change detection info (when was the component last changed, and when was it added).
     ///
     /// ```

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/world_query_derive.stderr
@@ -6,13 +6,13 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
   |
   = help: the following other types implement trait `ReadOnlyQueryData`:
             MutableUnmarked
+            MutableUnmarkedReffed
             MutableMarkedReadOnly
+            MutableMarkedReffed
             NestedMutableUnmarked
+            NestedMutableUnmarkedReffed
             bevy_ecs::change_detection::Ref<'__w, T>
             Has<T>
-            AnyOf<()>
-            AnyOf<(F0,)>
-            AnyOf<(F0, F1)>
           and $N others
 note: required by a bound in `_::assert_readonly`
  --> tests/ui/world_query_derive.rs:7:10
@@ -29,13 +29,13 @@ error[E0277]: the trait bound `MutableMarked: ReadOnlyQueryData` is not satisfie
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
              MutableUnmarked
+             MutableUnmarkedReffed
              MutableMarkedReadOnly
+             MutableMarkedReffed
              NestedMutableUnmarked
+             NestedMutableUnmarkedReffed
              bevy_ecs::change_detection::Ref<'__w, T>
              Has<T>
-             AnyOf<()>
-             AnyOf<(F0,)>
-             AnyOf<(F0, F1)>
            and $N others
 note: required by a bound in `_::assert_readonly`
   --> tests/ui/world_query_derive.rs:18:10


### PR DESCRIPTION
# Objective

- fix #11517 by adding a `get_ref` method for `Query` and `QueryState`

## Solution

-  Add `get_ref` method for `QueryState`
-  Add `get_ref` method for `Query`

## Changelog

- The `QueryData` trait has another associated type - `ReadOnlySmartRef`. `ReadOnlySmartRef` is the type we get when we request read-only, change-detection-enabled, shared access to the data. For example:
access of `&T` is `Ref<T>`, the same is true for `&mut T`, because this access is explicitly read-only, and as such is analogous to first converting a `QueryData` to its read-only form (`QueryData::ReadOnly`) and then to its `QueryData::ReadOnlySmartRef` form. 
- The `QueryData` derive macro changed a bit in its implementation to reflect the above changes.
- The `QueryData` implementations of many types have changed to reflect the above changes.
- `get_ref` , `get_component_ref`, `iter_ref`, `as_readonly_smart_ref` methods were added to `QueryState`
- `get_ref`, `iter_ref`, `iter_combinations_ref`, `iter_many_ref`, `par_iter_ref`, `get_component_ref`, `component_ref`, `single_ref`, `get_single_ref`,  methods was added to `Query`
- `system_query_get_ref` test was added to make sure `Query<Ref<T>>` and `Query<&T>` + `get_ref` produce the same result. 

## Migration guide

- An associated type was added to the public `QueryData` trait: `ReadOnlySmartRef`. If the type you're implementing `QueryData` for can be accessed using some change-detection-enabled, read-only way, for example: the `Ref` smart pointer - then define `ReadOnlySmartRef` to be that type. If it can't be accessed that way, then keep `ReadOnlySmartRef` the same as `ReadOnly`.
 For example:
```rust
// Before:
impl<'a, C: Component> QueryData for &'a C {
    type ReadOnly = &'a C; // Regular read-only access
}

impl QueryData for Entity {
    type ReadOnly = Entity; // Standard read-only access of a Copy type
}

// After:
impl<'a, C: Component> QueryData for &'a C {
    type ReadOnly = &'a C; // Regular read-only access
    type ReadOnlySmartRef = Ref<'a, C>; // We can use `Ref` for change detection
}

impl QueryData for Entity {
    type ReadOnly = Entity; // Standard read-only access of a Copy type
    type ReadOnlySmartRef = Entity; // No option for change-detection, so keep it the same as `Self::ReadOnly`
}

```
