### PR TITLE
Rustdoc links in bevy_ui

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -33,6 +33,11 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 ///
 /// Note that you can also control the visibility of a node using the [`Display`](crate::ui_node::Display) property,
 /// which fully collapses it during layout calculations.
+///
+/// # See also
+///
+/// - [`ButtonBundle`](crate::node_bundles::ButtonBundle) which includes this component
+/// - [`RelativeCursorPosition`] to obtain the position of the cursor relative to current node
 #[derive(Component, Copy, Clone, Eq, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 #[cfg_attr(
@@ -63,9 +68,10 @@ impl Default for Interaction {
 
 /// A component storing the position of the mouse relative to the node, (0., 0.) being the top-left corner and (1., 1.) being the bottom-right
 /// If the mouse is not over the node, the value will go beyond the range of (0., 0.) to (1., 1.)
-
 ///
-/// It can be used alongside interaction to get the position of the press.
+/// It can be used alongside [`Interaction`] to get the position of the press.
+///
+/// The component is updated when it is in the same entity with [`Node`].
 #[derive(Component, Copy, Clone, Default, PartialEq, Debug, Reflect)]
 #[reflect(Component, Default, PartialEq)]
 #[cfg_attr(

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -18,9 +18,11 @@ use bevy_sprite::TextureAtlas;
 use bevy_text::{BreakLineOn, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
-/// The basic UI node
+/// The basic UI node.
 ///
-/// Useful as a container for a variety of child nodes.
+/// Contains the [`Node`] component and other components required to make a container.
+///
+/// See [`node_bundles`](crate::node_bundles) for more specialized bundles like [`TextBundle`].
 #[derive(Bundle, Clone, Debug)]
 pub struct NodeBundle {
     /// Describes the logical size of the node

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -14,7 +14,14 @@ use bevy_window::{PrimaryWindow, WindowRef};
 use std::num::{NonZeroI16, NonZeroU16};
 use thiserror::Error;
 
-/// Describes the size of a UI node
+/// Base component for a UI node, which also provides the computed size of the node.
+///
+/// # See also
+///
+/// - [`node_bundles`](crate::node_bundles) for the list of built-in bundles that set up UI node
+/// - [`RelativeCursorPosition`](crate::RelativeCursorPosition)
+///   to obtain the cursor position relative to this node
+/// - [`Interaction`](crate::Interaction) to obtain the interaction state of this node
 #[derive(Component, Debug, Copy, Clone, Reflect)]
 #[reflect(Component, Default)]
 pub struct Node {


### PR DESCRIPTION
# Objective

No links between types make create rustdoc harder to understand.

## Solution

Add links. Also tweak some sentences.