### PR TITLE
Derive `Debug` for `Framecount`

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -140,7 +140,7 @@ fn tick_global_task_pools(_main_thread_marker: Option<NonSend<NonSendMarker>>) {
 /// [`FrameCount`] will wrap to 0 after exceeding [`u32::MAX`]. Within reasonable
 /// assumptions, one may exploit wrapping arithmetic to determine the number of frames
 /// that have elapsed between two observations – see [`u32::wrapping_sub()`].
-#[derive(Default, Resource, Clone, Copy)]
+#[derive(Debug, Default, Resource, Clone, Copy)]
 pub struct FrameCount(pub u32);
 
 /// Adds frame counting functionality to Apps.


### PR DESCRIPTION

# Objective

- I wanted this for an example, and I think it's a fundamentally handy debugging tool (with already public fields).

## Solution

-  `derive(Debug)` for `FrameCount`
