### PR TITLE
Avoid unconditionally unwrapping the Result - UI Stack System

### DIFF
--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -58,11 +58,9 @@ pub fn ui_stack_system(
     fill_stack_recursively(&mut ui_stack.uinodes, &mut global_context);
 
     for (i, entity) in ui_stack.uinodes.iter().enumerate() {
-        update_query
-            .get_mut(*entity)
-            .unwrap()
-            .bypass_change_detection()
-            .stack_index = i as u32;
+        if let Ok(mut node) = update_query.get_mut(*entity) {
+            node.bypass_change_detection().stack_index = i as u32;
+        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Fixes #11572

## Solution

- Avoid unconditionally unwrapping the `Result` in the `ui_stack_system` function.
