### PR TITLE
fix text height calc

### DIFF
--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -177,10 +177,10 @@ impl TextMeasureInfo {
             max: Vec2::ZERO,
         };
 
-        let min = info.compute_size(Vec2::new(0.0, f32::INFINITY));
-        let max = info.compute_size(Vec2::INFINITY);
-        info.min = min;
-        info.max = max;
+        let min_width = info.compute_size(Vec2::new(0.0, f32::INFINITY));
+        let max_width = info.compute_size(Vec2::INFINITY);
+        info.min = min_width.min(max_width);
+        info.max = min_width.max(max_width);
         info
     }
 

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -92,7 +92,9 @@ fn create_text_measure(
     match TextMeasureInfo::from_text(&text, fonts, scale_factor) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
-                content_size.set(FixedMeasure { size: Vec2::new(measure.max.x, measure.min.y) });
+                content_size.set(FixedMeasure {
+                    size: Vec2::new(measure.max.x, measure.min.y),
+                });
             } else {
                 content_size.set(TextMeasure { info: measure });
             }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -92,7 +92,7 @@ fn create_text_measure(
     match TextMeasureInfo::from_text(&text, fonts, scale_factor) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
-                content_size.set(FixedMeasure { size: measure.max });
+                content_size.set(FixedMeasure { size: Vec2::new(measure.max.x, measure.min.y) });
             } else {
                 content_size.set(TextMeasure { info: measure });
             }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -92,6 +92,9 @@ fn create_text_measure(
     match TextMeasureInfo::from_text(&text, fonts, scale_factor) {
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
+                // with no wrapping the text will always be a single line, which is as wide as
+                // possible and as short as possible. so we use the max width and min height 
+                // directly.
                 content_size.set(FixedMeasure {
                     size: Vec2::new(measure.max.x, measure.min.y),
                 });

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -93,7 +93,7 @@ fn create_text_measure(
         Ok(measure) => {
             if text.linebreak_behavior == BreakLineOn::NoWrap {
                 // with no wrapping the text will always be a single line, which is as wide as
-                // possible and as short as possible. so we use the max width and min height 
+                // possible and as short as possible. so we use the max width and min height
                 // directly.
                 content_size.set(FixedMeasure {
                     size: Vec2::new(measure.max.x, measure.min.y),


### PR DESCRIPTION
# Objective

fixes #11542

## Solution

It's not clear to me what the expected result from a taffy measure function is, i think there's ambiguity in the arguments. but, currently we disregard available_height entirely and return the height for the requested width regardless of what height space is requested. this seems wrong. in particular, when known width and height are None, available width is MaxContent and available height is MaxContent, we always return a height of 1 line, when the actual max height is line height * word count.

this pr changes it so that text measure returns:
- width (unchanged in this pr)
  - if available width is known or definite, the given width
  - if available width is min or max, the min or max possible.

- height:
  - if available height is known or definite, the given height
  - if available width is known or definite, the exact height that given width yields
  - if width is unknown and available height is min or max, the min or max possible

this seems to fix my issue and seems to otherwise preserve existing behaviour as far as i can tell, but there are no tests that i'm aware of.

note that this won't provide useful results when height is known and width is MinContent, i.e. solving for the minimum width that yields the given height. this doesn't work in browsers either so i think that's fine.

requires #10690