### PR TITLE
Enable the `unsafe_op_in_unsafe_fn` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,9 @@ match_same_arms = "warn"
 semicolon_if_nothing_returned = "warn"
 map_flatten = "warn"
 
+[workspace.lints.rust]
+unsafe_op_in_unsafe_fn = "warn"
+
 [lints]
 workspace = true
 

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -88,7 +88,7 @@ impl ReflectAsset {
         handle: UntypedHandle,
     ) -> Option<&'w mut dyn Reflect> {
         // SAFETY: requirements are deferred to the caller
-        (self.get_unchecked_mut)(world, handle)
+        unsafe { (self.get_unchecked_mut)(world, handle) }
     }
 
     /// Equivalent of [`Assets::add`]

--- a/crates/bevy_dynamic_plugin/src/lib.rs
+++ b/crates/bevy_dynamic_plugin/src/lib.rs
@@ -1,3 +1,6 @@
+// FIXME(11590): remove this once the lint is fixed
+#![allow(unsafe_op_in_unsafe_fn)]
+
 mod loader;
 
 pub use loader::*;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,3 +1,5 @@
+// FIXME(11590): remove this once the lint is fixed
+#![allow(unsafe_op_in_unsafe_fn)]
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 

--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -52,7 +52,7 @@ type GizmosState<T> = (
 pub struct GizmosFetchState<T: GizmoConfigGroup> {
     state: <GizmosState<T> as SystemParam>::State,
 }
-// SAFETY: All methods are delegated to existing `SystemParam` implemntations
+// SAFETY: All methods are delegated to existing `SystemParam` implementations
 unsafe impl<T: GizmoConfigGroup> SystemParam for Gizmos<'_, '_, T> {
     type State = GizmosFetchState<T>;
     type Item<'w, 's> = Gizmos<'w, 's, T>;
@@ -77,8 +77,10 @@ unsafe impl<T: GizmoConfigGroup> SystemParam for Gizmos<'_, '_, T> {
         world: UnsafeWorldCell<'w>,
         change_tick: Tick,
     ) -> Self::Item<'w, 's> {
-        let (f0, f1) =
-            GizmosState::<T>::get_param(&mut state.state, system_meta, world, change_tick);
+        // SAFETY: Delegated to existing `SystemParam` implementations
+        let (f0, f1) = unsafe {
+            GizmosState::<T>::get_param(&mut state.state, system_meta, world, change_tick)
+        };
         // Accessing the GizmoConfigStore in the immediate mode API reduces performance significantly.
         // Implementing SystemParam manually allows us to do it to here
         // Having config available allows for early returns when gizmos are disabled

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -1,4 +1,8 @@
-#![allow(clippy::all, clippy::undocumented_unsafe_blocks)]
+#![allow(
+    unsafe_op_in_unsafe_fn,
+    clippy::all,
+    clippy::undocumented_unsafe_blocks
+)]
 
 use glam::{Vec2, Vec3};
 

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
 #![warn(missing_docs)]
+// FIXME(11590): remove this once the lint is fixed
+#![allow(unsafe_op_in_unsafe_fn)]
 
 use core::fmt::{self, Formatter, Pointer};
 use core::{

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -540,7 +540,8 @@ impl ReflectFromPtr {
     /// `val` must be a pointer to value of the type that the [`ReflectFromPtr`] was constructed for.
     /// This can be verified by checking that the type id returned by [`ReflectFromPtr::type_id`] is the expected one.
     pub unsafe fn as_reflect<'a>(&self, val: Ptr<'a>) -> &'a dyn Reflect {
-        (self.from_ptr)(val)
+        // SAFETY: contract uphold by the caller.
+        unsafe { (self.from_ptr)(val) }
     }
 
     /// Convert `PtrMut` into `&mut dyn Reflect`.
@@ -550,7 +551,8 @@ impl ReflectFromPtr {
     /// `val` must be a pointer to a value of the type that the [`ReflectFromPtr`] was constructed for
     /// This can be verified by checking that the type id returned by [`ReflectFromPtr::type_id`] is the expected one.
     pub unsafe fn as_reflect_mut<'a>(&self, val: PtrMut<'a>) -> &'a mut dyn Reflect {
-        (self.from_ptr_mut)(val)
+        // SAFETY: contract uphold by the caller.
+        unsafe { (self.from_ptr_mut)(val) }
     }
     /// Get a function pointer to turn a `Ptr` into `&dyn Reflect` for
     /// the type this [`ReflectFromPtr`] was constructed for.

--- a/crates/bevy_render/src/extract_param.rs
+++ b/crates/bevy_render/src/extract_param.rs
@@ -83,12 +83,14 @@ where
         // SAFETY:
         // - The caller ensures that `world` is the same one that `init_state` was called with.
         // - The caller ensures that no other `SystemParam`s will conflict with the accesses we have registered.
-        let main_world = Res::<MainWorld>::get_param(
-            &mut state.main_world_state,
-            system_meta,
-            world,
-            change_tick,
-        );
+        let main_world = unsafe {
+            Res::<MainWorld>::get_param(
+                &mut state.main_world_state,
+                system_meta,
+                world,
+                change_tick,
+            )
+        };
         let item = state.state.get(main_world.into_inner());
         Extract { item }
     }


### PR DESCRIPTION
# Objective

- Partial fix of #11590

## Solution

- Enable `unsafe_op_in_unsafe_fn` at workspace level
- Fix the lint for most of the crates
