### PR TITLE
Use batch spawn in benchmarks

### DIFF
--- a/benches/benches/bevy_ecs/iteration/iter_simple.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple.rs
@@ -19,15 +19,15 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Position(Vec3::X),
                 Rotation(Vec3::X),
                 Velocity(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query::<(&Velocity, &mut Position)>();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach.rs
@@ -19,15 +19,15 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Position(Vec3::X),
                 Rotation(Vec3::X),
                 Velocity(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query::<(&Velocity, &mut Position)>();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_sparse_set.rs
@@ -21,15 +21,15 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Position(Vec3::X),
                 Rotation(Vec3::X),
                 Velocity(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query::<(&Velocity, &mut Position)>();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide.rs
@@ -33,9 +33,8 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Rotation(Vec3::X),
                 Position::<0>(Vec3::X),
@@ -48,8 +47,9 @@ impl<'w> Benchmark<'w> {
                 Velocity::<3>(Vec3::X),
                 Position::<4>(Vec3::X),
                 Velocity::<4>(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_foreach_wide_sparse_set.rs
@@ -35,9 +35,8 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Rotation(Vec3::X),
                 Position::<0>(Vec3::X),
@@ -50,8 +49,9 @@ impl<'w> Benchmark<'w> {
                 Velocity::<3>(Vec3::X),
                 Position::<4>(Vec3::X),
                 Velocity::<4>(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_sparse_set.rs
@@ -21,15 +21,15 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Position(Vec3::X),
                 Rotation(Vec3::X),
                 Velocity(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query::<(&Velocity, &mut Position)>();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_system.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_system.rs
@@ -19,15 +19,15 @@ impl Benchmark {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Position(Vec3::X),
                 Rotation(Vec3::X),
                 Velocity(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         fn query_system(mut query: Query<(&Velocity, &mut Position)>) {
             for (velocity, mut position) in &mut query {

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide.rs
@@ -33,9 +33,8 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Rotation(Vec3::X),
                 Position::<0>(Vec3::X),
@@ -48,8 +47,9 @@ impl<'w> Benchmark<'w> {
                 Velocity::<3>(Vec3::X),
                 Position::<4>(Vec3::X),
                 Velocity::<4>(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query();
         Self(world, query)

--- a/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
+++ b/benches/benches/bevy_ecs/iteration/iter_simple_wide_sparse_set.rs
@@ -35,9 +35,8 @@ impl<'w> Benchmark<'w> {
     pub fn new() -> Self {
         let mut world = World::new();
 
-        // TODO: batch this
-        for _ in 0..10_000 {
-            world.spawn((
+        world.spawn_batch(
+            std::iter::repeat((
                 Transform(Mat4::from_scale(Vec3::ONE)),
                 Rotation(Vec3::X),
                 Position::<0>(Vec3::X),
@@ -50,8 +49,9 @@ impl<'w> Benchmark<'w> {
                 Velocity::<3>(Vec3::X),
                 Position::<4>(Vec3::X),
                 Velocity::<4>(Vec3::X),
-            ));
-        }
+            ))
+            .take(10_000),
+        );
 
         let query = world.query();
         Self(world, query)


### PR DESCRIPTION
# Objective

- The benchmarks for `bevy_ecs`' `iter_simple` group use `for` loops instead of `World::spawn_batch`.
- There's a TODO comment that says to batch spawn them.

## Solution

- Replace the `for` loops with `World::spawn_batch`.