### PR TITLE
Make SavedAsset::get_labeled accept &str as label

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -8,6 +8,7 @@ linker = "clang"
 rustflags = [
   "-Clink-arg=-fuse-ld=lld", # Use LLD Linker
   "-Zshare-generics=y",      # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=0",             # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 # NOTE: you must install [Mach-O LLD Port](https://lld.llvm.org/MachO/index.html) on mac. you can easily do this by installing llvm which includes lld with the "brew" package manager:
@@ -16,17 +17,22 @@ rustflags = [
 rustflags = [
   "-Clink-arg=-fuse-ld=/usr/local/opt/llvm/bin/ld64.lld", # Use LLD Linker
   "-Zshare-generics=y",                                   # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=0",                                          # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 [target.aarch64-apple-darwin]
 rustflags = [
   "-Clink-arg=-fuse-ld=/opt/homebrew/opt/llvm/bin/ld64.lld", # Use LLD Linker
   "-Zshare-generics=y",                                      # (Nightly) Make the current crate share its generic instantiations
+  "-Zthreads=0",                                             # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 
 [target.x86_64-pc-windows-msvc]
-linker = "rust-lld.exe"            # Use LLD Linker
-rustflags = ["-Zshare-generics=n"]
+linker = "rust-lld.exe" # Use LLD Linker
+rustflags = [
+  "-Zshare-generics=n",
+  "-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
+]
 
 # Optional: Uncommenting the following improves compile times, but reduces the amount of debug info to 'line number tables only'
 # In most cases the gains are negligible, but if you are on macos and have slow compile times you should see significant gains.

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -95,11 +95,15 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset>(
+    pub fn get_labeled<B: Asset, Q>(
         &self,
-        label: impl Into<CowArc<'static, str>>,
-    ) -> Option<SavedAsset<B>> {
-        let labeled = self.labeled_assets.get(&label.into())?;
+        label: &Q,
+    ) -> Option<SavedAsset<B>> 
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq
+    {
+        let labeled = self.labeled_assets.get(label)?;
         let value = labeled.asset.value.downcast_ref::<B>()?;
         Some(SavedAsset {
             value,
@@ -108,25 +112,33 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the type-erased labeled asset, if it exists and matches this type.
-    pub fn get_erased_labeled(
+    pub fn get_erased_labeled<Q>(
         &self,
-        label: impl Into<CowArc<'static, str>>,
-    ) -> Option<&ErasedLoadedAsset> {
-        let labeled = self.labeled_assets.get(&label.into())?;
+        label: &Q,
+    ) -> Option<&ErasedLoadedAsset> 
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
         Some(&labeled.asset)
     }
 
     /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
-    pub fn get_untyped_handle(
+    pub fn get_untyped_handle<Q>(
         &self,
-        label: impl Into<CowArc<'static, str>>,
-    ) -> Option<&UntypedHandle> {
-        let labeled = self.labeled_assets.get(&label.into())?;
+        label: &Q,
+    ) -> Option<&UntypedHandle> 
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
         Some(&labeled.handle)
     }
 
     /// Iterate over all labels for "labeled assets" in the loaded asset
-    pub fn iter_labels(&self) -> impl Iterator<Item = &CowArc<'static, str>> {
-        self.labeled_assets.keys()
+    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
+        self.labeled_assets.keys().map(|s| &**s)
     }
 }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -116,7 +116,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         Some(&labeled.asset)
     }
 
-    /// Returns the [`UntypedHandle`] of the [`LabeledAsset`] with the provided 'label', if it exists.
+    /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
     pub fn get_untyped_handle(
         &self,
         label: impl Into<CowArc<'static, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -116,7 +116,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         Some(&labeled.asset)
     }
 
-    /// Returns the `UntypedHandle` of the `LabeledAsset` with Label 'label', if it exists.
+    /// Returns the [`UntypedHandle`] of the [`LabeledAsset`] with the provided 'label', if it exists.
     pub fn get_untyped_handle(
         &self,
         label: impl Into<CowArc<'static, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -2,7 +2,7 @@ use crate::{io::Writer, meta::Settings, Asset, ErasedLoadedAsset};
 use crate::{AssetLoader, LabeledAsset, UntypedHandle};
 use bevy_utils::{BoxedFuture, CowArc, HashMap};
 use serde::{Deserialize, Serialize};
-use std::ops::Deref;
+use std::{borrow::Borrow, hash::Hash, ops::Deref};
 
 /// Saves an [`Asset`] of a given [`AssetSaver::Asset`] type. [`AssetSaver::OutputLoader`] will then be used to load the saved asset
 /// in the final deployed application. The saver should produce asset bytes in a format that [`AssetSaver::OutputLoader`] can read.

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -116,7 +116,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         Some(&labeled.asset)
     }
 
-    /// Returns the UntypedHandle of the LabeledAsset with Label 'label', if it exists.
+    /// Returns the `UntypedHandle`` of the `LabeledAsset`` with Label 'label', if it exists.
     pub fn get_untyped_handle(
         &self,
         label: impl Into<CowArc<'static, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -95,13 +95,10 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(
-        &self,
-        label: &Q,
-    ) -> Option<SavedAsset<B>> 
+    pub fn get_labeled<B: Asset, Q>(&self, label: &Q) -> Option<SavedAsset<B>>
     where
         CowArc<'static, str>: Borrow<Q>,
-        Q: ?Sized + Hash + Eq
+        Q: ?Sized + Hash + Eq,
     {
         let labeled = self.labeled_assets.get(label)?;
         let value = labeled.asset.value.downcast_ref::<B>()?;
@@ -112,10 +109,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the type-erased labeled asset, if it exists and matches this type.
-    pub fn get_erased_labeled<Q>(
-        &self,
-        label: &Q,
-    ) -> Option<&ErasedLoadedAsset> 
+    pub fn get_erased_labeled<Q>(&self, label: &Q) -> Option<&ErasedLoadedAsset>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
@@ -125,10 +119,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
     }
 
     /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
-    pub fn get_untyped_handle<Q>(
-        &self,
-        label: &Q,
-    ) -> Option<&UntypedHandle> 
+    pub fn get_untyped_handle<Q>(&self, label: &Q) -> Option<&UntypedHandle>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -115,11 +115,11 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         let labeled = self.labeled_assets.get(&label.into())?;
         Some(&labeled.asset)
     }
-    
+
     /// Returns the UntypedHandle of the LabeledAsset with Label 'label', if it exists.
     pub fn get_untyped_handle(
         &self,
-        label: impl Into<CowArc<'static, str>>
+        label: impl Into<CowArc<'static, str>>,
     ) -> Option<&UntypedHandle> {
         let labeled = self.labeled_assets.get(&label.into())?;
         Some(&labeled.handle)

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -116,7 +116,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         Some(&labeled.asset)
     }
 
-    /// Returns the `UntypedHandle`` of the `LabeledAsset`` with Label 'label', if it exists.
+    /// Returns the `UntypedHandle` of the `LabeledAsset` with Label 'label', if it exists.
     pub fn get_untyped_handle(
         &self,
         label: impl Into<CowArc<'static, str>>,

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -1,5 +1,5 @@
 use crate::{io::Writer, meta::Settings, Asset, ErasedLoadedAsset};
-use crate::{AssetLoader, LabeledAsset};
+use crate::{AssetLoader, LabeledAsset, UntypedHandle};
 use bevy_utils::{BoxedFuture, CowArc, HashMap};
 use serde::{Deserialize, Serialize};
 use std::ops::Deref;
@@ -115,9 +115,18 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         let labeled = self.labeled_assets.get(&label.into())?;
         Some(&labeled.asset)
     }
+    
+    /// Returns the UntypedHandle of the LabeledAsset with Label 'label', if it exists.
+    pub fn get_untyped_handle(
+        &self,
+        label: impl Into<CowArc<'static, str>>
+    ) -> Option<&UntypedHandle> {
+        let labeled = self.labeled_assets.get(&label.into())?;
+        Some(&labeled.handle)
+    }
 
     /// Iterate over all labels for "labeled assets" in the loaded asset
-    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
-        self.labeled_assets.keys().map(|s| &**s)
+    pub fn iter_labels(&self) -> impl Iterator<Item = &CowArc<'static, str>> {
+        self.labeled_assets.keys()
     }
 }


### PR DESCRIPTION
# Objective

- SavedAsset's iter_labels returns ```&str```, however accessing LabeledAssets requires ```CowArc<'static, str>```
- Although SavedAsset holds UntypedHandles in its hashmap of LabeledAssets, they are inaccessible as LabeledAssets are casted to SavedAsset or ErasedLoadedAsset, which don't contain their UntypedHandles
- Adresses #11609

## Solution

- Used Trait bounds to allow for either ```CowArc<'static, str>``` or ```&str``` to be used as a label in get_labeled and get_erased_labeled.
- Added method get_untyped_handle to get UntypedHandle from the LabeledAsset.
