### PR TITLE
Add a way to dump shaders

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -337,6 +337,11 @@ impl Plugin for RenderPlugin {
         if let Some(future_renderer_resources) =
             app.world.remove_resource::<FutureRendererResources>()
         {
+            let dump_shaders = match &self.render_creation {
+                RenderCreation::Manual(_, _, _, _, _) => None,
+                RenderCreation::Automatic(wgpu_settings) => wgpu_settings.dump_naga_shaders.clone(),
+            };
+
             let (device, queue, adapter_info, render_adapter, instance) =
                 future_renderer_resources.0.lock().unwrap().take().unwrap();
 
@@ -349,7 +354,7 @@ impl Plugin for RenderPlugin {
 
             render_app
                 .insert_resource(instance)
-                .insert_resource(PipelineCache::new(device.clone()))
+                .insert_resource(PipelineCache::new(device.clone(), dump_shaders))
                 .insert_resource(device)
                 .insert_resource(queue)
                 .insert_resource(render_adapter)

--- a/crates/bevy_render/src/render_resource/shader.rs
+++ b/crates/bevy_render/src/render_resource/shader.rs
@@ -4,7 +4,7 @@ use bevy_asset::{io::Reader, Asset, AssetLoader, AssetPath, Handle, LoadContext}
 use bevy_reflect::TypePath;
 use bevy_utils::{tracing::error, BoxedFuture};
 use futures_lite::AsyncReadExt;
-use std::{borrow::Cow, marker::Copy};
+use std::borrow::Cow;
 use thiserror::Error;
 
 define_atomic_id!(ShaderId);
@@ -71,6 +71,7 @@ impl Shader {
         let source = source.into();
         let path = path.into();
         let (import_path, imports) = Shader::preprocess(&source, &path);
+
         Shader {
             path,
             imports,

--- a/crates/bevy_render/src/settings.rs
+++ b/crates/bevy_render/src/settings.rs
@@ -50,6 +50,8 @@ pub struct WgpuSettings {
     pub gles3_minor_version: Gles3MinorVersion,
     /// These are for controlling WGPU's debug information to eg. enable validation and shader debug info in release builds.
     pub instance_flags: InstanceFlags,
+    /// This allows for dumping the
+    pub dump_naga_shaders: Option<NagaShaderOutputFormat>,
 }
 
 impl Default for WgpuSettings {
@@ -113,6 +115,7 @@ impl Default for WgpuSettings {
             dx12_shader_compiler: dx12_compiler,
             gles3_minor_version,
             instance_flags,
+            dump_naga_shaders: None,
         }
     }
 }
@@ -170,4 +173,14 @@ pub fn settings_priority_from_env() -> Option<WgpuSettingsPriority> {
             _ => return None,
         },
     )
+}
+
+#[derive(Clone)]
+pub enum NagaShaderOutputFormat {
+    Wgsl,
+    Glsl,
+    Hlsl,
+    Spirv,
+    // TODO: Unsupported
+    // Naga,
 }


### PR DESCRIPTION
# Objective

There's been a few requests for a way to dump our semi-compiled shaders (after naga-oil transforms them with the imports).

## Solution

~~Steal~~ Borrow the code from @robtfm's https://github.com/robtfm/naga_oil_cli and implement it in bevy's shader cache, with an option you can set at startup in the RenderPlugin:
```rust
            DefaultPlugins.set(RenderPlugin {
                render_creation: bevy_internal::render::settings::RenderCreation::Automatic(
                    WgpuSettings {
                        dump_naga_shaders: Some(
                            bevy_internal::render::settings::NagaShaderOutputFormat::Spirv,
                        ),
                        ..default()
                    },
                ),
            }),
```

TODO:
- [ ] log an error if Glsl is chosen but the required naga feature isn't enabled
- [ ] output all the pipelines (prepend the filename with the hash maybe?) instead of just the latest ones to be compiled
- [ ] Add msl output (metal)
- [ ] cfg block it so it doesn't try to write to files on web (could maybe print it to console on web?)
- [ ] Add an env variable for it so it's less annoying to setup.
- Consider adding Naga output format support (I'd rather not add `serde_json` to bevy_render as a dependency, but I'm pretty sure we already have dependencies on it, at least for the `gltf` crate).

---

## Changelog
TODO