### PR TITLE
Fix example send_and_receive_events

### DIFF
--- a/examples/ecs/send_and_receive_events.rs
+++ b/examples/ecs/send_and_receive_events.rs
@@ -27,6 +27,8 @@ fn main() {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)
         .add_event::<DebugEvent>()
+        .add_event::<A>()
+        .add_event::<B>()
         .add_systems(Update, read_and_write_different_event_types)
         .add_systems(
             Update,

--- a/examples/ecs/send_and_receive_events.rs
+++ b/examples/ecs/send_and_receive_events.rs
@@ -73,7 +73,7 @@ struct DebugEvent {
 
 /// A system that sends all combinations of events.
 fn send_events(mut events: EventWriter<DebugEvent>, frame_count: Res<FrameCount>) {
-    info!("Sending events for frame {:?}", *frame_count);
+    println!("Sending events for frame {:?}", *frame_count);
 
     events.send(DebugEvent {
         resend_from_param_set: false,
@@ -111,7 +111,7 @@ fn send_and_receive_param_set(
     mut param_set: ParamSet<(EventReader<DebugEvent>, EventWriter<DebugEvent>)>,
     frame_count: Res<FrameCount>,
 ) {
-    info!(
+    println!(
         "Sending and receiving events for frame {} with a `ParamSet`",
         frame_count.0
     );
@@ -142,7 +142,7 @@ fn send_and_receive_manual_event_reader(
     mut events: ResMut<Events<DebugEvent>>,
     frame_count: Res<FrameCount>,
 ) {
-    info!(
+    println!(
         "Sending and receiving events for frame {} with a `Local<ManualEventReader>",
         frame_count.0
     );


### PR DESCRIPTION
# Objective

- Example `send_and_receive_events` added in #11574 panics
```
thread 'Compute Task Pool (3)' panicked at bevy/crates/bevy_ecs/src/system/system_param.rs:570:17:
Resource requested by send_and_receive_events::read_and_write_different_event_types does not exist: bevy_ecs::event::Events<send_and_receive_events::A>
Encountered a panic in system `send_and_receive_events::read_and_write_different_event_types`!
Encountered a panic in system `bevy_app::main_schedule::Main::run_main`!
```

## Solution

- Register the events used in the system
- Don't use logger as it's not setup with `MinimalPlugins`, just print
