### PR TITLE
impl `Borrow` and `AsRef` for `CowArc`

### DIFF
--- a/crates/bevy_utils/src/cow_arc.rs
+++ b/crates/bevy_utils/src/cow_arc.rs
@@ -45,6 +45,13 @@ impl<'a, T: ?Sized> Borrow<T> for CowArc<'a, T> {
     }
 }
 
+impl<'a, T: ?Sized> AsRef<T> for CowArc<'a, T> {
+    #[inline]
+    fn as_ref(&self) -> &T {
+        self
+    }
+}
+
 impl<'a, T: ?Sized> CowArc<'a, T>
 where
     &'a T: Into<Arc<T>>,

--- a/crates/bevy_utils/src/cow_arc.rs
+++ b/crates/bevy_utils/src/cow_arc.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Borrow,
     fmt::{Debug, Display},
     hash::Hash,
     ops::Deref,
@@ -34,6 +35,13 @@ impl<'a, T: ?Sized> Deref for CowArc<'a, T> {
             CowArc::Borrowed(v) | CowArc::Static(v) => v,
             CowArc::Owned(v) => v,
         }
+    }
+}
+
+impl<'a, T: ?Sized> Borrow<T> for CowArc<'a, T> {
+    #[inline]
+    fn borrow(&self) -> &T {
+        self
     }
 }
 


### PR DESCRIPTION
# Objective

- Allow `HashMap<Cow<'_, T>, _>` to use `&T` as key for `HashMap::get`
- Makes `CowArc` more like `Cow`

## Solution

Implements `Borrow<T>` and `AsRef<T>` for `CowArc<T>`. 

