### PR TITLE
Mark `DynamicPluginLoadError` internal error types as source

### DIFF
--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -8,9 +8,9 @@ use bevy_app::{App, CreatePlugin, Plugin};
 #[derive(Debug, Error)]
 pub enum DynamicPluginLoadError {
     #[error("cannot load library for dynamic plugin: {0}")]
-    Library(libloading::Error),
+    Library(#[source] libloading::Error),
     #[error("dynamic library does not contain a valid Bevy dynamic plugin")]
-    Plugin(libloading::Error),
+    Plugin(#[source] libloading::Error),
 }
 
 /// Dynamically links a plugin at the given path. The plugin must export a function with the


### PR DESCRIPTION
# Objective

- [`thiserror`](https://docs.rs/thiserror/) is used to derive the error type on `bevy_dynamic_plugin`'s [`DynamicPluginLoadError`](https://docs.rs/bevy_dynamic_plugin/latest/bevy_dynamic_plugin/enum.DynamicPluginLoadError.html).
- It is an enum where each variant wraps a `libloading` error type.
- `thiserror` supports marking this internal error types as `#[source]` so it can automatically fill out the [`Error::source`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source) method.
- This allows other error handling libraries to get more information about the error than what Bevy by default provides. It increases interoperability between libraries.

## Solution

- Mark the internal `libloading::Error` of `DynamicPluginLoadError` with `#[source]`.

---

## Changelog


- Implemented the [`Error::source`](https://doc.rust-lang.org/std/error/trait.Error.html#method.source) method for [`DynamicPluginLoadError`](https://docs.rs/bevy_dynamic_plugin/latest/bevy_dynamic_plugin/enum.DynamicPluginLoadError.html).

---

Here is the output from `cargo-expand` before and after the change.

```rust
// Before
impl Error for DynamicPluginLoadError {}
```

```rust
// After
impl Error for DynamicPluginLoadError {
    fn source(&self) -> Option<&(dyn Error + 'static)> {
        use thiserror::__private::AsDynError as _;

        match self {
            DynamicPluginLoadError::Library { 0: source, .. } => {
                Some(source.as_dyn_error())
            }
            DynamicPluginLoadError::Plugin { 0: source, .. } => {
                Some(source.as_dyn_error())
            }
        }
    }
}
```