### PR TITLE
bevy_dynamic_plugin: fix `unsafe_op_in_unsafe_fn` lint

### DIFF
--- a/crates/bevy_dynamic_plugin/src/lib.rs
+++ b/crates/bevy_dynamic_plugin/src/lib.rs
@@ -1,5 +1,3 @@
-// FIXME(11590): remove this once the lint is fixed
-#![allow(unsafe_op_in_unsafe_fn)]
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
 

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -21,19 +21,29 @@ pub enum DynamicPluginLoadError {
 /// The specified plugin must be linked against the exact same libbevy.so as this program.
 /// In addition the `_bevy_create_plugin` symbol must not be manually created, but instead created
 /// by deriving `DynamicPlugin` on a unit struct implementing [`Plugin`].
+/// 
+/// Dynamically loading plugins is orchestrated through dynamic linking. When linking against foreign
+/// code, initialization routines may be run (as well as termination routines when the program exits).
+/// The caller of this function is responsible for ensuring these routines are sound. For more
+/// information, please see the safety section of [`libloading::Library::new`].
 pub unsafe fn dynamically_load_plugin<P: AsRef<OsStr>>(
     path: P,
 ) -> Result<(Library, Box<dyn Plugin>), DynamicPluginLoadError> {
-    // TODO: Safety comment for `Library::new`, `Library::get`, and `Box::from_raw`.
-    unsafe {
-        let lib = Library::new(path).map_err(DynamicPluginLoadError::Library)?;
-        let func: Symbol<CreatePlugin> = lib
-            .get(b"_bevy_create_plugin")
-            .map_err(DynamicPluginLoadError::Plugin)?;
-        let plugin = Box::from_raw(func());
+    // SAFETY: Caller must follow the safety requirements of Library::new.
+    let lib = unsafe { Library::new(path).map_err(DynamicPluginLoadError::Library)? };
 
-        Ok((lib, plugin))
-    }
+    // SAFETY: Loaded plugins are not allowed to specify `_bevy_create_plugin` symbol manually, but must
+    // instead automatically generate it through `DynamicPlugin`.
+    let func: Symbol<CreatePlugin> = unsafe {
+        lib.get(b"_bevy_create_plugin")
+        .map_err(DynamicPluginLoadError::Plugin)?
+    };
+
+    // SAFETY: `func` is automatically generated and is guaranteed to return a pointer created using
+    // `Box::into_raw`.
+    let plugin = unsafe { Box::from_raw(func()) };
+
+    Ok((lib, plugin))
 }
 
 pub trait DynamicPluginExt {

--- a/crates/bevy_dynamic_plugin/src/loader.rs
+++ b/crates/bevy_dynamic_plugin/src/loader.rs
@@ -21,7 +21,7 @@ pub enum DynamicPluginLoadError {
 /// The specified plugin must be linked against the exact same libbevy.so as this program.
 /// In addition the `_bevy_create_plugin` symbol must not be manually created, but instead created
 /// by deriving `DynamicPlugin` on a unit struct implementing [`Plugin`].
-/// 
+///
 /// Dynamically loading plugins is orchestrated through dynamic linking. When linking against foreign
 /// code, initialization routines may be run (as well as termination routines when the program exits).
 /// The caller of this function is responsible for ensuring these routines are sound. For more
@@ -36,7 +36,7 @@ pub unsafe fn dynamically_load_plugin<P: AsRef<OsStr>>(
     // instead automatically generate it through `DynamicPlugin`.
     let func: Symbol<CreatePlugin> = unsafe {
         lib.get(b"_bevy_create_plugin")
-        .map_err(DynamicPluginLoadError::Plugin)?
+            .map_err(DynamicPluginLoadError::Plugin)?
     };
 
     // SAFETY: `func` is automatically generated and is guaranteed to return a pointer created using


### PR DESCRIPTION
# Objective

- Part of #11590.

## Solution

- Fix `unsafe_op_in_unsafe_fn` for `bevy_dynamic_plugin`.

---

## Changelog

- Added further restrictions to the safety requirements of `bevy_dynamic_plugin::dynamically_load_plugin`.

---

I had a few issues, specifically with the safety comment on `dynamically_load_plugin`. There are three different unsafe functions called within the function body, and they all need their own justification / message.

Also, would it be unsound to call `dynamically_load_plugin` multiple times on the same file? I feel the documentation needs to be more clear.