### PR TITLE
Fix AssetTransformer breaking LabeledAssets

### DIFF
--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -187,18 +187,21 @@ impl<
                 loader: std::any::type_name::<Loader>().to_string(),
                 settings: settings.loader_settings,
             });
-            let loaded_asset = context.load_source_asset(loader_meta).await?;
+            let mut loaded_asset = context.load_source_asset(loader_meta).await?;
 
             let transformed_asset = self
                 .transformer
                 .transform(
-                    TransformedAsset::<Loader::Asset>::from_loaded(loaded_asset).unwrap(),
+                    TransformedAsset::<Loader::Asset>::from_loaded(&mut loaded_asset).unwrap(),
                     &settings.transformer_settings,
                 )
                 .await
                 .map_err(|err| ProcessError::AssetTransformError(err.into()))?;
 
-            let saved_asset = SavedAsset::<T::AssetOutput>::from_transformed(&transformed_asset);
+            let saved_asset = SavedAsset::<T::AssetOutput>::from_asset_and_loaded(
+                &transformed_asset,
+                &loaded_asset,
+            );
 
             let output_settings = self
                 .saver

--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -6,8 +6,8 @@ use crate::{
     meta::{AssetAction, AssetMeta, AssetMetaDyn, ProcessDependencyInfo, ProcessedInfo, Settings},
     processor::AssetProcessor,
     saver::{AssetSaver, SavedAsset},
-    transformer::AssetTransformer,
-    AssetLoadError, AssetLoader, AssetPath, DeserializeMetaError, ErasedLoadedAsset, LoadedAsset,
+    transformer::{AssetTransformer, TransformedAsset},
+    AssetLoadError, AssetLoader, AssetPath, DeserializeMetaError, ErasedLoadedAsset,
     MissingAssetLoaderForExtensionError, MissingAssetLoaderForTypeNameError,
 };
 use bevy_utils::BoxedFuture;
@@ -158,6 +158,8 @@ pub enum ProcessError {
     WrongMetaType,
     #[error("Encountered an error while saving the asset: {0}")]
     AssetSaveError(#[from] Box<dyn std::error::Error + Send + Sync + 'static>),
+    #[error("Encountered an error while transforming the asset: {0}")]
+    AssetTransformError(Box<dyn std::error::Error + Send + Sync + 'static>),
     #[error("Assets without extensions are not supported.")]
     ExtensionRequired,
 }
@@ -185,18 +187,18 @@ impl<
                 loader: std::any::type_name::<Loader>().to_string(),
                 settings: settings.loader_settings,
             });
-            let loaded_asset = context
-                .load_source_asset(loader_meta)
-                .await?
-                .take::<Loader::Asset>()
-                .expect("Asset type is known");
+            let loaded_asset = context.load_source_asset(loader_meta).await?;
+
             let transformed_asset = self
                 .transformer
-                .transform(loaded_asset, &settings.transformer_settings)?;
-            let loaded_transformed_asset =
-                ErasedLoadedAsset::from(LoadedAsset::from(transformed_asset));
-            let saved_asset =
-                SavedAsset::<T::AssetOutput>::from_loaded(&loaded_transformed_asset).unwrap();
+                .transform(
+                    TransformedAsset::<Loader::Asset>::from_loaded(loaded_asset).unwrap(),
+                    &settings.transformer_settings,
+                )
+                .await
+                .map_err(|err| ProcessError::AssetTransformError(err.into()))?;
+
+            let saved_asset = SavedAsset::<T::AssetOutput>::from_transformed(&transformed_asset);
 
             let output_settings = self
                 .saver

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -1,4 +1,3 @@
-use crate::transformer::TransformedAsset;
 use crate::{io::Writer, meta::Settings, Asset, ErasedLoadedAsset};
 use crate::{AssetLoader, Handle, LabeledAsset, UntypedHandle};
 use bevy_utils::{BoxedFuture, CowArc, HashMap};
@@ -89,11 +88,11 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         })
     }
 
-    /// Creates a new [`SavedAsset`] from the TransformedAsset `asset`
-    pub fn from_transformed(asset: &'a TransformedAsset<A>) -> Self {
+    /// Creates a new [`SavedAsset`] from the `asset` and the labeled_assets in loaded
+    pub fn from_asset_and_loaded(asset: &'a A, loaded: &'a ErasedLoadedAsset) -> Self {
         Self {
-            value: &asset.value,
-            labeled_assets: &asset.labeled_assets,
+            value: &asset,
+            labeled_assets: &loaded.labeled_assets,
         }
     }
 

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -1,5 +1,7 @@
-use crate::{meta::Settings, Asset};
+use crate::{meta::Settings, Asset, ErasedLoadedAsset, Handle, LabeledAsset, UntypedHandle};
+use bevy_utils::{BoxedFuture, CowArc, HashMap};
 use serde::{Deserialize, Serialize};
+use std::{borrow::Borrow, hash::Hash, ops::Deref};
 
 /// Transforms an [`Asset`] of a given [`AssetTransformer::AssetInput`] type to an [`Asset`] of [`AssetTransformer::AssetOutput`] type.
 pub trait AssetTransformer: Send + Sync + 'static {
@@ -9,12 +11,201 @@ pub trait AssetTransformer: Send + Sync + 'static {
     type AssetOutput: Asset;
     /// The settings type used by this [`AssetTransformer`].
     type Settings: Settings + Default + Serialize + for<'a> Deserialize<'a>;
-    /// The type of [error](`std::error::Error`) which could be encountered by this saver.
+    /// The type of [error](`std::error::Error`) which could be encountered by this transformer.
     type Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>;
 
+    /// Transformes the given [`TransformedAsset`] to [`AssetTransformer::AssetOutput`].
+    /// The [`TransformedAsset`]'s labeled_assets can be altered to add new Labeled Sub-Assets
+    /// The passed in `settings` can influence how the `asset` is transformed
     fn transform<'a>(
         &'a self,
-        asset: Self::AssetInput,
+        asset: TransformedAsset<Self::AssetInput>,
         settings: &'a Self::Settings,
-    ) -> Result<Self::AssetOutput, Box<dyn std::error::Error + Send + Sync + 'static>>;
+    ) -> BoxedFuture<'a, Result<TransformedAsset<Self::AssetOutput>, Self::Error>>;
+}
+
+/// An [`Asset`] (and any "sub assets") intended to be transformed
+pub struct TransformedAsset<A: Asset> {
+    pub(crate) value: A,
+    pub(crate) labeled_assets: HashMap<CowArc<'static, str>, LabeledAsset>,
+}
+
+impl<A: Asset> Deref for TransformedAsset<A> {
+    type Target = A;
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl<A: Asset> TransformedAsset<A> {
+    /// Creates a new [`TransformedAsset`] from `asset` if its internal value matches `A`.
+    pub fn from_loaded(asset: ErasedLoadedAsset) -> Option<Self> {
+        if let Ok(value) = asset.value.downcast::<A>() {
+            return Some(TransformedAsset {
+                value: *value,
+                labeled_assets: asset.labeled_assets,
+            });
+        }
+        return None;
+    }
+    /// Creates a new [`TransformedAsset`] using the `asset`, copying the labeled assets from the old [`TransformedAsset`]
+    pub fn replace_asset<B: Asset>(self, asset: B) -> TransformedAsset<B> {
+        TransformedAsset::<B> {
+            value: asset,
+            labeled_assets: self.labeled_assets,
+        }
+    }
+    /// Retrieves the value of this asset.
+    #[inline]
+    pub fn get(&self) -> &A {
+        &self.value
+    }
+    /// Mutably retrieves the value of this asset.
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut A {
+        &mut self.value
+    }
+    /// Returns the labeled asset, if it exists and matches this type.
+    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get_mut(label)?;
+        let value: &B = labeled.asset.value.downcast_ref::<B>()?;
+        Some(TransformedSubAsset {
+            value,
+            labeled_assets: &mut labeled.asset.labeled_assets,
+        })
+    }
+    /// Returns the type-erased labeled asset, if it exists and matches this type.
+    pub fn get_erased_labeled<Q>(&self, label: &Q) -> Option<&ErasedLoadedAsset>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        Some(&labeled.asset)
+    }
+    /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
+    pub fn get_untyped_handle<Q>(&self, label: &Q) -> Option<UntypedHandle>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        Some(labeled.handle.clone())
+    }
+    /// Returns the [`Handle`] of the labeled asset with the provided 'label', if it exists and is an asset of type `B`
+    pub fn get_handle<Q, B: Asset>(&self, label: &Q) -> Option<Handle<B>>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
+            return Some(handle);
+        }
+        return None;
+    }
+    /// Adds `asset` as a labeled sub asset using `label` and `handle`
+    pub fn insert_labeled(
+        &mut self,
+        label: impl Into<CowArc<'static, str>>,
+        handle: impl Into<UntypedHandle>,
+        asset: impl Into<ErasedLoadedAsset>,
+    ) {
+        let labeled = LabeledAsset {
+            asset: asset.into(),
+            handle: handle.into(),
+        };
+        self.labeled_assets.insert(label.into(), labeled);
+    }
+    /// Iterate over all labels for "labeled assets" in the loaded asset
+    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
+        self.labeled_assets.keys().map(|s| &**s)
+    }
+}
+
+/// A "sub asset" (and any further labeled "sub assets") of a [`TransformedAsset`].
+pub struct TransformedSubAsset<'a, A: Asset> {
+    value: &'a A,
+    labeled_assets: &'a mut HashMap<CowArc<'static, str>, LabeledAsset>,
+}
+
+impl<'a, A: Asset> Deref for TransformedSubAsset<'a, A> {
+    type Target = A;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+
+impl<'a, A: Asset> TransformedSubAsset<'a, A> {
+    /// Creates a new [`SavedAsset`] from `asset` if its internal value matches `A`.
+    pub fn from_loaded(asset: &'a mut ErasedLoadedAsset) -> Option<Self> {
+        let value = asset.value.downcast_ref::<A>()?;
+        Some(TransformedSubAsset {
+            value,
+            labeled_assets: &mut asset.labeled_assets,
+        })
+    }
+
+    /// Retrieves the value of this asset.
+    #[inline]
+    pub fn get(&self) -> &'a A {
+        self.value
+    }
+
+    /// Returns the labeled asset, if it exists and matches this type.
+    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get_mut(label)?;
+        let value = labeled.asset.value.downcast_ref::<B>()?;
+        Some(TransformedSubAsset {
+            value,
+            labeled_assets: &mut labeled.asset.labeled_assets,
+        })
+    }
+
+    /// Returns the type-erased labeled asset, if it exists and matches this type.
+    pub fn get_erased_labeled<Q>(&self, label: &Q) -> Option<&ErasedLoadedAsset>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        Some(&labeled.asset)
+    }
+
+    /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
+    pub fn get_untyped_handle<Q>(&self, label: &Q) -> Option<UntypedHandle>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        Some(labeled.handle.clone())
+    }
+
+    /// Returns the [`Handle`] of the labeled asset with the provided 'label', if it exists and is an asset of type `B`
+    pub fn get_handle<Q, B: Asset>(&self, label: &Q) -> Option<Handle<B>>
+    where
+        CowArc<'static, str>: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        let labeled = self.labeled_assets.get(label)?;
+        if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
+            return Some(handle);
+        }
+        return None;
+    }
+
+    /// Iterate over all labels for "labeled assets" in the loaded asset
+    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
+        self.labeled_assets.keys().map(|s| &**s)
+    }
 }

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -21,39 +21,30 @@ pub trait AssetTransformer: Send + Sync + 'static {
         &'a self,
         asset: TransformedAsset<Self::AssetInput>,
         settings: &'a Self::Settings,
-    ) -> BoxedFuture<'a, Result<TransformedAsset<Self::AssetOutput>, Self::Error>>;
+    ) -> BoxedFuture<'a, Result<Self::AssetOutput, Self::Error>>;
 }
 
 /// An [`Asset`] (and any "sub assets") intended to be transformed
-pub struct TransformedAsset<A: Asset> {
-    pub(crate) value: A,
-    pub(crate) labeled_assets: HashMap<CowArc<'static, str>, LabeledAsset>,
+pub struct TransformedAsset<'a, A: Asset> {
+    pub(crate) value: &'a mut A,
+    pub(crate) labeled_assets: &'a mut HashMap<CowArc<'static, str>, LabeledAsset>,
 }
 
-impl<A: Asset> Deref for TransformedAsset<A> {
+impl<'a, A: Asset> Deref for TransformedAsset<'a, A> {
     type Target = A;
     fn deref(&self) -> &Self::Target {
         &self.value
     }
 }
 
-impl<A: Asset> TransformedAsset<A> {
+impl<'a, A: Asset> TransformedAsset<'a, A> {
     /// Creates a new [`TransformedAsset`] from `asset` if its internal value matches `A`.
-    pub fn from_loaded(asset: ErasedLoadedAsset) -> Option<Self> {
-        if let Ok(value) = asset.value.downcast::<A>() {
-            return Some(TransformedAsset {
-                value: *value,
-                labeled_assets: asset.labeled_assets,
-            });
-        }
-        return None;
-    }
-    /// Creates a new [`TransformedAsset`] using the `asset`, copying the labeled assets from the old [`TransformedAsset`]
-    pub fn replace_asset<B: Asset>(self, asset: B) -> TransformedAsset<B> {
-        TransformedAsset::<B> {
-            value: asset,
-            labeled_assets: self.labeled_assets,
-        }
+    pub fn from_loaded(asset: &'a mut ErasedLoadedAsset) -> Option<Self> {
+        let value = asset.value.downcast_mut::<A>()?;
+        Some(TransformedAsset {
+            value,
+            labeled_assets: &mut asset.labeled_assets,
+        })
     }
     /// Retrieves the value of this asset.
     #[inline]
@@ -66,14 +57,14 @@ impl<A: Asset> TransformedAsset<A> {
         &mut self.value
     }
     /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
+    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedAsset<B>>
     where
         CowArc<'static, str>: Borrow<Q>,
         Q: ?Sized + Hash + Eq,
     {
         let labeled = self.labeled_assets.get_mut(label)?;
-        let value: &B = labeled.asset.value.downcast_ref::<B>()?;
-        Some(TransformedSubAsset {
+        let value = labeled.asset.value.downcast_mut::<B>()?;
+        Some(TransformedAsset {
             value,
             labeled_assets: &mut labeled.asset.labeled_assets,
         })
@@ -121,89 +112,6 @@ impl<A: Asset> TransformedAsset<A> {
         };
         self.labeled_assets.insert(label.into(), labeled);
     }
-    /// Iterate over all labels for "labeled assets" in the loaded asset
-    pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
-        self.labeled_assets.keys().map(|s| &**s)
-    }
-}
-
-/// A "sub asset" (and any further labeled "sub assets") of a [`TransformedAsset`].
-pub struct TransformedSubAsset<'a, A: Asset> {
-    value: &'a A,
-    labeled_assets: &'a mut HashMap<CowArc<'static, str>, LabeledAsset>,
-}
-
-impl<'a, A: Asset> Deref for TransformedSubAsset<'a, A> {
-    type Target = A;
-
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
-}
-
-impl<'a, A: Asset> TransformedSubAsset<'a, A> {
-    /// Creates a new [`SavedAsset`] from `asset` if its internal value matches `A`.
-    pub fn from_loaded(asset: &'a mut ErasedLoadedAsset) -> Option<Self> {
-        let value = asset.value.downcast_ref::<A>()?;
-        Some(TransformedSubAsset {
-            value,
-            labeled_assets: &mut asset.labeled_assets,
-        })
-    }
-
-    /// Retrieves the value of this asset.
-    #[inline]
-    pub fn get(&self) -> &'a A {
-        self.value
-    }
-
-    /// Returns the labeled asset, if it exists and matches this type.
-    pub fn get_labeled<B: Asset, Q>(&mut self, label: &Q) -> Option<TransformedSubAsset<B>>
-    where
-        CowArc<'static, str>: Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
-    {
-        let labeled = self.labeled_assets.get_mut(label)?;
-        let value = labeled.asset.value.downcast_ref::<B>()?;
-        Some(TransformedSubAsset {
-            value,
-            labeled_assets: &mut labeled.asset.labeled_assets,
-        })
-    }
-
-    /// Returns the type-erased labeled asset, if it exists and matches this type.
-    pub fn get_erased_labeled<Q>(&self, label: &Q) -> Option<&ErasedLoadedAsset>
-    where
-        CowArc<'static, str>: Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
-    {
-        let labeled = self.labeled_assets.get(label)?;
-        Some(&labeled.asset)
-    }
-
-    /// Returns the [`UntypedHandle`] of the labeled asset with the provided 'label', if it exists.
-    pub fn get_untyped_handle<Q>(&self, label: &Q) -> Option<UntypedHandle>
-    where
-        CowArc<'static, str>: Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
-    {
-        let labeled = self.labeled_assets.get(label)?;
-        Some(labeled.handle.clone())
-    }
-
-    /// Returns the [`Handle`] of the labeled asset with the provided 'label', if it exists and is an asset of type `B`
-    pub fn get_handle<Q, B: Asset>(&self, label: &Q) -> Option<Handle<B>>
-    where
-        CowArc<'static, str>: Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
-    {
-        let labeled = self.labeled_assets.get(label)?;
-        if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
-            return Some(handle);
-        }
-        return None;
-    }
-
     /// Iterate over all labels for "labeled assets" in the loaded asset
     pub fn iter_labels(&self) -> impl Iterator<Item = &str> {
         self.labeled_assets.keys().map(|s| &**s)


### PR DESCRIPTION
# Objective

- `AssetTransformer` provides an input asset, and output an asset, but provides no access to the `LabeledAsset`'s created by the `AssetLoader`. Labeled sub assets are an extremely important piece of many assets, Gltf in particular, and without them the amount of transformation on an asset is limited. In order for `AssetTransformer`'s to be useful, they need to have access to these sub assets.
- LabeledAsset's loaded by `AssetLoader`s are provided to `AssetSaver`s in the `LoadAndSave` process, but the `LoadTransformAndSave` process drops these values in the transform stage, and so `AssetSaver` is given none.
- Fixes #11606

Ideally the AssetTransformer should not ignore labeled sub assets, and they should be kept at least for the AssetSaver

## Solution

- I created a new struct similar to `SavedAsset` named `TransformedAsset` which holds a mutable referece to an asset and the hashmap of `LabeledAsset`s. The `AssetTransformer` then intakes a `TransformedAsset` holding the input `Asset` and returns the output `Asset`. This gives the transform function access to the labeled sub assets created by the `AssetLoader`.
- The LoadTransformAndSave processor was then reworked to use the new structs, stopping the LabeledAssets from being dropped.

---

## Changelog

#### saver.rs
- Changed get_untyped_handle to return a UntypedHandle directly rather than a reference. Also added get_handle as a typed variant of get_untyped_handle.
- Added from_asset_and_loaded as a constructor from an asset and an ```ErasedLoadedAsset``` whihc holds the labeled assets
#### process.rs
- Switched code to work with new TransformedAsset type
- Added a ProcessError for AssetTransformer
#### transformer.rs
- Created TransformedAsset struct.
- Switched AssetTransformer::transform to use TransformedAsset as input
- Switched AssetTransformer to use a BoxedFuture like AssetLoader and AssetSaver to allow for async transformation code
