### PR TITLE
run examples on macOS to validate PRs

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -110,17 +110,62 @@ jobs:
       - name: save traces
         uses: actions/upload-artifact@v4
         with:
-          name: example-traces.zip
+          name: example-traces-linux
           path: traces.zip
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots.zip
+          name: screenshots-linux
           path: screenshots.zip
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:
-          name: example-run
+          name: example-run-linux
+          path: example-run/
+
+  run-examples-macos-metal:
+    if: ${{ github.event_name == 'merge_group' }}
+    runs-on: macos-14
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Disable audio
+        # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
+        run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
+      - name: Build bevy
+        # this uses the same command as when running the example to ensure build is reused
+        run: |
+          TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome"
+      - name: Run examples
+        run: |
+          for example in .github/example-run/*.ron; do
+            example_name=`basename $example .ron`
+            echo -n $example_name > last_example_run
+            echo "running $example_name - "`date`
+            time TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome"
+            sleep 10
+            if [ `find ./ -maxdepth 1 -name 'screenshot-*.png' -print -quit` ]; then
+              mkdir screenshots-$example_name
+              mv screenshot-*.png screenshots-$example_name/
+            fi
+          done
+          zip traces.zip trace*.json
+          zip -r screenshots.zip screenshots-*
+      - name: save traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-traces-macos
+          path: traces.zip
+      - name: save screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-macos
+          path: screenshots.zip
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        with:
+          name: example-run-macos
           path: example-run/
 
   run-examples-on-wasm:

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -222,7 +222,7 @@ jobs:
       - name: Save screenshots
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots
+          name: screenshots-wasm
           path: .github/start-wasm-example/screenshot-*.png
 
   build-without-default-features:

--- a/tools/example-showcase/disable-audio.patch
+++ b/tools/example-showcase/disable-audio.patch
@@ -1,0 +1,32 @@
+diff --git a/crates/bevy_audio/src/audio_output.rs b/crates/bevy_audio/src/audio_output.rs
+index 3e8082e23..624769443 100644
+--- a/crates/bevy_audio/src/audio_output.rs
++++ b/crates/bevy_audio/src/audio_output.rs
+@@ -7,7 +7,7 @@ use bevy_ecs::{prelude::*, system::SystemParam};
+ use bevy_math::Vec3;
+ use bevy_transform::prelude::GlobalTransform;
+ use bevy_utils::tracing::warn;
+-use rodio::{OutputStream, OutputStreamHandle, Sink, Source, SpatialSink};
++use rodio::{OutputStreamHandle, Sink, Source, SpatialSink};
+ 
+ use crate::AudioSink;
+ 
+@@ -30,18 +30,10 @@ pub(crate) struct AudioOutput {
+ 
+ impl Default for AudioOutput {
+     fn default() -> Self {
+-        if let Ok((stream, stream_handle)) = OutputStream::try_default() {
+-            // We leak `OutputStream` to prevent the audio from stopping.
+-            std::mem::forget(stream);
+-            Self {
+-                stream_handle: Some(stream_handle),
+-            }
+-        } else {
+         warn!("No audio device found.");
+         Self {
+             stream_handle: None,
+         }
+-        }
+     }
+ }
+ 

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -228,6 +228,15 @@ fn main() {
                 .run()
                 .unwrap();
 
+                // Don't try to get an audio output stream in CI as there isn't one
+                // On macOS m1 runner in GitHub Actions, getting one timeouts after 15 minutes
+                cmd!(
+                    sh,
+                    "git apply --ignore-whitespace tools/example-showcase/disable-audio.patch"
+                )
+                .run()
+                .unwrap();
+
                 // Sort the examples so that they are not run by category
                 examples_to_run.sort_by_key(|example| {
                     let mut hasher = DefaultHasher::new();


### PR DESCRIPTION
# Objective

- CI doesn't validate running examples on macOS
- GitHub now has free m1 runners with a virtualised GPU https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

## Solution

- Add a job to run examples on macOS when trying to merge a PR
- Add a patch to disable audio in CI as it timeouts after 15 minutes on macOS, and fails anyway on the other runners
