### PR TITLE
Rename RayTest to RayCast

### DIFF
--- a/crates/bevy_math/src/bounding/mod.rs
+++ b/crates/bevy_math/src/bounding/mod.rs
@@ -60,7 +60,7 @@ pub use bounded2d::*;
 mod bounded3d;
 pub use bounded3d::*;
 
-mod raytest2d;
-pub use raytest2d::*;
-mod raytest3d;
-pub use raytest3d::*;
+mod raycast2d;
+pub use raycast2d::*;
+mod raycast3d;
+pub use raycast3d::*;

--- a/crates/bevy_math/src/bounding/raycast2d.rs
+++ b/crates/bevy_math/src/bounding/raycast2d.rs
@@ -3,7 +3,7 @@ use crate::{primitives::Direction2d, Ray2d, Vec2};
 
 /// A raycast intersection test for 2D bounding volumes
 #[derive(Debug)]
-pub struct RayTest2d {
+pub struct RayCast2d {
     /// The ray for the test
     pub ray: Ray2d,
     /// The maximum distance for the ray
@@ -12,13 +12,13 @@ pub struct RayTest2d {
     direction_recip: Vec2,
 }
 
-impl RayTest2d {
-    /// Construct a [`RayTest2d`] from an origin, [`Direction2d`], and max distance.
+impl RayCast2d {
+    /// Construct a [`RayCast2d`] from an origin, [`Direction2d`], and max distance.
     pub fn new(origin: Vec2, direction: Direction2d, max: f32) -> Self {
         Self::from_ray(Ray2d { origin, direction }, max)
     }
 
-    /// Construct a [`RayTest2d`] from a [`Ray2d`] and max distance.
+    /// Construct a [`RayCast2d`] from a [`Ray2d`] and max distance.
     pub fn from_ray(ray: Ray2d, max: f32) -> Self {
         Self {
             ray,
@@ -86,13 +86,13 @@ impl RayTest2d {
     }
 }
 
-impl IntersectsVolume<Aabb2d> for RayTest2d {
+impl IntersectsVolume<Aabb2d> for RayCast2d {
     fn intersects(&self, volume: &Aabb2d) -> bool {
         self.aabb_intersection_at(volume).is_some()
     }
 }
 
-impl IntersectsVolume<BoundingCircle> for RayTest2d {
+impl IntersectsVolume<BoundingCircle> for RayCast2d {
     fn intersects(&self, volume: &BoundingCircle) -> bool {
         self.circle_intersection_at(volume).is_some()
     }
@@ -102,7 +102,7 @@ impl IntersectsVolume<BoundingCircle> for RayTest2d {
 #[derive(Debug)]
 pub struct AabbCast2d {
     /// The ray along which to cast the bounding volume
-    pub ray: RayTest2d,
+    pub ray: RayCast2d,
     /// The aabb that is being cast
     pub aabb: Aabb2d,
 }
@@ -116,7 +116,7 @@ impl AabbCast2d {
     /// Construct an [`AabbCast2d`] from an [`Aabb2d`], [`Ray2d`], and max distance.
     pub fn from_ray(aabb: Aabb2d, ray: Ray2d, max: f32) -> Self {
         Self {
-            ray: RayTest2d::from_ray(ray, max),
+            ray: RayCast2d::from_ray(ray, max),
             aabb,
         }
     }
@@ -139,7 +139,7 @@ impl IntersectsVolume<Aabb2d> for AabbCast2d {
 #[derive(Debug)]
 pub struct BoundingCircleCast {
     /// The ray along which to cast the bounding volume
-    pub ray: RayTest2d,
+    pub ray: RayCast2d,
     /// The circle that is being cast
     pub circle: BoundingCircle,
 }
@@ -153,7 +153,7 @@ impl BoundingCircleCast {
     /// Construct a [`BoundingCircleCast`] from a [`BoundingCircle`], [`Ray2d`], and max distance.
     pub fn from_ray(circle: BoundingCircle, ray: Ray2d, max: f32) -> Self {
         Self {
-            ray: RayTest2d::from_ray(ray, max),
+            ray: RayCast2d::from_ray(ray, max),
             circle,
         }
     }
@@ -183,37 +183,37 @@ mod tests {
         for (test, volume, expected_distance) in &[
             (
                 // Hit the center of a centered bounding circle
-                RayTest2d::new(Vec2::Y * -5., Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::Y * -5., Direction2d::Y, 90.),
                 BoundingCircle::new(Vec2::ZERO, 1.),
                 4.,
             ),
             (
                 // Hit the center of a centered bounding circle, but from the other side
-                RayTest2d::new(Vec2::Y * 5., -Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::Y * 5., -Direction2d::Y, 90.),
                 BoundingCircle::new(Vec2::ZERO, 1.),
                 4.,
             ),
             (
                 // Hit the center of an offset circle
-                RayTest2d::new(Vec2::ZERO, Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::Y, 90.),
                 BoundingCircle::new(Vec2::Y * 3., 2.),
                 1.,
             ),
             (
                 // Just barely hit the circle before the max distance
-                RayTest2d::new(Vec2::X, Direction2d::Y, 1.),
+                RayCast2d::new(Vec2::X, Direction2d::Y, 1.),
                 BoundingCircle::new(Vec2::ONE, 0.01),
                 0.99,
             ),
             (
                 // Hit a circle off-center
-                RayTest2d::new(Vec2::X, Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::X, Direction2d::Y, 90.),
                 BoundingCircle::new(Vec2::Y * 5., 2.),
                 3.268,
             ),
             (
                 // Barely hit a circle on the side
-                RayTest2d::new(Vec2::X * 0.99999, Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::X * 0.99999, Direction2d::Y, 90.),
                 BoundingCircle::new(Vec2::Y * 5., 1.),
                 4.996,
             ),
@@ -231,7 +231,7 @@ mod tests {
                 actual_distance
             );
 
-            let inverted_ray = RayTest2d::new(test.ray.origin, -test.ray.direction, test.max);
+            let inverted_ray = RayCast2d::new(test.ray.origin, -test.ray.direction, test.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -241,17 +241,17 @@ mod tests {
         for (test, volume) in &[
             (
                 // The ray doesn't go in the right direction
-                RayTest2d::new(Vec2::ZERO, Direction2d::X, 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::X, 90.),
                 BoundingCircle::new(Vec2::Y * 2., 1.),
             ),
             (
                 // Ray's alignment isn't enough to hit the circle
-                RayTest2d::new(Vec2::ZERO, Direction2d::from_xy(1., 1.).unwrap(), 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::from_xy(1., 1.).unwrap(), 90.),
                 BoundingCircle::new(Vec2::Y * 2., 1.),
             ),
             (
                 // The ray's maximum distance isn't high enough
-                RayTest2d::new(Vec2::ZERO, Direction2d::Y, 0.5),
+                RayCast2d::new(Vec2::ZERO, Direction2d::Y, 0.5),
                 BoundingCircle::new(Vec2::Y * 2., 1.),
             ),
         ] {
@@ -275,7 +275,7 @@ mod tests {
                 -Direction2d::Y,
             ] {
                 for max in &[0., 1., 900.] {
-                    let test = RayTest2d::new(*origin, *direction, *max);
+                    let test = RayCast2d::new(*origin, *direction, *max);
 
                     let case = format!(
                         "Case:\n  origin: {:?}\n  Direction: {:?}\n  Max: {}",
@@ -295,37 +295,37 @@ mod tests {
         for (test, volume, expected_distance) in &[
             (
                 // Hit the center of a centered aabb
-                RayTest2d::new(Vec2::Y * -5., Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::Y * -5., Direction2d::Y, 90.),
                 Aabb2d::new(Vec2::ZERO, Vec2::ONE),
                 4.,
             ),
             (
                 // Hit the center of a centered aabb, but from the other side
-                RayTest2d::new(Vec2::Y * 5., -Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::Y * 5., -Direction2d::Y, 90.),
                 Aabb2d::new(Vec2::ZERO, Vec2::ONE),
                 4.,
             ),
             (
                 // Hit the center of an offset aabb
-                RayTest2d::new(Vec2::ZERO, Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::Y, 90.),
                 Aabb2d::new(Vec2::Y * 3., Vec2::splat(2.)),
                 1.,
             ),
             (
                 // Just barely hit the aabb before the max distance
-                RayTest2d::new(Vec2::X, Direction2d::Y, 1.),
+                RayCast2d::new(Vec2::X, Direction2d::Y, 1.),
                 Aabb2d::new(Vec2::ONE, Vec2::splat(0.01)),
                 0.99,
             ),
             (
                 // Hit an aabb off-center
-                RayTest2d::new(Vec2::X, Direction2d::Y, 90.),
+                RayCast2d::new(Vec2::X, Direction2d::Y, 90.),
                 Aabb2d::new(Vec2::Y * 5., Vec2::splat(2.)),
                 3.,
             ),
             (
                 // Barely hit an aabb on corner
-                RayTest2d::new(Vec2::X * -0.001, Direction2d::from_xy(1., 1.).unwrap(), 90.),
+                RayCast2d::new(Vec2::X * -0.001, Direction2d::from_xy(1., 1.).unwrap(), 90.),
                 Aabb2d::new(Vec2::Y * 2., Vec2::ONE),
                 1.414,
             ),
@@ -343,7 +343,7 @@ mod tests {
                 actual_distance
             );
 
-            let inverted_ray = RayTest2d::new(test.ray.origin, -test.ray.direction, test.max);
+            let inverted_ray = RayCast2d::new(test.ray.origin, -test.ray.direction, test.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -353,17 +353,17 @@ mod tests {
         for (test, volume) in &[
             (
                 // The ray doesn't go in the right direction
-                RayTest2d::new(Vec2::ZERO, Direction2d::X, 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::X, 90.),
                 Aabb2d::new(Vec2::Y * 2., Vec2::ONE),
             ),
             (
                 // Ray's alignment isn't enough to hit the aabb
-                RayTest2d::new(Vec2::ZERO, Direction2d::from_xy(1., 0.99).unwrap(), 90.),
+                RayCast2d::new(Vec2::ZERO, Direction2d::from_xy(1., 0.99).unwrap(), 90.),
                 Aabb2d::new(Vec2::Y * 2., Vec2::ONE),
             ),
             (
                 // The ray's maximum distance isn't high enough
-                RayTest2d::new(Vec2::ZERO, Direction2d::Y, 0.5),
+                RayCast2d::new(Vec2::ZERO, Direction2d::Y, 0.5),
                 Aabb2d::new(Vec2::Y * 2., Vec2::ONE),
             ),
         ] {
@@ -387,7 +387,7 @@ mod tests {
                 -Direction2d::Y,
             ] {
                 for max in &[0., 1., 900.] {
-                    let test = RayTest2d::new(*origin, *direction, *max);
+                    let test = RayCast2d::new(*origin, *direction, *max);
 
                     let case = format!(
                         "Case:\n  origin: {:?}\n  Direction: {:?}\n  Max: {}",
@@ -464,7 +464,7 @@ mod tests {
             );
 
             let inverted_ray =
-                RayTest2d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
+                RayCast2d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -531,7 +531,7 @@ mod tests {
             );
 
             let inverted_ray =
-                RayTest2d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
+                RayCast2d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }

--- a/crates/bevy_math/src/bounding/raycast3d.rs
+++ b/crates/bevy_math/src/bounding/raycast3d.rs
@@ -3,7 +3,7 @@ use crate::{primitives::Direction3d, Ray3d, Vec3};
 
 /// A raycast intersection test for 3D bounding volumes
 #[derive(Debug)]
-pub struct RayTest3d {
+pub struct RayCast3d {
     /// The ray for the test
     pub ray: Ray3d,
     /// The maximum distance for the ray
@@ -12,13 +12,13 @@ pub struct RayTest3d {
     direction_recip: Vec3,
 }
 
-impl RayTest3d {
-    /// Construct a [`RayTest3d`] from an origin, [`Direction3d`], and max distance.
+impl RayCast3d {
+    /// Construct a [`RayCast3d`] from an origin, [`Direction3d`], and max distance.
     pub fn new(origin: Vec3, direction: Direction3d, max: f32) -> Self {
         Self::from_ray(Ray3d { origin, direction }, max)
     }
 
-    /// Construct a [`RayTest3d`] from a [`Ray3d`] and max distance.
+    /// Construct a [`RayCast3d`] from a [`Ray3d`] and max distance.
     pub fn from_ray(ray: Ray3d, max: f32) -> Self {
         Self {
             ray,
@@ -93,13 +93,13 @@ impl RayTest3d {
     }
 }
 
-impl IntersectsVolume<Aabb3d> for RayTest3d {
+impl IntersectsVolume<Aabb3d> for RayCast3d {
     fn intersects(&self, volume: &Aabb3d) -> bool {
         self.aabb_intersection_at(volume).is_some()
     }
 }
 
-impl IntersectsVolume<BoundingSphere> for RayTest3d {
+impl IntersectsVolume<BoundingSphere> for RayCast3d {
     fn intersects(&self, volume: &BoundingSphere) -> bool {
         self.sphere_intersection_at(volume).is_some()
     }
@@ -109,7 +109,7 @@ impl IntersectsVolume<BoundingSphere> for RayTest3d {
 #[derive(Debug)]
 pub struct AabbCast3d {
     /// The ray along which to cast the bounding volume
-    pub ray: RayTest3d,
+    pub ray: RayCast3d,
     /// The aabb that is being cast
     pub aabb: Aabb3d,
 }
@@ -123,7 +123,7 @@ impl AabbCast3d {
     /// Construct an [`AabbCast3d`] from an [`Aabb3d`], [`Ray3d`], and max distance.
     pub fn from_ray(aabb: Aabb3d, ray: Ray3d, max: f32) -> Self {
         Self {
-            ray: RayTest3d::from_ray(ray, max),
+            ray: RayCast3d::from_ray(ray, max),
             aabb,
         }
     }
@@ -146,7 +146,7 @@ impl IntersectsVolume<Aabb3d> for AabbCast3d {
 #[derive(Debug)]
 pub struct BoundingSphereCast {
     /// The ray along which to cast the bounding volume
-    pub ray: RayTest3d,
+    pub ray: RayCast3d,
     /// The sphere that is being cast
     pub sphere: BoundingSphere,
 }
@@ -160,7 +160,7 @@ impl BoundingSphereCast {
     /// Construct a [`BoundingSphereCast`] from a [`BoundingSphere`], [`Ray3d`], and max distance.
     pub fn from_ray(sphere: BoundingSphere, ray: Ray3d, max: f32) -> Self {
         Self {
-            ray: RayTest3d::from_ray(ray, max),
+            ray: RayCast3d::from_ray(ray, max),
             sphere,
         }
     }
@@ -190,37 +190,37 @@ mod tests {
         for (test, volume, expected_distance) in &[
             (
                 // Hit the center of a centered bounding sphere
-                RayTest3d::new(Vec3::Y * -5., Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::Y * -5., Direction3d::Y, 90.),
                 BoundingSphere::new(Vec3::ZERO, 1.),
                 4.,
             ),
             (
                 // Hit the center of a centered bounding sphere, but from the other side
-                RayTest3d::new(Vec3::Y * 5., -Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::Y * 5., -Direction3d::Y, 90.),
                 BoundingSphere::new(Vec3::ZERO, 1.),
                 4.,
             ),
             (
                 // Hit the center of an offset sphere
-                RayTest3d::new(Vec3::ZERO, Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::ZERO, Direction3d::Y, 90.),
                 BoundingSphere::new(Vec3::Y * 3., 2.),
                 1.,
             ),
             (
                 // Just barely hit the sphere before the max distance
-                RayTest3d::new(Vec3::X, Direction3d::Y, 1.),
+                RayCast3d::new(Vec3::X, Direction3d::Y, 1.),
                 BoundingSphere::new(Vec3::new(1., 1., 0.), 0.01),
                 0.99,
             ),
             (
                 // Hit a sphere off-center
-                RayTest3d::new(Vec3::X, Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::X, Direction3d::Y, 90.),
                 BoundingSphere::new(Vec3::Y * 5., 2.),
                 3.268,
             ),
             (
                 // Barely hit a sphere on the side
-                RayTest3d::new(Vec3::X * 0.99999, Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::X * 0.99999, Direction3d::Y, 90.),
                 BoundingSphere::new(Vec3::Y * 5., 1.),
                 4.996,
             ),
@@ -238,7 +238,7 @@ mod tests {
                 actual_distance
             );
 
-            let inverted_ray = RayTest3d::new(test.ray.origin, -test.ray.direction, test.max);
+            let inverted_ray = RayCast3d::new(test.ray.origin, -test.ray.direction, test.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -248,17 +248,17 @@ mod tests {
         for (test, volume) in &[
             (
                 // The ray doesn't go in the right direction
-                RayTest3d::new(Vec3::ZERO, Direction3d::X, 90.),
+                RayCast3d::new(Vec3::ZERO, Direction3d::X, 90.),
                 BoundingSphere::new(Vec3::Y * 2., 1.),
             ),
             (
                 // Ray's alignment isn't enough to hit the sphere
-                RayTest3d::new(Vec3::ZERO, Direction3d::from_xyz(1., 1., 1.).unwrap(), 90.),
+                RayCast3d::new(Vec3::ZERO, Direction3d::from_xyz(1., 1., 1.).unwrap(), 90.),
                 BoundingSphere::new(Vec3::Y * 2., 1.),
             ),
             (
                 // The ray's maximum distance isn't high enough
-                RayTest3d::new(Vec3::ZERO, Direction3d::Y, 0.5),
+                RayCast3d::new(Vec3::ZERO, Direction3d::Y, 0.5),
                 BoundingSphere::new(Vec3::Y * 2., 1.),
             ),
         ] {
@@ -284,7 +284,7 @@ mod tests {
                 -Direction3d::Z,
             ] {
                 for max in &[0., 1., 900.] {
-                    let test = RayTest3d::new(*origin, *direction, *max);
+                    let test = RayCast3d::new(*origin, *direction, *max);
 
                     let case = format!(
                         "Case:\n  origin: {:?}\n  Direction: {:?}\n  Max: {}",
@@ -304,37 +304,37 @@ mod tests {
         for (test, volume, expected_distance) in &[
             (
                 // Hit the center of a centered aabb
-                RayTest3d::new(Vec3::Y * -5., Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::Y * -5., Direction3d::Y, 90.),
                 Aabb3d::new(Vec3::ZERO, Vec3::ONE),
                 4.,
             ),
             (
                 // Hit the center of a centered aabb, but from the other side
-                RayTest3d::new(Vec3::Y * 5., -Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::Y * 5., -Direction3d::Y, 90.),
                 Aabb3d::new(Vec3::ZERO, Vec3::ONE),
                 4.,
             ),
             (
                 // Hit the center of an offset aabb
-                RayTest3d::new(Vec3::ZERO, Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::ZERO, Direction3d::Y, 90.),
                 Aabb3d::new(Vec3::Y * 3., Vec3::splat(2.)),
                 1.,
             ),
             (
                 // Just barely hit the aabb before the max distance
-                RayTest3d::new(Vec3::X, Direction3d::Y, 1.),
+                RayCast3d::new(Vec3::X, Direction3d::Y, 1.),
                 Aabb3d::new(Vec3::new(1., 1., 0.), Vec3::splat(0.01)),
                 0.99,
             ),
             (
                 // Hit an aabb off-center
-                RayTest3d::new(Vec3::X, Direction3d::Y, 90.),
+                RayCast3d::new(Vec3::X, Direction3d::Y, 90.),
                 Aabb3d::new(Vec3::Y * 5., Vec3::splat(2.)),
                 3.,
             ),
             (
                 // Barely hit an aabb on corner
-                RayTest3d::new(
+                RayCast3d::new(
                     Vec3::X * -0.001,
                     Direction3d::from_xyz(1., 1., 1.).unwrap(),
                     90.,
@@ -356,7 +356,7 @@ mod tests {
                 actual_distance
             );
 
-            let inverted_ray = RayTest3d::new(test.ray.origin, -test.ray.direction, test.max);
+            let inverted_ray = RayCast3d::new(test.ray.origin, -test.ray.direction, test.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -366,12 +366,12 @@ mod tests {
         for (test, volume) in &[
             (
                 // The ray doesn't go in the right direction
-                RayTest3d::new(Vec3::ZERO, Direction3d::X, 90.),
+                RayCast3d::new(Vec3::ZERO, Direction3d::X, 90.),
                 Aabb3d::new(Vec3::Y * 2., Vec3::ONE),
             ),
             (
                 // Ray's alignment isn't enough to hit the aabb
-                RayTest3d::new(
+                RayCast3d::new(
                     Vec3::ZERO,
                     Direction3d::from_xyz(1., 0.99, 1.).unwrap(),
                     90.,
@@ -380,7 +380,7 @@ mod tests {
             ),
             (
                 // The ray's maximum distance isn't high enough
-                RayTest3d::new(Vec3::ZERO, Direction3d::Y, 0.5),
+                RayCast3d::new(Vec3::ZERO, Direction3d::Y, 0.5),
                 Aabb3d::new(Vec3::Y * 2., Vec3::ONE),
             ),
         ] {
@@ -406,7 +406,7 @@ mod tests {
                 -Direction3d::Z,
             ] {
                 for max in &[0., 1., 900.] {
-                    let test = RayTest3d::new(*origin, *direction, *max);
+                    let test = RayCast3d::new(*origin, *direction, *max);
 
                     let case = format!(
                         "Case:\n  origin: {:?}\n  Direction: {:?}\n  Max: {}",
@@ -483,7 +483,7 @@ mod tests {
             );
 
             let inverted_ray =
-                RayTest3d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
+                RayCast3d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }
@@ -550,7 +550,7 @@ mod tests {
             );
 
             let inverted_ray =
-                RayTest3d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
+                RayCast3d::new(test.ray.ray.origin, -test.ray.ray.direction, test.ray.max);
             assert!(!inverted_ray.intersects(volume), "{}", case);
         }
     }


### PR DESCRIPTION
# Objective

- `RayTest` vs `AabbCast` and `CircleCast` is inconsistent

## Solution

- Renaming the other two would only make the name more confusing, so we rename `RayTest2d/3d` to `RayCast2d/3d`