### PR TITLE
Adding derive Reflect for tick structs

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -21,6 +21,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_ecs::component::{ComponentId, ComponentTicks, Tick};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant, Uuid};
@@ -40,11 +41,19 @@ pub struct TypeRegistrationPlugin;
 
 impl Plugin for TypeRegistrationPlugin {
     fn build(&self, app: &mut App) {
-        app.register_type::<Entity>().register_type::<Name>();
+        app.register_type::<Name>();
 
+        register_ecs_types(app);
         register_rust_types(app);
         register_math_types(app);
     }
+}
+
+fn register_ecs_types(app: &mut App) {
+    app.register_type::<Entity>()
+        .register_type::<ComponentId>()
+        .register_type::<Tick>()
+        .register_type::<ComponentTicks>();
 }
 
 fn register_rust_types(app: &mut App) {

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::{OwningPtr, UnsafeCellDeref};
+#[cfg(feature = "bevy_reflect")]
 use bevy_reflect::Reflect;
 use std::cell::UnsafeCell;
 use std::{
@@ -287,8 +288,12 @@ impl ComponentInfo {
 /// Given a type `T` which implements [`Component`], the `ComponentId` for `T` can be retrieved
 /// from a `World` using [`World::component_id()`] or via [`Components::component_id()`]. Access
 /// to the `ComponentId` for a [`Resource`] is available via [`Components::resource_id()`].
-#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Reflect)]
-#[reflect(Debug, Hash, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(Reflect),
+    reflect(Debug, Hash, PartialEq)
+)]
 pub struct ComponentId(usize);
 
 impl ComponentId {
@@ -671,8 +676,8 @@ impl Components {
 
 /// A value that tracks when a system ran relative to other systems.
 /// This is used to power change detection.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Reflect)]
-#[reflect(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug, PartialEq))]
 pub struct Tick {
     tick: u32,
 }
@@ -765,8 +770,8 @@ impl<'a> TickCells<'a> {
 }
 
 /// Records when a component was added and when it was last mutably dereferenced (or added).
-#[derive(Copy, Clone, Debug, Reflect)]
-#[reflect(Debug)]
+#[derive(Copy, Clone, Debug)]
+#[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct ComponentTicks {
     pub(crate) added: Tick,
     pub(crate) changed: Tick,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -287,7 +287,7 @@ impl ComponentInfo {
 /// Given a type `T` which implements [`Component`], the `ComponentId` for `T` can be retrieved
 /// from a `World` using [`World::component_id()`] or via [`Components::component_id()`]. Access
 /// to the `ComponentId` for a [`Resource`] is available via [`Components::resource_id()`].
-#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Reflect)]
 pub struct ComponentId(usize);
 
 impl ComponentId {
@@ -763,7 +763,7 @@ impl<'a> TickCells<'a> {
 }
 
 /// Records when a component was added and when it was last mutably dereferenced (or added).
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Reflect)]
 pub struct ComponentTicks {
     pub(crate) added: Tick,
     pub(crate) changed: Tick,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -10,6 +10,7 @@ use crate::{
 };
 pub use bevy_ecs_macros::Component;
 use bevy_ptr::{OwningPtr, UnsafeCellDeref};
+use bevy_reflect::Reflect;
 use std::cell::UnsafeCell;
 use std::{
     alloc::Layout,
@@ -18,7 +19,6 @@ use std::{
     marker::PhantomData,
     mem::needs_drop,
 };
-use bevy_reflect::Reflect;
 
 /// A data type that can be used to store data for an [entity].
 ///

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -18,6 +18,7 @@ use std::{
     marker::PhantomData,
     mem::needs_drop,
 };
+use bevy_reflect::Reflect;
 
 /// A data type that can be used to store data for an [entity].
 ///
@@ -669,7 +670,7 @@ impl Components {
 
 /// A value that tracks when a system ran relative to other systems.
 /// This is used to power change detection.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Reflect)]
 pub struct Tick {
     tick: u32,
 }

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -288,6 +288,7 @@ impl ComponentInfo {
 /// from a `World` using [`World::component_id()`] or via [`Components::component_id()`]. Access
 /// to the `ComponentId` for a [`Resource`] is available via [`Components::resource_id()`].
 #[derive(Debug, Copy, Clone, Hash, Ord, PartialOrd, Eq, PartialEq, Reflect)]
+#[reflect(Debug, Hash, PartialEq)]
 pub struct ComponentId(usize);
 
 impl ComponentId {
@@ -671,6 +672,7 @@ impl Components {
 /// A value that tracks when a system ran relative to other systems.
 /// This is used to power change detection.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Reflect)]
+#[reflect(Debug, PartialEq)]
 pub struct Tick {
     tick: u32,
 }
@@ -764,6 +766,7 @@ impl<'a> TickCells<'a> {
 
 /// Records when a component was added and when it was last mutably dereferenced (or added).
 #[derive(Copy, Clone, Debug, Reflect)]
+#[reflect(Debug)]
 pub struct ComponentTicks {
     pub(crate) added: Tick,
     pub(crate) changed: Tick,


### PR DESCRIPTION
# Objective

- Deriving `Reflect` for some public ChangeDetection/Tick structs in bevy_ecs
