### PR TITLE
shadow performance

### DIFF
--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -68,9 +68,11 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
     }
 
     /// Specifies the shadow batch key (see [`Material::shadow_material_key`]). By default, extended materials
-    /// use the base material key.
-    fn shadow_material_key(&self, base_key: Option<u64>) -> Option<u64> {
-        base_key
+    /// do not batch for shadows. 
+    /// If the extension doesn't modify vertices or apply discards based on extended material properties, you 
+    /// may be able to improve shadow performance by returning the base material key.
+    fn shadow_material_key(&self, _base_key: Option<u64>) -> Option<u64> {
+        None
     }
 
     /// Customizes the default [`RenderPipelineDescriptor`] for a specific entity using the entity's

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -67,6 +67,12 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
         ShaderRef::Default
     }
 
+    /// Specifies the shadow batch key (see [`Material::shadow_material_key`]). By default, extended materials
+    /// use the base material key.
+    fn shadow_material_key(&self, base_key: Option<u64>) -> Option<u64> {
+        base_key
+    }
+
     /// Customizes the default [`RenderPipelineDescriptor`] for a specific entity using the entity's
     /// [`MaterialPipelineKey`] and [`MeshVertexBufferLayout`] as input.
     /// Specialization for the base material is applied before this function is called.
@@ -209,6 +215,11 @@ impl<B: Material, E: MaterialExtension> Material for ExtendedMaterial<B, E> {
             ShaderRef::Default => B::deferred_fragment_shader(),
             specified => specified,
         }
+    }
+
+    fn shadow_material_key(&self) -> Option<u64> {
+        self.extension
+            .shadow_material_key(self.base.shadow_material_key())
     }
 
     fn specialize(

--- a/crates/bevy_pbr/src/extended_material.rs
+++ b/crates/bevy_pbr/src/extended_material.rs
@@ -68,8 +68,8 @@ pub trait MaterialExtension: Asset + AsBindGroup + Clone + Sized {
     }
 
     /// Specifies the shadow batch key (see [`Material::shadow_material_key`]). By default, extended materials
-    /// do not batch for shadows. 
-    /// If the extension doesn't modify vertices or apply discards based on extended material properties, you 
+    /// do not batch for shadows.
+    /// If the extension doesn't modify vertices or apply discards based on extended material properties, you
     /// may be able to improve shadow performance by returning the base material key.
     fn shadow_material_key(&self, _base_key: Option<u64>) -> Option<u64> {
         None

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -181,8 +181,8 @@ pub trait Material: Asset + AsBindGroup + Clone + Sized {
         Ok(())
     }
 
-    /// Specify a batch key to use for shadows. Returning Some(value) allows batching of distinct materials which will produce 
-    /// the same depth-prepass output (such as opaque [`StandardMaterial`]s with different textures), rendering with the first 
+    /// Specify a batch key to use for shadows. Returning Some(value) allows batching of distinct materials which will produce
+    /// the same depth-prepass output (such as opaque [`StandardMaterial`]s with different textures), rendering with the first
     /// material of the batch for all meshes.
     fn shadow_material_key(&self) -> Option<u64> {
         None

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -180,6 +180,13 @@ pub trait Material: Asset + AsBindGroup + Clone + Sized {
     ) -> Result<(), SpecializedMeshPipelineError> {
         Ok(())
     }
+
+    /// Specify a batch key to use for shadows. Returning Some(value) allows batching of distinct materials which will produce 
+    /// the same depth-prepass output (such as opaque [`StandardMaterial`]s with different textures), rendering with the first 
+    /// material of the batch for all meshes.
+    fn shadow_material_key(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Adds the necessary ECS resources and render logic to enable rendering entities using the given [`Material`]
@@ -773,16 +780,33 @@ pub struct MaterialProperties {
 pub struct PreparedMaterial<T: Material> {
     pub bindings: Vec<(u32, OwnedBindingResource)>,
     pub bind_group: BindGroup,
+    pub shadow_bind_group_id: MaterialBindGroupId,
     pub key: T::Data,
     pub properties: MaterialProperties,
 }
 
-#[derive(Component, Clone, Copy, Default, PartialEq, Eq, Deref, DerefMut)]
-pub struct MaterialBindGroupId(Option<BindGroupId>);
+#[derive(Component, Clone, Copy, Default)]
+pub enum MaterialBindGroupId {
+    #[default]
+    Unbatched,
+    Instance(BindGroupId),
+    Group(u64),
+}
+
+impl PartialEq for MaterialBindGroupId {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Instance(l0), Self::Instance(r0)) => l0 == r0,
+            (Self::Group(l0), Self::Group(r0)) => l0 == r0,
+            // unbatched should never report equal to prevent batching
+            _ => false,
+        }
+    }
+}
 
 impl<T: Material> PreparedMaterial<T> {
     pub fn get_bind_group_id(&self) -> MaterialBindGroupId {
-        MaterialBindGroupId(Some(self.bind_group.id()))
+        MaterialBindGroupId::Instance(self.bind_group.id())
     }
 }
 
@@ -937,9 +961,14 @@ fn prepare_material<M: Material>(
         OpaqueRendererMethod::Deferred => OpaqueRendererMethod::Deferred,
         OpaqueRendererMethod::Auto => default_opaque_render_method,
     };
+    let shadow_bind_group_id = match material.shadow_material_key() {
+        Some(key) => MaterialBindGroupId::Group(key),
+        None => MaterialBindGroupId::Instance(prepared.bind_group.id()),
+    };
     Ok(PreparedMaterial {
         bindings: prepared.bindings,
         bind_group: prepared.bind_group,
+        shadow_bind_group_id,
         key: prepared.data,
         properties: MaterialProperties {
             alpha_mode: material.alpha_mode(),

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -801,6 +801,11 @@ impl Material for StandardMaterial {
         PBR_SHADER_HANDLE.into()
     }
 
+    fn shadow_material_key(&self) -> Option<u64> {
+        // we can batch all pure opaque materials together for shadow rendering
+        (self.alpha_mode == AlphaMode::Opaque).then_some(0)
+    }
+
     fn specialize(
         _pipeline: &MaterialPipeline<Self>,
         descriptor: &mut RenderPipelineDescriptor,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1590,12 +1590,12 @@ pub fn queue_shadows<M: Material>(
     shadow_draw_functions: Res<DrawFunctions<Shadow>>,
     prepass_pipeline: Res<PrepassPipeline<M>>,
     render_meshes: Res<RenderAssets<Mesh>>,
-    render_mesh_instances: Res<RenderMeshInstances>,
+    mut render_mesh_instances: ResMut<RenderMeshInstances>,
     render_materials: Res<RenderMaterials<M>>,
     render_material_instances: Res<RenderMaterialInstances<M>>,
     mut pipelines: ResMut<SpecializedMeshPipelines<PrepassPipeline<M>>>,
     pipeline_cache: Res<PipelineCache>,
-    view_lights: Query<(Entity, &ViewLightEntities)>,
+    view_lights: Query<(Entity, &ExtractedView, &ViewLightEntities)>,
     mut view_light_shadow_phases: Query<(&LightEntity, &mut RenderPhase<Shadow>)>,
     point_light_entities: Query<&CubemapVisibleEntities, With<ExtractedPointLight>>,
     directional_light_entities: Query<&CascadesVisibleEntities, With<ExtractedDirectionalLight>>,
@@ -1603,7 +1603,8 @@ pub fn queue_shadows<M: Material>(
 ) where
     M::Data: PartialEq + Eq + Hash + Clone,
 {
-    for (entity, view_lights) in &view_lights {
+    for (entity, view, view_lights) in &view_lights {
+        let rangefinder = view.rangefinder3d();
         let draw_shadow_mesh = shadow_draw_functions.read().id::<DrawPrepass<M>>();
         for view_light_entity in view_lights.lights.iter().copied() {
             let (light_entity, mut shadow_phase) =
@@ -1635,7 +1636,7 @@ pub fn queue_shadows<M: Material>(
             // NOTE: Lights with shadow mapping disabled will have no visible entities
             // so no meshes will be queued
             for entity in visible_entities.iter().copied() {
-                let Some(mesh_instance) = render_mesh_instances.get(&entity) else {
+                let Some(mesh_instance) = render_mesh_instances.get_mut(&entity) else {
                     continue;
                 };
                 if !mesh_instance.shadow_caster {
@@ -1685,11 +1686,16 @@ pub fn queue_shadows<M: Material>(
                     }
                 };
 
+                mesh_instance.prepass_material_bind_group_id = material.shadow_bind_group_id;
+
+                let distance = rangefinder
+                    .distance_translation(&mesh_instance.transforms.transform.translation);
+
                 shadow_phase.add(Shadow {
                     draw_function: draw_shadow_mesh,
                     pipeline: pipeline_id,
                     entity,
-                    distance: 0.0, // TODO: sort front-to-back
+                    distance,
                     batch_range: 0..1,
                     dynamic_offset: None,
                 });

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1686,7 +1686,7 @@ pub fn queue_shadows<M: Material>(
                     }
                 };
 
-                mesh_instance.prepass_material_bind_group_id = material.shadow_bind_group_id;
+                mesh_instance.shadow_material_bind_group_id = material.shadow_bind_group_id;
 
                 shadow_phase.add(Shadow {
                     draw_function: draw_shadow_mesh,
@@ -1734,7 +1734,7 @@ impl PhaseItem for Shadow {
         // Grouping all draw commands using the same pipeline together performs
         // better than rebinding everything at a high rate, and grouping by mesh
         // allows batching to reduce draw calls.
-        items.sort_by_key(Self::sort_key);
+        items.sort_unstable_by_key(Self::sort_key);
     }
 
     #[inline]

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -257,7 +257,7 @@ pub struct RenderMeshInstance {
     pub transforms: MeshTransforms,
     pub mesh_asset_id: AssetId<Mesh>,
     pub material_bind_group_id: MaterialBindGroupId,
-    pub prepass_material_bind_group_id: MaterialBindGroupId,
+    pub shadow_material_bind_group_id: MaterialBindGroupId,
     pub shadow_caster: bool,
     pub automatic_batching: bool,
 }
@@ -329,7 +329,7 @@ pub fn extract_meshes(
                     transforms,
                     shadow_caster: !not_shadow_caster,
                     material_bind_group_id: MaterialBindGroupId::default(),
-                    prepass_material_bind_group_id: MaterialBindGroupId::default(),
+                    shadow_material_bind_group_id: MaterialBindGroupId::default(),
                     automatic_batching: !no_automatic_batching,
                 },
             ));
@@ -527,7 +527,7 @@ impl GetBatchData for ShadowMeshPipeline {
                 maybe_lightmap.map(|lightmap| lightmap.uv_rect),
             ),
             mesh_instance.automatic_batching.then_some((
-                mesh_instance.prepass_material_bind_group_id,
+                mesh_instance.shadow_material_bind_group_id,
                 mesh_instance.mesh_asset_id,
                 maybe_lightmap.map(|lightmap| lightmap.image),
             )),

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -41,6 +41,10 @@ struct Args {
     /// the number of different textures from which to randomly select the material base color. 0 means no textures.
     #[argh(option, default = "0")]
     material_texture_count: usize,
+
+    /// enable cascaded shadow map
+    #[argh(switch)]
+    shadows: bool,
 }
 
 #[derive(Default, Clone)]
@@ -185,7 +189,13 @@ fn setup(
         }
     }
 
-    commands.spawn(DirectionalLightBundle { ..default() });
+    commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            shadows_enabled: args.shadows,
+            ..default()
+        },
+        ..default()
+    });
 }
 
 fn init_textures(args: &Args, images: &mut Assets<Image>) -> Vec<Handle<Image>> {


### PR DESCRIPTION
# Objective

some minor optimisations for shadow rendering performance

## Solution

- added `--shadows` option to many_cubes for testing
- added mesh-id sorting for shadow phase items.
- when rendering shadows, added material batching for materials that have a common depth-prepass output (such as opaque `StandardMaterial`s). the material must support the batching via `Material::shadow_material_key`
- added shadow batching for extended materials, using ~~the base material's key~~ no batching by default. ~~i am not sure if this is the right thing to do, it will cause some existing `ExtendedMaterial`s to render incorrectly (e.g. if they move vertices based on material data). the alternative is to by default disable shadow batching for extended materials (it could still be enabled by authors)~~

# perf impacts:
command line | current fps | new fps
--- | --- | ---
cargo run --example many_cubes --release -- --benchmark --shadows | 27 | 27
cargo run --example many_cubes --release -- --benchmark --shadows --vary-per-instance | 2.5 | 12

when sharing a material handle there is no impact as expected. when using distinct materials the frame rate increases ~5x.

this is obviously an exaggeration of real world impacts, but on a random real world scene i had

scenario | fps
--- | ---
without shadows | 110
with shadows current | 50
with shadows new | 64
with shadows just sorting | 57
with shadows just batching | 60

a second test scene (thanks @Elabajaba) showed a smaller change from 56fps to 60fps.