### PR TITLE
bevy_reflect: Custom attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2068,6 +2068,17 @@ category = "Reflection"
 wasm = false
 
 [[example]]
+name = "custom_attributes"
+path = "examples/reflection/custom_attributes.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.custom_attributes]
+name = "Custom Attributes"
+description = "Registering and accessing custom attributes on reflected types"
+category = "Reflection"
+wasm = false
+
+[[example]]
 name = "dynamic_types"
 path = "examples/reflection/dynamic_types.rs"
 doc-scrape-examples = true

--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -513,6 +513,10 @@ impl ContainerAttributes {
         }
     }
 
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
+    }
+
     /// The custom where configuration found within `#[reflect(...)]` attributes on this type.
     pub fn custom_where(&self) -> Option<&WhereClause> {
         self.custom_where.as_ref()

--- a/crates/bevy_reflect/derive/src/container_attributes.rs
+++ b/crates/bevy_reflect/derive/src/container_attributes.rs
@@ -5,6 +5,7 @@
 //! the derive helper attribute for `Reflect`, which looks like:
 //! `#[reflect(PartialEq, Default, ...)]` and `#[reflect_value(PartialEq, Default, ...)]`.
 
+use crate::custom_attributes::CustomAttributes;
 use crate::derive_data::ReflectTraitToImpl;
 use crate::utility;
 use crate::utility::terminated_parser;
@@ -187,6 +188,7 @@ pub(crate) struct ContainerAttributes {
     type_path_attrs: TypePathAttrs,
     custom_where: Option<WhereClause>,
     no_field_bounds: bool,
+    custom_attributes: CustomAttributes,
     idents: Vec<Ident>,
 }
 
@@ -227,7 +229,9 @@ impl ContainerAttributes {
         trait_: ReflectTraitToImpl,
     ) -> syn::Result<()> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(Token![where]) {
+        if lookahead.peek(Token![@]) {
+            self.custom_attributes.parse_custom_attribute(input)
+        } else if lookahead.peek(Token![where]) {
             self.parse_custom_where(input)
         } else if lookahead.peek(kw::from_reflect) {
             self.parse_from_reflect(input, trait_)

--- a/crates/bevy_reflect/derive/src/custom_attributes.rs
+++ b/crates/bevy_reflect/derive/src/custom_attributes.rs
@@ -1,0 +1,86 @@
+use proc_macro2::{Ident, TokenStream};
+use quote::quote;
+use std::collections::HashMap;
+use syn::parse::{Parse, ParseStream};
+use syn::punctuated::Punctuated;
+use syn::spanned::Spanned;
+use syn::{parenthesized, Lit, LitStr, Path, Token};
+
+#[derive(Default, Clone)]
+pub(crate) struct CustomAttributes {
+    attributes: HashMap<String, Lit>,
+}
+
+impl CustomAttributes {
+    /// Generates a `TokenStream` for `CustomAttributes` construction.
+    pub fn to_tokens(&self, bevy_reflect_path: &Path) -> TokenStream {
+        let attributes = self.attributes.iter().map(|(name, value)| {
+            quote! {
+                .with_attribute(#name, #value)
+            }
+        });
+
+        quote! {
+            #bevy_reflect_path::attributes::CustomAttributes::default()
+                #(#attributes)*
+        }
+    }
+
+    /// Inserts a custom attribute into the map.
+    pub fn insert(&mut self, name: LitStr, value: Lit) -> syn::Result<()> {
+        let key = name.value();
+        if self.attributes.contains_key(&key) {
+            return Err(syn::Error::new_spanned(name, "duplicate custom attribute"));
+        }
+
+        self.attributes.insert(key, value);
+
+        Ok(())
+    }
+
+    /// Parse `@` (custom attribute) attribute.
+    ///
+    /// Examples:
+    /// - `#[reflect(@(foo = "bar"))]`
+    /// - `#[reflect(@(min = 0.0, max = 1.0))]`
+    pub fn parse_custom_attribute(&mut self, input: ParseStream) -> syn::Result<()> {
+        input.parse::<Token![@]>()?;
+
+        let content;
+        parenthesized!(content in input);
+
+        let custom_attrs = content.parse_terminated(CustomAttribute::parse, Token![,])?;
+
+        for custom_attr in custom_attrs {
+            let name = custom_attr
+                .name
+                .iter()
+                .map(Ident::to_string)
+                .collect::<Vec<_>>()
+                .join("::");
+
+            self.insert(
+                LitStr::new(&name, custom_attr.name.span()),
+                custom_attr.value,
+            )?;
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) struct CustomAttribute {
+    name: Punctuated<Ident, Token![::]>,
+    _eq: Token![=],
+    value: Lit,
+}
+
+impl Parse for CustomAttribute {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        Ok(Self {
+            name: Punctuated::<Ident, Token![::]>::parse_separated_nonempty(input)?,
+            _eq: input.parse::<Token![=]>()?,
+            value: input.parse::<Lit>()?,
+        })
+    }
+}

--- a/crates/bevy_reflect/derive/src/custom_attributes.rs
+++ b/crates/bevy_reflect/derive/src/custom_attributes.rs
@@ -4,11 +4,11 @@ use quote::quote;
 use std::collections::HashMap;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parenthesized, Lit, LitStr, Path, Token};
+use syn::{parenthesized, Expr, LitStr, Path, Token};
 
 #[derive(Default, Clone)]
 pub(crate) struct CustomAttributes {
-    attributes: HashMap<SpannedString, Lit>,
+    attributes: HashMap<SpannedString, Expr>,
 }
 
 impl CustomAttributes {
@@ -27,7 +27,7 @@ impl CustomAttributes {
     }
 
     /// Inserts a custom attribute into the map.
-    pub fn insert(&mut self, name: impl Into<SpannedString>, value: Lit) -> syn::Result<()> {
+    pub fn insert(&mut self, name: impl Into<SpannedString>, value: Expr) -> syn::Result<()> {
         let name = name.into();
         if self.attributes.contains_key(&name) {
             return Err(syn::Error::new_spanned(name, "duplicate custom attribute"));
@@ -80,15 +80,15 @@ impl CustomAttributes {
 pub(crate) struct CustomAttribute {
     name: Path,
     _eq: Token![=],
-    value: Lit,
+    value: Expr,
 }
 
 impl Parse for CustomAttribute {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(Self {
             name: Path::parse_mod_style(input)?,
-            _eq: input.parse::<Token![=]>()?,
-            value: input.parse::<Lit>()?,
+            _eq: input.parse()?,
+            value: input.parse()?,
         })
     }
 }

--- a/crates/bevy_reflect/derive/src/custom_attributes.rs
+++ b/crates/bevy_reflect/derive/src/custom_attributes.rs
@@ -1,22 +1,19 @@
-use crate::utility::SpannedString;
 use proc_macro2::TokenStream;
 use quote::quote;
-use std::collections::HashMap;
 use syn::parse::ParseStream;
-use syn::spanned::Spanned;
-use syn::{Expr, ExprLit, Lit, LitBool, LitStr, Path, Token};
+use syn::{Expr, Path, Token};
 
 #[derive(Default, Clone)]
 pub(crate) struct CustomAttributes {
-    attributes: HashMap<SpannedString, Expr>,
+    attributes: Vec<Expr>,
 }
 
 impl CustomAttributes {
     /// Generates a `TokenStream` for `CustomAttributes` construction.
     pub fn to_tokens(&self, bevy_reflect_path: &Path) -> TokenStream {
-        let attributes = self.attributes.iter().map(|(name, value)| {
+        let attributes = self.attributes.iter().map(|value| {
             quote! {
-                .with_attribute(#name, #value)
+                .with_attribute(#value)
             }
         });
 
@@ -26,57 +23,20 @@ impl CustomAttributes {
         }
     }
 
-    /// Inserts a custom attribute into the map.
-    pub fn insert(&mut self, name: impl Into<SpannedString>, value: Expr) -> syn::Result<()> {
-        let name = name.into();
-        if self.attributes.contains_key(&name) {
-            return Err(syn::Error::new_spanned(name, "duplicate custom attribute"));
-        }
-
-        self.attributes.insert(name, value);
-
+    /// Inserts a custom attribute into the list.
+    pub fn push(&mut self, value: Expr) -> syn::Result<()> {
+        self.attributes.push(value);
         Ok(())
     }
 
     /// Parse `@` (custom attribute) attribute.
     ///
     /// Examples:
-    /// - `#[reflect(@hidden))]`
-    /// - `#[reflect(@foo = Bar::baz("qux"))]`
-    /// - `#[reflect(@min = 0.0, @max = 1.0)]`
+    /// - `#[reflect(@Foo))]`
+    /// - `#[reflect(@Bar::baz("qux"))]`
+    /// - `#[reflect(@0..256u8)]`
     pub fn parse_custom_attribute(&mut self, input: ParseStream) -> syn::Result<()> {
         input.parse::<Token![@]>()?;
-
-        let path = Path::parse_mod_style(input)?;
-        let value = if input.peek(Token![=]) {
-            input.parse::<Token![=]>()?;
-            input.parse::<Expr>()?
-        } else {
-            Expr::Lit(ExprLit {
-                attrs: Vec::new(),
-                lit: Lit::Bool(LitBool::new(true, path.span())),
-            })
-        };
-
-        let mut name = path
-            .segments
-            .iter()
-            .map(|segment| segment.ident.to_string())
-            .collect::<Vec<_>>()
-            .join("::");
-
-        if path.leading_colon.is_some() {
-            name.insert_str(0, "::");
-        }
-
-        self.insert(
-            // Note that the call to `.span()` will only return the span of the first token.
-            // This isn't ideal, but should be fine— especially for single-ident names.
-            // See: https://docs.rs/syn/2.0.48/syn/spanned/index.html#limitations
-            LitStr::new(&name, path.span()),
-            value,
-        )?;
-
-        Ok(())
+        self.push(input.parse()?)
     }
 }

--- a/crates/bevy_reflect/derive/src/derive_data.rs
+++ b/crates/bevy_reflect/derive/src/derive_data.rs
@@ -760,9 +760,12 @@ impl<'a> EnumVariant<'a> {
             }
         };
 
+        let custom_attributes = self.attrs.custom_attributes.to_tokens(bevy_reflect_path);
+
         #[allow(unused_mut)] // Needs mutability for the feature gate
         let mut info = quote! {
             #bevy_reflect_path::#info_struct::new(#args)
+                .with_custom_attributes(#custom_attributes)
         };
 
         #[cfg(feature = "documentation")]

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -74,7 +74,7 @@ pub(crate) struct FieldAttributes {
     pub ignore: ReflectIgnoreBehavior,
     /// Sets the default behavior of this field.
     pub default: DefaultBehavior,
-    /// Custom attributes created via `#[reflect(@(...))]`.
+    /// Custom attributes created via `#[reflect(@...)]`.
     pub custom_attributes: CustomAttributes,
 }
 

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -7,10 +7,11 @@
 use crate::utility::terminated_parser;
 use crate::REFLECT_ATTRIBUTE_NAME;
 use proc_macro2::Ident;
+use quote::quote;
 use std::collections::HashMap;
 use syn::parse::{Parse, ParseStream};
 use syn::punctuated::Punctuated;
-use syn::{parenthesized, Attribute, Lit, LitStr, Meta, Token};
+use syn::{parenthesized, Attribute, Lit, LitStr, Meta, Path, Token};
 
 mod kw {
     syn::custom_keyword!(ignore);
@@ -72,6 +73,22 @@ pub(crate) enum DefaultBehavior {
 #[derive(Default, Clone)]
 pub(crate) struct CustomAttributes {
     attributes: HashMap<String, Lit>,
+}
+
+impl CustomAttributes {
+    /// Generates a `TokenStream` for `CustomAttributes` construction.
+    pub fn to_tokens(&self, bevy_reflect_path: &Path) -> proc_macro2::TokenStream {
+        let attributes = self.attributes.iter().map(|(name, value)| {
+            quote! {
+                .with_attribute(#name, #value)
+            }
+        });
+
+        quote! {
+            #bevy_reflect_path::attributes::CustomAttributes::default()
+                #(#attributes)*
+        }
+    }
 }
 
 /// A container for attributes defined on a reflected type's field.

--- a/crates/bevy_reflect/derive/src/field_attributes.rs
+++ b/crates/bevy_reflect/derive/src/field_attributes.rs
@@ -111,14 +111,14 @@ impl FieldAttributes {
     /// Parses a single field attribute.
     fn parse_field_attribute(&mut self, input: ParseStream) -> syn::Result<()> {
         let lookahead = input.lookahead1();
-        if lookahead.peek(kw::ignore) {
+        if lookahead.peek(Token![@]) {
+            self.parse_custom_attribute(input)
+        } else if lookahead.peek(kw::ignore) {
             self.parse_ignore(input)
         } else if lookahead.peek(kw::skip_serializing) {
             self.parse_skip_serializing(input)
         } else if lookahead.peek(kw::default) {
             self.parse_default(input)
-        } else if lookahead.peek(Token![@]) {
-            self.parse_custom_attribute(input)
         } else {
             Err(lookahead.error())
         }

--- a/crates/bevy_reflect/derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/derive/src/impls/enums.rs
@@ -409,19 +409,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         #unit { #declare_field : value, .. } if #ref_index == #reflect_idx => #FQOption::Some(value)
                     });
 
-                    #[cfg(feature = "documentation")]
-                    let with_docs = {
-                        let doc = quote::ToTokens::to_token_stream(&field.doc);
-                        Some(quote!(.with_docs(#doc)))
-                    };
-                    #[cfg(not(feature = "documentation"))]
-                    let with_docs: Option<proc_macro2::TokenStream> = None;
-
-                    let field_ty = &field.data.ty;
-                    quote! {
-                        #bevy_reflect_path::UnnamedField::new::<#field_ty>(#reflect_idx)
-                        #with_docs
-                    }
+                    field.to_info_tokens(bevy_reflect_path)
                 });
 
                 let field_len = args.len();
@@ -444,19 +432,7 @@ fn generate_impls(reflect_enum: &ReflectEnum, ref_index: &Ident, ref_name: &Iden
                         #unit{ .. } if #ref_index == #reflect_idx => #FQOption::Some(#field_name)
                     });
 
-                    #[cfg(feature = "documentation")]
-                    let with_docs = {
-                        let doc = quote::ToTokens::to_token_stream(&field.doc);
-                        Some(quote!(.with_docs(#doc)))
-                    };
-                    #[cfg(not(feature = "documentation"))]
-                    let with_docs: Option<proc_macro2::TokenStream> = None;
-
-                    let field_ty = &field.data.ty;
-                    quote! {
-                        #bevy_reflect_path::NamedField::new::<#field_ty>(#field_name)
-                        #with_docs
-                    }
+                    field.to_info_tokens(bevy_reflect_path)
                 });
 
                 let field_len = args.len();

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -45,34 +45,11 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             }
         });
 
-    let field_infos = reflect_struct
-        .active_fields()
-        .map(|field| field.to_info_tokens(bevy_reflect_path));
-
-    #[cfg(feature = "documentation")]
-    let info_generator = {
-        let doc = reflect_struct.meta().doc();
-        quote! {
-            #bevy_reflect_path::StructInfo::new::<Self>(&fields).with_docs(#doc)
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let info_generator = {
-        quote! {
-            #bevy_reflect_path::StructInfo::new::<Self>(&fields)
-        }
-    };
-
     let where_clause_options = reflect_struct.where_clause_options();
     let typed_impl = impl_typed(
         reflect_struct.meta(),
         &where_clause_options,
-        quote! {
-            let fields = [#(#field_infos),*];
-            let info = #info_generator;
-            #bevy_reflect_path::TypeInfo::Struct(info)
-        },
+        reflect_struct.to_info_tokens(false),
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());

--- a/crates/bevy_reflect/derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/structs.rs
@@ -26,7 +26,6 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         .active_fields()
         .map(|field| ident_or_index(field.data.ident.as_ref(), field.declaration_index))
         .collect::<Vec<_>>();
-    let field_types = reflect_struct.active_types();
     let field_count = field_idents.len();
     let field_indices = (0..field_count).collect::<Vec<usize>>();
 
@@ -46,22 +45,9 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
             }
         });
 
-    #[cfg(feature = "documentation")]
-    let field_generator = {
-        let docs = reflect_struct
-            .active_fields()
-            .map(|field| ToTokens::to_token_stream(&field.doc));
-        quote! {
-            #(#bevy_reflect_path::NamedField::new::<#field_types>(#field_names).with_docs(#docs) ,)*
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let field_generator = {
-        quote! {
-            #(#bevy_reflect_path::NamedField::new::<#field_types>(#field_names) ,)*
-        }
-    };
+    let field_infos = reflect_struct
+        .active_fields()
+        .map(|field| field.to_info_tokens(bevy_reflect_path));
 
     #[cfg(feature = "documentation")]
     let info_generator = {
@@ -83,7 +69,7 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
         reflect_struct.meta(),
         &where_clause_options,
         quote! {
-            let fields = [#field_generator];
+            let fields = [#(#field_infos),*];
             let info = #info_generator;
             #bevy_reflect_path::TypeInfo::Struct(info)
         },

--- a/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/derive/src/impls/tuple_structs.rs
@@ -38,33 +38,10 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
             }
         });
 
-    let field_infos = reflect_struct
-        .active_fields()
-        .map(|field| field.to_info_tokens(bevy_reflect_path));
-
-    #[cfg(feature = "documentation")]
-    let info_generator = {
-        let doc = reflect_struct.meta().doc();
-        quote! {
-           #bevy_reflect_path::TupleStructInfo::new::<Self>(&fields).with_docs(#doc)
-        }
-    };
-
-    #[cfg(not(feature = "documentation"))]
-    let info_generator = {
-        quote! {
-            #bevy_reflect_path::TupleStructInfo::new::<Self>(&fields)
-        }
-    };
-
     let typed_impl = impl_typed(
         reflect_struct.meta(),
         &where_clause_options,
-        quote! {
-            let fields = [#(#field_infos),*];
-            let info = #info_generator;
-            #bevy_reflect_path::TypeInfo::TupleStruct(info)
-        },
+        reflect_struct.to_info_tokens(true),
     );
 
     let type_path_impl = impl_type_path(reflect_struct.meta());

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -17,6 +17,7 @@
 extern crate proc_macro;
 
 mod container_attributes;
+mod custom_attributes;
 mod derive_data;
 #[cfg(feature = "documentation")]
 mod documentation;

--- a/crates/bevy_reflect/derive/src/lib.rs
+++ b/crates/bevy_reflect/derive/src/lib.rs
@@ -274,6 +274,36 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 /// // {/* ... */}
 /// ```
 ///
+/// ## `#[reflect(@...)]`
+///
+/// This attribute can be used to register custom attributes to the type's `TypeInfo`.
+///
+/// It accepts any expression after the `@` symbol that resolves to a value which implements `Reflect`.
+///
+/// Any number of custom attributes may be registered, however, each the type of each attribute must be unique.
+/// If two attributes of the same type are registered, the last one will overwrite the first.
+///
+/// ### Example
+///
+/// ```ignore
+/// #[derive(Reflect)]
+/// struct Required;
+///
+/// #[derive(Reflect)]
+/// struct EditorTooltip(String);
+///
+/// impl EditorTooltip {
+///   fn new(text: &str) -> Self {
+///     Self(text.to_string())
+///   }
+/// }
+///
+/// #[derive(Reflect)]
+/// // Specify a "required" status and tooltip:
+/// #[reflect(@Required, @EditorTooltip::new("An ID is required!"))]
+/// struct Id(u8);
+/// ```
+///
 /// # Field Attributes
 ///
 /// Along with the container attributes, this macro comes with some attributes that may be applied
@@ -296,6 +326,35 @@ fn match_reflect_impls(ast: DeriveInput, source: ReflectImplSource) -> TokenStre
 ///
 /// What this does is register the `SerializationData` type within the `GetTypeRegistration` implementation,
 /// which will be used by the reflection serializers to determine whether or not the field is serializable.
+///
+/// ## `#[reflect(@...)]`
+///
+/// This attribute can be used to register custom attributes to the field's `TypeInfo`.
+///
+/// It accepts any expression after the `@` symbol that resolves to a value which implements `Reflect`.
+///
+/// Any number of custom attributes may be registered, however, each the type of each attribute must be unique.
+/// If two attributes of the same type are registered, the last one will overwrite the first.
+///
+/// ### Example
+///
+/// ```ignore
+/// #[derive(Reflect)]
+/// struct EditorTooltip(String);
+///
+/// impl EditorTooltip {
+///   fn new(text: &str) -> Self {
+///     Self(text.to_string())
+///   }
+/// }
+///
+/// #[derive(Reflect)]
+/// struct Slider {
+///   // Specify a custom range and tooltip:
+///   #[reflect(@0.0..=1.0, @EditorTooltip::new("Must be between 0 and 1"))]
+///   value: f32,
+/// }
+/// ```
 ///
 /// [`reflect_trait`]: macro@reflect_trait
 #[proc_macro_derive(Reflect, attributes(reflect, reflect_value, type_path, type_name))]

--- a/crates/bevy_reflect/derive/src/utility.rs
+++ b/crates/bevy_reflect/derive/src/utility.rs
@@ -7,6 +7,7 @@ use bevy_macro_utils::{
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
+use std::hash::{Hash, Hasher};
 use syn::parse::{Parse, ParseStream, Peek};
 use syn::punctuated::Punctuated;
 use syn::{spanned::Spanned, LitStr, Member, Path, Token, Type, WhereClause};
@@ -442,5 +443,41 @@ where
         }
 
         Ok(punctuated)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SpannedString {
+    pub value: String,
+    pub span: Span,
+}
+
+impl ToTokens for SpannedString {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let lit = LitStr::new(&self.value, self.span);
+        lit.to_tokens(tokens);
+    }
+}
+
+impl From<LitStr> for SpannedString {
+    fn from(value: LitStr) -> Self {
+        Self {
+            value: value.value(),
+            span: value.span(),
+        }
+    }
+}
+
+impl Eq for SpannedString {}
+
+impl PartialEq for SpannedString {
+    fn eq(&self, other: &Self) -> bool {
+        self.value == other.value
+    }
+}
+
+impl Hash for SpannedString {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.value.hash(state);
     }
 }

--- a/crates/bevy_reflect/derive/src/utility.rs
+++ b/crates/bevy_reflect/derive/src/utility.rs
@@ -7,7 +7,6 @@ use bevy_macro_utils::{
 };
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
-use std::hash::{Hash, Hasher};
 use syn::parse::{Parse, ParseStream, Peek};
 use syn::punctuated::Punctuated;
 use syn::{spanned::Spanned, LitStr, Member, Path, Token, Type, WhereClause};
@@ -443,41 +442,5 @@ where
         }
 
         Ok(punctuated)
-    }
-}
-
-#[derive(Clone)]
-pub(crate) struct SpannedString {
-    pub value: String,
-    pub span: Span,
-}
-
-impl ToTokens for SpannedString {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        let lit = LitStr::new(&self.value, self.span);
-        lit.to_tokens(tokens);
-    }
-}
-
-impl From<LitStr> for SpannedString {
-    fn from(value: LitStr) -> Self {
-        Self {
-            value: value.value(),
-            span: value.span(),
-        }
-    }
-}
-
-impl Eq for SpannedString {}
-
-impl PartialEq for SpannedString {
-    fn eq(&self, other: &Self) -> bool {
-        self.value == other.value
-    }
-}
-
-impl Hash for SpannedString {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.value.hash(state);
     }
 }

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -122,6 +122,28 @@ mod tests {
     }
 
     #[test]
+    fn should_derive_custom_attributes_on_struct_container() {
+        #[derive(Reflect)]
+        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        struct Slider {
+            value: f32,
+        }
+
+        let TypeInfo::Struct(info) = Slider::type_info() else {
+            panic!("expected struct info");
+        };
+
+        let attributes = info.custom_attributes();
+
+        let hint = attributes
+            .get("::bevy_editor::hint")
+            .unwrap()
+            .value::<&str>();
+
+        assert_eq!(Some(&"My awesome custom attribute!"), hint);
+    }
+
+    #[test]
     fn should_derive_custom_attributes_on_struct_fields() {
         #[derive(Reflect)]
         struct Slider {
@@ -149,6 +171,26 @@ mod tests {
     }
 
     #[test]
+    fn should_derive_custom_attributes_on_tuple_container() {
+        #[derive(Reflect)]
+        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        struct Slider(f32);
+
+        let TypeInfo::TupleStruct(info) = Slider::type_info() else {
+            panic!("expected tuple struct info");
+        };
+
+        let attributes = info.custom_attributes();
+
+        let hint = attributes
+            .get("::bevy_editor::hint")
+            .unwrap()
+            .value::<&str>();
+
+        assert_eq!(Some(&"My awesome custom attribute!"), hint);
+    }
+
+    #[test]
     fn should_derive_custom_attributes_on_tuple_struct_fields() {
         #[derive(Reflect)]
         struct Slider(
@@ -173,6 +215,30 @@ mod tests {
         assert_eq!(Some(&0.0), min);
         assert_eq!(Some(&1.0), max);
         assert_eq!(Some(&"Range: 0.0 to 1.0"), hint);
+    }
+
+    #[test]
+    fn should_derive_custom_attributes_on_enum_container() {
+        #[derive(Reflect)]
+        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        enum Color {
+            Transparent,
+            Grayscale(f32),
+            Rgb { r: u8, g: u8, b: u8 },
+        }
+
+        let TypeInfo::Enum(info) = Color::type_info() else {
+            panic!("expected enum info");
+        };
+
+        let attributes = info.custom_attributes();
+
+        let hint = attributes
+            .get("::bevy_editor::hint")
+            .unwrap()
+            .value::<&str>();
+
+        assert_eq!(Some(&"My awesome custom attribute!"), hint);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -243,13 +243,20 @@ mod tests {
 
     #[test]
     fn should_derive_custom_attributes_on_enum_variants() {
+        #[derive(Reflect, Debug, PartialEq)]
+        enum Display {
+            Toggle,
+            Slider,
+            Picker,
+        }
+
         #[derive(Reflect)]
         enum Color {
-            #[reflect(@(display = "toggle"))]
+            #[reflect(@(display = Display::Toggle))]
             Transparent,
-            #[reflect(@(display = "slider"))]
+            #[reflect(@(display = Display::Slider))]
             Grayscale(f32),
-            #[reflect(@(display = "picker"))]
+            #[reflect(@(display = Display::Picker))]
             Rgb { r: u8, g: u8, b: u8 },
         }
 
@@ -265,8 +272,8 @@ mod tests {
             .custom_attributes()
             .get("display")
             .unwrap()
-            .value::<&str>();
-        assert_eq!(Some(&"toggle"), display);
+            .value::<Display>();
+        assert_eq!(Some(&Display::Toggle), display);
 
         let VariantInfo::Tuple(grayscale_variant) = info.variant("Grayscale").unwrap() else {
             panic!("expected tuple variant");
@@ -276,8 +283,8 @@ mod tests {
             .custom_attributes()
             .get("display")
             .unwrap()
-            .value::<&str>();
-        assert_eq!(Some(&"slider"), display);
+            .value::<Display>();
+        assert_eq!(Some(&Display::Slider), display);
 
         let VariantInfo::Struct(rgb_variant) = info.variant("Rgb").unwrap() else {
             panic!("expected struct variant");
@@ -287,8 +294,8 @@ mod tests {
             .custom_attributes()
             .get("display")
             .unwrap()
-            .value::<&str>();
-        assert_eq!(Some(&"picker"), display);
+            .value::<Display>();
+        assert_eq!(Some(&Display::Picker), display);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -128,44 +128,45 @@ impl Debug for CustomAttribute {
 ///
 /// # Params
 ///
+/// * `$self` - The name of the variable containing the custom attributes (usually `self`).
 /// * `$attributes` - The name of the field containing the [`CustomAttributes`].
 /// * `$term` - (Optional) The term used to describe the type containing the custom attributes.
 ///   This is purely used to generate better documentation. Defaults to `"item"`.
 ///
 macro_rules! impl_custom_attribute_methods {
-    ($attributes: ident) => {
-        $crate::attributes::impl_custom_attribute_methods!($attributes, "item");
+    ($self:ident . $attributes:ident, $term:literal) => {
+        $crate::attributes::impl_custom_attribute_methods!($self, &$self.$attributes, "item");
     };
-    ($attributes: ident, $term: literal) => {
+    ($self:ident, $attributes:expr, $term:literal) => {
         #[doc = concat!("Returns the custom attributes for this ", $term, ".")]
-        pub fn custom_attributes(&self) -> &$crate::attributes::CustomAttributes {
-            &self.$attributes
+        pub fn custom_attributes(&$self) -> &$crate::attributes::CustomAttributes {
+            $attributes
         }
 
         /// Gets a custom attribute by type.
         ///
         /// For dynamically accessing an attribute, see [`get_attribute_by_id`](Self::get_attribute_by_id).
-        pub fn get_attribute<T: $crate::Reflect>(&self) -> Option<&T> {
-            self.$attributes.get::<T>()
+        pub fn get_attribute<T: $crate::Reflect>(&$self) -> Option<&T> {
+            $self.custom_attributes().get::<T>()
         }
 
         /// Gets a custom attribute by its [`TypeId`](std::any::TypeId).
         ///
         /// This is the dynamic equivalent of [`get_attribute`](Self::get_attribute).
-        pub fn get_attribute_by_id(&self, id: ::std::any::TypeId) -> Option<&dyn $crate::Reflect> {
-            self.$attributes.get_by_id(id)
+        pub fn get_attribute_by_id(&$self, id: ::std::any::TypeId) -> Option<&dyn $crate::Reflect> {
+            $self.custom_attributes().get_by_id(id)
         }
 
         #[doc = concat!("Returns `true` if this ", $term, " has a custom attribute of the specified type.")]
         #[doc = "\n\nFor dynamically checking if an attribute exists, see [`has_attribute_by_id`](Self::has_attribute_by_id)."]
-        pub fn has_attribute<T: $crate::Reflect>(&self) -> bool {
-            self.$attributes.contains::<T>()
+        pub fn has_attribute<T: $crate::Reflect>(&$self) -> bool {
+            $self.custom_attributes().contains::<T>()
         }
 
         #[doc = concat!("Returns `true` if this ", $term, " has a custom attribute with the specified [`TypeId`](::std::any::TypeId).")]
         #[doc = "\n\nThis is the dynamic equivalent of [`has_attribute`](Self::has_attribute)"]
-        pub fn has_attribute_by_id(&self, id: ::std::any::TypeId) -> bool {
-            self.$attributes.contains_by_id(id)
+        pub fn has_attribute_by_id(&$self, id: ::std::any::TypeId) -> bool {
+            $self.custom_attributes().contains_by_id(id)
         }
     };
 }

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -124,7 +124,7 @@ mod tests {
     #[test]
     fn should_derive_custom_attributes_on_struct_container() {
         #[derive(Reflect)]
-        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        #[reflect(@::bevy_editor::hint = "My awesome custom attribute!")]
         struct Slider {
             value: f32,
         }
@@ -147,8 +147,8 @@ mod tests {
     fn should_derive_custom_attributes_on_struct_fields() {
         #[derive(Reflect)]
         struct Slider {
-            #[reflect(@(min = 0.0, max = 1.0))]
-            #[reflect(@(bevy_editor::hint = "Range: 0.0 to 1.0"))]
+            #[reflect(@min = 0.0, @max = 1.0)]
+            #[reflect(@bevy_editor::hint = "Range: 0.0 to 1.0")]
             value: f32,
         }
 
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn should_derive_custom_attributes_on_tuple_container() {
         #[derive(Reflect)]
-        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        #[reflect(@::bevy_editor::hint = "My awesome custom attribute!")]
         struct Slider(f32);
 
         let TypeInfo::TupleStruct(info) = Slider::type_info() else {
@@ -194,8 +194,8 @@ mod tests {
     fn should_derive_custom_attributes_on_tuple_struct_fields() {
         #[derive(Reflect)]
         struct Slider(
-            #[reflect(@(min = 0.0, max = 1.0))]
-            #[reflect(@(bevy_editor::hint = "Range: 0.0 to 1.0"))]
+            #[reflect(@min = 0.0, @max = 1.0)]
+            #[reflect(@bevy_editor::hint = "Range: 0.0 to 1.0")]
             f32,
         );
 
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn should_derive_custom_attributes_on_enum_container() {
         #[derive(Reflect)]
-        #[reflect(@(::bevy_editor::hint = "My awesome custom attribute!"))]
+        #[reflect(@::bevy_editor::hint = "My awesome custom attribute!")]
         enum Color {
             Transparent,
             Grayscale(f32),
@@ -252,11 +252,11 @@ mod tests {
 
         #[derive(Reflect)]
         enum Color {
-            #[reflect(@(display = Display::Toggle))]
+            #[reflect(@display = Display::Toggle)]
             Transparent,
-            #[reflect(@(display = Display::Slider))]
+            #[reflect(@display = Display::Slider)]
             Grayscale(f32),
-            #[reflect(@(display = Display::Picker))]
+            #[reflect(@display = Display::Picker)]
             Rgb { r: u8, g: u8, b: u8 },
         }
 
@@ -303,13 +303,13 @@ mod tests {
         #[derive(Reflect)]
         enum Color {
             Transparent,
-            Grayscale(#[reflect(@(min = 0.0, max = 1.0))] f32),
+            Grayscale(#[reflect(@min = 0.0, @max = 1.0)] f32),
             Rgb {
-                #[reflect(@(min = 0u8, max = 255u8))]
+                #[reflect(@min = 0u8, @max = 255u8)]
                 r: u8,
-                #[reflect(@(min = 0u8, max = 255u8))]
+                #[reflect(@min = 0u8, @max = 255u8)]
                 g: u8,
-                #[reflect(@(min = 0u8, max = 255u8))]
+                #[reflect(@min = 0u8, @max = 255u8)]
                 b: u8,
             },
         }

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -137,11 +137,21 @@ mod tests {
     }
 
     #[test]
-    fn should_create_custom_attributes() {
+    fn should_get_custom_attribute() {
         let attributes = CustomAttributes::default().with_attribute(0.0..=1.0);
 
         let value = attributes.get::<RangeInclusive<f64>>().unwrap();
         assert_eq!(&(0.0..=1.0), value);
+    }
+
+    #[test]
+    fn should_get_custom_attribute_dynamically() {
+        let attributes = CustomAttributes::default().with_attribute(String::from("Hello, World!"));
+
+        let value = attributes.get_by_id(TypeId::of::<String>()).unwrap();
+        assert!(value
+            .reflect_partial_eq(&String::from("Hello, World!"))
+            .unwrap());
     }
 
     #[test]

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -1,0 +1,121 @@
+use crate::Reflect;
+use alloc::borrow::Cow;
+use bevy_utils::HashMap;
+use core::fmt::{Debug, Formatter};
+use core::hash::Hash;
+
+#[derive(Debug, Default)]
+pub struct CustomAttributes {
+    attributes: HashMap<Cow<'static, str>, CustomAttribute>,
+}
+
+impl CustomAttributes {
+    pub fn with_attribute<T: Reflect>(
+        mut self,
+        name: impl Into<Cow<'static, str>>,
+        value: T,
+    ) -> Self {
+        self.attributes
+            .insert(name.into(), CustomAttribute::new(value));
+
+        self
+    }
+
+    pub fn contains<K>(&self, name: &K) -> bool
+    where
+        Cow<'static, str>: core::borrow::Borrow<K>,
+        K: Eq + Hash + ?Sized,
+    {
+        self.attributes.contains_key(name)
+    }
+
+    pub fn get<K>(&self, name: &K) -> Option<&CustomAttribute>
+    where
+        Cow<'static, str>: core::borrow::Borrow<K>,
+        K: Eq + Hash + ?Sized,
+    {
+        self.attributes.get(name)
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = (&str, &CustomAttribute)> {
+        self.attributes.iter().map(|(k, v)| (k.as_ref(), v))
+    }
+
+    pub fn len(&self) -> usize {
+        self.attributes.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.attributes.is_empty()
+    }
+}
+
+pub struct CustomAttribute {
+    value: Box<dyn Reflect>,
+}
+
+impl CustomAttribute {
+    pub fn new<T: Reflect>(value: T) -> Self {
+        Self {
+            value: Box::new(value),
+        }
+    }
+
+    pub fn value<T: Reflect>(&self) -> Option<&T> {
+        self.value.downcast_ref()
+    }
+
+    pub fn reflect_value(&self) -> &dyn Reflect {
+        &*self.value
+    }
+}
+
+impl Debug for CustomAttribute {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        self.value.debug(f)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as bevy_reflect;
+
+    #[test]
+    fn should_create_custom_attributes() {
+        let attributes = CustomAttributes::default()
+            .with_attribute("min", 0.0_f32)
+            .with_attribute("max", 1.0_f32);
+
+        let value = attributes.get("max").unwrap().value::<f32>();
+
+        assert_eq!(Some(&1.0), value);
+    }
+
+    #[test]
+    fn should_debug_custom_attributes() {
+        let attributes = CustomAttributes::default()
+            .with_attribute("label", String::from("My awesome custom attribute!"));
+
+        let debug = format!("{:?}", attributes);
+
+        assert_eq!(
+            r#"CustomAttributes { attributes: {"label": "My awesome custom attribute!"} }"#,
+            debug
+        );
+
+        #[derive(Reflect)]
+        struct Foo {
+            value: i32,
+        }
+
+        let attributes = CustomAttributes::default().with_attribute("foo", Foo { value: 42 });
+
+        let debug = format!("{:?}", attributes);
+
+        assert_eq!(
+            r#"CustomAttributes { attributes: {"foo": bevy_reflect::attributes::tests::Foo { value: 42 }} }"#,
+            debug
+        );
+    }
+}

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -342,4 +342,23 @@ mod tests {
         assert_eq!(Some(&0), min);
         assert_eq!(Some(&255), max);
     }
+
+    #[test]
+    fn should_treat_path_as_bool_when_no_value_is_given() {
+        #[derive(Reflect)]
+        struct Foo {
+            #[reflect(@bar)]
+            value: i32,
+        }
+
+        let TypeInfo::Struct(info) = Foo::type_info() else {
+            panic!("expected struct info");
+        };
+
+        let field_attributes = info.field("value").unwrap().custom_attributes();
+
+        let bar = field_attributes.get("bar").unwrap().value::<bool>();
+
+        assert_eq!(Some(&true), bar);
+    }
 }

--- a/crates/bevy_reflect/src/attributes.rs
+++ b/crates/bevy_reflect/src/attributes.rs
@@ -242,6 +242,56 @@ mod tests {
     }
 
     #[test]
+    fn should_derive_custom_attributes_on_enum_variants() {
+        #[derive(Reflect)]
+        enum Color {
+            #[reflect(@(display = "toggle"))]
+            Transparent,
+            #[reflect(@(display = "slider"))]
+            Grayscale(f32),
+            #[reflect(@(display = "picker"))]
+            Rgb { r: u8, g: u8, b: u8 },
+        }
+
+        let TypeInfo::Enum(info) = Color::type_info() else {
+            panic!("expected enum info");
+        };
+
+        let VariantInfo::Unit(transparent_variant) = info.variant("Transparent").unwrap() else {
+            panic!("expected unit variant");
+        };
+
+        let display = transparent_variant
+            .custom_attributes()
+            .get("display")
+            .unwrap()
+            .value::<&str>();
+        assert_eq!(Some(&"toggle"), display);
+
+        let VariantInfo::Tuple(grayscale_variant) = info.variant("Grayscale").unwrap() else {
+            panic!("expected tuple variant");
+        };
+
+        let display = grayscale_variant
+            .custom_attributes()
+            .get("display")
+            .unwrap()
+            .value::<&str>();
+        assert_eq!(Some(&"slider"), display);
+
+        let VariantInfo::Struct(rgb_variant) = info.variant("Rgb").unwrap() else {
+            panic!("expected struct variant");
+        };
+
+        let display = rgb_variant
+            .custom_attributes()
+            .get("display")
+            .unwrap()
+            .value::<&str>();
+        assert_eq!(Some(&"picker"), display);
+    }
+
+    #[test]
     fn should_derive_custom_attributes_on_enum_variant_fields() {
         #[derive(Reflect)]
         enum Color {

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,4 +1,4 @@
-use crate::attributes::CustomAttributes;
+use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{DynamicEnum, Reflect, TypePath, TypePathTable, VariantInfo, VariantType};
 use bevy_utils::HashMap;
 use std::any::{Any, TypeId};
@@ -258,16 +258,13 @@ impl EnumInfo {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The custom attributes of this enum.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this enum, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "enum");
 }
 
 /// An iterator over the fields in the current enum variant.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -264,7 +264,7 @@ impl EnumInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "enum");
+    impl_custom_attribute_methods!(self.custom_attributes, "enum");
 }
 
 /// An iterator over the fields in the current enum variant.

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -1,7 +1,9 @@
+use crate::attributes::CustomAttributes;
 use crate::{DynamicEnum, Reflect, TypePath, TypePathTable, VariantInfo, VariantType};
 use bevy_utils::HashMap;
 use std::any::{Any, TypeId};
 use std::slice::Iter;
+use std::sync::Arc;
 
 /// A trait used to power [enum-like] operations via [reflection].
 ///
@@ -138,6 +140,7 @@ pub struct EnumInfo {
     variants: Box<[VariantInfo]>,
     variant_names: Box<[&'static str]>,
     variant_indices: HashMap<&'static str, usize>,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -164,6 +167,7 @@ impl EnumInfo {
             variants: variants.to_vec().into_boxed_slice(),
             variant_names,
             variant_indices,
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -173,6 +177,14 @@ impl EnumInfo {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this enum.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// A slice containing the names of all variants in order.
@@ -244,6 +256,11 @@ impl EnumInfo {
     /// Check if the given type matches the enum type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The custom attributes of this enum.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
     }
 
     /// The docstring of this enum, if any.

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -84,6 +84,16 @@ impl VariantInfo {
             Self::Unit(info) => info.docs(),
         }
     }
+
+    impl_custom_attribute_methods!(
+        self,
+        match self {
+            Self::Struct(info) => info.custom_attributes(),
+            Self::Tuple(info) => info.custom_attributes(),
+            Self::Unit(info) => info.custom_attributes(),
+        },
+        "variant"
+    );
 }
 
 /// Type info for struct variants.
@@ -179,7 +189,7 @@ impl StructVariantInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "variant");
+    impl_custom_attribute_methods!(self.custom_attributes, "variant");
 }
 
 /// Type info for tuple variants.
@@ -244,7 +254,7 @@ impl TupleVariantInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "variant");
+    impl_custom_attribute_methods!(self.custom_attributes, "variant");
 }
 
 /// Type info for unit variants.
@@ -292,5 +302,5 @@ impl UnitVariantInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "variant");
+    impl_custom_attribute_methods!(self.custom_attributes, "variant");
 }

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -1,4 +1,4 @@
-use crate::attributes::CustomAttributes;
+use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{NamedField, UnnamedField};
 use bevy_utils::HashMap;
 use std::slice::Iter;
@@ -173,16 +173,13 @@ impl StructVariantInfo {
             .collect()
     }
 
-    /// The custom attributes of this variant.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "variant");
 }
 
 /// Type info for tuple variants.
@@ -241,16 +238,13 @@ impl TupleVariantInfo {
         self.fields.len()
     }
 
-    /// The custom attributes of this variant.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "variant");
 }
 
 /// Type info for unit variants.
@@ -292,14 +286,11 @@ impl UnitVariantInfo {
         self.name
     }
 
-    /// The custom attributes of this variant.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "variant");
 }

--- a/crates/bevy_reflect/src/enums/variants.rs
+++ b/crates/bevy_reflect/src/enums/variants.rs
@@ -1,6 +1,8 @@
+use crate::attributes::CustomAttributes;
 use crate::{NamedField, UnnamedField};
 use bevy_utils::HashMap;
 use std::slice::Iter;
+use std::sync::Arc;
 
 /// Describes the form of an enum variant.
 #[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
@@ -91,6 +93,7 @@ pub struct StructVariantInfo {
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -105,6 +108,7 @@ impl StructVariantInfo {
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -114,6 +118,14 @@ impl StructVariantInfo {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this variant.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// The name of this variant.
@@ -161,6 +173,11 @@ impl StructVariantInfo {
             .collect()
     }
 
+    /// The custom attributes of this variant.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
+    }
+
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
@@ -173,6 +190,7 @@ impl StructVariantInfo {
 pub struct TupleVariantInfo {
     name: &'static str,
     fields: Box<[UnnamedField]>,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -183,6 +201,7 @@ impl TupleVariantInfo {
         Self {
             name,
             fields: fields.to_vec().into_boxed_slice(),
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -192,6 +211,14 @@ impl TupleVariantInfo {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this variant.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// The name of this variant.
@@ -214,6 +241,11 @@ impl TupleVariantInfo {
         self.fields.len()
     }
 
+    /// The custom attributes of this variant.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
+    }
+
     /// The docstring of this variant, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
@@ -225,6 +257,7 @@ impl TupleVariantInfo {
 #[derive(Clone, Debug)]
 pub struct UnitVariantInfo {
     name: &'static str,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -234,6 +267,7 @@ impl UnitVariantInfo {
     pub fn new(name: &'static str) -> Self {
         Self {
             name,
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -245,9 +279,22 @@ impl UnitVariantInfo {
         Self { docs, ..self }
     }
 
+    /// Sets the custom attributes for this variant.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
+    }
+
     /// The name of this variant.
     pub fn name(&self) -> &'static str {
         self.name
+    }
+
+    /// The custom attributes of this variant.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
     }
 
     /// The docstring of this variant, if any.

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,5 +1,7 @@
+use crate::attributes::CustomAttributes;
 use crate::{Reflect, TypePath, TypePathTable};
 use std::any::{Any, TypeId};
+use std::sync::Arc;
 
 /// The named field of a reflected struct.
 #[derive(Clone, Debug)]
@@ -7,6 +9,7 @@ pub struct NamedField {
     name: &'static str,
     type_path: TypePathTable,
     type_id: TypeId,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -18,6 +21,7 @@ impl NamedField {
             name,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -27,6 +31,14 @@ impl NamedField {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this field.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// The name of the field.
@@ -61,6 +73,11 @@ impl NamedField {
         TypeId::of::<T>() == self.type_id
     }
 
+    /// The custom attributes of this field.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
+    }
+
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
@@ -74,6 +91,7 @@ pub struct UnnamedField {
     index: usize,
     type_path: TypePathTable,
     type_id: TypeId,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -84,6 +102,7 @@ impl UnnamedField {
             index,
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -93,6 +112,14 @@ impl UnnamedField {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this field.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// Returns the index of the field.
@@ -125,6 +152,11 @@ impl UnnamedField {
     /// Check if the given type matches the field type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The custom attributes of this field.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
     }
 
     /// The docstring of this field, if any.

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -1,4 +1,4 @@
-use crate::attributes::CustomAttributes;
+use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{Reflect, TypePath, TypePathTable};
 use std::any::{Any, TypeId};
 use std::sync::Arc;
@@ -73,16 +73,13 @@ impl NamedField {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The custom attributes of this field.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "field");
 }
 
 /// The unnamed field of a reflected tuple or tuple struct.
@@ -154,14 +151,11 @@ impl UnnamedField {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The custom attributes of this field.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this field, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "field");
 }

--- a/crates/bevy_reflect/src/fields.rs
+++ b/crates/bevy_reflect/src/fields.rs
@@ -79,7 +79,7 @@ impl NamedField {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "field");
+    impl_custom_attribute_methods!(self.custom_attributes, "field");
 }
 
 /// The unnamed field of a reflected tuple or tuple struct.
@@ -157,5 +157,5 @@ impl UnnamedField {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "field");
+    impl_custom_attribute_methods!(self.custom_attributes, "field");
 }

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2089,15 +2089,6 @@ bevy_reflect::tests::Test {
     }
 
     #[test]
-    fn should_allow_custom_attributes() {
-        #[derive(Reflect)]
-        struct Slider {
-            #[reflect(@(min = 0.0, max = 1.0))]
-            value: f32,
-        }
-    }
-
-    #[test]
     fn should_allow_custom_where() {
         #[derive(Reflect)]
         #[reflect(where T: Default)]

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -511,6 +511,7 @@ mod impls {
     mod uuid;
 }
 
+pub mod attributes;
 mod enums;
 pub mod serde;
 pub mod std_traits;

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -2088,6 +2088,15 @@ bevy_reflect::tests::Test {
     }
 
     #[test]
+    fn should_allow_custom_attributes() {
+        #[derive(Reflect)]
+        struct Slider {
+            #[reflect(@(min = 0.0, max = 1.0))]
+            value: f32,
+        }
+    }
+
+    #[test]
     fn should_allow_custom_where() {
         #[derive(Reflect)]
         #[reflect(where T: Default)]

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -195,7 +195,7 @@ impl StructInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "struct");
+    impl_custom_attribute_methods!(self.custom_attributes, "struct");
 }
 
 /// An iterator over the field values of a struct.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,4 +1,4 @@
-use crate::attributes::CustomAttributes;
+use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{
     self as bevy_reflect, ApplyError, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, TypeInfo, TypePath, TypePathTable,
@@ -189,16 +189,13 @@ impl StructInfo {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The custom attributes of this struct.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this struct, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "struct");
 }
 
 /// An iterator over the field values of a struct.

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,3 +1,4 @@
+use crate::attributes::CustomAttributes;
 use crate::{
     self as bevy_reflect, ApplyError, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, TypeInfo, TypePath, TypePathTable,
@@ -5,6 +6,7 @@ use crate::{
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::HashMap;
 use std::fmt::{Debug, Formatter};
+use std::sync::Arc;
 use std::{
     any::{Any, TypeId},
     borrow::Cow,
@@ -81,6 +83,7 @@ pub struct StructInfo {
     fields: Box<[NamedField]>,
     field_names: Box<[&'static str]>,
     field_indices: HashMap<&'static str, usize>,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -107,6 +110,7 @@ impl StructInfo {
             fields: fields.to_vec().into_boxed_slice(),
             field_names,
             field_indices,
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -116,6 +120,14 @@ impl StructInfo {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this struct.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// A slice containing the names of all fields in order.
@@ -175,6 +187,11 @@ impl StructInfo {
     /// Check if the given type matches the struct type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The custom attributes of this struct.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
     }
 
     /// The docstring of this struct, if any.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,6 +1,6 @@
 use bevy_reflect_derive::impl_type_path;
 
-use crate::attributes::CustomAttributes;
+use crate::attributes::{impl_custom_attribute_methods, CustomAttributes};
 use crate::{
     self as bevy_reflect, ApplyError, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField,
@@ -140,16 +140,13 @@ impl TupleStructInfo {
         TypeId::of::<T>() == self.type_id
     }
 
-    /// The custom attributes of this struct.
-    pub fn custom_attributes(&self) -> &CustomAttributes {
-        &self.custom_attributes
-    }
-
     /// The docstring of this struct, if any.
     #[cfg(feature = "documentation")]
     pub fn docs(&self) -> Option<&'static str> {
         self.docs
     }
+
+    impl_custom_attribute_methods!(custom_attributes, "struct");
 }
 
 /// An iterator over the field values of a tuple struct.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -146,7 +146,7 @@ impl TupleStructInfo {
         self.docs
     }
 
-    impl_custom_attribute_methods!(custom_attributes, "struct");
+    impl_custom_attribute_methods!(self.custom_attributes, "struct");
 }
 
 /// An iterator over the field values of a tuple struct.

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,5 +1,6 @@
 use bevy_reflect_derive::impl_type_path;
 
+use crate::attributes::CustomAttributes;
 use crate::{
     self as bevy_reflect, ApplyError, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned,
     ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField,
@@ -7,6 +8,7 @@ use crate::{
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
+use std::sync::Arc;
 
 /// A trait used to power [tuple struct-like] operations via [reflection].
 ///
@@ -59,6 +61,7 @@ pub struct TupleStructInfo {
     type_path: TypePathTable,
     type_id: TypeId,
     fields: Box<[UnnamedField]>,
+    custom_attributes: Arc<CustomAttributes>,
     #[cfg(feature = "documentation")]
     docs: Option<&'static str>,
 }
@@ -75,6 +78,7 @@ impl TupleStructInfo {
             type_path: TypePathTable::of::<T>(),
             type_id: TypeId::of::<T>(),
             fields: fields.to_vec().into_boxed_slice(),
+            custom_attributes: Arc::new(CustomAttributes::default()),
             #[cfg(feature = "documentation")]
             docs: None,
         }
@@ -84,6 +88,14 @@ impl TupleStructInfo {
     #[cfg(feature = "documentation")]
     pub fn with_docs(self, docs: Option<&'static str>) -> Self {
         Self { docs, ..self }
+    }
+
+    /// Sets the custom attributes for this struct.
+    pub fn with_custom_attributes(self, custom_attributes: CustomAttributes) -> Self {
+        Self {
+            custom_attributes: Arc::new(custom_attributes),
+            ..self
+        }
     }
 
     /// Get the field at the given index.
@@ -126,6 +138,11 @@ impl TupleStructInfo {
     /// Check if the given type matches the tuple struct type.
     pub fn is<T: Any>(&self) -> bool {
         TypeId::of::<T>() == self.type_id
+    }
+
+    /// The custom attributes of this struct.
+    pub fn custom_attributes(&self) -> &CustomAttributes {
+        &self.custom_attributes
     }
 
     /// The docstring of this struct, if any.

--- a/examples/README.md
+++ b/examples/README.md
@@ -321,6 +321,7 @@ Example | Description
 
 Example | Description
 --- | ---
+[Custom Attributes](../examples/reflection/custom_attributes.rs) | Registering and accessing custom attributes on reflected types
 [Dynamic Types](../examples/reflection/dynamic_types.rs) | How dynamic types are used with reflection
 [Generic Reflection](../examples/reflection/generic_reflection.rs) | Registers concrete instances of generic types that may be used with reflection
 [Reflection](../examples/reflection/reflection.rs) | Demonstrates how reflection in Bevy provides a way to dynamically interact with Rust types

--- a/examples/reflection/custom_attributes.rs
+++ b/examples/reflection/custom_attributes.rs
@@ -1,0 +1,90 @@
+//! Demonstrates how to register and access custom attributes on reflected types.
+
+use bevy::reflect::{Reflect, TypeInfo, Typed};
+use std::any::TypeId;
+use std::ops::RangeInclusive;
+
+fn main() {
+    // Bevy supports statically registering custom attribute data on reflected types,
+    // which can then be accessed at runtime via the type's `TypeInfo`.
+    // Attributes are registered using the `#[reflect(@...)]` syntax,
+    // where the `...` is any expression that resolves to a value which implements `Reflect`.
+    // Note that these attributes are stored based on their type:
+    // if two attributes have the same type, the second one will overwrite the first.
+
+    // Here is an example of registering custom attributes on a type:
+    #[derive(Reflect)]
+    struct Slider {
+        #[reflect(@RangeInclusive::<f32>::new(0.0, 1.0))]
+        // Alternatively, we could have used the `0.0..=1.0` syntax,
+        // but remember to ensure the type is the one you want!
+        #[reflect(@0.0..=1.0_f32)]
+        value: f32,
+    }
+
+    // Now, we can access the custom attributes at runtime:
+    let TypeInfo::Struct(type_info) = Slider::type_info() else {
+        panic!("expected struct");
+    };
+
+    let field = type_info.field("value").unwrap();
+
+    let range = field.get_attribute::<RangeInclusive<f32>>().unwrap();
+    assert_eq!(*range, 0.0..=1.0);
+
+    // And remember that our attributes can be any type that implements `Reflect`:
+    #[derive(Reflect)]
+    struct Required;
+
+    #[derive(Reflect, PartialEq, Debug)]
+    struct Tooltip(String);
+
+    impl Tooltip {
+        fn new(text: &str) -> Self {
+            Self(text.to_string())
+        }
+    }
+
+    #[derive(Reflect)]
+    #[reflect(@Required, @Tooltip::new("An ID is required!"))]
+    struct Id(u8);
+
+    let TypeInfo::TupleStruct(type_info) = Id::type_info() else {
+        panic!("expected struct");
+    };
+
+    // We can check if an attribute simply exists on our type:
+    assert!(type_info.has_attribute::<Required>());
+
+    // We can also get attribute data dynamically:
+    let some_type_id = TypeId::of::<Tooltip>();
+
+    let tooltip: &dyn Reflect = type_info.get_attribute_by_id(some_type_id).unwrap();
+    assert_eq!(
+        tooltip.downcast_ref::<Tooltip>(),
+        Some(&Tooltip::new("An ID is required!"))
+    );
+
+    // And again, attributes of the same type will overwrite each other:
+    #[derive(Reflect)]
+    enum Status {
+        // This will result in `false` being stored:
+        #[reflect(@true)]
+        #[reflect(@false)]
+        Disabled,
+        // This will result in `true` being stored:
+        #[reflect(@false)]
+        #[reflect(@true)]
+        Enabled,
+    }
+
+    let TypeInfo::Enum(type_info) = Status::type_info() else {
+        panic!("expected enum");
+    };
+
+    let disabled = type_info.variant("Disabled").unwrap();
+    assert!(!disabled.get_attribute::<bool>().unwrap());
+
+    let enabled = type_info.variant("Enabled").unwrap();
+    assert!(enabled.get_attribute::<bool>().unwrap());
+}


### PR DESCRIPTION
# Objective

As work on the editor starts to ramp up, it might be nice to start allowing types to specify custom attributes. These can be used to provide certain functionality to fields, such as ranges or controlling how data is displayed.

A good example of this can be seen in [`bevy-inspector-egui`](https://github.com/jakobhellermann/bevy-inspector-egui) with its [`InspectorOptions`](https://docs.rs/bevy-inspector-egui/0.22.1/bevy_inspector_egui/struct.InspectorOptions.html):

```rust
#[derive(Reflect, Default, InspectorOptions)]
#[reflect(InspectorOptions)]
struct Slider {
    #[inspector(min = 0.0, max = 1.0)]
    value: f32,
}
```

Normally, as demonstrated in the example above, these attributes are handled by a derive macro and stored in a corresponding `TypeData` struct (i.e. `ReflectInspectorOptions`).

Ideally, we would have a good way of defining this directly via reflection so that users don't need to create and manage a whole proc macro just to allow these sorts of attributes.

And note that this doesn't have to just be for inspectors and editors. It can be used for things done purely on the code side of things.

## Solution

Create a new method for storing attributes on fields via the `Reflect` derive.

These custom attributes are stored in type info (e.g. `NamedField`, `StructInfo`, etc.).

```rust
#[derive(Reflect)]
struct Slider {
    #[reflect(@0.0..=1.0)]
    value: f64,
}

let TypeInfo::Struct(info) = Slider::type_info() else {
    panic!("expected struct info");
};

let field = info.field("value").unwrap();

let range = field.get_attribute::<RangeInclusive<f64>>().unwrap();
assert_eq!(*range, 0.0..=1.0);
```

## TODO

- [x] ~~Bikeshed syntax~~ Went with a type-based approach, prefixed by `@` for ease of parsing and flexibility
- [x] Add support for custom struct/tuple struct field attributes
- [x] Add support for custom enum variant field attributes
- [x] ~~Add support for custom enum variant attributes (maybe?)~~ ~~Will require a larger refactor. Can be saved for a future PR if we really want it.~~ Actually, we apparently still have support for variant attributes despite not using them, so it was pretty easy to add lol.
- [x] Add support for custom container attributes
- [x] Allow custom attributes to store any reflectable value (not just `Lit`)
- [x] ~~Store attributes in registry~~ This PR used to store these in attributes in the registry, however, it has since switched over to storing them in type info
- [x] Add example

## Bikeshedding

> [!note]
> This section was made for the old method of handling custom attributes, which stored them by name (i.e. `some_attribute = 123`). The PR has shifted away from that, to a more type-safe approach.
>
> This section has been left for reference.

There are a number of ways we can syntactically handle custom attributes. Feel free to leave a comment on your preferred one! Ideally we want one that is clear, readable, and concise since these will potentially see _a lot_ of use.

Below is a small, non-exhaustive list of them. Note that the `skip_serializing` reflection attribute is added to demonstrate how each case plays with existing reflection attributes.

<details>
<summary>List</summary>

##### 1. `@(name = value)`

> The `@` was chosen to make them stand out from other attributes and because the "at" symbol is a subtle pneumonic for "attribute". Of course, other symbols could be used (e.g. `$`, `#`, etc.).

```rust
#[derive(Reflect)]
struct Slider {
    #[reflect(@(min = 0.0, max = 1.0), skip_serializing)]
    #[[reflect(@(bevy_editor::hint = "Range: 0.0 to 1.0"))]
    value: f32,
}
```

##### 2. `@name = value`

> This is my personal favorite.

```rust
#[derive(Reflect)]
struct Slider {
    #[reflect(@min = 0.0, @max = 1.0, skip_serializing)]
    #[[reflect(@bevy_editor::hint = "Range: 0.0 to 1.0")]
    value: f32,
}
```

##### 3. `custom_attr(name = value)`

> `custom_attr` can be anything. Other possibilities include `with` or `tag`.

```rust
#[derive(Reflect)]
struct Slider {
    #[reflect(custom_attr(min = 0.0, max = 1.0), skip_serializing)]
    #[[reflect(custom_attr(bevy_editor::hint = "Range: 0.0 to 1.0"))]
    value: f32,
}
```

##### 4. `reflect_attr(name = value)`

```rust
#[derive(Reflect)]
struct Slider {
    #[reflect(skip_serializing)]
    #[reflect_attr(min = 0.0, max = 1.0)]
    #[[reflect_attr(bevy_editor::hint = "Range: 0.0 to 1.0")]
    value: f32,
}
```

</details>

---

## Changelog

- Added support for custom attributes on reflected types (i.e. `#[reflect(@Foo::new("bar")]`)
