### PR TITLE
Subtract 1 from text positions to account for glyph texture padding.

### DIFF
--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -136,7 +136,7 @@ impl GlyphBrush {
                     }
                 };
 
-                let position = adjust.position(Vec2::new(x, y));
+                let position = adjust.position(Vec2::new(x, y) - 1.);
 
                 positioned_glyphs.push(PositionedGlyph {
                     position,

--- a/crates/bevy_text/src/glyph_brush.rs
+++ b/crates/bevy_text/src/glyph_brush.rs
@@ -136,6 +136,8 @@ impl GlyphBrush {
                     }
                 };
 
+                // We must offset by 1 to account for glyph texture padding.
+                // See https://github.com/bevyengine/bevy/pull/11662
                 let position = adjust.position(Vec2::new(x, y) - 1.);
 
                 positioned_glyphs.push(PositionedGlyph {


### PR DESCRIPTION
# Objective

Glyph positions don't account for padding added to the font texture atlas, resulting in them being off by one physical pixel in both axis.

## Example
```rust
use bevy::{
    prelude::*, window::WindowResolution
};

fn main() {
    App::new()
        .add_plugins(DefaultPlugins.set(WindowPlugin {
            primary_window: Some(Window {
                resolution: WindowResolution::default().with_scale_factor_override(1.),
                ..Default::default()
            }),
            ..Default::default()
        }))
        .add_systems(Startup, setup)
        .run();
}

fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
    commands.spawn(Camera2dBundle::default());
    commands.spawn(
        TextBundle::from_section(
            "QQQQQ",
            TextStyle {
                font: asset_server.load("FiraMono-Medium.ttf"),
                font_size: 14.0,
                ..default()
            },
        )
        .with_style(Style {
            left:Val::Px(10.),
            top: Val::Px(10.),
            ..default()
        })
        .with_background_color(Color::RED)
    );
}
```

<img width="350" alt="QQQQQ-bad" src="https://github.com/bevyengine/bevy/assets/27962798/6a509aee-64c8-4ee8-a8c1-77ee65355898">

The coordinates are off by one in physical coordinates, not logical. So the difference only becomes obvious with `UiScale` and the window scale factor set to low values.

## Solution

Translate glyph positions by -1 in both axes.

<img width="300" alt="QQQQQ-good" src="https://github.com/bevyengine/bevy/assets/27962798/16e3f6d9-1223-48e0-9fdd-b682a3e8ade4">

---

## Changelog

* Translate the positions for each glyph by -1 in both axes in `bevy_text::glyph_brush::process_glyphs`