### PR TITLE
Add `ReflectKind`

### DIFF
--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,6 +1,9 @@
 use crate::io::AssetSourceId;
 use bevy_reflect::{
-    std_traits::ReflectDefault, utility::NonGenericTypeInfoCell, FromReflect, FromType, GetTypeRegistration, Reflect, ReflectDeserialize, ReflectFromPtr, ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, TypeInfo, TypePath, TypeRegistration, Typed, ValueInfo
+    std_traits::ReflectDefault, utility::NonGenericTypeInfoCell, FromReflect, FromType,
+    GetTypeRegistration, Reflect, ReflectDeserialize, ReflectFromPtr, ReflectFromReflect,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, TypeInfo, TypePath,
+    TypeRegistration, Typed, ValueInfo,
 };
 use bevy_utils::CowArc;
 use serde::{de::Visitor, Deserialize, Serialize};

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -1,9 +1,6 @@
 use crate::io::AssetSourceId;
 use bevy_reflect::{
-    std_traits::ReflectDefault, utility::NonGenericTypeInfoCell, FromReflect, FromType,
-    GetTypeRegistration, Reflect, ReflectDeserialize, ReflectFromPtr, ReflectFromReflect,
-    ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, TypeInfo, TypePath, TypeRegistration,
-    Typed, ValueInfo,
+    std_traits::ReflectDefault, utility::NonGenericTypeInfoCell, FromReflect, FromType, GetTypeRegistration, Reflect, ReflectDeserialize, ReflectFromPtr, ReflectFromReflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, ReflectSerialize, TypeInfo, TypePath, TypeRegistration, Typed, ValueInfo
 };
 use bevy_utils::CowArc;
 use serde::{de::Visitor, Deserialize, Serialize};
@@ -680,6 +677,9 @@ impl Reflect for AssetPath<'static> {
     ) -> Result<(), Box<dyn bevy_reflect::Reflect>> {
         *self = <dyn bevy_reflect::Reflect>::take(value)?;
         Ok(())
+    }
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Value
     }
     fn reflect_ref(&self) -> ReflectRef {
         ReflectRef::Value(self)

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -264,6 +264,10 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 }
             }
 
+            fn reflect_kind(&self) -> #bevy_reflect_path::ReflectKind {
+                #bevy_reflect_path::ReflectKind::Enum
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::Enum(self)
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/structs.rs
@@ -219,6 +219,10 @@ pub(crate) fn impl_struct(reflect_struct: &ReflectStruct) -> proc_macro2::TokenS
                 }
             }
 
+            fn reflect_kind(&self) -> #bevy_reflect_path::ReflectKind {
+                #bevy_reflect_path::ReflectKind::Struct
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::Struct(self)
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/tuple_structs.rs
@@ -187,6 +187,10 @@ pub(crate) fn impl_tuple_struct(reflect_struct: &ReflectStruct) -> proc_macro2::
                 }
             }
 
+            fn reflect_kind(&self) -> #bevy_reflect_path::ReflectKind {
+                #bevy_reflect_path::ReflectKind::TupleStruct
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::TupleStruct(self)
             }

--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/values.rs
@@ -101,6 +101,10 @@ pub(crate) fn impl_value(meta: &ReflectMeta) -> proc_macro2::TokenStream {
                 #FQResult::Ok(())
             }
 
+            fn reflect_kind(&self) -> #bevy_reflect_path::ReflectKind {
+                #bevy_reflect_path::ReflectKind::Value
+            }
+
             fn reflect_ref(&self) -> #bevy_reflect_path::ReflectRef {
                 #bevy_reflect_path::ReflectRef::Value(self)
             }

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,6 +1,5 @@
 use crate::{
-    self as bevy_reflect, utility::reflect_hasher, Reflect, ReflectMut, ReflectOwned, ReflectRef,
-    TypeInfo, TypePath, TypePathTable,
+    self as bevy_reflect, utility::reflect_hasher, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
 };
 use bevy_reflect_derive::impl_type_path;
 use std::{
@@ -266,6 +265,11 @@ impl Reflect for DynamicArray {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Array
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/array.rs
+++ b/crates/bevy_reflect/src/array.rs
@@ -1,5 +1,6 @@
 use crate::{
-    self as bevy_reflect, utility::reflect_hasher, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
+    self as bevy_reflect, utility::reflect_hasher, Reflect, ReflectKind, ReflectMut, ReflectOwned,
+    ReflectRef, TypeInfo, TypePath, TypePathTable,
 };
 use bevy_reflect_derive::impl_type_path;
 use std::{

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -1,9 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, DynamicStruct, DynamicTuple,
-    Enum, Reflect, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, VariantFieldIter,
-    VariantType,
+    self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, DynamicStruct, DynamicTuple, Enum, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, VariantFieldIter, VariantType
 };
 use std::any::Any;
 use std::fmt::Formatter;
@@ -377,6 +375,11 @@ impl Reflect for DynamicEnum {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Enum
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -1,7 +1,9 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, DynamicStruct, DynamicTuple, Enum, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo, VariantFieldIter, VariantType
+    self as bevy_reflect, enum_debug, enum_hash, enum_partial_eq, DynamicStruct, DynamicTuple,
+    Enum, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Struct, Tuple, TypeInfo,
+    VariantFieldIter, VariantType,
 };
 use std::any::Any;
 use std::fmt::Formatter;

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -6,7 +6,9 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter, Reflect, ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed
+    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter,
+    Reflect, ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
+    TypeRegistration, Typed,
 };
 
 impl<T: smallvec::Array + TypePath + Send + Sync> List for SmallVec<T>

--- a/crates/bevy_reflect/src/impls/smallvec.rs
+++ b/crates/bevy_reflect/src/impls/smallvec.rs
@@ -6,9 +6,7 @@ use std::any::Any;
 
 use crate::utility::GenericTypeInfoCell;
 use crate::{
-    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter,
-    Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypeRegistration, Typed,
+    self as bevy_reflect, FromReflect, FromType, GetTypeRegistration, List, ListInfo, ListIter, Reflect, ReflectFromPtr, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed
 };
 
 impl<T: smallvec::Array + TypePath + Send + Sync> List for SmallVec<T>
@@ -117,6 +115,10 @@ where
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::List
     }
 
     fn reflect_ref(&self) -> ReflectRef {

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -3,8 +3,8 @@ use crate::{self as bevy_reflect, ReflectFromPtr, ReflectFromReflect, ReflectOwn
 use crate::{
     impl_type_path, map_apply, map_partial_eq, Array, ArrayInfo, ArrayIter, DynamicEnum,
     DynamicMap, Enum, EnumInfo, FromReflect, FromType, GetTypeRegistration, List, ListInfo,
-    ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectMut, ReflectRef,
-    ReflectSerialize, TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed,
+    ListIter, Map, MapInfo, MapIter, Reflect, ReflectDeserialize, ReflectKind, ReflectMut,
+    ReflectRef, ReflectSerialize, TupleVariantInfo, TypeInfo, TypePath, TypeRegistration, Typed,
     UnitVariantInfo, UnnamedField, ValueInfo, VariantFieldIter, VariantInfo, VariantType,
 };
 
@@ -317,6 +317,10 @@ macro_rules! impl_reflect_for_veclike {
                 Ok(())
             }
 
+            fn reflect_kind(&self) -> ReflectKind {
+                ReflectKind::List
+            }
+
             fn reflect_ref(&self) -> ReflectRef {
                 ReflectRef::List(self)
             }
@@ -535,6 +539,10 @@ macro_rules! impl_reflect_for_hashmap {
                 Ok(())
             }
 
+            fn reflect_kind(&self) -> ReflectKind {
+                ReflectKind::Map
+            }
+
             fn reflect_ref(&self) -> ReflectRef {
                 ReflectRef::Map(self)
             }
@@ -685,6 +693,11 @@ impl<T: Reflect + TypePath, const N: usize> Reflect for [T; N] {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Array
     }
 
     #[inline]
@@ -935,6 +948,10 @@ impl<T: FromReflect + TypePath> Reflect for Option<T> {
         Ok(())
     }
 
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Enum
+    }
+
     fn reflect_ref(&self) -> ReflectRef {
         ReflectRef::Enum(self)
     }
@@ -1078,6 +1095,10 @@ impl Reflect for Cow<'static, str> {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Value
     }
 
     fn reflect_ref(&self) -> ReflectRef {
@@ -1253,6 +1274,10 @@ impl<T: FromReflect + Clone + TypePath> Reflect for Cow<'static, [T]> {
         Ok(())
     }
 
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::List
+    }
+
     fn reflect_ref(&self) -> ReflectRef {
         ReflectRef::List(self)
     }
@@ -1346,6 +1371,10 @@ impl Reflect for &'static Path {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Value
     }
 
     fn reflect_ref(&self) -> ReflectRef {
@@ -1443,6 +1472,10 @@ impl Reflect for Cow<'static, Path> {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Value
     }
 
     fn reflect_ref(&self) -> ReflectRef {

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -90,8 +90,8 @@
 //! Since most data is passed around as `dyn Reflect`,
 //! the `Reflect` trait has methods for going to and from these subtraits.
 //!
-//! [`Reflect::reflect_ref`], [`Reflect::reflect_mut`], and [`Reflect::reflect_owned`] all return
-//! an enum that respectively contains immutable, mutable, and owned access to the type as a subtrait object.
+//! [`Reflect::reflect_kind`], [`Reflect::reflect_ref`], [`Reflect::reflect_mut`], and [`Reflect::reflect_owned`] all return
+//! an enum that respectively contains zero-sized, immutable, mutable, and owned access to the type as a subtrait object.
 //!
 //! For example, we can get out a `dyn Tuple` from our reflected tuple type using one of these methods.
 //!

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -6,7 +6,8 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::utility::reflect_hasher;
 use crate::{
-    self as bevy_reflect, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
+    self as bevy_reflect, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    TypeInfo, TypePath, TypePathTable,
 };
 
 /// A trait used to power [list-like] operations via [reflection].

--- a/crates/bevy_reflect/src/list.rs
+++ b/crates/bevy_reflect/src/list.rs
@@ -6,8 +6,7 @@ use bevy_reflect_derive::impl_type_path;
 
 use crate::utility::reflect_hasher;
 use crate::{
-    self as bevy_reflect, FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-    TypePath, TypePathTable,
+    self as bevy_reflect, FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
 };
 
 /// A trait used to power [list-like] operations via [reflection].
@@ -316,6 +315,11 @@ impl Reflect for DynamicList {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::List
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -6,7 +6,8 @@ use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
 use crate::{
-    self as bevy_reflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
+    self as bevy_reflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
+    TypePath, TypePathTable,
 };
 
 /// A trait used to power [map-like] operations via [reflection].

--- a/crates/bevy_reflect/src/map.rs
+++ b/crates/bevy_reflect/src/map.rs
@@ -6,8 +6,7 @@ use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
 
 use crate::{
-    self as bevy_reflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
-    TypePathTable,
+    self as bevy_reflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
 };
 
 /// A trait used to power [map-like] operations via [reflection].
@@ -352,6 +351,10 @@ impl Reflect for DynamicMap {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Map
     }
 
     fn reflect_ref(&self) -> ReflectRef {

--- a/crates/bevy_reflect/src/path/access.rs
+++ b/crates/bevy_reflect/src/path/access.rs
@@ -2,8 +2,8 @@
 
 use std::{borrow::Cow, fmt};
 
-use super::error::{AccessErrorKind, TypeKind};
-use crate::{AccessError, Reflect, ReflectMut, ReflectRef, VariantType};
+use super::error::AccessErrorKind;
+use crate::{AccessError, Reflect, ReflectKind, ReflectMut, ReflectRef, VariantType};
 
 type InnerResult<T> = Result<T, AccessErrorKind>;
 
@@ -55,7 +55,7 @@ impl<'a> Access<'a> {
         offset: Option<usize>,
     ) -> Result<&'r dyn Reflect, AccessError<'a>> {
         self.element_inner(base)
-            .and_then(|opt| opt.ok_or(AccessErrorKind::MissingField(base.into())))
+            .and_then(|opt| opt.ok_or(AccessErrorKind::MissingField(base.reflect_kind())))
             .map_err(|err| err.with_access(self.clone(), offset))
     }
 
@@ -78,7 +78,7 @@ impl<'a> Access<'a> {
             },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
                 Err(AccessErrorKind::IncompatibleTypes {
-                    expected: TypeKind::Struct,
+                    expected: ReflectKind::Struct,
                     actual: actual.into(),
                 })
             }
@@ -90,14 +90,14 @@ impl<'a> Access<'a> {
                 actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
-                expected: TypeKind::Tuple,
+                expected: ReflectKind::Tuple,
                 actual: actual.into(),
             }),
 
             (&Self::ListIndex(index), List(list)) => Ok(list.get(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get(index)),
             (Self::ListIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
-                expected: TypeKind::List,
+                expected: ReflectKind::List,
                 actual: actual.into(),
             }),
         }
@@ -108,7 +108,7 @@ impl<'a> Access<'a> {
         base: &'r mut dyn Reflect,
         offset: Option<usize>,
     ) -> Result<&'r mut dyn Reflect, AccessError<'a>> {
-        let kind = base.into();
+        let kind = base.reflect_kind();
 
         self.element_inner_mut(base)
             .and_then(|maybe| maybe.ok_or(AccessErrorKind::MissingField(kind)))
@@ -137,7 +137,7 @@ impl<'a> Access<'a> {
             },
             (Self::Field(_) | Self::FieldIndex(_), actual) => {
                 Err(AccessErrorKind::IncompatibleTypes {
-                    expected: TypeKind::Struct,
+                    expected: ReflectKind::Struct,
                     actual: actual.into(),
                 })
             }
@@ -149,14 +149,14 @@ impl<'a> Access<'a> {
                 actual => Err(invalid_variant(VariantType::Tuple, actual)),
             },
             (Self::TupleIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
-                expected: TypeKind::Tuple,
+                expected: ReflectKind::Tuple,
                 actual: actual.into(),
             }),
 
             (&Self::ListIndex(index), List(list)) => Ok(list.get_mut(index)),
             (&Self::ListIndex(index), Array(list)) => Ok(list.get_mut(index)),
             (Self::ListIndex(_), actual) => Err(AccessErrorKind::IncompatibleTypes {
-                expected: TypeKind::List,
+                expected: ReflectKind::List,
                 actual: actual.into(),
             }),
         }

--- a/crates/bevy_reflect/src/path/error.rs
+++ b/crates/bevy_reflect/src/path/error.rs
@@ -1,22 +1,22 @@
 use std::fmt;
 
 use super::Access;
-use crate::{Reflect, ReflectMut, ReflectRef, VariantType};
+use crate::{ReflectKind, VariantType};
 
 /// The kind of [`AccessError`], along with some kind-specific information.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum AccessErrorKind {
     /// An error that occurs when a certain type doesn't
     /// contain the value referenced by the [`Access`].
-    MissingField(TypeKind),
+    MissingField(ReflectKind),
 
     /// An error that occurs when using an [`Access`] on the wrong type.
     /// (i.e. a [`ListIndex`](Access::ListIndex) on a struct, or a [`TupleIndex`](Access::TupleIndex) on a list)
     IncompatibleTypes {
-        /// The [`TypeKind`] that was expected based on the [`Access`].
-        expected: TypeKind,
-        /// The actual [`TypeKind`] that was found.
-        actual: TypeKind,
+        /// The [`ReflectKind`] that was expected based on the [`Access`].
+        expected: ReflectKind,
+        /// The actual [`ReflectKind`] that was found.
+        actual: ReflectKind,
     },
 
     /// An error that occurs when using an [`Access`] on the wrong enum variant.
@@ -127,81 +127,3 @@ impl std::fmt::Display for AccessError<'_> {
     }
 }
 impl std::error::Error for AccessError<'_> {}
-
-/// The kind of the type trying to be accessed.
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[allow(missing_docs /* Variants are self-explanatory */)]
-pub enum TypeKind {
-    Struct,
-    TupleStruct,
-    Tuple,
-    List,
-    Array,
-    Map,
-    Enum,
-    Value,
-    Unit,
-}
-
-impl fmt::Display for TypeKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            TypeKind::Struct => f.pad("struct"),
-            TypeKind::TupleStruct => f.pad("tuple struct"),
-            TypeKind::Tuple => f.pad("tuple"),
-            TypeKind::List => f.pad("list"),
-            TypeKind::Array => f.pad("array"),
-            TypeKind::Map => f.pad("map"),
-            TypeKind::Enum => f.pad("enum"),
-            TypeKind::Value => f.pad("value"),
-            TypeKind::Unit => f.pad("unit"),
-        }
-    }
-}
-impl From<ReflectRef<'_>> for TypeKind {
-    fn from(value: ReflectRef) -> Self {
-        match value {
-            ReflectRef::Struct(_) => TypeKind::Struct,
-            ReflectRef::TupleStruct(_) => TypeKind::TupleStruct,
-            ReflectRef::Tuple(_) => TypeKind::Tuple,
-            ReflectRef::List(_) => TypeKind::List,
-            ReflectRef::Array(_) => TypeKind::Array,
-            ReflectRef::Map(_) => TypeKind::Map,
-            ReflectRef::Enum(_) => TypeKind::Enum,
-            ReflectRef::Value(_) => TypeKind::Value,
-        }
-    }
-}
-impl From<&dyn Reflect> for TypeKind {
-    fn from(value: &dyn Reflect) -> Self {
-        value.reflect_ref().into()
-    }
-}
-impl From<ReflectMut<'_>> for TypeKind {
-    fn from(value: ReflectMut) -> Self {
-        match value {
-            ReflectMut::Struct(_) => TypeKind::Struct,
-            ReflectMut::TupleStruct(_) => TypeKind::TupleStruct,
-            ReflectMut::Tuple(_) => TypeKind::Tuple,
-            ReflectMut::List(_) => TypeKind::List,
-            ReflectMut::Array(_) => TypeKind::Array,
-            ReflectMut::Map(_) => TypeKind::Map,
-            ReflectMut::Enum(_) => TypeKind::Enum,
-            ReflectMut::Value(_) => TypeKind::Value,
-        }
-    }
-}
-impl From<&mut dyn Reflect> for TypeKind {
-    fn from(value: &mut dyn Reflect) -> Self {
-        value.reflect_ref().into()
-    }
-}
-impl From<VariantType> for TypeKind {
-    fn from(value: VariantType) -> Self {
-        match value {
-            VariantType::Struct => TypeKind::Struct,
-            VariantType::Tuple => TypeKind::Tuple,
-            VariantType::Unit => TypeKind::Unit,
-        }
-    }
-}

--- a/crates/bevy_reflect/src/path/mod.rs
+++ b/crates/bevy_reflect/src/path/mod.rs
@@ -493,7 +493,7 @@ mod tests {
     use super::*;
     use crate as bevy_reflect;
     use crate::*;
-    use error::{AccessErrorKind, TypeKind};
+    use error::AccessErrorKind;
 
     #[derive(Reflect)]
     struct A {
@@ -564,8 +564,8 @@ mod tests {
 
     fn invalid_access(
         offset: usize,
-        actual: TypeKind,
-        expected: TypeKind,
+        actual: ReflectKind,
+        expected: ReflectKind,
         access: &'static str,
     ) -> StaticError {
         ReflectPathError::InvalidAccess(AccessError {
@@ -735,7 +735,7 @@ mod tests {
         assert_eq!(
             a.reflect_path("x.notreal").err().unwrap(),
             ReflectPathError::InvalidAccess(AccessError {
-                kind: AccessErrorKind::MissingField(TypeKind::Struct),
+                kind: AccessErrorKind::MissingField(ReflectKind::Struct),
                 access: access_field("notreal"),
                 offset: Some(2),
             })
@@ -756,11 +756,11 @@ mod tests {
         );
         assert_eq!(
             a.reflect_path("x[0]").err().unwrap(),
-            invalid_access(2, TypeKind::Struct, TypeKind::List, "x[0]")
+            invalid_access(2, ReflectKind::Struct, ReflectKind::List, "x[0]")
         );
         assert_eq!(
             a.reflect_path("y.x").err().unwrap(),
-            invalid_access(2, TypeKind::List, TypeKind::Struct, "y.x")
+            invalid_access(2, ReflectKind::List, ReflectKind::Struct, "y.x")
         );
     }
 

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -10,12 +10,31 @@ use std::{
 
 use crate::utility::NonGenericTypeInfoCell;
 
-/// An immutable enumeration of "kinds" of reflected type.
+macro_rules! impl_reflect_enum {
+    ($name:ty) => {
+        impl $name {
+            pub fn kind(&self) -> ReflectKind {
+                match self {
+                    Self::Struct(_) => ReflectKind::Struct,
+                    Self::TupleStruct(_) => ReflectKind::TupleStruct,
+                    Self::Tuple(_) => ReflectKind::Tuple,
+                    Self::List(_) => ReflectKind::List,
+                    Self::Array(_) => ReflectKind::Array,
+                    Self::Map(_) => ReflectKind::Map,
+                    Self::Enum(_) => ReflectKind::Enum,
+                    Self::Value(_) => ReflectKind::Value,
+                }
+            }
+        }
+    };
+}
+
+/// An immutable enumeration of "kinds" of a reflected type.
 ///
 /// Each variant contains a trait object with methods specific to a kind of
 /// type.
 ///
-/// A `ReflectRef` is obtained via [`Reflect::reflect_ref`].
+/// A [`ReflectRef`] is obtained via [`Reflect::reflect_ref`].
 pub enum ReflectRef<'a> {
     Struct(&'a dyn Struct),
     TupleStruct(&'a dyn TupleStruct),
@@ -26,13 +45,14 @@ pub enum ReflectRef<'a> {
     Enum(&'a dyn Enum),
     Value(&'a dyn Reflect),
 }
+impl_reflect_enum!(ReflectRef<'_>);
 
-/// A mutable enumeration of "kinds" of reflected type.
+/// A mutable enumeration of "kinds" of a reflected type.
 ///
 /// Each variant contains a trait object with methods specific to a kind of
 /// type.
 ///
-/// A `ReflectMut` is obtained via [`Reflect::reflect_mut`].
+/// A [`ReflectMut`] is obtained via [`Reflect::reflect_mut`].
 pub enum ReflectMut<'a> {
     Struct(&'a mut dyn Struct),
     TupleStruct(&'a mut dyn TupleStruct),
@@ -43,13 +63,14 @@ pub enum ReflectMut<'a> {
     Enum(&'a mut dyn Enum),
     Value(&'a mut dyn Reflect),
 }
+impl_reflect_enum!(ReflectMut<'_>);
 
-/// An owned enumeration of "kinds" of reflected type.
+/// An owned enumeration of "kinds" of a reflected type.
 ///
 /// Each variant contains a trait object with methods specific to a kind of
 /// type.
 ///
-/// A `ReflectOwned` is obtained via [`Reflect::reflect_owned`].
+/// A [`ReflectOwned`] is obtained via [`Reflect::reflect_owned`].
 pub enum ReflectOwned {
     Struct(Box<dyn Struct>),
     TupleStruct(Box<dyn TupleStruct>),
@@ -59,6 +80,24 @@ pub enum ReflectOwned {
     Map(Box<dyn Map>),
     Enum(Box<dyn Enum>),
     Value(Box<dyn Reflect>),
+}
+impl_reflect_enum!(ReflectOwned);
+
+/// An enumuration of the "kinds" of a reflected type.
+///
+/// Each variant contains a trait object with methods specific to a kind of
+/// type.
+///
+/// A [`ReflectKind`] is obtained via [`ReflectRef::kind`], [`ReflectMut::kind`] or [`ReflectOwned::kind`].
+pub enum ReflectKind {
+    Struct,
+    TupleStruct,
+    Tuple,
+    List,
+    Array,
+    Map,
+    Enum,
+    Value,
 }
 
 /// The core trait of [`bevy_reflect`], used for accessing and modifying data dynamically.

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -228,10 +228,9 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// Returns an enumeration of "kinds" of type.
     ///
     /// See [`ReflectKind`].
-    fn reflect_kind(&self) -> ReflectKind;
-    //  {
-    //     self.reflect_ref().kind()
-    // }
+    fn reflect_kind(&self) -> ReflectKind {
+        self.reflect_ref().kind()
+    }
 
     /// Returns an immutable enumeration of "kinds" of type.
     ///

--- a/crates/bevy_reflect/src/reflect.rs
+++ b/crates/bevy_reflect/src/reflect.rs
@@ -225,7 +225,7 @@ pub trait Reflect: DynamicTypePath + Any + Send + Sync {
     /// containing the trait object.
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>>;
 
-    /// Returns an enumeration of "kinds" of type.
+    /// Returns a zero-sized enumeration of "kinds" of type.
     ///
     /// See [`ReflectKind`].
     fn reflect_kind(&self) -> ReflectKind {

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,5 +1,6 @@
 use crate::{
-    self as bevy_reflect, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
+    self as bevy_reflect, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    TypeInfo, TypePath, TypePathTable,
 };
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};

--- a/crates/bevy_reflect/src/struct_trait.rs
+++ b/crates/bevy_reflect/src/struct_trait.rs
@@ -1,6 +1,5 @@
 use crate::{
-    self as bevy_reflect, NamedField, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo,
-    TypePath, TypePathTable,
+    self as bevy_reflect, NamedField, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypePathTable
 };
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::{Entry, HashMap};
@@ -442,6 +441,11 @@ impl Reflect for DynamicStruct {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Struct
     }
 
     #[inline]

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,7 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::all_tuples;
 
-use crate::TypePathTable;
+use crate::{ReflectKind, TypePathTable};
 use crate::{
     self as bevy_reflect, utility::GenericTypePathCell, FromReflect, GetTypeRegistration, Reflect,
     ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
@@ -345,6 +345,11 @@ impl Reflect for DynamicTuple {
     }
 
     #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Tuple
+    }
+
+    #[inline]
     fn reflect_ref(&self) -> ReflectRef {
         ReflectRef::Tuple(self)
     }
@@ -543,6 +548,10 @@ macro_rules! impl_reflect_tuple {
             fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
                 *self = value.take()?;
                 Ok(())
+            }
+            
+            fn reflect_kind(&self) -> ReflectKind {
+                ReflectKind::Tuple
             }
 
             fn reflect_ref(&self) -> ReflectRef {

--- a/crates/bevy_reflect/src/tuple.rs
+++ b/crates/bevy_reflect/src/tuple.rs
@@ -1,12 +1,12 @@
 use bevy_reflect_derive::impl_type_path;
 use bevy_utils::all_tuples;
 
-use crate::{ReflectKind, TypePathTable};
 use crate::{
     self as bevy_reflect, utility::GenericTypePathCell, FromReflect, GetTypeRegistration, Reflect,
     ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
     UnnamedField,
 };
+use crate::{ReflectKind, TypePathTable};
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
 use std::slice::Iter;
@@ -549,7 +549,7 @@ macro_rules! impl_reflect_tuple {
                 *self = value.take()?;
                 Ok(())
             }
-            
+
             fn reflect_kind(&self) -> ReflectKind {
                 ReflectKind::Tuple
             }

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,7 +1,8 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField
+    self as bevy_reflect, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef,
+    Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField,
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};

--- a/crates/bevy_reflect/src/tuple_struct.rs
+++ b/crates/bevy_reflect/src/tuple_struct.rs
@@ -1,8 +1,7 @@
 use bevy_reflect_derive::impl_type_path;
 
 use crate::{
-    self as bevy_reflect, DynamicTuple, Reflect, ReflectMut, ReflectOwned, ReflectRef, Tuple,
-    TypeInfo, TypePath, TypePathTable, UnnamedField,
+    self as bevy_reflect, DynamicTuple, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, Tuple, TypeInfo, TypePath, TypePathTable, UnnamedField
 };
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
@@ -344,6 +343,11 @@ impl Reflect for DynamicTupleStruct {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+
+    #[inline]
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::TupleStruct
     }
 
     #[inline]

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -9,8 +9,8 @@ use bevy_ecs::{
 };
 use bevy_reflect::{
     utility::{reflect_hasher, NonGenericTypeInfoCell},
-    FromReflect, Reflect, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath, Typed,
-    ValueInfo,
+    FromReflect, Reflect, ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypePath,
+    Typed, ValueInfo,
 };
 use bevy_utils::{thiserror::Error, HashMap, HashSet};
 use serde::{Deserialize, Serialize};
@@ -121,6 +121,9 @@ impl Reflect for RenderAssetUsages {
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
+    }
+    fn reflect_kind(&self) -> bevy_reflect::ReflectKind {
+        ReflectKind::Value
     }
     fn reflect_ref(&self) -> bevy_reflect::ReflectRef {
         ReflectRef::Value(self)


### PR DESCRIPTION
# Objective

Fix https://github.com/bevyengine/bevy/issues/11657

## Solution

Add a `ReflectKind` enum, add `Reflect::reflect_kind` which returns a `ReflectKind`, and add `kind` method implementions to `ReflectRef`, `ReflectMut`, and `ReflectOwned`, which returns a `ReflectKind`.

I also changed `AccessError` to use this new struct instead of it's own `TypeKind` struct. 

---

## Changelog

- Added `ReflectKind`, an enumeration over the kinds of a reflected type without its data.
- Added `Reflect::reflect_kind` (with default implementation)
- Added implementation for the `kind` method on `ReflectRef`, `ReflectMut`, and `ReflectOwned` which gives their kind without any information, as a `ReflectKind`