### PR TITLE
 Update tracing-tracy requirement from 0.10.4 to 0.11.0 and tracy-client requirement from 0.16.4 to 0.17.0

### DIFF
--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -28,7 +28,7 @@ tracing-error = { version = "0.2.0", optional = true }
 # Tracy dependency compatibility table:
 # https://github.com/nagisa/rust_tracy_client
 tracing-tracy = { version = "0.11.0", optional = true }
-tracy-client = { version = "0.16.4", optional = true }
+tracy-client = { version = "0.17.0", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_log-sys = "0.3.0"

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -27,7 +27,7 @@ tracing-error = { version = "0.2.0", optional = true }
 
 # Tracy dependency compatibility table:
 # https://github.com/nagisa/rust_tracy_client
-tracing-tracy = { version = "0.10.4", optional = true }
+tracing-tracy = { version = "0.11.0", optional = true }
 tracy-client = { version = "0.16.4", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -174,7 +174,7 @@ impl Plugin for LogPlugin {
             };
 
             #[cfg(feature = "tracing-tracy")]
-            let tracy_layer = tracing_tracy::TracyLayer::new();
+            let tracy_layer = tracing_tracy::TracyLayer::default();
 
             let fmt_layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
 


### PR DESCRIPTION
# Objective

- Update `tracing-tracy`.
- Closes #11598.

## Solution

- Bump `tracing-tracy` to 0.11.0 and `tracy-client` alongside it to 0.17.0 to avoid duplicating that dependency in the deps tree.
- `TracyLayer` is now configurable on creation, so use the default config.