### PR TITLE
Add a case-insensitive check for `Key::Character` value

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1443,14 +1443,45 @@ pub enum Key {
 }
 
 impl Key {
-    /// Returns a `Key` with uppercase character if `self` is `Key::Character`.
+    /// Returns an uppercase version if `self` is a `Key::Character`.
     /// Otherwise, returns a `Clone` of `self`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_input::keyboard::Key;
+    ///
+    /// assert_eq!(Key::Character("B".into()).to_uppercase_character(), Key::Character("B".into()));
+    /// assert_eq!(Key::Character("b".into()).to_uppercase_character(), Key::Character("B".into()));
+    /// assert_eq!(Key::ArrowUp.to_uppercase_character(), Key::ArrowUp);
+    /// ```
     pub fn to_uppercase_character(&self) -> Self {
         match self.clone() {
             Key::Character(character) => {
                 Self::Character(character.to_string().to_uppercase().into())
             }
             other_kind => other_kind,
+        }
+    }
+
+    /// Returns true if `self` is a `Key::Character(character_self)`
+    /// and `character_self` is an ASCII case-insensitive match with the given `character`.
+    /// Otherwise, it means they are not matched or if `self` is not a `Key::Character`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use bevy_input::keyboard::Key;
+    ///
+    /// assert!(Key::Character("B".into()).eq_ignore_ascii_case("B"));
+    /// assert!(Key::Character("b".into()).eq_ignore_ascii_case("B"));
+    /// assert!(!Key::ArrowUp.eq_ignore_ascii_case("B"));
+    /// ```
+    pub fn eq_ignore_ascii_case(&self, character: impl AsRef<str>) -> bool {
+        if let Key::Character(character_self) = self {
+            character_self.eq_ignore_ascii_case(character.as_ref())
+        } else {
+            false
         }
     }
 }

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1466,7 +1466,7 @@ impl Key {
 
     /// Returns true if `self` is a `Key::Character(character_self)`
     /// and `character_self` is an ASCII case-insensitive match with the given `character`.
-    /// Otherwise, it means they are not matched or if `self` is not a `Key::Character`.
+    /// Otherwise, it means they are not matched or `self` is not a `Key::Character`.
     ///
     /// # Examples
     ///

--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -1441,3 +1441,16 @@ pub enum Key {
     /// General-purpose function key.
     F35,
 }
+
+impl Key {
+    /// Returns a `Key` with uppercase character if `self` is `Key::Character`.
+    /// Otherwise, returns a `Clone` of `self`.
+    pub fn to_uppercase_character(&self) -> Self {
+        match self.clone() {
+            Key::Character(character) => {
+                Self::Character(character.to_string().to_uppercase().into())
+            }
+            other_kind => other_kind,
+        }
+    }
+}

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -287,9 +287,7 @@ pub fn convert_physical_key_code(virtual_key_code: winit::keyboard::PhysicalKey)
 
 pub fn convert_logical_key(logical_key_code: &winit::keyboard::Key) -> bevy_input::keyboard::Key {
     match logical_key_code {
-        Key::Character(s) => {
-            bevy_input::keyboard::Key::Character(s.to_string().to_uppercase().into())
-        }
+        Key::Character(s) => bevy_input::keyboard::Key::Character(s.clone()),
         Key::Unidentified(nk) => bevy_input::keyboard::Key::Unidentified(convert_native_key(nk)),
         Key::Dead(c) => bevy_input::keyboard::Key::Dead(c.to_owned()),
         Key::Named(NamedKey::Alt) => bevy_input::keyboard::Key::Alt,

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -1,3 +1,6 @@
+use winit::keyboard::{Key, NamedKey, NativeKey};
+use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
+
 use bevy_ecs::entity::Entity;
 use bevy_input::{
     keyboard::{KeyCode, KeyboardInput, NativeKeyCode},
@@ -7,7 +10,6 @@ use bevy_input::{
 };
 use bevy_math::Vec2;
 use bevy_window::{CursorIcon, EnabledButtons, WindowLevel, WindowTheme};
-use winit::keyboard::{Key, NamedKey, NativeKey};
 
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyEvent,
@@ -16,7 +18,7 @@ pub fn convert_keyboard_input(
     KeyboardInput {
         state: convert_element_state(keyboard_input.state),
         key_code: convert_physical_key_code(keyboard_input.physical_key),
-        logical_key: convert_logical_key(&keyboard_input.logical_key),
+        logical_key: convert_logical_key(&keyboard_input.key_without_modifiers()),
         window,
     }
 }

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -1,6 +1,3 @@
-use winit::keyboard::{Key, NamedKey, NativeKey};
-use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
-
 use bevy_ecs::entity::Entity;
 use bevy_input::{
     keyboard::{KeyCode, KeyboardInput, NativeKeyCode},
@@ -10,6 +7,8 @@ use bevy_input::{
 };
 use bevy_math::Vec2;
 use bevy_window::{CursorIcon, EnabledButtons, WindowLevel, WindowTheme};
+use winit::keyboard::{Key, NamedKey, NativeKey};
+use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyEvent,

--- a/crates/bevy_winit/src/converters.rs
+++ b/crates/bevy_winit/src/converters.rs
@@ -8,7 +8,6 @@ use bevy_input::{
 use bevy_math::Vec2;
 use bevy_window::{CursorIcon, EnabledButtons, WindowLevel, WindowTheme};
 use winit::keyboard::{Key, NamedKey, NativeKey};
-use winit::platform::modifier_supplement::KeyEventExtModifierSupplement;
 
 pub fn convert_keyboard_input(
     keyboard_input: &winit::event::KeyEvent,
@@ -17,7 +16,7 @@ pub fn convert_keyboard_input(
     KeyboardInput {
         state: convert_element_state(keyboard_input.state),
         key_code: convert_physical_key_code(keyboard_input.physical_key),
-        logical_key: convert_logical_key(&keyboard_input.key_without_modifiers()),
+        logical_key: convert_logical_key(&keyboard_input.logical_key),
         window,
     }
 }
@@ -288,7 +287,9 @@ pub fn convert_physical_key_code(virtual_key_code: winit::keyboard::PhysicalKey)
 
 pub fn convert_logical_key(logical_key_code: &winit::keyboard::Key) -> bevy_input::keyboard::Key {
     match logical_key_code {
-        Key::Character(s) => bevy_input::keyboard::Key::Character(s.clone()),
+        Key::Character(s) => {
+            bevy_input::keyboard::Key::Character(s.to_string().to_uppercase().into())
+        }
         Key::Unidentified(nk) => bevy_input::keyboard::Key::Unidentified(convert_native_key(nk)),
         Key::Dead(c) => bevy_input::keyboard::Key::Dead(c.to_owned()),
         Key::Named(NamedKey::Alt) => bevy_input::keyboard::Key::Alt,


### PR DESCRIPTION
# Objective

Fixes #11689 if logical letter keys should remain consistent regardless of external factors.
Reporting both lowercase and UPPERCASE logical letter keys is adding a burden on us to make shortcuts in the games.

## Solution

~~Apply the upstream [suggestion](https://github.com/rust-windowing/winit/issues/3453).~~
~~- Use `key_without_modifiers` in `convert_keyboard_input` for `convert_logical_key`.~~

~~- Use `to_uppercase` to all OSs because some of them don't support `key_without_modifiers`.~~

### Add `Key::to_uppercase_character()`.

Returns an uppercase version if `self` is a `Key::Character`.
Otherwise, returns a `Clone` of `self`.

For example:

```rust
use bevy_input::keyboard::Key;

assert_eq!(Key::Character("B".into()).to_uppercase_character(), Key::Character("B".into()));
assert_eq!(Key::Character("b".into()).to_uppercase_character(), Key::Character("B".into()));
assert_eq!(Key::ArrowUp.to_uppercase_character(), Key::ArrowUp);
```

### Expose the `SmolStr::eq_ignore_ascii_case(&str)` to `Key`.

Returns true if `self` is a `Key::Character(character_self)` and `character_self` is an ASCII case-insensitive match with the given `character`.
Otherwise, it means they are not matched or `self` is not a `Key::Character`.

For example:

```rust
use bevy_input::keyboard::Key;

assert!(Key::Character("B".into()).eq_ignore_ascii_case("B"));
assert!(Key::Character("b".into()).eq_ignore_ascii_case("B"));
assert!(!Key::ArrowUp.eq_ignore_ascii_case("B"));
```

## Changelog

### Before

The main Bevy after the merge of #10702 occurs the situation that all letter logical keys, for example, the 'W' key is reporting a lowercase 'w' normally and an uppercase 'W' when CapsLock is activated or Shift is pressed.

If dealing with both case, we have to repeat the following boilerplate code:

```rust
/// Binds with the logical keys rather than physical keys without this PR
fn listen_keyboard_input_events(mut events: EventReader<KeyboardInput>) {
    for event in events.read() {
        if let Key::Character(character) = event.logical_key {
            if character.eq_ignore_ascii_case("A") {
              info!("A key has been pressed!")
            }
        }
        // Other cases...
        match event.logical_key {
            Key::Character("w".into()) | Key::Character("W".into()) => {
              info!("W key has been pressed!")
            }
            Key::Character(c) if c.eq_ignore_ascii_case("S") => {
              info!("S key has been pressed!")
            }
            Key::ArrowUp => {
              info!("ArrowUp key has been pressed!")
            }
            // Other cases...
            _ => continue,
        }
        // Or via if-let
    }
}
```

### After

Now in this case, we have:

```rust
/// Binds with the logical keys rather than physical keys via current PR.
fn listen_keyboard_input_events(mut events: EventReader<KeyboardInput>) {
    for event in events.read() {
        if event.logical_key.eq_ignore_ascii_case("W") {
            info!("W key has been pressed!")
        }
        // Other cases...
        match event.logical_key.to_uppercase_character() {
            Key::Character("W".into()) => {
              info!("W key has been pressed!")
            }
            Key::ArrowUp => {
              info!("ArrowUp key has been pressed!")
            }
            // Other cases...
            _ => continue,
        }
    }
}
```