### PR TITLE
fix(primitives): fix polygon gizmo rendering bug

### DIFF
--- a/crates/bevy_gizmos/src/primitives/dim2.rs
+++ b/crates/bevy_gizmos/src/primitives/dim2.rs
@@ -467,9 +467,9 @@ impl<'w, 's, const N: usize, T: GizmoConfigGroup> GizmoPrimitive2d<Polygon<N>>
 
         // Check if the polygon needs a closing point
         let closing_point = {
-            let last = primitive.vertices.last();
-            (primitive.vertices.first() != last)
-                .then_some(last)
+            let first = primitive.vertices.first();
+            (primitive.vertices.last() != first)
+                .then_some(first)
                 .flatten()
                 .cloned()
         };
@@ -503,9 +503,9 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive2d<BoxedPolygon> for Gizmos<'w, 
         }
 
         let closing_point = {
-            let last = primitive.vertices.last();
-            (primitive.vertices.first() != last)
-                .then_some(last)
+            let first = primitive.vertices.first();
+            (primitive.vertices.last() != first)
+                .then_some(first)
                 .flatten()
                 .cloned()
         };


### PR DESCRIPTION
This is just a minor fix extracted from #11697

A logic error. We tried to close the polygon shape, if the user specifies an
unclosed polygon. The closing linestring previously didn't close the polygon
though, but instead added a zero length line at the last coordinate.
