### PR TITLE
Expose query accesses

### DIFF
--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -121,7 +121,7 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Adds an archetypal (indirect) access to the element given by `index`.
     ///
-    /// This is for elements that are not accessed (and thus will never cause to conflicts),
+    /// This is for elements that are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     pub fn add_archetypal(&mut self, index: T) {
         self.archetypal.grow(index.sparse_set_index() + 1);

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -469,6 +469,20 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
     pub fn is_subset(&self, other: &FilteredAccess<T>) -> bool {
         self.required.is_subset(&other.required) && self.access().is_subset(other.access())
     }
+
+    /// Returns the components this access filters for.
+    pub fn get_with(&self) -> impl Iterator<Item = T> + '_ {
+        self.filter_sets
+            .iter()
+            .flat_map(|f| f.with.ones().map(T::get_sparse_set_index))
+    }
+
+    /// Returns the components this access filters out.
+    pub fn get_without(&self) -> impl Iterator<Item = T> + '_ {
+        self.filter_sets
+            .iter()
+            .flat_map(|f| f.without.ones().map(T::get_sparse_set_index))
+    }
 }
 
 #[derive(Clone, Eq, PartialEq)]

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -295,7 +295,7 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns the indices of the elements that this has an archetypal access to.
     ///
-    /// These are elements that are not access (and thus will never cause conflicts),
+    /// These are elements that are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {
         self.archetypal.ones().map(T::get_sparse_set_index)

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -146,7 +146,7 @@ impl<T: SparseSetIndex> Access<T> {
     }
 
     /// Returns true if this has an archetypal (indirect) access to the element given by `index`.
-    /// 
+    ///
     /// This is an element that is not accessed (and thus will never lead to conflicts),
     /// but whose presence in an archetype affects a query result.
     pub fn has_archetypal(&self, index: T) -> bool {
@@ -291,7 +291,7 @@ impl<T: SparseSetIndex> Access<T> {
     }
 
     /// Returns the indices of the elements that this has an archetypal access to.
-    /// 
+    ///
     /// Archetypal accesses will never lead to conflicts, but the presence of the data
     /// they refer to affects query results
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -123,6 +123,10 @@ impl<T: SparseSetIndex> Access<T> {
     ///
     /// This is for elements whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
+    ///
+    /// Currently, this is only used for [`Has<T>`].
+    ///
+    /// [`Has<T>`]: crate::query::Has
     pub fn add_archetypal(&mut self, index: T) {
         self.archetypal.grow(index.sparse_set_index() + 1);
         self.archetypal.insert(index.sparse_set_index());
@@ -152,6 +156,10 @@ impl<T: SparseSetIndex> Access<T> {
     ///
     /// This is an element whose value is not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
+    ///
+    /// Currently, this is only used for [`Has<T>`].
+    ///
+    /// [`Has<T>`]: crate::query::Has
     pub fn has_archetypal(&self, index: T) -> bool {
         self.archetypal.contains(index.sparse_set_index())
     }
@@ -297,6 +305,10 @@ impl<T: SparseSetIndex> Access<T> {
     ///
     /// These are elements whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
+    ///
+    /// Currently, this is only used for [`Has<T>`].
+    ///
+    /// [`Has<T>`]: crate::query::Has
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {
         self.archetypal.ones().map(T::get_sparse_set_index)
     }

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -119,7 +119,10 @@ impl<T: SparseSetIndex> Access<T> {
         self.writes.insert(index.sparse_set_index());
     }
 
-    /// Adds an archetypal (inderect) access to the element given by `index`.
+    /// Adds an archetypal (indirect) access to the element given by `index`.
+    ///
+    /// This is for elements that are not accessed (and thus will never cause to conflicts),
+    /// but whose presence in an archetype may affect query results.
     pub fn add_archetypal(&mut self, index: T) {
         self.archetypal.grow(index.sparse_set_index() + 1);
         self.archetypal.insert(index.sparse_set_index());
@@ -147,8 +150,8 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns true if this has an archetypal (indirect) access to the element given by `index`.
     ///
-    /// This is an element that is not accessed (and thus will never lead to conflicts),
-    /// but whose presence in an archetype affects a query result.
+    /// This is an element that is not accessed (and thus will never cause conflicts),
+    /// but whose presence in an archetype may affect query results.
     pub fn has_archetypal(&self, index: T) -> bool {
         self.archetypal.contains(index.sparse_set_index())
     }
@@ -292,8 +295,8 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns the indices of the elements that this has an archetypal access to.
     ///
-    /// Archetypal accesses will never lead to conflicts, but the presence of the data
-    /// they refer to affects query results
+    /// These are elements that are not access (and thus will never cause conflicts),
+    /// but whose presence in an archetype may affect query results.
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {
         self.archetypal.ones().map(T::get_sparse_set_index)
     }
@@ -495,15 +498,15 @@ impl<T: SparseSetIndex> FilteredAccess<T> {
         self.required.is_subset(&other.required) && self.access().is_subset(other.access())
     }
 
-    /// Returns the components this access filters for.
-    pub fn get_with(&self) -> impl Iterator<Item = T> + '_ {
+    /// Returns the indices of the elements that this access filters for.
+    pub fn with_filters(&self) -> impl Iterator<Item = T> + '_ {
         self.filter_sets
             .iter()
             .flat_map(|f| f.with.ones().map(T::get_sparse_set_index))
     }
 
-    /// Returns the components this access filters out.
-    pub fn get_without(&self) -> impl Iterator<Item = T> + '_ {
+    /// Returns the indices of the elements that this access filters out.
+    pub fn without_filters(&self) -> impl Iterator<Item = T> + '_ {
         self.filter_sets
             .iter()
             .flat_map(|f| f.without.ones().map(T::get_sparse_set_index))

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -121,7 +121,7 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Adds an archetypal (indirect) access to the element given by `index`.
     ///
-    /// This is for elements that are not accessed (and thus will never cause conflicts),
+    /// This is for elements whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     pub fn add_archetypal(&mut self, index: T) {
         self.archetypal.grow(index.sparse_set_index() + 1);
@@ -150,7 +150,7 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns true if this has an archetypal (indirect) access to the element given by `index`.
     ///
-    /// This is an element that is not accessed (and thus will never cause conflicts),
+    /// This is an element whose value is not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     pub fn has_archetypal(&self, index: T) -> bool {
         self.archetypal.contains(index.sparse_set_index())
@@ -295,7 +295,7 @@ impl<T: SparseSetIndex> Access<T> {
 
     /// Returns the indices of the elements that this has an archetypal access to.
     ///
-    /// These are elements that are not accessed (and thus will never cause conflicts),
+    /// These are elements whose values are not accessed (and thus will never cause conflicts),
     /// but whose presence in an archetype may affect query results.
     pub fn archetypal(&self) -> impl Iterator<Item = T> + '_ {
         self.archetypal.ones().map(T::get_sparse_set_index)

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1403,7 +1403,10 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
         *fetch
     }
 
-    fn update_component_access(&component_id: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+    fn update_component_access(
+        &component_id: &Self::State,
+        access: &mut FilteredAccess<ComponentId>,
+    ) {
         access.access_mut().add_archetypal(component_id);
     }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1403,8 +1403,8 @@ unsafe impl<T: Component> WorldQuery for Has<T> {
         *fetch
     }
 
-    fn update_component_access(_state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {
-        // Do nothing as presence of `Has<T>` never affects whether two queries are disjoint
+    fn update_component_access(&component_id: &Self::State, access: &mut FilteredAccess<ComponentId>) {
+        access.access_mut().add_archetypal(component_id);
     }
 
     fn init_state(world: &mut World) -> ComponentId {

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -95,6 +95,26 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     ) -> &QueryState<NewD, NewF> {
         &*(self as *const QueryState<D, F> as *const QueryState<NewD, NewF>)
     }
+
+    /// Returns the archetype components accessed by this query.
+    pub fn archetype_component_access(&self) -> &Access<ArchetypeComponentId> {
+        &self.archetype_component_access
+    }
+
+    /// Returns the components accessed by this query.
+    pub fn component_access(&self) -> &FilteredAccess<ComponentId> {
+        &self.component_access
+    }
+
+    /// Returns the tables matched by this query.
+    pub fn matched_tables(&self) -> &[TableId] {
+        &self.matched_table_ids
+    }
+
+    /// Returns the archetypes matched by this query.
+    pub fn matched_archetypes(&self) -> &[ArchetypeId] {
+        &self.matched_archetype_ids
+    }
 }
 
 impl<D: QueryData, F: QueryFilter> QueryState<D, F> {


### PR DESCRIPTION
# Objective

It would be useful to be able to inspect a `QueryState`'s accesses so we can detect when the data it accesses changes without having to iterate it. However there are two things preventing this:

* These accesses are unnecessarily encapsulated.
* `Has<T>` indirectly accesses `T`, but does not register it.

## Solution

* Expose accesses and matches used by `QueryState`.
* Add the notion of "archetypal" accesses, which are not accessed directly, but whose presence in an archetype affects a query result.
