### PR TITLE
Enable warning for the `clippy::question_mark` lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ undocumented_unsafe_blocks = "warn"
 redundant_else = "warn"
 match_same_arms = "warn"
 semicolon_if_nothing_returned = "warn"
+question_mark = "warn"
 
 ptr_as_ptr = "warn"
 ptr_cast_constness = "warn"

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -493,9 +493,9 @@ impl<A: Asset> TryFrom<UntypedHandle> for Handle<A> {
         match value {
             UntypedHandle::Strong(handle) => Ok(Handle::Strong(handle)),
             UntypedHandle::Weak(id) => {
-                let Ok(id) = id.try_into() else {
-                    return Err(UntypedAssetConversionError::TypeIdMismatch { expected, found });
-                };
+                let id = id
+                    .try_into()
+                    .map_err(|_| UntypedAssetConversionError::TypeIdMismatch { expected, found })?;
                 Ok(Handle::Weak(id))
             }
         }

--- a/crates/bevy_asset/src/saver.rs
+++ b/crates/bevy_asset/src/saver.rs
@@ -18,7 +18,7 @@ pub trait AssetSaver: Send + Sync + 'static {
     type Error: Into<Box<dyn std::error::Error + Send + Sync + 'static>>;
 
     /// Saves the given runtime [`Asset`] by writing it to a byte format using `writer`. The passed in `settings` can influence how the
-    /// `asset` is saved.  
+    /// `asset` is saved.
     fn save<'a>(
         &'a self,
         writer: &'a mut Writer,
@@ -32,7 +32,7 @@ pub trait AssetSaver: Send + Sync + 'static {
 /// A type-erased dynamic variant of [`AssetSaver`] that allows callers to save assets without knowing the actual type of the [`AssetSaver`].
 pub trait ErasedAssetSaver: Send + Sync + 'static {
     /// Saves the given runtime [`ErasedLoadedAsset`] by writing it to a byte format using `writer`. The passed in `settings` can influence how the
-    /// `asset` is saved.  
+    /// `asset` is saved.
     fn save<'a>(
         &'a self,
         writer: &'a mut Writer,
@@ -146,10 +146,7 @@ impl<'a, A: Asset> SavedAsset<'a, A> {
         Q: ?Sized + Hash + Eq,
     {
         let labeled = self.labeled_assets.get(label)?;
-        if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
-            return Some(handle);
-        }
-        None
+        labeled.handle.clone().try_typed::<B>().ok()
     }
 
     /// Iterate over all labels for "labeled assets" in the loaded asset

--- a/crates/bevy_asset/src/transformer.rs
+++ b/crates/bevy_asset/src/transformer.rs
@@ -50,13 +50,11 @@ impl<A: Asset> DerefMut for TransformedAsset<A> {
 impl<A: Asset> TransformedAsset<A> {
     /// Creates a new [`TransformedAsset`] from `asset` if its internal value matches `A`.
     pub fn from_loaded(asset: ErasedLoadedAsset) -> Option<Self> {
-        if let Ok(value) = asset.value.downcast::<A>() {
-            return Some(TransformedAsset {
-                value: *value,
-                labeled_assets: asset.labeled_assets,
-            });
-        }
-        None
+        let value = asset.value.downcast::<A>().ok()?;
+        Some(TransformedAsset {
+            value: *value,
+            labeled_assets: asset.labeled_assets,
+        })
     }
     /// Creates a new [`TransformedAsset`] from `asset`, transferring the `labeled_assets` from this [`TransformedAsset`] to the new one
     pub fn replace_asset<B: Asset>(self, asset: B) -> TransformedAsset<B> {
@@ -217,10 +215,7 @@ impl<'a, A: Asset> TransformedSubAsset<'a, A> {
         Q: ?Sized + Hash + Eq,
     {
         let labeled = self.labeled_assets.get(label)?;
-        if let Ok(handle) = labeled.handle.clone().try_typed::<B>() {
-            return Some(handle);
-        }
-        None
+        labeled.handle.clone().try_typed::<B>().ok()
     }
     /// Adds `asset` as a labeled sub asset using `label` and `handle`
     pub fn insert_labeled(

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -222,9 +222,7 @@ pub fn ui_focus_system(
         // reverse the iterator to traverse the tree from closest nodes to furthest
         .rev()
         .filter_map(|entity| {
-            let Ok(node) = node_query.get_mut(*entity) else {
-                return None;
-            };
+            let node = node_query.get_mut(*entity).ok()?;
 
             let view_visibility = node.view_visibility?;
             // Nodes that are not rendered should not be interactable


### PR DESCRIPTION
# Objective

- Enable the `warn` level for the `clippy::question_mark` lint. It seems rather uncontroversial and general good practice to me.

## Solution

- Enable the lint.
- Use the question mark/`ok` adapter to simplify some `Option`/`Result` returns. I can revert that and keep only the changes highlighted by the lint if preferable.
- Fix some trailing whitespace.
