### PR TITLE
Fix a few typos in error docs

### DIFF
--- a/errors/B0001.md
+++ b/errors/B0001.md
@@ -1,6 +1,6 @@
 # B0001
 
-To keep [Rust rules on references](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#the-rules-of-references) (either one mutable reference or any number of immutable references) on a component, it is not possible to have two queries on the same component when one request mutable access to it in the same system.
+To keep [Rust rules on references](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#the-rules-of-references) (either one mutable reference or any number of immutable references) on a component, it is not possible to have two queries on the same component when one requests mutable access to it in the same system.
 
 Erroneous code example:
 
@@ -62,7 +62,7 @@ fn main() {
 
 Solution #2: use a `ParamSet`
 
-A `ParamSet` will let you have conflicting queries as a parameter, but you will still be responsible of not using them at the same time in your system.
+A `ParamSet` will let you have conflicting queries as a parameter, but you will still be responsible for not using them at the same time in your system.
 
 ```rust,no_run
 use bevy::prelude::*;

--- a/errors/B0002.md
+++ b/errors/B0002.md
@@ -22,9 +22,9 @@ fn main() {
 }
 ```
 
-This will panic, as it's not possible to have both a mutable and an immutable resource on `State` at the same time.
+This will panic, as it's not possible to have both a mutable and an immutable resource on `Assets<StandardMaterial>` at the same time.
 
-As a mutable resource already provide access to the current resource value, you can remove the immutable resource.
+As a mutable resource already provides access to the current resource value, so you can remove the immutable resource.
 
 ```rust,no_run
 use bevy::prelude::*;


### PR DESCRIPTION
# Objective

I noticed a few typos in these docs recently.

## Solution

Minimal fixes so that these sentences make sense.