### PR TITLE
don't run `create_surfaces` system if not needed

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -43,7 +43,12 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<ExtractedWindows>()
                 .init_resource::<WindowSurfaces>()
                 .add_systems(ExtractSchedule, extract_windows)
-                .add_systems(Render, create_surfaces.in_set(RenderSet::PrepareAssets))
+                .add_systems(
+                    Render,
+                    create_surfaces
+                        .run_if(need_new_surfaces)
+                        .in_set(RenderSet::PrepareAssets),
+                )
                 .add_systems(Render, prepare_windows.in_set(RenderSet::ManageViews));
         }
     }
@@ -417,6 +422,18 @@ pub fn prepare_windows(
             });
         }
     }
+}
+
+pub fn need_new_surfaces(
+    windows: Res<ExtractedWindows>,
+    window_surfaces: Res<WindowSurfaces>,
+) -> bool {
+    for window in windows.windows.values() {
+        if !window_surfaces.configured_windows.contains(&window.entity) {
+            return true;
+        }
+    }
+    false
 }
 
 /// Creates window surfaces.

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -43,8 +43,8 @@ impl Plugin for WindowRenderPlugin {
                 .init_resource::<ExtractedWindows>()
                 .init_resource::<WindowSurfaces>()
                 .add_systems(ExtractSchedule, extract_windows)
-                .add_systems(Render, prepare_windows.in_set(RenderSet::PrepareAssets))
-                .add_systems(Render, create_surfaces.in_set(RenderSet::ManageViews));
+                .add_systems(Render, create_surfaces.in_set(RenderSet::PrepareAssets))
+                .add_systems(Render, prepare_windows.in_set(RenderSet::ManageViews));
         }
     }
 


### PR DESCRIPTION
# Objective

- Change set of systems as I made a mistake in #11672 
- Don't block main when not needed
- Fixes #11235 

## Solution

- add a run condition so that the system won't run and block main if not needed
