### PR TITLE
bevy_render: use the non-send marker from bevy_core

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
+use bevy_core::NonSendMarker;
 use bevy_ecs::prelude::*;
 use bevy_utils::{default, tracing::debug, EntityHashMap, HashSet};
 use bevy_window::{
@@ -27,10 +28,6 @@ use screenshot::{
 };
 
 use super::Msaa;
-
-/// Token to ensure a system runs on the main thread.
-#[derive(Resource, Default)]
-pub struct NonSendMarker;
 
 pub struct WindowRenderPlugin;
 

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -7,7 +7,6 @@ use crate::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
-use bevy_core::NonSendMarker;
 use bevy_ecs::prelude::*;
 use bevy_utils::{default, tracing::debug, EntityHashMap, HashSet};
 use bevy_window::{
@@ -437,7 +436,9 @@ pub fn need_new_surfaces(
 pub fn create_surfaces(
     // By accessing a NonSend resource, we tell the scheduler to put this system on the main thread,
     // which is necessary for some OS's
-    #[cfg(any(target_os = "macos", target_os = "ios"))] _marker: Option<NonSend<NonSendMarker>>,
+    #[cfg(any(target_os = "macos", target_os = "ios"))] _marker: Option<
+        NonSend<bevy_core::NonSendMarker>,
+    >,
     windows: Res<ExtractedWindows>,
     mut window_surfaces: ResMut<WindowSurfaces>,
     render_instance: Res<RenderInstance>,


### PR DESCRIPTION
# Objective

- There are too many `NonSendMarker` https://docs.rs/bevy/0.12.1/bevy/index.html?search=nonsendmarker
- There should be only one

## Solution

- Use the marker type from bevy_core in bevy_render

---

## Migration Guide

- If you were using `bevy::render::view::NonSendMarker` or `bevy::render::view::window::NonSendMarker`, use `bevy::core::NonSendMarker` instead
