### PR TITLE
Missing registrations

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -58,6 +58,7 @@ fn register_rust_types(app: &mut App) {
         .register_type::<Option<String>>()
         .register_type::<Option<bool>>()
         .register_type::<Option<f64>>()
+        .register_type::<Vec<f32>>()
         .register_type::<Cow<'static, str>>()
         .register_type::<Cow<'static, Path>>()
         .register_type::<Duration>()

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -57,6 +57,7 @@ fn register_rust_types(app: &mut App) {
         .register_type::<HashSet<String>>()
         .register_type::<Option<String>>()
         .register_type::<Option<bool>>()
+        .register_type::<Option<f32>>()
         .register_type::<Option<f64>>()
         .register_type::<Vec<f32>>()
         .register_type::<Cow<'static, str>>()

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -1,7 +1,7 @@
 use crate::ReflectComponent;
 use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
-use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{color::Color, extract_component::ExtractComponent, prelude::Camera};
 
 /// Configures the “classic” computer graphics [distance fog](https://en.wikipedia.org/wiki/Distance_fog) effect,
@@ -49,7 +49,7 @@ use bevy_render::{color::Color, extract_component::ExtractComponent, prelude::Ca
 /// [`StandardMaterial`](crate::StandardMaterial) instances via the `fog_enabled` flag.
 #[derive(Debug, Clone, Component, Reflect, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct FogSettings {
     /// The color of the fog effect.
     ///

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -244,6 +244,8 @@ impl Plugin for PbrPlugin {
             .register_type::<PointLightShadowMap>()
             .register_type::<SpotLight>()
             .register_type::<ShadowFilteringMethod>()
+            .register_type::<ParallaxMappingMethod>()
+            .register_type::<OpaqueRendererMethod>()
             .init_resource::<AmbientLight>()
             .init_resource::<GlobalVisiblePointLights>()
             .init_resource::<DirectionalLightShadowMap>()

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -243,6 +243,8 @@ impl Plugin for PbrPlugin {
             .register_type::<PointLight>()
             .register_type::<PointLightShadowMap>()
             .register_type::<SpotLight>()
+            .register_type::<FogSettings>()
+            .register_type::<FogFalloff>()
             .register_type::<ShadowFilteringMethod>()
             .register_type::<ParallaxMappingMethod>()
             .register_type::<OpaqueRendererMethod>()

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -246,7 +246,7 @@ impl Default for DirectionalLightShadowMap {
 /// }.into();
 /// ```
 #[derive(Component, Clone, Debug, Reflect)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct CascadeShadowConfig {
     /// The (positive) distance to the far boundary of each cascade.
     pub bounds: Vec<f32>,

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -23,7 +23,7 @@ use crate::{
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, UVec4, Vec3, Vec4, Vec4Swizzles};
-use bevy_reflect::Reflect;
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::HashMap;
 use std::sync::{
@@ -129,7 +129,7 @@ impl ExtractedView {
 
 /// Configures basic color grading parameters to adjust the image appearance. Grading is applied just before/after tonemapping for a given [`Camera`](crate::camera::Camera) entity.
 #[derive(Component, Reflect, Debug, Copy, Clone, ShaderType)]
-#[reflect(Component)]
+#[reflect(Component, Default)]
 pub struct ColorGrading {
     /// Exposure value (EV) offset, measured in stops.
     pub exposure: f32,

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -109,8 +109,6 @@ impl Plugin for UiPlugin {
             .register_type::<JustifyItems>()
             .register_type::<JustifySelf>()
             .register_type::<Node>()
-            // NOTE: used by Style::aspect_ratio
-            .register_type::<Option<f32>>()
             .register_type::<Overflow>()
             .register_type::<OverflowAxis>()
             .register_type::<PositionType>()


### PR DESCRIPTION
# Objective

During my exploratory work on the remote editor, I found a couple of types that were either not registered, or that were missing `ReflectDefault`.

## Solution

- Added registration and `ReflectDefault` where applicable
- (Drive by fix) Moved `Option<f32>` registration to `bevy_core` instead of `bevy_ui`, along with similar types.

---

## Changelog

- Fixed: Registered `FogSettings`, `FogFalloff`, `ParallaxMappingMethod`, `OpaqueRendererMethod` structs for reflection
- Fixed: Registered `ReflectDefault` trait for `ColorGrading` and `CascadeShadowConfig` structs
