### PR TITLE
Don't try to create a uniform buffer for light probes if there are no views.

### DIFF
--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -411,6 +411,11 @@ fn upload_light_probes(
     render_device: Res<RenderDevice>,
     render_queue: Res<RenderQueue>,
 ) {
+    // If there are no views, bail.
+    if views.is_empty() {
+        return;
+    }
+
     // Initialize the uniform buffer writer.
     let mut writer = light_probes_buffer
         .get_writer(views.iter().len(), &render_device, &render_queue)


### PR DESCRIPTION
Don't try to create a uniform buffer for light probes if there are no views.

Fixes the panic on examples that have no views, such as `touch_input_events`.