### PR TITLE
Parallelized transform propagation

### DIFF
--- a/crates/bevy_transform/src/systems.rs
+++ b/crates/bevy_transform/src/systems.rs
@@ -78,7 +78,7 @@ pub fn propagate_transforms(
                 &transform_query,
                 &parent_query,
                 root,
-            )
+            );
         };
     });
     // Optimistically work on each changed entity in parallel. The following algorithm finds minimal
@@ -89,7 +89,7 @@ pub fn propagate_transforms(
             return;
         };
         // Abort if the ancestors of this entity also have changed transforms or are orphaned.
-        let mut current = entity.clone();
+        let mut current = entity;
         loop {
             let Ok((_, current_parent)) = parent_query.get(current) else {
                 if orphaned_entities.binary_search(&current).is_ok() {
@@ -121,7 +121,9 @@ pub fn propagate_transforms(
         //      changed or orphaned and this includes all possible cases when the root propagation calls `transform_query`.
         //   2. To look up the parent transform just above, which cannot conflict because it is queried on an ancestor which `transform_query`
         //      will never visit.
-        unsafe { propagate_recursive(parent_transform, &transform_query, &parent_query, entity) };
+        unsafe {
+            propagate_recursive(parent_transform, &transform_query, &parent_query, entity);
+        };
     });
 }
 


### PR DESCRIPTION
# Objective

Currently we traverse every tree in the entity hierarchy top-to-bottom every frame to update transforms. We iterate separate trees in parallel, but in practice (and especially when loading complex gltf scenes) the world tends to consist of a few very deep trees, and several users and reported performance problems (see for example https://github.com/bevyengine/bevy/pull/9442).

Fixes https://github.com/bevyengine/bevy/issues/7840 (partially).

## Solution

This is the first of two PRs I am publishing to address this problem. In this PR, I deal with trying to start updating transforms as deeply into the tree as possible, while also running as much of the traversal in parallel as possible.

`propagate_transforms` now preforms two passes of parallel iteration. The first pass updates all root and orphaned nodes (just as before) but now we skip any trees without top-level changes instead of immediately doing a depth-first traversal. The second pass then walks up the tree from every changed non-root node to find minimal disjoint sub-trees containing changed transforms, and then propagates transforms down each sub-tree in parallel.

These optimizations should significantly improve the case when most transform changes occur near the leaves of the entity hierarchy. The best case performance (all changes are leaves) should be much better than current. The worse case (when all changes are in roots) should be approximately just as fast as the current implementation.

This is just a proposal. Please evaluate it for efficiency and safety. While this algorithm seems intuitively correct to me, and I have done my best to justify the new unsafe block, am not super happy with the logic in the second safety comment.
