### PR TITLE
Typo in [`ScheduleLabel`] derive macro

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -478,7 +478,7 @@ pub fn derive_schedule_label(input: TokenStream) -> TokenStream {
         .segments
         .push(format_ident!("ScheduleLabel").into());
     dyn_eq_path.segments.push(format_ident!("DynEq").into());
-    derive_label(input, "ScheduleName", &trait_path, &dyn_eq_path)
+    derive_label(input, "ScheduleLabel", &trait_path, &dyn_eq_path)
 }
 
 /// Derive macro generating an impl of the trait `SystemSet`.


### PR DESCRIPTION
[`ScheduleLabel`] derive macro uses "ScheduleName" as the trait name by mistake. This only affects the error message when a user tries to use the derive macro on a union type. No other code is affected.