### PR TITLE
Fix `CameraProjectionPlugin` not implementing `Plugin` in some cases

### DIFF
--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -10,20 +10,9 @@ use bevy_reflect::{
 use serde::{Deserialize, Serialize};
 
 /// Adds [`Camera`](crate::camera::Camera) driver systems for a given projection type.
-pub struct CameraProjectionPlugin<T: CameraProjection>(PhantomData<T>);
-
-impl<T: CameraProjection> Default for CameraProjectionPlugin<T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-
-/// Label for [`camera_system<T>`], shared across all `T`.
-///
-/// [`camera_system<T>`]: crate::camera::camera_system
-#[derive(SystemSet, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct CameraUpdateSystem;
-
+pub struct CameraProjectionPlugin<T: CameraProjection + Component + GetTypeRegistration>(
+    PhantomData<T>,
+);
 impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
     fn build(&self, app: &mut App) {
         app.register_type::<T>()
@@ -47,6 +36,17 @@ impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraPro
             );
     }
 }
+impl<T: CameraProjection + Component + GetTypeRegistration> Default for CameraProjectionPlugin<T> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+/// Label for [`camera_system<T>`], shared across all `T`.
+///
+/// [`camera_system<T>`]: crate::camera::camera_system
+#[derive(SystemSet, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct CameraUpdateSystem;
 
 /// Trait to control the projection matrix of a camera.
 ///


### PR DESCRIPTION
# Objective

`CameraProjectionPlugin<T>`'s bounds are `T: CameraProjection`. But the bounds for `CameraProjectionPlugin` implementing `Plugin` are `T: CameraProjection + Component + GetTypeRegistration`. This means that if `T` is valid for `CameraProjectionPlugin`'s bounds, but not the plugin implementation's bounds, then `CameraProjectionPlugin` would not implement `Plugin`. Which is weird because you'd expect a struct with `Plugin` in the name to implement `Plugin`.

## Solution

Make `CameraProjectionPlugin<T>`'s bounds `T: CameraProjection + Component + GetTypeRegistration`. I also rearranged some of the code.

---

## Changelog

- Changed `CameraProjectionPlugin<T>`'s bounds to `T: CameraProjection + Component + GetTypeRegistration`

## Migration Guide

`CameraProjectionPlugin<T>`'s trait bounds now require `T` to implement `CameraProjection`, `Component`, and `GetTypeRegistration`. This shouldn't affect most existing code as `CameraProjectionPlugin<T>` never implemented `Plugin` unless those bounds were met.
