### PR TITLE
Mention Resource where missing from component/resource related type docs

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -711,7 +711,7 @@ where
 change_detection_impl!(Ref<'w, T>, T,);
 impl_debug!(Ref<'w, T>,);
 
-/// Unique mutable borrow of an entity's component
+/// Unique mutable borrow of an entity's component or of a resource.
 pub struct Mut<'w, T: ?Sized> {
     pub(crate) value: &'w mut T,
     pub(crate) ticks: TicksMut<'w>,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -267,12 +267,12 @@ impl ComponentInfo {
     }
 }
 
-/// A value which uniquely identifies the type of a [`Component`] within a
+/// A value which uniquely identifies the type of a [`Component`] of [`Resource`] within a
 /// [`World`].
 ///
 /// Each time a new `Component` type is registered within a `World` using
-/// [`World::init_component`](World::init_component) or
-/// [`World::init_component_with_descriptor`](World::init_component_with_descriptor),
+/// e.g. [`World::init_component`] or [`World::init_component_with_descriptor`]
+/// or a Resource with e.g. [`World::init_resource`],
 /// a corresponding `ComponentId` is created to track it.
 ///
 /// While the distinction between `ComponentId` and [`TypeId`] may seem superficial, breaking them
@@ -769,7 +769,7 @@ impl<'a> TickCells<'a> {
     }
 }
 
-/// Records when a component was added and when it was last mutably dereferenced (or added).
+/// Records when a component or resource was added and when it was last mutably dereferenced (or added).
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect), reflect(Debug))]
 pub struct ComponentTicks {
@@ -778,25 +778,25 @@ pub struct ComponentTicks {
 }
 
 impl ComponentTicks {
-    /// Returns `true` if the component was added after the system last ran.
+    /// Returns `true` if the component or resource was added after the system last ran.
     #[inline]
     pub fn is_added(&self, last_run: Tick, this_run: Tick) -> bool {
         self.added.is_newer_than(last_run, this_run)
     }
 
-    /// Returns `true` if the component was added or mutably dereferenced after the system last ran.
+    /// Returns `true` if the component or resource was added or mutably dereferenced after the system last ran.
     #[inline]
     pub fn is_changed(&self, last_run: Tick, this_run: Tick) -> bool {
         self.changed.is_newer_than(last_run, this_run)
     }
 
-    /// Returns the tick recording the time this component was most recently changed.
+    /// Returns the tick recording the time this component or resource was most recently changed.
     #[inline]
     pub fn last_changed_tick(&self) -> Tick {
         self.changed
     }
 
-    /// Returns the tick recording the time this component was added.
+    /// Returns the tick recording the time this component or resource was added.
     #[inline]
     pub fn added_tick(&self) -> Tick {
         self.added
@@ -829,7 +829,7 @@ impl ComponentTicks {
     }
 }
 
-/// A [`SystemParam`] that provides access to the [`ComponentId`] for a specific type.
+/// A [`SystemParam`] that provides access to the [`ComponentId`] for a specific component type.
 ///
 /// # Example
 /// ```


### PR DESCRIPTION
Several of the types that are used for both components and resources only mention components in their description. Fixes this.