### PR TITLE
Rename many types to better reflect their usability (in the context of `Components` and `Resources`)

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
-use bevy_ecs::component::{ComponentId, ComponentTicks, Tick};
+use bevy_ecs::component::{ComponentTicks, DataId, Tick};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 use bevy_utils::{Duration, HashSet, Instant, Uuid};
@@ -49,7 +49,7 @@ impl Plugin for TypeRegistrationPlugin {
 
 fn register_ecs_types(app: &mut App) {
     app.register_type::<Entity>()
-        .register_type::<ComponentId>()
+        .register_type::<DataId>()
         .register_type::<Tick>()
         .register_type::<ComponentTicks>();
 }

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -120,14 +120,14 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         // SAFETY:
-        // - ComponentId is returned in field-definition-order. [from_components] and [get_components] use field-definition-order
+        // - DataId is returned in field-definition-order. [from_components] and [get_components] use field-definition-order
         // - `Bundle::get_components` is exactly once for each member. Rely's on the Component -> Bundle implementation to properly pass
         //   the correct `StorageType` into the callback.
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
             fn component_ids(
-                components: &mut #ecs_path::component::Components,
+                components: &mut #ecs_path::component::WorldData,
                 storages: &mut #ecs_path::storage::Storages,
-                ids: &mut impl FnMut(#ecs_path::component::ComponentId)
+                ids: &mut impl FnMut(#ecs_path::component::DataId)
             ){
                 #(#field_component_ids)*
             }
@@ -204,7 +204,7 @@ pub fn impl_param_set(_input: TokenStream) -> TokenStream {
             where #(#param: ReadOnlySystemParam,)*
             { }
 
-            // SAFETY: Relevant parameter ComponentId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts
+            // SAFETY: Relevant parameter DataId and ArchetypeComponentId access is applied to SystemMeta. If any ParamState conflicts
             // with any prior access, a panic will occur.
             unsafe impl<'_w, '_s, #(#param: SystemParam,)*> SystemParam for ParamSet<'_w, '_s, (#(#param,)*)>
             {

--- a/crates/bevy_ecs/macros/src/world_query.rs
+++ b/crates/bevy_ecs/macros/src/world_query.rs
@@ -160,7 +160,7 @@ pub(crate) fn world_query_impl(
                 }
             }
 
-            fn update_component_access(state: &Self::State, _access: &mut #path::query::FilteredAccess<#path::component::ComponentId>) {
+            fn update_component_access(state: &Self::State, _access: &mut #path::query::FilteredAccess<#path::component::DataId>) {
                 #( <#field_types>::update_component_access(&state.#named_field_idents, _access); )*
             }
 
@@ -176,7 +176,7 @@ pub(crate) fn world_query_impl(
                 })
             }
 
-            fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::ComponentId) -> bool) -> bool {
+            fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(#path::component::DataId) -> bool) -> bool {
                 true #(&& <#field_types>::matches_component_set(&state.#named_field_idents, _set_contains_id))*
             }
         }

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -61,7 +61,7 @@ mod tests {
     use crate::{
         bundle::Bundle,
         change_detection::Ref,
-        component::{Component, ComponentId},
+        component::{Component, DataId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
         system::Resource,
@@ -147,7 +147,7 @@ mod tests {
         }
         let mut ids = Vec::new();
         <FooBundle as Bundle>::component_ids(
-            &mut world.components,
+            &mut world.world_data,
             &mut world.storages,
             &mut |id| {
                 ids.push(id);
@@ -201,7 +201,7 @@ mod tests {
 
         let mut ids = Vec::new();
         <NestedBundle as Bundle>::component_ids(
-            &mut world.components,
+            &mut world.world_data,
             &mut world.storages,
             &mut |id| {
                 ids.push(id);
@@ -257,7 +257,7 @@ mod tests {
 
         let mut ids = Vec::new();
         <BundleWithIgnored as Bundle>::component_ids(
-            &mut world.components,
+            &mut world.world_data,
             &mut world.storages,
             &mut |id| {
                 ids.push(id);
@@ -1372,14 +1372,14 @@ mod tests {
         let mut world = World::new();
         let query = world.query_filtered::<&mut A, Changed<B>>();
 
-        let mut expected = FilteredAccess::<ComponentId>::default();
-        let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_id = world.components.get_id(TypeId::of::<B>()).unwrap();
+        let mut expected = FilteredAccess::<DataId>::default();
+        let a_id = world.world_data.get_id(TypeId::of::<A>()).unwrap();
+        let b_id = world.world_data.get_id(TypeId::of::<B>()).unwrap();
         expected.add_write(a_id);
         expected.add_read(b_id);
         assert!(
             query.component_access.eq(&expected),
-            "ComponentId access from query fetch and query filter should be combined"
+            "DataId access from query fetch and query filter should be combined"
         );
     }
 

--- a/crates/bevy_ecs/src/query/access.rs
+++ b/crates/bevy_ecs/src/query/access.rs
@@ -19,7 +19,7 @@ use std::marker::PhantomData;
 /// the set. With `FormattedBitSet`, we convert the present set entries into
 /// what they stand for, it is much clearer what is going on:
 /// ```text
-/// read_and_writes: [ ComponentId(5), ComponentId(7) ]
+/// read_and_writes: [ DataId(5), DataId(7) ]
 /// ```
 struct FormattedBitSet<'a, T: SparseSetIndex> {
     bit_set: &'a FixedBitSet,

--- a/crates/bevy_ecs/src/query/builder.rs
+++ b/crates/bevy_ecs/src/query/builder.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use crate::{component::ComponentId, prelude::*};
+use crate::{component::DataId, prelude::*};
 
 use super::{FilteredAccess, QueryData, QueryFilter};
 
@@ -33,7 +33,7 @@ use super::{FilteredAccess, QueryData, QueryFilter};
 /// let (entity, b) = query.single(&world);
 ///```
 pub struct QueryBuilder<'w, D: QueryData = (), F: QueryFilter = ()> {
-    access: FilteredAccess<ComponentId>,
+    access: FilteredAccess<DataId>,
     world: &'w mut World,
     or: bool,
     first: bool,
@@ -79,7 +79,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
     }
 
     /// Adds access to self's underlying [`FilteredAccess`] respecting [`Self::or`] and [`Self::and`]
-    pub fn extend_access(&mut self, mut access: FilteredAccess<ComponentId>) {
+    pub fn extend_access(&mut self, mut access: FilteredAccess<DataId>) {
         if self.or {
             if self.first {
                 access.required.clear();
@@ -117,8 +117,8 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
         self
     }
 
-    /// Adds [`With<T>`] to the [`FilteredAccess`] of self from a runtime [`ComponentId`].
-    pub fn with_id(&mut self, id: ComponentId) -> &mut Self {
+    /// Adds [`With<T>`] to the [`FilteredAccess`] of self from a runtime [`DataId`].
+    pub fn with_id(&mut self, id: DataId) -> &mut Self {
         let mut access = FilteredAccess::default();
         access.and_with(id);
         self.extend_access(access);
@@ -131,8 +131,8 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
         self
     }
 
-    /// Adds [`Without<T>`] to the [`FilteredAccess`] of self from a runtime [`ComponentId`].
-    pub fn without_id(&mut self, id: ComponentId) -> &mut Self {
+    /// Adds [`Without<T>`] to the [`FilteredAccess`] of self from a runtime [`DataId`].
+    pub fn without_id(&mut self, id: DataId) -> &mut Self {
         let mut access = FilteredAccess::default();
         access.and_without(id);
         self.extend_access(access);
@@ -140,14 +140,14 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
     }
 
     /// Adds `&T` to the [`FilteredAccess`] of self.
-    pub fn ref_id(&mut self, id: ComponentId) -> &mut Self {
+    pub fn ref_id(&mut self, id: DataId) -> &mut Self {
         self.with_id(id);
         self.access.add_read(id);
         self
     }
 
     /// Adds `&mut T` to the [`FilteredAccess`] of self.
-    pub fn mut_id(&mut self, id: ComponentId) -> &mut Self {
+    pub fn mut_id(&mut self, id: DataId) -> &mut Self {
         self.with_id(id);
         self.access.add_write(id);
         self
@@ -205,7 +205,7 @@ impl<'w, D: QueryData, F: QueryFilter> QueryBuilder<'w, D, F> {
     }
 
     /// Returns a reference to the the [`FilteredAccess`] that will be provided to the built [`Query`].
-    pub fn access(&self) -> &FilteredAccess<ComponentId> {
+    pub fn access(&self) -> &FilteredAccess<DataId> {
         &self.access
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1,7 +1,7 @@
 use crate::{
     archetype::{Archetype, ArchetypeComponentId, ArchetypeGeneration, ArchetypeId},
     change_detection::Mut,
-    component::{ComponentId, Tick},
+    component::{DataId, Tick},
     entity::Entity,
     prelude::{Component, FromWorld},
     query::{
@@ -32,7 +32,7 @@ pub struct QueryState<D: QueryData, F: QueryFilter = ()> {
     pub(crate) matched_tables: FixedBitSet,
     pub(crate) matched_archetypes: FixedBitSet,
     pub(crate) archetype_component_access: Access<ArchetypeComponentId>,
-    pub(crate) component_access: FilteredAccess<ComponentId>,
+    pub(crate) component_access: FilteredAccess<DataId>,
     // NOTE: we maintain both a TableId bitset and a vec because iterating the vec is faster
     pub(crate) matched_table_ids: Vec<TableId>,
     // NOTE: we maintain both a ArchetypeId bitset and a vec because iterating the vec is faster
@@ -274,7 +274,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Update the current [`QueryState`] with information from the provided [`Archetype`]
-    /// (if applicable, i.e. if the archetype has any intersecting [`ComponentId`] with the current [`QueryState`]).
+    /// (if applicable, i.e. if the archetype has any intersecting [`DataId`] with the current [`QueryState`]).
     pub fn new_archetype(&mut self, archetype: &Archetype) {
         if D::matches_component_set(&self.fetch_state, &|id| archetype.contains(id))
             && F::matches_component_set(&self.filter_state, &|id| archetype.contains(id))
@@ -298,15 +298,15 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     }
 
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
-    pub fn matches_component_set(&self, set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+    pub fn matches_component_set(&self, set_contains_id: &impl Fn(DataId) -> bool) -> bool {
         self.component_access.filter_sets.iter().any(|set| {
             set.with
                 .ones()
-                .all(|index| set_contains_id(ComponentId::get_sparse_set_index(index)))
+                .all(|index| set_contains_id(DataId::get_sparse_set_index(index)))
                 && set
                     .without
                     .ones()
-                    .all(|index| !set_contains_id(ComponentId::get_sparse_set_index(index)))
+                    .all(|index| !set_contains_id(DataId::get_sparse_set_index(index)))
         })
     }
 

--- a/crates/bevy_ecs/src/query/world_query.rs
+++ b/crates/bevy_ecs/src/query/world_query.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::Archetype,
-    component::{ComponentId, Tick},
+    component::{DataId, Tick},
     entity::Entity,
     query::FilteredAccess,
     storage::{Table, TableRow},
@@ -103,7 +103,7 @@ pub unsafe trait WorldQuery {
     /// or [`FilteredEntityMut`](crate::world::FilteredEntityMut).
     ///
     /// Called when constructing a [`QueryLens`](crate::system::QueryLens) or calling [`QueryState::from_builder`](super::QueryState::from_builder)
-    fn set_access(_state: &mut Self::State, _access: &FilteredAccess<ComponentId>) {}
+    fn set_access(_state: &mut Self::State, _access: &FilteredAccess<DataId>) {}
 
     /// Fetch [`Self::Item`](`WorldQuery::Item`) for either the given `entity` in the current [`Table`],
     /// or for the given `entity` in the current [`Archetype`]. This must always be called after
@@ -123,7 +123,7 @@ pub unsafe trait WorldQuery {
     /// Adds any component accesses used by this [`WorldQuery`] to `access`.
     // This does not have a default body of `{}` because 99% of cases need to add accesses
     // and forgetting to do so would be unsound.
-    fn update_component_access(state: &Self::State, access: &mut FilteredAccess<ComponentId>);
+    fn update_component_access(state: &Self::State, access: &mut FilteredAccess<DataId>);
 
     /// Creates and initializes a [`State`](WorldQuery::State) for this [`WorldQuery`] type.
     fn init_state(world: &mut World) -> Self::State;
@@ -134,7 +134,7 @@ pub unsafe trait WorldQuery {
     /// Returns `true` if this query matches a set of components. Otherwise, returns `false`.
     fn matches_component_set(
         state: &Self::State,
-        set_contains_id: &impl Fn(ComponentId) -> bool,
+        set_contains_id: &impl Fn(DataId) -> bool,
     ) -> bool;
 }
 
@@ -199,7 +199,7 @@ macro_rules! impl_tuple_world_query {
                 ($($name::fetch($name, _entity, _table_row),)*)
             }
 
-            fn update_component_access(state: &Self::State, _access: &mut FilteredAccess<ComponentId>) {
+            fn update_component_access(state: &Self::State, _access: &mut FilteredAccess<DataId>) {
                 let ($($name,)*) = state;
                 $($name::update_component_access($name, _access);)*
             }
@@ -212,7 +212,7 @@ macro_rules! impl_tuple_world_query {
                 Some(($($name::get_state(_world)?,)*))
             }
 
-            fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(ComponentId) -> bool) -> bool {
+            fn matches_component_set(state: &Self::State, _set_contains_id: &impl Fn(DataId) -> bool) -> bool {
                 let ($($name,)*) = state;
                 true $(&& $name::matches_component_set($name, _set_contains_id))*
             }

--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     self as bevy_ecs,
-    component::{Component, ComponentId, ComponentIdFor, Tick},
+    component::{Component, ComponentIdFor, DataId, Tick},
     entity::Entity,
     event::{Event, EventId, EventIterator, EventIteratorWithId, Events, ManualEventReader},
     prelude::Local,
@@ -66,7 +66,7 @@ impl<T: Component> DerefMut for RemovedComponentReader<T> {
 /// Stores the [`RemovedComponents`] event buffers for all types of component in a given [`World`].
 #[derive(Default, Debug)]
 pub struct RemovedComponentEvents {
-    event_sets: SparseSet<ComponentId, Events<RemovedComponentEntity>>,
+    event_sets: SparseSet<DataId, Events<RemovedComponentEntity>>,
 }
 
 impl RemovedComponentEvents {
@@ -84,15 +84,12 @@ impl RemovedComponentEvents {
     }
 
     /// Gets the event storage for a given component.
-    pub fn get(
-        &self,
-        component_id: impl Into<ComponentId>,
-    ) -> Option<&Events<RemovedComponentEntity>> {
+    pub fn get(&self, component_id: impl Into<DataId>) -> Option<&Events<RemovedComponentEntity>> {
         self.event_sets.get(component_id.into())
     }
 
     /// Sends a removal event for the specified component.
-    pub fn send(&mut self, component_id: impl Into<ComponentId>, entity: Entity) {
+    pub fn send(&mut self, component_id: impl Into<DataId>, entity: Entity) {
         self.event_sets
             .get_or_insert_with(component_id.into(), Default::default)
             .send(RemovedComponentEntity(entity));

--- a/crates/bevy_ecs/src/system/adapter_system.rs
+++ b/crates/bevy_ecs/src/system/adapter_system.rs
@@ -85,7 +85,7 @@ where
         std::any::TypeId::of::<Self>()
     }
 
-    fn component_access(&self) -> &crate::query::Access<crate::component::ComponentId> {
+    fn component_access(&self) -> &crate::query::Access<crate::component::DataId> {
         self.system.component_access()
     }
 

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -4,7 +4,7 @@ use bevy_ptr::UnsafeCellDeref;
 
 use crate::{
     archetype::ArchetypeComponentId,
-    component::{ComponentId, Tick},
+    component::{DataId, Tick},
     prelude::World,
     query::Access,
     schedule::InternedSystemSet,
@@ -109,7 +109,7 @@ pub struct CombinatorSystem<Func, A, B> {
     a: A,
     b: B,
     name: Cow<'static, str>,
-    component_access: Access<ComponentId>,
+    component_access: Access<DataId>,
     archetype_component_access: Access<ArchetypeComponentId>,
 }
 
@@ -146,7 +146,7 @@ where
         std::any::TypeId::of::<Self>()
     }
 
-    fn component_access(&self) -> &Access<ComponentId> {
+    fn component_access(&self) -> &Access<DataId> {
         &self.component_access
     }
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::ArchetypeComponentId,
-    component::{ComponentId, Tick},
+    component::{DataId, Tick},
     query::Access,
     schedule::{InternedSystemSet, SystemSet},
     system::{
@@ -71,7 +71,7 @@ where
     }
 
     #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
+    fn component_access(&self) -> &Access<DataId> {
         self.system_meta.component_access_set.combined_access()
     }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -1,6 +1,6 @@
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeGeneration},
-    component::{ComponentId, Tick},
+    component::{DataId, Tick},
     prelude::FromWorld,
     query::{Access, FilteredAccessSet},
     schedule::{InternedSystemSet, SystemSet},
@@ -20,7 +20,7 @@ use super::{In, IntoSystem, ReadOnlySystem};
 #[derive(Clone)]
 pub struct SystemMeta {
     pub(crate) name: Cow<'static, str>,
-    pub(crate) component_access_set: FilteredAccessSet<ComponentId>,
+    pub(crate) component_access_set: FilteredAccessSet<DataId>,
     pub(crate) archetype_component_access: Access<ArchetypeComponentId>,
     // NOTE: this must be kept private. making a SystemMeta non-send is irreversible to prevent
     // SystemParams from overriding each other
@@ -459,7 +459,7 @@ where
     }
 
     #[inline]
-    fn component_access(&self) -> &Access<ComponentId> {
+    fn component_access(&self) -> &Access<DataId> {
         self.system_meta.component_access_set.combined_access()
     }
 

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -96,7 +96,7 @@
 //! - [`SystemChangeTick`]
 //! - [`Archetypes`](crate::archetype::Archetypes) (Provides Archetype metadata)
 //! - [`Bundles`](crate::bundle::Bundles) (Provides Bundles metadata)
-//! - [`Components`](crate::component::Components) (Provides Components metadata)
+//! - [`WorldData`](crate::component::WorldData) (Provides Components & Resources metadata)
 //! - [`Entities`](crate::entity::Entities) (Provides Entities metadata)
 //! - All tuples between 1 to 16 elements where each element implements [`SystemParam`]
 //! - [`()` (unit primitive type)](https://doc.rust-lang.org/stable/std/primitive.unit.html)
@@ -335,7 +335,7 @@ mod tests {
         archetype::{ArchetypeComponentId, Archetypes},
         bundle::Bundles,
         change_detection::DetectChanges,
-        component::{Component, Components, Tick},
+        component::{Component, Tick, WorldData},
         entity::{Entities, Entity},
         prelude::AnyOf,
         query::{Added, Changed, Or, With, Without},
@@ -1019,7 +1019,7 @@ mod tests {
         world.spawn((W(42), W(true)));
         fn sys(
             archetypes: &Archetypes,
-            components: &Components,
+            components: &WorldData,
             entities: &Entities,
             bundles: &Bundles,
             query: Query<Entity, With<W<i32>>>,
@@ -1039,7 +1039,7 @@ mod tests {
                 for component_id in &bundle_components {
                     assert!(
                         components.get_info(*component_id).is_some(),
-                        "every bundle component exists in Components"
+                        "every bundle component exists in WorldData"
                     );
                 }
                 assert_eq!(

--- a/crates/bevy_ecs/src/system/system.rs
+++ b/crates/bevy_ecs/src/system/system.rs
@@ -4,7 +4,7 @@ use core::fmt::Debug;
 use crate::component::Tick;
 use crate::schedule::InternedSystemSet;
 use crate::world::unsafe_world_cell::UnsafeWorldCell;
-use crate::{archetype::ArchetypeComponentId, component::ComponentId, query::Access, world::World};
+use crate::{archetype::ArchetypeComponentId, component::DataId, query::Access, world::World};
 
 use std::any::TypeId;
 use std::borrow::Cow;
@@ -33,10 +33,10 @@ pub trait System: Send + Sync + 'static {
     /// Returns the [`TypeId`] of the underlying system type.
     fn type_id(&self) -> TypeId;
     /// Returns the system's component [`Access`].
-    fn component_access(&self) -> &Access<ComponentId>;
+    fn component_access(&self) -> &Access<DataId>;
     /// Returns the system's archetype component [`Access`].
     fn archetype_component_access(&self) -> &Access<ArchetypeComponentId>;
-    /// Returns true if the system is [`Send`].
+    /// Returns true if the system is [`Send`]
     fn is_send(&self) -> bool;
 
     /// Returns true if the system must be run exclusively.

--- a/crates/bevy_ecs/src/world/spawn_batch.rs
+++ b/crates/bevy_ecs/src/world/spawn_batch.rs
@@ -36,12 +36,12 @@ where
 
         let bundle_info = world
             .bundles
-            .init_info::<I::Item>(&mut world.components, &mut world.storages);
+            .init_info::<I::Item>(&mut world.world_data, &mut world.storages);
         world.entities.reserve(length as u32);
         let mut spawner = bundle_info.get_bundle_spawner(
             &mut world.entities,
             &mut world.archetypes,
-            &world.components,
+            &world.world_data,
             &mut world.storages,
             change_tick,
         );

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -423,7 +423,7 @@ mod tests {
             }
         }
 
-        let u32_component_id = world.components.get_resource_id(TypeId::of::<A>()).unwrap();
+        let u32_component_id = world.world_data.get_resource_id(TypeId::of::<A>()).unwrap();
         let u32_archetype_component_id = world
             .get_resource_archetype_component_id(u32_component_id)
             .unwrap();

--- a/crates/bevy_scene/src/dynamic_scene_builder.rs
+++ b/crates/bevy_scene/src/dynamic_scene_builder.rs
@@ -1,5 +1,5 @@
 use crate::{DynamicEntity, DynamicScene, SceneFilter};
-use bevy_ecs::component::{Component, ComponentId};
+use bevy_ecs::component::{Component, DataId};
 use bevy_ecs::system::Resource;
 use bevy_ecs::{
     prelude::Entity,
@@ -53,7 +53,7 @@ use std::collections::BTreeMap;
 /// let dynamic_scene = DynamicSceneBuilder::from_world(&world).extract_entity(entity).build();
 /// ```
 pub struct DynamicSceneBuilder<'w> {
-    extracted_resources: BTreeMap<ComponentId, Box<dyn Reflect>>,
+    extracted_resources: BTreeMap<DataId, Box<dyn Reflect>>,
     extracted_scene: BTreeMap<Entity, DynamicEntity>,
     component_filter: SceneFilter,
     resource_filter: SceneFilter,

--- a/examples/ecs/dynamic.rs
+++ b/examples/ecs/dynamic.rs
@@ -6,7 +6,7 @@ use std::{alloc::Layout, io::Write, ptr::NonNull};
 use bevy::prelude::*;
 use bevy::{
     ecs::{
-        component::{ComponentDescriptor, ComponentId, ComponentInfo, StorageType},
+        component::{DataDescriptor, DataId, DataInfo, StorageType},
         query::{QueryBuilder, QueryData},
         world::FilteredEntityMut,
     },
@@ -45,8 +45,8 @@ query, q  Query for entities
 fn main() {
     let mut world = World::new();
     let mut lines = std::io::stdin().lines();
-    let mut component_names = HashMap::<String, ComponentId>::new();
-    let mut component_info = HashMap::<ComponentId, ComponentInfo>::new();
+    let mut component_names = HashMap::<String, DataId>::new();
+    let mut component_info = HashMap::<DataId, DataInfo>::new();
 
     println!("{}", PROMPT);
     loop {
@@ -84,7 +84,7 @@ fn main() {
                     // Register our new component to the world with a layout specified by it's size
                     // SAFETY: [u64] is Send + Sync
                     let id = world.init_component_with_descriptor(unsafe {
-                        ComponentDescriptor::new_with_layout(
+                        DataDescriptor::new_with_layout(
                             name.to_string(),
                             StorageType::Table,
                             Layout::array::<u64>(size).unwrap(),
@@ -206,7 +206,7 @@ fn to_owning_ptrs(components: &mut [Vec<u64>]) -> Vec<OwningPtr<Aligned>> {
 fn parse_term<Q: QueryData>(
     str: &str,
     builder: &mut QueryBuilder<Q>,
-    components: &HashMap<String, ComponentId>,
+    components: &HashMap<String, DataId>,
 ) {
     let mut matched = false;
     let str = str.trim();
@@ -250,7 +250,7 @@ fn parse_term<Q: QueryData>(
 fn parse_query<Q: QueryData>(
     str: &str,
     builder: &mut QueryBuilder<Q>,
-    components: &HashMap<String, ComponentId>,
+    components: &HashMap<String, DataId>,
 ) {
     let str = str.split(',');
     str.for_each(|term| {


### PR DESCRIPTION
# Objective

- pick up the first half of #4955 (refactor & rename of common types)

## Solution

- [x] Rename many types that had the word `Component` in the them to a name without the word `Component` (usually `Data`) to reflect that they could be used in the context of resources as well.

---

## Changelog

- Rename `Components` to `WorldData`
- Rename `ComponentId` to `DataId`
- Rename `ComponentDescriptor` to `DataDescriptor`
- Rename `ComponentInfo` to `DataInfo`
- Rename some local variables in different methods to reflect these changes (use `component_id`, `data_id` and `resource_id` appropriately based on the context)
- Rename `components` field in `World` to `world_data`

## Migration Guide

- Use `WorldData` instead of `Components` 
- Use `DataId` instead of `ComponentId` 
- Use `DataDescriptor` instead of `ComponentDescriptor` 
- Use `DataInfo` instead of `ComponentInfo` 

## Additional Context

At first I wanted to f i x #3007 in one PR like #4955 tried but I realized that all of the refactoring and the renaming will make it very difficult to review. So I decided to split them out. This PR will be focused on renaming and iterating over all of the `Components` and `Resources` will be a different PR.
