### PR TITLE
Change relevant methods in World and co to return ResMut

### DIFF
--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -220,7 +220,7 @@ impl Main {
     /// A system that runs the "main schedule"
     pub fn run_main(world: &mut World, mut run_at_least_once: Local<bool>) {
         if !*run_at_least_once {
-            world.resource_scope(|world, order: Mut<MainScheduleOrder>| {
+            world.resource_scope(|world, order: ResMut<MainScheduleOrder>| {
                 for &label in &order.startup_labels {
                     let _ = world.try_run_schedule(label);
                 }
@@ -228,7 +228,7 @@ impl Main {
             *run_at_least_once = true;
         }
 
-        world.resource_scope(|world, order: Mut<MainScheduleOrder>| {
+        world.resource_scope(|world, order: ResMut<MainScheduleOrder>| {
             for &label in &order.labels {
                 let _ = world.try_run_schedule(label);
             }
@@ -302,7 +302,7 @@ impl FixedMainScheduleOrder {
 impl FixedMain {
     /// A system that runs the fixed timestep's "main schedule"
     pub fn run_fixed_main(world: &mut World) {
-        world.resource_scope(|world, order: Mut<FixedMainScheduleOrder>| {
+        world.resource_scope(|world, order: ResMut<FixedMainScheduleOrder>| {
             for &label in &order.labels {
                 let _ = world.try_run_schedule(label);
             }

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -1,9 +1,9 @@
 use crate::{App, Plugin};
 use bevy_ecs::{
+    change_detection::ResMut,
     schedule::{ExecutorKind, InternedScheduleLabel, Schedule, ScheduleLabel},
     system::{Local, Resource},
     world::World,
-    change_detection::ResMut
 };
 
 /// The schedule that contains the app logic that is evaluated each tick of [`App::update()`].

--- a/crates/bevy_app/src/main_schedule.rs
+++ b/crates/bevy_app/src/main_schedule.rs
@@ -2,7 +2,8 @@ use crate::{App, Plugin};
 use bevy_ecs::{
     schedule::{ExecutorKind, InternedScheduleLabel, Schedule, ScheduleLabel},
     system::{Local, Resource},
-    world::{Mut, World},
+    world::World,
+    change_detection::ResMut
 };
 
 /// The schedule that contains the app logic that is evaluated each tick of [`App::update()`].

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -1116,7 +1116,7 @@ impl AssetServer {
 
 /// A system that manages internal [`AssetServer`] events, such as finalizing asset loads.
 pub fn handle_internal_asset_events(world: &mut World) {
-    world.resource_scope(|world, server: Mut<AssetServer>| {
+    world.resource_scope(|world, server: ResMut<AssetServer>| {
         let mut infos = server.data.infos.write();
         let mut untyped_failures = vec![];
         for event in server.data.asset_event_receiver.try_iter() {

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -761,6 +761,15 @@ impl<'w, T: ?Sized> From<Mut<'w, T>> for Ref<'w, T> {
     }
 }
 
+impl<'w, R: ?Sized + Resource> From<Mut<'w, R>> for ResMut<'w, R> {
+    fn from(mut_ref: Mut<'w, R>) -> Self {
+        Self {
+            value: mut_ref.value,
+            ticks: mut_ref.ticks,
+        }
+    }
+}
+
 impl<'w, 'a, T> IntoIterator for &'a Mut<'w, T>
 where
     &'a T: IntoIterator,

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -60,12 +60,12 @@ mod tests {
     use crate::prelude::Or;
     use crate::{
         bundle::Bundle,
-        change_detection::Ref,
+        change_detection::{Ref, ResMut},
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
         system::Resource,
-        world::{EntityRef, Mut, World},
+        world::{EntityRef, World},
     };
     use bevy_tasks::{ComputeTaskPool, TaskPool};
     use std::num::NonZeroU32;

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1407,7 +1407,7 @@ mod tests {
     fn resource_scope() {
         let mut world = World::default();
         world.insert_resource(A(0));
-        world.resource_scope(|world: &mut World, mut value: Mut<A>| {
+        world.resource_scope(|world: &mut World, mut value: ResMut<A>| {
             value.0 += 1;
             assert!(!world.contains_resource::<A>());
         });

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,6 +1,6 @@
 use crate::reflect::AppTypeRegistry;
 use crate::system::{Command, EntityCommands, Resource};
-use crate::{entity::Entity, reflect::ReflectComponent, world::World, change_detection::ResMut};
+use crate::{change_detection::ResMut, entity::Entity, reflect::ReflectComponent, world::World};
 use bevy_reflect::{Reflect, TypeRegistry};
 use std::borrow::Cow;
 use std::marker::PhantomData;

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -1,7 +1,6 @@
-use crate::prelude::Mut;
 use crate::reflect::AppTypeRegistry;
 use crate::system::{Command, EntityCommands, Resource};
-use crate::{entity::Entity, reflect::ReflectComponent, world::World};
+use crate::{entity::Entity, reflect::ReflectComponent, world::World, change_detection::ResMut};
 use bevy_reflect::{Reflect, TypeRegistry};
 use std::borrow::Cow;
 use std::marker::PhantomData;

--- a/crates/bevy_ecs/src/reflect/entity_commands.rs
+++ b/crates/bevy_ecs/src/reflect/entity_commands.rs
@@ -237,7 +237,7 @@ pub struct InsertReflectWithRegistry<T: Resource + AsRef<TypeRegistry>> {
 
 impl<T: Resource + AsRef<TypeRegistry>> Command for InsertReflectWithRegistry<T> {
     fn apply(self, world: &mut World) {
-        world.resource_scope(|world, registry: Mut<T>| {
+        world.resource_scope(|world, registry: ResMut<T>| {
             let registry: &TypeRegistry = registry.as_ref().as_ref();
             insert_reflect(world, self.entity, registry, self.component);
         });
@@ -302,7 +302,7 @@ pub struct RemoveReflectWithRegistry<T: Resource + AsRef<TypeRegistry>> {
 
 impl<T: Resource + AsRef<TypeRegistry>> Command for RemoveReflectWithRegistry<T> {
     fn apply(self, world: &mut World) {
-        world.resource_scope(|world, registry: Mut<T>| {
+        world.resource_scope(|world, registry: ResMut<T>| {
             let registry: &TypeRegistry = registry.as_ref().as_ref();
             remove_reflect(world, self.entity, registry, self.component_type_name);
         });

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -167,7 +167,7 @@ impl SystemMeta {
 /// });
 ///
 /// // Later, fetch the cached system state, saving on overhead
-/// world.resource_scope(|world, mut cached_state: Mut<CachedSystemState>| {
+/// world.resource_scope(|world, mut cached_state: ResMut<CachedSystemState>| {
 ///     let mut event_reader = cached_state.event_state.get_mut(world);
 ///
 ///     for events in event_reader.read() {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     removal_detection::RemovedComponentEvents,
     schedule::{Schedule, ScheduleLabel, Schedules},
     storage::{ResourceData, Storages},
-    system::{Res, Resource},
+    system::{Res, ResMut, Resource},
     world::error::TryRunScheduleError,
 };
 use bevy_ptr::{OwningPtr, Ptr};
@@ -1337,7 +1337,7 @@ impl World {
     /// use [`get_resource_or_insert_with`](World::get_resource_or_insert_with).
     #[inline]
     #[track_caller]
-    pub fn resource_mut<R: Resource>(&mut self) -> Mut<'_, R> {
+    pub fn resource_mut<R: Resource>(&mut self) -> ResMut<'_, R> {
         match self.get_resource_mut() {
             Some(x) => x,
             None => panic!(
@@ -1370,7 +1370,7 @@ impl World {
 
     /// Gets a mutable reference to the resource of the given type if it exists
     #[inline]
-    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<Mut<'_, R>> {
+    pub fn get_resource_mut<R: Resource>(&mut self) -> Option<ResMut<'_, R>> {
         // SAFETY:
         // - `as_unsafe_world_cell` gives permission to access everything mutably
         // - `&mut self` ensures nothing in world is borrowed
@@ -1383,7 +1383,7 @@ impl World {
     pub fn get_resource_or_insert_with<R: Resource>(
         &mut self,
         func: impl FnOnce() -> R,
-    ) -> Mut<'_, R> {
+    ) -> ResMut<'_, R> {
         let change_tick = self.change_tick();
         let last_change_tick = self.last_change_tick();
 
@@ -1404,7 +1404,7 @@ impl World {
                 .debug_checked_unwrap()
         };
         // SAFETY: The underlying type of the resource is `R`.
-        unsafe { data.with_type::<R>() }
+        unsafe { data.with_type::<R>().into() }
     }
 
     /// Gets an immutable reference to the non-send resource of the given type, if it exists.
@@ -1637,13 +1637,16 @@ impl World {
     /// world.insert_resource(A(1));
     /// let entity = world.spawn(B(1)).id();
     ///
-    /// world.resource_scope(|world, mut a: Mut<A>| {
+    /// world.resource_scope(|world, mut a: ResMut<A>| {
     ///     let b = world.get_mut::<B>(entity).unwrap();
     ///     a.0 += b.0;
     /// });
     /// assert_eq!(world.get_resource::<A>().unwrap().0, 2);
     /// ```
-    pub fn resource_scope<R: Resource, U>(&mut self, f: impl FnOnce(&mut World, Mut<R>) -> U) -> U {
+    pub fn resource_scope<R: Resource, U>(
+        &mut self,
+        f: impl FnOnce(&mut World, ResMut<R>) -> U,
+    ) -> U {
         let last_change_tick = self.last_change_tick();
         let change_tick = self.change_tick();
 
@@ -1660,7 +1663,7 @@ impl World {
         // Read the value onto the stack to avoid potential mut aliasing.
         // SAFETY: `ptr` was obtained from the TypeId of `R`.
         let mut value = unsafe { ptr.read::<R>() };
-        let value_mut = Mut {
+        let value_mut = ResMut {
             value: &mut value,
             ticks: TicksMut {
                 added: &mut ticks.added,

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -1907,7 +1907,7 @@ impl World {
     }
 
     /// Runs both [`clear_entities`](Self::clear_entities) and [`clear_resources`](Self::clear_resources),
-    /// invalidating all [`Entity`] and resource fetches such as [`Res`], [`ResMut`](crate::system::ResMut)
+    /// invalidating all [`Entity`] and resource fetches such as [`Res`], [`ResMut`]
     pub fn clear_all(&mut self) {
         self.clear_entities();
         self.clear_resources();

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -56,7 +56,7 @@ use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
 /// struct OnlyComponentAccessWorld<'w>(UnsafeWorldCell<'w>);
 ///
 /// impl<'w> OnlyResourceAccessWorld<'w> {
-///     fn get_resource_mut<T: Resource>(&mut self) -> Option<Mut<'_, T>> {
+///     fn get_resource_mut<T: Resource>(&mut self) -> Option<ResMut<'_, T>> {
 ///         // SAFETY: resource access is allowed through this UnsafeWorldCell
 ///         unsafe { self.0.get_resource_mut::<T>() }
 ///     }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -46,7 +46,7 @@ use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
 ///
 /// ```
 /// use bevy_ecs::world::World;
-/// use bevy_ecs::change_detection::Mut;
+/// use bevy_ecs::change_detection::ResMut;
 /// use bevy_ecs::system::Resource;
 /// use bevy_ecs::world::unsafe_world_cell::UnsafeWorldCell;
 ///

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -14,7 +14,7 @@ use crate::{
     prelude::Component,
     removal_detection::RemovedComponentEvents,
     storage::{Column, ComponentSparseSet, Storages},
-    system::{Res, Resource},
+    system::{Res, ResMut, Resource},
 };
 use bevy_ptr::Ptr;
 use std::{any::TypeId, cell::UnsafeCell, fmt::Debug, marker::PhantomData};
@@ -436,7 +436,7 @@ impl<'w> UnsafeWorldCell<'w> {
     /// - the [`UnsafeWorldCell`] has permission to access the resource mutably
     /// - no other references to the resource exist at the same time
     #[inline]
-    pub unsafe fn get_resource_mut<R: Resource>(self) -> Option<Mut<'w, R>> {
+    pub unsafe fn get_resource_mut<R: Resource>(self) -> Option<ResMut<'w, R>> {
         let component_id = self.components().get_resource_id(TypeId::of::<R>())?;
         // SAFETY:
         // - caller ensures `self` has permission to access the resource mutably
@@ -444,7 +444,7 @@ impl<'w> UnsafeWorldCell<'w> {
         unsafe {
             self.get_resource_mut_by_id(component_id)
                 // `component_id` was gotten from `TypeId::of::<R>()`
-                .map(|ptr| ptr.with_type::<R>())
+                .map(|ptr| ptr.with_type::<R>().into())
         }
     }
 

--- a/crates/bevy_ecs/src/world/world_cell.rs
+++ b/crates/bevy_ecs/src/world/world_cell.rs
@@ -243,7 +243,7 @@ impl<'w> WorldCell<'w> {
             .get_resource_archetype_component_id(component_id)?;
         WorldBorrowMut::try_new(
             // SAFETY: access is checked by WorldBorrowMut
-            || unsafe { self.world.get_resource_mut::<T>() },
+            || unsafe { self.world.get_resource_mut::<T>().map(|res| res.into()) },
             archetype_component_id,
             self.access.clone(),
         )

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -463,7 +463,7 @@ unsafe fn initialize_render_app(app: &mut App) {
 /// the render schedule rather than during extraction to allow the commands to run in parallel with the
 /// main app when pipelined rendering is enabled.
 fn apply_extract_commands(render_world: &mut World) {
-    render_world.resource_scope(|render_world, mut schedules: Mut<Schedules>| {
+    render_world.resource_scope(|render_world, mut schedules: ResMut<Schedules>| {
         schedules
             .get_mut(ExtractSchedule)
             .unwrap()

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -2,10 +2,7 @@ use async_channel::{Receiver, Sender};
 
 use bevy_app::{App, AppLabel, Main, Plugin, SubApp};
 use bevy_ecs::{
-    schedule::MainThreadExecutor,
-    system::Resource,
-    world::World,
-    change_detection::ResMut,
+    change_detection::ResMut, schedule::MainThreadExecutor, system::Resource, world::World,
 };
 use bevy_tasks::ComputeTaskPool;
 

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -135,7 +135,7 @@ impl Plugin for PipelinedRenderingPlugin {
 // This function waits for the rendering world to be received,
 // runs extract, and then sends the rendering world back to the render thread.
 fn update_rendering(app_world: &mut World, _sub_app: &mut App) {
-    app_world.resource_scope(|world, main_thread_executor: Mut<MainThreadExecutor>| {
+    app_world.resource_scope(|world, main_thread_executor: ResMut<MainThreadExecutor>| {
         // we use a scope here to run any main thread tasks that the render world still needs to run
         // while we wait for the render world to be received.
         let mut render_app = ComputeTaskPool::get()

--- a/crates/bevy_render/src/pipelined_rendering.rs
+++ b/crates/bevy_render/src/pipelined_rendering.rs
@@ -4,7 +4,8 @@ use bevy_app::{App, AppLabel, Main, Plugin, SubApp};
 use bevy_ecs::{
     schedule::MainThreadExecutor,
     system::Resource,
-    world::{Mut, World},
+    world::World,
+    change_detection::ResMut,
 };
 use bevy_tasks::ComputeTaskPool;
 

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -306,7 +306,7 @@ impl<A: RenderAsset> FromWorld for CachedExtractRenderAssetSystemState<A> {
 /// into the "render world".
 fn extract_render_asset<A: RenderAsset>(mut commands: Commands, mut main_world: ResMut<MainWorld>) {
     main_world.resource_scope(
-        |world, mut cached_state: Mut<CachedExtractRenderAssetSystemState<A>>| {
+        |world, mut cached_state: ResMut<CachedExtractRenderAssetSystemState<A>>| {
             let (mut events, mut assets) = cached_state.state.get_mut(world);
 
             let mut changed_assets = HashSet::default();

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     prelude::{Commands, EventReader, IntoSystemConfigs, ResMut, Resource},
     schedule::SystemConfigs,
     system::{StaticSystemParam, SystemParam, SystemParamItem, SystemState},
-    world::{FromWorld, Mut},
+    world::FromWorld,
 };
 use bevy_reflect::{
     utility::{reflect_hasher, NonGenericTypeInfoCell},

--- a/crates/bevy_render/src/renderer/mod.rs
+++ b/crates/bevy_render/src/renderer/mod.rs
@@ -23,7 +23,7 @@ use wgpu::{
 
 /// Updates the [`RenderGraph`] with all of its nodes and then runs it to render the entire frame.
 pub fn render_system(world: &mut World) {
-    world.resource_scope(|world, mut graph: Mut<RenderGraph>| {
+    world.resource_scope(|world, mut graph: ResMut<RenderGraph>| {
         graph.update(world);
     });
     let graph = world.resource::<RenderGraph>();

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -5,7 +5,8 @@ use bevy_ecs::{
     event::{Event, Events, ManualEventReader},
     reflect::AppTypeRegistry,
     system::{Command, Resource},
-    world::{Mut, World},
+    world::World,
+    change_detection::ResMut,
 };
 use bevy_hierarchy::{Parent, PushChild};
 use bevy_utils::{tracing::error, EntityHashMap, HashMap, HashSet};

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -215,7 +215,7 @@ impl SceneSpawner {
         id: AssetId<DynamicScene>,
         entity_map: &mut EntityHashMap<Entity, Entity>,
     ) -> Result<(), SceneSpawnError> {
-        world.resource_scope(|world, scenes: Mut<Assets<DynamicScene>>| {
+        world.resource_scope(|world, scenes: ResMut<Assets<DynamicScene>>| {
             let scene = scenes
                 .get(id)
                 .ok_or(SceneSpawnError::NonExistentScene { id })?;
@@ -238,7 +238,7 @@ impl SceneSpawner {
         id: AssetId<Scene>,
         instance_id: InstanceId,
     ) -> Result<InstanceId, SceneSpawnError> {
-        world.resource_scope(|world, scenes: Mut<Assets<Scene>>| {
+        world.resource_scope(|world, scenes: ResMut<Assets<Scene>>| {
             let scene = scenes
                 .get(id)
                 .ok_or(SceneSpawnError::NonExistentRealScene { id })?;
@@ -387,7 +387,7 @@ impl SceneSpawner {
 
 /// System that handles scheduled scene instance spawning and despawning through a [`SceneSpawner`].
 pub fn scene_spawner_system(world: &mut World) {
-    world.resource_scope(|world, mut scene_spawner: Mut<SceneSpawner>| {
+    world.resource_scope(|world, mut scene_spawner: ResMut<SceneSpawner>| {
         // remove any loading instances where parent is deleted
         let mut dead_instances = HashSet::default();
         scene_spawner

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -1,12 +1,12 @@
 use crate::{DynamicScene, Scene};
 use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
 use bevy_ecs::{
+    change_detection::ResMut,
     entity::Entity,
     event::{Event, Events, ManualEventReader},
     reflect::AppTypeRegistry,
     system::{Command, Resource},
     world::World,
-    change_detection::ResMut,
 };
 use bevy_hierarchy::{Parent, PushChild};
 use bevy_utils::{tracing::error, EntityHashMap, HashMap, HashSet};


### PR DESCRIPTION
# Objective

- Fixes #11765 

## Solution

- Changed the current implementations to use `ResMut` instead of `Mut`

---

## Changelog

- In `World`: `resource_mut`, `get_resource_mut`, `get_resource_or_insert_with` now return `ResMut` / `Option<ResMut>` and `resource_scope`now accepts a function parameter of type `impl FnOnce(&mut World, ResMut<R>) -> U`
- In `UnsafeWorldCell`: `get_resource_mut` now returns `Option<ResMut>`
- Changed internal uses of these methods to use `ResMut` aswell.
- `ResMut<R>` now implements `From<Mut<R: Resource>>`

## Migration Guide

- For most use cases this should not require any action besides changing `Mut<T>` to `ResMut<T>` since they are very similar to each other and  `Mut<T>` implements `From<ResMut<'w, T>> for Mut<'w, T>`. But you could just call `.into()` if any problems arise.
