### PR TITLE
delete duplicate transform propagation configuration

### DIFF
--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -116,19 +116,6 @@ impl Plugin for TransformPlugin {
                         .ambiguous_with(PropagateTransformsSet),
                     propagate_transforms.in_set(PropagateTransformsSet),
                 ),
-            )
-            .configure_sets(
-                PostUpdate,
-                PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
-            )
-            .add_systems(
-                PostUpdate,
-                (
-                    sync_simple_transforms
-                        .in_set(TransformSystem::TransformPropagate)
-                        .ambiguous_with(PropagateTransformsSet),
-                    propagate_transforms.in_set(PropagateTransformsSet),
-                ),
             );
     }
 }


### PR DESCRIPTION
# Objective

- The transform propagation systems were being added twice to the schedule. Looks like a bad merge snuck in at some point.