### PR TITLE
use unrounded size to clip ui nodes

### DIFF
--- a/crates/bevy_ui/src/update.rs
+++ b/crates/bevy_ui/src/update.rs
@@ -80,7 +80,14 @@ fn update_clipping(
         // current node's clip and the inherited clip. This handles the case
         // of nested `Overflow::Hidden` nodes. If parent `clip` is not
         // defined, use the current node's clip.
-        let mut node_rect = node.logical_rect(global_transform);
+        let mut node_rect = Rect::from_center_size(
+            global_transform.translation().truncate(),
+            node.unrounded_size(),
+        );
+        node_rect = Rect {
+            min: node_rect.min.floor(),
+            max: node_rect.max.ceil(),
+        };
         if style.overflow.x == OverflowAxis::Visible {
             node_rect.min.x = -f32::INFINITY;
             node_rect.max.x = f32::INFINITY;


### PR DESCRIPTION
# Objective

clipping sometimes uses too-tight bounds when nodes are not aligned to pixel boundaries.

## Solution

use the unrounded size, and floor/ceil on the min/max of the clipping bounds.

before:
![overflow error](https://github.com/bevyengine/bevy/assets/50659922/7794b894-7329-401a-97ff-d7cd9bcb6990)

after:
![overflow fixed](https://github.com/bevyengine/bevy/assets/50659922/fdd15932-1a43-4300-88f2-cd6fdfdeab53)
