### PR TITLE
Update ahash to 0.8.7

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 detailed_trace = []
 
 [dependencies]
-ahash = "0.8.3"
+ahash = "0.8.7"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
 web-time = { version = "0.2" }
 uuid = { version = "1.1", features = ["v4", "serde"] }


### PR DESCRIPTION
# Objective

`bevy_utils` only requires aHash 0.8.3, which is broken on Rust 1.7.6:
```
error: could not compile `ahash` (lib) due to 1 previous error
error[E0635]: unknown feature `stdsimd`
```

See https://github.com/tkaitchuck/aHash/issues/200

This is fixed in aHash 0.8.7, so require at least that version (Cargo.lock is already up to date).