### PR TITLE
Fix undefined behavior in render world extraction

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -839,7 +839,9 @@ impl Entities {
         *free_cursor = 0;
         self.meta.reserve(count);
         // the EntityMeta struct only contains integers, and it is valid to have all bytes set to u8::MAX
-        self.meta.as_mut_ptr().write_bytes(u8::MAX, count);
+        self.meta
+            .as_mut_ptr()
+            .write_bytes(u8::MAX, count * mem::size_of::<EntityMeta>());
         self.meta.set_len(count);
 
         self.len = count as u32;


### PR DESCRIPTION
# Objective

`flush_and_reserve_invalid_assuming_no_entities` appears to contain an uninitialized memory error on line 842:
+ `EntityMeta` is 20 bytes.
+ `meta` is `Vec<EntityMeta>` with length 0 and capacity `count`.
+ `meta.as_mut_ptr().write_bytes(u8::MAX, count)` only initializes `count / 20` entries.
+ The following call to`set_len` requires `count` entries to be initialized first.

This may result in the use of uninitialized memory in the render world and undefined behavior.

## Solution

Write `count * mem::size_of<EntityMeta>()` bytes to fully initialize the vec.