### PR TITLE
Derive Ord for GamepadButtonType.

### DIFF
--- a/crates/bevy_input/src/gamepad.rs
+++ b/crates/bevy_input/src/gamepad.rs
@@ -167,7 +167,7 @@ impl Gamepads {
 /// [`GamepadButtonChangedEvent`]. It is also used in the [`GamepadButton`]
 /// which in turn is used to create the [`ButtonInput<GamepadButton>`] or
 /// [`Axis<GamepadButton>`] `bevy` resources.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Reflect, PartialOrd, Ord)]
 #[reflect(Debug, Hash, PartialEq)]
 #[cfg_attr(
     feature = "serialize",


### PR DESCRIPTION
# Objective

Use `GamepadButtonType` with library that requires `Ord`.

## Motivation

`KeyCode` derives `Ord` that I'm using with a trie for recognizing [input sequences](https://github.com/shanecelis/bevy-input-sequence/tree/trie). I would like to do the same for `GamepadButtonType` but am stymied by it not deriving `Ord`.

## Solution

This PR add derivations PartialOrd and Ord for `GamepadButtonType`.

## Workaround

If deriving `Ord` is not possible, I'd be happy to know how I might coerce `GamepadButtonType` into a `u32` or something else that is `Ord`, so I can wrap `GamepadButtonType` in a newtype. I suppose serializing with serde may work or reflect?
