### PR TITLE
Fix global wireframe behavior not being applied on new meshes

### DIFF
--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -45,10 +45,9 @@ impl Plugin for WireframePlugin {
                 (
                     global_color_changed.run_if(resource_changed::<WireframeConfig>),
                     wireframe_color_changed,
-                    apply_wireframe_material,
-                    // Run after `apply_wireframe_material` so that the global wireframe setting is applied
-                    // to a mesh on the same frame its wireframe marker component is removed.
-                    apply_global_wireframe_material.after(apply_wireframe_material),
+                    // Run `apply_global_wireframe_material` after `apply_wireframe_material` so that the global
+                    // wireframe setting is applied to a mesh on the same frame its wireframe marker component is removed.
+                    (apply_wireframe_material, apply_global_wireframe_material).chain(),
                 ),
             );
     }

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -46,7 +46,9 @@ impl Plugin for WireframePlugin {
                     global_color_changed.run_if(resource_changed::<WireframeConfig>),
                     wireframe_color_changed,
                     apply_wireframe_material,
-                    apply_global_wireframe_material,
+                    // Run after `apply_wireframe_material` so that the global wireframe setting is applied
+                    // to a mesh on the same frame its wireframe marker component is removed.
+                    apply_global_wireframe_material.after(apply_wireframe_material),
                 ),
             );
     }
@@ -137,7 +139,8 @@ fn wireframe_color_changed(
     }
 }
 
-/// Applies or remove the wireframe material to any mesh with a [`Wireframe`] component.
+/// Applies or remove the wireframe material to any mesh with a [`Wireframe`] component, and removes it
+/// for any mesh with a [`NoWireframe`] component.
 fn apply_wireframe_material(
     mut commands: Commands,
     mut materials: ResMut<Assets<WireframeMaterial>>,
@@ -145,10 +148,11 @@ fn apply_wireframe_material(
         (Entity, Option<&WireframeColor>),
         (With<Wireframe>, Without<Handle<WireframeMaterial>>),
     >,
+    no_wireframes: Query<Entity, (With<NoWireframe>, With<Handle<WireframeMaterial>>)>,
     mut removed_wireframes: RemovedComponents<Wireframe>,
     global_material: Res<GlobalWireframeMaterial>,
 ) {
-    for e in removed_wireframes.read() {
+    for e in removed_wireframes.read().chain(no_wireframes.iter()) {
         if let Some(mut commands) = commands.get_entity(e) {
             commands.remove::<Handle<WireframeMaterial>>();
         }
@@ -171,7 +175,7 @@ fn apply_wireframe_material(
 
 type WireframeFilter = (With<Handle<Mesh>>, Without<Wireframe>, Without<NoWireframe>);
 
-/// Applies or removes a wireframe material on any mesh without a [`Wireframe`] component.
+/// Applies or removes a wireframe material on any mesh without a [`Wireframe`] or [`NoWireframe`] component.
 fn apply_global_wireframe_material(
     mut commands: Commands,
     config: Res<WireframeConfig>,

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -46,7 +46,7 @@ impl Plugin for WireframePlugin {
                     global_color_changed.run_if(resource_changed::<WireframeConfig>),
                     wireframe_color_changed,
                     apply_wireframe_material,
-                    apply_global_wireframe_material.run_if(resource_changed::<WireframeConfig>),
+                    apply_global_wireframe_material,
                 ),
             );
     }


### PR DESCRIPTION
# Objective

- Fixes #11782.

## Solution

- Remove the run condition for `apply_global_wireframe_material`, since it prevent detecting when meshes are added or the `NoWireframe` marker component is removed from an entity. Alternatively this could be done by using a run condition like "added `Handle<Mesh>` or removed `NoWireframe` or `WireframeConfig` changed" but this seems less clear to me than directly letting the queries on `apply_global_wireframe_material` do the filtering.