### PR TITLE
Docs reflect that `RemovalDetection` also yields despawned entities

### DIFF
--- a/crates/bevy_ecs/src/removal_detection.rs
+++ b/crates/bevy_ecs/src/removal_detection.rs
@@ -99,7 +99,8 @@ impl RemovedComponentEvents {
     }
 }
 
-/// A [`SystemParam`] that grants access to the entities that had their `T` [`Component`] removed.
+/// A [`SystemParam`] that yields entities that had their `T` [`Component`]
+/// removed or have been despawned with it.
 ///
 /// This acts effectively the same as an [`EventReader`](crate::event::EventReader).
 ///


### PR DESCRIPTION
# Objective

I want to keep track of despawned entities.
I am aware of [`RemovedComponents`](https://docs.rs/bevy/0.12.1/bevy/ecs/prelude/struct.RemovedComponents.html).
However, the docs don't explicitly mention that despawned entities are also included in this event iterator.
I searched through the bevy tests to find `removal_tracking` in `crates/bevy_ecs/src/system/mod.rs` that confirmed the behavior:

```rust
            ...
            assert_eq!(
                removed_i32.read().collect::<Vec<_>>(),
                &[despawned.0],
                "despawning causes the correct entity to show up in the 'RemovedComponent' system parameter."
            );
            ...
```
 
## Solution

- Explicitly mention this behavior in docs.
