### PR TITLE
Fix `Quad` deprecation message mentioning a type that doesn't exist

### DIFF
--- a/crates/bevy_render/src/mesh/shape/mod.rs
+++ b/crates/bevy_render/src/mesh/shape/mod.rs
@@ -146,7 +146,7 @@ impl From<Box> for Mesh {
 /// A rectangle on the `XY` plane centered at the origin.
 #[deprecated(
     since = "0.13.0",
-    note = "please use the `Quad` primitive in `bevy_math` instead"
+    note = "please use the `Rectangle` primitive in `bevy_math` instead"
 )]
 #[derive(Debug, Copy, Clone)]
 pub struct Quad {


### PR DESCRIPTION
# Objective

The deprecation message of `bevy::render::mesh::shape::Quad` says that you should use  `bevy_math`'s `Quad` instead. But it doesn't exist.

## Solution

Mention the correct primitive: `Rectangle`