### PR TITLE
Put asset_events behind a run condition

### DIFF
--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -541,7 +541,7 @@ impl<A: Asset> Assets<A> {
     /// flush.
     ///
     /// [`asset_events`]: Self::asset_events
-    pub fn asset_events_condition(assets: Res<Self>) -> bool {
+    pub(crate) fn asset_events_condition(assets: Res<Self>) -> bool {
         !assets.queued_events.is_empty()
     }
 }

--- a/crates/bevy_asset/src/assets.rs
+++ b/crates/bevy_asset/src/assets.rs
@@ -536,6 +536,14 @@ impl<A: Asset> Assets<A> {
     pub fn asset_events(mut assets: ResMut<Self>, mut events: EventWriter<AssetEvent<A>>) {
         events.send_batch(assets.queued_events.drain(..));
     }
+
+    /// A run condition for [`asset_events`]. The system will not run if there are no events to
+    /// flush.
+    ///
+    /// [`asset_events`]: Self::asset_events
+    pub fn asset_events_condition(assets: Res<Self>) -> bool {
+        !assets.queued_events.is_empty()
+    }
 }
 
 /// A mutable iterator over [`Assets`].

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -386,7 +386,10 @@ impl AssetApp for App {
             .add_event::<AssetLoadFailedEvent<A>>()
             .register_type::<Handle<A>>()
             .register_type::<AssetId<A>>()
-            .add_systems(AssetEvents, Assets::<A>::asset_events)
+            .add_systems(
+                AssetEvents,
+                Assets::<A>::asset_events.run_if(Assets::<A>::asset_events_condition),
+            )
             .add_systems(UpdateAssets, Assets::<A>::track_assets.in_set(TrackAssets))
     }
 


### PR DESCRIPTION
# Objective
Scheduling low cost systems has significant overhead due to task pool contention and the extra machinery to schedule and run them. Following the example of #7728, `asset_events` is good example of this kind of system, where there is no work to be done when there are no queued asset events.

## Solution
Put a run condition on it that checks if there are any queued events.

## Performance
Tested against `many_foxes`, we can see a slight improvement in the total time spent in `UpdateAssets`. Also noted much less volatility due to not being at the whim of the OS thread scheduler.
![image](https://github.com/bevyengine/bevy/assets/3137680/e0b282bf-27d0-4fe4-81b9-ecd72ab258e5)
