### PR TITLE
Remove CameraProjectionPlugin

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -7,7 +7,7 @@ use bevy_reflect::Reflect;
 use bevy_render::{
     camera::{
         Camera, CameraMainTextureUsages, CameraProjection, CameraRenderGraph,
-        OrthographicProjection,
+        OrthographicProjection, Projection,
     },
     extract_component::ExtractComponent,
     primitives::Frustum,
@@ -26,7 +26,7 @@ pub struct Camera2d;
 pub struct Camera2dBundle {
     pub camera: Camera,
     pub camera_render_graph: CameraRenderGraph,
-    pub projection: OrthographicProjection,
+    pub projection: Projection,
     pub visible_entities: VisibleEntities,
     pub frustum: Frustum,
     pub transform: Transform,
@@ -39,11 +39,11 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        let projection = OrthographicProjection {
+        let projection = Projection::from(OrthographicProjection {
             far: 1000.,
             near: -1000.,
             ..Default::default()
-        };
+        });
         let transform = Transform::default();
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
@@ -72,10 +72,10 @@ impl Camera2dBundle {
     pub fn new_with_far(far: f32) -> Self {
         // we want 0 to be "closest" and +far to be "farthest" in 2d, so we offset
         // the camera's translation by far and use a right handed coordinate system
-        let projection = OrthographicProjection {
+        let projection = Projection::from(OrthographicProjection {
             far,
             ..Default::default()
-        };
+        });
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -666,7 +666,7 @@ impl NormalizedRenderTarget {
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
 /// [`PerspectiveProjection`]: crate::camera::PerspectiveProjection
 #[allow(clippy::too_many_arguments)]
-pub fn camera_system<T: CameraProjection + Component>(
+pub fn camera_system(
     mut window_resized_events: EventReader<WindowResized>,
     mut window_created_events: EventReader<WindowCreated>,
     mut window_scale_factor_changed_events: EventReader<WindowScaleFactorChanged>,
@@ -675,7 +675,7 @@ pub fn camera_system<T: CameraProjection + Component>(
     windows: Query<(Entity, &Window)>,
     images: Res<Assets<Image>>,
     manual_texture_views: Res<ManualTextureViews>,
-    mut cameras: Query<(&mut Camera, &mut T)>,
+    mut cameras: Query<(&mut Camera, &mut Projection)>,
 ) {
     let primary_window = primary_window.iter().next();
 

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -34,8 +34,6 @@ impl Plugin for CameraPlugin {
             .init_resource::<ClearColor>()
             .add_plugins((
                 CameraProjectionPlugin::<Projection>::default(),
-                CameraProjectionPlugin::<OrthographicProjection>::default(),
-                CameraProjectionPlugin::<PerspectiveProjection>::default(),
                 ExtractResourcePlugin::<ManualTextureViews>::default(),
                 ExtractResourcePlugin::<ClearColor>::default(),
                 ExtractComponentPlugin::<CameraMainTextureUsages>::default(),

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -15,10 +15,15 @@ use crate::{
     extract_component::ExtractComponentPlugin, extract_resource::ExtractResourcePlugin,
     render_graph::RenderGraph, ExtractSchedule, Render, RenderApp, RenderSet,
 };
-use bevy_app::{App, Plugin};
-use bevy_ecs::schedule::IntoSystemConfigs;
+use bevy_app::{App, Plugin, PostStartup, PostUpdate};
+use bevy_ecs::schedule::{IntoSystemConfigs, SystemSet};
 
-#[derive(Default)]
+/// Label for [`camera_system`].
+///
+/// [`camera_system`]: crate::camera::camera_system
+#[derive(SystemSet, Clone, Eq, PartialEq, Hash, Debug, Default)]
+pub struct CameraUpdateSystem;
+
 pub struct CameraPlugin;
 
 impl Plugin for CameraPlugin {
@@ -30,10 +35,12 @@ impl Plugin for CameraPlugin {
             .register_type::<RenderTarget>()
             .register_type::<ClearColor>()
             .register_type::<ClearColorConfig>()
+            .register_type::<Projection>()
             .init_resource::<ManualTextureViews>()
             .init_resource::<ClearColor>()
+            .add_systems(PostStartup, camera_system.in_set(CameraUpdateSystem))
+            .add_systems(PostUpdate, camera_system.in_set(CameraUpdateSystem))
             .add_plugins((
-                CameraProjectionPlugin::<Projection>::default(),
                 ExtractResourcePlugin::<ManualTextureViews>::default(),
                 ExtractResourcePlugin::<ClearColor>::default(),
                 ExtractComponentPlugin::<CameraMainTextureUsages>::default(),

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -136,8 +136,8 @@ impl Default for Projection {
 }
 
 /// A 3D camera projection in which distant objects appear smaller than close objects.
-#[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default)]
+#[derive(Debug, Clone, Reflect)]
+#[reflect(Default)]
 pub struct PerspectiveProjection {
     /// The vertical field of view (FOV) in radians.
     ///
@@ -320,8 +320,8 @@ impl DivAssign<f32> for ScalingMode {
 ///     ..OrthographicProjection::default()
 /// });
 /// ```
-#[derive(Component, Debug, Clone, Reflect)]
-#[reflect(Component, Default)]
+#[derive(Debug, Clone, Reflect)]
+#[reflect(Default)]
 pub struct OrthographicProjection {
     /// The distance of the near clipping plane in world units.
     ///

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -1,54 +1,11 @@
-use std::marker::PhantomData;
 use std::ops::{Div, DivAssign, Mul, MulAssign};
 
 use crate::primitives::Frustum;
-use bevy_app::{App, Plugin, PostStartup, PostUpdate};
 use bevy_ecs::{prelude::*, reflect::ReflectComponent};
 use bevy_math::{AspectRatio, Mat4, Rect, Vec2, Vec3A};
-use bevy_reflect::{
-    std_traits::ReflectDefault, GetTypeRegistration, Reflect, ReflectDeserialize, ReflectSerialize,
-};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_transform::components::GlobalTransform;
 use serde::{Deserialize, Serialize};
-
-/// Adds [`Camera`](crate::camera::Camera) driver systems for a given projection type.
-pub struct CameraProjectionPlugin<T: CameraProjection>(PhantomData<T>);
-
-impl<T: CameraProjection> Default for CameraProjectionPlugin<T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-
-/// Label for [`camera_system<T>`], shared across all `T`.
-///
-/// [`camera_system<T>`]: crate::camera::camera_system
-#[derive(SystemSet, Clone, Eq, PartialEq, Hash, Debug)]
-pub struct CameraUpdateSystem;
-
-impl<T: CameraProjection + Component + GetTypeRegistration> Plugin for CameraProjectionPlugin<T> {
-    fn build(&self, app: &mut App) {
-        app.register_type::<T>()
-            .add_systems(
-                PostStartup,
-                crate::camera::camera_system::<T>
-                    .in_set(CameraUpdateSystem)
-                    // We assume that each camera will only have one projection,
-                    // so we can ignore ambiguities with all other monomorphizations.
-                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(CameraUpdateSystem),
-            )
-            .add_systems(
-                PostUpdate,
-                crate::camera::camera_system::<T>
-                    .in_set(CameraUpdateSystem)
-                    // We assume that each camera will only have one projection,
-                    // so we can ignore ambiguities with all other monomorphizations.
-                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(CameraUpdateSystem),
-            );
-    }
-}
 
 /// Trait to control the projection matrix of a camera.
 ///

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -213,9 +213,9 @@ impl Plugin for VisibilityPlugin {
             PostUpdate,
             (
                 calculate_bounds.in_set(CalculateBounds),
-                update_frusta::<Projection>
+                update_frusta
                     .in_set(UpdateProjectionFrusta)
-                    .after(camera_system::<Projection>)
+                    .after(camera_system)
                     .after(TransformSystem::TransformPropagate),
                 (visibility_propagate_system, reset_view_visibility).in_set(VisibilityPropagate),
                 check_visibility
@@ -254,10 +254,10 @@ pub fn calculate_bounds(
 /// This system is used in system sets [`VisibilitySystems::UpdateProjectionFrusta`],
 /// [`VisibilitySystems::UpdatePerspectiveFrusta`], and
 /// [`VisibilitySystems::UpdateOrthographicFrusta`].
-pub fn update_frusta<T: Component + CameraProjection + Send + Sync + 'static>(
+pub fn update_frusta(
     mut views: Query<
-        (&GlobalTransform, &T, &mut Frustum),
-        Or<(Changed<GlobalTransform>, Changed<T>)>,
+        (&GlobalTransform, &Projection, &mut Frustum),
+        Or<(Changed<GlobalTransform>, Changed<Projection>)>,
     >,
 ) {
     for (transform, projection, mut frustum) in &mut views {

--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -14,10 +14,7 @@ use thread_local::ThreadLocal;
 
 use crate::deterministic::DeterministicRenderingConfig;
 use crate::{
-    camera::{
-        camera_system, Camera, CameraProjection, OrthographicProjection, PerspectiveProjection,
-        Projection,
-    },
+    camera::{camera_system, Camera, CameraProjection, Projection},
     mesh::Mesh,
     primitives::{Aabb, Frustum, Sphere},
 };
@@ -216,23 +213,6 @@ impl Plugin for VisibilityPlugin {
             PostUpdate,
             (
                 calculate_bounds.in_set(CalculateBounds),
-                update_frusta::<OrthographicProjection>
-                    .in_set(UpdateOrthographicFrusta)
-                    .after(camera_system::<OrthographicProjection>)
-                    .after(TransformSystem::TransformPropagate)
-                    // We assume that no camera will have more than one projection component,
-                    // so these systems will run independently of one another.
-                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(update_frusta::<PerspectiveProjection>)
-                    .ambiguous_with(update_frusta::<Projection>),
-                update_frusta::<PerspectiveProjection>
-                    .in_set(UpdatePerspectiveFrusta)
-                    .after(camera_system::<PerspectiveProjection>)
-                    .after(TransformSystem::TransformPropagate)
-                    // We assume that no camera will have more than one projection component,
-                    // so these systems will run independently of one another.
-                    // FIXME: Add an archetype invariant for this https://github.com/bevyengine/bevy/issues/1481.
-                    .ambiguous_with(update_frusta::<Projection>),
                 update_frusta::<Projection>
                     .in_set(UpdateProjectionFrusta)
                     .after(camera_system::<Projection>)

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -528,7 +528,6 @@ mod tests {
     use bevy_math::vec2;
     use bevy_math::Vec2;
     use bevy_render::camera::ManualTextureViews;
-    use bevy_render::camera::OrthographicProjection;
     use bevy_render::texture::Image;
     use bevy_utils::prelude::default;
     use bevy_utils::HashMap;
@@ -575,7 +574,7 @@ mod tests {
         ui_schedule.add_systems(
             (
                 // UI is driven by calculated camera target info, so we need to run the camera system first
-                bevy_render::camera::camera_system::<OrthographicProjection>,
+                bevy_render::camera::camera_system,
                 update_target_camera_system,
                 apply_deferred,
                 ui_layout_system,

--- a/examples/2d/pixel_grid_snap.rs
+++ b/examples/2d/pixel_grid_snap.rs
@@ -163,12 +163,17 @@ fn rotate(time: Res<Time>, mut transforms: Query<&mut Transform, With<Rotate>>) 
 /// Scales camera projection to fit the window (integer multiples only).
 fn fit_canvas(
     mut resize_events: EventReader<WindowResized>,
-    mut projections: Query<&mut OrthographicProjection, With<OuterCamera>>,
+    mut projections: Query<&mut Projection, With<OuterCamera>>,
 ) {
     for event in resize_events.read() {
         let h_scale = event.width / RES_WIDTH as f32;
         let v_scale = event.height / RES_HEIGHT as f32;
+
         let mut projection = projections.single_mut();
+        let Projection::Orthographic(ref mut projection) = *projection else {
+            continue;
+        };
+
         projection.scale = 1. / h_scale.min(v_scale).round();
     }
 }


### PR DESCRIPTION
# Objective

Draft for discussion.

It's not totally clear to me why all the generic machinery around these "inner projection types" exists when we are mainly using the `Projection` enum.

I tried yanking them out and I don't think it broke anything. But there's a lot of pub stuff in here, so maybe things are this way for a reason.

Fixes #11799

## Solution

Remove `Component` from `PerspectiveProjection` and `OrthographicProjection`, and associated generic code.

## Changelog

TODO

## Migration Guide

`PerspectiveProjection` and `OrthographicProjection` are no longer components. Use `Projection` instead.
`CameraUpdateSystem` has moved to `bevy::render::camera::CameraUpdateSystem`.

`CameraProjectionPlugin` was removed. If you were using this, let us know.
`camera_system` and `update_frusta` are no longer generic. If you were using the generics, let us know.