### PR TITLE
Stop copying the light probe array to the stack in the shader.

### DIFF
--- a/crates/bevy_pbr/src/light_probe/environment_map.wgsl
+++ b/crates/bevy_pbr/src/light_probe/environment_map.wgsl
@@ -30,10 +30,7 @@ fn compute_radiances(
     var radiances: EnvironmentMapRadiances;
 
     // Search for a reflection probe that contains the fragment.
-    var query_result = query_light_probe(
-        light_probes.reflection_probes,
-        light_probes.reflection_probe_count,
-        world_position);
+    var query_result = query_light_probe(world_position, /*is_irradiance_volume=*/ false);
 
     // If we didn't find a reflection probe, use the view environment map if applicable.
     if (query_result.texture_index < 0) {

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
@@ -13,10 +13,7 @@
 // Slide 28, "Ambient Cube Basis"
 fn irradiance_volume_light(world_position: vec3<f32>, N: vec3<f32>) -> vec3<f32> {
     // Search for an irradiance volume that contains the fragment.
-    let query_result = query_light_probe(
-        light_probes.irradiance_volumes,
-        light_probes.irradiance_volume_count,
-        world_position);
+    let query_result = query_light_probe(world_position, /*is_irradiance_volume=*/ true);
 
     // If there was no irradiance volume found, bail out.
     if (query_result.texture_index < 0) {

--- a/crates/bevy_pbr/src/light_probe/light_probe.wgsl
+++ b/crates/bevy_pbr/src/light_probe/light_probe.wgsl
@@ -1,5 +1,6 @@
 #define_import_path bevy_pbr::light_probe
 
+#import bevy_pbr::mesh_view_bindings::light_probes
 #import bevy_pbr::mesh_view_types::LightProbe
 
 // The result of searching for a light probe.
@@ -28,20 +29,28 @@ fn transpose_affine_matrix(matrix: mat3x4<f32>) -> mat4x4<f32> {
 //
 // TODO: Interpolate between multiple light probes.
 fn query_light_probe(
-    in_light_probes: array<LightProbe, 8u>,
-    light_probe_count: i32,
     world_position: vec3<f32>,
+    is_irradiance_volume: bool,
 ) -> LightProbeQueryResult {
-    // This is needed to index into the array with a non-constant expression.
-    var light_probes = in_light_probes;
-
     var result: LightProbeQueryResult;
     result.texture_index = -1;
+
+    var light_probe_count: i32;
+    if is_irradiance_volume {
+        light_probe_count = light_probes.irradiance_volume_count;
+    } else {
+        light_probe_count = light_probes.reflection_probe_count;
+    }
 
     for (var light_probe_index: i32 = 0;
             light_probe_index < light_probe_count && result.texture_index < 0;
             light_probe_index += 1) {
-        let light_probe = light_probes[light_probe_index];
+        var light_probe: LightProbe;
+        if is_irradiance_volume {
+            light_probe = light_probes.irradiance_volumes[light_probe_index];
+        } else {
+            light_probe = light_probes.reflection_probes[light_probe_index];
+        }
 
         // Unpack the inverse transform.
         let inverse_transform =


### PR DESCRIPTION
This was causing a severe performance regression when light probes were enabled.

Fixes #11787.