### PR TITLE
Replace `crossbeam::scope` reference with `thread::scope` in docs

### DIFF
--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -207,7 +207,7 @@ impl TaskPool {
     /// passing a scope object into it. The scope object provided to the callback can be used
     /// to spawn tasks. This function will await the completion of all tasks before returning.
     ///
-    /// This is similar to `rayon::scope` and `crossbeam::scope`
+    /// This is similar to [`thread::scope`] and `rayon::scope`.
     ///
     /// # Example
     ///


### PR DESCRIPTION
# Objective

- [`crossbeam::scope`](https://docs.rs/crossbeam/latest/crossbeam/fn.scope.html) is soft-deprecated in favor of the standard library's implementation.

## Solution

- Replace reference in `TaskPool`'s docs to mention `std::thread::scope` instead.