### PR TITLE
Add remote_asset_loader example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -319,6 +319,7 @@ bytemuck = "1.7"
 futures-lite = "2.0.1"
 crossbeam-channel = "0.5.0"
 argh = "0.1.12"
+ehttp = { version = "0.4.0", features = ["native-async"] }
 
 [[example]]
 name = "hello_world"
@@ -1224,6 +1225,17 @@ name = "Custom Asset IO"
 description = "Implements a custom AssetReader"
 category = "Assets"
 wasm = true
+
+[[example]]
+name = "remote_asset_loader"
+path = "examples/asset/remote_asset_loader.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.remote_asset_loader]
+name = "Remote Asset Loader"
+description = "Implements a RemoteAssetLoader to download assets from CDN."
+category = "Assets"
+wasm = false
 
 [[example]]
 name = "embedded_asset"

--- a/examples/README.md
+++ b/examples/README.md
@@ -197,6 +197,7 @@ Example | Description
 [Custom Asset IO](../examples/asset/custom_asset_reader.rs) | Implements a custom AssetReader
 [Embedded Asset](../examples/asset/embedded_asset.rs) | Embed an asset in the application binary and load it
 [Hot Reloading of Assets](../examples/asset/hot_asset_reloading.rs) | Demonstrates automatic reloading of assets when modified on disk
+[Remote Asset Loader](../examples/asset/remote_asset_loader.rs) | Implements a RemoteAssetLoader to download assets from CDN.
 
 ## Async Tasks
 

--- a/examples/asset/remote_asset_loader.rs
+++ b/examples/asset/remote_asset_loader.rs
@@ -1,17 +1,18 @@
 //! Implements a remote asset loader.
-//! An [AssetReader] is what the asset server uses to read the raw bytes of assets.
-//! This example also showcases how to use [AssetWriter].
+//! An [`AssetReader`] is what the asset server uses to read the raw bytes of assets.
+//! This example also showcases how to use [`AssetWriter`].
 //! Note that it won't work on wasm or Android because these platforms lack a default
 //! [`AssetWriter`] implementation for now, but it's possible to implement your own.
 
 use bevy::{
     asset::io::{
-        AssetReader, AssetReaderError, AssetSource, AssetSourceId, AssetWriter, PathStream, Reader,
+        AssetReader, AssetReaderError, AssetSource, AssetSourceId, AssetWriter, AssetWriterError,
+        PathStream, Reader,
     },
+    log::LogPlugin,
     prelude::*,
     utils::BoxedFuture,
 };
-use bevy_internal::{asset::io::AssetWriterError, log::LogPlugin};
 use futures_lite::AsyncRead;
 use std::{path::Path, sync::Arc};
 

--- a/examples/asset/remote_asset_loader.rs
+++ b/examples/asset/remote_asset_loader.rs
@@ -161,17 +161,33 @@ fn main() {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
+
+    commands.spawn(TextBundle::from_section(
+        "This font was loaded\nfrom a CDN",
+        TextStyle {
+            // If this font exists on local disk, it will be used, else it will be downloaded
+            // from our CDN and then loaded.
+            font: asset_server.load("fonts/ProtestRevolution-Regular.ttf"),
+            font_size: 50.0,
+            ..default()
+        },
+    ));
+
     commands.spawn(
-        // Create a TextBundle that has a Text with a single section.
         TextBundle::from_section(
-            "hello\nbevy!",
+            "This font was lodaded\nfrom local disk",
             TextStyle {
-                // If this font exists on local disk, it will be used, else it will be downloaded
-                // from our CDN and then loaded.
-                font: asset_server.load("fonts/ProtestRevolution-Regular.ttf"),
+                // This font already exists, so nothing will be downloaded.
+                font: asset_server.load("fonts/FiraSans-Bold.ttf"),
                 font_size: 50.0,
                 ..default()
             },
-        ),
+        )
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(5.0),
+            right: Val::Px(5.0),
+            ..default()
+        }),
     );
 }

--- a/examples/asset/remote_asset_loader.rs
+++ b/examples/asset/remote_asset_loader.rs
@@ -1,0 +1,167 @@
+//! Implements a remote asset loader.
+//! An [`AssetReader`] is what the asset server uses to read the raw bytes of assets.
+//! This example also showcase how to use [`AssetWriter`], thus will won't work on
+//! wasm or Android, since those platforms doesn't have [`AssetWriter`].
+
+use bevy::{
+    asset::io::{
+        AssetReader, AssetReaderError, AssetSource, AssetSourceId, AssetWriter, PathStream, Reader,
+    },
+    prelude::*,
+    utils::BoxedFuture,
+};
+use bevy_internal::asset::io::AssetWriterError;
+use futures_lite::AsyncRead;
+use std::{path::Path, sync::Arc};
+
+/// A remote asset loader implementation that will try to read asset local and, if not found,
+/// download it remotely from a CDN.
+struct RemoteAssetLoader {
+    cdn_prefix: String,
+    reader: Box<dyn AssetReader>,
+    writer: Box<dyn AssetWriter>,
+}
+
+impl RemoteAssetLoader {
+    fn new() -> Self {
+        // Create the root directory if it doesn't exists on local disk.
+        let create_root_dir = true;
+        let writer = AssetSource::get_default_writer("assets".to_string())(create_root_dir)
+            .expect("Current platform doesn't support asset writing.");
+        let reader = AssetSource::get_default_reader("assets".to_string())();
+
+        // This is the CDN which will be downloaded the font when missing localy.
+        let cdn_prefix =
+            "https://github.com/google/fonts/raw/main/ofl/protestrevolution/".to_string();
+
+        RemoteAssetLoader {
+            reader,
+            writer,
+            cdn_prefix,
+        }
+    }
+
+    /// Remote download the asset from CDN.
+    async fn read_remote<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> Result<Box<dyn AsyncRead + Send + Sync + Unpin + 'a>, AssetReaderError> {
+        // Only the asset name is needed, not the folder.
+        let asset_name = path.file_name().unwrap().to_str().unwrap();
+        let mut url = self.cdn_prefix.clone();
+        url.push_str(asset_name);
+
+        // A simple GET request is used, but you could set custom headers, auth and so on.
+        let request = ehttp::Request::get(url);
+
+        let body = match ehttp::fetch_async(request).await {
+            Ok(response) => {
+                // Since this is an example, only check for 200 status, but in a real world use
+                // it would be wise to check for others 2xx or 3xx status.
+                if response.status != 200 {
+                    return Err(AssetReaderError::HttpError(response.status));
+                }
+
+                response.bytes
+            }
+            Err(error) => {
+                warn!("Failed to read remote asset: {error}");
+                return Err(AssetReaderError::HttpError(500));
+            }
+        };
+
+        // Try to save the downloaded asset on disk.
+        if let Err(AssetWriterError::Io(error)) = self.writer.write_bytes(path, &body).await {
+            return Err(AssetReaderError::Io(Arc::new(error)));
+        }
+
+        // Try to read again the asset, since its saved on disk now.
+        self.reader.read(path).await
+    }
+}
+
+impl AssetReader for RemoteAssetLoader {
+    fn read<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxedFuture<'a, Result<Box<Reader<'a>>, AssetReaderError>> {
+        Box::pin(async move {
+            // First check if the default reader will find the asset local. If it doesn't find
+            // then try to read from CDN.
+            match self.reader.read(path).await {
+                Ok(reader) => Ok(reader),
+                Err(error) => match error {
+                    AssetReaderError::NotFound(_) => {
+                        debug!("Asset {path:?} not found on local disk. Downloading from CDN.");
+                        self.read_remote(path).await
+                    }
+                    _ => Err(error),
+                },
+            }
+        })
+    }
+
+    fn read_meta<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxedFuture<'a, Result<Box<Reader<'a>>, AssetReaderError>> {
+        // Just forward the call to default reader.
+        self.reader.read_meta(path)
+    }
+
+    fn read_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxedFuture<'a, Result<Box<PathStream>, AssetReaderError>> {
+        // Just forward the call to default reader.
+        self.reader.read_directory(path)
+    }
+
+    fn is_directory<'a>(
+        &'a self,
+        path: &'a Path,
+    ) -> BoxedFuture<'a, Result<bool, AssetReaderError>> {
+        // Just forward the call to default reader.
+        self.reader.is_directory(path)
+    }
+}
+
+/// A plugins that registers our new asset loader
+struct RemoteAssetLoaderPlugin;
+
+impl Plugin for RemoteAssetLoaderPlugin {
+    fn build(&self, app: &mut App) {
+        app.register_asset_source(
+            AssetSourceId::Default,
+            AssetSource::build().with_reader(|| Box::new(RemoteAssetLoader::new())),
+        );
+    }
+}
+
+fn main() {
+    let mut app = App::new();
+    app.add_plugins((RemoteAssetLoaderPlugin, DefaultPlugins))
+        .add_systems(Startup, setup)
+        .run();
+
+    // Just a cleanup to remove the downloaded font, so the example will be able to download
+    // next time.
+    let _ = std::fs::remove_file("assets/fonts/ProtestRevolution-Regular.ttf");
+}
+
+fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
+    commands.spawn(Camera2dBundle::default());
+    commands.spawn(
+        // Create a TextBundle that has a Text with a single section.
+        TextBundle::from_section(
+            "hello\nbevy!",
+            TextStyle {
+                // If this font exists on local disk, it will be used, else it will be downloaded
+                // from our CDN and then loaded.
+                font: asset_server.load("fonts/ProtestRevolution-Regular.ttf"),
+                font_size: 50.0,
+                ..default()
+            },
+        ),
+    );
+}


### PR DESCRIPTION
# Objective

- Showcase how to use `AssetReader` and `AssetWriter` to download an asset from a CDN when it doesn't exists local.

## Solution

- Add an example (`remote_asset_loader`) which showcases how to download an asset from a CDN.
- Add `ehttp` as a new `dev-dependencies`.

## Additional Context

- This is somewhat related to #11694 since I'm also using `ehttp` and the same `features`.
- This example won't work on wasm or Android since I need `AssetWriter`.
- I'm using a Google Font since its Open Font License and it is compatible with MIT and Apache 2.0 (AFAIK);
- At the end of the example `main`, I use `std::fs::remove_file` to "manually" do some cleanup, to avoid adding things to `asset` folder whenever someone runs this example.
