### PR TITLE
Allow extended materials to exclude `StandardMaterial` inputs that they don't want.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1965,6 +1965,16 @@ category = "Shaders"
 wasm = true
 
 [[example]]
+name = "extended_material_decal"
+path = "examples/shader/extended_material_decal.rs"
+
+[package.metadata.example.extended_material_decal]
+name = "Extended Material Decal"
+description = "Applies a decal to a standard material"
+category = "Shaders"
+wasm = true
+
+[[example]]
 name = "shader_prepass"
 path = "examples/shader/shader_prepass.rs"
 doc-scrape-examples = true

--- a/assets/shaders/extended_material_decal.wgsl
+++ b/assets/shaders/extended_material_decal.wgsl
@@ -1,0 +1,29 @@
+#import bevy_pbr::pbr_bindings::{base_color_texture, base_color_sampler}
+#import bevy_pbr::pbr_fragment::pbr_input_from_standard_material
+#import bevy_pbr::pbr_functions::apply_lighting_and_postprocessing
+#import bevy_pbr::mesh_view_bindings::view
+
+#ifdef PREPASS_PIPELINE
+#import bevy_pbr::prepass_io::{VertexOutput, FragmentOutput}
+#else
+#import bevy_pbr::forward_io::{VertexOutput, FragmentOutput}
+#endif
+
+@group(2) @binding(100) var decal_texture: texture_2d<f32>;
+@group(2) @binding(101) var decal_sampler: sampler;
+
+@fragment
+fn fragment(in: VertexOutput, @builtin(front_facing) is_front: bool) -> FragmentOutput {
+    var pbr = pbr_input_from_standard_material(in, is_front);
+
+    // Modify PBR as necessary.
+    var color = textureSampleBias(base_color_texture, base_color_sampler, in.uv, view.mip_bias);
+    let decal_uv = (in.uv + vec2(-0.1, -0.2)) * 4.0;
+    if (all(decal_uv >= vec2(0.0)) && all(decal_uv <= vec2(1.0))) {
+        let decal = textureSampleBias(decal_texture, decal_sampler, decal_uv, view.mip_bias);
+        color = vec4(mix(color.rgb, decal.rgb, decal.a), color.a);
+    }
+    pbr.material.base_color = color;
+
+    return apply_lighting_and_postprocessing(pbr);
+}

--- a/examples/shader/extended_material_decal.rs
+++ b/examples/shader/extended_material_decal.rs
@@ -1,0 +1,115 @@
+//! Applies a decal to a standard material.
+
+use bevy::{
+    pbr::{
+        exclude_standard_material_features, ExtendedMaterial, MaterialExtension,
+        MaterialExtensionKey, MaterialExtensionPipeline, OpaqueRendererMethod,
+        StandardMaterialExclusions,
+    },
+    prelude::*,
+    render::mesh::MeshVertexBufferLayout,
+    render::render_resource::*,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(MaterialPlugin::<
+            ExtendedMaterial<StandardMaterial, DecalExtension>,
+        >::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, rotate_things)
+        .run();
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ExtendedMaterial<StandardMaterial, DecalExtension>>>,
+    asset_server: ResMut<AssetServer>,
+) {
+    // sphere
+    commands.spawn(MaterialMeshBundle {
+        mesh: meshes.add(Sphere::new(1.0)),
+        transform: Transform::from_xyz(0.0, 0.5, 0.0),
+        material: materials.add(ExtendedMaterial {
+            base: StandardMaterial {
+                base_color_texture: Some(asset_server.load("textures/parallax_example/cube_color.png")),
+                // can be used in forward or deferred mode.
+                opaque_render_method: OpaqueRendererMethod::Auto,
+                // in deferred mode, only the PbrInput can be modified (uvs, color and other material properties),
+                // in forward mode, the output can also be modified after lighting is applied.
+                // see the fragment shader `extended_material.wgsl` for more info.
+                // Note: to run in deferred mode, you must also add a `DeferredPrepass` component to the camera and either
+                // change the above to `OpaqueRendererMethod::Deferred` or add the `DefaultOpaqueRendererMethod` resource.
+                ..Default::default()
+            },
+            extension: DecalExtension {
+                decal: asset_server.load("textures/rpg/chars/vendor/generic-rpg-vendor.png"),
+            },
+        }),
+        ..default()
+    });
+
+    // light
+    commands.spawn((
+        PointLightBundle {
+            point_light: PointLight {
+                intensity: 150_000.0,
+                ..default()
+            },
+            ..default()
+        },
+        Rotate,
+    ));
+
+    // camera
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+}
+
+#[derive(Component)]
+struct Rotate;
+
+fn rotate_things(mut q: Query<&mut Transform, With<Rotate>>, time: Res<Time>) {
+    for mut t in q.iter_mut() {
+        t.translation = Vec3::new(
+            time.elapsed_seconds().sin(),
+            0.5,
+            time.elapsed_seconds().cos(),
+        ) * 4.0;
+    }
+}
+
+#[derive(Asset, AsBindGroup, Reflect, Debug, Clone)]
+struct DecalExtension {
+    // We need to ensure that the bindings of the base material and the extension do not conflict,
+    // so we start from binding slot 100, leaving slots 0-99 for the base material.
+    #[texture(100)]
+    #[sampler(101)]
+    decal: Handle<Image>,
+}
+
+impl MaterialExtension for DecalExtension {
+    fn fragment_shader() -> ShaderRef {
+        "shaders/extended_material_decal.wgsl".into()
+    }
+
+    fn deferred_fragment_shader() -> ShaderRef {
+        "shaders/extended_material_decal.wgsl".into()
+    }
+
+    fn specialize(
+        _: &MaterialExtensionPipeline,
+        descriptor: &mut RenderPipelineDescriptor,
+        _: &MeshVertexBufferLayout,
+        _: MaterialExtensionKey<Self>,
+    ) -> Result<(), SpecializedMeshPipelineError> {
+        Ok(exclude_standard_material_features(
+            descriptor,
+            StandardMaterialExclusions::BASE_COLOR,
+        ))
+    }
+}


### PR DESCRIPTION
This makes it possible to use only portions of
`pbr_input_from_standard_material`, which improves ergonomics of common use cases. A simple example is provided that applies a decal to a texture.

Possible follow-ups to improve ergonomics further include:

* Figure out how to get rid of the ugly `#ifdef PREPASS_PIPELINE` in the WGSL file.

* More convenient WGSL combinators to do common things like blend images together.

* A special type of `ExtendedMaterial` that features an `AssetLoader` that can create an `ExtendedMaterial` directly from a `.wgsl` file, with no Rust code involved.

* A declarative node graph framework, built on the above, that can generate `.wgsl` files from nodes, like Blender Eevee does.

This is mostly a draft to get feedback on the API.

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

### Added

* A new function, `bevy_pbr::pbr_material::exclude_standard_material_features`, has been added to make authoring extended materials easier. You can now override any arbitrary subset of the PBR inputs (base color, emission color, etc.). See `extended_material_decal.rs` for an example of use.

* A new shader function, `pbr_functions::apply_lighting_and_postprocessing`, is available, in order to reduce boilerplate for the common case of an extended material that simply wants to override some PBR inputs.