### PR TITLE
Add method for querying whether a given short type path is ambiguous

### DIFF
--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -238,12 +238,14 @@ impl TypeRegistry {
     ///
     /// # Example
     /// ```
-    /// # use bevy_reflect::{TypeRegistry, Reflect};
+    /// # use bevy_reflect::TypeRegistry;
     /// # mod foo {
+    /// #     use bevy_reflect::Reflect;
     /// #     #[derive(Reflect)]
     /// #     struct MyType;
     /// # }
     /// # mod bar {
+    /// #     use bevy_reflect::Reflect;
     /// #     #[derive(Reflect)]
     /// #     struct MyType;
     /// # }

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -234,6 +234,13 @@ impl TypeRegistry {
             .and_then(|id| self.registrations.get_mut(id))
     }
 
+    /// Returns `true` if the given [short type path] is ambiguous.
+    ///
+    /// [short type path]: TypePath::short_type_path
+    pub fn is_ambiguous(&self, short_type_path: &str) -> bool {
+        self.ambiguous_names.contains(short_type_path)
+    }
+
     /// Returns a reference to the [`TypeData`] of type `T` associated with the given [`TypeId`].
     ///
     /// The returned value may be used to downcast [`Reflect`] trait objects to

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -243,7 +243,7 @@ impl TypeRegistry {
     /// #     struct MyType;
     /// # }
     /// # mod bar {
-    /// #    struct MyType;
+    /// #     struct MyType;
     /// # }
     /// let mut type_registry = TypeRegistry::default();
     /// type_registry.register::<foo::MyType>();

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -234,7 +234,22 @@ impl TypeRegistry {
             .and_then(|id| self.registrations.get_mut(id))
     }
 
-    /// Returns `true` if the given [short type path] is ambiguous.
+    /// Returns `true` if the given [short type path] is ambiguous, that is, it matches multiple registered types.
+    ///
+    /// # Example
+    /// ```
+    /// # use bevy_reflect::{TypeRegistry};
+    /// # mod foo {
+    /// #     struct MyType;
+    /// # }
+    /// # mod bar {
+    /// #    struct MyType;
+    /// # }
+    /// let mut type_registry = TypeRegistry::default();
+    /// type_registry.register::<foo::MyType>();
+    /// type_registry.register::<bar::MyType>();
+    /// assert_eq!(type_registry.is_ambiguous("MyType"), true);
+    /// ```
     ///
     /// [short type path]: TypePath::short_type_path
     pub fn is_ambiguous(&self, short_type_path: &str) -> bool {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -211,7 +211,7 @@ impl TypeRegistry {
     /// If the short type path is ambiguous, or if no type with the given path
     /// has been registered, returns `None`.
     ///
-    /// [type path]: TypePath::short_type_path
+    /// [short type path]: TypePath::short_type_path
     pub fn get_with_short_type_path(&self, short_type_path: &str) -> Option<&TypeRegistration> {
         self.short_path_to_id
             .get(short_type_path)
@@ -224,7 +224,7 @@ impl TypeRegistry {
     /// If the short type path is ambiguous, or if no type with the given path
     /// has been registered, returns `None`.
     ///
-    /// [type path]: TypePath::short_type_path
+    /// [short type path]: TypePath::short_type_path
     pub fn get_with_short_type_path_mut(
         &mut self,
         short_type_path: &str,

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -242,12 +242,12 @@ impl TypeRegistry {
     /// # mod foo {
     /// #     use bevy_reflect::Reflect;
     /// #     #[derive(Reflect)]
-    /// #     struct MyType;
+    /// #     pub struct MyType;
     /// # }
     /// # mod bar {
     /// #     use bevy_reflect::Reflect;
     /// #     #[derive(Reflect)]
-    /// #     struct MyType;
+    /// #     pub struct MyType;
     /// # }
     /// let mut type_registry = TypeRegistry::default();
     /// type_registry.register::<foo::MyType>();

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -238,11 +238,13 @@ impl TypeRegistry {
     ///
     /// # Example
     /// ```
-    /// # use bevy_reflect::{TypeRegistry};
+    /// # use bevy_reflect::{TypeRegistry, Reflect};
     /// # mod foo {
+    /// #     #[derive(Reflect)]
     /// #     struct MyType;
     /// # }
     /// # mod bar {
+    /// #     #[derive(Reflect)]
     /// #     struct MyType;
     /// # }
     /// let mut type_registry = TypeRegistry::default();


### PR DESCRIPTION
# Objective

Currently, the `ambiguous_names` hash set in `TypeRegistry` is used to keep track of short type names that are ambiguous, and to require the use of long type names for these types.

However, there's no way for the consumer of `TypeRegistry` to known whether a given call to `get_with_short_type_path()` or `get_with_short_type_path_mut()` failed because a type was not registered at all, or because the short name is ambiguous.

This can be used, for example, for better error reporting to the user by an editor tool. Here's some code that uses this, from my remote protocol exploration branch:

```rust
let type_registration = type_registry
  .get_with_type_path(component_name)
  .or_else(|| registry.get_with_short_type_path(component_name))
  .ok_or_else(|| {
      if type_registry.is_ambiguous(component_name) {
          BrpError::ComponentAmbiguous(component_name.clone())
      } else {
          BrpError::MissingTypeRegistration(component_name.clone())
      }
  })?
```

## Solution

- Introduces a `is_ambiguous()` method.
- Also drive-by fixes two documentation comments that had broken links.

---

## Changelog

- Added a `TypeRegistry::is_ambiguous()` method, for checking whether a given short type path is ambiguous (e.g. `MyType` potentially matching either `some_crate::MyType` or `another_crate::MyType`)