### PR TITLE
Fix sysinfo CPU brand output

### DIFF
--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -99,14 +99,20 @@ pub mod internal {
     }
 
     pub(crate) fn log_system_info() {
-        let mut sys = sysinfo::System::new();
-        sys.refresh_cpu();
-        sys.refresh_memory();
+        let sys = System::new_with_specifics(
+            RefreshKind::new()
+                .with_cpu(CpuRefreshKind::new())
+                .with_memory(MemoryRefreshKind::new().with_ram()),
+        );
 
         let info = SystemInfo {
             os: System::long_os_version().unwrap_or_else(|| String::from("not available")),
             kernel: System::kernel_version().unwrap_or_else(|| String::from("not available")),
-            cpu: sys.global_cpu_info().brand().trim().to_string(),
+            cpu: sys
+                .cpus()
+                .first()
+                .map(|cpu| cpu.brand().trim().to_string())
+                .unwrap_or_else(|| String::from("not available")),
             core_count: sys
                 .physical_core_count()
                 .map(|x| x.to_string())


### PR DESCRIPTION
# Objective

sysinfo was updated to 0.30 in #11071. Ever since then the `cpu` field of the `SystemInfo` struct that gets printed every time one starts an bevy app has been empty. This is because the following part of the sysinfo migration guide was overlooked:

---

### `Cpu` changes

Information like `Cpu::brand`, `Cpu::vendor_id` or `Cpu::frequency` are not set on the "global" CPU.

---

## Solution

- Get the CPU brand information from a specific CPU instead. In this case, just choose the first one. It's theoretically possible for different CPUs to have different names, but in practice this doesn't really happen I think. Even Intel's newer hybrid processors use a uniform name for all CPUs in my experience.
- We can use this opportunity to also update our `sysinfo::System` initialization here to only fetch the information we're interested in.