### PR TITLE
Overwrite gizmo group in `insert_gizmo_group`

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -183,16 +183,16 @@ impl AppGizmoBuilder for App {
         group: T,
         config: GizmoConfig,
     ) -> &mut Self {
+        self.world
+            .get_resource_or_insert_with::<GizmoConfigStore>(Default::default)
+            .insert(config, group);
+
         if self.world.contains_resource::<GizmoStorage<T>>() {
             return self;
         }
 
         self.init_resource::<GizmoStorage<T>>()
             .add_systems(Last, update_gizmo_meshes::<T>);
-
-        self.world
-            .get_resource_or_insert_with::<GizmoConfigStore>(Default::default)
-            .insert(config, group);
 
         let Ok(render_app) = self.get_sub_app_mut(RenderApp) else {
             return self;


### PR DESCRIPTION
# Objective

I tried using `insert_gizmo_group` to configure my physics gizmos in a bevy_xpbd example, but was surprised to see that nothing happened. I found out that the method does *not* overwrite gizmo groups that have already been initialized (with `init_gizmo_group`). This is unexpected, since methods like `insert_resource` *do* overwrite.

## Solution

Insert the configuration even if it has already been initialized.