### PR TITLE
Static and cached marker components

### DIFF
--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -45,6 +45,7 @@ impl PluginGroup for DefaultPlugins {
             .add(bevy_core::TaskPoolPlugin::default())
             .add(bevy_core::TypeRegistrationPlugin)
             .add(bevy_core::FrameCountPlugin)
+            .add(bevy_core::StaticPlugin)
             .add(bevy_time::TimePlugin)
             .add(bevy_transform::TransformPlugin)
             .add(bevy_hierarchy::HierarchyPlugin)

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -18,6 +18,7 @@ pbr_transmission_textures = []
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.12.0" }
 bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
+bevy_core = { path = "../bevy_core", version = "0.12.0" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
 bevy_math = { path = "../bevy_math", version = "0.12.0" }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use bevy_app::{App, Plugin};
 use bevy_asset::{Asset, AssetApp, AssetEvent, AssetId, AssetServer, Assets, Handle};
+use bevy_core::Cached;
 use bevy_core_pipeline::{
     core_3d::{
         AlphaMask3d, Camera3d, Opaque3d, ScreenSpaceTransmissionQuality, Transmissive3d,

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["bevy"]
 [dependencies]
 # bevy
 bevy_app = { path = "../bevy_app", version = "0.12.0" }
+bevy_core = { path = "../bevy_core", version = "0.12.0" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", features = [
   "bevy_reflect",
 ] }

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -17,6 +17,7 @@ pub mod prelude {
 }
 
 use bevy_app::prelude::*;
+use bevy_core::remove_cached_dynamics;
 use bevy_ecs::prelude::*;
 use bevy_hierarchy::ValidParentCheckPlugin;
 use bevy_math::{Affine3A, Mat4, Vec3};
@@ -119,7 +120,9 @@ impl Plugin for TransformPlugin {
             )
             .configure_sets(
                 PostUpdate,
-                PropagateTransformsSet.in_set(TransformSystem::TransformPropagate),
+                PropagateTransformsSet
+                    .in_set(TransformSystem::TransformPropagate)
+                    .after(remove_cached_dynamics),
             )
             .add_systems(
                 PostUpdate,

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -131,12 +131,15 @@ fn setup(
                 let spherical_polar_theta_phi =
                     fibonacci_spiral_on_sphere(golden_ratio, i, N_POINTS);
                 let unit_sphere_p = spherical_polar_to_cartesian(spherical_polar_theta_phi);
-                commands.spawn(PbrBundle {
-                    mesh: mesh.clone(),
-                    material: materials.choose(&mut material_rng).unwrap().clone(),
-                    transform: Transform::from_translation((radius * unit_sphere_p).as_vec3()),
-                    ..default()
-                });
+                commands.spawn((
+                    PbrBundle {
+                        mesh: mesh.clone(),
+                        material: materials.choose(&mut material_rng).unwrap().clone(),
+                        transform: Transform::from_translation((radius * unit_sphere_p).as_vec3()),
+                        ..default()
+                    },
+                    Static,
+                ));
             }
 
             // camera
@@ -152,34 +155,46 @@ fn setup(
                         continue;
                     }
                     // cube
-                    commands.spawn(PbrBundle {
-                        mesh: mesh.clone(),
-                        material: materials.choose(&mut material_rng).unwrap().clone(),
-                        transform: Transform::from_xyz((x as f32) * 2.5, (y as f32) * 2.5, 0.0),
-                        ..default()
-                    });
-                    commands.spawn(PbrBundle {
-                        mesh: mesh.clone(),
-                        material: materials.choose(&mut material_rng).unwrap().clone(),
-                        transform: Transform::from_xyz(
-                            (x as f32) * 2.5,
-                            HEIGHT as f32 * 2.5,
-                            (y as f32) * 2.5,
-                        ),
-                        ..default()
-                    });
-                    commands.spawn(PbrBundle {
-                        mesh: mesh.clone(),
-                        material: materials.choose(&mut material_rng).unwrap().clone(),
-                        transform: Transform::from_xyz((x as f32) * 2.5, 0.0, (y as f32) * 2.5),
-                        ..default()
-                    });
-                    commands.spawn(PbrBundle {
-                        mesh: mesh.clone(),
-                        material: materials.choose(&mut material_rng).unwrap().clone(),
-                        transform: Transform::from_xyz(0.0, (x as f32) * 2.5, (y as f32) * 2.5),
-                        ..default()
-                    });
+                    commands.spawn((
+                        PbrBundle {
+                            mesh: mesh.clone(),
+                            material: materials.choose(&mut material_rng).unwrap().clone(),
+                            transform: Transform::from_xyz((x as f32) * 2.5, (y as f32) * 2.5, 0.0),
+                            ..default()
+                        },
+                        Static,
+                    ));
+                    commands.spawn((
+                        PbrBundle {
+                            mesh: mesh.clone(),
+                            material: materials.choose(&mut material_rng).unwrap().clone(),
+                            transform: Transform::from_xyz(
+                                (x as f32) * 2.5,
+                                HEIGHT as f32 * 2.5,
+                                (y as f32) * 2.5,
+                            ),
+                            ..default()
+                        },
+                        Static,
+                    ));
+                    commands.spawn((
+                        PbrBundle {
+                            mesh: mesh.clone(),
+                            material: materials.choose(&mut material_rng).unwrap().clone(),
+                            transform: Transform::from_xyz((x as f32) * 2.5, 0.0, (y as f32) * 2.5),
+                            ..default()
+                        },
+                        Static,
+                    ));
+                    commands.spawn((
+                        PbrBundle {
+                            mesh: mesh.clone(),
+                            material: materials.choose(&mut material_rng).unwrap().clone(),
+                            transform: Transform::from_xyz(0.0, (x as f32) * 2.5, (y as f32) * 2.5),
+                            ..default()
+                        },
+                        Static,
+                    ));
                 }
             }
             // camera
@@ -190,7 +205,7 @@ fn setup(
         }
     }
 
-    commands.spawn(DirectionalLightBundle { ..default() });
+    commands.spawn((DirectionalLightBundle { ..default() }, Static));
 }
 
 fn init_textures(args: &Args, images: &mut Assets<Image>) -> Vec<Handle<Image>> {


### PR DESCRIPTION
# Objective

Bevy assumes all entities are entirely dynamic. This is a good default, because it encourages us to keep bevy scalable and efficient. Unfortunately this means we often waste some of our limited compute each frame re-exporting and re-processing data that hasn't actually changed.

There should be a way to mark entities that only need to be processed once without needing to rely on change detection (which is not efficient when the number of changes is small compared to the number of queried items).

## Solution

Add two new table-backed marker components: `Static` and `Cached`.

Bevy assumes that while an entity is marked as `Static`, it's properties will not change in any way visible to the user. You can basically think of `Static` entities as being part of "the map" or "the game world". Bevy doesn't set `Static` on any entities by default; that is left to the end user. Static objects can be easily excluded from systems like `propagate_transforms` with `Without<Static>`.

After the first frame in which a `Static` entity is view-visible, it is marked as `Cached`. Render extraction systems can simply remove a `entity_map.clear()` and add a `Without<Cached>` query bound to retain extracted `Static` information. `Cached` is removed automatically from entities that are not `Static`, and can also be manually unset in the main world to cause a cache flush.

`Static` and `Cached` are tabled-backed. This means there is a reasonably large fixed cost to adding or removing these components. But this also means that entities with these components get kicked off into their own archetypes, and so have no query-iteration overhead (unlike `Changed<T>`). This can lead to large performance gains in several schedules (but particularly in render extraction) when the vast majority of rendered objects are `Static`, and `Static` is only rarely added or removed.

---

The current implementation is a prototype. I am still trying to identify other hot queries that could benefit from `Without<Cached>`.

I have profiled this against `many_cubes` and `many_lights`. Both show a significant potential for improvement over main, but I'd like to hold off on posting any of my results until this is more complete.

Here are some potential issues:
+ Cache invalidation has no GC and relies on visibility. In order to make query extraction efficient, entries in `render_mesh_instances` are never cleared. `Cached` controls when they are overwritten, and only visible entities are accessed. The memory cost is minimal compared to the time cost of clearing out-of-view cached items.
+ Currently there is no way to disable or enable `Static` and `Cached` stuff. I plan to add this but it may require tweaking `propagate_transforms`.
+ `propagate_transforms` needs to visit every static node with children. Combining this approach with https://github.com/bevyengine/bevy/pull/11760 will significantly improve this issue.
