### PR TITLE
Use question mark operator when possible

### DIFF
--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -493,9 +493,7 @@ fn entity_from_path(
     let mut parts = path.parts.iter().enumerate();
 
     // check the first name is the root node which we already have
-    let Some((_, root_name)) = parts.next() else {
-        return None;
-    };
+    let (_, root_name) = parts.next()?;
     if names.get(current_entity) != Ok(root_name) {
         return None;
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1668,9 +1668,7 @@ impl<'w> FilteredEntityRef<'w> {
     /// Returns `None` if the entity does not have a component of type `T`.
     #[inline]
     pub fn get<T: Component>(&self) -> Option<&'w T> {
-        let Some(id) = self.entity.world().components().get_id(TypeId::of::<T>()) else {
-            return None;
-        };
+        let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
         self.access
             .has_read(id)
             // SAFETY: We have read access so we must have the component
@@ -1683,9 +1681,7 @@ impl<'w> FilteredEntityRef<'w> {
     /// Returns `None` if the entity does not have a component of type `T`.
     #[inline]
     pub fn get_ref<T: Component>(&self) -> Option<Ref<'w, T>> {
-        let Some(id) = self.entity.world().components().get_id(TypeId::of::<T>()) else {
-            return None;
-        };
+        let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
         self.access
             .has_read(id)
             // SAFETY: We have read access so we must have the component
@@ -1696,9 +1692,7 @@ impl<'w> FilteredEntityRef<'w> {
     /// detection in custom runtimes.
     #[inline]
     pub fn get_change_ticks<T: Component>(&self) -> Option<ComponentTicks> {
-        let Some(id) = self.entity.world().components().get_id(TypeId::of::<T>()) else {
-            return None;
-        };
+        let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
         self.access
             .has_read(id)
             // SAFETY: We have read access so we must have the component
@@ -1944,9 +1938,7 @@ impl<'w> FilteredEntityMut<'w> {
     /// Returns `None` if the entity does not have a component of type `T`.
     #[inline]
     pub fn get_mut<T: Component>(&mut self) -> Option<Mut<'_, T>> {
-        let Some(id) = self.entity.world().components().get_id(TypeId::of::<T>()) else {
-            return None;
-        };
+        let id = self.entity.world().components().get_id(TypeId::of::<T>())?;
         self.access
             .has_write(id)
             // SAFETY: We have write access so we must have the component

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -225,9 +225,7 @@ pub fn ui_focus_system(
                 return None;
             };
 
-            let Some(view_visibility) = node.view_visibility else {
-                return None;
-            };
+            let view_visibility = node.view_visibility?;
             // Nodes that are not rendered should not be interactable
             if !view_visibility.get() {
                 // Reset their interaction to None to avoid strange stuck state
@@ -237,13 +235,10 @@ pub fn ui_focus_system(
                 }
                 return None;
             }
-            let Some(camera_entity) = node
+            let camera_entity = node
                 .target_camera
                 .map(TargetCamera::entity)
-                .or(default_ui_camera.get())
-            else {
-                return None;
-            };
+                .or(default_ui_camera.get())?;
 
             let node_rect = node.node.logical_rect(node.global_transform);
 


### PR DESCRIPTION
# Objective

- There are multiple instances of `let Some(x) = ... else { None };` throughout the project.
- Because `Option<T>` implements [`Try`](https://doc.rust-lang.org/stable/std/ops/trait.Try.html), it can use the question mark `?` operator.

## Solution

- Use question mark operator instead of `let Some(x) = ... else { None }`.

---

There was another PR that did a similar thing a few weeks ago, but I couldn't find it.