### PR TITLE
Fix a few Clippy lints

### DIFF
--- a/crates/bevy_render/src/view/visibility/mod.rs
+++ b/crates/bevy_render/src/view/visibility/mod.rs
@@ -50,7 +50,8 @@ pub enum Visibility {
 impl PartialEq<Visibility> for &Visibility {
     #[inline]
     fn eq(&self, other: &Visibility) -> bool {
-        **self == *other
+        // Use the base Visibility == Visibility implementation.
+        <Visibility as PartialEq<Visibility>>::eq(*self, other)
     }
 }
 
@@ -58,7 +59,8 @@ impl PartialEq<Visibility> for &Visibility {
 impl PartialEq<&Visibility> for Visibility {
     #[inline]
     fn eq(&self, other: &&Visibility) -> bool {
-        *self == **other
+        // Use the base Visibility == Visibility implementation.
+        <Visibility as PartialEq<Visibility>>::eq(self, *other)
     }
 }
 

--- a/crates/bevy_tasks/src/task_pool.rs
+++ b/crates/bevy_tasks/src/task_pool.rs
@@ -120,7 +120,7 @@ pub struct TaskPool {
 
 impl TaskPool {
     thread_local! {
-        static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = async_executor::LocalExecutor::new();
+        static LOCAL_EXECUTOR: async_executor::LocalExecutor<'static> = const { async_executor::LocalExecutor::new() };
         static THREAD_EXECUTOR: Arc<ThreadExecutor<'static>> = Arc::new(ThreadExecutor::new());
     }
 


### PR DESCRIPTION
# Objective

- The current implementations for `&Visibility == Visibility` and `Visibility == &Visibility` are ambiguous, so they raise a warning for being unconditionally recursive.
- `TaskPool`'s `LOCAL_EXECUTOR` thread local calls a `const` constructor in a non-`const` context.

## Solution

- Make `&Visibility == Visibility` and `Visibility == &Visibility` implementations use `Visibility == Visibility`.
- Wrap `LocalExecutor::new` in a special `const` block supported by [`thread_local`](https://doc.rust-lang.org/stable/std/macro.thread_local.html).

---

This lints were found by running:

```shell
$ cargo clippy --workspace
```

There are a few other warnings that were more complicated, so I chose not to include them in this PR.

<details>
  <summary>Here they are...</summary>

```shell
warning: function cannot return without recursing
  --> crates/bevy_utils/src/cow_arc.rs:92:5
   |
92 | /     fn eq(&self, other: &Self) -> bool {
93 | |         self.deref().eq(other.deref())
94 | |     }
   | |_____^
   |
note: recursive call site
  --> crates/bevy_utils/src/cow_arc.rs:93:9
   |
93 |         self.deref().eq(other.deref())
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

warning: method `get_path` is never used
  --> crates/bevy_reflect/src/serde/de.rs:26:8
   |
25 | trait StructLikeInfo {
   |       -------------- method in this trait
26 |     fn get_path(&self) -> &str;
   |        ^^^^^^^^
   |
   = note: `#[warn(dead_code)]` on by default

warning: methods `get_path` and `get_field` are never used
  --> crates/bevy_reflect/src/serde/de.rs:34:8
   |
33 | trait TupleLikeInfo {
   |       ------------- methods in this trait
34 |     fn get_path(&self) -> &str;
   |        ^^^^^^^^
35 |     fn get_field(&self, index: usize) -> Option<&UnnamedField>;
   |        ^^^^^^^^^
```

The other warnings are fixed by #11865.

</details>