### PR TITLE
Un-hardcode positions and colors in `2d_shapes` example

### DIFF
--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -1,6 +1,7 @@
 //! Shows how to render simple primitive shapes with a single color.
 
 use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
+use bevy_internal::sprite::Mesh2dHandle;
 
 fn main() {
     App::new()
@@ -9,6 +10,8 @@ fn main() {
         .run();
 }
 
+const X_EXTENT: f32 = 600.;
+
 fn setup(
     mut commands: Commands,
     mut meshes: ResMut<Assets<Mesh>>,
@@ -16,57 +19,32 @@ fn setup(
 ) {
     commands.spawn(Camera2dBundle::default());
 
-    // Circle
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Circle { radius: 50.0 }).into(),
-        material: materials.add(Color::VIOLET),
-        transform: Transform::from_translation(Vec3::new(-275.0, 0.0, 0.0)),
-        ..default()
-    });
+    let shapes = [
+        Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
+        Mesh2dHandle(meshes.add(Ellipse::new(25.0, 50.0))),
+        Mesh2dHandle(meshes.add(Capsule2d::new(25.0, 50.0))),
+        Mesh2dHandle(meshes.add(Rectangle::new(50.0, 100.0))),
+        Mesh2dHandle(meshes.add(RegularPolygon::new(50.0, 6))),
+        Mesh2dHandle(meshes.add(Triangle2d::new(
+            Vec2::Y * 50.0,
+            Vec2::new(-50.0, -50.0),
+            Vec2::new(50.0, -50.0),
+        ))),
+    ];
+    let num_shapes = shapes.len();
 
-    // Ellipse
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Ellipse::new(25.0, 50.0)).into(),
-        material: materials.add(Color::TURQUOISE),
-        transform: Transform::from_translation(Vec3::new(-150.0, 0.0, 0.0)),
-        ..default()
-    });
+    for (i, shape) in shapes.into_iter().enumerate() {
+        let color = Color::hsl(360. * i as f32 / num_shapes as f32, 0.95, 0.7);
 
-    // Capsule
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Capsule2d::new(25.0, 50.0)).into(),
-        material: materials.add(Color::LIME_GREEN),
-        transform: Transform::from_translation(Vec3::new(-50.0, 0.0, 0.0)),
-        ..default()
-    });
-
-    // Rectangle
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(Rectangle::new(50.0, 100.0)).into(),
-        material: materials.add(Color::YELLOW),
-        transform: Transform::from_translation(Vec3::new(50.0, 0.0, 0.0)),
-        ..default()
-    });
-
-    // Hexagon
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes.add(RegularPolygon::new(50.0, 6)).into(),
-        material: materials.add(Color::ORANGE),
-        transform: Transform::from_translation(Vec3::new(175.0, 0.0, 0.0)),
-        ..default()
-    });
-
-    // Triangle
-    commands.spawn(MaterialMesh2dBundle {
-        mesh: meshes
-            .add(Triangle2d::new(
-                Vec2::Y * 50.0,
-                Vec2::new(-50.0, -50.0),
-                Vec2::new(50.0, -50.0),
-            ))
-            .into(),
-        material: materials.add(Color::ORANGE_RED),
-        transform: Transform::from_translation(Vec3::new(300.0, 0.0, 0.0)),
-        ..default()
-    });
+        commands.spawn(MaterialMesh2dBundle {
+            mesh: shape,
+            material: materials.add(color),
+            transform: Transform::from_translation(Vec3::new(
+                -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
+                0.0,
+                0.0,
+            )),
+            ..default()
+        });
+    }
 }

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -36,6 +36,7 @@ fn setup(
     let num_shapes = shapes.len();
 
     for (i, shape) in shapes.into_iter().enumerate() {
+        // Distribute colors evenly across the rainbow.
         let color = Color::hsl(360. * i as f32 / num_shapes as f32, 0.95, 0.7);
 
         commands.spawn(MaterialMesh2dBundle {

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -42,6 +42,7 @@ fn setup(
             mesh: shape,
             material: materials.add(color),
             transform: Transform::from_translation(Vec3::new(
+                // Distribute shapes from -X_EXTENT to +X_EXTENT.
                 -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
                 0.0,
                 0.0,

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -1,7 +1,9 @@
 //! Shows how to render simple primitive shapes with a single color.
 
-use bevy::{prelude::*, sprite::MaterialMesh2dBundle};
-use bevy_internal::sprite::Mesh2dHandle;
+use bevy::{
+    prelude::*,
+    sprite::{MaterialMesh2dBundle, Mesh2dHandle},
+};
 
 fn main() {
     App::new()

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -42,7 +42,7 @@ fn setup(
         commands.spawn(MaterialMesh2dBundle {
             mesh: shape,
             material: materials.add(color),
-            transform: Transform::from_translation(Vec3::new(
+            transform: Transform::from_xyz(
                 // Distribute shapes from -X_EXTENT to +X_EXTENT.
                 -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
                 0.0,

--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -47,7 +47,7 @@ fn setup(
                 -X_EXTENT / 2. + i as f32 / (num_shapes - 1) as f32 * X_EXTENT,
                 0.0,
                 0.0,
-            )),
+            ),
             ..default()
         });
     }


### PR DESCRIPTION
# Objective

We recently got some neat new 2d shapes and the shapes are no longer centered on the screen.

The hardcoded positions and colors are a pain to deal with when a new shape is added.

## Solution

Delete a bunch of code and position shapes evenly. Assign colors evenly too.

## Before

<img width="1280" alt="Screenshot 2024-02-14 at 3 17 40 PM" src="https://github.com/bevyengine/bevy/assets/200550/cc9fd9a8-4019-4907-a50e-621cb656c20a">

## After

<img width="1280" alt="Screenshot 2024-02-14 at 3 17 24 PM" src="https://github.com/bevyengine/bevy/assets/200550/033a3f91-d3bc-4ec8-af59-42a221f8b8e7">

