### PR TITLE
New Exposure and Lighting Defaults (and calibrate examples)

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -145,6 +145,7 @@ pub struct Camera3dBundle {
     pub tonemapping: Tonemapping,
     pub dither: DebandDither,
     pub color_grading: ColorGrading,
+    pub exposure: Exposure,
     pub main_texture_usages: CameraMainTextureUsages,
 }
 
@@ -161,9 +162,10 @@ impl Default for Camera3dBundle {
             global_transform: Default::default(),
             camera_3d: Default::default(),
             tonemapping: Default::default(),
-            dither: DebandDither::Enabled,
-            color_grading: ColorGrading::default(),
+            color_grading: Default::default(),
+            exposure: Default::default(),
             main_texture_usages: Default::default(),
+            dither: DebandDither::Enabled,
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -2,7 +2,7 @@ use crate::tonemapping::{DebandDither, Tonemapping};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
-    camera::{Camera, CameraMainTextureUsages, CameraRenderGraph, Projection},
+    camera::{Camera, CameraMainTextureUsages, CameraRenderGraph, Exposure, Projection},
     extract_component::ExtractComponent,
     primitives::Frustum,
     render_resource::{LoadOp, TextureUsages},

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -84,10 +84,8 @@ impl ExtractComponent for Skybox {
     type QueryFilter = ();
     type Out = (Self, SkyboxUniforms);
 
-    fn extract_component(
-        (skybox, exposure_settings): QueryItem<'_, Self::QueryData>,
-    ) -> Option<Self::Out> {
-        let exposure = exposure_settings
+    fn extract_component((skybox, exposure): QueryItem<'_, Self::QueryData>) -> Option<Self::Out> {
+        let exposure = exposure
             .map(|e| e.exposure())
             .unwrap_or_else(|| Exposure::default().exposure());
 

--- a/crates/bevy_core_pipeline/src/skybox/mod.rs
+++ b/crates/bevy_core_pipeline/src/skybox/mod.rs
@@ -7,7 +7,7 @@ use bevy_ecs::{
     system::{Commands, Query, Res, ResMut, Resource},
 };
 use bevy_render::{
-    camera::ExposureSettings,
+    camera::Exposure,
     extract_component::{
         ComponentUniforms, DynamicUniformIndex, ExtractComponent, ExtractComponentPlugin,
         UniformComponentPlugin,
@@ -80,7 +80,7 @@ pub struct Skybox {
 }
 
 impl ExtractComponent for Skybox {
-    type QueryData = (&'static Self, Option<&'static ExposureSettings>);
+    type QueryData = (&'static Self, Option<&'static Exposure>);
     type QueryFilter = ();
     type Out = (Self, SkyboxUniforms);
 
@@ -89,7 +89,7 @@ impl ExtractComponent for Skybox {
     ) -> Option<Self::Out> {
         let exposure = exposure_settings
             .map(|e| e.exposure())
-            .unwrap_or_else(|| ExposureSettings::default().exposure());
+            .unwrap_or_else(|| Exposure::default().exposure());
 
         Some((
             skybox.clone(),

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -70,9 +70,9 @@ pub mod light_consts {
         /// The amount of light (lux) on a overcast day; typical TV studio lighting
         pub const OVERCAST_DAY: f32 = 1000.;
         /// The amount of light (lux) in full daylight (not direct sun).
-        pub const FULL_DAYLIGHT: f32 = 10_000.;
+        pub const FULL_DAYLIGHT: f32 = 20_000.;
         /// The amount of light (lux) in direct sunlight.
-        pub const DIRECT_SUNLIGHT: f32 = 50_000.;
+        pub const DIRECT_SUNLIGHT: f32 = 100_000.;
     }
 }
 
@@ -265,7 +265,7 @@ impl Default for DirectionalLight {
     fn default() -> Self {
         DirectionalLight {
             color: Color::rgb(1.0, 1.0, 1.0),
-            illuminance: light_consts::lux::OVERCAST_DAY,
+            illuminance: light_consts::lux::FULL_DAYLIGHT,
             shadows_enabled: false,
             shadow_depth_bias: Self::DEFAULT_SHADOW_DEPTH_BIAS,
             shadow_normal_bias: Self::DEFAULT_SHADOW_NORMAL_BIAS,

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -645,7 +645,7 @@ impl Default for AmbientLight {
     fn default() -> Self {
         Self {
             color: Color::WHITE,
-            brightness: 20.0,
+            brightness: 80.0,
         }
     }
 }

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -113,7 +113,10 @@ impl Default for PointLight {
     fn default() -> Self {
         PointLight {
             color: Color::rgb(1.0, 1.0, 1.0),
-            intensity: 2000.0, // Roughly a 20-watt LED bulb
+            // 1,000,000 lumens is a very large "cinema light" capable of registering brightly at Bevy's
+            // default "very overcast day" exposure level. For "indoor lighting" with a lower exposure,
+            // this would be way too bright.
+            intensity: 1_000_000.0,
             range: 20.0,
             radius: 0.0,
             shadows_enabled: false,

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -69,6 +69,8 @@ pub mod light_consts {
         pub const CLEAR_SUNRISE: f32 = 400.;
         /// The amount of light (lux) on a overcast day; typical TV studio lighting
         pub const OVERCAST_DAY: f32 = 1000.;
+        /// The amount of light (lux) from ambient daylight (not direct sunlight).
+        pub const AMBIENT_DAYLIGHT: f32 = 10_000.;
         /// The amount of light (lux) in full daylight (not direct sun).
         pub const FULL_DAYLIGHT: f32 = 20_000.;
         /// The amount of light (lux) in direct sunlight.
@@ -184,7 +186,10 @@ impl Default for SpotLight {
         // a quarter arc attenuating from the center
         Self {
             color: Color::rgb(1.0, 1.0, 1.0),
-            intensity: 2000.0, // Roughly a 20-watt LED bulb
+            // 1,000,000 lumens is a very large "cinema light" capable of registering brightly at Bevy's
+            // default "very overcast day" exposure level. For "indoor lighting" with a lower exposure,
+            // this would be way too bright.
+            intensity: 1_000_000.0,
             range: 20.0,
             radius: 0.0,
             shadows_enabled: false,
@@ -265,7 +270,7 @@ impl Default for DirectionalLight {
     fn default() -> Self {
         DirectionalLight {
             color: Color::rgb(1.0, 1.0, 1.0),
-            illuminance: light_consts::lux::FULL_DAYLIGHT,
+            illuminance: light_consts::lux::AMBIENT_DAYLIGHT,
             shadows_enabled: false,
             shadow_depth_bias: Self::DEFAULT_SHADOW_DEPTH_BIAS,
             shadow_normal_bias: Self::DEFAULT_SHADOW_NORMAL_BIAS,

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -90,12 +90,12 @@ pub struct ComputedCameraValues {
 ///
 /// <https://en.wikipedia.org/wiki/Exposure_(photography)>
 #[derive(Component)]
-pub struct ExposureSettings {
+pub struct Exposure {
     /// <https://en.wikipedia.org/wiki/Exposure_value#Tabulated_exposure_values>
     pub ev100: f32,
 }
 
-impl ExposureSettings {
+impl Exposure {
     pub const SUNLIGHT: Self = Self {
         ev100: Self::EV100_SUNLIGHT,
     };
@@ -124,7 +124,7 @@ impl ExposureSettings {
     }
 }
 
-impl Default for ExposureSettings {
+impl Default for Exposure {
     fn default() -> Self {
         Self::INDOOR
     }
@@ -798,7 +798,7 @@ pub fn extract_cameras(
             &VisibleEntities,
             &Frustum,
             Option<&ColorGrading>,
-            Option<&ExposureSettings>,
+            Option<&Exposure>,
             Option<&TemporalJitter>,
             Option<&RenderLayers>,
             Option<&Projection>,
@@ -860,7 +860,7 @@ pub fn extract_cameras(
                     sorted_camera_index_for_target: 0,
                     exposure: exposure_settings
                         .map(|e| e.exposure())
-                        .unwrap_or_else(|| ExposureSettings::default().exposure()),
+                        .unwrap_or_else(|| Exposure::default().exposure()),
                 },
                 ExtractedView {
                     projection: camera.projection_matrix(),

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -105,10 +105,23 @@ impl Exposure {
     pub const INDOOR: Self = Self {
         ev100: Self::EV100_INDOOR,
     };
+    /// This value was calibrated to match Blender's implicit/default exposure as closely as possible.
+    /// It also happens to be a reasonable default.
+    ///
+    /// See <https://github.com/bevyengine/bevy/issues/11577> for details.
+    pub const BLENDER: Self = Self {
+        ev100: Self::EV100_BLENDER,
+    };
 
     pub const EV100_SUNLIGHT: f32 = 15.0;
     pub const EV100_OVERCAST: f32 = 12.0;
     pub const EV100_INDOOR: f32 = 7.0;
+
+    /// This value was calibrated to match Blender's implicit/default exposure as closely as possible.
+    /// It also happens to be a reasonable default.
+    ///
+    /// See <https://github.com/bevyengine/bevy/issues/11577> for details.
+    pub const EV100_BLENDER: f32 = 9.7;
 
     pub fn from_physical_camera(physical_camera_parameters: PhysicalCameraParameters) -> Self {
         Self {
@@ -126,12 +139,12 @@ impl Exposure {
 
 impl Default for Exposure {
     fn default() -> Self {
-        Self::INDOOR
+        Self::BLENDER
     }
 }
 
 /// Parameters based on physical camera characteristics for calculating
-/// EV100 values for use with [`ExposureSettings`].
+/// EV100 values for use with [`Exposure`].
 #[derive(Clone, Copy)]
 pub struct PhysicalCameraParameters {
     /// <https://en.wikipedia.org/wiki/F-number>
@@ -815,7 +828,7 @@ pub fn extract_cameras(
         visible_entities,
         frustum,
         color_grading,
-        exposure_settings,
+        exposure,
         temporal_jitter,
         render_layers,
         projection,
@@ -858,7 +871,7 @@ pub fn extract_cameras(
                     clear_color: camera.clear_color.clone(),
                     // this will be set in sort_cameras
                     sorted_camera_index_for_target: 0,
-                    exposure: exposure_settings
+                    exposure: exposure
                         .map(|e| e.exposure())
                         .unwrap_or_else(|| Exposure::default().exposure()),
                 },

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -7,7 +7,7 @@ pub use window::*;
 
 use crate::{
     camera::{
-        CameraMainTextureUsages, ClearColor, ClearColorConfig, ExposureSettings, ExtractedCamera,
+        CameraMainTextureUsages, ClearColor, ClearColorConfig, Exposure, ExtractedCamera,
         ManualTextureViews, MipBias, TemporalJitter,
     },
     extract_resource::{ExtractResource, ExtractResourcePlugin},
@@ -434,7 +434,7 @@ pub fn prepare_view_uniforms(
                 world_position: extracted_view.transform.translation(),
                 exposure: extracted_camera
                     .map(|c| c.exposure)
-                    .unwrap_or_else(|| ExposureSettings::default().exposure()),
+                    .unwrap_or_else(|| Exposure::default().exposure()),
                 viewport,
                 frustum,
                 color_grading: extracted_view.color_grading,

--- a/examples/3d/3d_gizmos.rs
+++ b/examples/3d/3d_gizmos.rs
@@ -41,13 +41,12 @@ fn setup(
         ..default()
     });
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/3d/3d_scene.rs
+++ b/examples/3d/3d_scene.rs
@@ -30,13 +30,12 @@ fn setup(
         ..default()
     });
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
     // camera

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -64,13 +64,14 @@ fn setup(
         ));
     }
 
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
+            intensity: 10_000_000.,
+            range: 100.0,
             ..default()
         },
-        transform: Transform::from_xyz(8.0, 16.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(8.0, 16.0, 8.0),
         ..default()
     });
 

--- a/examples/3d/3d_viewport_to_world.rs
+++ b/examples/3d/3d_viewport_to_world.rs
@@ -66,7 +66,6 @@ fn setup(
     // light
     commands.spawn(DirectionalLightBundle {
         transform: Transform::from_translation(Vec3::ONE).looking_at(Vec3::ZERO, Vec3::Y),
-        directional_light: DirectionalLight::default(),
         ..default()
     });
 

--- a/examples/3d/animated_material.rs
+++ b/examples/3d/animated_material.rs
@@ -25,7 +25,7 @@ fn setup(
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            intensity: 1_000.0,
+            intensity: 2_000.0,
         },
     ));
 

--- a/examples/3d/anti_aliasing.rs
+++ b/examples/3d/anti_aliasing.rs
@@ -289,7 +289,7 @@ fn setup(
     // Light
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+            illuminance: light_consts::lux::FULL_DAYLIGHT,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/atmospheric_fog.rs
+++ b/examples/3d/atmospheric_fog.rs
@@ -61,7 +61,6 @@ fn setup_terrain_scene(
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
             color: Color::rgb(0.98, 0.95, 0.82),
-            illuminance: light_consts::lux::OVERCAST_DAY,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/blend_modes.rs
+++ b/examples/3d/blend_modes.rs
@@ -167,12 +167,8 @@ fn setup(
     }
 
     // Light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
-            ..default()
-        },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/3d/deferred_rendering.rs
+++ b/examples/3d/deferred_rendering.rs
@@ -58,7 +58,7 @@ fn setup(
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            intensity: 250.0,
+            intensity: 2000.0,
         },
         DepthPrepass,
         MotionVectorPrepass,
@@ -68,7 +68,7 @@ fn setup(
 
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+            illuminance: 15_000.,
             shadows_enabled: true,
             ..default()
         },
@@ -140,7 +140,7 @@ fn setup(
     // Light
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 150.0,
+            intensity: 800.0,
             radius: 0.125,
             shadows_enabled: true,
             color: sphere_color,

--- a/examples/3d/fog.rs
+++ b/examples/3d/fog.rs
@@ -17,7 +17,6 @@
 use bevy::{
     pbr::{NotShadowCaster, NotShadowReceiver},
     prelude::*,
-    render::camera::ExposureSettings,
 };
 
 fn main() {
@@ -43,9 +42,6 @@ fn setup_camera_fog(mut commands: Commands) {
             },
             ..default()
         },
-        // This is a dark scene,
-        // increasing the exposure makes it easier to see
-        ExposureSettings { ev100: 4.0 },
     ));
 }
 
@@ -119,7 +115,6 @@ fn setup_pyramid_scene(
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(0.0, 1.0, 0.0),
         point_light: PointLight {
-            intensity: 4_000.,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/generate_custom_mesh.rs
+++ b/examples/3d/generate_custom_mesh.rs
@@ -57,11 +57,7 @@ fn setup(
     });
 
     // Light up the scene.
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
-            ..default()
-        },
+    commands.spawn(PointLightBundle {
         transform: camera_and_light_transform,
         ..default()
     });

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -6,7 +6,7 @@ use std::f32::consts::PI;
 use bevy::{
     pbr::{light_consts, CascadeShadowConfigBuilder},
     prelude::*,
-    render::camera::{ExposureSettings, PhysicalCameraParameters},
+    render::camera::{Exposure, PhysicalCameraParameters},
 };
 
 fn main() {
@@ -273,14 +273,14 @@ fn setup(
             transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
             ..default()
         },
-        ExposureSettings::from_physical_camera(**parameters),
+        Exposure::from_physical_camera(**parameters),
     ));
 }
 
 fn update_exposure(
     key_input: Res<ButtonInput<KeyCode>>,
     mut parameters: ResMut<Parameters>,
-    mut query: Query<&mut ExposureSettings>,
+    mut query: Query<&mut Exposure>,
     mut text: Query<&mut Text>,
 ) {
     // TODO: Clamp values to a reasonable range
@@ -311,7 +311,7 @@ fn update_exposure(
     );
     text.sections[2].value = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
 
-    *query.single_mut() = ExposureSettings::from_physical_camera(**parameters);
+    *query.single_mut() = Exposure::from_physical_camera(**parameters);
 }
 
 fn animate_light_direction(

--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -268,19 +268,17 @@ fn setup(
     );
 
     // camera
-    commands.spawn((
-        Camera3dBundle {
-            transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-            ..default()
-        },
-        Exposure::from_physical_camera(**parameters),
-    ));
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        exposure: Exposure::from_physical_camera(**parameters),
+        ..default()
+    });
 }
 
 fn update_exposure(
     key_input: Res<ButtonInput<KeyCode>>,
     mut parameters: ResMut<Parameters>,
-    mut query: Query<&mut Exposure>,
+    mut exposure: Query<&mut Exposure>,
     mut text: Query<&mut Text>,
 ) {
     // TODO: Clamp values to a reasonable range
@@ -311,7 +309,7 @@ fn update_exposure(
     );
     text.sections[2].value = format!("Sensitivity: ISO {:.0}\n", parameters.sensitivity_iso);
 
-    *query.single_mut() = Exposure::from_physical_camera(**parameters);
+    *exposure.single_mut() = Exposure::from_physical_camera(**parameters);
 }
 
 fn animate_light_direction(

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -6,10 +6,7 @@ use bevy::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            color: Color::WHITE,
-            brightness: 0.0,
-        })
+        .insert_resource(AmbientLight::NONE)
         .add_systems(Startup, setup)
         .add_systems(Update, add_lightmaps_to_meshes)
         .run();
@@ -21,10 +18,10 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         ..default()
     });
 
-    commands.spawn((Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(-278.0, 273.0, 800.0),
         ..default()
-    },));
+    });
 }
 
 fn add_lightmaps_to_meshes(

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -31,7 +31,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/orthographic.rs
+++ b/examples/3d/orthographic.rs
@@ -59,12 +59,8 @@ fn setup(
         ..default()
     });
     // light
-    commands.spawn(DirectionalLightBundle {
-        transform: Transform::from_xyz(3.0, 8.0, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
-            ..default()
-        },
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(3.0, 8.0, 5.0),
         ..default()
     });
 }

--- a/examples/3d/parallax_mapping.rs
+++ b/examples/3d/parallax_mapping.rs
@@ -222,9 +222,8 @@ fn setup(
     // light
     commands
         .spawn(PointLightBundle {
-            transform: Transform::from_xyz(1.8, 0.7, -1.1),
+            transform: Transform::from_xyz(2.0, 1.0, -1.1),
             point_light: PointLight {
-                intensity: 100_000.0, // Mini-sun point light
                 shadows_enabled: true,
                 ..default()
             },

--- a/examples/3d/parenting.rs
+++ b/examples/3d/parenting.rs
@@ -55,12 +55,8 @@ fn setup(
             });
         });
     // light
-    commands.spawn(DirectionalLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, -4.0).looking_at(Vec3::ZERO, Vec3::Y),
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
-            ..default()
-        },
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, -4.0),
         ..default()
     });
     // camera

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,6 +1,6 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
-use bevy::{asset::LoadState, prelude::*, render::camera::ExposureSettings};
+use bevy::{asset::LoadState, prelude::*, render::camera::Exposure};
 
 fn main() {
     App::new()
@@ -48,6 +48,15 @@ fn setup(
             ..default()
         }),
         transform: Transform::from_xyz(-5.0, -2.5, 0.0),
+        ..default()
+    });
+
+    commands.spawn(DirectionalLightBundle {
+        transform: Transform::from_xyz(50.0, 50.0, 50.0).looking_at(Vec3::ZERO, Vec3::Y),
+        directional_light: DirectionalLight {
+            illuminance: 1_500.,
+            ..default()
+        },
         ..default()
     });
 
@@ -121,9 +130,8 @@ fn setup(
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            intensity: 7000.0,
+            intensity: 900.0,
         },
-        ExposureSettings::OVERCAST,
     ));
 }
 

--- a/examples/3d/pbr.rs
+++ b/examples/3d/pbr.rs
@@ -1,6 +1,6 @@
 //! This example shows how to configure Physically Based Rendering (PBR) parameters.
 
-use bevy::{asset::LoadState, prelude::*, render::camera::Exposure};
+use bevy::{asset::LoadState, prelude::*};
 
 fn main() {
     App::new()

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -8,7 +8,6 @@
 
 use bevy::core_pipeline::Skybox;
 use bevy::prelude::*;
-use bevy::render::camera::Exposure;
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 

--- a/examples/3d/reflection_probes.rs
+++ b/examples/3d/reflection_probes.rs
@@ -8,7 +8,7 @@
 
 use bevy::core_pipeline::Skybox;
 use bevy::prelude::*;
-use bevy::render::camera::ExposureSettings;
+use bevy::render::camera::Exposure;
 
 use std::fmt::{Display, Formatter, Result as FmtResult};
 
@@ -106,17 +106,14 @@ fn spawn_scene(commands: &mut Commands, asset_server: &AssetServer) {
 
 // Spawns the camera.
 fn spawn_camera(commands: &mut Commands) {
-    commands.spawn((
-        Camera3dBundle {
-            camera: Camera {
-                hdr: true,
-                ..default()
-            },
-            transform: Transform::from_xyz(-6.483, 0.325, 4.381).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn(Camera3dBundle {
+        camera: Camera {
+            hdr: true,
             ..default()
         },
-        ExposureSettings::OVERCAST,
-    ));
+        transform: Transform::from_xyz(-6.483, 0.325, 4.381).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
 }
 
 // Creates the sphere mesh and spawns it.

--- a/examples/3d/render_to_texture.rs
+++ b/examples/3d/render_to_texture.rs
@@ -89,7 +89,13 @@ fn setup(
     // NOTE: we add the light to all layers so it affects both the rendered-to-texture cube, and the cube on which we display the texture
     // Setting the layer to RenderLayers::layer(0) would cause the main view to be lit, but the rendered-to-texture cube to be unlit.
     // Setting the layer to RenderLayers::layer(1) would cause the rendered-to-texture cube to be lit, but the main view to be unlit.
-    commands.spawn((DirectionalLightBundle::default(), RenderLayers::all()));
+    commands.spawn((
+        PointLightBundle {
+            transform: Transform::from_translation(Vec3::new(0.0, 0.0, 10.0)),
+            ..default()
+        },
+        RenderLayers::all(),
+    ));
 
     commands.spawn((
         Camera3dBundle {

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -3,10 +3,7 @@
 #[path = "../helpers/camera_controller.rs"]
 mod camera_controller;
 
-use bevy::{
-    pbr::{light_consts, ShadowFilteringMethod},
-    prelude::*,
-};
+use bevy::{pbr::ShadowFilteringMethod, prelude::*};
 use camera_controller::{CameraController, CameraControllerPlugin};
 
 fn main() {

--- a/examples/3d/shadow_biases.rs
+++ b/examples/3d/shadow_biases.rs
@@ -71,7 +71,6 @@ fn setup(
             });
             builder.spawn(DirectionalLightBundle {
                 directional_light: DirectionalLight {
-                    illuminance: light_consts::lux::OVERCAST_DAY,
                     shadow_depth_bias: 0.0,
                     shadow_normal_bias: 0.0,
                     shadows_enabled: true,

--- a/examples/3d/spherical_area_lights.rs
+++ b/examples/3d/spherical_area_lights.rs
@@ -4,7 +4,10 @@ use bevy::prelude::*;
 
 fn main() {
     App::new()
-        .insert_resource(AmbientLight::NONE)
+        .insert_resource(AmbientLight {
+            brightness: 60.0,
+            ..default()
+        })
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();
@@ -16,10 +19,10 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // camera
-    commands.spawn((Camera3dBundle {
+    commands.spawn(Camera3dBundle {
         transform: Transform::from_xyz(0.2, 1.5, 2.5).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
-    },));
+    });
 
     // plane
     commands.spawn(PbrBundle {
@@ -37,7 +40,7 @@ fn setup(
     let radius_range = 0.0..0.4;
     let pos_len = position_range.end - position_range.start;
     let radius_len = radius_range.end - radius_range.start;
-    let mesh = meshes.add(Sphere::new(0.5).mesh().uv(120, 64));
+    let mesh = meshes.add(Sphere::new(1.0).mesh().uv(120, 64));
 
     for i in 0..COUNT {
         let percent = i as f32 / COUNT as f32;
@@ -59,7 +62,6 @@ fn setup(
             .with_children(|children| {
                 children.spawn(PointLightBundle {
                     point_light: PointLight {
-                        intensity: 4000.0,
                         radius,
                         color: Color::rgb(0.2, 0.2, 1.0),
                         ..default()

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -8,7 +8,7 @@ use rand::{rngs::StdRng, Rng, SeedableRng};
 fn main() {
     App::new()
         .insert_resource(AmbientLight {
-            brightness: 4.0,
+            brightness: 20.0,
             ..default()
         })
         .add_plugins(DefaultPlugins)

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -3,7 +3,7 @@
 use bevy::{
     core_pipeline::experimental::taa::{TemporalAntiAliasBundle, TemporalAntiAliasPlugin},
     pbr::{
-        light_consts, ScreenSpaceAmbientOcclusionBundle, ScreenSpaceAmbientOcclusionQualityLevel,
+        ScreenSpaceAmbientOcclusionBundle, ScreenSpaceAmbientOcclusionQualityLevel,
         ScreenSpaceAmbientOcclusionSettings,
     },
     prelude::*,

--- a/examples/3d/ssao.rs
+++ b/examples/3d/ssao.rs
@@ -14,7 +14,7 @@ use std::f32::consts::PI;
 fn main() {
     App::new()
         .insert_resource(AmbientLight {
-            brightness: light_consts::lux::OVERCAST_DAY,
+            brightness: 1000.,
             ..default()
         })
         .add_plugins((DefaultPlugins, TemporalAntiAliasPlugin))
@@ -81,7 +81,6 @@ fn setup(
 
     commands.spawn(DirectionalLightBundle {
         directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -76,7 +76,7 @@ fn setup(
         EnvironmentMapLight {
             diffuse_map: asset_server.load("environment_maps/pisa_diffuse_rgb9e5_zstd.ktx2"),
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
-            intensity: 50.0,
+            intensity: 2000.0,
         },
     ));
 
@@ -191,8 +191,8 @@ fn setup_basic_scene(
     commands.spawn((
         DirectionalLightBundle {
             directional_light: DirectionalLight {
+                illuminance: 15_000.,
                 shadows_enabled: true,
-                illuminance: light_consts::lux::OVERCAST_DAY,
                 ..default()
             },
             transform: Transform::from_rotation(Quat::from_euler(

--- a/examples/3d/tonemapping.rs
+++ b/examples/3d/tonemapping.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     core_pipeline::tonemapping::Tonemapping,
-    pbr::{light_consts, CascadeShadowConfigBuilder},
+    pbr::CascadeShadowConfigBuilder,
     prelude::*,
     reflect::TypePath,
     render::{

--- a/examples/3d/transmission.rs
+++ b/examples/3d/transmission.rs
@@ -27,7 +27,7 @@ use bevy::{
     },
     pbr::{NotShadowCaster, PointLightShadowMap, TransmittedShadowReceiver},
     prelude::*,
-    render::camera::{ExposureSettings, TemporalJitter},
+    render::camera::{Exposure, TemporalJitter},
     render::view::ColorGrading,
 };
 
@@ -334,6 +334,7 @@ fn setup(
                 ..default()
             },
             tonemapping: Tonemapping::TonyMcMapface,
+            exposure: Exposure { ev100: 6.0 },
             ..default()
         },
         #[cfg(not(all(feature = "webgl2", target_arch = "wasm32")))]
@@ -344,7 +345,6 @@ fn setup(
             specular_map: asset_server.load("environment_maps/pisa_specular_rgb9e5_zstd.ktx2"),
         },
         BloomSettings::default(),
-        ExposureSettings { ev100: 6.0 },
     ));
 
     // Controls Text

--- a/examples/3d/transparency_3d.rs
+++ b/examples/3d/transparency_3d.rs
@@ -76,13 +76,12 @@ fn setup(
     });
 
     // Light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/3d/two_passes.rs
+++ b/examples/3d/two_passes.rs
@@ -31,13 +31,12 @@ fn setup(
     });
 
     // Light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/3d/update_gltf_scene.rs
+++ b/examples/3d/update_gltf_scene.rs
@@ -19,7 +19,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(DirectionalLightBundle {
         transform: Transform::from_xyz(4.0, 25.0, 8.0).looking_at(Vec3::ZERO, Vec3::Y),
         directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/vertex_colors.rs
+++ b/examples/3d/vertex_colors.rs
@@ -44,9 +44,8 @@ fn setup(
     });
 
     // Light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            illuminance: light_consts::lux::OVERCAST_DAY,
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -94,11 +94,7 @@ fn setup(
 
     // light
     commands.spawn(PointLightBundle {
-        transform: Transform::from_xyz(0.0, 2.0, 0.0),
-        point_light: PointLight {
-            intensity: 2000.0,
-            ..default()
-        },
+        transform: Transform::from_xyz(2.0, 4.0, 2.0),
         ..default()
     });
 

--- a/examples/animation/animated_fox.rs
+++ b/examples/animation/animated_fox.rs
@@ -7,6 +7,10 @@ use bevy::{animation::RepeatAnimation, pbr::CascadeShadowConfigBuilder, prelude:
 
 fn main() {
     App::new()
+        .insert_resource(AmbientLight {
+            color: Color::WHITE,
+            brightness: 2000.,
+        })
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(

--- a/examples/animation/cubic_curve.rs
+++ b/examples/animation/cubic_curve.rs
@@ -47,12 +47,14 @@ fn setup(
     ));
 
     // Some light to see something
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
+            intensity: 10_000_000.,
+            range: 100.0,
             ..default()
         },
-        transform: Transform::from_xyz(8., 16., 8.).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(8., 16., 8.),
         ..default()
     });
 

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -20,7 +20,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
-            brightness: 150.0,
+            brightness: 3000.0,
             ..default()
         })
         .add_systems(Startup, setup)

--- a/examples/animation/morph_targets.rs
+++ b/examples/animation/morph_targets.rs
@@ -44,7 +44,6 @@ fn setup(asset_server: Res<AssetServer>, mut commands: Commands) {
         ..default()
     });
     commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight::default(),
         transform: Transform::from_rotation(Quat::from_rotation_z(PI / 2.0)),
         ..default()
     });

--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -80,7 +80,6 @@ fn setup(
     });
     // light
     commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight::default(),
         transform: Transform::from_xyz(4.0, 5.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });

--- a/examples/audio/spatial_audio_3d.rs
+++ b/examples/audio/spatial_audio_3d.rs
@@ -57,10 +57,6 @@ fn setup(
 
     // light
     commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            shadows_enabled: true,
-            ..default()
-        },
         transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -1,15 +1,11 @@
 //! Shows how to iterate over combinations of query results.
 
-use bevy::{pbr::AmbientLight, prelude::*};
+use bevy::prelude::*;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(AmbientLight {
-            brightness: 1.0,
-            ..default()
-        })
         .insert_resource(ClearColor(Color::BLACK))
         .add_systems(Startup, generate_bodies)
         .add_systems(FixedUpdate, (interact_bodies, integrate))
@@ -114,7 +110,6 @@ fn generate_bodies(
             p.spawn(PointLightBundle {
                 point_light: PointLight {
                     color: Color::WHITE,
-                    intensity: 500_000.0,
                     range: 100.0,
                     radius: star_radius,
                     ..default()

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -115,7 +115,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMu
     commands.spawn(PointLightBundle {
         transform: Transform::from_xyz(4.0, 10.0, 4.0),
         point_light: PointLight {
-            intensity: 500_000.0,
+            intensity: 2_000_000.0,
             shadows_enabled: true,
             range: 30.0,
             ..default()
@@ -344,7 +344,7 @@ fn spawn_bonus(
                 children.spawn(PointLightBundle {
                     point_light: PointLight {
                         color: Color::rgb(1.0, 1.0, 0.0),
-                        intensity: 100_000.0,
+                        intensity: 500_000.0,
                         range: 10.0,
                         ..default()
                     },

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -34,7 +34,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
 
     // light
     commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight::default(),
         transform: Transform::from_xyz(3.0, 2.0, 1.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..Default::default()
     });

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -333,7 +333,13 @@ fn setup(
         Rotates,
     ));
     // light
-    commands.spawn(DirectionalLightBundle::default());
+    commands.spawn(DirectionalLightBundle {
+        directional_light: DirectionalLight {
+            illuminance: 1_000.,
+            ..default()
+        },
+        ..default()
+    });
 }
 
 #[derive(Component)]

--- a/examples/shader/shader_material_screenspace_texture.rs
+++ b/examples/shader/shader_material_screenspace_texture.rs
@@ -29,9 +29,8 @@ fn setup(
         material: standard_materials.add(Color::rgb(0.3, 0.5, 0.3)),
         ..default()
     });
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight::default(),
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/shader/shader_prepass.rs
+++ b/examples/shader/shader_prepass.rs
@@ -123,12 +123,12 @@ fn setup(
     });
 
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
             shadows_enabled: true,
             ..default()
         },
-        transform: Transform::from_xyz(4.0, 8.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
 

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -48,7 +48,7 @@ fn setup(
     warn!(include_str!("warning_string.txt"));
 
     const LIGHT_RADIUS: f32 = 0.3;
-    const LIGHT_INTENSITY: f32 = 10.0;
+    const LIGHT_INTENSITY: f32 = 1000.0;
     const RADIUS: f32 = 50.0;
     const N_LIGHTS: usize = 100_000;
 

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -47,12 +47,8 @@ fn setup(
         ..default()
     });
     // light
-    commands.spawn(DirectionalLightBundle {
-        directional_light: DirectionalLight {
-            shadows_enabled: true,
-            ..default()
-        },
-        transform: Transform::from_xyz(3.0, 3.0, 3.0).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });
     // camera

--- a/examples/window/screenshot.rs
+++ b/examples/window/screenshot.rs
@@ -48,6 +48,10 @@ fn setup(
     });
     // light
     commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            shadows_enabled: true,
+            ..default()
+        },
         transform: Transform::from_xyz(4.0, 8.0, 4.0),
         ..default()
     });

--- a/tests/window/minimising.rs
+++ b/tests/window/minimising.rs
@@ -49,7 +49,6 @@ fn setup_3d(
     // light
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 1500.0,
             shadows_enabled: true,
             ..default()
         },

--- a/tests/window/resizing.rs
+++ b/tests/window/resizing.rs
@@ -132,7 +132,6 @@ fn setup_3d(
     // light
     commands.spawn(PointLightBundle {
         point_light: PointLight {
-            intensity: 1500.0,
             shadows_enabled: true,
             ..default()
         },


### PR DESCRIPTION
# Objective

After adding configurable exposure, we set the default ev100 value to `7` (indoor). This brought us out of sync with Blender's configuration and defaults. This PR changes the default to `9.7` (bright indoor or very overcast outdoors), as I calibrated in #11577. This feels like a very reasonable default.

The other changes generally center around tweaking Bevy's lighting defaults and examples to play nicely with this number, alongside a few other tweaks and improvements. 

Note that for artistic reasons I have reverted some examples, which changed to directional lights in #11581, back to point lights.
 
Fixes #11577 

---

## Changelog

- Changed `Exposure::ev100` from `7` to `9.7` to better match Blender
- Renamed `ExposureSettings` to `Exposure`
- `Camera3dBundle` now includes `Exposure` for discoverability
- Bumped `FULL_DAYLIGHT ` and `DIRECT_SUNLIGHT` to represent the middle-to-top of those ranges instead of near the bottom
- Added new `AMBIENT_DAYLIGHT` constant and set that as the new `DirectionalLight` default illuminance. 
- `PointLight` and `SpotLight` now have a default `intensity` of 1,000,000 lumens. This makes them actually useful in the context of the new "semi-outdoor" exposure and puts them in the "cinema lighting" category instead of the "common household light" category. They are also reasonably close to the Blender default.
- `AmbientLight` default has been bumped from `20` to `80`.

## Migration Guide

- The increased `Exposure::ev100` means that all existing 3D lighting will need to be adjusted to match (DirectionalLights, PointLights,  SpotLights, EnvironmentMapLights, etc). Or alternatively, you can adjust the `Exposure::ev100` on your cameras to work nicely with your current lighting values. If you are currently relying on default intensity values, you might need to change the intensity to achieve the same effect. Note that in Bevy 0.12, point/spot lights had a different hard coded ev100 value than directional lights. In Bevy 0.13, they use the same ev100, so if you have both in your scene, the _scale_ between these light types has changed and you will likely need to adjust one or both of them.