### PR TITLE
Implement and register Reflect (value) for CameraRenderGraph and CameraMainTextureUsages

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -477,7 +477,8 @@ impl Default for CameraOutputMode {
 }
 
 /// Configures the [`RenderGraph`](crate::render_graph::RenderGraph) name assigned to be run for a given [`Camera`] entity.
-#[derive(Component, Deref, DerefMut)]
+#[derive(Component, Deref, DerefMut, Reflect, Clone)]
+#[reflect_value(Component)]
 pub struct CameraRenderGraph(InternedRenderSubGraph);
 
 impl CameraRenderGraph {
@@ -752,7 +753,8 @@ pub fn camera_system<T: CameraProjection + Component>(
 }
 
 /// This component lets you control the [`TextureUsages`] field of the main texture generated for the camera
-#[derive(Component, ExtractComponent, Clone, Copy)]
+#[derive(Component, ExtractComponent, Clone, Copy, Reflect)]
+#[reflect_value(Component)]
 pub struct CameraMainTextureUsages(pub TextureUsages);
 impl Default for CameraMainTextureUsages {
     fn default() -> Self {

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -30,6 +30,8 @@ impl Plugin for CameraPlugin {
             .register_type::<RenderTarget>()
             .register_type::<ClearColor>()
             .register_type::<ClearColorConfig>()
+            .register_type::<CameraRenderGraph>()
+            .register_type::<CameraMainTextureUsages>()
             .init_resource::<ManualTextureViews>()
             .init_resource::<ClearColor>()
             .add_plugins((


### PR DESCRIPTION
# Objective

The new render graph labels do not (and cannot) implement normal Reflect, which breaks spawning scenes with cameras (including GLTF scenes). Likewise, the new `CameraMainTextureUsages` also does not (and cannot) implement normal Reflect because it uses `wgpu::TextureUsages` under the hood.

Fixes #11852

## Solution

This implements minimal "reflect value" for `CameraRenderGraph` and `CameraMainTextureUsages` and registers the types, which satisfies our spawn logic.

Note that this _does not_ fix scene serialization for these types, which will require more significant changes. We will especially need to think about how (and if) "interned labels" will fit into the scene system. For the purposes of 0.13, I think this is the best we can do. Given that this serialization issue is prevalent throughout Bevy atm, I'm ok with adding a couple more to the pile. When we roll out the new scene system, we will be forced to solve these on a case-by-case basis.

---

## Changelog

- Implement Reflect (value) for `CameraMainTextureUsages` and `CameraRenderGraph`, and register those types.
