### PR TITLE
Change MeshUniform::new() to be public.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -218,7 +218,7 @@ pub struct MeshUniform {
 }
 
 impl MeshUniform {
-    fn new(mesh_transforms: &MeshTransforms, maybe_lightmap_uv_rect: Option<Rect>) -> Self {
+    pub fn new(mesh_transforms: &MeshTransforms, maybe_lightmap_uv_rect: Option<Rect>) -> Self {
         let (inverse_transpose_model_a, inverse_transpose_model_b) =
             mesh_transforms.transform.inverse_transpose_3x3();
         Self {


### PR DESCRIPTION
# Objective

Provide a public replacement for `Into<MeshUniform>` trait impl which was removed by #10231.

I made use of this in the `bevy_mod_outline` crate and will have to duplicate this function if it's not accessible.

## Solution

Change the MeshUniform::new() method to be public.