### PR TITLE
Rename Core Render Graph Labels

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -5,8 +5,8 @@ mod upsampling_pipeline;
 pub use settings::{BloomCompositeMode, BloomPrefilterSettings, BloomSettings};
 
 use crate::{
-    core_2d::graph::{Labels2d, SubGraph2d},
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_2d::graph::{Core2d, Node2d},
+    core_3d::graph::{Core3d, Node3d},
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Handle};
@@ -72,20 +72,16 @@ impl Plugin for BloomPlugin {
                 ),
             )
             // Add bloom to the 3d render graph
-            .add_render_graph_node::<ViewNodeRunner<BloomNode>>(SubGraph3d, Labels3d::Bloom)
+            .add_render_graph_node::<ViewNodeRunner<BloomNode>>(Core3d, Node3d::Bloom)
             .add_render_graph_edges(
-                SubGraph3d,
-                (
-                    Labels3d::EndMainPass,
-                    Labels3d::Bloom,
-                    Labels3d::Tonemapping,
-                ),
+                Core3d,
+                (Node3d::EndMainPass, Node3d::Bloom, Node3d::Tonemapping),
             )
             // Add bloom to the 2d render graph
-            .add_render_graph_node::<ViewNodeRunner<BloomNode>>(SubGraph2d, Labels2d::Bloom)
+            .add_render_graph_node::<ViewNodeRunner<BloomNode>>(Core2d, Node2d::Bloom)
             .add_render_graph_edges(
-                SubGraph2d,
-                (Labels2d::MainPass, Labels2d::Bloom, Labels2d::Tonemapping),
+                Core2d,
+                (Node2d::MainPass, Node2d::Bloom, Node2d::Tonemapping),
             );
     }
 

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core_2d::graph::{Labels2d, SubGraph2d},
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_2d::graph::{Core2d, Node2d},
+    core_3d::graph::{Core3d, Node3d},
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
 };
 use bevy_app::prelude::*;
@@ -125,35 +125,35 @@ impl Plugin for CASPlugin {
 
         {
             render_app
-                .add_render_graph_node::<CASNode>(SubGraph3d, Labels3d::ContrastAdaptiveSharpening)
+                .add_render_graph_node::<CASNode>(Core3d, Node3d::ContrastAdaptiveSharpening)
                 .add_render_graph_edge(
-                    SubGraph3d,
-                    Labels3d::Tonemapping,
-                    Labels3d::ContrastAdaptiveSharpening,
+                    Core3d,
+                    Node3d::Tonemapping,
+                    Node3d::ContrastAdaptiveSharpening,
                 )
                 .add_render_graph_edges(
-                    SubGraph3d,
+                    Core3d,
                     (
-                        Labels3d::Fxaa,
-                        Labels3d::ContrastAdaptiveSharpening,
-                        Labels3d::EndMainPassPostProcessing,
+                        Node3d::Fxaa,
+                        Node3d::ContrastAdaptiveSharpening,
+                        Node3d::EndMainPassPostProcessing,
                     ),
                 );
         }
         {
             render_app
-                .add_render_graph_node::<CASNode>(SubGraph2d, Labels2d::ConstrastAdaptiveSharpening)
+                .add_render_graph_node::<CASNode>(Core2d, Node2d::ConstrastAdaptiveSharpening)
                 .add_render_graph_edge(
-                    SubGraph2d,
-                    Labels2d::Tonemapping,
-                    Labels2d::ConstrastAdaptiveSharpening,
+                    Core2d,
+                    Node2d::Tonemapping,
+                    Node2d::ConstrastAdaptiveSharpening,
                 )
                 .add_render_graph_edges(
-                    SubGraph2d,
+                    Core2d,
                     (
-                        Labels2d::Fxaa,
-                        Labels2d::ConstrastAdaptiveSharpening,
-                        Labels2d::EndMainPassPostProcessing,
+                        Node2d::Fxaa,
+                        Node2d::ConstrastAdaptiveSharpening,
+                        Node2d::EndMainPassPostProcessing,
                     ),
                 );
         }

--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -1,7 +1,5 @@
-use crate::{
-    core_3d::graph::SubGraph3d,
-    tonemapping::{DebandDither, Tonemapping},
-};
+use crate::core_2d::graph::Core2d;
+use crate::tonemapping::{DebandDither, Tonemapping};
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_render::{
@@ -14,8 +12,6 @@ use bevy_render::{
     view::VisibleEntities,
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
-
-use super::graph::SubGraph2d;
 
 #[derive(Component, Default, Reflect, Clone, ExtractComponent)]
 #[extract_component_filter(With<Camera>)]
@@ -47,7 +43,7 @@ impl Default for Camera2dBundle {
         let transform = Transform::default();
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
-            camera_render_graph: CameraRenderGraph::new(SubGraph2d),
+            camera_render_graph: CameraRenderGraph::new(Core2d),
             projection,
             visible_entities: VisibleEntities::default(),
             frustum,
@@ -79,7 +75,7 @@ impl Camera2dBundle {
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
-            camera_render_graph: CameraRenderGraph::new(SubGraph3d),
+            camera_render_graph: CameraRenderGraph::new(Core2d),
             projection,
             visible_entities: VisibleEntities::default(),
             frustum,

--- a/crates/bevy_core_pipeline/src/core_2d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/mod.rs
@@ -5,14 +5,14 @@ pub mod graph {
     use bevy_render::render_graph::{RenderLabel, RenderSubGraph};
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderSubGraph)]
-    pub struct SubGraph2d;
+    pub struct Core2d;
 
     pub mod input {
         pub const VIEW_ENTITY: &str = "view_entity";
     }
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    pub enum Labels2d {
+    pub enum Node2d {
         MsaaWriteback,
         MainPass,
         Bloom,
@@ -46,7 +46,7 @@ use bevy_utils::{nonmax::NonMaxU32, FloatOrd};
 
 use crate::{tonemapping::TonemappingNode, upscaling::UpscalingNode};
 
-use self::graph::{Labels2d, SubGraph2d};
+use self::graph::{Core2d, Node2d};
 
 pub struct Core2dPlugin;
 
@@ -68,21 +68,18 @@ impl Plugin for Core2dPlugin {
             );
 
         render_app
-            .add_render_sub_graph(SubGraph2d)
-            .add_render_graph_node::<MainPass2dNode>(SubGraph2d, Labels2d::MainPass)
-            .add_render_graph_node::<ViewNodeRunner<TonemappingNode>>(
-                SubGraph2d,
-                Labels2d::Tonemapping,
-            )
-            .add_render_graph_node::<EmptyNode>(SubGraph2d, Labels2d::EndMainPassPostProcessing)
-            .add_render_graph_node::<ViewNodeRunner<UpscalingNode>>(SubGraph2d, Labels2d::Upscaling)
+            .add_render_sub_graph(Core2d)
+            .add_render_graph_node::<MainPass2dNode>(Core2d, Node2d::MainPass)
+            .add_render_graph_node::<ViewNodeRunner<TonemappingNode>>(Core2d, Node2d::Tonemapping)
+            .add_render_graph_node::<EmptyNode>(Core2d, Node2d::EndMainPassPostProcessing)
+            .add_render_graph_node::<ViewNodeRunner<UpscalingNode>>(Core2d, Node2d::Upscaling)
             .add_render_graph_edges(
-                SubGraph2d,
+                Core2d,
                 (
-                    Labels2d::MainPass,
-                    Labels2d::Tonemapping,
-                    Labels2d::EndMainPassPostProcessing,
-                    Labels2d::Upscaling,
+                    Node2d::MainPass,
+                    Node2d::Tonemapping,
+                    Node2d::EndMainPassPostProcessing,
+                    Node2d::Upscaling,
                 ),
             );
     }

--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -1,4 +1,7 @@
-use crate::tonemapping::{DebandDither, Tonemapping};
+use crate::{
+    core_3d::graph::Core3d,
+    tonemapping::{DebandDither, Tonemapping},
+};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render::{
@@ -10,8 +13,6 @@ use bevy_render::{
 };
 use bevy_transform::prelude::{GlobalTransform, Transform};
 use serde::{Deserialize, Serialize};
-
-use super::graph::SubGraph3d;
 
 /// Configuration for the "main 3d render graph".
 #[derive(Component, Reflect, Clone, ExtractComponent)]
@@ -152,7 +153,7 @@ pub struct Camera3dBundle {
 impl Default for Camera3dBundle {
     fn default() -> Self {
         Self {
-            camera_render_graph: CameraRenderGraph::new(SubGraph3d),
+            camera_render_graph: CameraRenderGraph::new(Core3d),
             camera: Default::default(),
             projection: Default::default(),
             visible_entities: Default::default(),

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -7,14 +7,14 @@ pub mod graph {
     use bevy_render::render_graph::{RenderLabel, RenderSubGraph};
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderSubGraph)]
-    pub struct SubGraph3d;
+    pub struct Core3d;
 
     pub mod input {
         pub const VIEW_ENTITY: &str = "view_entity";
     }
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    pub enum Labels3d {
+    pub enum Node3d {
         MsaaWriteback,
         Prepass,
         DeferredPrepass,
@@ -86,7 +86,7 @@ use crate::{
     upscaling::UpscalingNode,
 };
 
-use self::graph::{Labels3d, SubGraph3d};
+use self::graph::{Core3d, Node3d};
 
 pub struct Core3dPlugin;
 
@@ -132,52 +132,49 @@ impl Plugin for Core3dPlugin {
             );
 
         render_app
-            .add_render_sub_graph(SubGraph3d)
-            .add_render_graph_node::<ViewNodeRunner<PrepassNode>>(SubGraph3d, Labels3d::Prepass)
+            .add_render_sub_graph(Core3d)
+            .add_render_graph_node::<ViewNodeRunner<PrepassNode>>(Core3d, Node3d::Prepass)
             .add_render_graph_node::<ViewNodeRunner<DeferredGBufferPrepassNode>>(
-                SubGraph3d,
-                Labels3d::DeferredPrepass,
+                Core3d,
+                Node3d::DeferredPrepass,
             )
             .add_render_graph_node::<ViewNodeRunner<CopyDeferredLightingIdNode>>(
-                SubGraph3d,
-                Labels3d::CopyDeferredLightingId,
+                Core3d,
+                Node3d::CopyDeferredLightingId,
             )
-            .add_render_graph_node::<EmptyNode>(SubGraph3d, Labels3d::EndPrepasses)
-            .add_render_graph_node::<EmptyNode>(SubGraph3d, Labels3d::StartMainPass)
+            .add_render_graph_node::<EmptyNode>(Core3d, Node3d::EndPrepasses)
+            .add_render_graph_node::<EmptyNode>(Core3d, Node3d::StartMainPass)
             .add_render_graph_node::<ViewNodeRunner<MainOpaquePass3dNode>>(
-                SubGraph3d,
-                Labels3d::MainOpaquePass,
+                Core3d,
+                Node3d::MainOpaquePass,
             )
             .add_render_graph_node::<ViewNodeRunner<MainTransmissivePass3dNode>>(
-                SubGraph3d,
-                Labels3d::MainTransmissivePass,
+                Core3d,
+                Node3d::MainTransmissivePass,
             )
             .add_render_graph_node::<ViewNodeRunner<MainTransparentPass3dNode>>(
-                SubGraph3d,
-                Labels3d::MainTransparentPass,
+                Core3d,
+                Node3d::MainTransparentPass,
             )
-            .add_render_graph_node::<EmptyNode>(SubGraph3d, Labels3d::EndMainPass)
-            .add_render_graph_node::<ViewNodeRunner<TonemappingNode>>(
-                SubGraph3d,
-                Labels3d::Tonemapping,
-            )
-            .add_render_graph_node::<EmptyNode>(SubGraph3d, Labels3d::EndMainPassPostProcessing)
-            .add_render_graph_node::<ViewNodeRunner<UpscalingNode>>(SubGraph3d, Labels3d::Upscaling)
+            .add_render_graph_node::<EmptyNode>(Core3d, Node3d::EndMainPass)
+            .add_render_graph_node::<ViewNodeRunner<TonemappingNode>>(Core3d, Node3d::Tonemapping)
+            .add_render_graph_node::<EmptyNode>(Core3d, Node3d::EndMainPassPostProcessing)
+            .add_render_graph_node::<ViewNodeRunner<UpscalingNode>>(Core3d, Node3d::Upscaling)
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 (
-                    Labels3d::Prepass,
-                    Labels3d::DeferredPrepass,
-                    Labels3d::CopyDeferredLightingId,
-                    Labels3d::EndPrepasses,
-                    Labels3d::StartMainPass,
-                    Labels3d::MainOpaquePass,
-                    Labels3d::MainTransmissivePass,
-                    Labels3d::MainTransparentPass,
-                    Labels3d::EndMainPass,
-                    Labels3d::Tonemapping,
-                    Labels3d::EndMainPassPostProcessing,
-                    Labels3d::Upscaling,
+                    Node3d::Prepass,
+                    Node3d::DeferredPrepass,
+                    Node3d::CopyDeferredLightingId,
+                    Node3d::EndPrepasses,
+                    Node3d::StartMainPass,
+                    Node3d::MainOpaquePass,
+                    Node3d::MainTransmissivePass,
+                    Node3d::MainTransparentPass,
+                    Node3d::EndMainPass,
+                    Node3d::Tonemapping,
+                    Node3d::EndMainPassPostProcessing,
+                    Node3d::Upscaling,
                 ),
             );
     }

--- a/crates/bevy_core_pipeline/src/fxaa/mod.rs
+++ b/crates/bevy_core_pipeline/src/fxaa/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
-    core_2d::graph::{Labels2d, SubGraph2d},
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_2d::graph::{Core2d, Node2d},
+    core_3d::graph::{Core3d, Node3d},
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
 };
 use bevy_app::prelude::*;
@@ -95,22 +95,22 @@ impl Plugin for FxaaPlugin {
         render_app
             .init_resource::<SpecializedRenderPipelines<FxaaPipeline>>()
             .add_systems(Render, prepare_fxaa_pipelines.in_set(RenderSet::Prepare))
-            .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(SubGraph3d, Labels3d::Fxaa)
+            .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(Core3d, Node3d::Fxaa)
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 (
-                    Labels3d::Tonemapping,
-                    Labels3d::Fxaa,
-                    Labels3d::EndMainPassPostProcessing,
+                    Node3d::Tonemapping,
+                    Node3d::Fxaa,
+                    Node3d::EndMainPassPostProcessing,
                 ),
             )
-            .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(SubGraph2d, Labels2d::Fxaa)
+            .add_render_graph_node::<ViewNodeRunner<FxaaNode>>(Core2d, Node2d::Fxaa)
             .add_render_graph_edges(
-                SubGraph2d,
+                Core2d,
                 (
-                    Labels2d::Tonemapping,
-                    Labels2d::Fxaa,
-                    Labels2d::EndMainPassPostProcessing,
+                    Node2d::Tonemapping,
+                    Node2d::Fxaa,
+                    Node2d::EndMainPassPostProcessing,
                 ),
             );
     }

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -1,7 +1,7 @@
 use crate::{
     blit::{BlitPipeline, BlitPipelineKey},
-    core_2d::graph::{Labels2d, SubGraph2d},
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_2d::graph::{Core2d, Node2d},
+    core_3d::graph::{Core3d, Node3d},
 };
 use bevy_app::{App, Plugin};
 use bevy_ecs::prelude::*;
@@ -32,17 +32,13 @@ impl Plugin for MsaaWritebackPlugin {
         );
         {
             render_app
-                .add_render_graph_node::<MsaaWritebackNode>(SubGraph2d, Labels2d::MsaaWriteback)
-                .add_render_graph_edge(SubGraph2d, Labels2d::MsaaWriteback, Labels2d::MainPass);
+                .add_render_graph_node::<MsaaWritebackNode>(Core2d, Node2d::MsaaWriteback)
+                .add_render_graph_edge(Core2d, Node2d::MsaaWriteback, Node2d::MainPass);
         }
         {
             render_app
-                .add_render_graph_node::<MsaaWritebackNode>(SubGraph3d, Labels3d::MsaaWriteback)
-                .add_render_graph_edge(
-                    SubGraph3d,
-                    Labels3d::MsaaWriteback,
-                    Labels3d::StartMainPass,
-                );
+                .add_render_graph_node::<MsaaWritebackNode>(Core3d, Node3d::MsaaWriteback)
+                .add_render_graph_edge(Core3d, Node3d::MsaaWriteback, Node3d::StartMainPass);
         }
     }
 }

--- a/crates/bevy_core_pipeline/src/taa/mod.rs
+++ b/crates/bevy_core_pipeline/src/taa/mod.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_3d::graph::{Core3d, Node3d},
     fullscreen_vertex_shader::fullscreen_shader_vertex_state,
     prelude::Camera3d,
     prepass::{DepthPrepass, MotionVectorPrepass, ViewPrepassTextures},
@@ -64,17 +64,14 @@ impl Plugin for TemporalAntiAliasPlugin {
                     prepare_taa_history_textures.in_set(RenderSet::PrepareResources),
                 ),
             )
-            .add_render_graph_node::<ViewNodeRunner<TemporalAntiAliasNode>>(
-                SubGraph3d,
-                Labels3d::Taa,
-            )
+            .add_render_graph_node::<ViewNodeRunner<TemporalAntiAliasNode>>(Core3d, Node3d::Taa)
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 (
-                    Labels3d::EndMainPass,
-                    Labels3d::Taa,
-                    Labels3d::Bloom,
-                    Labels3d::Tonemapping,
+                    Node3d::EndMainPass,
+                    Node3d::Taa,
+                    Node3d::Bloom,
+                    Node3d::Tonemapping,
                 ),
             );
     }

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -1,12 +1,12 @@
 use crate::{
-    graph::LabelsPbr, irradiance_volume::IrradianceVolume, prelude::EnvironmentMapLight,
+    graph::NodePbr, irradiance_volume::IrradianceVolume, prelude::EnvironmentMapLight,
     MeshPipeline, MeshViewBindGroup, RenderViewLightProbes, ScreenSpaceAmbientOcclusionSettings,
     ViewLightProbesUniformOffset,
 };
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_core_pipeline::{
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_3d::graph::{Core3d, Node3d},
     deferred::{
         copy_lighting_id::DeferredLightingIdDepthTexture, DEFERRED_LIGHTING_PASS_ID_DEPTH_FORMAT,
     },
@@ -116,15 +116,15 @@ impl Plugin for DeferredPbrLightingPlugin {
                 (prepare_deferred_lighting_pipelines.in_set(RenderSet::Prepare),),
             )
             .add_render_graph_node::<ViewNodeRunner<DeferredOpaquePass3dPbrLightingNode>>(
-                SubGraph3d,
-                LabelsPbr::DeferredLightingPass,
+                Core3d,
+                NodePbr::DeferredLightingPass,
             )
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 (
-                    Labels3d::StartMainPass,
-                    LabelsPbr::DeferredLightingPass,
-                    Labels3d::MainOpaquePass,
+                    Node3d::StartMainPass,
+                    NodePbr::DeferredLightingPass,
+                    Node3d::MainOpaquePass,
                 ),
             );
     }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -19,7 +19,6 @@ mod render;
 mod ssao;
 
 pub use alpha::*;
-use bevy_core_pipeline::core_3d::graph::{Labels3d, SubGraph3d};
 pub use bundle::*;
 pub use extended_material::*;
 pub use fog::*;
@@ -58,7 +57,7 @@ pub mod graph {
     use bevy_render::render_graph::RenderLabel;
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    pub enum LabelsPbr {
+    pub enum NodePbr {
         /// Label for the shadow pass node.
         ShadowPass,
         /// Label for the screen space ambient occlusion render node.
@@ -67,8 +66,10 @@ pub mod graph {
     }
 }
 
+use crate::{deferred::DeferredPbrLightingPlugin, graph::NodePbr};
 use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, AssetApp, Assets, Handle};
+use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     camera::{CameraUpdateSystem, Projection},
@@ -84,8 +85,6 @@ use bevy_render::{
     ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::TransformSystem;
-
-use crate::{deferred::DeferredPbrLightingPlugin, graph::LabelsPbr};
 
 pub const PBR_TYPES_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(1708015359337029744);
 pub const PBR_BINDINGS_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(5635987986427308186);
@@ -367,9 +366,9 @@ impl Plugin for PbrPlugin {
 
         let shadow_pass_node = ShadowPassNode::new(&mut render_app.world);
         let mut graph = render_app.world.resource_mut::<RenderGraph>();
-        let draw_3d_graph = graph.get_sub_graph_mut(SubGraph3d).unwrap();
-        draw_3d_graph.add_node(LabelsPbr::ShadowPass, shadow_pass_node);
-        draw_3d_graph.add_node_edge(LabelsPbr::ShadowPass, Labels3d::StartMainPass);
+        let draw_3d_graph = graph.get_sub_graph_mut(Core3d).unwrap();
+        draw_3d_graph.add_node(NodePbr::ShadowPass, shadow_pass_node);
+        draw_3d_graph.add_node_edge(NodePbr::ShadowPass, Node3d::StartMainPass);
 
         render_app.ignore_ambiguity(
             bevy_render::Render,

--- a/crates/bevy_pbr/src/ssao/mod.rs
+++ b/crates/bevy_pbr/src/ssao/mod.rs
@@ -1,7 +1,8 @@
+use crate::NodePbr;
 use bevy_app::{App, Plugin};
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_core_pipeline::{
-    core_3d::graph::{Labels3d, SubGraph3d},
+    core_3d::graph::{Core3d, Node3d},
     prelude::Camera3d,
     prepass::{DepthPrepass, NormalPrepass, ViewPrepassTextures},
 };
@@ -36,8 +37,6 @@ use bevy_utils::{
     tracing::{error, warn},
 };
 use std::mem;
-
-use crate::LabelsPbr;
 
 const PREPROCESS_DEPTH_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(102258915420479);
 const GTAO_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(253938746510568);
@@ -112,16 +111,16 @@ impl Plugin for ScreenSpaceAmbientOcclusionPlugin {
                 ),
             )
             .add_render_graph_node::<ViewNodeRunner<SsaoNode>>(
-                SubGraph3d,
-                LabelsPbr::ScreenSpaceAmbientOcclusion,
+                Core3d,
+                NodePbr::ScreenSpaceAmbientOcclusion,
             )
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 (
                     // END_PRE_PASSES -> SCREEN_SPACE_AMBIENT_OCCLUSION -> MAIN_PASS
-                    Labels3d::EndPrepasses,
-                    LabelsPbr::ScreenSpaceAmbientOcclusion,
-                    Labels3d::StartMainPass,
+                    Node3d::EndPrepasses,
+                    NodePbr::ScreenSpaceAmbientOcclusion,
+                    Node3d::StartMainPass,
                 ),
             );
     }

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -678,7 +678,7 @@ mod tests {
     use bevy_utils::HashSet;
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    enum TestLabels {
+    enum TestLabel {
         A,
         B,
         C,
@@ -742,53 +742,53 @@ mod tests {
     #[test]
     fn test_graph_edges() {
         let mut graph = RenderGraph::default();
-        graph.add_node(TestLabels::A, TestNode::new(0, 1));
-        graph.add_node(TestLabels::B, TestNode::new(0, 1));
-        graph.add_node(TestLabels::C, TestNode::new(1, 1));
-        graph.add_node(TestLabels::D, TestNode::new(1, 0));
+        graph.add_node(TestLabel::A, TestNode::new(0, 1));
+        graph.add_node(TestLabel::B, TestNode::new(0, 1));
+        graph.add_node(TestLabel::C, TestNode::new(1, 1));
+        graph.add_node(TestLabel::D, TestNode::new(1, 0));
 
-        graph.add_slot_edge(TestLabels::A, "out_0", TestLabels::C, "in_0");
-        graph.add_node_edge(TestLabels::B, TestLabels::C);
-        graph.add_slot_edge(TestLabels::C, 0, TestLabels::D, 0);
+        graph.add_slot_edge(TestLabel::A, "out_0", TestLabel::C, "in_0");
+        graph.add_node_edge(TestLabel::B, TestLabel::C);
+        graph.add_slot_edge(TestLabel::C, 0, TestLabel::D, 0);
 
         assert!(
-            input_nodes(TestLabels::A, &graph).is_empty(),
+            input_nodes(TestLabel::A, &graph).is_empty(),
             "A has no inputs"
         );
         assert_eq!(
-            output_nodes(TestLabels::A, &graph),
-            HashSet::from_iter((TestLabels::C,).into_array()),
+            output_nodes(TestLabel::A, &graph),
+            HashSet::from_iter((TestLabel::C,).into_array()),
             "A outputs to C"
         );
 
         assert!(
-            input_nodes(TestLabels::B, &graph).is_empty(),
+            input_nodes(TestLabel::B, &graph).is_empty(),
             "B has no inputs"
         );
         assert_eq!(
-            output_nodes(TestLabels::B, &graph),
-            HashSet::from_iter((TestLabels::C,).into_array()),
+            output_nodes(TestLabel::B, &graph),
+            HashSet::from_iter((TestLabel::C,).into_array()),
             "B outputs to C"
         );
 
         assert_eq!(
-            input_nodes(TestLabels::C, &graph),
-            HashSet::from_iter((TestLabels::A, TestLabels::B).into_array()),
+            input_nodes(TestLabel::C, &graph),
+            HashSet::from_iter((TestLabel::A, TestLabel::B).into_array()),
             "A and B input to C"
         );
         assert_eq!(
-            output_nodes(TestLabels::C, &graph),
-            HashSet::from_iter((TestLabels::D,).into_array()),
+            output_nodes(TestLabel::C, &graph),
+            HashSet::from_iter((TestLabel::D,).into_array()),
             "C outputs to D"
         );
 
         assert_eq!(
-            input_nodes(TestLabels::D, &graph),
-            HashSet::from_iter((TestLabels::C,).into_array()),
+            input_nodes(TestLabel::D, &graph),
+            HashSet::from_iter((TestLabel::C,).into_array()),
             "C inputs to D"
         );
         assert!(
-            output_nodes(TestLabels::D, &graph).is_empty(),
+            output_nodes(TestLabel::D, &graph).is_empty(),
             "D has no outputs"
         );
     }
@@ -812,12 +812,12 @@ mod tests {
 
         let mut graph = RenderGraph::default();
 
-        graph.add_node(TestLabels::A, MyNode { value: 42 });
+        graph.add_node(TestLabel::A, MyNode { value: 42 });
 
-        let node: &MyNode = graph.get_node(TestLabels::A).unwrap();
+        let node: &MyNode = graph.get_node(TestLabel::A).unwrap();
         assert_eq!(node.value, 42, "node value matches");
 
-        let result: Result<&TestNode, RenderGraphError> = graph.get_node(TestLabels::A);
+        let result: Result<&TestNode, RenderGraphError> = graph.get_node(TestLabel::A);
         assert_eq!(
             result.unwrap_err(),
             RenderGraphError::WrongNodeType,
@@ -829,17 +829,17 @@ mod tests {
     fn test_slot_already_occupied() {
         let mut graph = RenderGraph::default();
 
-        graph.add_node(TestLabels::A, TestNode::new(0, 1));
-        graph.add_node(TestLabels::B, TestNode::new(0, 1));
-        graph.add_node(TestLabels::C, TestNode::new(1, 1));
+        graph.add_node(TestLabel::A, TestNode::new(0, 1));
+        graph.add_node(TestLabel::B, TestNode::new(0, 1));
+        graph.add_node(TestLabel::C, TestNode::new(1, 1));
 
-        graph.add_slot_edge(TestLabels::A, 0, TestLabels::C, 0);
+        graph.add_slot_edge(TestLabel::A, 0, TestLabel::C, 0);
         assert_eq!(
-            graph.try_add_slot_edge(TestLabels::B, 0, TestLabels::C, 0),
+            graph.try_add_slot_edge(TestLabel::B, 0, TestLabel::C, 0),
             Err(RenderGraphError::NodeInputSlotAlreadyOccupied {
-                node: TestLabels::C.intern(),
+                node: TestLabel::C.intern(),
                 input_slot: 0,
-                occupied_by_node: TestLabels::A.intern(),
+                occupied_by_node: TestLabel::A.intern(),
             }),
             "Adding to a slot that is already occupied should return an error"
         );
@@ -849,16 +849,16 @@ mod tests {
     fn test_edge_already_exists() {
         let mut graph = RenderGraph::default();
 
-        graph.add_node(TestLabels::A, TestNode::new(0, 1));
-        graph.add_node(TestLabels::B, TestNode::new(1, 0));
+        graph.add_node(TestLabel::A, TestNode::new(0, 1));
+        graph.add_node(TestLabel::B, TestNode::new(1, 0));
 
-        graph.add_slot_edge(TestLabels::A, 0, TestLabels::B, 0);
+        graph.add_slot_edge(TestLabel::A, 0, TestLabel::B, 0);
         assert_eq!(
-            graph.try_add_slot_edge(TestLabels::A, 0, TestLabels::B, 0),
+            graph.try_add_slot_edge(TestLabel::A, 0, TestLabel::B, 0),
             Err(RenderGraphError::EdgeAlreadyExists(Edge::SlotEdge {
-                output_node: TestLabels::A.intern(),
+                output_node: TestLabel::A.intern(),
                 output_index: 0,
-                input_node: TestLabels::B.intern(),
+                input_node: TestLabel::B.intern(),
                 input_index: 0,
             })),
             "Adding to a duplicate edge should return an error"
@@ -885,30 +885,30 @@ mod tests {
         }
 
         let mut graph = RenderGraph::default();
-        graph.add_node(TestLabels::A, SimpleNode);
-        graph.add_node(TestLabels::B, SimpleNode);
-        graph.add_node(TestLabels::C, SimpleNode);
+        graph.add_node(TestLabel::A, SimpleNode);
+        graph.add_node(TestLabel::B, SimpleNode);
+        graph.add_node(TestLabel::C, SimpleNode);
 
-        graph.add_node_edges((TestLabels::A, TestLabels::B, TestLabels::C));
+        graph.add_node_edges((TestLabel::A, TestLabel::B, TestLabel::C));
 
         assert_eq!(
-            output_nodes(TestLabels::A, &graph),
-            HashSet::from_iter((TestLabels::B,).into_array()),
+            output_nodes(TestLabel::A, &graph),
+            HashSet::from_iter((TestLabel::B,).into_array()),
             "A -> B"
         );
         assert_eq!(
-            input_nodes(TestLabels::B, &graph),
-            HashSet::from_iter((TestLabels::A,).into_array()),
+            input_nodes(TestLabel::B, &graph),
+            HashSet::from_iter((TestLabel::A,).into_array()),
             "A -> B"
         );
         assert_eq!(
-            output_nodes(TestLabels::B, &graph),
-            HashSet::from_iter((TestLabels::C,).into_array()),
+            output_nodes(TestLabel::B, &graph),
+            HashSet::from_iter((TestLabel::C,).into_array()),
             "B -> C"
         );
         assert_eq!(
-            input_nodes(TestLabels::C, &graph),
-            HashSet::from_iter((TestLabels::B,).into_array()),
+            input_nodes(TestLabel::C, &graph),
+            HashSet::from_iter((TestLabel::B,).into_array()),
             "B -> C"
         );
     }

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -2,8 +2,8 @@ mod pipeline;
 mod render_pass;
 mod ui_material_pipeline;
 
-use bevy_core_pipeline::core_2d::graph::{Labels2d, SubGraph2d};
-use bevy_core_pipeline::core_3d::graph::{Labels3d, SubGraph3d};
+use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
+use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
 use bevy_render::{
@@ -15,7 +15,7 @@ pub use pipeline::*;
 pub use render_pass::*;
 pub use ui_material_pipeline::*;
 
-use crate::graph::{LabelsUi, SubGraphUi};
+use crate::graph::{NodeUi, SubGraphUi};
 use crate::{
     texture_slice::ComputedTextureSlices, BackgroundColor, BorderColor, CalculatedClip,
     ContentSize, DefaultUiCamera, Node, Outline, Style, TargetCamera, UiImage, UiScale, Val,
@@ -53,7 +53,7 @@ pub mod graph {
     pub struct SubGraphUi;
 
     #[derive(Debug, Hash, PartialEq, Eq, Clone, RenderLabel)]
-    pub enum LabelsUi {
+    pub enum NodeUi {
         UiPass,
     }
 }
@@ -106,27 +106,27 @@ pub fn build_ui_render(app: &mut App) {
     let ui_graph_3d = get_ui_graph(render_app);
     let mut graph = render_app.world.resource_mut::<RenderGraph>();
 
-    if let Some(graph_2d) = graph.get_sub_graph_mut(SubGraph2d) {
+    if let Some(graph_2d) = graph.get_sub_graph_mut(Core2d) {
         graph_2d.add_sub_graph(SubGraphUi, ui_graph_2d);
-        graph_2d.add_node(LabelsUi::UiPass, RunGraphOnViewNode::new(SubGraphUi));
-        graph_2d.add_node_edge(Labels2d::MainPass, LabelsUi::UiPass);
-        graph_2d.add_node_edge(Labels2d::EndMainPassPostProcessing, LabelsUi::UiPass);
-        graph_2d.add_node_edge(LabelsUi::UiPass, Labels2d::Upscaling);
+        graph_2d.add_node(NodeUi::UiPass, RunGraphOnViewNode::new(SubGraphUi));
+        graph_2d.add_node_edge(Node2d::MainPass, NodeUi::UiPass);
+        graph_2d.add_node_edge(Node2d::EndMainPassPostProcessing, NodeUi::UiPass);
+        graph_2d.add_node_edge(NodeUi::UiPass, Node2d::Upscaling);
     }
 
-    if let Some(graph_3d) = graph.get_sub_graph_mut(SubGraph3d) {
+    if let Some(graph_3d) = graph.get_sub_graph_mut(Core3d) {
         graph_3d.add_sub_graph(SubGraphUi, ui_graph_3d);
-        graph_3d.add_node(LabelsUi::UiPass, RunGraphOnViewNode::new(SubGraphUi));
-        graph_3d.add_node_edge(Labels3d::EndMainPass, LabelsUi::UiPass);
-        graph_3d.add_node_edge(Labels3d::EndMainPassPostProcessing, LabelsUi::UiPass);
-        graph_3d.add_node_edge(LabelsUi::UiPass, Labels3d::Upscaling);
+        graph_3d.add_node(NodeUi::UiPass, RunGraphOnViewNode::new(SubGraphUi));
+        graph_3d.add_node_edge(Node3d::EndMainPass, NodeUi::UiPass);
+        graph_3d.add_node_edge(Node3d::EndMainPassPostProcessing, NodeUi::UiPass);
+        graph_3d.add_node_edge(NodeUi::UiPass, Node3d::Upscaling);
     }
 }
 
 fn get_ui_graph(render_app: &mut App) -> RenderGraph {
     let ui_pass_node = UiPassNode::new(&mut render_app.world);
     let mut ui_graph = RenderGraph::default();
-    ui_graph.add_node(LabelsUi::UiPass, ui_pass_node);
+    ui_graph.add_node(NodeUi::UiPass, ui_pass_node);
     ui_graph
 }
 

--- a/examples/shader/post_processing.rs
+++ b/examples/shader/post_processing.rs
@@ -7,7 +7,7 @@
 
 use bevy::{
     core_pipeline::{
-        core_3d::graph::{Labels3d, SubGraph3d},
+        core_3d::graph::{Core3d, Node3d},
         fullscreen_vertex_shader::fullscreen_shader_vertex_state,
     },
     ecs::query::QueryItem,
@@ -78,18 +78,18 @@ impl Plugin for PostProcessPlugin {
             // matching the [`ViewQuery`]
             .add_render_graph_node::<ViewNodeRunner<PostProcessNode>>(
                 // Specify the label of the graph, in this case we want the graph for 3d
-                SubGraph3d,
+                Core3d,
                 // It also needs the label of the node
                 PostProcessLabel,
             )
             .add_render_graph_edges(
-                SubGraph3d,
+                Core3d,
                 // Specify the node ordering.
                 // This will automatically create all required node edges to enforce the given ordering.
                 (
-                    Labels3d::Tonemapping,
+                    Node3d::Tonemapping,
                     PostProcessLabel,
-                    Labels3d::EndMainPassPostProcessing,
+                    Node3d::EndMainPassPostProcessing,
                 ),
             );
     }


### PR DESCRIPTION
# Objective

#10644 introduced nice "statically typed" labels that replace the old strings. I would like to propose some changes to the names introduced:

* `SubGraph2d` -> `Core2d` and `SubGraph3d` -> `Core3d`. The names of these graphs have been / should continue to be the "core 2d" graph not the "sub graph 2d" graph. The crate is called `bevy_core_pipeline`, the modules are still `core_2d` and `core_3d`, etc.
* `Labels2d` and `Labels3d`, at the very least, should not be plural to follow naming conventions. A Label enum is not a "collection of labels", it is a _specific_ Label. However I think `Label2d` and `Label3d` is significantly less clear than `Node2d` and `Node3d`, so I propose those changes here. I've done the same for `LabelsPbr` -> `NodePbr` and `LabelsUi` -> `NodeUi`

Additionally, #10644 accidentally made one of the Camera2dBundle constructors use the 3D graph instead of the 2D graph. I've fixed that here.
 
---

## Changelog

* Renamed `SubGraph2d` -> `Core2d`, `SubGraph3d` -> `Core3d`, `Labels2d` -> `Node2d`, `Labels3d` -> `Node3d`, `LabelsUi` -> `NodeUi`, `LabelsPbr` -> `NodePbr`
