### PR TITLE
Support optional clear color in ColorAttachment.

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -836,16 +836,18 @@ pub fn prepare_prepass_textures(
         });
 
         commands.entity(entity).insert(ViewPrepassTextures {
-            depth: cached_depth_texture.map(|t| ColorAttachment::new(t, None, Color::BLACK)),
-            normal: cached_normals_texture.map(|t| ColorAttachment::new(t, None, Color::BLACK)),
+            depth: cached_depth_texture.map(|t| ColorAttachment::new(t, None, Some(Color::BLACK))),
+            normal: cached_normals_texture
+                .map(|t| ColorAttachment::new(t, None, Some(Color::BLACK))),
             // Red and Green channels are X and Y components of the motion vectors
             // Blue channel doesn't matter, but set to 0.0 for possible faster clear
             // https://gpuopen.com/performance/#clears
             motion_vectors: cached_motion_vectors_texture
-                .map(|t| ColorAttachment::new(t, None, Color::BLACK)),
-            deferred: cached_deferred_texture.map(|t| ColorAttachment::new(t, None, Color::BLACK)),
+                .map(|t| ColorAttachment::new(t, None, Some(Color::BLACK))),
+            deferred: cached_deferred_texture
+                .map(|t| ColorAttachment::new(t, None, Some(Color::BLACK))),
             deferred_lighting_pass_id: cached_deferred_lighting_pass_id_texture
-                .map(|t| ColorAttachment::new(t, None, Color::BLACK)),
+                .map(|t| ColorAttachment::new(t, None, Some(Color::BLACK))),
             size,
         });
     }

--- a/crates/bevy_render/src/texture/texture_attachment.rs
+++ b/crates/bevy_render/src/texture/texture_attachment.rs
@@ -13,7 +13,7 @@ use wgpu::{
 pub struct ColorAttachment {
     pub texture: CachedTexture,
     pub resolve_target: Option<CachedTexture>,
-    clear_color: Color,
+    clear_color: Option<Color>,
     is_first_call: Arc<AtomicBool>,
 }
 
@@ -21,7 +21,7 @@ impl ColorAttachment {
     pub fn new(
         texture: CachedTexture,
         resolve_target: Option<CachedTexture>,
-        clear_color: Color,
+        clear_color: Option<Color>,
     ) -> Self {
         Self {
             texture,
@@ -43,10 +43,9 @@ impl ColorAttachment {
                 view: &resolve_target.default_view,
                 resolve_target: Some(&self.texture.default_view),
                 ops: Operations {
-                    load: if first_call {
-                        LoadOp::Clear(self.clear_color.into())
-                    } else {
-                        LoadOp::Load
+                    load: match (self.clear_color, first_call) {
+                        (Some(clear_color), true) => LoadOp::Clear(clear_color.into()),
+                        (None, _) | (Some(_), false) => LoadOp::Load,
                     },
                     store: StoreOp::Store,
                 },
@@ -67,10 +66,9 @@ impl ColorAttachment {
             view: &self.texture.default_view,
             resolve_target: None,
             ops: Operations {
-                load: if first_call {
-                    LoadOp::Clear(self.clear_color.into())
-                } else {
-                    LoadOp::Load
+                load: match (self.clear_color, first_call) {
+                    (Some(clear_color), true) => LoadOp::Clear(clear_color.into()),
+                    (None, _) | (Some(_), false) => LoadOp::Load,
                 },
                 store: StoreOp::Store,
             },

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -493,8 +493,9 @@ pub fn prepare_view_targets(
                 };
 
                 let clear_color = match camera.clear_color {
-                    ClearColorConfig::Custom(color) => color,
-                    _ => clear_color_global.0,
+                    ClearColorConfig::Custom(color) => Some(color),
+                    ClearColorConfig::None => None,
+                    _ => Some(clear_color_global.0),
                 };
 
                 let (a, b, sampled) = textures


### PR DESCRIPTION
This represents when the user has configured `ClearColorConfig::None` in their application. If the clear color is `None`, we will always `Load` instead of attempting to clear the attachment on the first call.

Fixes #11883.