### PR TITLE
WebGPU: fix web-sys version

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -100,6 +100,8 @@ async-channel = "2.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
+# web-sys doesn't follow semver for the WebGPU APIs as they are unstable
+# Make sure that WebGPU builds work when changing this!
 web-sys = { version = "=0.3.67", features = [
   'Blob',
   'Document',

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -100,7 +100,7 @@ async-channel = "2.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = "0.3"
-web-sys = { version = "0.3", features = [
+web-sys = { version = "=0.3.67", features = [
   'Blob',
   'Document',
   'Element',


### PR DESCRIPTION
# Objective

- Being able to build for WebGPU

```
error[E0061]: this function takes 1 argument but 3 arguments were supplied
   --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:375:22
    |
375 |     let mut mapped = web_sys::GpuDepthStencilState::new(
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
376 |         map_compare_function(desc.depth_compare),
    |         ---------------------------------------- unexpected argument of type `GpuCompareFunction`
377 |         desc.depth_write_enabled,
    |         ------------------------ unexpected argument of type `bool`
    |
note: associated function defined here
   --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuDepthStencilState.rs:27:12
    |
27  |     pub fn new(format: GpuTextureFormat) -> Self {
    |            ^^^
help: remove the extra arguments
    |
376 -         map_compare_function(desc.depth_compare),
376 +         map_texture_format(desc.format),
    |

error[E0061]: this function takes 1 argument but 2 arguments were supplied
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1693:13
     |
1693 |             web_sys::GpuVertexState::new(desc.vertex.entry_point, &module.0);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ -------------------------
     |                                          |
     |                                          unexpected argument of type `&str`
     |                                          help: remove the extra argument
     |
note: associated function defined here
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuVertexState.rs:27:12
     |
27   |     pub fn new(module: &GpuShaderModule) -> Self {
     |            ^^^

error[E0061]: this function takes 2 arguments but 3 arguments were supplied
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1768:17
     |
1768 |                 web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
     |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ----------------             -------- unexpected argument of type `&js_sys::Array`
     |                                                |
     |                                                expected `&GpuShaderModule`, found `&str`
     |
     = note: expected reference `&GpuShaderModule`
                found reference `&str`
note: associated function defined here
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuFragmentState.rs:27:12
     |
27   |     pub fn new(module: &GpuShaderModule, targets: &::wasm_bindgen::JsValue) -> Self {
     |            ^^^
help: remove the extra argument
     |
1768 -                 web_sys::GpuFragmentState::new(frag.entry_point, &module.0, &targets);
1768 +                 web_sys::GpuFragmentState::new(/* &GpuShaderModule */, &module.0);
     |

error[E0061]: this function takes 1 argument but 2 arguments were supplied
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:1793:13
     |
1793 |             web_sys::GpuProgrammableStage::new(desc.entry_point, &shader_module.0);
     |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ------------------
     |                                                |
     |                                                unexpected argument of type `&str`
     |                                                help: remove the extra argument
     |
note: associated function defined here
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/web-sys-0.3.68/src/features/gen_GpuProgrammableStage.rs:27:12
     |
27   |     pub fn new(module: &GpuShaderModule) -> Self {
     |            ^^^

error[E0599]: no method named `write_timestamp` found for struct `GpuCommandEncoder` in the current scope
    --> .cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/webgpu.rs:2505:14
     |
2503 | /         encoder_data
2504 | |             .0
2505 | |             .write_timestamp(&query_set_data.0, query_index);
     | |             -^^^^^^^^^^^^^^^ method not found in `GpuCommandEncoder`
     | |_____________|
     |

Some errors have detailed explanations: E0061, E0599.
For more information about an error, try `rustc --explain E0061`.
```

## Solution

- `web-sys` doesn't follow semver for the WebGPU APIs as they are unstable. Force using a compatible version
