### PR TITLE
Alpha discard

### DIFF
--- a/assets/shaders/custom_clustered_decal.wgsl
+++ b/assets/shaders/custom_clustered_decal.wgsl
@@ -19,7 +19,11 @@ fn fragment(
     var pbr_input = pbr_input_from_standard_material(in, is_front);
 
     // Alpha discard.
-    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+    pbr_input.material.base_color = alpha_discard(
+        pbr_input.material.flags,
+        pbr_input.material.alpha_cutoff,
+        pbr_input.material.base_color,
+    );
 
     // Apply the normal decals.
     clustered::apply_decals(&pbr_input);

--- a/assets/shaders/extended_material.wgsl
+++ b/assets/shaders/extended_material.wgsl
@@ -40,7 +40,11 @@ fn fragment(
     pbr_input.material.base_color.b = pbr_input.material.base_color.r;
 
     // alpha discard
-    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+    pbr_input.material.base_color = alpha_discard(
+        pbr_input.material.flags,
+        pbr_input.material.alpha_cutoff,
+        pbr_input.material.base_color
+    );
 
 #ifdef PREPASS_PIPELINE
     // in deferred mode we can't modify anything after that, as lighting is run in a separate fullscreen shader.

--- a/crates/bevy_pbr/src/render/pbr.wgsl
+++ b/crates/bevy_pbr/src/render/pbr.wgsl
@@ -66,7 +66,11 @@ fn fragment(
     var pbr_input = pbr_input_from_standard_material(in, is_front);
 
     // alpha discard
-    pbr_input.material.base_color = alpha_discard(pbr_input.material, pbr_input.material.base_color);
+    pbr_input.material.base_color = alpha_discard(
+        pbr_input.material.flags,
+        pbr_input.material.alpha_cutoff,
+        pbr_input.material.base_color
+    );
 
     // clustered decals
     apply_decals(&pbr_input);

--- a/crates/bevy_pbr/src/render/pbr_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_functions.wgsl
@@ -104,9 +104,9 @@ fn visibility_range_dither(frag_coord: vec4<f32>, dither: i32) {
 }
 #endif
 
-fn alpha_discard(material: pbr_types::StandardMaterial, output_color: vec4<f32>) -> vec4<f32> {
+fn alpha_discard(material_flags: u32, alpha_cutoff: f32, output_color: vec4<f32>) -> vec4<f32> {
     var color = output_color;
-    let alpha_mode = material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
+    let alpha_mode = material_flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
     if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_OPAQUE {
         // NOTE: If rendering as opaque, alpha should be ignored so set to 1.0
         color.a = 1.0;
@@ -118,7 +118,7 @@ fn alpha_discard(material: pbr_types::StandardMaterial, output_color: vec4<f32>)
     // alpha mask.
     else if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK ||
             alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ALPHA_TO_COVERAGE {
-        if color.a >= material.alpha_cutoff {
+        if color.a >= alpha_cutoff {
             // NOTE: If rendering as masked alpha and >= the cutoff, render as fully opaque
             color.a = 1.0;
         } else {

--- a/crates/bevy_pbr/src/render/pbr_prepass.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass.wgsl
@@ -50,7 +50,7 @@ fn fragment(
     pbr_functions::visibility_range_dither(in.position, in.visibility_range_dither);
 #endif  // VISIBILITY_RANGE_DITHER
 
-    pbr_prepass_functions::prepass_alpha_discard(in);
+    pbr_prepass_functions::prepass_sample_color_and_alpha_discard(in);
 #endif  // MESHLET_MESH_MATERIAL_PASS
 
     var out: prepass_io::FragmentOutput;
@@ -146,6 +146,6 @@ fn fragment(
 #else
 @fragment
 fn fragment(in: prepass_io::VertexOutput) {
-    pbr_prepass_functions::prepass_alpha_discard(in);
+    pbr_prepass_functions::prepass_sample_color_and_alpha_discard(in);
 }
 #endif // PREPASS_FRAGMENT

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -18,17 +18,41 @@
 // Cutoff used for the premultiplied alpha modes BLEND, ADD, and ALPHA_TO_COVERAGE.
 const PREMULTIPLIED_ALPHA_CUTOFF = 0.05;
 
+// Reusable alpha discard logic suitable for use by custom materials in the prepass.
 // We can use a simplified version of alpha_discard() here since we only need to handle the alpha_cutoff
-fn prepass_alpha_discard(in: VertexOutput) {
+fn prepass_alpha_discard(material_flags: u32, alpha_cutoff: f32, output_color: vec4<f32>) {
+    let alpha_mode = material_flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
+    if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {
+        if output_color.a < alpha_cutoff {
+            discard;
+        }
+    } else if (alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND ||
+            alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ADD ||
+            alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ALPHA_TO_COVERAGE) {
+        if output_color.a < PREMULTIPLIED_ALPHA_CUTOFF {
+            discard;
+        }
+    } else if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_PREMULTIPLIED {
+        if all(output_color < vec4(PREMULTIPLIED_ALPHA_CUTOFF)) {
+            discard;
+        }
+    }
+}
+
+// Samples the StandardMaterial's base color (including the base color texture, if any) and then
+// invokes `prepass_alpha_discard` with the material's flags and alpha cutoff.
+fn prepass_sample_color_and_alpha_discard(in: VertexOutput) {
 
 #ifdef MAY_DISCARD
 #ifdef BINDLESS
     let slot = mesh[in.instance_index].material_and_lightmap_bind_group_slot & 0xffffu;
     var output_color: vec4<f32> = pbr_bindings::material_array[material_indices[slot].material].base_color;
     let flags = pbr_bindings::material_array[material_indices[slot].material].flags;
+    let alpha_cutoff = pbr_bindings::material_array[material_indices[slot].material].alpha_cutoff;
 #else   // BINDLESS
     var output_color: vec4<f32> = pbr_bindings::material.base_color;
     let flags = pbr_bindings::material.flags;
+    let alpha_cutoff = pbr_bindings::material.alpha_cutoff;
 #endif  // BINDLESS
 
 #ifdef VERTEX_UVS
@@ -60,28 +84,7 @@ fn prepass_alpha_discard(in: VertexOutput) {
     }
 #endif // VERTEX_UVS
 
-    let alpha_mode = flags & pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_RESERVED_BITS;
-    if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_MASK {
-#ifdef BINDLESS
-        let alpha_cutoff = pbr_bindings::material_array[material_indices[slot].material].alpha_cutoff;
-#else   // BINDLESS
-        let alpha_cutoff = pbr_bindings::material.alpha_cutoff;
-#endif  // BINDLESS
-        if output_color.a < alpha_cutoff {
-            discard;
-        }
-    } else if (alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_BLEND ||
-            alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ADD ||
-            alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_ALPHA_TO_COVERAGE) {
-        if output_color.a < PREMULTIPLIED_ALPHA_CUTOFF {
-            discard;
-        }
-    } else if alpha_mode == pbr_types::STANDARD_MATERIAL_FLAGS_ALPHA_MODE_PREMULTIPLIED {
-        if all(output_color < vec4(PREMULTIPLIED_ALPHA_CUTOFF)) {
-            discard;
-        }
-    }
-
+    prepass_alpha_discard(flags, alpha_cutoff, output_color);
 #endif // MAY_DISCARD
 }
 


### PR DESCRIPTION
# Objective

I want to call the `pbr_functions::alpha_discard` shader function from my own material shader, but it only takes a `StandardMaterial` parameter.

## Solution

This PR replaces the `StandardMaterial` parameter with less restrictive ones so my shader can call it.

---

## Changelog

- The signature of `pbr_functions::alpha_discard` changed by replacing `StandardMaterial` with only the `flags` and `alpha_cutoff` fields.

## Migration Guide

Replace this:

```wgsl
pbr_functions::alpha_discard(material, ...);
```

with this:

```wgsl
pbr_functions::alpha_discard(material.flags, material.alpha_cutoff, ...);
```
