### PR TITLE
Add a `[lints]` entry for workspace members missing it

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,6 +6,9 @@ description = "Benchmarks for Bevy engine"
 publish = false
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dev-dependencies]
 glam = "0.25"
 rand = "0.8"

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,9 +6,6 @@ description = "Benchmarks for Bevy engine"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
-
 [dev-dependencies]
 glam = "0.25"
 rand = "0.8"

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["bevy"]
 [lib]
 proc-macro = true
 
+[lints]
+workspace = true
+
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
 

--- a/crates/bevy_gizmos/macros/src/lib.rs
+++ b/crates/bevy_gizmos/macros/src/lib.rs
@@ -1,8 +1,11 @@
+//! Derive implementations for `bevy_gizmos`.
+
 use bevy_macro_utils::BevyManifest;
 use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, parse_quote, DeriveInput, Path};
 
+/// Implements the [`GizmoConfigGroup`] trait for a gizmo config group type.
 #[proc_macro_derive(GizmoConfigGroup)]
 pub fn derive_gizmo_config_group(input: TokenStream) -> TokenStream {
     let mut ast = parse_macro_input!(input as DeriveInput);

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -6,5 +6,8 @@ description = "Bevy's error codes"
 publish = false
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 bevy = { path = ".." }

--- a/errors/src/lib.rs
+++ b/errors/src/lib.rs
@@ -1,3 +1,7 @@
+//! Definitions of Bevy's error codes that might occur at runtime.
+//!
+//! These either manifest as a warning or a panic.
+
 #[doc = include_str!("../B0001.md")]
 pub struct B0001;
 

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -6,6 +6,9 @@ description = "handle templated pages in Bevy repository"
 publish = false
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 toml_edit = { version = "0.21", default-features = false, features = ["parse"] }
 tera = "1.15"

--- a/tools/build-templated-pages/src/main.rs
+++ b/tools/build-templated-pages/src/main.rs
@@ -1,3 +1,5 @@
+//! Tool used to build the templated pages of the Bevy website.
+
 use bitflags::bitflags;
 
 mod examples;

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -5,7 +5,9 @@ edition = "2021"
 description = "Build an example for wasm"
 publish = false
 license = "MIT OR Apache-2.0"
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[lints]
+workspace = true
 
 [dependencies]
 xshell = "0.2"

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -1,3 +1,5 @@
+//! Tool used to build Bevy examples for wasm.
+
 use std::{fs::File, io::Write};
 
 use clap::{Parser, ValueEnum};

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -6,6 +6,9 @@ description = "CI script for Bevy"
 publish = false
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 xshell = "0.2"
 bitflags = "2.3"

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,3 +1,5 @@
+//! CI script used for Bevy.
+
 use xshell::{cmd, Shell};
 
 use bitflags::bitflags;

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -6,6 +6,9 @@ description = "Run examples"
 publish = false
 license = "MIT OR Apache-2.0"
 
+[lints]
+workspace = true
+
 [dependencies]
 xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -1,3 +1,5 @@
+//! Tool to run all examples or generate a showcase page for the Bevy website.
+
 use std::{
     collections::{hash_map::DefaultHasher, HashMap},
     fmt::Display,


### PR DESCRIPTION
# Objective

- Some workspace members do not inherit the global lints.

## Solution

- Add a `[lints]` entry for all files returned by `rg  --files-without-match -F "[lints]" **/Cargo.toml`, except the compile failure tests since these aren't part of the workspace.
- Add some docstrings where needed.
