### PR TITLE
Derive Reflect for Exposure

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -89,7 +89,8 @@ pub struct ComputedCameraValues {
 /// How much energy a `Camera3d` absorbs from incoming light.
 ///
 /// <https://en.wikipedia.org/wiki/Exposure_(photography)>
-#[derive(Component)]
+#[derive(Component, Clone, Copy, Reflect)]
+#[reflect_value(Component)]
 pub struct Exposure {
     /// <https://en.wikipedia.org/wiki/Exposure_value#Tabulated_exposure_values>
     pub ev100: f32,

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -32,6 +32,7 @@ impl Plugin for CameraPlugin {
             .register_type::<ClearColorConfig>()
             .register_type::<CameraRenderGraph>()
             .register_type::<CameraMainTextureUsages>()
+            .register_type::<Exposure>()
             .init_resource::<ManualTextureViews>()
             .init_resource::<ClearColor>()
             .add_plugins((


### PR DESCRIPTION
# Objective

- Don't crash when loading a scene with a camera

## Solution

- Derive Reflect for Exposure

Closes https://github.com/bevyengine/bevy/issues/11905