### PR TITLE
Disable irradiance volumes on WebGL and WebGPU.

### DIFF
--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -157,6 +157,11 @@ use super::LightProbeComponent;
 pub const IRRADIANCE_VOLUME_SHADER_HANDLE: Handle<Shader> =
     Handle::weak_from_u128(160299515939076705258408299184317675488);
 
+/// On WebGL and WebGPU, we must disable irradiance volumes, as otherwise we can
+/// overflow the number of texture bindings when deferred rendering is in use
+/// (see issue #11885).
+pub(crate) const IRRADIANCE_VOLUMES_ARE_USABLE: bool = cfg!(not(target_arch = "wasm32"));
+
 /// The component that defines an irradiance volume.
 ///
 /// See [`crate::irradiance_volume`] for detailed information.

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.wgsl
@@ -8,6 +8,8 @@
     light_probes,
 };
 
+#ifdef IRRADIANCE_VOLUMES_ARE_USABLE
+
 // See:
 // https://advances.realtimerendering.com/s2006/Mitchell-ShadingInValvesSourceEngine.pdf
 // Slide 28, "Ambient Cube Basis"
@@ -50,3 +52,5 @@ fn irradiance_volume_light(world_position: vec3<f32>, N: vec3<f32>) -> vec3<f32>
     let NN = N * N;
     return (rgb_x * NN.x + rgb_y * NN.y + rgb_z * NN.z) * query_result.intensity;
 }
+
+#endif  // IRRADIANCE_VOLUMES_ARE_USABLE

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -50,6 +50,8 @@ use crate::render::{
 };
 use crate::*;
 
+use self::irradiance_volume::IRRADIANCE_VOLUMES_ARE_USABLE;
+
 use super::skin::SkinIndices;
 
 #[derive(Default)]
@@ -825,7 +827,7 @@ impl SpecializedMeshPipeline for MeshPipeline {
             shader_defs.push("ENVIRONMENT_MAP".into());
         }
 
-        if key.contains(MeshPipelineKey::IRRADIANCE_VOLUME) {
+        if key.contains(MeshPipelineKey::IRRADIANCE_VOLUME) && IRRADIANCE_VOLUMES_ARE_USABLE {
             shader_defs.push("IRRADIANCE_VOLUME".into());
         }
 
@@ -863,6 +865,10 @@ impl SpecializedMeshPipeline for MeshPipeline {
 
         if self.binding_arrays_are_usable {
             shader_defs.push("MULTIPLE_LIGHT_PROBES_IN_ARRAY".into());
+        }
+
+        if IRRADIANCE_VOLUMES_ARE_USABLE {
+            shader_defs.push("IRRADIANCE_VOLUMES_ARE_USABLE".into());
         }
 
         let format = if key.contains(MeshPipelineKey::HDR) {

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -46,12 +46,14 @@
 #endif
 @group(0) @binding(15) var environment_map_sampler: sampler;
 
+#ifdef IRRADIANCE_VOLUMES_ARE_USABLE
 #ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
 @group(0) @binding(16) var irradiance_volumes: binding_array<texture_3d<f32>, 8u>;
 #else
 @group(0) @binding(16) var irradiance_volume: texture_3d<f32>;
 #endif
 @group(0) @binding(17) var irradiance_volume_sampler: sampler;
+#endif
 
 // NB: If you change these, make sure to update `tonemapping_shared.wgsl` too.
 @group(0) @binding(18) var dt_lut_texture: texture_3d<f32>;


### PR DESCRIPTION
They cause the number of texture bindings to overflow on those platforms. Ultimately, we shouldn't unconditionally disable them, but this fixes a crash blocking 0.13.

Closes #11885.