### PR TITLE
Remove `naga_oil` dependency from `bevy_pbr`

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -58,10 +58,7 @@ symphonia-vorbis = ["bevy_audio/symphonia-vorbis"]
 symphonia-wav = ["bevy_audio/symphonia-wav"]
 
 # Shader formats
-shader_format_glsl = [
-  "bevy_render/shader_format_glsl",
-  "bevy_pbr?/shader_format_glsl",
-]
+shader_format_glsl = ["bevy_render/shader_format_glsl"]
 shader_format_spirv = ["bevy_render/shader_format_spirv"]
 
 serialize = [

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["bevy"]
 [features]
 webgl = []
 webgpu = []
-shader_format_glsl = ["naga_oil/glsl"]
 pbr_transmission_textures = []
 
 [dependencies]
@@ -38,15 +37,6 @@ bytemuck = { version = "1", features = ["derive"] }
 radsort = "0.1"
 smallvec = "1.6"
 thread_local = "1.0"
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-naga_oil = "0.13"
-
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# Omit the `glsl` feature in non-WebAssembly by default.
-naga_oil = { version = "0.13", default-features = false, features = [
-  "test_shader",
-] }
 
 [lints]
 workspace = true

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -73,9 +73,6 @@ wgpu = { version = "0.19.1", default-features = false, features = [
   "fragile-send-sync-non-atomic-wasm",
 ] }
 naga = { version = "0.19", features = ["wgsl-in"] }
-naga_oil = { version = "0.13", default-features = false, features = [
-  "test_shader",
-] }
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"
 bytemuck = { version = "1.5", features = ["derive"] }
@@ -98,7 +95,15 @@ profiling = { version = "1", features = [
 ], optional = true }
 async-channel = "2.1.0"
 
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Omit the `glsl` feature in non-WebAssembly by default.
+naga_oil = { version = "0.13", default-features = false, features = [
+  "test_shader",
+] }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+naga_oil = "0.13"
 js-sys = "0.3"
 # web-sys doesn't follow semver for the WebGPU APIs as they are unstable
 # Make sure that WebGPU builds work when changing this!


### PR DESCRIPTION
# Objective

Fixes #11908

## Solution

- Remove the `naga_oil` dependency from `bevy_pbr`.
- We were doing a little dance to disable `glsl` support on not-wasm, so incorporate that dance into `bevy_render`'s `Cargo.toml`.