### PR TITLE
Fix duplicate `encase_derive_impl` dependency

### DIFF
--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.12.0" }
-encase_derive_impl = "0.6.1"
+encase_derive_impl = "0.7"
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

Another PR failed CI due to duplicate deps, and I noticed this one in particular while scanning through the error messages.

I think this was missed in #11082.

## Solution

Bump `encase_derive_impl` dep in `bevy_encase_derive` to same version as `encase` dep for `bevy_render`.

I spot-checked a few examples, and glanced at the [changelog](<https://github.com/teoxoy/encase/blob/main/CHANGELOG.md#v070-2024-01-02>) and I don't think there's anything to be concerned about, but I barely know what this thing does.
