### PR TITLE
Release 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 categories = ["game-engines", "graphics", "gui", "rendering"]
 description = "A refreshingly simple data-driven game engine and app framework"
@@ -305,8 +305,8 @@ embedded_watcher = ["bevy_internal/embedded_watcher"]
 bevy_debug_stepping = ["bevy_internal/bevy_debug_stepping"]
 
 [dependencies]
-bevy_dylib = { path = "crates/bevy_dylib", version = "0.12.0", default-features = false, optional = true }
-bevy_internal = { path = "crates/bevy_internal", version = "0.12.0", default-features = false }
+bevy_dylib = { path = "crates/bevy_dylib", version = "0.13.0", default-features = false, optional = true }
+bevy_internal = { path = "crates/bevy_internal", version = "0.13.0", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_a11y"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides accessibility support for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,9 +10,9 @@ keywords = ["bevy", "accessibility", "a11y"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
 
 accesskit = "0.12"
 

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_animation"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides animation functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,19 +10,19 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_time = { path = "../bevy_time", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_time = { path = "../bevy_time", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
 
 [lints]
 workspace = true

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_app"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides core App functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -17,11 +17,11 @@ bevy_reflect = ["dep:bevy_reflect", "bevy_ecs/bevy_reflect"]
 
 [dependencies]
 # bevy
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", default-features = false }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", optional = true }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0", default-features = false }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", optional = true }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_asset"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides asset functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -18,13 +18,13 @@ asset_processor = []
 watch = []
 
 [dependencies]
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset_macros = { path = "macros", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset_macros = { path = "macros", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 async-broadcast = "0.5"
 async-fs = "2.0"
@@ -40,7 +40,7 @@ serde = { version = "1", features = ["derive"] }
 thiserror = "1.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-bevy_winit = { path = "../bevy_winit", version = "0.12.0" }
+bevy_winit = { path = "../bevy_winit", version = "0.13.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wasm-bindgen = { version = "0.2" }
@@ -52,7 +52,7 @@ js-sys = "0.3"
 notify-debouncer-full = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/macros/Cargo.toml
+++ b/crates/bevy_asset/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_asset_macros"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Derive implementations for bevy_asset"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.13.0" }
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_audio"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides audio functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,16 +10,16 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 rodio = { version = "0.17", default-features = false }

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_core"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides core functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -11,18 +11,18 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0", features = [
   "bevy_reflect",
 ] }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", features = [
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0", features = [
   "bevy_reflect",
 ] }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 bytemuck = "1.5"

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_core_pipeline"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = [
   "Bevy Contributors <bevyengine@gmail.com>",
@@ -21,17 +21,17 @@ tonemapping_luts = ["bevy_render/ktx2", "bevy_render/zstd"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0" }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 serde = { version = "1", features = ["derive"] }
 bitflags = "2.3"

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_derive"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides derive implementations for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.13.0" }
 
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_diagnostic"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides diagnostic functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,12 +14,12 @@ dynamic_linking = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_time = { path = "../bevy_time", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_time = { path = "../bevy_time", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 const-fnv1a-hash = "1.1.0"
 

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_dylib"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Force the Bevy Engine to be dynamically linked for faster linking"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 crate-type = ["dylib"]
 
 [dependencies]
-bevy_internal = { path = "../bevy_internal", version = "0.12.0", default-features = false }
+bevy_internal = { path = "../bevy_internal", version = "0.13.0", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_dynamic_plugin"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides dynamic plugin loading capabilities for non-wasm platforms"
 homepage = "https://bevyengine.org"
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
 
 # other
 libloading = { version = "0.8" }

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Bevy Engine's entity component system"
 homepage = "https://bevyengine.org"
@@ -16,11 +16,11 @@ bevy_debug_stepping = []
 default = ["bevy_reflect", "bevy_debug_stepping"]
 
 [dependencies]
-bevy_ptr = { path = "../bevy_ptr", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", optional = true }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_ecs_macros = { path = "macros", version = "0.12.0" }
+bevy_ptr = { path = "../bevy_ptr", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", optional = true }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_ecs_macros = { path = "macros", version = "0.13.0" }
 
 async-channel = "2.1.0"
 thread_local = "1.1.4"

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ecs_macros"
-version = "0.12.0"
+version = "0.13.0"
 description = "Bevy ECS Macros"
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.13.0" }
 
 syn = "2.0"
 quote = "1.0"

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_encase_derive"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Bevy derive macro for encase"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.13.0" }
 encase_derive_impl = "0.7"
 
 [lints]

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gilrs"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Gamepad system made using Gilrs for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,12 +10,12 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_input = { path = "../bevy_input", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_time = { path = "../bevy_time", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_input = { path = "../bevy_input", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_time = { path = "../bevy_time", version = "0.13.0" }
 
 # other
 gilrs = "0.10.1"

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gizmos"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides gizmos for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,20 +14,20 @@ webgpu = []
 
 [dependencies]
 # Bevy
-bevy_pbr = { path = "../bevy_pbr", version = "0.12.0", optional = true }
-bevy_sprite = { path = "../bevy_sprite", version = "0.12.0", optional = true }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_gizmos_macros = { path = "macros", version = "0.12.0" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.13.0", optional = true }
+bevy_sprite = { path = "../bevy_sprite", version = "0.13.0", optional = true }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_gizmos_macros = { path = "macros", version = "0.13.0" }
 
 [lints]
 workspace = true

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gizmos_macros"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Derive implementations for bevy_gizmos"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.13.0" }
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_gltf"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Bevy Engine GLTF loading"
 homepage = "https://bevyengine.org"
@@ -14,26 +14,26 @@ pbr_transmission_textures = []
 
 [dependencies]
 # bevy
-bevy_animation = { path = "../bevy_animation", version = "0.12.0", optional = true }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_pbr = { path = "../bevy_pbr", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_animation = { path = "../bevy_animation", version = "0.13.0", optional = true }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_pbr = { path = "../bevy_pbr", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_scene = { path = "../bevy_scene", version = "0.12.0", features = [
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_scene = { path = "../bevy_scene", version = "0.13.0", features = [
   "bevy_render",
 ] }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 gltf = { version = "1.4.0", default-features = false, features = [

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_hierarchy"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides hierarchy functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -16,14 +16,14 @@ reflect = ["bevy_ecs/bevy_reflect", "bevy_reflect"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0", optional = true }
-bevy_core = { path = "../bevy_core", version = "0.12.0", optional = true }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", default-features = false }
-bevy_log = { path = "../bevy_log", version = "0.12.0", optional = true }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0", optional = true }
+bevy_core = { path = "../bevy_core", version = "0.13.0", optional = true }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0", default-features = false }
+bevy_log = { path = "../bevy_log", version = "0.13.0", optional = true }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ], optional = true }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 [lints]
 workspace = true

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_input"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides input functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,11 +14,11 @@ serialize = ["serde"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "glam",
   "smol_str",
 ] }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_internal"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "An internal Bevy crate used to facilitate optional dynamic linking via the 'dynamic_linking' feature"
 homepage = "https://bevyengine.org"
@@ -162,41 +162,41 @@ bevy_debug_stepping = [
 
 [dependencies]
 # bevy
-bevy_a11y = { path = "../bevy_a11y", version = "0.12.0" }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_input = { path = "../bevy_input", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_ptr = { path = "../bevy_ptr", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_a11y = { path = "../bevy_a11y", version = "0.13.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_input = { path = "../bevy_input", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_ptr = { path = "../bevy_ptr", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_time = { path = "../bevy_time", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
+bevy_time = { path = "../bevy_time", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
 # bevy (optional)
-bevy_animation = { path = "../bevy_animation", optional = true, version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", optional = true, version = "0.12.0" }
-bevy_audio = { path = "../bevy_audio", optional = true, version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.12.0" }
-bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.12.0" }
-bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.12.0" }
-bevy_render = { path = "../bevy_render", optional = true, version = "0.12.0" }
-bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.12.0" }
-bevy_scene = { path = "../bevy_scene", optional = true, version = "0.12.0" }
-bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.12.0" }
-bevy_text = { path = "../bevy_text", optional = true, version = "0.12.0" }
-bevy_ui = { path = "../bevy_ui", optional = true, version = "0.12.0" }
-bevy_winit = { path = "../bevy_winit", optional = true, version = "0.12.0" }
-bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.12.0" }
-bevy_gizmos = { path = "../bevy_gizmos", optional = true, version = "0.12.0", default-features = false }
+bevy_animation = { path = "../bevy_animation", optional = true, version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", optional = true, version = "0.13.0" }
+bevy_audio = { path = "../bevy_audio", optional = true, version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.13.0" }
+bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.13.0" }
+bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.13.0" }
+bevy_render = { path = "../bevy_render", optional = true, version = "0.13.0" }
+bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.13.0" }
+bevy_scene = { path = "../bevy_scene", optional = true, version = "0.13.0" }
+bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.13.0" }
+bevy_text = { path = "../bevy_text", optional = true, version = "0.13.0" }
+bevy_ui = { path = "../bevy_ui", optional = true, version = "0.13.0" }
+bevy_winit = { path = "../bevy_winit", optional = true, version = "0.13.0" }
+bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.13.0" }
+bevy_gizmos = { path = "../bevy_gizmos", optional = true, version = "0.13.0", default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_log"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides logging for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -13,9 +13,9 @@ trace = ["tracing-error"]
 trace_tracy_memory = ["dep:tracy-client"]
 
 [dependencies]
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
 
 tracing-subscriber = { version = "0.3.1", features = [
   "registry",

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_macro_utils"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_math"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides math functionality for Bevy Engine"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_mikktspace"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 authors = [
   "Benjamin Wasty <benny.wasty@gmail.com>",

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_pbr"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Adds PBR rendering to Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -15,19 +15,19 @@ pbr_transmission_textures = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
 
 # other
 bitflags = "2.3"

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ptr"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Utilities for working with untyped pointers in a more safe way"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_reflect"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Dynamically interact with rust types"
 homepage = "https://bevyengine.org"
@@ -21,12 +21,12 @@ documentation = ["bevy_reflect_derive/documentation"]
 
 [dependencies]
 # bevy
-bevy_math = { path = "../bevy_math", version = "0.12.0", features = [
+bevy_math = { path = "../bevy_math", version = "0.13.0", features = [
   "serialize",
 ], optional = true }
-bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_ptr = { path = "../bevy_ptr", version = "0.12.0" }
+bevy_reflect_derive = { path = "bevy_reflect_derive", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_ptr = { path = "../bevy_ptr", version = "0.13.0" }
 
 # other
 erased-serde = "0.4"

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_reflect_derive"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Derive implementations for bevy_reflect"
 homepage = "https://bevyengine.org"
@@ -17,7 +17,7 @@ default = []
 documentation = []
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.13.0" }
 
 syn = { version = "2.0", features = ["full"] }
 proc-macro2 = "1.0"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_render"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides rendering functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -37,25 +37,25 @@ webgpu = ["wgpu/webgpu"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core = { path = "../bevy_core", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core = { path = "../bevy_core", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render_macros = { path = "macros", version = "0.12.0" }
-bevy_time = { path = "../bevy_time", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
+bevy_render_macros = { path = "macros", version = "0.13.0" }
+bevy_time = { path = "../bevy_time", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
 
 # rendering
 image = { version = "0.24", default-features = false }

--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_render_macros"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Derive implementations for bevy_render"
 homepage = "https://bevyengine.org"
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 proc-macro = true
 
 [dependencies]
-bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.12.0" }
+bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.13.0" }
 
 syn = "2.0"
 proc-macro2 = "1.0"

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_scene"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides scene functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,17 +14,17 @@ serialize = ["dep:serde", "uuid/serde"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_render = { path = "../bevy_render", version = "0.12.0", optional = true }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0", optional = true }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_sprite"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides sprite functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,19 +14,19 @@ webgpu = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
 
 # other
 bytemuck = { version = "1.5", features = ["derive"] }

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_tasks"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A task executor for Bevy Engine"
 homepage = "https://bevyengine.org"

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_text"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides text functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,18 +14,18 @@ default_font = []
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_sprite = { path = "../bevy_sprite", version = "0.12.0" }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_sprite = { path = "../bevy_sprite", version = "0.13.0" }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 ab_glyph = "0.2.6"

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_time"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides time functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -15,14 +15,14 @@ bevy_ci_testing = ["bevy_app/bevy_ci_testing"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0", features = [
   "bevy_reflect",
 ] }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 crossbeam-channel = "0.5.0"

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_transform"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides transform functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,21 +10,21 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0", features = [
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0", features = [
   "bevy_reflect",
 ] }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }
 thiserror = "1.0"
 
 [dev-dependencies]
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0", features = ["approx"] }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0", features = ["approx"] }
 approx = "0.5.1"
 
 [features]

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_ui"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A custom ECS-driven UI framework built specifically for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -10,25 +10,25 @@ keywords = ["bevy"]
 
 [dependencies]
 # bevy
-bevy_a11y = { path = "../bevy_a11y", version = "0.12.0" }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_asset = { path = "../bevy_asset", version = "0.12.0" }
-bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_input = { path = "../bevy_input", version = "0.12.0" }
-bevy_log = { path = "../bevy_log", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_a11y = { path = "../bevy_a11y", version = "0.13.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_asset = { path = "../bevy_asset", version = "0.13.0" }
+bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_input = { path = "../bevy_input", version = "0.13.0" }
+bevy_log = { path = "../bevy_log", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "bevy",
 ] }
-bevy_render = { path = "../bevy_render", version = "0.12.0" }
-bevy_sprite = { path = "../bevy_sprite", version = "0.12.0" }
-bevy_text = { path = "../bevy_text", version = "0.12.0", optional = true }
-bevy_transform = { path = "../bevy_transform", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_render = { path = "../bevy_render", version = "0.13.0" }
+bevy_sprite = { path = "../bevy_sprite", version = "0.13.0" }
+bevy_text = { path = "../bevy_text", version = "0.13.0", optional = true }
+bevy_transform = { path = "../bevy_transform", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 
 # other
 taffy = { version = "0.3.10" }

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_utils"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A collection of utils for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -17,7 +17,7 @@ tracing = { version = "0.1", default-features = false, features = ["std"] }
 web-time = { version = "0.2" }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 hashbrown = { version = "0.14", features = ["serde"] }
-bevy_utils_proc_macros = { version = "0.12.0", path = "macros" }
+bevy_utils_proc_macros = { version = "0.13.0", path = "macros" }
 petgraph = "0.6"
 thiserror = "1.0"
 nonmax = "0.5"

--- a/crates/bevy_utils/macros/Cargo.toml
+++ b/crates/bevy_utils/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_utils_proc_macros"
-version = "0.12.0"
+version = "0.13.0"
 description = "Bevy Utils Proc Macros"
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_window"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Provides windowing functionality for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -14,16 +14,16 @@ serialize = ["serde", "smol_str/serde"]
 
 [dependencies]
 # bevy
-bevy_a11y = { path = "../bevy_a11y", version = "0.12.0" }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_reflect = { path = "../bevy_reflect", version = "0.12.0", features = [
+bevy_a11y = { path = "../bevy_a11y", version = "0.13.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_reflect = { path = "../bevy_reflect", version = "0.13.0", features = [
   "glam",
 ] }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 # Used for close_on_esc
-bevy_input = { path = "../bevy_input", version = "0.12.0" }
+bevy_input = { path = "../bevy_input", version = "0.13.0" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bevy_winit"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A winit window and input backend for Bevy Engine"
 homepage = "https://bevyengine.org"
@@ -16,16 +16,16 @@ accesskit_unix = ["accesskit_winit/accesskit_unix", "accesskit_winit/async-io"]
 
 [dependencies]
 # bevy
-bevy_a11y = { path = "../bevy_a11y", version = "0.12.0" }
-bevy_app = { path = "../bevy_app", version = "0.12.0" }
-bevy_derive = { path = "../bevy_derive", version = "0.12.0" }
-bevy_ecs = { path = "../bevy_ecs", version = "0.12.0" }
-bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.12.0" }
-bevy_input = { path = "../bevy_input", version = "0.12.0" }
-bevy_math = { path = "../bevy_math", version = "0.12.0" }
-bevy_window = { path = "../bevy_window", version = "0.12.0" }
-bevy_utils = { path = "../bevy_utils", version = "0.12.0" }
-bevy_tasks = { path = "../bevy_tasks", version = "0.12.0" }
+bevy_a11y = { path = "../bevy_a11y", version = "0.13.0" }
+bevy_app = { path = "../bevy_app", version = "0.13.0" }
+bevy_derive = { path = "../bevy_derive", version = "0.13.0" }
+bevy_ecs = { path = "../bevy_ecs", version = "0.13.0" }
+bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.13.0" }
+bevy_input = { path = "../bevy_input", version = "0.13.0" }
+bevy_math = { path = "../bevy_math", version = "0.13.0" }
+bevy_window = { path = "../bevy_window", version = "0.13.0" }
+bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
+bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
 
 # other
 # feature rwh_06 refers to window_raw_handle@v0.6

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "build-templated-pages"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "handle templated pages in Bevy repository"
 publish = false

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "example-showcase"
-version = "0.1.0"
+version = "0.13.0"
 edition = "2021"
 description = "Run examples"
 publish = false


### PR DESCRIPTION
Bump Bevy crates to 0.13.0 in preparation for release.

(Note that we accidentally skipped the `0.13.0-dev` step this cycle)