### PR TITLE
Use the scroll wheel to control the camera speed in examples

### DIFF
--- a/examples/tools/scene_viewer/main.rs
+++ b/examples/tools/scene_viewer/main.rs
@@ -116,7 +116,12 @@ fn setup_scene_after_load(
         let mut projection = PerspectiveProjection::default();
         projection.far = projection.far.max(size * 10.0);
 
-        let camera_controller = CameraController::default();
+        let walk_speed = size * 3.0;
+        let camera_controller = CameraController {
+            walk_speed,
+            run_speed: 3.0 * walk_speed,
+            ..default()
+        };
 
         // Display the controls of the scene viewer
         info!("{}", camera_controller);


### PR DESCRIPTION
# Objective

- Closes #9384.

## Solution

- Make the movement speed of the `CameraController` adjustable with the scroll wheel as mentioned [here](https://github.com/bevyengine/bevy/issues/9384#issuecomment-1668957931). The speed use an exponential progression (10% increase per scroll tick by default) to allow adapting the speed to different scales.
- For the `scene_viewer` example, make the default speed proportional to the size of the scene using what's computed for the default camera placement. This gives a good enough default to fly over the scene from the outside. I don't think there's a good way to get a default speed fitting for all scenes since some are meant to be viewed from outside while other are traversable environments.
