### PR TITLE
add `finish` function to SubApp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1565,6 +1565,17 @@ category = "ECS (Entity Component System)"
 wasm = false
 
 [[example]]
+name = "sub_app_communication"
+path = "examples/ecs/sub_app_communication.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.sub_app_communication]
+name = "SubApp Communication"
+description = "Demonstrates one way to communicate between the main app and one of it's sub apps"
+category = "ECS (Entity Component System)"
+wasm = false
+
+[[example]]
 name = "system_piping"
 path = "examples/ecs/system_piping.rs"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1571,7 +1571,7 @@ doc-scrape-examples = true
 
 [package.metadata.example.sub_app_communication]
 name = "SubApp Communication"
-description = "Demonstrates one way to communicate between the main app and one of it's sub apps"
+description = "Demonstrates using events to send data in and out of a SubApp"
 category = "ECS (Entity Component System)"
 wasm = false
 

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -140,9 +140,13 @@ pub struct SubApp {
     /// The [`SubApp`]'s instance of [`App`]
     pub app: App,
 
-    /// A function that allows access to both the main [`App`] [`World`] and the [`SubApp`]. This is
+    /// A function that allows access to both the main [`App`] [`World`] and the [`SubApp`] before the sub app updates. This is
     /// useful for moving data between the sub app and the main app.
     extract: Box<dyn Fn(&mut World, &mut App) + Send>,
+
+    /// A function that allows access to both the main [`App`] [`World`] and the [`SubApp`] after the sub app updates. This is
+    /// useful for moving data between the sub app and the main app.
+    insert: Box<dyn Fn(&mut World, &mut App) + Send>,
 }
 
 impl SubApp {
@@ -156,7 +160,19 @@ impl SubApp {
         Self {
             app,
             extract: Box::new(extract),
+            insert: Box::new(|_, _| ()),
         }
+    }
+
+    /// Adds a function to be called after [`update`](App::update).
+    ///
+    /// The provided function `insert` is normally called by the [`update`](App::update) method.
+    /// Before insert is called, the [`Schedule`] of the sub app is run. The [`World`]
+    /// parameter represents the main app world, while the [`App`] parameter is just a mutable
+    /// reference to the `SubApp` itself.
+    pub fn with_insert(mut self, insert: impl Fn(&mut World, &mut App) + Send + 'static) -> Self {
+        self.insert = Box::new(insert);
+        self
     }
 
     /// Runs the [`SubApp`]'s default schedule.
@@ -168,6 +184,11 @@ impl SubApp {
     /// Extracts data from main world to this sub-app.
     pub fn extract(&mut self, main_world: &mut World) {
         (self.extract)(main_world, &mut self.app);
+    }
+
+    /// Inserts data from this sub-app to the main world.
+    pub fn insert(&mut self, main_world: &mut World) {
+        (self.insert)(main_world, &mut self.app);
     }
 }
 
@@ -267,6 +288,7 @@ impl App {
             let _sub_app_span = info_span!("sub app", name = ?_label).entered();
             sub_app.extract(&mut self.world);
             sub_app.run();
+            sub_app.insert(&mut self.world);
         }
 
         self.world.clear_trackers();

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -167,7 +167,7 @@ impl SubApp {
     /// Adds a function to be called after [`update`](App::update).
     ///
     /// The provided function `finish` is normally called by the [`update`](App::update) method.
-    /// Before finish is called, the [`Schedule`] of the sub app is run. The [`World`]
+    /// Finish is called after the [`Schedule`] of the sub app has run. The [`World`]
     /// parameter represents the main app world, while the [`App`] parameter is just a mutable
     /// reference to the `SubApp` itself.
     pub fn with_finish(mut self, insert: impl Fn(&mut World, &mut App) + Send + 'static) -> Self {
@@ -186,7 +186,7 @@ impl SubApp {
         (self.extract)(main_world, &mut self.app);
     }
 
-    /// Finishes data from this sub-app to the main world.
+    /// Finishes the sub-app's update by invoking the [`Self::with_finish`] callback.
     pub fn finish(&mut self, main_world: &mut World) {
         (self.finish)(main_world, &mut self.app);
     }

--- a/examples/README.md
+++ b/examples/README.md
@@ -246,7 +246,7 @@ Example | Description
 [Send and receive events](../examples/ecs/send_and_receive_events.rs) | Demonstrates how to send and receive events of the same type in a single system
 [Startup System](../examples/ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 [State](../examples/ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state
-[SubApp Communication](../examples/ecs/sub_app_communication.rs) | Demonstrates one way to communicate between the main app and one of it's sub apps
+[SubApp Communication](../examples/ecs/sub_app_communication.rs) | Demonstrates using events to send data in and out of a SubApp
 [System Closure](../examples/ecs/system_closure.rs) | Show how to use closures as systems, and how to configure `Local` variables by capturing external state
 [System Parameter](../examples/ecs/system_param.rs) | Illustrates creating custom system parameters with `SystemParam`
 [System Piping](../examples/ecs/system_piping.rs) | Pipe the output of one system into a second, allowing you to handle any errors gracefully

--- a/examples/README.md
+++ b/examples/README.md
@@ -246,6 +246,7 @@ Example | Description
 [Send and receive events](../examples/ecs/send_and_receive_events.rs) | Demonstrates how to send and receive events of the same type in a single system
 [Startup System](../examples/ecs/startup_system.rs) | Demonstrates a startup system (one that runs once when the app starts up)
 [State](../examples/ecs/state.rs) | Illustrates how to use States to control transitioning from a Menu state to an InGame state
+[SubApp Communication](../examples/ecs/sub_app_communication.rs) | Demonstrates one way to communicate between the main app and one of it's sub apps
 [System Closure](../examples/ecs/system_closure.rs) | Show how to use closures as systems, and how to configure `Local` variables by capturing external state
 [System Parameter](../examples/ecs/system_param.rs) | Illustrates creating custom system parameters with `SystemParam`
 [System Piping](../examples/ecs/system_piping.rs) | Pipe the output of one system into a second, allowing you to handle any errors gracefully

--- a/examples/ecs/sub_app_communication.rs
+++ b/examples/ecs/sub_app_communication.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how to add and communicate with a [`SubApp`](bevy_internal::app::SubApp)
+//! Demonstrates using events to send data in and out of a [`SubApp`](bevy_internal::app::SubApp)
 
 use bevy::{
     app::{AppExit, AppLabel, SubApp},

--- a/examples/ecs/sub_app_communication.rs
+++ b/examples/ecs/sub_app_communication.rs
@@ -1,0 +1,166 @@
+//! Demonstrates how to add and communicate with a [`SubApp`](bevy_internal::app::SubApp)
+
+use bevy::prelude::*;
+use bevy_internal::{
+    app::{AppExit, AppLabel, SubApp},
+    ecs::event::ManualEventReader,
+};
+
+/// Events meant to be sent TO the sub app
+#[derive(Event, Clone)]
+enum ToSubAppEvent {
+    HelloFromMainApp,
+}
+
+/// Events meant to be recieved FROM the sub app
+#[derive(Event, Clone)]
+enum FromSubAppEvent {
+    HelloFromSubApp,
+    PleaseExit,
+}
+
+fn main() {
+    // We create our app normally
+    let mut main_app = App::new();
+
+    // Add whichever plugins we need
+    main_app
+        .add_plugins((DefaultPlugins, SubAppPlugin))
+        // We need to register both events
+        .add_event::<ToSubAppEvent>()
+        .add_event::<FromSubAppEvent>()
+        .add_systems(Update, handle_main_events);
+
+    main_app.run();
+}
+
+// This is just a normal system which consumes our events on the main app side
+fn handle_main_events(
+    // Get events from the sub app
+    mut event_reader_from_sub_app: EventReader<FromSubAppEvent>,
+    // Write events to the sub app
+    mut event_writer_to_sub_app: EventWriter<ToSubAppEvent>,
+    // Close the program
+    mut event_writer_app_exit: EventWriter<AppExit>,
+) {
+    // We can iterate over these events like normal
+    for event in event_reader_from_sub_app.read() {
+        match event {
+            // We recieved a "Hello" from the sub app
+            FromSubAppEvent::HelloFromSubApp => info!("MainApp: Recieved hello from sub app!"),
+            // We recieved a request to close the program
+            FromSubAppEvent::PleaseExit => {
+                info!("MainApp: Recieved request to exit from sub app!");
+                event_writer_app_exit.send(AppExit);
+                return;
+            }
+        }
+    }
+
+    // Let's send our own "Hello"
+    event_writer_to_sub_app.send(ToSubAppEvent::HelloFromMainApp);
+}
+
+// All SubApp's require an AppLabel
+#[derive(AppLabel, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct SubAppLabel;
+
+// This resource will store the EventReader state for ToSubAppEvents
+#[derive(Resource, Default)]
+struct EventReaderToState(ManualEventReader<ToSubAppEvent>);
+
+// This resource will store the EventReader state for FromSubAppEvents
+#[derive(Resource, Default)]
+struct EventReaderFromState(ManualEventReader<FromSubAppEvent>);
+
+// We'll create a plugin for our sub app
+struct SubAppPlugin;
+
+impl Plugin for SubAppPlugin {
+    fn build(&self, app: &mut App) {
+        // We create our app which will become a SubApp of the main app
+        let mut our_sub_app = App::new();
+
+        // Add whichever plugins we need
+        our_sub_app
+            .add_plugins(MinimalPlugins)
+            // We need to register both events here as well
+            .add_event::<ToSubAppEvent>()
+            .add_event::<FromSubAppEvent>()
+            .init_resource::<EventReaderToState>()
+            .init_resource::<EventReaderFromState>()
+            .add_systems(Update, handle_sub_events);
+
+        // Now we need to build the SubApp wrapper around our app
+        // We can pass either a closure or a function which takes mutable
+        // references main app's world and our sub app's app
+        // Note we also setup a post-sync function
+        let sub_app = SubApp::new(our_sub_app, pre_sync).with_insert(post_sync);
+        // Finally we can insert our SubApp into the main app
+        app.insert_sub_app(SubAppLabel, sub_app);
+    }
+}
+
+// This is just a normal system which consumes our events on the sub app side
+// Note we are now reading ToSubAppEvent and writing FromSubAppEvent
+fn handle_sub_events(
+    // Get events to the sub app
+    mut event_reader_to_sub_app: EventReader<ToSubAppEvent>,
+    // Write events to the main app
+    mut event_writer_from_sub_app: EventWriter<FromSubAppEvent>,
+) {
+    // We can iterate over these events like normal
+    for event in event_reader_to_sub_app.read() {
+        match event {
+            // We recieved a "Hello" from the main app
+            ToSubAppEvent::HelloFromMainApp => {
+                info!("SubApp: Recieved hello from main app!");
+                // Be polite and say "Hello" back
+                event_writer_from_sub_app.send(FromSubAppEvent::HelloFromSubApp);
+                // We are done, let's request that the main app closes
+                event_writer_from_sub_app.send(FromSubAppEvent::PleaseExit);
+            }
+        }
+    }
+}
+
+// This will run before our sub app's schedule allowing for us to extract data from the main world
+fn pre_sync(main_world: &mut World, sub_app: &mut App) {
+    // Retrieve our event reader state
+    sub_app
+        .world
+        .resource_scope(|sub_world, mut event_reader: Mut<EventReaderToState>| {
+            // Retrieve our events
+            main_world.resource_scope(|_main_world, events: Mut<Events<ToSubAppEvent>>| {
+                // Retrieve our EventWriter to write the events from the main app to the sub app
+                sub_world.resource_scope(
+                    |_sub_world, mut event_writer: Mut<Events<ToSubAppEvent>>| {
+                        for event in event_reader.0.read(&events) {
+                            event_writer.send(event.clone());
+                        }
+                    },
+                );
+            });
+        });
+}
+
+// This will run after our sub app's schedule allowing for us to insert data in the main world
+fn post_sync(main_world: &mut World, sub_app: &mut App) {
+    // Retrieve our event reader state
+    sub_app
+        .world
+        .resource_scope(|sub_world, mut event_reader: Mut<EventReaderFromState>| {
+            // Retrieve our events
+            sub_world.resource_scope(|_sub_world, events: Mut<Events<FromSubAppEvent>>| {
+                // Retrieve our EventWriter to write the events from the sub app to the main app
+                main_world.resource_scope(
+                    |_main_world, mut event_writer: Mut<Events<FromSubAppEvent>>| {
+                        // Read all events from the sub app and pass them to the main app
+                        for event in event_reader.0.read(&events) {
+                            event_writer.send(event.clone());
+                        }
+                    },
+                );
+            });
+        });
+}

--- a/examples/ecs/sub_app_communication.rs
+++ b/examples/ecs/sub_app_communication.rs
@@ -1,9 +1,9 @@
 //! Demonstrates how to add and communicate with a [`SubApp`](bevy_internal::app::SubApp)
 
-use bevy::prelude::*;
-use bevy_internal::{
+use bevy::{
     app::{AppExit, AppLabel, SubApp},
     ecs::event::ManualEventReader,
+    prelude::*,
 };
 
 /// Events meant to be sent TO the sub app

--- a/examples/ecs/sub_app_communication.rs
+++ b/examples/ecs/sub_app_communication.rs
@@ -95,7 +95,7 @@ impl Plugin for SubAppPlugin {
         // We can pass either a closure or a function which takes mutable
         // references main app's world and our sub app's app
         // Note we also setup a post-sync function
-        let sub_app = SubApp::new(our_sub_app, pre_sync).with_insert(post_sync);
+        let sub_app = SubApp::new(our_sub_app, pre_sync).with_finish(post_sync);
         // Finally we can insert our SubApp into the main app
         app.insert_sub_app(SubAppLabel, sub_app);
     }


### PR DESCRIPTION
# Objective

SubApp had a "sync point" prior to updating - `SubApp::extract`. This adds a new "sync point" after the sub app schedule runs.
This will allow passing of events to (extract) and from (insert) the sub app through `world.get_resource_mut::<Events<SomeEvent>>()` and `app.world.get_resource_mut::<Events<SomeEvent>>()` allowing for a main app to act as a view/controller while the sub app acts as a model.

## Solution

- Added an `Box<dyn Fn>` identical to `extract` named `finish` to `SubApp`.
- Passed in the closure `|_, _| ()` as the default value for insert as an option seemed more clunky, and changing the `new()` function would break anything relying on the current new implementation. Outside of cache loading, calling a function which returns will be faster than checking is_none, and minimal sub apps being created makes me feel like this was ok.
- Added a builder function to `SubApp` allowing insert to be set to a fn.
- Called `(sub_app.finish)` after `sub_app.run()` during `App::update`

### Note: ~~`insert` was used as it is the opposite of `extract` although in my use case, I think of them more as sync points than a pipeline extracting it's data.~~
---

## Changelog

Added: SubApp will now call the finish function after it runs it's schedule providing a mirror opposite of extract.
Added: SubApp::with_finish()
