### PR TITLE
Add bevy_gizmos/macros to publish script

### DIFF
--- a/tools/publish.sh
+++ b/tools/publish.sh
@@ -35,6 +35,7 @@ crates=(
     bevy_gltf
     bevy_scene
     bevy_sprite
+    bevy_gizmos/macros
     bevy_gizmos
     bevy_text
     bevy_a11y


### PR DESCRIPTION
# Objective

This crate is needed if we want to successfully publish other Bevy crates (hint: we do!)