### PR TITLE
Add single-f32 constructors for a few (very few) primitives

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -538,6 +538,15 @@ impl Rectangle {
         }
     }
 
+    /// Create a `Rectangle` from a single length.
+    /// The resulting `Rectangle` will be the same size in every direction.
+    #[inline(always)]
+    pub fn from_length(length: f32) -> Self {
+        Self {
+            half_size: Vec2::splat(length / 2.0),
+        }
+    }
+
     /// Get the size of the rectangle
     #[inline(always)]
     pub fn size(&self) -> Vec2 {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -422,6 +422,15 @@ impl Cuboid {
         }
     }
 
+    /// Create a `Cuboid` from a single length.
+    /// The resulting `Cuboid` will be the same size in every direction.
+    #[inline(always)]
+    pub fn from_length(length: f32) -> Self {
+        Self {
+            half_size: Vec3::splat(length / 2.0),
+        }
+    }
+
     /// Get the size of the cuboid
     #[inline(always)]
     pub fn size(&self) -> Vec3 {

--- a/crates/bevy_render/src/mesh/primitives/dim3/plane.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/plane.rs
@@ -46,6 +46,16 @@ impl PlaneMeshBuilder {
         }
     }
 
+    /// Creates a new [`PlaneMeshBuilder`] from the given length, with the normal pointing upwards,
+    /// and the resulting [`PlaneMeshBuilder`] being a square.
+    #[inline]
+    pub fn from_length(length: f32) -> Self {
+        Self {
+            half_size: Vec2::splat(length) / 2.0,
+            ..Default::default()
+        }
+    }
+
     /// Sets the normal of the plane, aka the direction the plane is facing.
     #[inline]
     #[doc(alias = "facing")]


### PR DESCRIPTION
# Objective

- I hated having to do `Cuboid::new(1.0, 1.0, 1.0)` or `Cuboid::from_size(Vec3::splat(1.0))` when there should be a much easier way to do this.

## Solution

- Implemented a `from_length()` method that only takes in a single float, and constructs a primitive of equal size in all directions.
- Ex:
  ```rs
  // These:
  Cuboid::new(1.0, 1.0, 1.0);
  Cuboid::from_size(Vec3::splat(1.0));
  // Are equivalent to this:
  Cuboid::from_length(1.0);
  ```
 - For the rest of the changed primitives:
    ```rs
    Rectangle::from_length(1.0);
    Plane3d::default().mesh().from_length(1.0);
    ```