### PR TITLE
revert PointLightBundle to DirectionalLightBundle change made to asset_loading example between 0.12.1 and 0.13.0

### DIFF
--- a/examples/asset/asset_loading.rs
+++ b/examples/asset/asset_loading.rs
@@ -79,8 +79,8 @@ fn setup(
         ..default()
     });
     // light
-    commands.spawn(DirectionalLightBundle {
-        transform: Transform::from_xyz(4.0, 5.0, 4.0).looking_at(Vec3::ZERO, Vec3::Y),
+    commands.spawn(PointLightBundle {
+        transform: Transform::from_xyz(4.0, 5.0, 4.0),
         ..default()
     });
     // camera


### PR DESCRIPTION
# Objective

- revert a single-line change made to `examples/asset/asset_loading` example between `v0.12.1` release and `v0.13.0` release which resulted in a too-bright, washed-out rendering

## Solution

- reverted the changes made to this example between `v0.12.1` and `v0.13.0`