### PR TITLE
text2d example: animate_scale no longer unnecessarily performs the same translation at each Update

### DIFF
--- a/examples/2d/text2d.rs
+++ b/examples/2d/text2d.rs
@@ -63,6 +63,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn((
         Text2dBundle {
             text: Text::from_section("scale", text_style).with_justify(text_justification),
+            transform: Transform::from_translation(Vec3::new(400.0, 0.0, 0.0)),
             ..default()
         },
         AnimateScale,
@@ -187,8 +188,6 @@ fn animate_scale(
     // Consider changing font-size instead of scaling the transform. Scaling a Text2D will scale the
     // rendered quad, resulting in a pixellated look.
     for mut transform in &mut query {
-        transform.translation = Vec3::new(400.0, 0.0, 0.0);
-
         let scale = (time.elapsed_seconds().sin() + 1.1) * 2.0;
         transform.scale.x = scale;
         transform.scale.y = scale;


### PR DESCRIPTION
# Objective

- The `transform.translation` of a `TextBundle` in this example is unnecessarily set to the same constant position over and over in each `Update`. Newbies might be confused as to why this translation is being performed over and over.

## Solution

- perform the translation only once, when the `Text2dBundle` is instantiated