### PR TITLE
scene example: remove unnecessary reflect(FromWorld)

### DIFF
--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -34,7 +34,7 @@ struct ComponentA {
 // trait comes into play. `FromWorld` gives you access to your App's current ECS `Resources`
 // when you construct your component.
 #[derive(Component, Reflect)]
-#[reflect(Component, FromWorld)]
+#[reflect(Component)]
 struct ComponentB {
     pub value: String,
     #[reflect(skip_serializing)]


### PR DESCRIPTION
# Objective

- `#[reflect(FromWorld)]` was added to `ComponentB` somewhere between `v0.12.1` and `v0.13.0`, but it is unnecessary

## Solution

- remove the unnecessary `FromWorld`
