### PR TITLE
rename Camera3dBundle's 'dither' field to 'deband_dither' to align with Camera2dBundle

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/camera_3d.rs
@@ -144,7 +144,7 @@ pub struct Camera3dBundle {
     pub global_transform: GlobalTransform,
     pub camera_3d: Camera3d,
     pub tonemapping: Tonemapping,
-    pub dither: DebandDither,
+    pub deband_dither: DebandDither,
     pub color_grading: ColorGrading,
     pub exposure: Exposure,
     pub main_texture_usages: CameraMainTextureUsages,
@@ -166,7 +166,7 @@ impl Default for Camera3dBundle {
             color_grading: Default::default(),
             exposure: Default::default(),
             main_texture_usages: Default::default(),
-            dither: DebandDither::Enabled,
+            deband_dither: DebandDither::Enabled,
         }
     }
 }


### PR DESCRIPTION
# Objective

- having different field names for `Camera2dBundle` and `Camera3dBundle` implies that there is something different between these fields when there is not

## Solution

- rename the field in `Camera3dBundle` to align with `Camera2dBundle`

## Migration Guide

- use the new `deband_dither` field name with `Camera3dBundle`, rather than the old field name, `dither`