### PR TITLE
Make `App` be `#[must_use]`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -60,6 +60,7 @@ pub(crate) enum AppError {
 ///    println!("hello world");
 /// }
 /// ```
+#[must_use]
 pub struct App {
     /// The main ECS [`World`] of the [`App`].
     /// This stores and provides access to all the main data of the application.


### PR DESCRIPTION
# Objective

Make it harder to use `App` incorrectly.

## Solution

Add the `#[must_use]` attribute to `App`, this prevents you from creating an `App` and not using it.

---

## Changelog

- Add `#[must_use]` attribute to `App`. 