### PR TITLE
Use `is` method instead of `downcast_ref::<T>().is_some()` in `App::is_plugin_added`

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -673,7 +673,7 @@ impl App {
     {
         self.plugin_registry
             .iter()
-            .any(|p| p.downcast_ref::<T>().is_some())
+            .any(|p| p.is::<T>())
     }
 
     /// Returns a vector of references to any plugins of type `T` that have been added.

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -671,9 +671,7 @@ impl App {
     where
         T: Plugin,
     {
-        self.plugin_registry
-            .iter()
-            .any(|p| p.is::<T>())
+        self.plugin_registry.iter().any(|p| p.is::<T>())
     }
 
     /// Returns a vector of references to any plugins of type `T` that have been added.


### PR DESCRIPTION
# Objective

Improve code quality and performance

## Solution

Instead of using `plugin.downcast_ref::<T>().is_some()` in `App::is_plugin_added`, use `plugin.is::<T>()`. Which is more performant and cleaner.