### PR TITLE
Fix Steam overlay flickering somehow

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -302,14 +302,10 @@ impl Plugin for RenderPlugin {
                             RenderInstance(Arc::new(instance)),
                         ));
                     };
-                    // In wasm, spawn a task and detach it for execution
-                    #[cfg(target_arch = "wasm32")]
+
                     bevy_tasks::IoTaskPool::get()
                         .spawn_local(async_renderer)
                         .detach();
-                    // Otherwise, just block for it to complete
-                    #[cfg(not(target_arch = "wasm32"))]
-                    futures_lite::future::block_on(async_renderer);
 
                     // SAFETY: Plugins should be set up on the main thread.
                     unsafe { initialize_render_app(app) };


### PR DESCRIPTION
# Objective

I've noticed that in Bevy versions since 0.12, the Steam overlay flickers a lot and doesn't let me use it properly.

Initially, I thought that the problem is in bevy_steamworks, or in steamworks itself, but it turns out that the error appears only in the last two versions of Bevy, independent of steamworks. The steps to reproduce the flicker are described [here](https://github.com/HouraiTeahouse/bevy_steamworks/issues/31).

## Solution

After going through Bevy commits between 0.11 and 0.12, I found the problematic [commit](https://github.com/bevyengine/bevy/commit/401b2e77f3d4e8fe39f21ef51961d2a5bbedf9b6) and fixed the flickering problem by poking around. 

I have no idea why it didn't work before and why it works now, but hopefully we'll figure it out here