### PR TITLE
Qualify embedded_asset expansion with $crate::

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -219,7 +219,7 @@ pub fn _embedded_asset_path(
 #[macro_export]
 macro_rules! embedded_asset {
     ($app: ident, $path: expr) => {{
-        embedded_asset!($app, "src", $path)
+        $crate::embedded_asset!($app, "src", $path)
     }};
 
     ($app: ident, $source_path: expr, $path: expr) => {{


### PR DESCRIPTION
# Objective

Right now, if you call `embedded_asset` with 2 arguments as a qualified path it doesn't work (`bevy::asset::embedded_asset!(app, "foo.wgsl")` -> "cannot find macro `embedded_asset` in this scope")

## Solution

Use `$crate::` in expansion for 2-arg case.