### PR TITLE
Fix dds feature dependencies in bevy_core_pipeline

### DIFF
--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [features]
-dds = []
+dds = ["bevy_render/dds"]
 trace = []
 webgl = []
 webgpu = []


### PR DESCRIPTION
# Objective

- Fixes #11960
- The compilation of `bevy_core_pipeline` failed with the `dds` feature enabled

## Solution

- Enable the `dds` feature of `bevy_render` when enabling it for `bevy_core_pipeline`