### PR TITLE
Add the serde feature to bitflags for bevy_render.

### DIFF
--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -74,7 +74,7 @@ wgpu = { version = "0.19.1", default-features = false, features = [
 ] }
 naga = { version = "0.19", features = ["wgsl-in"] }
 serde = { version = "1", features = ["derive"] }
-bitflags = "2.3"
+bitflags = { version = "2.3", features = ["serde"] }
 bytemuck = { version = "1.5", features = ["derive"] }
 downcast-rs = "1.2.0"
 thread_local = "1.1"


### PR DESCRIPTION
# Objective

Fixes #11964.

## Solution

Adds the `serde` feature to `bitflags` for `bevy_render`. This makes `bevy_render` compile correctly when used alone.

---

## Changelog

- Fixed an issue where depending on `bevy_render` alone would fail to compile.
