### PR TITLE
Add MapEntities trait for Transform

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -5,6 +5,7 @@ use bevy_math::{Affine3A, Mat3, Mat4, Quat, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
 use std::ops::Mul;
+use bevy_ecs::entity::{EntityMapper, MapEntities};
 
 /// Describe the position of an entity. If the entity has a parent, the position is relative
 /// to its parent position.
@@ -446,5 +447,11 @@ impl Mul<Vec3> for Transform {
 
     fn mul(self, value: Vec3) -> Self::Output {
         self.transform_point(value)
+    }
+}
+
+// No need to map any entities for Transform
+impl MapEntities for Transform {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
     }
 }

--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -1,11 +1,11 @@
 use super::GlobalTransform;
+use bevy_ecs::entity::{EntityMapper, MapEntities};
 use bevy_ecs::{component::Component, reflect::ReflectComponent};
 use bevy_math::primitives::Direction3d;
 use bevy_math::{Affine3A, Mat3, Mat4, Quat, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_reflect::Reflect;
 use std::ops::Mul;
-use bevy_ecs::entity::{EntityMapper, MapEntities};
 
 /// Describe the position of an entity. If the entity has a parent, the position is relative
 /// to its parent position.
@@ -452,6 +452,5 @@ impl Mul<Vec3> for Transform {
 
 // No need to map any entities for Transform
 impl MapEntities for Transform {
-    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
-    }
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {}
 }


### PR DESCRIPTION
# Objective

- Since the refactor of the MapEntities trait to be more flexible (https://github.com/bevyengine/bevy/pull/11428), I wanted to switch my library to use bevy's MapEntities trait instead of an internal trait (also because it's the only way to mutate the inner entity of the `Parent` and `Children` components, bevy doesn't expose a public way to modify them)

-  In my library every message I send implements MapEntities, meaning that the message/component needs to potentially call `map_entities()` to map any entities inside the message/component from the remote world to the local world.

- The problem is that I cannot directly use components that are defined in external crates (for example `Transform`, defined in bevy), because they don't implement `MapEntities`


## Solution

- Make bevy components implement a no-op `MapEntities` to indicate that they do not perform any entity mapping.

## Alternatives

- I guess the alternative would be to have some form of specialization? and to only call MapEntities if the message/component implements it