### PR TITLE
Add `SystemSet` wrapper to `run_fixed_main_schedule`

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -60,7 +60,7 @@ impl Plugin for TimePlugin {
                 First,
                 (time_system, virtual_time_system.after(time_system)).in_set(TimeSystem),
             )
-            .add_systems(RunFixedMainLoop, run_fixed_main_schedule.in_set(RunFixedMainSchedule);
+            .add_systems(RunFixedMainLoop, run_fixed_main_schedule.in_set(RunFixedMainSchedule));
 
         // ensure the events are not dropped until `FixedMain` systems can observe them
         app.init_resource::<EventUpdateSignal>()

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -60,7 +60,10 @@ impl Plugin for TimePlugin {
                 First,
                 (time_system, virtual_time_system.after(time_system)).in_set(TimeSystem),
             )
-            .add_systems(RunFixedMainLoop, run_fixed_main_schedule.in_set(RunFixedMainSchedule));
+            .add_systems(
+                RunFixedMainLoop, 
+                run_fixed_main_schedule.in_set(RunFixedMainSchedule),
+            );
 
         // ensure the events are not dropped until `FixedMain` systems can observe them
         app.init_resource::<EventUpdateSignal>()

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -39,7 +39,7 @@ pub struct TimePlugin;
 /// this.
 pub struct TimeSystem;
 
-/// Allow consumers to easily configure `run_fixed_main_schedule` by exposing a SystemSet.
+/// Allow consumers to easily configure `run_fixed_main_schedule` by exposing a `SystemSet`.
 #[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
 pub struct RunFixedMainSchedule;
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -61,7 +61,7 @@ impl Plugin for TimePlugin {
                 (time_system, virtual_time_system.after(time_system)).in_set(TimeSystem),
             )
             .add_systems(
-                RunFixedMainLoop, 
+                RunFixedMainLoop,
                 run_fixed_main_schedule.in_set(RunFixedMainSchedule),
             );
 

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -39,6 +39,10 @@ pub struct TimePlugin;
 /// this.
 pub struct TimeSystem;
 
+/// Allow consumers to easily configure `run_fixed_main_schedule` by exposing a SystemSet.
+#[derive(Debug, PartialEq, Eq, Clone, Hash, SystemSet)]
+pub struct RunFixedMainSchedule;
+
 impl Plugin for TimePlugin {
     fn build(&self, app: &mut App) {
         app.init_resource::<Time>()
@@ -56,7 +60,7 @@ impl Plugin for TimePlugin {
                 First,
                 (time_system, virtual_time_system.after(time_system)).in_set(TimeSystem),
             )
-            .add_systems(RunFixedMainLoop, run_fixed_main_schedule);
+            .add_systems(RunFixedMainLoop, run_fixed_main_schedule.in_set(RunFixedMainSchedule);
 
         // ensure the events are not dropped until `FixedMain` systems can observe them
         app.init_resource::<EventUpdateSignal>()


### PR DESCRIPTION

# Objective

Workaround for https://github.com/bevyengine/bevy/issues/11970

The goal is to enable consumers to apply `run_if` conditions to `run_fixed_main_schedule` after it has been added to `ScheduleGraph`

## Solution

It is trivial to configure a `SystemSet` via:

```rust
app.configure_sets(RunFixedUpdateLoop, RunFixedMainSchedule.run_if(in_state(AppState::TellStory)));
```

but it is difficult/impossible to configure a `System` via:

```rust
// TODO: This does not appear to be supported
app.add_system(run_fixed_main_schedule.run_if(in_state(AppState::TellStory));
```

Introducing a `SystemSet` here allows for desired configurability.