### PR TITLE
Enable queue phase parallelization by using Parallel to back RenderPhase

### DIFF
--- a/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_opaque_pass_3d_node.rs
@@ -75,14 +75,14 @@ impl ViewNode for MainOpaquePass3dNode {
             }
 
             // Opaque draws
-            if !opaque_phase.items.is_empty() {
+            if !opaque_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _opaque_main_pass_3d_span = info_span!("opaque_main_pass_3d").entered();
                 opaque_phase.render(&mut render_pass, world, view_entity);
             }
 
             // Alpha draws
-            if !alpha_mask_phase.items.is_empty() {
+            if !alpha_mask_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _alpha_mask_main_pass_3d_span = info_span!("alpha_mask_main_pass_3d").entered();
                 alpha_mask_phase.render(&mut render_pass, world, view_entity);

--- a/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transmissive_pass_3d_node.rs
@@ -53,7 +53,7 @@ impl ViewNode for MainTransmissivePass3dNode {
         #[cfg(feature = "trace")]
         let _main_transmissive_pass_3d_span = info_span!("main_transmissive_pass_3d").entered();
 
-        if !transmissive_phase.items.is_empty() {
+        if !transmissive_phase.is_empty() {
             let screen_space_specular_transmission_steps =
                 camera_3d.screen_space_specular_transmission_steps;
             if screen_space_specular_transmission_steps > 0 {
@@ -67,7 +67,7 @@ impl ViewNode for MainTransmissivePass3dNode {
                 // might want to use a more sophisticated heuristic (e.g. based on view bounds, or with an exponential
                 // falloff so that nearby objects have more levels of transparency available to them)
                 for range in split_range(
-                    0..transmissive_phase.items.len(),
+                    0..transmissive_phase.len(),
                     screen_space_specular_transmission_steps,
                 ) {
                     // Copy the main texture to the transmission texture, allowing to use the color output of the

--- a/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/main_transparent_pass_3d_node.rs
@@ -31,7 +31,7 @@ impl ViewNode for MainTransparentPass3dNode {
     ) -> Result<(), NodeRunError> {
         let view_entity = graph.view_entity();
 
-        if !transparent_phase.items.is_empty() {
+        if !transparent_phase.is_empty() {
             // Run the transparent pass, sorted back-to-front
             // NOTE: Scoped to drop the mutable borrow of render_context
             #[cfg(feature = "trace")]

--- a/crates/bevy_core_pipeline/src/core_3d/mod.rs
+++ b/crates/bevy_core_pipeline/src/core_3d/mod.rs
@@ -617,7 +617,7 @@ pub fn prepare_core_3d_transmission_textures(
         }
 
         // Don't prepare a transmission texture if there are no transmissive items to render
-        if transmissive_3d_phase.items.is_empty() {
+        if transmissive_3d_phase.is_empty() {
             continue;
         }
 

--- a/crates/bevy_core_pipeline/src/deferred/node.rs
+++ b/crates/bevy_core_pipeline/src/deferred/node.rs
@@ -138,14 +138,14 @@ impl ViewNode for DeferredGBufferPrepassNode {
             }
 
             // Opaque draws
-            if !opaque_deferred_phase.items.is_empty() {
+            if !opaque_deferred_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _opaque_prepass_span = info_span!("opaque_deferred").entered();
                 opaque_deferred_phase.render(&mut render_pass, world, view_entity);
             }
 
             // Alpha masked draws
-            if !alpha_mask_deferred_phase.items.is_empty() {
+            if !alpha_mask_deferred_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _alpha_mask_deferred_span = info_span!("alpha_mask_deferred").entered();
                 alpha_mask_deferred_phase.render(&mut render_pass, world, view_entity);

--- a/crates/bevy_core_pipeline/src/prepass/node.rs
+++ b/crates/bevy_core_pipeline/src/prepass/node.rs
@@ -89,14 +89,14 @@ impl ViewNode for PrepassNode {
             }
 
             // Opaque draws
-            if !opaque_prepass_phase.items.is_empty() {
+            if !opaque_prepass_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _opaque_prepass_span = info_span!("opaque_prepass").entered();
                 opaque_prepass_phase.render(&mut render_pass, world, view_entity);
             }
 
             // Alpha masked draws
-            if !alpha_mask_prepass_phase.items.is_empty() {
+            if !alpha_mask_prepass_phase.is_empty() {
                 #[cfg(feature = "trace")]
                 let _alpha_mask_prepass_span = info_span!("alpha_mask_prepass").entered();
                 alpha_mask_prepass_phase.render(&mut render_pass, world, view_entity);

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -146,15 +146,15 @@ fn queue_line_gizmos_2d(
     msaa: Res<Msaa>,
     line_gizmos: Query<(Entity, &Handle<LineGizmo>, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<LineGizmo>>,
-    mut views: Query<(
+    views: Query<(
         &ExtractedView,
-        &mut RenderPhase<Transparent2d>,
+        &RenderPhase<Transparent2d>,
         Option<&RenderLayers>,
     )>,
 ) {
     let draw_function = draw_functions.read().get_id::<DrawLineGizmo2d>().unwrap();
 
-    for (view, mut transparent_phase, render_layers) in &mut views {
+    for (view, transparent_phase, render_layers) in &views {
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())
             | Mesh2dPipelineKey::from_hdr(view.hdr);
 

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -161,9 +161,9 @@ fn queue_line_gizmos_3d(
     msaa: Res<Msaa>,
     line_gizmos: Query<(Entity, &Handle<LineGizmo>, &GizmoMeshConfig)>,
     line_gizmo_assets: Res<RenderAssets<LineGizmo>>,
-    mut views: Query<(
+    views: Query<(
         &ExtractedView,
-        &mut RenderPhase<Transparent3d>,
+        &RenderPhase<Transparent3d>,
         Option<&RenderLayers>,
         (
             Has<NormalPrepass>,
@@ -177,10 +177,10 @@ fn queue_line_gizmos_3d(
 
     for (
         view,
-        mut transparent_phase,
+        transparent_phase,
         render_layers,
         (normal_prepass, depth_prepass, motion_vector_prepass, deferred_prepass),
-    ) in &mut views
+    ) in &views
     {
         let render_layers = render_layers.copied().unwrap_or_default();
 

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -469,7 +469,7 @@ pub fn queue_material_meshes<M: Material>(
     mut render_mesh_instances: ResMut<RenderMeshInstances>,
     render_material_instances: Res<RenderMaterialInstances<M>>,
     render_lightmaps: Res<RenderLightmaps>,
-    mut views: Query<(
+    views: Query<(
         &ExtractedView,
         &VisibleEntities,
         Option<&Tonemapping>,
@@ -485,10 +485,10 @@ pub fn queue_material_meshes<M: Material>(
         Option<&Camera3d>,
         Has<TemporalJitter>,
         Option<&Projection>,
-        &mut RenderPhase<Opaque3d>,
-        &mut RenderPhase<AlphaMask3d>,
-        &mut RenderPhase<Transmissive3d>,
-        &mut RenderPhase<Transparent3d>,
+        &RenderPhase<Opaque3d>,
+        &RenderPhase<AlphaMask3d>,
+        &RenderPhase<Transmissive3d>,
+        &RenderPhase<Transparent3d>,
         (
             Has<RenderViewLightProbes<EnvironmentMapLight>>,
             Has<RenderViewLightProbes<IrradianceVolume>>,
@@ -508,12 +508,12 @@ pub fn queue_material_meshes<M: Material>(
         camera_3d,
         temporal_jitter,
         projection,
-        mut opaque_phase,
-        mut alpha_mask_phase,
-        mut transmissive_phase,
-        mut transparent_phase,
+        opaque_phase,
+        alpha_mask_phase,
+        transmissive_phase,
+        transparent_phase,
         (has_environment_maps, has_irradiance_volumes),
-    ) in &mut views
+    ) in &views
     {
         let draw_opaque_pbr = opaque_draw_functions.read().id::<DrawMaterial<M>>();
         let draw_alpha_mask_pbr = alpha_mask_draw_functions.read().id::<DrawMaterial<M>>();

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -694,14 +694,14 @@ pub fn queue_prepass_material_meshes<M: Material>(
     render_materials: Res<RenderMaterials<M>>,
     render_material_instances: Res<RenderMaterialInstances<M>>,
     render_lightmaps: Res<RenderLightmaps>,
-    mut views: Query<
+    views: Query<
         (
             &ExtractedView,
             &VisibleEntities,
-            Option<&mut RenderPhase<Opaque3dPrepass>>,
-            Option<&mut RenderPhase<AlphaMask3dPrepass>>,
-            Option<&mut RenderPhase<Opaque3dDeferred>>,
-            Option<&mut RenderPhase<AlphaMask3dDeferred>>,
+            Option<&RenderPhase<Opaque3dPrepass>>,
+            Option<&RenderPhase<AlphaMask3dPrepass>>,
+            Option<&RenderPhase<Opaque3dDeferred>>,
+            Option<&RenderPhase<AlphaMask3dDeferred>>,
             Option<&DepthPrepass>,
             Option<&NormalPrepass>,
             Option<&MotionVectorPrepass>,
@@ -736,15 +736,15 @@ pub fn queue_prepass_material_meshes<M: Material>(
     for (
         view,
         visible_entities,
-        mut opaque_phase,
-        mut alpha_mask_phase,
-        mut opaque_deferred_phase,
-        mut alpha_mask_deferred_phase,
+        opaque_phase,
+        alpha_mask_phase,
+        opaque_deferred_phase,
+        alpha_mask_deferred_phase,
         depth_prepass,
         normal_prepass,
         motion_vector_prepass,
         deferred_prepass,
-    ) in &mut views
+    ) in &views
     {
         let mut view_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
         if depth_prepass.is_some() {
@@ -839,7 +839,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                 AlphaMode::Opaque => {
                     if deferred {
                         opaque_deferred_phase
-                            .as_mut()
+                            .as_ref()
                             .unwrap()
                             .add(Opaque3dDeferred {
                                 entity: *visible_entity,
@@ -849,7 +849,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 batch_range: 0..1,
                                 dynamic_offset: None,
                             });
-                    } else if let Some(opaque_phase) = opaque_phase.as_mut() {
+                    } else if let Some(opaque_phase) = opaque_phase.as_ref() {
                         opaque_phase.add(Opaque3dPrepass {
                             entity: *visible_entity,
                             draw_function: opaque_draw_prepass,
@@ -866,7 +866,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                         + material.properties.depth_bias;
                     if deferred {
                         alpha_mask_deferred_phase
-                            .as_mut()
+                            .as_ref()
                             .unwrap()
                             .add(AlphaMask3dDeferred {
                                 entity: *visible_entity,
@@ -876,7 +876,7 @@ pub fn queue_prepass_material_meshes<M: Material>(
                                 batch_range: 0..1,
                                 dynamic_offset: None,
                             });
-                    } else if let Some(alpha_mask_phase) = alpha_mask_phase.as_mut() {
+                    } else if let Some(alpha_mask_phase) = alpha_mask_phase.as_ref() {
                         alpha_mask_phase.add(AlphaMask3dPrepass {
                             entity: *visible_entity,
                             draw_function: alpha_mask_draw_prepass,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1598,7 +1598,7 @@ pub fn queue_shadows<M: Material>(
     pipeline_cache: Res<PipelineCache>,
     render_lightmaps: Res<RenderLightmaps>,
     view_lights: Query<(Entity, &ViewLightEntities)>,
-    mut view_light_shadow_phases: Query<(&LightEntity, &mut RenderPhase<Shadow>)>,
+    view_light_shadow_phases: Query<(&LightEntity, &RenderPhase<Shadow>)>,
     point_light_entities: Query<&CubemapVisibleEntities, With<ExtractedPointLight>>,
     directional_light_entities: Query<&CascadesVisibleEntities, With<ExtractedDirectionalLight>>,
     spot_light_entities: Query<&VisibleEntities, With<ExtractedPointLight>>,
@@ -1608,8 +1608,8 @@ pub fn queue_shadows<M: Material>(
     for (entity, view_lights) in &view_lights {
         let draw_shadow_mesh = shadow_draw_functions.read().id::<DrawPrepass<M>>();
         for view_light_entity in view_lights.lights.iter().copied() {
-            let (light_entity, mut shadow_phase) =
-                view_light_shadow_phases.get_mut(view_light_entity).unwrap();
+            let (light_entity, shadow_phase) =
+                view_light_shadow_phases.get(view_light_entity).unwrap();
             let is_directional_light = matches!(light_entity, LightEntity::Directional { .. });
             let visible_entities = match light_entity {
                 LightEntity::Directional {

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -100,7 +100,7 @@ pub fn batch_and_prepare_render_phase<I: CachedRenderPipelinePhaseItem, F: GetBa
     };
 
     for mut phase in &mut views {
-        let items = phase.items.iter_mut().map(|item| {
+        let items = phase.iter_mut().map(|item| {
             let batch_data = process_item(item);
             (item.batch_range_mut(), batch_data)
         });

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -381,12 +381,12 @@ pub fn queue_material2d_meshes<M: Material2d>(
     render_materials: Res<RenderMaterials2d<M>>,
     mut render_mesh_instances: ResMut<RenderMesh2dInstances>,
     render_material_instances: Res<RenderMaterial2dInstances<M>>,
-    mut views: Query<(
+    views: Query<(
         &ExtractedView,
         &VisibleEntities,
         Option<&Tonemapping>,
         Option<&DebandDither>,
-        &mut RenderPhase<Transparent2d>,
+        &RenderPhase<Transparent2d>,
     )>,
 ) where
     M::Data: PartialEq + Eq + Hash + Clone,
@@ -395,7 +395,7 @@ pub fn queue_material2d_meshes<M: Material2d>(
         return;
     }
 
-    for (view, visible_entities, tonemapping, dither, mut transparent_phase) in &mut views {
+    for (view, visible_entities, tonemapping, dither, transparent_phase) in &views {
         let draw_transparent_pbr = transparent_draw_functions.read().id::<DrawMaterial2d<M>>();
 
         let mut view_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -687,14 +687,13 @@ pub fn queue_uinodes(
     extracted_uinodes: Res<ExtractedUiNodes>,
     ui_pipeline: Res<UiPipeline>,
     mut pipelines: ResMut<SpecializedRenderPipelines<UiPipeline>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<TransparentUi>)>,
+    views: Query<(&ExtractedView, &RenderPhase<TransparentUi>)>,
     pipeline_cache: Res<PipelineCache>,
     draw_functions: Res<DrawFunctions<TransparentUi>>,
 ) {
     let draw_function = draw_functions.read().id::<DrawUi>();
     for (entity, extracted_uinode) in extracted_uinodes.uinodes.iter() {
-        let Ok((view, mut transparent_phase)) = views.get_mut(extracted_uinode.camera_entity)
-        else {
+        let Ok((view, transparent_phase)) = views.get(extracted_uinode.camera_entity) else {
             continue;
         };
 
@@ -767,8 +766,8 @@ pub fn prepare_uinodes(
             let mut batch_item_index = 0;
             let mut batch_image_handle = AssetId::invalid();
 
-            for item_index in 0..ui_phase.items.len() {
-                let item = &mut ui_phase.items[item_index];
+            for item_index in 0..ui_phase.len() {
+                let item = &mut ui_phase[item_index];
                 if let Some(extracted_uinode) = extracted_uinodes.uinodes.get(&item.entity) {
                     let mut existing_batch = batches.last_mut();
 
@@ -949,7 +948,7 @@ pub fn prepare_uinodes(
                     }
                     index += QUAD_INDICES.len() as u32;
                     existing_batch.unwrap().1.range.end = index;
-                    ui_phase.items[batch_item_index].batch_range_mut().end += 1;
+                    ui_phase[batch_item_index].batch_range_mut().end += 1;
                 } else {
                     batch_image_handle = AssetId::invalid();
                 }

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -56,7 +56,7 @@ impl Node for UiPassNode {
         else {
             return Ok(());
         };
-        if transparent_phase.items.is_empty() {
+        if transparent_phase.is_empty() {
             return Ok(());
         }
 

--- a/crates/bevy_utils/src/parallel_queue.rs
+++ b/crates/bevy_utils/src/parallel_queue.rs
@@ -64,9 +64,17 @@ impl<T: Send> Parallel<Vec<T>> {
             .iter_mut()
             .map(|queue| queue.get_mut().len())
             .sum();
-        out.reserve(size);
+        if !out.is_empty() {
+            out.reserve(size);
+        }
         for queue in self.locals.iter_mut() {
-            out.append(queue.get_mut());
+            // Avoid copying if there's nothing in the output.
+            if out.is_empty() {
+                *out = queue.take();
+                out.reserve(size - out.len());
+            } else {
+                out.append(queue.get_mut());
+            }
         }
     }
 }

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -345,9 +345,9 @@ pub fn queue_colored_mesh2d(
     msaa: Res<Msaa>,
     render_meshes: Res<RenderAssets<Mesh>>,
     render_mesh_instances: Res<RenderMesh2dInstances>,
-    mut views: Query<(
+    views: Query<(
         &VisibleEntities,
-        &mut RenderPhase<Transparent2d>,
+        &RenderPhase<Transparent2d>,
         &ExtractedView,
     )>,
 ) {

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -355,7 +355,7 @@ pub fn queue_colored_mesh2d(
         return;
     }
     // Iterate each view (a camera is a view)
-    for (visible_entities, mut transparent_phase, view) in &mut views {
+    for (visible_entities, transparent_phase, view) in &views {
         let draw_colored_mesh2d = transparent_draw_functions.read().id::<DrawColoredMesh2d>();
 
         let mesh_key = Mesh2dPipelineKey::from_msaa_samples(msaa.samples())

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -117,13 +117,13 @@ fn queue_custom(
     meshes: Res<RenderAssets<Mesh>>,
     render_mesh_instances: Res<RenderMeshInstances>,
     material_meshes: Query<Entity, With<InstanceMaterialData>>,
-    mut views: Query<(&ExtractedView, &mut RenderPhase<Transparent3d>)>,
+    views: Query<(&ExtractedView, &RenderPhase<Transparent3d>)>,
 ) {
     let draw_custom = transparent_3d_draw_functions.read().id::<DrawCustom>();
 
     let msaa_key = MeshPipelineKey::from_msaa_samples(msaa.samples());
 
-    for (view, mut transparent_phase) in &mut views {
+    for (view, transparent_phase) in &views {
         let view_key = msaa_key | MeshPipelineKey::from_hdr(view.hdr);
         let rangefinder = view.rangefinder3d();
         for entity in &material_meshes {


### PR DESCRIPTION
# Objective
Part 2 on the quest to resolve #3548. Many of the queue and prepare systems are unable to run in parallel, creating a potential CPU bottleneck when dense and varied scenes.

## Solution
Use `Parallel`, introduced in #7348, to provide a cleaner implementation of #4899's thread-local queues, so systems can add phase items to the queue without needing a mutable reference to the render phase. As multiple systems with read-only access can parallelize under Bevy's system executor, many of these systems are "read-only" in the eyes of the scheduler, and thus do not block them from running in parallel with each other.

This potentially adds a bit of additional overhead on a per item basis, due to needing to fetch the thread-local queue for each item, though it may be mitigable by providing a `RenderPhase::extend` option that takes an iterator instead of adding items one by one.

As a additional optimization, this PR includes a change to `Parallel::drain_into` to avoid copying if the output `Vec` is known to be empty to avoid the copying overhead when there's only one system that enqueued items before sorting.

IMO, this design is *much* cleaner than the one in #4899, though it may be a bit rough to grok for people seeing it for the first time.

## Performance
TODO

---

## Changelog
Changed: `RenderPhase::add` now only requires a `
Changed: `RenderPhase`'s fields are now private

## Migration Guide
TODO