### PR TITLE
Remove the UpdateAssets and AssetEvents schedules

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -46,10 +46,10 @@ use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
     processor::{AssetProcessor, Process},
 };
-use bevy_app::{App, First, MainScheduleOrder, Plugin, PostUpdate};
+use bevy_app::{App, First, Plugin, PreUpdate};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
-    schedule::{IntoSystemConfigs, IntoSystemSetConfigs, ScheduleLabel, SystemSet},
+    schedule::{IntoSystemConfigs, IntoSystemSetConfigs, SystemSet},
     system::Resource,
     world::FromWorld,
 };
@@ -146,7 +146,6 @@ impl AssetPlugin {
 
 impl Plugin for AssetPlugin {
     fn build(&self, app: &mut App) {
-        app.init_schedule(UpdateAssets).init_schedule(AssetEvents);
         let embedded = EmbeddedAssetRegistry::default();
         {
             let mut sources = app
@@ -219,15 +218,11 @@ impl Plugin for AssetPlugin {
             .init_asset::<()>()
             .add_event::<UntypedAssetLoadFailedEvent>()
             .configure_sets(
-                UpdateAssets,
+                PreUpdate,
                 TrackAssets.after(handle_internal_asset_events),
             )
-            .add_systems(UpdateAssets, handle_internal_asset_events)
+            .add_systems(PreUpdate, handle_internal_asset_events)
             .register_type::<AssetPath>();
-
-        let mut order = app.world.resource_mut::<MainScheduleOrder>();
-        order.insert_after(First, UpdateAssets);
-        order.insert_after(PostUpdate, AssetEvents);
     }
 }
 
@@ -387,10 +382,12 @@ impl AssetApp for App {
             .register_type::<Handle<A>>()
             .register_type::<AssetId<A>>()
             .add_systems(
-                AssetEvents,
-                Assets::<A>::asset_events.run_if(Assets::<A>::asset_events_condition),
+                First,
+                Assets::<A>::asset_events
+                    .before(bevy_ecs::event::event_update_system::<AssetEvent::<A>>)
+                    .run_if(Assets::<A>::asset_events_condition),
             )
-            .add_systems(UpdateAssets, Assets::<A>::track_assets.in_set(TrackAssets))
+            .add_systems(PreUpdate, Assets::<A>::track_assets.in_set(TrackAssets))
     }
 
     fn register_asset_reflect<A>(&mut self) -> &mut Self
@@ -423,13 +420,13 @@ impl AssetApp for App {
 pub struct TrackAssets;
 
 /// Schedule where [`Assets`] resources are updated.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub struct UpdateAssets;
 
 /// Schedule where events accumulated in [`Assets`] are applied to the [`AssetEvent`] [`Events`] resource.
 ///
 /// [`Events`]: bevy_ecs::event::Events
-#[derive(Debug, Hash, PartialEq, Eq, Clone, ScheduleLabel)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub struct AssetEvents;
 
 #[cfg(test)]

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -382,7 +382,8 @@ impl AssetApp for App {
                 First,
                 Assets::<A>::asset_events
                     .before(bevy_ecs::event::event_update_system::<AssetEvent<A>>)
-                    .run_if(Assets::<A>::asset_events_condition),
+                    .run_if(Assets::<A>::asset_events_condition)
+                    .in_set(AssetEvents),
             )
             .add_systems(PreUpdate, Assets::<A>::track_assets.in_set(TrackAssets))
     }
@@ -416,11 +417,7 @@ impl AssetApp for App {
 #[derive(SystemSet, Hash, Debug, PartialEq, Eq, Clone)]
 pub struct TrackAssets;
 
-/// Schedule where [`Assets`] resources are updated.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-pub struct UpdateAssets;
-
-/// Schedule where events accumulated in [`Assets`] are applied to the [`AssetEvent`] [`Events`] resource.
+/// A system set where events accumulated in [`Assets`] are applied to the [`AssetEvent`] [`Events`] resource.
 ///
 /// [`Events`]: bevy_ecs::event::Events
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -217,10 +217,7 @@ impl Plugin for AssetPlugin {
             .init_asset::<LoadedUntypedAsset>()
             .init_asset::<()>()
             .add_event::<UntypedAssetLoadFailedEvent>()
-            .configure_sets(
-                PreUpdate,
-                TrackAssets.after(handle_internal_asset_events),
-            )
+            .configure_sets(PreUpdate, TrackAssets.after(handle_internal_asset_events))
             .add_systems(PreUpdate, handle_internal_asset_events)
             .register_type::<AssetPath>();
     }
@@ -384,7 +381,7 @@ impl AssetApp for App {
             .add_systems(
                 First,
                 Assets::<A>::asset_events
-                    .before(bevy_ecs::event::event_update_system::<AssetEvent::<A>>)
+                    .before(bevy_ecs::event::event_update_system::<AssetEvent<A>>)
                     .run_if(Assets::<A>::asset_events_condition),
             )
             .add_systems(PreUpdate, Assets::<A>::track_assets.in_set(TrackAssets))


### PR DESCRIPTION
# Objective
Fix #11845.

## Solution
Remove the `UpdateAssets` and `AssetEvents` schedules. Moved the `UpdateAssets` systems to `PreUpdate`, and `AssetEvents` systems into `First`. The former is meant to run before any of the event flushes.

## Future Work
It'd be ideal if we could manually flush the events for assets to avoid needing two, sort of redundant, systems. This should at least let them potentially run in parallel with all of the systems in the schedules they were moved to.

---

## Changelog
Removed: `UpdateAssets` schedule from the main schedule. All systems have been moved to `PreUpdate`.
Removed: `AssetEvents` schedule from the main schedule. All systems have been move to `First` with the same system sets.

## Migration Guide
TODO