### PR TITLE
guess image formats

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -24,7 +24,7 @@ use wgpu::{Extent3d, TextureDimension, TextureFormat, TextureViewDescriptor};
 pub const TEXTURE_ASSET_INDEX: u64 = 0;
 pub const SAMPLER_ASSET_INDEX: u64 = 1;
 
-#[derive(Debug, Serialize, Deserialize, Copy, Clone)]
+#[derive(Debug, Serialize, Deserialize, Copy, Clone, PartialEq, Eq)]
 pub enum ImageFormat {
     Avif,
     Basis,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -99,6 +99,26 @@ impl ImageFormat {
             ImageFormat::Basis | ImageFormat::Ktx2 => return None,
         })
     }
+
+    pub fn from_image_crate_format(format: image::ImageFormat) -> Option<Self> {
+        Some(match format {
+            image::ImageFormat::Avif => ImageFormat::Avif,
+            image::ImageFormat::Bmp => ImageFormat::Bmp,
+            image::ImageFormat::Dds => ImageFormat::Dds,
+            image::ImageFormat::Farbfeld => ImageFormat::Farbfeld,
+            image::ImageFormat::Gif => ImageFormat::Gif,
+            image::ImageFormat::OpenExr => ImageFormat::OpenExr,
+            image::ImageFormat::Hdr => ImageFormat::Hdr,
+            image::ImageFormat::Ico => ImageFormat::Ico,
+            image::ImageFormat::Jpeg => ImageFormat::Jpeg,
+            image::ImageFormat::Png => ImageFormat::Png,
+            image::ImageFormat::Pnm => ImageFormat::Pnm,
+            image::ImageFormat::Tga => ImageFormat::Tga,
+            image::ImageFormat::Tiff => ImageFormat::Tiff,
+            image::ImageFormat::WebP => ImageFormat::WebP,
+            _ => return None,
+        })
+    }
 }
 
 #[derive(Asset, Reflect, Debug, Clone)]
@@ -734,6 +754,8 @@ pub enum TextureError {
     InvalidImageMimeType(String),
     #[error("invalid image extension: {0}")]
     InvalidImageExtension(String),
+    #[error("invalid image content type: {0:?}")]
+    InvalidImageContentType(image::ImageFormat),
     #[error("failed to load an image: {0}")]
     ImageError(#[from] image::ImageError),
     #[error("unsupported texture format: {0}")]

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -85,12 +85,13 @@ impl ImageFormat {
             _ => return None,
         })
     }
+}
 
-    /// Attempts to convert to [`image::ImageFormat`].
-    ///
-    /// Unsupported formats will become [`None`].
-    pub fn as_image_crate_format(&self) -> Option<image::ImageFormat> {
-        Some(match self {
+impl TryFrom<ImageFormat> for image::ImageFormat {
+    type Error = ();
+
+    fn try_from(value: ImageFormat) -> Result<Self, Self::Error> {
+        Ok(match value {
             ImageFormat::Avif => image::ImageFormat::Avif,
             ImageFormat::Bmp => image::ImageFormat::Bmp,
             ImageFormat::Dds => image::ImageFormat::Dds,
@@ -105,15 +106,16 @@ impl ImageFormat {
             ImageFormat::Tga => image::ImageFormat::Tga,
             ImageFormat::Tiff => image::ImageFormat::Tiff,
             ImageFormat::WebP => image::ImageFormat::WebP,
-            ImageFormat::Basis | ImageFormat::Ktx2 => return None,
+            ImageFormat::Basis | ImageFormat::Ktx2 => return Err(()),
         })
     }
+}
 
-    /// Attempts to convert from [`image::ImageFormat`].
-    ///
-    /// Unsupported formats will become [`None`].
-    pub fn from_image_crate_format(format: image::ImageFormat) -> Option<Self> {
-        Some(match format {
+impl TryFrom<image::ImageFormat> for ImageFormat {
+    type Error = ();
+
+    fn try_from(value: image::ImageFormat) -> Result<Self, Self::Error> {
+        Ok(match value {
             image::ImageFormat::Avif => ImageFormat::Avif,
             image::ImageFormat::Bmp => ImageFormat::Bmp,
             image::ImageFormat::Dds => ImageFormat::Dds,
@@ -128,7 +130,7 @@ impl ImageFormat {
             image::ImageFormat::Tga => ImageFormat::Tga,
             image::ImageFormat::Tiff => ImageFormat::Tiff,
             image::ImageFormat::WebP => ImageFormat::WebP,
-            _ => return None,
+            _ => return Err(()),
         })
     }
 }
@@ -710,8 +712,8 @@ impl Image {
             }
             _ => {
                 let image_crate_format = format
-                    .as_image_crate_format()
-                    .ok_or_else(|| TextureError::UnsupportedTextureFormat(format!("{format:?}")))?;
+                    .try_into()
+                    .map_err(|_| TextureError::UnsupportedTextureFormat(format!("{format:?}")))?;
                 let mut reader = image::io::Reader::new(std::io::Cursor::new(buffer));
                 reader.set_format(image_crate_format);
                 reader.no_limits();

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -100,6 +100,9 @@ impl ImageFormat {
         })
     }
 
+    /// Attempts to convert from [`image::ImageFormat`].
+    ///
+    /// Unsupported formats will become [`None`].
     pub fn from_image_crate_format(format: image::ImageFormat) -> Option<Self> {
         Some(match format {
             image::ImageFormat::Avif => ImageFormat::Avif,

--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -45,6 +45,9 @@ pub enum ImageFormat {
 }
 
 impl ImageFormat {
+    /// Returns the image format for the given mime type.
+    ///
+    /// Unsupported formats will become [`None`].
     pub fn from_mime_type(mime_type: &str) -> Option<Self> {
         Some(match mime_type.to_ascii_lowercase().as_str() {
             "image/bmp" | "image/x-bmp" => ImageFormat::Bmp,
@@ -58,6 +61,9 @@ impl ImageFormat {
         })
     }
 
+    /// Returns the image format for the given extension.
+    ///
+    /// Unsupported formats will become [`None`].
     pub fn from_extension(extension: &str) -> Option<Self> {
         Some(match extension.to_ascii_lowercase().as_str() {
             "avif" => ImageFormat::Avif,
@@ -80,6 +86,9 @@ impl ImageFormat {
         })
     }
 
+    /// Attempts to convert to [`image::ImageFormat`].
+    ///
+    /// Unsupported formats will become [`None`].
     pub fn as_image_crate_format(&self) -> Option<image::ImageFormat> {
         Some(match self {
             ImageFormat::Avif => image::ImageFormat::Avif,

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -46,11 +46,17 @@ pub(crate) const IMG_FILE_EXTENSIONS: &[&str] = &[
     "ppm",
 ];
 
+/// The method for determining the [`ImageFormat`] of the loaded image.
+///
+/// By default we attempt to determine the format automatically from the header block of the binary data.
 #[derive(Serialize, Deserialize, Default, Debug)]
 pub enum ImageFormatSetting {
+    /// Determine the image format by inspecting the header block of the image binary data.
     #[default]
     FromContent,
+    /// Determine the image format from the filename extension.
     FromExtension,
+    /// Specify an explicit format for the image.
     Format(ImageFormat),
 }
 

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -109,13 +109,13 @@ impl AssetLoader for ImageLoader {
                     let image_crate_format =
                         image::guess_format(&bytes).map_err(|err| FileTextureError {
                             error: TextureError::ImageError(err),
-                            path: format!("{}", load_context.path().display()),
+                            path: load_context.path().display().to_string(),
                         })?;
 
                     let format = ImageFormat::from_image_crate_format(image_crate_format)
                         .ok_or_else(|| FileTextureError {
                             error: TextureError::InvalidImageContentType(image_crate_format),
-                            path: format!("{}", load_context.path().display()),
+                            path: load_context.path().display().to_string(),
                         })?;
                     ImageType::Format(format)
                 }
@@ -134,7 +134,7 @@ impl AssetLoader for ImageLoader {
             )
             .map_err(|err| FileTextureError {
                 error: err,
-                path: format!("{}", load_context.path().display()),
+                path: load_context.path().display().to_string(),
             })?)
         })
     }

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -115,8 +115,9 @@ impl AssetLoader for ImageLoader {
                             path: load_context.path().display().to_string(),
                         })?;
 
-                    let format = ImageFormat::from_image_crate_format(image_crate_format)
-                        .ok_or_else(|| FileTextureError {
+                    let format = image_crate_format
+                        .try_into()
+                        .map_err(|_| FileTextureError {
                             error: TextureError::InvalidImageContentType(image_crate_format),
                             path: load_context.path().display().to_string(),
                         })?;

--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -1,5 +1,6 @@
 use bevy_asset::{io::Reader, AssetLoader, AsyncReadExt, LoadContext};
 use bevy_ecs::prelude::{FromWorld, World};
+use bevy_log::warn;
 use thiserror::Error;
 
 use crate::{
@@ -18,6 +19,8 @@ pub struct ImageLoader {
 }
 
 pub(crate) const IMG_FILE_EXTENSIONS: &[&str] = &[
+    // special extension that doesn't map to any particular format. useful for loading assets of unknown format with ImageFormatSetting::FromContent
+    "image",
     #[cfg(feature = "basis-universal")]
     "basis",
     #[cfg(feature = "bmp")]
@@ -117,6 +120,14 @@ impl AssetLoader for ImageLoader {
                             error: TextureError::InvalidImageContentType(image_crate_format),
                             path: load_context.path().display().to_string(),
                         })?;
+
+                    // validate that the file format matches the content
+                    if let Some(ext_format) = ImageFormat::from_extension(ext) {
+                        if ext_format != format {
+                            warn!("mismatched format for {}, filename extension `{}` has content of type {:?}", load_context.path().display(), ext, format);
+                        }
+                    }
+
                     ImageType::Format(format)
                 }
                 ImageFormatSetting::FromExtension => ImageType::Extension(ext),


### PR DESCRIPTION
# Objective

provide an option to use `image::guess_format` to determine the image format, and make it the default. 

useful when loading images of unknown format (eg from urls without extension/mimetype), and more robust when loading mislabelled files.
