### PR TITLE
Save 16 bytes per MeshUniform in uniform/storage buffers

### DIFF
--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -201,6 +201,13 @@ pub struct MeshUniform {
     // Affine 4x3 matrices transposed to 3x4
     pub transform: [Vec4; 3],
     pub previous_transform: [Vec4; 3],
+    // 3x3 matrix packed in mat2x4 and f32 as:
+    //   [0].xyz, [1].x,
+    //   [1].yz, [2].xy
+    //   [2].z
+    pub inverse_transpose_model_a: [Vec4; 2],
+    pub inverse_transpose_model_b: f32,
+    pub flags: u32,
     // Four 16-bit unsigned normalized UV values packed into a `UVec2`:
     //
     //                         <--- MSB                   LSB --->
@@ -211,13 +218,6 @@ pub struct MeshUniform {
     //
     // (MSB: most significant bit; LSB: least significant bit.)
     pub lightmap_uv_rect: UVec2,
-    // 3x3 matrix packed in mat2x4 and f32 as:
-    //   [0].xyz, [1].x,
-    //   [1].yz, [2].xy
-    //   [2].z
-    pub inverse_transpose_model_a: [Vec4; 2],
-    pub inverse_transpose_model_b: f32,
-    pub flags: u32,
 }
 
 impl MeshUniform {


### PR DESCRIPTION
# Objective

- Save 16 bytes per MeshUniform in uniform/storage buffers.

## Solution

- Reorder members of MeshUniform to capitalise on alignment and size rules for tighter data packing. Before the size of a MeshUniform was 160 bytes, and after it is 144 bytes, saving 16 bytes of unused padding for alignment.

---

## Changelog

- Reduced the size of MeshUniform by 16 bytes.