### PR TITLE
Fix example docs on embedded_asset macro

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -183,7 +183,7 @@ pub fn _embedded_asset_path(
 /// # use bevy_asset::{Asset, AssetServer};
 /// # use bevy_reflect::TypePath;
 /// # let asset_server: AssetServer = panic!();
-/// #[derive(Asset, TypePath)]
+/// # #[derive(Asset, TypePath)]
 /// # struct Shader;
 /// let shader = asset_server.load::<Shader>("embedded://bevy_rock/render/rock.wgsl");
 /// ```


### PR DESCRIPTION
# Objective

The derive macro wasn't doc-commented, so it showed up in the generated doc as follow:

```rust
#[derive(Asset, TypePath)]
let shader = asset_server.load::<Shader>("embedded://bevy_rock/render/rock.wgsl");
```

Which is very confusing

## Solution

Comment the `derive` attribute as well