### PR TITLE
Update async-channel to 2.2.0

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -183,7 +183,7 @@ pub fn _embedded_asset_path(
 /// # use bevy_asset::{Asset, AssetServer};
 /// # use bevy_reflect::TypePath;
 /// # let asset_server: AssetServer = panic!();
-/// #[derive(Asset, TypePath)]
+/// # #[derive(Asset, TypePath)]
 /// # struct Shader;
 /// let shader = asset_server.load::<Shader>("embedded://bevy_rock/render/rock.wgsl");
 /// ```

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -22,7 +22,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.13.0" }
 bevy_utils = { path = "../bevy_utils", version = "0.13.0" }
 bevy_ecs_macros = { path = "macros", version = "0.13.0" }
 
-async-channel = "2.1.0"
+async-channel = "2.2.0"
 fixedbitset = "0.4.2"
 rustc-hash = "1.1"
 downcast-rs = "1.2"

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -93,7 +93,7 @@ encase = { version = "0.7", features = ["glam"] }
 profiling = { version = "1", features = [
   "profile-with-tracing",
 ], optional = true }
-async-channel = "2.1.0"
+async-channel = "2.2.0"
 
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -14,7 +14,7 @@ multi-threaded = []
 [dependencies]
 futures-lite = "2.0.1"
 async-executor = "1.7.2"
-async-channel = "2.1.0"
+async-channel = "2.2.0"
 async-io = { version = "2.0.0", optional = true }
 async-task = "4.2.0"
 concurrent-queue = "2.0.0"


### PR DESCRIPTION
# Objective

bevy 0.13 does not compile with async_channel 2.1.0

See

https://cdn.discordapp.com/attachments/1208557723973591051/1208557724229439518/image.png?ex=65e3b817&is=65d14317&hm=b0eccc620b3239d3f1c9ffff70aa6f149d3546a47fcd14f70ab5c0667144ecf5&

## Solution

Update async_channel to 2.2.0
