### PR TITLE
Use `embedded_asset` to load shaders

### DIFF
--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -8,7 +8,9 @@ use crate::io::{
     memory::{Dir, MemoryAssetReader, Value},
     AssetSource, AssetSourceBuilders,
 };
-use bevy_ecs::system::Resource;
+use crate::AssetServer;
+use bevy_app::App;
+use bevy_ecs::{system::Resource, world::World};
 use std::path::{Path, PathBuf};
 
 pub const EMBEDDED: &str = "embedded";
@@ -99,6 +101,71 @@ impl EmbeddedAssetRegistry {
     }
 }
 
+/// Trait for the [`load_embedded_asset!`] macro, to access [`AssetServer`]
+/// from arbitrary things.
+///
+/// [`load_embedded_asset!`]: crate::load_embedded_asset
+pub trait GetAssetServer {
+    fn get_asset_server(&self) -> &AssetServer;
+}
+impl GetAssetServer for App {
+    fn get_asset_server(&self) -> &AssetServer {
+        self.world.get_asset_server()
+    }
+}
+impl GetAssetServer for World {
+    fn get_asset_server(&self) -> &AssetServer {
+        self.resource()
+    }
+}
+impl GetAssetServer for AssetServer {
+    fn get_asset_server(&self) -> &AssetServer {
+        self
+    }
+}
+
+/// Load an [embedded asset](crate::embedded_asset).
+///
+/// This is useful if the embedded asset in question is not publicly exposed, but
+/// you need to use it internally.
+///
+/// # Syntax
+///
+/// This macro takes two arguments and an optional third one:
+/// 1. The asset source. It may be `AssetServer`, `World` or `App`.
+/// 2. The path to the asset to embed, as a string literal.
+/// 3. Optionally, a closure of the same type as in [`AssetServer::load_with_settings`].
+///    Consider explicitly typing the closure argument in case of type error.
+///
+/// # Usage
+///
+/// The advantage compared to using directly [`AssetServer::load`] is:
+/// - This also accepts [`World`] and [`App`] arguments.
+/// - This uses the exact same path as `embedded_asset!`, so you can keep it
+///   consistent.
+///
+/// As a rule of thumb:
+/// - If the asset in used in the same module as it is declared using `embedded_asset!`,
+///   use this macro.
+/// - Otherwise, use `AssetServer::load`.
+#[macro_export]
+macro_rules! load_embedded_asset {
+    (@get: $path: literal, $provider: expr) => {{
+        let path = $crate::embedded_path!($path);
+        let path = $crate::AssetPath::from_path_buf(path).with_source("embedded");
+        let asset_server = $crate::io::embedded::GetAssetServer::get_asset_server($provider);
+        (path, asset_server)
+    }};
+    ($provider: expr, $path: literal, $settings: expr) => {{
+        let (path, asset_server) = $crate::load_embedded_asset!(@get: $path, $provider);
+        asset_server.load_with_settings(path, $settings)
+    }};
+    ($provider: expr, $path: literal) => {{
+        let (path, asset_server) = $crate::load_embedded_asset!(@get: $path, $provider);
+        asset_server.load(path)
+    }};
+}
+
 /// Returns the [`Path`] for a given `embedded` asset.
 /// This is used internally by [`embedded_asset`] and can be used to get a [`Path`]
 /// that matches the [`AssetPath`](crate::AssetPath) used by that asset.
@@ -106,9 +173,9 @@ impl EmbeddedAssetRegistry {
 /// [`embedded_asset`]: crate::embedded_asset
 #[macro_export]
 macro_rules! embedded_path {
-    ($path_str: expr) => {{
-        embedded_path!("src", $path_str)
-    }};
+    ($path_str: expr) => {
+        $crate::embedded_path!("src", $path_str)
+    };
 
     ($source_path: expr, $path_str: expr) => {{
         let crate_name = module_path!().split(':').next().unwrap();
@@ -152,7 +219,7 @@ pub fn _embedded_asset_path(
 /// Creates a new `embedded` asset by embedding the bytes of the given path into the current binary
 /// and registering those bytes with the `embedded` [`AssetSource`].
 ///
-/// This accepts the current [`App`](bevy_app::App) as the first parameter and a path `&str` (relative to the current file) as the second.
+/// This accepts the current [`App`] as the first parameter and a path `&str` (relative to the current file) as the second.
 ///
 /// By default this will generate an [`AssetPath`] using the following rules:
 ///
@@ -177,14 +244,19 @@ pub fn _embedded_asset_path(
 ///
 /// `embedded_asset!(app, "rock.wgsl")`
 ///
-/// `rock.wgsl` can now be loaded by the [`AssetServer`](crate::AssetServer) with the following path:
+/// `rock.wgsl` can now be loaded by the [`AssetServer`] as follow:
 ///
 /// ```no_run
-/// # use bevy_asset::{Asset, AssetServer};
+/// # use bevy_asset::{Asset, AssetServer, load_embedded_asset};
 /// # use bevy_reflect::TypePath;
 /// # let asset_server: AssetServer = panic!();
 /// # #[derive(Asset, TypePath)]
 /// # struct Shader;
+/// // If we are loading the shader in the same module we used `embedded_asset!`:
+/// let shader = load_embedded_asset!(&asset_server, "rock.wgsl");
+/// # let _: bevy_asset::Handle<Shader> = shader;
+///
+/// // If the goal is to expose the asset **to the end user**:
 /// let shader = asset_server.load::<Shader>("embedded://bevy_rock/render/rock.wgsl");
 /// ```
 ///
@@ -218,11 +290,7 @@ pub fn _embedded_asset_path(
 /// [`embedded_path`]: crate::embedded_path
 #[macro_export]
 macro_rules! embedded_asset {
-    ($app: ident, $path: expr) => {{
-        $crate::embedded_asset!($app, "src", $path)
-    }};
-
-    ($app: ident, $source_path: expr, $path: expr) => {{
+    ($app: expr, $source_path: expr, $path: expr) => {{
         let mut embedded = $app
             .world
             .resource_mut::<$crate::io::embedded::EmbeddedAssetRegistry>();
@@ -230,6 +298,9 @@ macro_rules! embedded_asset {
         let watched_path = $crate::io::embedded::watched_path(file!(), $path);
         embedded.insert_asset(watched_path, &path, include_bytes!($path));
     }};
+    ($app: expr, $path: expr) => {
+        $crate::embedded_asset!($app, "src", $path)
+    };
 }
 
 /// Returns the path used by the watcher.

--- a/crates/bevy_asset/src/path.rs
+++ b/crates/bevy_asset/src/path.rs
@@ -222,6 +222,16 @@ impl<'a> AssetPath<'a> {
         Ok((source, path, label))
     }
 
+    /// Creates a new [`AssetPath`] from a [`PathBuf`].
+    #[inline]
+    pub fn from_path_buf(path_buf: PathBuf) -> AssetPath<'a> {
+        AssetPath {
+            path: CowArc::Owned(path_buf.into()),
+            source: AssetSourceId::Default,
+            label: None,
+        }
+    }
+
     /// Creates a new [`AssetPath`] from a [`Path`].
     #[inline]
     pub fn from_path(path: &'a Path) -> AssetPath<'a> {

--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -3,11 +3,12 @@ use crate::{
     prepass::{DeferredPrepass, ViewPrepassTextures},
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::load_embedded_asset;
 use bevy_ecs::prelude::*;
 use bevy_math::UVec2;
 use bevy_render::{
     camera::ExtractedCamera,
+    load_and_forget_shader,
     render_resource::{binding_types::texture_2d, *},
     renderer::RenderDevice,
     texture::{CachedTexture, TextureCache},
@@ -23,18 +24,11 @@ use bevy_render::{
 
 use super::DEFERRED_LIGHTING_PASS_ID_DEPTH_FORMAT;
 
-pub const COPY_DEFERRED_LIGHTING_ID_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(5230948520734987);
 pub struct CopyDeferredLightingIdPlugin;
 
 impl Plugin for CopyDeferredLightingIdPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            COPY_DEFERRED_LIGHTING_ID_SHADER_HANDLE,
-            "copy_deferred_lighting_id.wgsl",
-            Shader::from_wgsl
-        );
+        load_and_forget_shader!(app, "copy_deferred_lighting_id.wgsl");
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
         };
@@ -137,6 +131,7 @@ impl FromWorld for CopyDeferredLightingIdPipeline {
             ),
         );
 
+        let shader = load_embedded_asset!(world, "copy_deferred_lighting_id.wgsl");
         let pipeline_id =
             world
                 .resource_mut::<PipelineCache>()
@@ -145,7 +140,7 @@ impl FromWorld for CopyDeferredLightingIdPipeline {
                     layout: vec![layout.clone()],
                     vertex: fullscreen_shader_vertex_state(),
                     fragment: Some(FragmentState {
-                        shader: COPY_DEFERRED_LIGHTING_ID_SHADER_HANDLE,
+                        shader,
                         shader_defs: vec![],
                         entry_point: "fragment".into(),
                         targets: vec![],

--- a/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
+++ b/crates/bevy_core_pipeline/src/fullscreen_vertex_shader/mod.rs
@@ -1,6 +1,10 @@
 use bevy_asset::Handle;
 use bevy_render::{prelude::Shader, render_resource::VertexState};
 
+// TODO: Migrate this to the embedded setup.
+// Currently not possible, because it would require modifying
+// fullscreen_shader_vertex_state to accept context, which greatly increases
+// code complexity on user-side.
 pub const FULLSCREEN_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7837534426033940724);
 
 /// uses the [`FULLSCREEN_SHADER_HANDLE`] to output a

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -55,7 +55,7 @@ pub mod prelude {
 
 use aabb::AabbGizmoPlugin;
 use bevy_app::{App, Last, Plugin};
-use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
+use bevy_asset::{embedded_asset, Asset, AssetApp, Assets, Handle};
 use bevy_color::LinearRgba;
 use bevy_core::cast_slice;
 use bevy_ecs::{
@@ -76,7 +76,7 @@ use bevy_render::{
     render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::{
         binding_types::uniform_buffer, BindGroup, BindGroupEntries, BindGroupLayout,
-        BindGroupLayoutEntries, Buffer, BufferInitDescriptor, BufferUsages, Shader, ShaderStages,
+        BindGroupLayoutEntries, Buffer, BufferInitDescriptor, BufferUsages, ShaderStages,
         ShaderType, VertexAttribute, VertexBufferLayout, VertexFormat, VertexStepMode,
     },
     renderer::RenderDevice,
@@ -90,8 +90,6 @@ use gizmos::GizmoStorage;
 use light::LightGizmoPlugin;
 use std::{any::TypeId, mem};
 
-const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
-
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
 pub struct GizmoPlugin;
 
@@ -103,7 +101,7 @@ impl Plugin for GizmoPlugin {
             "bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one."
         );
 
-        load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
+        embedded_asset!(app, "lines.wgsl");
 
         app.register_type::<GizmoConfig>()
             .register_type::<GizmoConfigStore>()

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::GizmoMeshConfig, line_gizmo_vertex_buffer_layouts, DrawLineGizmo, GizmoRenderSystem,
-    LineGizmo, LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
+    LineGizmo, LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::Handle;
@@ -57,6 +57,7 @@ impl Plugin for LineGizmo2dPlugin {
 
 #[derive(Clone, Resource)]
 struct LineGizmoPipeline {
+    line_shader: Handle<Shader>,
     mesh_pipeline: Mesh2dPipeline,
     uniform_layout: BindGroupLayout,
 }
@@ -64,6 +65,7 @@ struct LineGizmoPipeline {
 impl FromWorld for LineGizmoPipeline {
     fn from_world(render_world: &mut World) -> Self {
         LineGizmoPipeline {
+            line_shader: bevy_asset::load_embedded_asset!(render_world, "lines.wgsl"),
             mesh_pipeline: render_world.resource::<Mesh2dPipeline>().clone(),
             uniform_layout: render_world
                 .resource::<LineGizmoUniformBindgroupLayout>()
@@ -101,13 +103,13 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: LINE_SHADER_HANDLE,
+                shader: self.line_shader.clone_weak(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: line_gizmo_vertex_buffer_layouts(key.strip),
             },
             fragment: Some(FragmentState {
-                shader: LINE_SHADER_HANDLE,
+                shader: self.line_shader.clone_weak(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -1,6 +1,6 @@
 use crate::{
     config::GizmoMeshConfig, line_gizmo_vertex_buffer_layouts, DrawLineGizmo, GizmoRenderSystem,
-    LineGizmo, LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup, LINE_SHADER_HANDLE,
+    LineGizmo, LineGizmoUniformBindgroupLayout, SetLineGizmoBindGroup,
 };
 use bevy_app::{App, Plugin};
 use bevy_asset::Handle;
@@ -59,6 +59,7 @@ impl Plugin for LineGizmo3dPlugin {
 
 #[derive(Clone, Resource)]
 struct LineGizmoPipeline {
+    line_shader: Handle<Shader>,
     mesh_pipeline: MeshPipeline,
     uniform_layout: BindGroupLayout,
 }
@@ -66,6 +67,7 @@ struct LineGizmoPipeline {
 impl FromWorld for LineGizmoPipeline {
     fn from_world(render_world: &mut World) -> Self {
         LineGizmoPipeline {
+            line_shader: bevy_asset::load_embedded_asset!(render_world, "lines.wgsl"),
             mesh_pipeline: render_world.resource::<MeshPipeline>().clone(),
             uniform_layout: render_world
                 .resource::<LineGizmoUniformBindgroupLayout>()
@@ -110,13 +112,13 @@ impl SpecializedRenderPipeline for LineGizmoPipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: LINE_SHADER_HANDLE,
+                shader: self.line_shader.clone_weak(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: line_gizmo_vertex_buffer_layouts(key.strip),
             },
             fragment: Some(FragmentState {
-                shader: LINE_SHADER_HANDLE,
+                shader: self.line_shader.clone_weak(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     ViewLightProbesUniformOffset,
 };
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, Handle};
+use bevy_asset::{embedded_asset, load_embedded_asset, Handle};
 use bevy_core_pipeline::{
     core_3d::graph::{Core3d, Node3d},
     deferred::{
@@ -32,9 +32,6 @@ use crate::{
 };
 
 pub struct DeferredPbrLightingPlugin;
-
-pub const DEFERRED_LIGHTING_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(2708011359337029741);
 
 pub const DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID: u8 = 1;
 
@@ -98,12 +95,7 @@ impl Plugin for DeferredPbrLightingPlugin {
         ))
         .add_systems(PostUpdate, insert_deferred_lighting_pass_id_component);
 
-        load_internal_asset!(
-            app,
-            DEFERRED_LIGHTING_SHADER_HANDLE,
-            "deferred_lighting.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "deferred_lighting.wgsl");
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;
@@ -229,6 +221,7 @@ impl ViewNode for DeferredOpaquePass3dPbrLightingNode {
 pub struct DeferredLightingLayout {
     mesh_pipeline: MeshPipeline,
     bind_group_layout_1: BindGroupLayout,
+    deferred_lighting_shader: Handle<Shader>,
 }
 
 #[derive(Component)]
@@ -324,13 +317,13 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
                 self.bind_group_layout_1.clone(),
             ],
             vertex: VertexState {
-                shader: DEFERRED_LIGHTING_SHADER_HANDLE,
+                shader: self.deferred_lighting_shader.clone_weak(),
                 shader_defs: shader_defs.clone(),
                 entry_point: "vertex".into(),
                 buffers: Vec::new(),
             },
             fragment: Some(FragmentState {
-                shader: DEFERRED_LIGHTING_SHADER_HANDLE,
+                shader: self.deferred_lighting_shader.clone_weak(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {
@@ -379,6 +372,7 @@ impl FromWorld for DeferredLightingLayout {
         Self {
             mesh_pipeline: world.resource::<MeshPipeline>().clone(),
             bind_group_layout_1: layout,
+            deferred_lighting_shader: load_embedded_asset!(world, "deferred_lighting.wgsl"),
         }
     }
 }

--- a/crates/bevy_pbr/src/light_probe/environment_map.rs
+++ b/crates/bevy_pbr/src/light_probe/environment_map.rs
@@ -56,8 +56,8 @@ use bevy_render::{
     prelude::SpatialBundle,
     render_asset::RenderAssets,
     render_resource::{
-        binding_types, BindGroupLayoutEntryBuilder, Sampler, SamplerBindingType, Shader,
-        TextureSampleType, TextureView,
+        binding_types, BindGroupLayoutEntryBuilder, Sampler, SamplerBindingType, TextureSampleType,
+        TextureView,
     },
     renderer::RenderDevice,
     texture::{FallbackImage, Image},
@@ -71,10 +71,6 @@ use crate::{
 };
 
 use super::{LightProbeComponent, RenderViewLightProbes};
-
-/// A handle to the environment map helper shader.
-pub const ENVIRONMENT_MAP_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(154476556247605696);
 
 /// A pair of cubemap textures that represent the surroundings of a specific
 /// area in space.

--- a/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
+++ b/crates/bevy_pbr/src/light_probe/irradiance_volume.rs
@@ -136,8 +136,8 @@ use bevy_ecs::component::Component;
 use bevy_render::{
     render_asset::RenderAssets,
     render_resource::{
-        binding_types, BindGroupLayoutEntryBuilder, Sampler, SamplerBindingType, Shader,
-        TextureSampleType, TextureView,
+        binding_types, BindGroupLayoutEntryBuilder, Sampler, SamplerBindingType, TextureSampleType,
+        TextureView,
     },
     renderer::RenderDevice,
     texture::{FallbackImage, Image},
@@ -153,9 +153,6 @@ use crate::{
 };
 
 use super::LightProbeComponent;
-
-pub const IRRADIANCE_VOLUME_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(160299515939076705258408299184317675488);
 
 /// On WebGL and WebGPU, we must disable irradiance volumes, as otherwise we can
 /// overflow the number of texture bindings when deferred rendering is in use

--- a/crates/bevy_pbr/src/light_probe/mod.rs
+++ b/crates/bevy_pbr/src/light_probe/mod.rs
@@ -1,7 +1,7 @@
 //! Light probes for baked global illumination.
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::AssetId;
 use bevy_core_pipeline::core_3d::Camera3d;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
@@ -16,9 +16,10 @@ use bevy_math::{Affine3A, Mat4, Vec3A, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     extract_instances::ExtractInstancesPlugin,
+    load_and_forget_shader,
     primitives::{Aabb, Frustum},
     render_asset::RenderAssets,
-    render_resource::{DynamicUniformBuffer, Sampler, Shader, ShaderType, TextureView},
+    render_resource::{DynamicUniformBuffer, Sampler, ShaderType, TextureView},
     renderer::{RenderDevice, RenderQueue},
     settings::WgpuFeatures,
     texture::{FallbackImage, Image},
@@ -31,16 +32,9 @@ use bevy_utils::{tracing::error, FloatOrd, HashMap};
 use std::hash::Hash;
 use std::ops::Deref;
 
-use crate::{
-    irradiance_volume::IRRADIANCE_VOLUME_SHADER_HANDLE,
-    light_probe::environment_map::{
-        EnvironmentMapIds, EnvironmentMapLight, ENVIRONMENT_MAP_SHADER_HANDLE,
-    },
-};
+use crate::light_probe::environment_map::{EnvironmentMapIds, EnvironmentMapLight};
 
 use self::irradiance_volume::IrradianceVolume;
-
-pub const LIGHT_PROBE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(8954249792581071582);
 
 pub mod environment_map;
 pub mod irradiance_volume;
@@ -298,24 +292,9 @@ impl LightProbe {
 
 impl Plugin for LightProbePlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            LIGHT_PROBE_SHADER_HANDLE,
-            "light_probe.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            ENVIRONMENT_MAP_SHADER_HANDLE,
-            "environment_map.wgsl",
-            Shader::from_wgsl
-        );
-        load_internal_asset!(
-            app,
-            IRRADIANCE_VOLUME_SHADER_HANDLE,
-            "irradiance_volume.wgsl",
-            Shader::from_wgsl
-        );
+        load_and_forget_shader!(app, "light_probe.wgsl");
+        load_and_forget_shader!(app, "environment_map.wgsl");
+        load_and_forget_shader!(app, "irradiance_volume.wgsl");
 
         app.register_type::<LightProbe>()
             .register_type::<EnvironmentMapLight>()

--- a/crates/bevy_pbr/src/lightmap/mod.rs
+++ b/crates/bevy_pbr/src/lightmap/mod.rs
@@ -29,7 +29,7 @@
 //! [`bevy-baked-gi`]: https://github.com/pcwalton/bevy-baked-gi
 
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{AssetId, Handle};
 use bevy_ecs::entity::EntityHashMap;
 use bevy_ecs::{
     component::Component,
@@ -40,17 +40,14 @@ use bevy_ecs::{
 };
 use bevy_math::{uvec2, vec4, Rect, UVec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_render::load_and_forget_shader;
 use bevy_render::{
-    mesh::Mesh, render_asset::RenderAssets, render_resource::Shader, texture::Image,
-    view::ViewVisibility, Extract, ExtractSchedule, RenderApp,
+    mesh::Mesh, render_asset::RenderAssets, texture::Image, view::ViewVisibility, Extract,
+    ExtractSchedule, RenderApp,
 };
 use bevy_utils::HashSet;
 
 use crate::RenderMeshInstances;
-
-/// The ID of the lightmap shader.
-pub const LIGHTMAP_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(285484768317531991932943596447919767152);
 
 /// A plugin that provides an implementation of lightmaps.
 pub struct LightmapPlugin;
@@ -117,12 +114,7 @@ pub struct RenderLightmaps {
 
 impl Plugin for LightmapPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            LIGHTMAP_SHADER_HANDLE,
-            "lightmap.wgsl",
-            Shader::from_wgsl
-        );
+        load_and_forget_shader!(app, "lightmap.wgsl");
     }
 
     fn finish(&self, app: &mut App) {

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -771,7 +771,7 @@ impl From<&StandardMaterial> for StandardMaterialKey {
 
 impl Material for StandardMaterial {
     fn fragment_shader() -> ShaderRef {
-        PBR_SHADER_HANDLE.into()
+        crate::shader_ref(bevy_asset::embedded_path!("render/pbr.wgsl"))
     }
 
     #[inline]
@@ -807,11 +807,11 @@ impl Material for StandardMaterial {
     }
 
     fn prepass_fragment_shader() -> ShaderRef {
-        PBR_PREPASS_SHADER_HANDLE.into()
+        crate::shader_ref(bevy_asset::embedded_path!("render/pbr_prepass.wgsl"))
     }
 
     fn deferred_fragment_shader() -> ShaderRef {
-        PBR_SHADER_HANDLE.into()
+        crate::shader_ref(bevy_asset::embedded_path!("render/pbr.wgsl"))
     }
 
     fn specialize(

--- a/crates/bevy_pbr/src/render/fog.rs
+++ b/crates/bevy_pbr/src/render/fog.rs
@@ -1,11 +1,11 @@
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
 use bevy_color::LinearRgba;
 use bevy_ecs::prelude::*;
 use bevy_math::{Vec3, Vec4};
 use bevy_render::{
     extract_component::ExtractComponentPlugin,
-    render_resource::{DynamicUniformBuffer, Shader, ShaderType},
+    load_and_forget_shader,
+    render_resource::{DynamicUniformBuffer, ShaderType},
     renderer::{RenderDevice, RenderQueue},
     view::ExtractedView,
     Render, RenderApp, RenderSet,
@@ -122,15 +122,12 @@ pub struct ViewFogUniformOffset {
     pub offset: u32,
 }
 
-/// Handle for the fog WGSL Shader internal asset
-pub const FOG_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(4913569193382610166);
-
 /// A plugin that consolidates fog extraction, preparation and related resources/assets
 pub struct FogPlugin;
 
 impl Plugin for FogPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(app, FOG_SHADER_HANDLE, "fog.wgsl", Shader::from_wgsl);
+        load_and_forget_shader!(app, "fog.wgsl");
 
         app.register_type::<FogSettings>();
         app.add_plugins(ExtractComponentPlugin::<FogSettings>::default());

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -1,6 +1,6 @@
 use crate::{Material, MaterialPipeline, MaterialPipelineKey, MaterialPlugin};
 use bevy_app::{Plugin, Startup, Update};
-use bevy_asset::{load_internal_asset, Asset, Assets, Handle};
+use bevy_asset::{embedded_asset, Asset, AssetPath, Assets, Handle};
 use bevy_color::{Color, LinearRgba};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
@@ -8,8 +8,6 @@ use bevy_render::{
     extract_resource::ExtractResource, mesh::MeshVertexBufferLayoutRef, prelude::*,
     render_resource::*,
 };
-
-pub const WIREFRAME_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(192598014480025766);
 
 /// A [`Plugin`] that draws wireframes.
 ///
@@ -24,12 +22,7 @@ pub const WIREFRAME_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(19259
 pub struct WireframePlugin;
 impl Plugin for WireframePlugin {
     fn build(&self, app: &mut bevy_app::App) {
-        load_internal_asset!(
-            app,
-            WIREFRAME_SHADER_HANDLE,
-            "render/wireframe.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "render/wireframe.wgsl");
 
         app.register_type::<Wireframe>()
             .register_type::<NoWireframe>()
@@ -203,7 +196,7 @@ pub struct WireframeMaterial {
 
 impl Material for WireframeMaterial {
     fn fragment_shader() -> ShaderRef {
-        WIREFRAME_SHADER_HANDLE.into()
+        ShaderRef::Path(AssetPath::parse("embedded://bevy_pbr/wireframe.wgsl"))
     }
 
     fn specialize(

--- a/crates/bevy_render/src/globals.rs
+++ b/crates/bevy_render/src/globals.rs
@@ -1,24 +1,21 @@
 use crate::{
     extract_resource::ExtractResource,
-    prelude::Shader,
+    load_and_forget_shader,
     render_resource::{ShaderType, UniformBuffer},
     renderer::{RenderDevice, RenderQueue},
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Handle};
 use bevy_core::FrameCount;
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
 use bevy_time::Time;
 
-pub const GLOBALS_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(17924628719070609599);
-
 pub struct GlobalsPlugin;
 
 impl Plugin for GlobalsPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(app, GLOBALS_TYPE_HANDLE, "globals.wgsl", Shader::from_wgsl);
+        load_and_forget_shader!(app, "globals.wgsl");
         app.register_type::<GlobalsUniform>();
 
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -136,7 +136,7 @@ struct ShaderCache {
     composer: naga_oil::compose::Composer,
 }
 
-#[derive(Clone, PartialEq, Eq, Debug, Hash)]
+#[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ShaderDefVal {
     Bool(String, bool),
     Int(String, i32),

--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -1,7 +1,6 @@
 pub mod visibility;
 pub mod window;
 
-use bevy_asset::{load_internal_asset, Handle};
 pub use visibility::*;
 pub use window::*;
 
@@ -11,7 +10,8 @@ use crate::{
         ManualTextureViews, MipBias, TemporalJitter,
     },
     extract_resource::{ExtractResource, ExtractResourcePlugin},
-    prelude::{Image, Shader},
+    load_and_forget_shader,
+    prelude::Image,
     primitives::Frustum,
     render_asset::RenderAssets,
     render_phase::ViewRangefinder3d,
@@ -35,13 +35,11 @@ use wgpu::{
     TextureDescriptor, TextureDimension, TextureFormat, TextureUsages,
 };
 
-pub const VIEW_TYPE_HANDLE: Handle<Shader> = Handle::weak_from_u128(15421373904451797197);
-
 pub struct ViewPlugin;
 
 impl Plugin for ViewPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(app, VIEW_TYPE_HANDLE, "view.wgsl", Shader::from_wgsl);
+        load_and_forget_shader!(app, "view.wgsl");
 
         app.register_type::<InheritedVisibility>()
             .register_type::<ViewVisibility>()

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,7 +1,7 @@
+//! Provides 2D sprite rendering functionality.
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
 
-//! Provides 2D sprite rendering functionality.
 mod bundle;
 mod dynamic_texture_atlas_builder;
 mod mesh2d;
@@ -36,14 +36,14 @@ pub use texture_atlas_builder::*;
 pub use texture_slice::*;
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetApp, Assets, Handle};
+use bevy_asset::{AssetApp, Assets, Handle};
 use bevy_core_pipeline::core_2d::Transparent2d;
 use bevy_ecs::prelude::*;
 use bevy_render::{
     mesh::Mesh,
     primitives::Aabb,
     render_phase::AddRenderCommand,
-    render_resource::{Shader, SpecializedRenderPipelines},
+    render_resource::SpecializedRenderPipelines,
     texture::Image,
     view::{NoFrustumCulling, VisibilitySystems},
     ExtractSchedule, Render, RenderApp, RenderSet,
@@ -52,8 +52,6 @@ use bevy_render::{
 /// Adds support for 2D sprite rendering.
 #[derive(Default)]
 pub struct SpritePlugin;
-
-pub const SPRITE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(2763343953151597127);
 
 /// System set for sprite rendering.
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
@@ -64,12 +62,7 @@ pub enum SpriteSystem {
 
 impl Plugin for SpritePlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            SPRITE_SHADER_HANDLE,
-            "render/sprite.wgsl",
-            Shader::from_wgsl
-        );
+        bevy_render::load_and_forget_shader!(app, "render/sprite.wgsl");
         app.init_asset::<TextureAtlasLayout>()
             .register_asset_reflect::<TextureAtlasLayout>()
             .register_type::<Sprite>()

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -1,25 +1,18 @@
 use crate::{Material2d, Material2dPlugin, MaterialMesh2dBundle};
+
 use bevy_app::{App, Plugin};
-use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
+use bevy_asset::{embedded_asset, Asset, AssetApp, AssetPath, Assets, Handle};
 use bevy_color::{Color, LinearRgba};
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
 use bevy_render::{render_asset::RenderAssets, render_resource::*, texture::Image};
-
-pub const COLOR_MATERIAL_SHADER_HANDLE: Handle<Shader> =
-    Handle::weak_from_u128(3253086872234592509);
 
 #[derive(Default)]
 pub struct ColorMaterialPlugin;
 
 impl Plugin for ColorMaterialPlugin {
     fn build(&self, app: &mut App) {
-        load_internal_asset!(
-            app,
-            COLOR_MATERIAL_SHADER_HANDLE,
-            "color_material.wgsl",
-            Shader::from_wgsl
-        );
+        embedded_asset!(app, "color_material.wgsl");
 
         app.add_plugins(Material2dPlugin::<ColorMaterial>::default())
             .register_asset_reflect::<ColorMaterial>();
@@ -105,7 +98,9 @@ impl AsBindGroupShaderType<ColorMaterialUniform> for ColorMaterial {
 
 impl Material2d for ColorMaterial {
     fn fragment_shader() -> ShaderRef {
-        COLOR_MATERIAL_SHADER_HANDLE.into()
+        ShaderRef::Path(AssetPath::parse(
+            "embedded://bevy_sprite/mesh2d/color_material.wgsl",
+        ))
     }
 }
 

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -2,9 +2,9 @@ use std::ops::Range;
 
 use crate::{
     texture_atlas::{TextureAtlas, TextureAtlasLayout},
-    ComputedTextureSlices, Sprite, SPRITE_SHADER_HANDLE,
+    ComputedTextureSlices, Sprite,
 };
-use bevy_asset::{AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{load_embedded_asset, AssetEvent, AssetId, Assets, Handle};
 use bevy_color::LinearRgba;
 use bevy_core_pipeline::{
     core_2d::Transparent2d,
@@ -46,6 +46,7 @@ pub struct SpritePipeline {
     view_layout: BindGroupLayout,
     material_layout: BindGroupLayout,
     pub dummy_white_gpu_image: GpuImage,
+    pub sprite_shader: Handle<Shader>,
 }
 
 impl FromWorld for SpritePipeline {
@@ -111,6 +112,7 @@ impl FromWorld for SpritePipeline {
             view_layout,
             material_layout,
             dummy_white_gpu_image,
+            sprite_shader: load_embedded_asset!(world, "sprite.wgsl"),
         }
     }
 }
@@ -256,13 +258,13 @@ impl SpecializedRenderPipeline for SpritePipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: SPRITE_SHADER_HANDLE,
+                shader: self.sprite_shader.clone_weak(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![instance_rate_vertex_buffer_layout],
             },
             fragment: Some(FragmentState {
-                shader: SPRITE_SHADER_HANDLE,
+                shader: self.sprite_shader.clone_weak(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -20,7 +20,7 @@ use crate::{
 };
 
 use bevy_app::prelude::*;
-use bevy_asset::{load_internal_asset, AssetEvent, AssetId, Assets, Handle};
+use bevy_asset::{embedded_asset, AssetEvent, AssetId, Assets};
 use bevy_ecs::entity::EntityHashMap;
 use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, Rect, URect, UVec4, Vec2, Vec3, Vec4Swizzles};
@@ -55,8 +55,6 @@ pub mod graph {
     }
 }
 
-pub const UI_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(13012847047162779583);
-
 #[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
 pub enum RenderUiSystem {
     ExtractBackgrounds,
@@ -66,7 +64,7 @@ pub enum RenderUiSystem {
 }
 
 pub fn build_ui_render(app: &mut App) {
-    load_internal_asset!(app, UI_SHADER_HANDLE, "ui.wgsl", Shader::from_wgsl);
+    embedded_asset!(app, "ui.wgsl");
 
     let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
         return;

--- a/crates/bevy_ui/src/render/pipeline.rs
+++ b/crates/bevy_ui/src/render/pipeline.rs
@@ -1,3 +1,4 @@
+use bevy_asset::{load_embedded_asset, Handle};
 use bevy_ecs::prelude::*;
 use bevy_render::{
     render_resource::{
@@ -13,6 +14,7 @@ use bevy_render::{
 pub struct UiPipeline {
     pub view_layout: BindGroupLayout,
     pub image_layout: BindGroupLayout,
+    pub ui_shader: Handle<Shader>,
 }
 
 impl FromWorld for UiPipeline {
@@ -41,6 +43,7 @@ impl FromWorld for UiPipeline {
         UiPipeline {
             view_layout,
             image_layout,
+            ui_shader: load_embedded_asset!(world, "ui.wgsl"),
         }
     }
 }
@@ -71,13 +74,13 @@ impl SpecializedRenderPipeline for UiPipeline {
 
         RenderPipelineDescriptor {
             vertex: VertexState {
-                shader: super::UI_SHADER_HANDLE,
+                shader: self.ui_shader.clone_weak(),
                 entry_point: "vertex".into(),
                 shader_defs: shader_defs.clone(),
                 buffers: vec![vertex_layout],
             },
             fragment: Some(FragmentState {
-                shader: super::UI_SHADER_HANDLE,
+                shader: self.ui_shader.clone_weak(),
                 shader_defs,
                 entry_point: "fragment".into(),
                 targets: vec![Some(ColorTargetState {


### PR DESCRIPTION
# Objective

It can be tedious to develop rendering features for bevy itself without hot reloading, currently bevy shaders do not support hot reloading as they never got migrated to the `embedded` asset source system.

## Solution

This allows hot-reloading the PBR shaders, making it easier to develop rendering features for bevy (how did anyone manage to get anything done without hot reloading???)

### Unresolved questions

* I modified the prepass `fragment_required` logic. I'm not sure the change makes sense
* Testing: By definition, this change touches every rendering features. I've tested a few examples, but I'm not sure it universally works.
* How much of a performance hit is this?
* Ways to avoid `std::mem::forget`-ing the `Handle`s?
* `FULLSCREEN_SHADER_HANDLE` and ability to get `fullscreen_shader_vertex_state` without additional context.

---

## Change log

* Added `AssetPath::from_path_buf`. Similar to `from_path`, but accepts `PathBuf` without additional cloning
* Added `load_embedded_asset!` and `GetAssetServer` trait to `bevy_asset`. Acts like `AssetServer::load` but with the same paths as `embedded_asset!` (which requires this to be a macro).
* Added `load_and_forget_shader!` to `bevy_render`.
* Removed most `FOO_BAR_SHADER_HANDLE`s from the public API.
* Added the `shader_defs` field to `ShaderSettings` to allow specifying the `#define` used in a shader when loading it.

## Migration Guide

All shader handles exported by bevy (in the form of `const FOO_BAR_SHADER_HANDLE`) have been removed. If you were using it for monkey-patching, consider using the material extension API.

If it is not possible, please open an issue, those handles were never meant for monkey patching, and if you used it for something that hasn't a replacement, it's probably a feature worth adding to bevy.