### PR TITLE
Improve lighting in more examples

### DIFF
--- a/examples/3d/skybox.rs
+++ b/examples/3d/skybox.rs
@@ -80,7 +80,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
         CameraController::default(),
         Skybox {
             image: skybox_handle.clone(),
-            brightness: 150.0,
+            brightness: 1000.0,
         },
     ));
 

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -121,6 +121,18 @@ fn setup(
         transform: Transform::from_xyz(-4.0, 5.0, 10.0).looking_at(Vec3::ZERO, Vec3::Y),
         ..default()
     });
+
+    commands.spawn(TextBundle::from_section(
+        "\
+Controls
+--------
+Horizontal Movement: Arrow Keys
+Vertical Movement: Space and Shift",
+        TextStyle {
+            font_size: 24.0,
+            ..default()
+        }
+    ));
 }
 
 fn light_sway(time: Res<Time>, mut query: Query<(&mut Transform, &mut SpotLight)>) {

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -27,11 +27,14 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
     // ground plane
-    commands.spawn(PbrBundle {
-        mesh: meshes.add(Plane3d::default().mesh().size(100.0, 100.0)),
-        material: materials.add(Color::WHITE),
-        ..default()
-    });
+    commands.spawn((
+        PbrBundle {
+            mesh: meshes.add(Plane3d::default().mesh().size(100.0, 100.0)),
+            material: materials.add(Color::WHITE),
+            ..default()
+        },
+        Movable,
+    ));
 
     // cubes
     let mut rng = StdRng::seed_from_u64(19878367467713);
@@ -139,27 +142,31 @@ fn movement(
     time: Res<Time>,
     mut query: Query<&mut Transform, With<Movable>>,
 ) {
-    for mut transform in &mut query {
-        let mut direction = Vec3::ZERO;
-        if input.pressed(KeyCode::ArrowUp) {
-            direction.z -= 1.0;
-        }
-        if input.pressed(KeyCode::ArrowDown) {
-            direction.z += 1.0;
-        }
-        if input.pressed(KeyCode::ArrowLeft) {
-            direction.x -= 1.0;
-        }
-        if input.pressed(KeyCode::ArrowRight) {
-            direction.x += 1.0;
-        }
-        if input.pressed(KeyCode::PageUp) {
-            direction.y += 1.0;
-        }
-        if input.pressed(KeyCode::PageDown) {
-            direction.y -= 1.0;
-        }
+    // Calculate translation to move the cubes and ground plane
+    let mut translation = Vec3::ZERO;
 
-        transform.translation += time.delta_seconds() * 2.0 * direction;
+    if input.pressed(KeyCode::ArrowUp) {
+        translation.z += 1.0;
+    } else if input.pressed(KeyCode::ArrowDown) {
+        translation.z -= 1.0;
+    }
+
+    if input.pressed(KeyCode::ArrowLeft) {
+        translation.x += 1.0;
+    } else if input.pressed(KeyCode::ArrowRight) {
+        translation.x -= 1.0;
+    }
+
+    if input.pressed(KeyCode::ShiftLeft) {
+        translation.y += 1.0;
+    } else if input.pressed(KeyCode::Space) {
+        translation.y -= 1.0;
+    }
+
+    translation *= 2.0 * time.delta_seconds();
+
+    // Apply translation
+    for mut transform in &mut query {
+        transform.translation += translation;
     }
 }

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -74,7 +74,7 @@ fn setup(
                     transform: Transform::from_xyz(1.0 + x, 2.0, z)
                         .looking_at(Vec3::new(1.0 + x, 0.0, z), Vec3::X),
                     spot_light: SpotLight {
-                        intensity: 4000.0, // lumens
+                        intensity: 40_000.0, // lumens
                         color: Color::WHITE,
                         shadows_enabled: true,
                         inner_angle: PI / 4.0 * 0.85,

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -37,20 +37,25 @@ fn setup(
     let mut rng = StdRng::seed_from_u64(19878367467713);
     let cube_mesh = meshes.add(Cuboid::new(0.5, 0.5, 0.5));
     let blue = materials.add(Color::rgb_u8(124, 144, 255));
-    for _ in 0..40 {
-        let x = rng.gen_range(-5.0..5.0);
-        let y = rng.gen_range(0.0..3.0);
-        let z = rng.gen_range(-5.0..5.0);
-        commands.spawn((
-            PbrBundle {
-                mesh: cube_mesh.clone(),
-                material: blue.clone(),
-                transform: Transform::from_xyz(x, y, z),
-                ..default()
-            },
-            Movable,
-        ));
-    }
+
+    commands.spawn_batch(
+        std::iter::repeat_with(move || {
+            let x = rng.gen_range(-5.0..5.0);
+            let y = rng.gen_range(0.0..3.0);
+            let z = rng.gen_range(-5.0..5.0);
+
+            (
+                PbrBundle {
+                    mesh: cube_mesh.clone(),
+                    material: blue.clone(),
+                    transform: Transform::from_xyz(x, y, z),
+                    ..default()
+                },
+                Movable,
+            )
+        })
+        .take(40),
+    );
 
     let sphere_mesh = meshes.add(Sphere::new(0.05).mesh().uv(32, 18));
     let sphere_mesh_direction = meshes.add(Sphere::new(0.1).mesh().uv(32, 18));
@@ -64,6 +69,8 @@ fn setup(
         emissive: Color::rgba_linear(50.0, 0.0, 0.0, 0.0),
         ..default()
     });
+
+    // TODO: Batch spawn
     for x in 0..4 {
         for z in 0..4 {
             let x = x as f32 - 2.0;

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -13,7 +13,7 @@ fn main() {
         })
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (light_sway, movement))
+        .add_systems(Update, (light_sway, movement, rotation))
         .run();
 }
 
@@ -126,12 +126,13 @@ fn setup(
         "\
 Controls
 --------
-Horizontal Movement: Arrow Keys
-Vertical Movement: Space and Shift",
+Horizontal Movement: WASD
+Vertical Movement: Space and Shift
+Rotate Camera: Left and Right Arrows",
         TextStyle {
             font_size: 24.0,
             ..default()
-        }
+        },
     ));
 }
 
@@ -157,18 +158,21 @@ fn movement(
     // Calculate translation to move the cubes and ground plane
     let mut translation = Vec3::ZERO;
 
-    if input.pressed(KeyCode::ArrowUp) {
+    // Horizontal forward and backward movement
+    if input.pressed(KeyCode::KeyW) {
         translation.z += 1.0;
-    } else if input.pressed(KeyCode::ArrowDown) {
+    } else if input.pressed(KeyCode::KeyS) {
         translation.z -= 1.0;
     }
 
-    if input.pressed(KeyCode::ArrowLeft) {
+    // Horizontal left and right movement
+    if input.pressed(KeyCode::KeyA) {
         translation.x += 1.0;
-    } else if input.pressed(KeyCode::ArrowRight) {
+    } else if input.pressed(KeyCode::KeyD) {
         translation.x -= 1.0;
     }
 
+    // Vertical movement
     if input.pressed(KeyCode::ShiftLeft) {
         translation.y += 1.0;
     } else if input.pressed(KeyCode::Space) {
@@ -180,5 +184,20 @@ fn movement(
     // Apply translation
     for mut transform in &mut query {
         transform.translation += translation;
+    }
+}
+
+fn rotation(
+    mut query: Query<&mut Transform, With<Camera>>,
+    input: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+) {
+    let mut transform = query.single_mut();
+    let delta = time.delta_seconds();
+
+    if input.pressed(KeyCode::ArrowLeft) {
+        transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(delta));
+    } else if input.pressed(KeyCode::ArrowRight) {
+        transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(-delta));
     }
 }

--- a/examples/animation/animated_transform.rs
+++ b/examples/animation/animated_transform.rs
@@ -28,6 +28,16 @@ fn setup(
         ..default()
     });
 
+    // Light
+    commands.spawn(PointLightBundle {
+        point_light: PointLight {
+            intensity: 500_000.0,
+            ..default()
+        },
+        transform: Transform::from_xyz(0.0, 2.5, 0.0),
+        ..default()
+    });
+
     // Let's use the `Name` component to target entities. We can use anything we
     // like, but names are convenient.
     let planet = Name::new("planet");

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -9,7 +9,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .insert_resource(AmbientLight {
-            brightness: 150.0,
+            brightness: 750.0,
             ..default()
         })
         .add_systems(Startup, setup)

--- a/examples/animation/gltf_skinned_mesh.rs
+++ b/examples/animation/gltf_skinned_mesh.rs
@@ -20,7 +20,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     // Create a camera
     commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::ZERO, Vec3::Y),
+        transform: Transform::from_xyz(-2.0, 2.5, 5.0).looking_at(Vec3::new(0.0, 1.0, 0.0), Vec3::Y),
         ..default()
     });
 


### PR DESCRIPTION
# Objective

- #11868 changed the lighting system, forcing lights to increase their intensity. The PR fixed most examples, but missed a few. These I later caught in https://github.com/bevyengine/bevy-website/pull/1023.
- Related: #11982, #11981.
- While there, I noticed that the spotlight example could use a few easy improvements.

## Solution

- Increase lighting in `skybox`, `spotlight`, `animated_transform`, and `gltf_skinned_mesh`.
- Improve spotlight example.
  - Make ground plane move with cubes, so they don't phase into each other.
  - Batch spawn cubes.
  - Add controls text.
  - Change controls to allow rotating around spotlights.

## Showcase

TODO :)

---

## Changelog

- Increased lighting in `skybox`, `spotlight`, `animated_transform`, and `gltf_skinned_mesh` examples.
- Improved usability of `spotlight` example.
