### PR TITLE
Create imported_assets directory with full path

### DIFF
--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -75,16 +75,15 @@ impl FileAssetWriter {
     ///
     /// See `get_base_path` below.
     pub fn new<P: AsRef<Path> + std::fmt::Debug>(path: P, create_root: bool) -> Self {
+        let root_path = get_base_path().join(path.as_ref());
         if create_root {
-            if let Err(e) = std::fs::create_dir_all(&path) {
+            if let Err(e) = std::fs::create_dir_all(&root_path) {
                 error!(
                     "Failed to create root directory {:?} for file asset writer: {:?}",
-                    path, e
+                    root_path, e
                 );
             }
         }
-        Self {
-            root_path: get_base_path().join(path.as_ref()),
-        }
+        Self { root_path }
     }
 }


### PR DESCRIPTION
# Objective

- The file asset source currently creates the `imported_assets/Default` directory with relative path, which leads to wrongly created directories when the executable is run with a working directory different from the project root.

## Solution

- Use the full path instead.