### PR TITLE
reflect: treat proxy types correctly when serializing

### DIFF
--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
-    TypeInfo, TypeRegistry, VariantInfo, VariantType,
+    Array, Enum, List, Map, Reflect, ReflectFromReflect, ReflectRef, ReflectSerialize, Struct,
+    Tuple, TupleStruct, TypeInfo, TypeRegistry, VariantInfo, VariantType,
 };
 use serde::ser::{
     Error, SerializeStruct, SerializeStructVariant, SerializeTuple, SerializeTupleStruct,
@@ -32,12 +32,19 @@ fn get_serializable<'a, E: Error>(
     reflect_value: &'a dyn Reflect,
     type_registry: &TypeRegistry,
 ) -> Result<Serializable<'a>, E> {
+    let info = reflect_value.get_represented_type_info().ok_or_else(|| {
+        Error::custom(format_args!(
+            "Type '{}' does not represent any type",
+            reflect_value.reflect_type_path(),
+        ))
+    })?;
+
     let reflect_serialize = type_registry
-        .get_type_data::<ReflectSerialize>(reflect_value.type_id())
+        .get_type_data::<ReflectSerialize>(info.type_id())
         .ok_or_else(|| {
             Error::custom(format_args!(
                 "Type '{}' did not register ReflectSerialize",
-                reflect_value.reflect_type_path()
+                info.type_path(),
             ))
         })?;
     Ok(reflect_serialize.get_serializable(reflect_value))

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Array, Enum, List, Map, Reflect, ReflectFromReflect, ReflectRef, ReflectSerialize, Struct,
-    Tuple, TupleStruct, TypeInfo, TypeRegistry, VariantInfo, VariantType,
+    Array, Enum, List, Map, Reflect, ReflectRef, ReflectSerialize, Struct, Tuple, TupleStruct,
+    TypeInfo, TypeRegistry, VariantInfo, VariantType,
 };
 use serde::ser::{
     Error, SerializeStruct, SerializeStructVariant, SerializeTuple, SerializeTupleStruct,

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -435,9 +435,7 @@ pub struct ReflectSerialize {
     get_serializable: for<'a> fn(value: &'a dyn Reflect) -> Serializable,
 }
 
-impl<T: TypePath + FromReflect + erased_serde::Serialize> FromType<T>
-    for ReflectSerialize
-{
+impl<T: TypePath + FromReflect + erased_serde::Serialize> FromType<T> for ReflectSerialize {
     fn from_type() -> Self {
         ReflectSerialize {
             get_serializable: |value| {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -435,7 +435,7 @@ pub struct ReflectSerialize {
     get_serializable: for<'a> fn(value: &'a dyn Reflect) -> Serializable,
 }
 
-impl<T: TypePath + Reflect + FromReflect + erased_serde::Serialize> FromType<T>
+impl<T: TypePath + FromReflect + erased_serde::Serialize> FromType<T>
     for ReflectSerialize
 {
     fn from_type() -> Self {

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -1,4 +1,4 @@
-use crate::{serde::Serializable, Reflect, TypeInfo, TypePath, Typed};
+use crate::{serde::Serializable, FromReflect, Reflect, TypeInfo, TypePath, Typed};
 use bevy_ptr::{Ptr, PtrMut};
 use bevy_utils::{HashMap, HashSet, TypeIdMap};
 use downcast_rs::{impl_downcast, Downcast};
@@ -435,14 +435,22 @@ pub struct ReflectSerialize {
     get_serializable: for<'a> fn(value: &'a dyn Reflect) -> Serializable,
 }
 
-impl<T: Reflect + erased_serde::Serialize> FromType<T> for ReflectSerialize {
+impl<T: TypePath + Reflect + FromReflect + erased_serde::Serialize> FromType<T>
+    for ReflectSerialize
+{
     fn from_type() -> Self {
         ReflectSerialize {
             get_serializable: |value| {
-                let value = value.downcast_ref::<T>().unwrap_or_else(|| {
-                    panic!("ReflectSerialize::get_serialize called with type `{}`, even though it was created for `{}`", value.reflect_type_path(), std::any::type_name::<T>())
-                });
-                Serializable::Borrowed(value)
+                value
+                    .downcast_ref::<T>()
+                    .map(|value| Serializable::Borrowed(value))
+                    .or_else(|| T::from_reflect(value).map(|value| Serializable::Owned(Box::new(value))))
+                    .unwrap_or_else(|| {
+                        panic!(
+                            "FromReflect::from_reflect failed when called on type `{}` with this value: {value:?}",
+                            T::type_path(),
+                        );
+                    })
             },
         }
     }

--- a/examples/scene/scene.rs
+++ b/examples/scene/scene.rs
@@ -114,6 +114,7 @@ fn save_scene_system(world: &mut World) {
         component_b,
         ComponentA { x: 1.0, y: 2.0 },
         Transform::IDENTITY,
+        Name::new("joe"),
     ));
     scene_world.spawn(ComponentA { x: 3.0, y: 4.0 });
     scene_world.insert_resource(ResourceA { score: 1 });


### PR DESCRIPTION
# Objective

- Fixes #12001.
- Note this PR doesn't change any feature flags, however flaky the issue revealed they are.

## Solution

- Use `FromReflect` to convert proxy types to concrete ones in `ReflectSerialize::get_serializable`.
- Use `get_represented_type_info() -> type_id()` to get the correct type id to interact with the registry in `bevy_reflect::serde::ser::get_serializable`.

---

## Changelog

- Registering `ReflectSerialize` now imposes additional `FromReflect` and `TypePath` bounds.

## Migration Guide

- If `ReflectSerialize` is registered on a type, but `TypePath` or `FromReflect` implementations are omitted (perhaps by `#[reflect(type_path = false)` or `#[reflect(from_reflect = false)]`), the traits must now be implemented.
