### PR TITLE
Parse missing mime types

### DIFF
--- a/crates/bevy_render/src/texture/image.rs
+++ b/crates/bevy_render/src/texture/image.rs
@@ -47,13 +47,23 @@ pub enum ImageFormat {
 impl ImageFormat {
     pub fn from_mime_type(mime_type: &str) -> Option<Self> {
         Some(match mime_type.to_ascii_lowercase().as_str() {
+            "image/avif" => ImageFormat::Avif,
             "image/bmp" | "image/x-bmp" => ImageFormat::Bmp,
             "image/vnd-ms.dds" => ImageFormat::Dds,
+            "image/vnd.radiance" => ImageFormat::Hdr,
+            "image/gif" => ImageFormat::Gif,
+            "image/x-icon" => ImageFormat::Ico,
             "image/jpeg" => ImageFormat::Jpeg,
             "image/ktx2" => ImageFormat::Ktx2,
             "image/png" => ImageFormat::Png,
             "image/x-exr" => ImageFormat::OpenExr,
+            "image/x-portable-bitmap"
+            | "image/x-portable-graymap"
+            | "image/x-portable-pixmap"
+            | "image/x-portable-anymap" => ImageFormat::Pnm,
             "image/x-targa" | "image/x-tga" => ImageFormat::Tga,
+            "image/tiff" => ImageFormat::Tiff,
+            "image/webp" => ImageFormat::WebP,
             _ => return None,
         })
     }


### PR DESCRIPTION
# Objective

This PR adds some missing mime types to the `ImageFormat::from_mime_type` method. As discussed [in this comment on the Discord Bevy community](https://discord.com/channels/691052431525675048/691052431974465548/1209904290227949729):

> It's strange that Bevy supports parsing `ImageFormat::WebP` from a .webp str extension in the method below, but not from the mime type.
> 
> In comparison, the image crate does parse it: https://github.com/image-rs/image/blob/master/src/image.rs#L170

# Solution

For each of the missing mime types, I added them based on the `ImageFormat::from_mime_type` of the image crate: https://github.com/image-rs/image/blob/master/src/image.rs#L209, except for `ImageFormat::Basis` and `ImageFormat::Ktx2` which are not present in the image crate, and I ignore if they have a mime type or not*

\* apparently nowadays there is an official mime type: `image/ktx2` https://www.iana.org/assignments/media-types/image/ktx2

Any feedback is welcome! I thought of refactoring a bit more and delegating the mime type parsing to the image crate (and possibly the same for extensions), let me know if that's desired 🙂 
