### PR TITLE
Fix `SystemTypeSet::system_type` being out of sync with `System::type_id`

### DIFF
--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -9,7 +9,8 @@ use bevy_utils::intern::Interned;
 pub use bevy_utils::label::DynEq;
 
 use crate::system::{
-    ExclusiveSystemParamFunction, IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
+    ExclusiveFunctionSystem, ExclusiveSystemParamFunction, FunctionSystem,
+    IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
 };
 
 define_label!(
@@ -167,26 +168,28 @@ impl<S: SystemSet> IntoSystemSet<()> for S {
 // systems
 impl<Marker, F> IntoSystemSet<(IsFunctionSystem, Marker)> for F
 where
+    Marker: 'static,
     F: SystemParamFunction<Marker>,
 {
-    type Set = SystemTypeSet<Self>;
+    type Set = SystemTypeSet<FunctionSystem<Marker, F>>;
 
     #[inline]
     fn into_system_set(self) -> Self::Set {
-        SystemTypeSet::new()
+        SystemTypeSet::<FunctionSystem<Marker, F>>::new()
     }
 }
 
 // exclusive systems
 impl<Marker, F> IntoSystemSet<(IsExclusiveFunctionSystem, Marker)> for F
 where
+    Marker: 'static,
     F: ExclusiveSystemParamFunction<Marker>,
 {
-    type Set = SystemTypeSet<Self>;
+    type Set = SystemTypeSet<ExclusiveFunctionSystem<Marker, F>>;
 
     #[inline]
     fn into_system_set(self) -> Self::Set {
-        SystemTypeSet::new()
+        SystemTypeSet::<ExclusiveFunctionSystem<Marker, F>>::new()
     }
 }
 

--- a/crates/bevy_ecs/src/system/exclusive_function_system.rs
+++ b/crates/bevy_ecs/src/system/exclusive_function_system.rs
@@ -143,7 +143,7 @@ where
     }
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
-        let set = crate::schedule::SystemTypeSet::<F>::new();
+        let set = crate::schedule::SystemTypeSet::<Self>::new();
         vec![set.intern()]
     }
 

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -536,7 +536,7 @@ where
     }
 
     fn default_system_sets(&self) -> Vec<InternedSystemSet> {
-        let set = crate::schedule::SystemTypeSet::<F>::new();
+        let set = crate::schedule::SystemTypeSet::<Self>::new();
         vec![set.intern()]
     }
 


### PR DESCRIPTION
## Objective

Always have `some_system.into_system().type_id() == some_system.into_system_set().system_type().unwrap()`.

System sets have a `fn system_type() -> Option<TypeId>` that is implemented by  `SystemTypeSet` to returning the TypeId of the system's function type. This was implemented in https://github.com/bevyengine/bevy/pull/7715 and is used in `bevy_mod_debugdump` to handle `.after(function)` constraints.

Back then, `System::type_id` always also returned the type id of the function item, not of `FunctionSystem<M, F>`.

https://github.com/bevyengine/bevy/pull/11728 changes the behaviour of `System::type_id` so that it returns the id of the `FunctionSystem`/`ExclusiveFunctionSystem` wrapper, but it did not change `SystemTypeSet::system_type`, so doing the lookup breaks in `bevy_mod_debugdump`.

## Solution

Change `IntoSystemSet` for functions to return a `SystemTypeSet<FunctionSystem>` / `SystemTypeSet<ExclusiveFunctionSystem>` instead of `SystemTypeSet<F>`.