### PR TITLE
Make Globals visible in vertex shaders

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -250,7 +250,10 @@ fn layout_entries(
                 ),
             ),
             // Globals
-            (9, uniform_buffer::<GlobalsUniform>(false)),
+            (
+                9,
+                uniform_buffer::<GlobalsUniform>(false).visibility(ShaderStages::VERTEX_FRAGMENT),
+            ),
             // Fog
             (10, uniform_buffer::<GpuFog>(true)),
             // Light probes


### PR DESCRIPTION
# Objective

- Globals are supposed to be available in vertex shader but that was mistakenly removed in 0.13

## Solution

- Configure the visibility of the globals correctly

Fixes https://github.com/bevyengine/bevy/issues/12015