### PR TITLE
Increase modularity of bevy by making more features optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -114,6 +114,7 @@ bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
 bevy_a11y = ["bevy_internal/bevy_a11y"]
 bevy_input = ["bevy_internal/bevy_input"]
 bevy_window = ["bevy_internal/bevy_window"]
+bevy_transform = ["bevy_internal/bevy_transform"]
 
 # Adds PBR rendering
 bevy_pbr = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ workspace = true
 [features]
 default = [
   "animation",
+  "bevy_a11y",
   "bevy_asset",
   "bevy_audio",
   "bevy_gilrs",
@@ -64,7 +65,7 @@ default = [
   "bevy_gltf",
   "bevy_render",
   "bevy_sprite",
-  "bevy_a11y",
+  "bevy_transform",
   "bevy_input",
   "bevy_window",
   "bevy_text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ default = [
   "bevy_gltf",
   "bevy_render",
   "bevy_sprite",
+  "bevy_a11y",
+  "bevy_input",
+  "bevy_window",
   "bevy_text",
   "bevy_ui",
   "multi-threaded",
@@ -106,6 +109,10 @@ bevy_gilrs = ["bevy_internal/bevy_gilrs"]
 
 # [glTF](https://www.khronos.org/gltf/) support
 bevy_gltf = ["bevy_internal/bevy_gltf", "bevy_asset", "bevy_scene", "bevy_pbr"]
+
+bevy_a11y = ["bevy_internal/bevy_a11y"]
+bevy_input = ["bevy_internal/bevy_input"]
+bevy_window = ["bevy_internal/bevy_window"]
 
 # Adds PBR rendering
 bevy_pbr = [

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -162,14 +162,12 @@ bevy_debug_stepping = [
 
 [dependencies]
 # bevy
-bevy_a11y = { path = "../bevy_a11y", version = "0.14.0-dev" }
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_diagnostic = { path = "../bevy_diagnostic", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
-bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.14.0-dev" }
@@ -177,18 +175,19 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
 ] }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
-bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
-bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 # bevy (optional)
+bevy_a11y = { path = "../bevy_a11y", optional = true, version = "0.14.0-dev" }
 bevy_animation = { path = "../bevy_animation", optional = true, version = "0.14.0-dev" }
 bevy_asset = { path = "../bevy_asset", optional = true, version = "0.14.0-dev" }
 bevy_audio = { path = "../bevy_audio", optional = true, version = "0.14.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.14.0-dev" }
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.14.0-dev" }
+bevy_input = { path = "../bevy_input", optional = true, version = "0.14.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.14.0-dev" }
 bevy_render = { path = "../bevy_render", optional = true, version = "0.14.0-dev" }
+bevy_transform = { path = "../bevy_transform", optional = true, version = "0.14.0-dev" }
 bevy_dynamic_plugin = { path = "../bevy_dynamic_plugin", optional = true, version = "0.14.0-dev" }
 bevy_scene = { path = "../bevy_scene", optional = true, version = "0.14.0-dev" }
 bevy_sprite = { path = "../bevy_sprite", optional = true, version = "0.14.0-dev" }
@@ -197,6 +196,7 @@ bevy_ui = { path = "../bevy_ui", optional = true, version = "0.14.0-dev" }
 bevy_winit = { path = "../bevy_winit", optional = true, version = "0.14.0-dev" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.14.0-dev" }
 bevy_gizmos = { path = "../bevy_gizmos", optional = true, version = "0.14.0-dev", default-features = false }
+bevy_window = { path = "../bevy_window", optional = true, version = "0.14.0-dev" }
 
 [lints]
 workspace = true

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -51,9 +51,9 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_a11y")]
         {
-            group = group.add(bevy_a11y::AccessibilityPlugin);            
+            group = group.add(bevy_a11y::AccessibilityPlugin);
         }
-        
+
         #[cfg(feature = "bevy_asset")]
         {
             group = group.add(bevy_asset::AssetPlugin::default());
@@ -61,12 +61,12 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_input")]
         {
-            group = group.add(bevy_input::InputPlugin);            
+            group = group.add(bevy_input::InputPlugin);
         }
 
         #[cfg(feature = "bevy_transform")]
         {
-            group = group.add(bevy_transform::TransformPlugin);            
+            group = group.add(bevy_transform::TransformPlugin);
         }
 
         #[cfg(feature = "bevy_scene")]
@@ -147,7 +147,7 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_window")]
         {
-            group = group.add(bevy_window::WindowPlugin::default());            
+            group = group.add(bevy_window::WindowPlugin::default());
         }
 
         group = group.add(IgnoreAmbiguitiesPlugin);

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -46,16 +46,27 @@ impl PluginGroup for DefaultPlugins {
             .add(bevy_core::TypeRegistrationPlugin)
             .add(bevy_core::FrameCountPlugin)
             .add(bevy_time::TimePlugin)
-            .add(bevy_transform::TransformPlugin)
             .add(bevy_hierarchy::HierarchyPlugin)
-            .add(bevy_diagnostic::DiagnosticsPlugin)
-            .add(bevy_input::InputPlugin)
-            .add(bevy_window::WindowPlugin::default())
-            .add(bevy_a11y::AccessibilityPlugin);
+            .add(bevy_diagnostic::DiagnosticsPlugin);
 
+        #[cfg(feature = "bevy_a11y")]
+        {
+            group = group.add(bevy_a11y::AccessibilityPlugin);            
+        }
+        
         #[cfg(feature = "bevy_asset")]
         {
             group = group.add(bevy_asset::AssetPlugin::default());
+        }
+
+        #[cfg(feature = "bevy_input")]
+        {
+            group = group.add(bevy_input::Input);            
+        }
+
+        #[cfg(feature = "bevy_transform")]
+        {
+            group = group.add(bevy_transform::TransformPlugin);            
         }
 
         #[cfg(feature = "bevy_scene")]
@@ -132,6 +143,11 @@ impl PluginGroup for DefaultPlugins {
         #[cfg(feature = "bevy_gizmos")]
         {
             group = group.add(bevy_gizmos::GizmoPlugin);
+        }
+
+        #[cfg(feature = "bevy_window")]
+        {
+            group = group.add(bevy_window::WindowPlugin::default());            
         }
 
         group = group.add(IgnoreAmbiguitiesPlugin);

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -61,7 +61,7 @@ impl PluginGroup for DefaultPlugins {
 
         #[cfg(feature = "bevy_input")]
         {
-            group = group.add(bevy_input::Input);            
+            group = group.add(bevy_input::InputPlugin);            
         }
 
         #[cfg(feature = "bevy_transform")]

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -49,11 +49,6 @@ impl PluginGroup for DefaultPlugins {
             .add(bevy_hierarchy::HierarchyPlugin)
             .add(bevy_diagnostic::DiagnosticsPlugin);
 
-        #[cfg(feature = "bevy_a11y")]
-        {
-            group = group.add(bevy_a11y::AccessibilityPlugin);
-        }
-
         #[cfg(feature = "bevy_asset")]
         {
             group = group.add(bevy_asset::AssetPlugin::default());
@@ -148,6 +143,11 @@ impl PluginGroup for DefaultPlugins {
         #[cfg(feature = "bevy_window")]
         {
             group = group.add(bevy_window::WindowPlugin::default());
+        }
+
+        #[cfg(feature = "bevy_a11y")]
+        {
+            group = group.add(bevy_a11y::AccessibilityPlugin);
         }
 
         group = group.add(IgnoreAmbiguitiesPlugin);

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -6,6 +6,7 @@ pub mod prelude;
 mod default_plugins;
 pub use default_plugins::*;
 
+#[cfg(feature = "bevy_a11y")]
 pub mod a11y {
     //! Integrate with platform accessibility APIs.
     pub use bevy_a11y::*;
@@ -37,6 +38,7 @@ pub mod ecs {
     pub use bevy_ecs::*;
 }
 
+#[cfg(feature = "bevy_input")]
 pub mod input {
     //! Resources and events for inputs, e.g. mouse/keyboard, touch, gamepads, etc.
     pub use bevy_input::*;
@@ -83,6 +85,7 @@ pub mod hierarchy {
     pub use bevy_hierarchy::*;
 }
 
+#[cfg(feature = "bevy_transform")]
 pub mod transform {
     //! Local and global transforms (e.g. translation, scale, rotation).
     pub use bevy_transform::*;
@@ -93,6 +96,7 @@ pub mod utils {
     pub use bevy_utils::*;
 }
 
+#[cfg(feature = "bevy_window")]
 pub mod window {
     //! Configuration, creation, and management of one or more windows.
     pub use bevy_window::*;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,8 +1,8 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, input::prelude::*,
-    log::prelude::*, math::prelude::*, reflect::prelude::*, time::prelude::*,
-    transform::prelude::*, utils::prelude::*, window::prelude::*, DefaultPlugins, MinimalPlugins,
+    app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, log::prelude::*, 
+    math::prelude::*, reflect::prelude::*, time::prelude::*, utils::prelude::*, 
+    DefaultPlugins, MinimalPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};
@@ -22,6 +22,14 @@ pub use crate::animation::prelude::*;
 #[doc(hidden)]
 #[cfg(feature = "bevy_core_pipeline")]
 pub use crate::core_pipeline::prelude::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_input")]
+pub use crate::input::prelude::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_transform")]
+pub use crate::transform::prelude::*;
 
 #[doc(hidden)]
 #[cfg(feature = "bevy_pbr")]
@@ -58,3 +66,7 @@ pub use crate::gizmos::prelude::*;
 #[doc(hidden)]
 #[cfg(feature = "bevy_gilrs")]
 pub use crate::gilrs::*;
+
+#[doc(hidden)]
+#[cfg(feature = "bevy_window")]
+pub use crate::window::prelude::*;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -1,8 +1,8 @@
 #[doc(hidden)]
 pub use crate::{
-    app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, log::prelude::*, 
-    math::prelude::*, reflect::prelude::*, time::prelude::*, utils::prelude::*, 
-    DefaultPlugins, MinimalPlugins,
+    app::prelude::*, core::prelude::*, ecs::prelude::*, hierarchy::prelude::*, log::prelude::*,
+    math::prelude::*, reflect::prelude::*, time::prelude::*, utils::prelude::*, DefaultPlugins,
+    MinimalPlugins,
 };
 
 pub use bevy_derive::{bevy_main, Deref, DerefMut};


### PR DESCRIPTION
# Objective

Increase the modularity of bevy by making additional features optional.

Make the following features optional
* bevy_window
* bevy_input
* bevy_transform
* bevy_a11y

Future tasks
* make sysinfo optional
* make bevy_math optional
* consider making others optional

## Changelog

## Migration Guide

The following crates have been made optional:

* bevy_window
* bevy_a11y
* bevy_input
* bevy_transform

In projects that use use bevy with `default-features = false` you will want to enable with respective feature(s) above as required in your project.
