### PR TITLE
Allow re-use of an existing audio sink.

### DIFF
--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -85,7 +85,7 @@ pub trait AudioSinkPlayback {
 /// that source is unchanged, that translates to the audio restarting.
 #[derive(Component)]
 pub struct AudioSink {
-    pub(crate) sink: Sink,
+    pub sink: Sink,
 }
 
 impl AudioSinkPlayback for AudioSink {

--- a/crates/bevy_audio/src/sinks.rs
+++ b/crates/bevy_audio/src/sinks.rs
@@ -138,7 +138,7 @@ impl AudioSinkPlayback for AudioSink {
 /// that source is unchanged, that translates to the audio restarting.
 #[derive(Component)]
 pub struct SpatialAudioSink {
-    pub(crate) sink: SpatialSink,
+    pub sink: SpatialSink,
 }
 
 impl AudioSinkPlayback for SpatialAudioSink {


### PR DESCRIPTION
# Objective
Some users may benefit from avoiding archetype moves on entities and re-use of a sink on an entity, this also has some side benefits such as fine-grained control and inhibition of playing a current track if the current track is deemed to be a higher priority.

- Allow re-use of an audio sink which has been added to an entity using the `PlaybackSettings::ONCE` policy,

## Solution
- Make the required info public

---

## Changelog

- Allow reuse of AudioSink and SpatialAudioSink.

## Migration Guide
