### PR TITLE
Add `typos` - Source code spell checker 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,21 @@ jobs:
           echo 'Or if you use VSCode, use the `Even Better Toml` extension with 2 spaces'
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml'
 
+  typos:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check for typos
+        uses: crate-ci/typos@v1.18.2
+      - name: Typos info
+        if: failure()
+        run: |
+          echo 'To fix typos, please run `typos -w`'
+          echo 'To check for a diff, run `typos`'
+          echo 'You can find typos here: https://crates.io/crates/typos'
+          echo 'if you use VSCode, you can also install `Typos Spell Checker'
+          echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
+
 
   run-examples-on-windows-dx12:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
+      - uses: actions/checkout@v4
       - name: Check for typos
         uses: crate-ci/typos@v1.18.2
       - name: Typos info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -334,19 +334,19 @@ If you're new to Bevy, here's the workflow we use:
     * `cargo run -p ci -- doc` - to run doc tests and doc checks.
     * `cargo run -p ci -- compile` - to check that everything that must compile still does (examples and benches), and that some that shouldn't still don't ([`crates/bevy_ecs_compile_fail_tests`](./crates/bevy_ecs_compile_fail_tests)).
     * to get more information on commands available and what is run, check the [tools/ci crate](./tools/ci).
-
 4. When working with Markdown (`.md`) files, Bevy's CI will check markdown files (like this one) using [markdownlint](https://github.com/DavidAnson/markdownlint).
 To locally lint your files using the same workflow as our CI:
    1. Install [markdownlint-cli](https://github.com/igorshubovych/markdownlint-cli).
    2. Run `markdownlint -f -c .github/linters/.markdown-lint.yml .` in the root directory of the Bevy project.
-
 5. When working with Toml (`.toml`) files, Bevy's CI will check toml files using [taplo](https://taplo.tamasfe.dev/): `taplo fmt --check --diff`
    1. If you use VSCode, install [Even better toml](https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml) and format your files.
    2. If you want to use the cli tool, install [taplo-cli](https://taplo.tamasfe.dev/cli/installation/cargo.html) and run `taplo fmt --check --diff` to check for the formatting. Fix any issues by running `taplo fmt` in the root directory of the Bevy project.
-
-6. Push your changes to your fork on Github and open a Pull Request.
-7. Respond to any CI failures or review feedback. While CI failures must be fixed before we can merge your PR, you do not need to *agree* with all feedback from your reviews, merely acknowledge that it was given. If you cannot come to an agreement, leave the thread open and defer to a Maintainer or Project Lead's final judgement.
-8. When your PR is ready to merge, a Maintainer or Project Lead will review it and suggest final changes. If those changes are minimal they may even apply them directly to speed up merging.
+6. Check for typos. Bevy's CI will check for them using [typos](https://github.com/crate-ci/typos).
+   1. If you use VSCode, install [Typos Spell Checker](https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode).
+   2. You can also use the cli tool. Install [typos-cli](https://github.com/crate-ci/typos?tab=readme-ov-file#install) and run `typos` to check for typos, and fix them by running `typos -w`.
+7. Push your changes to your fork on Github and open a Pull Request.
+8. Respond to any CI failures or review feedback. While CI failures must be fixed before we can merge your PR, you do not need to *agree* with all feedback from your reviews, merely acknowledge that it was given. If you cannot come to an agreement, leave the thread open and defer to a Maintainer or Project Lead's final judgement.
+9. When your PR is ready to merge, a Maintainer or Project Lead will review it and suggest final changes. If those changes are minimal they may even apply them directly to speed up merging.
 
 If you end up adding a new official Bevy crate to the `bevy` repo:
 

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -133,7 +133,7 @@ fn evaluate_and_fold_conditions(conditions: &mut [BoxedCondition], world: &mut W
 #[cfg(test)]
 #[test]
 fn skip_automatic_sync_points() {
-    // Schedules automatically insert appy_deferred systems, but these should
+    // Schedules automatically insert apply_deferred systems, but these should
     // not be executed as they only serve as markers and are not initialized
     use crate::prelude::*;
     let mut sched = Schedule::default();

--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,7 @@
 [files]
 extend-exclude = [
   "*.pbxproj", # metadata file
-  "CHANGELOG.md" # To keep consistency between the comimit history/PRs.
+  "CHANGELOG.md" # To keep consistency between the commit history/PRs.
 ]
 
 # Corrections take the form of a key/value pair. The key is the incorrect word

--- a/typos.toml
+++ b/typos.toml
@@ -22,11 +22,10 @@ TOI = "TOI" # Time of impact
 
 [default]
 extend-ignore-identifiers-re = [
-  "iFO",        # iFO - Index of First Original Face
   "NDK",        # NDK - Native  Development Kit
   "inventario", # Inventory in Portuguese
   # Used in bevy_mikktspace
+  "iFO",
   "vOt",
-  "vOt2",
   "fLenOt",
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,13 @@ extend-exclude = [
 # word is treated as always correct. If the value is an empty string, the word
 # is treated as always incorrect.
 
+[default]
+extend-ignore-identifiers-re = [
+  "NDK", # NDK - Native  Development Kit
+  "Ot",  # Ot - Offset Tangent
+  "iFO", # iFO - Index of First Original Face
+]
+
 [default.extend-identifiers]
 ser = "ser" # ron::ser - Serializer
 

--- a/typos.toml
+++ b/typos.toml
@@ -18,11 +18,14 @@ Sur = "Sur" # macOS Big Sur - South
 [default.extend-words]
 LOD = "LOD" # Level of detail
 toi = "toi" # Time of impact
-Ot = "Ot"   # Ot - Offset Tangent
 
 [default]
 extend-ignore-identifiers-re = [
   "iFO",        # iFO - Index of First Original Face
   "NDK",        # NDK - Native  Development Kit
   "inventario", # Inventory in Portuguese
+  # Used in bevy_mikktspace
+  "vOt",
+  "vOt2",
+  "fLenOt",
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -1,6 +1,7 @@
 [files]
 extend-exclude = [
   "*.pbxproj", # metadata file
+  "CHANGELOG.md" # To keep consistency between the comimit history/PRs.
 ]
 
 # Corrections take the form of a key/value pair. The key is the incorrect word

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,21 @@
+[files]
+extend-exclude = [
+  "*.pbxproj", # metadata file
+]
+
+# Corrections take the form of a key/value pair. The key is the incorrect word
+# and the value is the correct word. If the key and value are the same, the
+# word is treated as always correct. If the value is an empty string, the word
+# is treated as always incorrect.
+
+[default.extend-identifiers]
+ser = "ser" # ron::ser - Serializer
+
+[default.extend-words]
+# Things that aren't typos
+toi = "toi" # Time of intersention
+LOD = "LOD" # Level of detail
+ND = "ND"   # NDK - Native  Development Kit
+Ot = "Ot"   # vOt - Vector Offset Tangent
+FO = "FO"   # iFO - Index of First Original Face
+Sur = "Sur" # macOS Big Sur - South

--- a/typos.toml
+++ b/typos.toml
@@ -22,7 +22,4 @@ ser = "ser" # ron::ser - Serializer
 # Things that aren't typos
 toi = "toi" # Time of intersention
 LOD = "LOD" # Level of detail
-ND = "ND"   # NDK - Native  Development Kit
-Ot = "Ot"   # vOt - Vector Offset Tangent
-FO = "FO"   # iFO - Index of First Original Face
 Sur = "Sur" # macOS Big Sur - South

--- a/typos.toml
+++ b/typos.toml
@@ -24,5 +24,5 @@ Ot = "Ot"   # Ot - Offset Tangent
 extend-ignore-identifiers-re = [
   "iFO",        # iFO - Index of First Original Face
   "NDK",        # NDK - Native  Development Kit
-  "inventario", # Inventory in Portugees
+  "inventario", # Inventory in Portuguese
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -8,6 +8,7 @@ extend-exclude = [
 # and the value is the correct word. If the key and value are the same, the
 # word is treated as always correct. If the value is an empty string, the word
 # is treated as always incorrect.
+# the toi of the mountain
 
 # Match Whole Word - Case Sensitive
 [default.extend-identifiers]
@@ -17,7 +18,7 @@ Sur = "Sur" # macOS Big Sur - South
 # Match Inside a Word - Case Insensitive
 [default.extend-words]
 LOD = "LOD" # Level of detail
-toi = "toi" # Time of impact
+TOI = "TOI" # Time of impact
 
 [default]
 extend-ignore-identifiers-re = [

--- a/typos.toml
+++ b/typos.toml
@@ -12,12 +12,12 @@ extend-exclude = [
 # Match Whole Word - Case Sensitive
 [default.extend-identifiers]
 ser = "ser" # ron::ser - Serializer
-toi = "toi" # Time of impact
 Sur = "Sur" # macOS Big Sur - South
 
 # Match Inside a Word - Case Insensitive
 [default.extend-words]
 LOD = "LOD" # Level of detail
+toi = "toi" # Time of impact
 Ot = "Ot"   # Ot - Offset Tangent
 
 [default]

--- a/typos.toml
+++ b/typos.toml
@@ -8,18 +8,19 @@ extend-exclude = [
 # word is treated as always correct. If the value is an empty string, the word
 # is treated as always incorrect.
 
+# Match Whole Word - Case Sensitive
+[default.extend-identifiers] 
+ser = "ser" # ron::ser - Serializer
+toi = "toi" # Time of intersention
+Sur = "Sur" # macOS Big Sur - South
+
+ # Match Inside a Word - Case Insensitive
+[default.extend-words]
+LOD = "LOD" # Level of detail
+Ot = "Ot"   # Ot - Offset Tangent
+
 [default]
 extend-ignore-identifiers-re = [
-  "NDK", # NDK - Native  Development Kit
-  "Ot",  # Ot - Offset Tangent
   "iFO", # iFO - Index of First Original Face
+  "NDK", # NDK - Native  Development Kit
 ]
-
-[default.extend-identifiers]
-ser = "ser" # ron::ser - Serializer
-
-[default.extend-words]
-# Things that aren't typos
-toi = "toi" # Time of intersention
-LOD = "LOD" # Level of detail
-Sur = "Sur" # macOS Big Sur - South

--- a/typos.toml
+++ b/typos.toml
@@ -24,4 +24,5 @@ Ot = "Ot"   # Ot - Offset Tangent
 extend-ignore-identifiers-re = [
   "iFO", # iFO - Index of First Original Face
   "NDK", # NDK - Native  Development Kit
+  "inventario" # Inventory in Portugees
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -1,7 +1,7 @@
 [files]
 extend-exclude = [
-  "*.pbxproj", # metadata file
-  "CHANGELOG.md" # To keep consistency between the commit history/PRs.
+  "*.pbxproj",    # metadata file
+  "CHANGELOG.md", # To keep consistency between the commit history/PRs.
 ]
 
 # Corrections take the form of a key/value pair. The key is the incorrect word
@@ -10,19 +10,19 @@ extend-exclude = [
 # is treated as always incorrect.
 
 # Match Whole Word - Case Sensitive
-[default.extend-identifiers] 
+[default.extend-identifiers]
 ser = "ser" # ron::ser - Serializer
 toi = "toi" # Time of intersention
 Sur = "Sur" # macOS Big Sur - South
 
- # Match Inside a Word - Case Insensitive
+# Match Inside a Word - Case Insensitive
 [default.extend-words]
 LOD = "LOD" # Level of detail
 Ot = "Ot"   # Ot - Offset Tangent
 
 [default]
 extend-ignore-identifiers-re = [
-  "iFO", # iFO - Index of First Original Face
-  "NDK", # NDK - Native  Development Kit
-  "inventario" # Inventory in Portugees
+  "iFO",        # iFO - Index of First Original Face
+  "NDK",        # NDK - Native  Development Kit
+  "inventario", # Inventory in Portugees
 ]

--- a/typos.toml
+++ b/typos.toml
@@ -12,7 +12,7 @@ extend-exclude = [
 # Match Whole Word - Case Sensitive
 [default.extend-identifiers]
 ser = "ser" # ron::ser - Serializer
-toi = "toi" # Time of intersention
+toi = "toi" # Time of impact
 Sur = "Sur" # macOS Big Sur - South
 
 # Match Inside a Word - Case Insensitive


### PR DESCRIPTION
# Objective

- Avoid misspellings throughout the codebase by using [`typos`](https://github.com/crate-ci/typos) in CI

Inspired by https://github.com/gfx-rs/wgpu/pull/5191

Typos is a minimal code speller written in rust that finds and corrects spelling mistakes among source code.
 - Fast enough to run on monorepos
 - Low false positives so you can run on PRs


## Solution

- Use [typos-action](https://github.com/marketplace/actions/typos-action) in CI
- Add how to use typos in the Contribution Guide
