### PR TITLE
Fix taplo CI - toml fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,16 +163,14 @@ jobs:
           VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: main
 
-  toml:
+  toml-fmt:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Install taplo
-        run: | 
-          curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
-          | gzip -d - \
-          | install -m 755 /dev/stdin /usr/local/bin/taplo
+        run: cargo install taplo-cli --locked
       - name: Run Taplo
         id: taplo
         run: taplo fmt --check --diff
@@ -180,7 +178,10 @@ jobs:
         if: failure()
         run: |
           echo 'To fix toml fmt, please run `taplo fmt`'
-          echo 'Or if you use VSCode, use the Even Better Toml extension'
+          echo 'To check for a diff, run `taplo fmt --check --diff'
+          echo 'You can find taplo here: https://taplo.tamasfe.dev/'
+          echo 'Or if you use VSCode, use the `Even Better Toml` extension with 2 spaces'
+          echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tamasfe.even-better-toml'
 
 
   run-examples-on-windows-dx12:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,7 @@ jobs:
           VALIDATE_MARKDOWN: true
           DEFAULT_BRANCH: main
 
-  toml-fmt:
+  toml:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -24,7 +24,9 @@ thiserror = "1.0"
 
 [dev-dependencies]
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
-bevy_math = { path = "../bevy_math", version = "0.14.0-dev", features = ["approx"] }
+bevy_math = { path = "../bevy_math", version = "0.14.0-dev", features = [
+  "approx",
+] }
 approx = "0.5.1"
 
 [features]


### PR DESCRIPTION
# Objective

- Taplo in CI is not running. The link used to download taplo doesn't work anymore.

## Solution
- Compile taplo directly with cargo
- Improve docs a little
- Run taplo
