### PR TITLE
Add a release step, add links to the github release note

### DIFF
--- a/docs/release_checklist.md
+++ b/docs/release_checklist.md
@@ -11,8 +11,9 @@
 7. Update book.
 8. Bump version number for all crates, using the "Release" workflow.
 9. Create tag on GitHub.
-10. Bump `latest` tag to most recent release.
-11. Run this workflow to update screenshots:
+10. Edit Github Release. Add links to the `Release announcement` and `Migration Guide`
+11. Bump `latest` tag to most recent release.
+12. Run this workflow to update screenshots:
     * <https://github.com/bevyengine/bevy-website/actions/workflows/update-screenshots.yml>
     * _This will block blog post releases (and take ~40 minutes) so do it early_.
 


### PR DESCRIPTION
# Objective

Add a release step to add the links `Release anouncement` and `Migration guide` to the GitHub release note.

- https://github.com/bevyengine/bevy/issues/12011#issuecomment-1955342378


