### PR TITLE
Remove unnecessary wildcards from `LogPlugin` and convert warnings to errors.

### DIFF
--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -217,12 +217,12 @@ impl Plugin for LogPlugin {
             bevy_utils::tracing::subscriber::set_global_default(finished_subscriber).is_err();
 
         match (logger_already_set, subscriber_already_set) {
-            (true, true) => warn!(
+            (true, true) => error!(
                 "Could not set global logger and tracing subscriber as they are already set. Consider disabling LogPlugin."
             ),
-            (true, _) => warn!("Could not set global logger as it is already set. Consider disabling LogPlugin."),
-            (_, true) => warn!("Could not set global tracing subscriber as it is already set. Consider disabling LogPlugin."),
-            _ => (),
+            (true, false) => error!("Could not set global logger as it is already set. Consider disabling LogPlugin."),
+            (false, true) => error!("Could not set global tracing subscriber as it is already set. Consider disabling LogPlugin."),
+            (false, false) => (),
         }
     }
 }


### PR DESCRIPTION
# Objective

Improve code quality and prevent bugs.

## Solution

I removed the unnecessary wildcards from `<LogPlugin as Plugin>::build`.

I also changed the warnings that would occur if the subscriber/logger was already set into errors.
