### PR TITLE
set pipeline to queued when shader is not yet available

### DIFF
--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -881,7 +881,9 @@ impl PipelineCache {
             CachedPipelineState::Err(err) => match err {
                 // Retry
                 PipelineCacheError::ShaderNotLoaded(_)
-                | PipelineCacheError::ShaderImportNotYetAvailable => {}
+                | PipelineCacheError::ShaderImportNotYetAvailable => {
+                    cached_pipeline.state = CachedPipelineState::Queued;
+                }
 
                 // Shader could not be processed ... retrying won't help
                 PipelineCacheError::ProcessShaderError(err) => {


### PR DESCRIPTION
# Objective

- Fixes #11977 - user defined shaders don't work in wasm
- After investigation, it won't work if the shader is not yet available when compiling the pipeline on all platforms, for example if you load many assets

## Solution

- Set the pipeline state to queued when it errs waiting for the shader so that it's retried
