### PR TITLE
Improve file watcher error msg

### DIFF
--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -490,7 +490,9 @@ impl AssetSource {
                     sender,
                     file_debounce_wait_time,
                 )
-                .expect("Failed to create file watcher"),
+                .unwrap_or_else(|e| {
+                    panic!("Failed to create file watcher from path {path:?}, {e:?}")
+                }),
             ));
             #[cfg(any(
                 not(feature = "file_watcher"),


### PR DESCRIPTION
# Objective

When dealing with custom asset sources it can be a bit tricky to get asset roots combined with relative paths correct.
It's even harder when it isn't mentioned which path was problematic.

## Solution

Mention which path failed for the file watcher.
