### PR TITLE
Fix `example-showcase` generated `code_path`

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -505,7 +505,7 @@ description = \"{}\"
 technical_name = \"{}\"
 link = \"/examples{}/{}/{}\"
 image = \"../static/screenshots/{}/{}.png\"
-code_path = \"content/examples{}/{}\"
+code_path = \"{}\"
 github_code_path = \"{}\"
 header_message = \"Examples ({})\"
 +++",
@@ -525,13 +525,9 @@ header_message = \"Examples ({})\"
                             &to_show.technical_name.replace('_', "-"),
                             &to_show.category,
                             &to_show.technical_name,
-                            match api {
-                                WebApi::Webgpu => "-webgpu",
-                                WebApi::Webgl2 => "",
-                            },
                             code_path
                                 .components()
-                                .skip(1)
+                                .skip(2)
                                 .collect::<PathBuf>()
                                 .display(),
                             &to_show.path,


### PR DESCRIPTION
# Objective

- `example-showcase` is a tool used by [`bevy-website`](https://github.com/bevyengine/bevy-website) to generate the list of examples.
- When generating the individual pages for examples, it generates `extra.code_path` to display the source code an each example.

```toml
[extra]
code_path = "path/to/example.rs"
```

- The current generated `code_path` is invalid and points to a missing folder.

```toml
[extra]
# This path is invalid
code_path = "content/examples-webgpu/../content/examples-webgpu/Tools/gamepad-viewer/gamepad_viewer.rs"
```

## Solution

- Change `code_path` generating to point to the correct Rust example file.

```toml
[extra]
# This is correct
code_path = "content/examples-webgpu/Tools/gamepad-viewer/gamepad_viewer.rs"
```

- I'm not sure why the invalid path works in CI, but it broke when I tried testing https://github.com/bevyengine/bevy-website/pull/1050 in CI.
- I'm going to do further testing to ensure this change won't break Github Actions.