### PR TITLE
bevy_reflect: Skip serializing `Instant`

### DIFF
--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -47,10 +47,14 @@ impl Plugin for TimePlugin {
             .init_resource::<Time<Fixed>>()
             .init_resource::<TimeUpdateStrategy>()
             .register_type::<Time>()
+            .register_type::<Real>()
+            .register_type::<Virtual>()
+            .register_type::<Fixed>()
             .register_type::<Time<Real>>()
             .register_type::<Time<Virtual>>()
             .register_type::<Time<Fixed>>()
             .register_type::<Timer>()
+            .register_type::<TimerMode>()
             .register_type::<Stopwatch>()
             .add_systems(
                 First,

--- a/crates/bevy_time/src/real.rs
+++ b/crates/bevy_time/src/real.rs
@@ -30,8 +30,11 @@ use crate::time::Time;
 /// [`last_update()`](Time::last_update) are recorded and accessible.
 #[derive(Debug, Copy, Clone, Reflect)]
 pub struct Real {
+    #[reflect(skip_serializing, default = "Instant::now")]
     startup: Instant,
+    #[reflect(skip_serializing)]
     first_update: Option<Instant>,
+    #[reflect(skip_serializing)]
     last_update: Option<Instant>,
 }
 


### PR DESCRIPTION
# Objective

> [!note]
> Blocked on #12024

Related to #12063

`Instant` is not serializable and should be marked as `skip_serializing` when deriving `Reflect`.

## Solution

Add `#[reflect(skip_serializing)]` to all `Instant`-containing fields (just `Real` from `bevy_time`).

---

## Changelog

- All `Instant`-containing fields in `bevy_time::Real` are now excluded from reflection serialization
- Registered the following types in `TimePlugin`:
  - `Real`
  - `Virtual`
  - `Fixed`
  - `TimerMode`
