### PR TITLE
Fix SimpleExecutor crash

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -4,11 +4,11 @@ use fixedbitset::FixedBitSet;
 use std::panic::AssertUnwindSafe;
 
 use crate::{
-    schedule::{BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule},
+    schedule::{
+        executor::is_apply_deferred, BoxedCondition, ExecutorKind, SystemExecutor, SystemSchedule,
+    },
     world::World,
 };
-
-use super::is_apply_deferred;
 
 /// A variant of [`SingleThreadedExecutor`](crate::schedule::SingleThreadedExecutor) that calls
 /// [`apply_deferred`](crate::system::System::apply_deferred) immediately after running each system.

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -8,6 +8,8 @@ use crate::{
     world::World,
 };
 
+use super::is_apply_deferred;
+
 /// A variant of [`SingleThreadedExecutor`](crate::schedule::SingleThreadedExecutor) that calls
 /// [`apply_deferred`](crate::system::System::apply_deferred) immediately after running each system.
 #[derive(Default)]
@@ -86,6 +88,10 @@ impl SystemExecutor for SimpleExecutor {
             }
 
             let system = &mut schedule.systems[system_index];
+            if is_apply_deferred(system) {
+                continue;
+            }
+
             let res = std::panic::catch_unwind(AssertUnwindSafe(|| {
                 system.run((), world);
             }));
@@ -124,4 +130,17 @@ fn evaluate_and_fold_conditions(conditions: &mut [BoxedCondition], world: &mut W
         .iter_mut()
         .map(|condition| condition.run((), world))
         .fold(true, |acc, res| acc && res)
+}
+
+#[cfg(test)]
+#[test]
+fn skip_automatic_sync_points() {
+    // Schedules automatically insert appy_deferred systems, but these should
+    // not be executed as they only serve as markers and are not initialized
+    use crate::prelude::*;
+    let mut sched = Schedule::default();
+    sched.set_executor_kind(ExecutorKind::Simple);
+    sched.add_systems((|_: Commands| (), || ()).chain());
+    let mut world = World::new();
+    sched.run(&mut world);
 }


### PR DESCRIPTION
# Objective

Since #9822, `SimpleExecutor` panics when an automatic sync point is inserted:

```rust
let mut sched = Schedule::default();
sched.set_executor_kind(ExecutorKind::Simple);
sched.add_systems((|_: Commands| (), || ()).chain());
sched.run(&mut World::new());
```
```
System's param_state was not found. Did you forget to initialize this system before running it?
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_ecs::schedule::executor::apply_deferred`!
```

## Solution

Don't try to run the `apply_deferred` system.
