### PR TITLE
asset hooks

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -285,6 +285,7 @@ impl VisitAssetDependencies for Vec<UntypedHandle> {
 pub trait AssetApp {
     /// Registers the given `loader` in the [`App`]'s [`AssetServer`].
     fn register_asset_loader<L: AssetLoader>(&mut self, loader: L) -> &mut Self;
+    fn register_asset_hook<A: Asset>(&mut self, hook: impl FnMut(&mut A) -> () + Send + Sync + 'static) -> &mut Self;
     /// Registers the given `processor` in the [`App`]'s [`AssetProcessor`].
     fn register_asset_processor<P: Process>(&mut self, processor: P) -> &mut Self;
     /// Registers the given [`AssetSourceBuilder`] with the given `id`.
@@ -323,6 +324,11 @@ pub trait AssetApp {
 impl AssetApp for App {
     fn register_asset_loader<L: AssetLoader>(&mut self, loader: L) -> &mut Self {
         self.world.resource::<AssetServer>().register_loader(loader);
+        self
+    }
+
+    fn register_asset_hook<A: Asset>(&mut self, hook: impl FnMut(&mut A) -> () + Send + Sync + 'static) -> &mut Self {
+        self.world.resource::<AssetServer>().register_asset_hook(hook);
         self
     }
 

--- a/crates/bevy_asset/src/loader.rs
+++ b/crates/bevy_asset/src/loader.rs
@@ -1,13 +1,7 @@
-use crate::{
-    io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader},
-    meta::{
-        loader_settings_meta_transform, AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfoMinimal,
-        Settings,
-    },
-    path::AssetPath,
-    Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, Handle, LoadedUntypedAsset,
-    UntypedAssetId, UntypedHandle,
-};
+use crate::{io::{AssetReaderError, MissingAssetSourceError, MissingProcessedAssetReaderError, Reader}, meta::{
+    loader_settings_meta_transform, AssetHash, AssetMeta, AssetMetaDyn, ProcessedInfoMinimal,
+    Settings,
+}, path::AssetPath, Asset, AssetLoadError, AssetServer, AssetServerMode, Assets, Handle, LoadedUntypedAsset, UntypedAssetId, UntypedHandle, AssetHooks};
 use bevy_ecs::world::World;
 use bevy_utils::{BoxedFuture, CowArc, HashMap, HashSet};
 use downcast_rs::{impl_downcast, Downcast};
@@ -234,6 +228,8 @@ impl ErasedLoadedAsset {
 pub trait AssetContainer: Downcast + Any + Send + Sync + 'static {
     fn insert(self: Box<Self>, id: UntypedAssetId, world: &mut World);
     fn asset_type_name(&self) -> &'static str;
+
+    fn load_hook(&mut self, asset_hooks: &mut AssetHooks);
 }
 
 impl_downcast!(AssetContainer);
@@ -245,6 +241,10 @@ impl<A: Asset> AssetContainer for A {
 
     fn asset_type_name(&self) -> &'static str {
         std::any::type_name::<A>()
+    }
+
+    fn load_hook(&mut self, asset_hooks: &mut AssetHooks) {
+        asset_hooks.trigger::<A>(self);
     }
 }
 

--- a/examples/3d/load_gltf.rs
+++ b/examples/3d/load_gltf.rs
@@ -12,6 +12,9 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .add_systems(Update, animate_light_direction)
+        .register_asset_hook::<bevy_internal::gltf::Gltf>(|gltf: &mut bevy_internal::gltf::Gltf| {
+            info!("number of scenes in gltf: {}", gltf.scenes.len());
+        })
         .run();
 }
 


### PR DESCRIPTION
# Objective

Need to perform transformations on gLTFs and other assets in the future, in order to parse it properly and spawn entities, components based on the data before it's loaded. 

## Solution

This pr allows any third party crate to register multiple transformations to apply to assets before they actually get loaded.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

### Added
register_asset_hook<A: Asset>(hook: impl FnMut(&mut A) -> () + Send + Sync + 'static) 
to register asset hooks.


