### PR TITLE
Add a way to get a strong handle from an AssetId

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -508,13 +508,13 @@ impl<A: Asset> TryFrom<UntypedHandle> for Handle<A> {
     }
 }
 
-/// Errors preventing the conversion of to/from an [`UntypedHandle`] and an [`Handle`].
+/// Errors preventing the conversion of to/from an [`UntypedHandle`] and a [`Handle`].
 #[derive(Error, Debug, PartialEq, Clone)]
 #[non_exhaustive]
 pub enum UntypedAssetConversionError {
-    /// Caused when trying to convert an [`UntypedHandle`] into an [`Handle`] of the wrong type.
+    /// Caused when trying to convert an [`UntypedHandle`] into a [`Handle`] of the wrong type.
     #[error(
-        "This UntypedHandle is for {found:?} and cannot be converted into an Handle<{expected:?}>"
+        "This UntypedHandle is for {found:?} and cannot be converted into a Handle<{expected:?}>"
     )]
     TypeIdMismatch { expected: TypeId, found: TypeId },
 }

--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -23,6 +23,7 @@ pub struct AssetHandleProvider {
     pub(crate) type_id: TypeId,
 }
 
+#[derive(Debug)]
 pub(crate) struct DropEvent {
     pub(crate) id: InternalAssetId,
     pub(crate) asset_server_managed: bool,

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -358,7 +358,7 @@ impl AssetInfos {
         }
     }
 
-    // Returns `true` if the asset should be removed from the collection
+    /// Returns `true` if the asset should be removed from the collection.
     pub(crate) fn process_handle_drop(&mut self, id: UntypedAssetId) -> bool {
         Self::process_handle_drop_internal(
             &mut self.infos,

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -797,9 +797,9 @@ impl AssetServer {
             .map(|h| h.typed_debug_checked())
     }
 
-    /// Get an `Handle` from an `AssetId`.
+    /// Get a `Handle` from an `AssetId`.
     ///
-    /// This only returns `Some` if `id` is derived from an `Handle` that was
+    /// This only returns `Some` if `id` is derived from a `Handle` that was
     /// loaded through an `AssetServer`, otherwise it returns `None`.
     ///
     /// Consider using [`Assets::get_strong_handle`] in the case the `Handle`

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -797,16 +797,25 @@ impl AssetServer {
             .map(|h| h.typed_debug_checked())
     }
 
+    /// Get an `Handle` from an `AssetId`.
+    ///
+    /// This only returns `Some` if `id` is derived from an `Handle` that was
+    /// loaded through an `AssetServer`, otherwise it returns `None`.
+    ///
+    /// Consider using [`Assets::get_strong_handle`] in the case the `Handle`
+    /// comes from [`Assets::add`].
     pub fn get_id_handle<A: Asset>(&self, id: AssetId<A>) -> Option<Handle<A>> {
         self.get_id_handle_untyped(id.untyped()).map(|h| h.typed())
     }
 
+    /// Get an `UntypedHandle` from an `UntypedAssetId`.
+    /// See [`AssetServer::get_id_handle`] for details.
     pub fn get_id_handle_untyped(&self, id: UntypedAssetId) -> Option<UntypedHandle> {
         self.data.infos.read().get_id_handle(id)
     }
 
     /// Returns `true` if the given `id` corresponds to an asset that is managed by this [`AssetServer`].
-    /// Otherwise, returns false.
+    /// Otherwise, returns `false`.
     pub fn is_managed(&self, id: impl Into<UntypedAssetId>) -> bool {
         self.data.infos.read().contains_key(id.into())
     }


### PR DESCRIPTION
# Objective

- Sometimes, it is useful to get a `Handle<T>` from an `AssetId<T>`. For example, when iterating `Assets` to find a specific asset. So much so that it's possible to do so with `AssetServer::get_id_handle`
- However, `AssetServer::get_id_handle` doesn't work with assets directly added to `Assets` using `Assets::add`.
- Fixes #12087

## Solution

- Add `Assets::get_strong_handle` to convert an `AssetId` into an `Handle`
- Document `AssetServer::get_id_handle` to explain its limitation and point to `get_strong_handle`.
- Add a test for `get_strong_handle`
- Add a `duplicate_handles` field to `Assets` to avoid dropping assets with a live handle generated by `get_strong_handle` (more reference counting yay…)
- Fix typos in `Assets` docs

---

## Changelog

- Add `Assets::get_strong_handle` to convert an `AssetId` into an `Handle`