### PR TITLE
remove unnecessary mut in query in ui_texture_slice example

### DIFF
--- a/examples/ui/ui_texture_slice.rs
+++ b/examples/ui/ui_texture_slice.rs
@@ -14,10 +14,10 @@ fn main() {
 }
 
 fn button_system(
-    mut interaction_query: Query<(&Interaction, &Children), (Changed<Interaction>, With<Button>)>,
+    interaction_query: Query<(&Interaction, &Children), (Changed<Interaction>, With<Button>)>,
     mut text_query: Query<&mut Text>,
 ) {
-    for (interaction, children) in &mut interaction_query {
+    for (interaction, children) in &interaction_query {
         let mut text = text_query.get_mut(children[0]).unwrap();
         match *interaction {
             Interaction::Pressed => {


### PR DESCRIPTION
# Objective

Keep the examples as correct as possible: Remove mutability from a query that is unused ui_texture_slice

## Solution

removed "mut"

---