### PR TITLE
Check `cfg` during CI and fix feature typos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -375,4 +375,26 @@ jobs:
               echo " Fix the issue by replacing 'bevy_internal' with 'bevy'"
               echo " Example: 'use bevy::sprite::MaterialMesh2dBundle;' instead of 'bevy_internal::sprite::MaterialMesh2dBundle;'"
               exit 1
-          fi                  
+          fi
+  check-cfg:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-check-doc-${{ hashFiles('**/Cargo.toml') }}
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: Build and check cfg typos
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- cfg-check

--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -3,9 +3,8 @@ pub use bevy_derive::AppLabel;
 use bevy_ecs::{
     prelude::*,
     schedule::{
-        apply_state_transition, common_conditions::run_once as run_once_condition,
-        run_enter_schedule, InternedScheduleLabel, IntoSystemConfigs, IntoSystemSetConfigs,
-        ScheduleBuildSettings, ScheduleLabel, StateTransitionEvent,
+        common_conditions::run_once as run_once_condition, run_enter_schedule,
+        InternedScheduleLabel, ScheduleBuildSettings, ScheduleLabel,
     },
 };
 use bevy_utils::{intern::Interned, thiserror::Error, tracing::debug, HashMap, HashSet};

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -98,6 +98,7 @@ pub use xyza::*;
 use bevy_render::color::LegacyColor;
 
 /// Describes the traits that a color should implement for consistency.
+#[allow(dead_code)]
 pub(crate) trait StandardColor
 where
     Self: core::fmt::Debug,

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -98,7 +98,7 @@ pub use xyza::*;
 use bevy_render::color::LegacyColor;
 
 /// Describes the traits that a color should implement for consistency.
-#[allow(dead_code)]
+#[allow(dead_code)] // This is an internal marker trait used to ensure that our color types impl the required traits
 pub(crate) trait StandardColor
 where
     Self: core::fmt::Debug,

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -5,7 +5,7 @@ mod name;
 mod serde;
 mod task_pool_options;
 
-use bevy_ecs::system::{ResMut, Resource};
+use bevy_ecs::system::Resource;
 pub use bytemuck::{bytes_of, cast_slice, Pod, Zeroable};
 pub use name::*;
 pub use task_pool_options::*;

--- a/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
+++ b/crates/bevy_core_pipeline/src/contrast_adaptive_sharpening/node.rs
@@ -2,7 +2,6 @@ use std::sync::Mutex;
 
 use crate::contrast_adaptive_sharpening::ViewCASPipeline;
 use bevy_ecs::prelude::*;
-use bevy_ecs::query::QueryState;
 use bevy_render::{
     extract_component::{ComponentUniforms, DynamicUniformIndex},
     render_graph::{Node, NodeRunError, RenderGraphContext},

--- a/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
+++ b/crates/bevy_core_pipeline/src/deferred/copy_lighting_id.rs
@@ -18,7 +18,6 @@ use bevy_render::{
 use bevy_ecs::query::QueryItem;
 use bevy_render::{
     render_graph::{NodeRunError, RenderGraphContext, ViewNode},
-    render_resource::{Operations, PipelineCache, RenderPassDescriptor},
     renderer::RenderContext,
 };
 

--- a/crates/bevy_core_pipeline/src/msaa_writeback.rs
+++ b/crates/bevy_core_pipeline/src/msaa_writeback.rs
@@ -9,7 +9,6 @@ use bevy_render::{
     camera::ExtractedCamera,
     color::LegacyColor,
     render_graph::{Node, NodeRunError, RenderGraphApp, RenderGraphContext},
-    render_resource::BindGroupEntries,
     renderer::RenderContext,
     view::{Msaa, ViewTarget},
     Render, RenderSet,

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -56,7 +56,7 @@ use crate::{
     storage::{SparseSetIndex, TableId, TableRow},
 };
 use serde::{Deserialize, Serialize};
-use std::{convert::TryFrom, fmt, hash::Hash, mem, num::NonZeroU32, sync::atomic::Ordering};
+use std::{fmt, hash::Hash, mem, num::NonZeroU32, sync::atomic::Ordering};
 
 #[cfg(target_has_atomic = "64")]
 use std::sync::atomic::AtomicI64 as AtomicIdCursor;

--- a/crates/bevy_ecs/src/query/iter.rs
+++ b/crates/bevy_ecs/src/query/iter.rs
@@ -49,7 +49,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///  - `table` must match D and F
     ///  - Both `D::IS_DENSE` and `F::IS_DENSE` must be true.
     #[inline]
-    #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
     pub(super) unsafe fn for_each_in_table_range<Func>(
         &mut self,
         func: &mut Func,
@@ -73,7 +73,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryIter<'w, 's, D, F> {
     ///  - `archetype` must match D and F
     ///  - Either `D::IS_DENSE` or `F::IS_DENSE` must be false.
     #[inline]
-    #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
     pub(super) unsafe fn for_each_in_archetype_range<Func>(
         &mut self,
         func: &mut Func,

--- a/crates/bevy_ecs/src/query/par_iter.rs
+++ b/crates/bevy_ecs/src/query/par_iter.rs
@@ -109,7 +109,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
     /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
     #[inline]
     pub fn for_each<FN: Fn(QueryItem<'w, D>) + Send + Sync + Clone>(self, func: FN) {
-        #[cfg(any(target = "wasm32", not(feature = "multi-threaded")))]
+        #[cfg(any(target_arch = "wasm32", not(feature = "multi-threaded")))]
         {
             // SAFETY:
             // This method can only be called once per instance of QueryParIter,
@@ -123,7 +123,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
                     .for_each(func);
             }
         }
-        #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
+        #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
         {
             let thread_count = bevy_tasks::ComputeTaskPool::get().thread_num();
             if thread_count <= 1 {
@@ -150,7 +150,7 @@ impl<'w, 's, D: QueryData, F: QueryFilter> QueryParIter<'w, 's, D, F> {
         }
     }
 
-    #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
     fn get_batch_size(&self, thread_count: usize) -> usize {
         if self.batching_strategy.batch_size_limits.is_empty() {
             return self.batching_strategy.batch_size_limits.start;

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -1117,7 +1117,7 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     /// with a mismatched [`WorldId`] is unsound.
     ///
     /// [`ComputeTaskPool`]: bevy_tasks::ComputeTaskPool
-    #[cfg(all(not(target = "wasm32"), feature = "multi-threaded"))]
+    #[cfg(all(not(target_arch = "wasm32"), feature = "multi-threaded"))]
     pub(crate) unsafe fn par_for_each_unchecked_manual<
         'w,
         FN: Fn(D::Item<'w>) + Send + Sync + Clone,

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -1,7 +1,6 @@
 use std::{
     collections::BTreeSet,
     fmt::{Debug, Write},
-    result::Result,
 };
 
 #[cfg(feature = "trace")]

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -14,6 +14,7 @@ webgpu = []
 pbr_transmission_textures = []
 shader_format_glsl = ["bevy_render/shader_format_glsl"]
 trace = ["bevy_render/trace"]
+ios_simulator = ["bevy_render/ios_simulator"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -12,6 +12,8 @@ keywords = ["bevy"]
 webgl = []
 webgpu = []
 pbr_transmission_textures = []
+shader_format_glsl = ["bevy_render/shader_format_glsl"]
+trace = ["bevy_render/trace"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_pbr/src/fog.rs
+++ b/crates/bevy_pbr/src/fog.rs
@@ -1,4 +1,3 @@
-use crate::ReflectComponent;
 use bevy_ecs::prelude::*;
 use bevy_math::Vec3;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};

--- a/crates/bevy_pbr/src/light.rs
+++ b/crates/bevy_pbr/src/light.rs
@@ -8,7 +8,6 @@ use bevy_math::{
 use bevy_reflect::prelude::*;
 use bevy_render::{
     camera::{Camera, CameraProjection},
-    color::LegacyColor,
     extract_component::ExtractComponent,
     extract_resource::ExtractResource,
     primitives::{Aabb, CascadesFrusta, CubemapFrusta, Frustum, HalfSpace, Sphere},

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -1,6 +1,5 @@
 use crate::*;
-use bevy_app::{App, Plugin};
-use bevy_asset::{Asset, AssetApp, AssetEvent, AssetId, AssetServer, Assets, Handle};
+use bevy_asset::{Asset, AssetEvent, AssetId, AssetServer};
 use bevy_core_pipeline::{
     core_3d::{
         AlphaMask3d, Camera3d, Opaque3d, ScreenSpaceTransmissionQuality, Transmissive3d,
@@ -16,19 +15,17 @@ use bevy_ecs::{
 };
 use bevy_reflect::Reflect;
 use bevy_render::{
-    camera::Projection,
     camera::TemporalJitter,
     extract_instances::{ExtractInstancesPlugin, ExtractedInstances},
     extract_resource::ExtractResource,
     mesh::{Mesh, MeshVertexBufferLayout},
-    prelude::Image,
-    render_asset::{prepare_assets, RenderAssets},
+    render_asset::RenderAssets,
     render_phase::*,
     render_resource::*,
     renderer::RenderDevice,
     texture::FallbackImage,
     view::{ExtractedView, Msaa, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract,
 };
 use bevy_utils::{tracing::error, HashMap, HashSet};
 use std::marker::PhantomData;

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -1,10 +1,7 @@
-use bevy_asset::{Asset, Handle};
+use bevy_asset::Asset;
 use bevy_math::{Affine2, Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
-use bevy_render::{
-    color::LegacyColor, mesh::MeshVertexBufferLayout, render_asset::RenderAssets,
-    render_resource::*, texture::Image,
-};
+use bevy_render::{mesh::MeshVertexBufferLayout, render_asset::RenderAssets, render_resource::*};
 
 use crate::deferred::DEFAULT_PBR_DEFERRED_LIGHTING_PASS_ID;
 use crate::*;

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -3,8 +3,7 @@ mod prepass_bindings;
 use bevy_render::render_resource::binding_types::uniform_buffer;
 pub use prepass_bindings::*;
 
-use bevy_app::{Plugin, PreUpdate};
-use bevy_asset::{load_internal_asset, AssetServer, Handle};
+use bevy_asset::{load_internal_asset, AssetServer};
 use bevy_core_pipeline::{core_3d::CORE_3D_DEPTH_FORMAT, prelude::Camera3d};
 use bevy_core_pipeline::{deferred::*, prepass::*};
 use bevy_ecs::{
@@ -25,7 +24,7 @@ use bevy_render::{
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
     view::{ExtractedView, Msaa, ViewUniform, ViewUniformOffset, ViewUniforms, VisibleEntities},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract,
 };
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::tracing::error;

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -4,7 +4,6 @@ use bevy_ecs::prelude::*;
 use bevy_math::{Mat4, UVec3, UVec4, Vec2, Vec3, Vec3Swizzles, Vec4, Vec4Swizzles};
 use bevy_render::{
     camera::Camera,
-    color::LegacyColor,
     mesh::Mesh,
     primitives::{CascadesFrusta, CubemapFrusta, Frustum},
     render_asset::RenderAssets,

--- a/crates/bevy_pbr/src/render/light.rs
+++ b/crates/bevy_pbr/src/render/light.rs
@@ -1212,7 +1212,7 @@ pub fn prepare_lights(
                     // NOTE: iOS Simulator is missing CubeArray support so we use Cube instead.
                     // See https://github.com/bevyengine/bevy/pull/12052 - remove if support is added.
                     #[cfg(all(
-                        not(ios_simulator),
+                        not(feature = "ios_simulator"),
                         any(
                             not(feature = "webgl"),
                             not(target_arch = "wasm32"),
@@ -1221,7 +1221,7 @@ pub fn prepare_lights(
                     ))]
                     dimension: Some(TextureViewDimension::CubeArray),
                     #[cfg(any(
-                        ios_simulator,
+                        feature = "ios_simulator",
                         all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))
                     ))]
                     dimension: Some(TextureViewDimension::Cube),

--- a/crates/bevy_pbr/src/render/mesh.rs
+++ b/crates/bevy_pbr/src/render/mesh.rs
@@ -1,11 +1,4 @@
-use crate::{
-    AtomicMaterialBindGroupId, MaterialBindGroupId, NotShadowCaster, NotShadowReceiver,
-    PreviousGlobalTransform, Shadow, ViewFogUniformOffset, ViewLightProbesUniformOffset,
-    ViewLightsUniformOffset, CLUSTERED_FORWARD_STORAGE_BUFFER_COUNT, MAX_CASCADES_PER_LIGHT,
-    MAX_DIRECTIONAL_LIGHTS,
-};
-use bevy_app::{Plugin, PostUpdate};
-use bevy_asset::{load_internal_asset, AssetId, Handle};
+use bevy_asset::{load_internal_asset, AssetId};
 use bevy_core_pipeline::{
     core_3d::{AlphaMask3d, Opaque3d, Transmissive3d, Transparent3d, CORE_3D_DEPTH_FORMAT},
     deferred::{AlphaMask3dDeferred, Opaque3dDeferred},
@@ -28,11 +21,9 @@ use bevy_render::{
     render_phase::{PhaseItem, RenderCommand, RenderCommandResult, TrackedRenderPass},
     render_resource::*,
     renderer::{RenderDevice, RenderQueue},
-    texture::{
-        BevyDefault, DefaultImageSampler, GpuImage, Image, ImageSampler, TextureFormatPixelInfo,
-    },
+    texture::{BevyDefault, DefaultImageSampler, GpuImage, ImageSampler, TextureFormatPixelInfo},
     view::{ViewTarget, ViewUniformOffset, ViewVisibility},
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract,
 };
 use bevy_transform::components::GlobalTransform;
 use bevy_utils::{tracing::error, Entry, HashMap, Hashed};
@@ -46,8 +37,7 @@ use crate::render::{
     morph::{
         extract_morphs, no_automatic_morph_batching, prepare_morphs, MorphIndices, MorphUniform,
     },
-    skin::{extract_skins, no_automatic_skin_batching, prepare_skins, SkinUniform},
-    MeshLayouts,
+    skin::no_automatic_skin_batching,
 };
 use crate::*;
 

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -23,11 +23,6 @@ use bevy_render::{
 
 #[cfg(all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu")))]
 use bevy_render::render_resource::binding_types::texture_cube;
-#[cfg(any(
-    not(feature = "webgl"),
-    not(target_arch = "wasm32"),
-    feature = "webgpu"
-))]
 use environment_map::EnvironmentMapLight;
 
 use crate::{

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -28,7 +28,6 @@ use bevy_render::render_resource::binding_types::texture_cube;
     not(target_arch = "wasm32"),
     feature = "webgpu"
 ))]
-use bevy_render::render_resource::binding_types::{texture_2d_array, texture_cube_array};
 use environment_map::EnvironmentMapLight;
 
 use crate::{

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -191,7 +191,7 @@ fn layout_entries(
             (
                 2,
                 #[cfg(all(
-                    not(ios_simulator),
+                    not(feature = "ios_simulator"),
                     any(
                         not(feature = "webgl"),
                         not(target_arch = "wasm32"),
@@ -200,7 +200,7 @@ fn layout_entries(
                 ))]
                 texture_cube_array(TextureSampleType::Depth),
                 #[cfg(any(
-                    ios_simulator,
+                    feature = "ios_simulator",
                     all(feature = "webgl", target_arch = "wasm32", not(feature = "webgpu"))
                 ))]
                 texture_cube(TextureSampleType::Depth),

--- a/crates/bevy_pbr/src/wireframe.rs
+++ b/crates/bevy_pbr/src/wireframe.rs
@@ -4,11 +4,7 @@ use bevy_asset::{load_internal_asset, Asset, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
 use bevy_render::{
-    color::LegacyColor,
-    extract_resource::ExtractResource,
-    mesh::{Mesh, MeshVertexBufferLayout},
-    prelude::*,
-    render_resource::*,
+    extract_resource::ExtractResource, mesh::MeshVertexBufferLayout, prelude::*, render_resource::*,
 };
 
 pub const WIREFRAME_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(192598014480025766);

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -3,7 +3,7 @@ use crate::{
     ArrayInfo, DynamicArray, DynamicEnum, DynamicList, DynamicMap, DynamicStruct, DynamicTuple,
     DynamicTupleStruct, DynamicVariant, EnumInfo, ListInfo, Map, MapInfo, NamedField, Reflect,
     ReflectDeserialize, StructInfo, StructVariantInfo, TupleInfo, TupleStructInfo,
-    TupleVariantInfo, TypeInfo, TypeRegistration, TypeRegistry, UnnamedField, VariantInfo,
+    TupleVariantInfo, TypeInfo, TypeRegistration, TypeRegistry, VariantInfo,
 };
 use erased_serde::Deserializer;
 use serde::de::{
@@ -23,8 +23,6 @@ pub trait DeserializeValue {
 }
 
 trait StructLikeInfo {
-    #[allow(dead_code)]
-    fn get_path(&self) -> &str;
     fn get_field(&self, name: &str) -> Option<&NamedField>;
     fn field_at(&self, index: usize) -> Option<&NamedField>;
     fn get_field_len(&self) -> usize;
@@ -32,10 +30,6 @@ trait StructLikeInfo {
 }
 
 trait TupleLikeInfo {
-    #[allow(dead_code)]
-    fn get_path(&self) -> &str;
-    #[allow(dead_code)]
-    fn get_field(&self, index: usize) -> Option<&UnnamedField>;
     fn get_field_len(&self) -> usize;
 }
 
@@ -48,10 +42,6 @@ trait Container {
 }
 
 impl StructLikeInfo for StructInfo {
-    fn get_path(&self) -> &str {
-        self.type_path()
-    }
-
     fn get_field(&self, name: &str) -> Option<&NamedField> {
         self.field(name)
     }
@@ -87,10 +77,6 @@ impl Container for StructInfo {
 }
 
 impl StructLikeInfo for StructVariantInfo {
-    fn get_path(&self) -> &str {
-        self.name()
-    }
-
     fn get_field(&self, name: &str) -> Option<&NamedField> {
         self.field(name)
     }
@@ -126,14 +112,6 @@ impl Container for StructVariantInfo {
 }
 
 impl TupleLikeInfo for TupleInfo {
-    fn get_path(&self) -> &str {
-        self.type_path()
-    }
-
-    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
-        self.field_at(index)
-    }
-
     fn get_field_len(&self) -> usize {
         self.field_len()
     }
@@ -157,14 +135,6 @@ impl Container for TupleInfo {
 }
 
 impl TupleLikeInfo for TupleStructInfo {
-    fn get_path(&self) -> &str {
-        self.type_path()
-    }
-
-    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
-        self.field_at(index)
-    }
-
     fn get_field_len(&self) -> usize {
         self.field_len()
     }
@@ -188,14 +158,6 @@ impl Container for TupleStructInfo {
 }
 
 impl TupleLikeInfo for TupleVariantInfo {
-    fn get_path(&self) -> &str {
-        self.name()
-    }
-
-    fn get_field(&self, index: usize) -> Option<&UnnamedField> {
-        self.field_at(index)
-    }
-
     fn get_field_len(&self) -> usize {
         self.field_len()
     }

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -23,6 +23,7 @@ pub trait DeserializeValue {
 }
 
 trait StructLikeInfo {
+    #[allow(dead_code)]
     fn get_path(&self) -> &str;
     fn get_field(&self, name: &str) -> Option<&NamedField>;
     fn field_at(&self, index: usize) -> Option<&NamedField>;
@@ -31,7 +32,9 @@ trait StructLikeInfo {
 }
 
 trait TupleLikeInfo {
+    #[allow(dead_code)]
     fn get_path(&self) -> &str;
+    #[allow(dead_code)]
     fn get_field(&self, index: usize) -> Option<&UnnamedField>;
     fn get_field_len(&self) -> usize;
 }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -34,6 +34,7 @@ wgpu_trace = ["wgpu/trace"]
 ci_limits = []
 webgl = ["wgpu/webgl"]
 webgpu = ["wgpu/webgpu"]
+ios_simulator = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -3,7 +3,7 @@ use std::ops::{Div, DivAssign, Mul, MulAssign};
 
 use crate::primitives::Frustum;
 use bevy_app::{App, Plugin, PostStartup, PostUpdate};
-use bevy_ecs::{prelude::*, reflect::ReflectComponent};
+use bevy_ecs::prelude::*;
 use bevy_math::{AspectRatio, Mat4, Rect, Vec2, Vec3A};
 use bevy_reflect::{
     std_traits::ReflectDefault, GetTypeRegistration, Reflect, ReflectDeserialize, ReflectSerialize,

--- a/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
@@ -354,7 +354,7 @@ pub mod binding_types {
     };
     use encase::ShaderType;
     use std::num::NonZeroU64;
-    use wgpu::{BindingType, StorageTextureAccess, TextureFormat};
+    use wgpu::{StorageTextureAccess, TextureFormat};
 
     use super::*;
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -285,7 +285,7 @@ impl ShaderCache {
                     shader_defs.push("SIXTEEN_BYTE_ALIGNMENT".into());
                 }
 
-                if cfg!(ios_simulator) {
+                if cfg!(feature = "ios_simulator") {
                     shader_defs.push("NO_CUBE_ARRAY_TEXTURES_SUPPORT".into());
                 }
 

--- a/crates/bevy_render/src/render_resource/pipeline_cache.rs
+++ b/crates/bevy_render/src/render_resource/pipeline_cache.rs
@@ -21,10 +21,7 @@ use std::{
 use thiserror::Error;
 #[cfg(feature = "shader_format_spirv")]
 use wgpu::util::make_spirv;
-use wgpu::{
-    DownlevelFlags, Features, PipelineLayoutDescriptor, PushConstantRange, ShaderModuleDescriptor,
-    VertexBufferLayout as RawVertexBufferLayout,
-};
+use wgpu::{DownlevelFlags, Features, VertexBufferLayout as RawVertexBufferLayout};
 
 use crate::render_resource::resource_macros::*;
 

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -277,7 +277,7 @@ impl<T: ShaderType + WriteInto> DynamicUniformBuffer<T> {
         device: &RenderDevice,
         queue: &'a RenderQueue,
     ) -> Option<DynamicUniformBufferWriter<'a, T>> {
-        let alignment = if cfg!(ios_simulator) {
+        let alignment = if cfg!(feature = "ios_simulator") {
             // On iOS simulator on silicon macs, metal validation check that the host OS alignment
             // is respected, but the device reports the correct value for iOS, which is smaller.
             // Use the larger value.

--- a/crates/bevy_render/src/texture/fallback_image.rs
+++ b/crates/bevy_render/src/texture/fallback_image.rs
@@ -5,7 +5,6 @@ use bevy_ecs::{
     system::{Resource, SystemParam},
 };
 use bevy_utils::HashMap;
-use wgpu::{Extent3d, TextureFormat};
 
 use crate::{
     prelude::Image,

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -4,8 +4,7 @@ use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
 use bevy_render::{
-    color::LegacyColor, prelude::Shader, render_asset::RenderAssets, render_resource::*,
-    texture::Image,
+    color::LegacyColor, render_asset::RenderAssets, render_resource::*, texture::Image,
 };
 
 pub const COLOR_MATERIAL_SHADER_HANDLE: Handle<Shader> =

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -24,7 +24,7 @@ use bevy_render::{
     },
     render_resource::{
         binding_types::{sampler, texture_2d, uniform_buffer},
-        BindGroupEntries, *,
+        *,
     },
     renderer::{RenderDevice, RenderQueue},
     texture::{

--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -6,10 +6,7 @@ use bevy_core_pipeline::core_2d::graph::{Core2d, Node2d};
 use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
 use bevy_core_pipeline::{core_2d::Camera2d, core_3d::Camera3d};
 use bevy_hierarchy::Parent;
-use bevy_render::{
-    render_phase::PhaseItem, render_resource::BindGroupEntries, view::ViewVisibility,
-    ExtractSchedule, Render,
-};
+use bevy_render::{render_phase::PhaseItem, view::ViewVisibility, ExtractSchedule, Render};
 use bevy_sprite::{SpriteAssetEvents, TextureAtlas};
 pub use pipeline::*;
 pub use render_pass::*;

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -1,16 +1,13 @@
 use std::{hash::Hash, marker::PhantomData, ops::Range};
 
-use bevy_app::{App, Plugin};
 use bevy_asset::*;
 use bevy_derive::{Deref, DerefMut};
 use bevy_ecs::{
-    prelude::{Component, Entity, EventReader},
-    query::{ROQueryItem, With},
-    schedule::IntoSystemConfigs,
+    prelude::Component,
+    query::ROQueryItem,
     storage::SparseSet,
     system::lifetimeless::{Read, SRes},
     system::*,
-    world::{FromWorld, World},
 };
 use bevy_math::{Mat4, Rect, Vec2, Vec4Swizzles};
 use bevy_render::{
@@ -22,7 +19,7 @@ use bevy_render::{
     renderer::{RenderDevice, RenderQueue},
     texture::{BevyDefault, FallbackImage, Image},
     view::*,
-    Extract, ExtractSchedule, Render, RenderApp, RenderSet,
+    Extract, ExtractSchedule, Render, RenderSet,
 };
 use bevy_transform::prelude::GlobalTransform;
 use bevy_utils::{FloatOrd, HashMap, HashSet};

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -20,7 +20,7 @@ pub use winit_config::*;
 pub use winit_windows::*;
 
 use bevy_app::{App, AppExit, Last, Plugin, PluginsState};
-use bevy_ecs::event::{Events, ManualEventReader};
+use bevy_ecs::event::ManualEventReader;
 use bevy_ecs::prelude::*;
 use bevy_ecs::system::SystemState;
 use bevy_input::{

--- a/examples/mobile/.cargo/config.toml
+++ b/examples/mobile/.cargo/config.toml
@@ -2,4 +2,4 @@
 # This needs some workarounds for now
 # See https://github.com/bevyengine/bevy/pull/10178 - remove if it's not needed anymore.
 [target.aarch64-apple-ios-sim]
-rustflags = ["--cfg=ios_simulator"]
+features = ["bevy_render/ios_simulator"]

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -16,6 +16,7 @@ bitflags! {
         const BENCH_CHECK = 0b01000000;
         const EXAMPLE_CHECK = 0b10000000;
         const COMPILE_CHECK = 0b100000000;
+        const CFG_CHECK = 0b1000000000;
     }
 }
 
@@ -38,6 +39,7 @@ fn main() {
         ("compile-fail", Check::COMPILE_FAIL),
         ("bench-check", Check::BENCH_CHECK),
         ("example-check", Check::EXAMPLE_CHECK),
+        ("cfg-check", Check::CFG_CHECK),
         ("doc-check", Check::DOC_CHECK),
         ("doc-test", Check::DOC_TEST),
     ];
@@ -154,5 +156,12 @@ fn main() {
         cmd!(sh, "cargo check --workspace")
             .run()
             .expect("Please fix compiler errors in output above.");
+    }
+
+    if what_to_run.contains(Check::CFG_CHECK) {
+        // Run cfg checks
+        cmd!(sh, "cargo check -Zcheck-cfg --workspace")
+            .run()
+            .expect("Please fix failing cfg checks in output above.");
     }
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -159,7 +159,8 @@ fn main() {
     }
 
     if what_to_run.contains(Check::CFG_CHECK) {
-        // Run cfg checks
+        // Check cfg and imports
+        std::env::set_var("RUSTFLAGS", "-D warnings");
         cmd!(sh, "cargo check -Zcheck-cfg --workspace")
             .run()
             .expect("Please fix failing cfg checks in output above.");


### PR DESCRIPTION
# Objective

- Add the new `-Zcheck-cfg` checks to catch more warnings
- Fixes #12091

## Solution

- Create a new `cfg-check` to the CI that runs `cargo check -Zcheck-cfg --workspace` using cargo nightly (and fails if there are warnings)
- Fix all warnings generated by the new check

---

## Changelog

- Remove all redundant imports
- Fix cfg wasm32 targets
- Add 3 dead code exceptions (should StandardColor be unused?)
- Convert ios_simulator to a feature (I'm not sure if this is the right way to do it, but the check complained before)

## Migration Guide

No breaking changes
