### PR TITLE
Reflect `GizmoConfigStore`

### DIFF
--- a/crates/bevy_gizmos/src/config.rs
+++ b/crates/bevy_gizmos/src/config.rs
@@ -3,8 +3,8 @@
 use crate as bevy_gizmos;
 pub use bevy_gizmos_macros::GizmoConfigGroup;
 
-use bevy_ecs::{component::Component, system::Resource};
-use bevy_reflect::{Reflect, TypePath};
+use bevy_ecs::{component::Component, reflect::ReflectResource, system::Resource};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect, TypePath};
 use bevy_render::view::RenderLayers;
 use bevy_utils::TypeIdMap;
 use core::panic;
@@ -27,9 +27,11 @@ pub struct DefaultGizmoConfigGroup;
 /// A [`Resource`] storing [`GizmoConfig`] and [`GizmoConfigGroup`] structs
 ///
 /// Use `app.init_gizmo_group::<T>()` to register a custom config group.
-#[derive(Resource, Default)]
+#[derive(Reflect, Resource, Default)]
+#[reflect(Resource, Default)]
 pub struct GizmoConfigStore {
     // INVARIANT: must map TypeId::of::<T>() to correct type T
+    #[reflect(ignore)]
     store: TypeIdMap<(GizmoConfig, Box<dyn Reflect>)>,
 }
 

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -98,6 +98,7 @@ impl Plugin for GizmoPlugin {
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 
         app.register_type::<GizmoConfig>()
+            .register_type::<GizmoConfigStore>()
             .add_plugins(UniformComponentPlugin::<LineGizmoUniform>::default())
             .init_asset::<LineGizmo>()
             .add_plugins(RenderAssetPlugin::<LineGizmo>::default())


### PR DESCRIPTION
# Objective

- Make `GizmoConfigStore` play well with reflection-based workflows like editors.

## Solution

- `#[derive(Reflect)]` and call `.register_type()`.