### PR TITLE
Fixed iOS documentation typo for xcrun command

### DIFF
--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -175,7 +175,7 @@ make run
 ```
 
 In an ideal world, this will boot up, install and run the app for the first
-iOS simulator in your `xcrun simctl devices list`. If this fails, you can
+iOS simulator in your `xcrun simctl list devices`. If this fails, you can
 specify the simulator device UUID via:
 
 ```sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -518,7 +518,7 @@ make run
 ```
 
 In an ideal world, this will boot up, install and run the app for the first
-iOS simulator in your `xcrun simctl devices list`. If this fails, you can
+iOS simulator in your `xcrun simctl list devices`. If this fails, you can
 specify the simulator device UUID via:
 
 ```sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -518,7 +518,7 @@ make run
 ```
 
 In an ideal world, this will boot up, install and run the app for the first
-iOS simulator in your `xcrun simctl list`. If this fails, you can
+iOS simulator in your `xcrun simctl devices list`. If this fails, you can
 specify the simulator device UUID via:
 
 ```sh

--- a/examples/README.md
+++ b/examples/README.md
@@ -518,7 +518,7 @@ make run
 ```
 
 In an ideal world, this will boot up, install and run the app for the first
-iOS simulator in your `xcrun simctl devices list`. If this fails, you can
+iOS simulator in your `xcrun simctl list`. If this fails, you can
 specify the simulator device UUID via:
 
 ```sh


### PR DESCRIPTION
```
$ xcrun simctl devices list
Unrecognized subcommand: devices
usage: simctl [--set <path>] [--profiles <path>] <subcommand> ...
       simctl help [subcommand]
Command line utility to control the Simulator
```

# Objective

- The `examples/README.md` contains an invalid example command for listing iOS devices using `xcrun`.
## Solution

- Update example command to omit the current invalid subcommand "`devices`".
