### PR TITLE
Early-exit bloom node if `intensity == 0.0`

### DIFF
--- a/crates/bevy_core_pipeline/src/bloom/mod.rs
+++ b/crates/bevy_core_pipeline/src/bloom/mod.rs
@@ -129,6 +129,10 @@ impl ViewNode for BloomNode {
         ): QueryItem<Self::ViewQuery>,
         world: &World,
     ) -> Result<(), NodeRunError> {
+        if bloom_settings.intensity == 0.0 {
+            return Ok(());
+        }
+
         let downsampling_pipeline_res = world.resource::<BloomDownsamplingPipeline>();
         let pipeline_cache = world.resource::<PipelineCache>();
         let uniforms = world.resource::<ComponentUniforms<BloomUniforms>>();


### PR DESCRIPTION
# Objective

- The bloom effect is currently somewhat costly (in terms of GPU time used), due to using fragment shaders for down- and upscaling (compute shaders generally perform better for such tasks).
- Additionally, one might have a `BloomSettings` on a camera whose `intensity` is only occasionally set to a non-zero value (eg. in outside areas or areas with bright lighting). Currently, the cost of the bloom shader is always incurred as long as the `BloomSettings` exists.

## Solution

- Bail out of the bloom render node when `intensity == 0.0`, making the effect free as long as it is turned all the way down.