### PR TITLE
Add Archetype::component_count

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -404,6 +404,12 @@ impl Archetype {
         self.components.indices()
     }
 
+    /// Gets the total amount of components in the archetype
+    #[inline]
+    pub fn component_count(&self) -> usize {
+        self.components.len()
+    }
+
     /// Fetches a immutable reference to the archetype's [`Edges`], a cache of
     /// archetypal relationships.
     #[inline]


### PR DESCRIPTION
Add Archetype::component_count utility method

# Objective

I wanted a method to count components on an archetype without iterating over them.

## Solution

Added `Archetype::component_count`