### PR TITLE
Fix typos

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -823,7 +823,7 @@ mod tests {
         schedule.add_systems(
             (
                 (|| {}).run_if(|| false),
-                // This system depends on a sytem that is always skipped.
+                // This system depends on a system that is always skipped.
                 |mut commands: Commands| {
                     commands.insert_resource(R);
                 },

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -210,7 +210,7 @@ impl AppGizmoBuilder for App {
 /// Holds handles to the line gizmos for each gizmo configuration group
 // As `TypeIdMap` iteration order depends on the order of insertions and deletions, this uses
 // `Option<Handle>` to be able to reserve the slot when creating the gizmo configuration group.
-// That way iteration order is stable accross executions and depends on the order of configuration
+// That way iteration order is stable across executions and depends on the order of configuration
 // group creation.
 #[derive(Resource, Default)]
 struct LineGizmoHandles {


### PR DESCRIPTION
# Objective

The new `typos` check added in #12036 is proving its value already.
It spotted some small typos: https://github.com/bevyengine/bevy/actions/runs/8053108519/job/21994719657?pr=12128

## Solution

Fix them.
