### PR TITLE
Make `TemporalJitter` and `MipBias` reflectable

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -975,7 +975,8 @@ pub fn sort_cameras(
 /// Do not use with [`OrthographicProjection`].
 ///
 /// [`OrthographicProjection`]: crate::camera::OrthographicProjection
-#[derive(Component, Clone, Default)]
+#[derive(Component, Clone, Default, Reflect)]
+#[reflect(Default, Component)]
 pub struct TemporalJitter {
     /// Offset is in range [-0.5, 0.5].
     pub offset: Vec2,
@@ -1001,5 +1002,6 @@ impl TemporalJitter {
 /// Camera component specifying a mip bias to apply when sampling from material textures.
 ///
 /// Often used in conjunction with antialiasing post-process effects to reduce textures blurriness.
-#[derive(Component)]
+#[derive(Default, Component, Reflect)]
+#[reflect(Default, Component)]
 pub struct MipBias(pub f32);

--- a/crates/bevy_render/src/camera/mod.rs
+++ b/crates/bevy_render/src/camera/mod.rs
@@ -33,6 +33,8 @@ impl Plugin for CameraPlugin {
             .register_type::<CameraRenderGraph>()
             .register_type::<CameraMainTextureUsages>()
             .register_type::<Exposure>()
+            .register_type::<TemporalJitter>()
+            .register_type::<MipBias>()
             .init_resource::<ManualTextureViews>()
             .init_resource::<ClearColor>()
             .add_plugins((


### PR DESCRIPTION
# Objective

- Make these types usable in reflection-based workflows.

## Solution

- The usual. Also reflect `Default` and `Component` behaviors so that the types can be constructed, inserted, and removed.
