### PR TITLE
CI: run long tasks on new macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         run: cargo run -p ci -- lints
 
   miri:
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
@@ -81,8 +81,6 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
           components: miri
-      - name: Install alsa and udev
-        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # To run the tests one item at a time for troubleshooting, use
         # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
@@ -200,39 +198,49 @@ jobs:
           echo 'You can find the extension here: https://marketplace.visualstudio.com/items?itemName=tekumara.typos-vscode'
 
 
-  run-examples-on-windows-dx12:
-    runs-on: windows-latest
-    timeout-minutes: 60
+  run-examples-macos-metal:
+    runs-on: macos-14
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@stable
-
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-windows-run-examples-${{ hashFiles('**/Cargo.toml') }}
-
+      - name: Disable audio
+        # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
+        run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
       - name: Build bevy
-        shell: bash
         # this uses the same command as when running the example to ensure build is reused
         run: |
-          WGPU_BACKEND=dx12 CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing"
-
+          TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome"
       - name: Run examples
-        shell: bash
         run: |
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
+            echo -n $example_name > last_example_run
             echo "running $example_name - "`date`
-            time WGPU_BACKEND=dx12 CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing"
+            time TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome"
             sleep 10
+            if [ `find ./ -maxdepth 1 -name 'screenshot-*.png' -print -quit` ]; then
+              mkdir screenshots-$example_name
+              mv screenshot-*.png screenshots-$example_name/
+            fi
           done
+          zip traces.zip trace*.json
+          zip -r screenshots.zip screenshots-*
+      - name: save traces
+        uses: actions/upload-artifact@v4
+        with:
+          name: example-traces-macos
+          path: traces.zip
+      - name: save screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: screenshots-macos
+          path: screenshots.zip
+      - uses: actions/upload-artifact@v4
+        if: ${{ failure() && github.event_name == 'pull_request' }}
+        with:
+          name: example-run-macos
+          path: example-run/
 
   check-doc:
     runs-on: ubuntu-latest
@@ -251,7 +259,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-        if: runner.os == 'linux'
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- doc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,18 +224,18 @@ jobs:
               mv screenshot-*.png screenshots-$example_name/
             fi
           done
-          zip traces.zip trace*.json
-          zip -r screenshots.zip screenshots-*
+          mkdir traces && mv trace*.json traces/
+          mkdir screenshots && mv screenshots-* screenshots/
       - name: save traces
         uses: actions/upload-artifact@v4
         with:
           name: example-traces-macos
-          path: traces.zip
+          path: traces
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
           name: screenshots-macos
-          path: screenshots.zip
+          path: screenshots
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -105,18 +105,18 @@ jobs:
               mv screenshot-*.png screenshots-$example_name/
             fi
           done
-          zip traces.zip trace*.json
-          zip -r screenshots.zip screenshots-*
+          mkdir traces && mv trace*.json traces/
+          mkdir screenshots && mv screenshots-* screenshots/
       - name: save traces
         uses: actions/upload-artifact@v4
         with:
           name: example-traces-linux
-          path: traces.zip
+          path: traces
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
           name: screenshots-linux
-          path: screenshots.zip
+          path: screenshots
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:
@@ -149,18 +149,18 @@ jobs:
               mv screenshot-*.png screenshots-$example_name/
             fi
           done
-          zip traces.zip trace*.json
-          zip -r screenshots.zip screenshots-*
+          mkdir traces && mv trace*.json traces/
+          mkdir screenshots && mv screenshots-* screenshots/
       - name: save traces
         uses: actions/upload-artifact@v4
         with:
           name: example-traces-windows
-          path: traces.zip
+          path: traces
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
           name: screenshots-windows
-          path: screenshots.zip
+          path: screenshots
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -123,27 +123,26 @@ jobs:
           name: example-run-linux
           path: example-run/
 
-  run-examples-macos-metal:
+  run-examples-on-windows-dx12:
     if: ${{ github.event_name == 'merge_group' }}
-    runs-on: macos-14
+    runs-on: windows-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Disable audio
-        # Disable audio through a patch. on github m1 runners, audio timeouts after 15 minutes
-        run: git apply --ignore-whitespace tools/example-showcase/disable-audio.patch
       - name: Build bevy
+        shell: bash
         # this uses the same command as when running the example to ensure build is reused
         run: |
-          TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome"
+          WGPU_BACKEND=dx12 TRACE_CHROME=trace-alien_cake_addict.json CI_TESTING_CONFIG=.github/example-run/alien_cake_addict.ron cargo build --example alien_cake_addict --features "bevy_ci_testing,trace,trace_chrome"
       - name: Run examples
+        shell: bash
         run: |
           for example in .github/example-run/*.ron; do
             example_name=`basename $example .ron`
             echo -n $example_name > last_example_run
             echo "running $example_name - "`date`
-            time TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome"
+            time WGPU_BACKEND=dx12 TRACE_CHROME=trace-$example_name.json CI_TESTING_CONFIG=$example cargo run --example $example_name --features "bevy_ci_testing,trace,trace_chrome"
             sleep 10
             if [ `find ./ -maxdepth 1 -name 'screenshot-*.png' -print -quit` ]; then
               mkdir screenshots-$example_name
@@ -155,17 +154,17 @@ jobs:
       - name: save traces
         uses: actions/upload-artifact@v4
         with:
-          name: example-traces-macos
+          name: example-traces-windows
           path: traces.zip
       - name: save screenshots
         uses: actions/upload-artifact@v4
         with:
-          name: screenshots-macos
+          name: screenshots-windows
           path: screenshots.zip
       - uses: actions/upload-artifact@v4
         if: ${{ failure() && github.event_name == 'pull_request' }}
         with:
-          name: example-run-macos
+          name: example-run-windows
           path: example-run/
 
   run-examples-on-wasm:


### PR DESCRIPTION
# Objective

- Make PR CI faster

## Solution

- Run example on macOS, Windows examples are now run on PR merge instead. This is the biggest change in duration
- Run miri on macOS. It doesn't change much the duration, but will free a runner 2 minutes earlier
- Don't run check-doc job as it hangs on macOS. Don't move too many job as there are less macOS-14 runners globally available and they are more limited

before:
<img width="794" alt="Screenshot 2024-02-26 at 20 47 07" src="https://github.com/bevyengine/bevy/assets/8672791/349292a1-cddd-4e4b-aba9-4dbaef1fc4d6">

after
<img width="790" alt="Screenshot 2024-02-26 at 20 47 23" src="https://github.com/bevyengine/bevy/assets/8672791/7b0983b2-0a8a-44d2-9bde-e4c6ecfbf97a">
