### PR TITLE
Fix fetching assets in Web Workers

### DIFF
--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -39,9 +39,8 @@ fn js_value_to_err<'a>(context: &'a str) -> impl FnOnce(JsValue) -> std::io::Err
 impl HttpWasmAssetReader {
     async fn fetch_bytes<'a>(&self, path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
         let global = js_sys::global();
-        let maybe_window =
-            Reflect::get(&global, &JsValue::from_str("Window"))
-                .map_err(js_value_to_err("reflect JavaScript global context"))?;
+        let maybe_window = Reflect::get(&global, &JsValue::from_str("Window"))
+            .map_err(js_value_to_err("reflect JavaScript global context"))?;
         let promise = if !maybe_window.is_undefined() {
             let window = global.dyn_into::<web_sys::Window>().unwrap();
             window.fetch_with_str(path.to_str().unwrap())
@@ -52,8 +51,10 @@ impl HttpWasmAssetReader {
                 let worker = global.dyn_into::<web_sys::WorkerGlobalScope>().unwrap();
                 worker.fetch_with_str(path.to_str().unwrap())
             } else {
-                let error = std::io::Error::new(std::io::ErrorKind::Other,
-                    "Unsupported JavaScript global context");
+                let error = std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "Unsupported JavaScript global context",
+                );
                 return Err(AssetReaderError::Io(error.into()));
             }
         };

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -12,11 +12,14 @@ use web_sys::Response;
 /// Represents the global object in the JavaScript context
 #[wasm_bindgen]
 extern "C" {
+    /// The [Global](https://developer.mozilla.org/en-US/docs/Glossary/Global_object) object.
     type Global;
 
+    /// The [window](https://developer.mozilla.org/en-US/docs/Web/API/Window) global object.
     #[wasm_bindgen(method, getter, js_name = Window)]
     fn window(this: &Global) -> JsValue;
 
+    /// The [WorkerGlobalScope](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope) global object.
     #[wasm_bindgen(method, getter, js_name = WorkerGlobalScope)]
     fn worker(this: &Global) -> JsValue;
 }
@@ -50,6 +53,7 @@ fn js_value_to_err<'a>(context: &'a str) -> impl FnOnce(JsValue) -> std::io::Err
 
 impl HttpWasmAssetReader {
     async fn fetch_bytes<'a>(&self, path: PathBuf) -> Result<Box<Reader<'a>>, AssetReaderError> {
+        // The JS global scope includes a self-reference via a specialising name, which can be used to determine the type of global context available.
         let global: Global = js_sys::global().unchecked_into();
         let promise = if !global.window().is_undefined() {
             let window: web_sys::Window = global.unchecked_into();


### PR DESCRIPTION
# Objective

This PR fixes #12125

## Solution

The logic in this PR was borrowed from gloo-net and essentially probes the global Javascript context to see if we are in a window or a worker before calling `fetch_with_str`.