### PR TITLE
Replace `FromWorld` requirement on `ReflectResource` and reflect `Resource` for `State<S>`

### DIFF
--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -57,9 +57,7 @@
 //!
 //! [`get_type_registration`]: bevy_reflect::GetTypeRegistration::get_type_registration
 
-use std::any::TypeId;
-
-use super::ReflectFromWorld;
+use super::from_reflect_or_world;
 use crate::{
     change_detection::Mut,
     component::Component,
@@ -309,48 +307,4 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
             },
         })
     }
-}
-
-/// Creates a `T` from a `&dyn Reflect`.
-///
-/// The first approach uses `T`'s implementation of `FromReflect`.
-/// If this fails, it falls back to default-initializing a new instance of `T` using its
-/// `ReflectFromWorld` data from the `world`'s `AppTypeRegistry` and `apply`ing the
-/// `&dyn Reflect` on it.
-///
-/// Panics if both approaches fail.
-fn from_reflect_or_world<T: FromReflect>(
-    reflected: &dyn Reflect,
-    world: &mut World,
-    registry: &TypeRegistry,
-) -> T {
-    if let Some(value) = T::from_reflect(reflected) {
-        return value;
-    }
-
-    // Clone the `ReflectFromWorld` because it's cheap and "frees"
-    // the borrow of `world` so that it can be passed to `from_world`.
-    let Some(reflect_from_world) = registry.get_type_data::<ReflectFromWorld>(TypeId::of::<T>())
-    else {
-        panic!(
-            "`FromReflect` failed and no `ReflectFromWorld` registration found for `{}`",
-            // FIXME: once we have unique reflect, use `TypePath`.
-            std::any::type_name::<T>(),
-        );
-    };
-
-    let Ok(mut value) = reflect_from_world
-        .from_world(world)
-        .into_any()
-        .downcast::<T>()
-    else {
-        panic!(
-            "the `ReflectFromWorld` registration for `{}` produced a value of a different type",
-            // FIXME: once we have unique reflect, use `TypePath`.
-            std::any::type_name::<T>(),
-        );
-    };
-
-    value.apply(reflected);
-    *value
 }

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -21,7 +21,7 @@ pub use from_world::{ReflectFromWorld, ReflectFromWorldFns};
 pub use map_entities::ReflectMapEntities;
 pub use resource::{ReflectResource, ReflectResourceFns};
 
-/// A [`Resource`] storing [`TypeRegistry`](bevy_reflect::TypeRegistry) for
+/// A [`Resource`] storing [`TypeRegistry`] for
 /// type registrations relevant to a whole app.
 #[derive(Resource, Clone, Default)]
 pub struct AppTypeRegistry(pub TypeRegistryArc);

--- a/crates/bevy_ecs/src/reflect/mod.rs
+++ b/crates/bevy_ecs/src/reflect/mod.rs
@@ -70,11 +70,7 @@ fn from_reflect_or_world<T: FromReflect>(
         );
     };
 
-    let Ok(mut value) = reflect_from_world
-        .from_world(world)
-        .into_any()
-        .downcast::<T>()
-    else {
+    let Ok(mut value) = reflect_from_world.from_world(world).take::<T>() else {
         panic!(
             "the `ReflectFromWorld` registration for `{}` produced a value of a different type",
             // FIXME: once we have unique reflect, use `TypePath`.
@@ -83,5 +79,5 @@ fn from_reflect_or_world<T: FromReflect>(
     };
 
     value.apply(reflected);
-    *value
+    value
 }

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -30,7 +30,7 @@ pub struct ReflectResource(ReflectResourceFns);
 /// > will not need.
 /// > Usually a [`ReflectResource`] is created for a type by deriving [`Reflect`]
 /// > and adding the `#[reflect(Resource)]` attribute.
-/// > After adding the component to the [`TypeRegistry`][bevy_reflect::TypeRegistry],
+/// > After adding the component to the [`TypeRegistry`],
 /// > its [`ReflectResource`] can then be retrieved when needed.
 ///
 /// Creating a custom [`ReflectResource`] may be useful if you need to create new resource types at

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -176,43 +176,43 @@ impl ReflectResource {
     }
 }
 
-impl<C: Resource + Reflect + FromReflect> FromType<C> for ReflectResource {
+impl<R: Resource + Reflect + FromReflect> FromType<R> for ReflectResource {
     fn from_type() -> Self {
         ReflectResource(ReflectResourceFns {
             insert: |world, reflected_resource, registry| {
-                let resource = from_reflect_or_world::<C>(reflected_resource, world, registry);
+                let resource = from_reflect_or_world::<R>(reflected_resource, world, registry);
                 world.insert_resource(resource);
             },
             apply: |world, reflected_resource| {
-                let mut resource = world.resource_mut::<C>();
+                let mut resource = world.resource_mut::<R>();
                 resource.apply(reflected_resource);
             },
             apply_or_insert: |world, reflected_resource, registry| {
-                if let Some(mut resource) = world.get_resource_mut::<C>() {
+                if let Some(mut resource) = world.get_resource_mut::<R>() {
                     resource.apply(reflected_resource);
                 } else {
-                    let resource = from_reflect_or_world::<C>(reflected_resource, world, registry);
+                    let resource = from_reflect_or_world::<R>(reflected_resource, world, registry);
                     world.insert_resource(resource);
                 }
             },
             remove: |world| {
-                world.remove_resource::<C>();
+                world.remove_resource::<R>();
             },
-            reflect: |world| world.get_resource::<C>().map(|res| res as &dyn Reflect),
+            reflect: |world| world.get_resource::<R>().map(|res| res as &dyn Reflect),
             reflect_unchecked_mut: |world| {
                 // SAFETY: all usages of `reflect_unchecked_mut` guarantee that there is either a single mutable
                 // reference or multiple immutable ones alive at any given point
                 unsafe {
-                    world.get_resource_mut::<C>().map(|res| Mut {
+                    world.get_resource_mut::<R>().map(|res| Mut {
                         value: res.value as &mut dyn Reflect,
                         ticks: res.ticks,
                     })
                 }
             },
             copy: |source_world, destination_world, registry| {
-                let source_resource = source_world.resource::<C>();
+                let source_resource = source_world.resource::<R>();
                 let destination_resource =
-                    from_reflect_or_world::<C>(source_resource, destination_world, registry);
+                    from_reflect_or_world::<R>(source_resource, destination_world, registry);
                 destination_world.insert_resource(destination_resource);
             },
         })

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -67,7 +67,7 @@ impl ReflectResourceFns {
     ///
     /// This is useful if you want to start with the default implementation before overriding some
     /// of the functions to create a custom implementation.
-    pub fn new<T: Resource + Reflect + FromReflect>() -> Self {
+    pub fn new<T: Resource + FromReflect>() -> Self {
         <ReflectResource as FromType<T>>::from_type().0
     }
 }
@@ -176,7 +176,7 @@ impl ReflectResource {
     }
 }
 
-impl<R: Resource + Reflect + FromReflect> FromType<R> for ReflectResource {
+impl<R: Resource + FromReflect> FromType<R> for ReflectResource {
     fn from_type() -> Self {
         ReflectResource(ReflectResourceFns {
             insert: |world, reflected_resource, registry| {

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -96,7 +96,11 @@ pub struct OnTransition<S: States> {
 /// }
 /// ```
 #[derive(Resource, Debug)]
-#[cfg_attr(feature = "bevy_reflect", derive(bevy_reflect::Reflect))]
+#[cfg_attr(
+    feature = "bevy_reflect",
+    derive(bevy_reflect::Reflect),
+    reflect(Resource)
+)]
 pub struct State<S: States>(S);
 
 impl<S: States> State<S> {

--- a/crates/bevy_scene/src/dynamic_scene.rs
+++ b/crates/bevy_scene/src/dynamic_scene.rs
@@ -90,7 +90,7 @@ impl DynamicScene {
 
             // If the world already contains an instance of the given resource
             // just apply the (possibly) new value, otherwise insert the resource
-            reflect_resource.apply_or_insert(world, &**resource);
+            reflect_resource.apply_or_insert(world, &**resource, &type_registry);
         }
 
         // For each component types that reference other entities, we keep track

--- a/crates/bevy_scene/src/scene.rs
+++ b/crates/bevy_scene/src/scene.rs
@@ -89,7 +89,7 @@ impl Scene {
                     type_path: registration.type_info().type_path().to_string(),
                 }
             })?;
-            reflect_resource.copy(&self.world, world);
+            reflect_resource.copy(&self.world, world, &type_registry);
         }
 
         for archetype in self.world.archetypes().iter() {


### PR DESCRIPTION
# Objective

- In #9623 I forgot to change the `FromWorld` requirement for `ReflectResource`, fix that;
- Fix #12129

## Solution

- Use the same approach as in #9623 to try using `FromReflect` and falling back to the `ReflectFromWorld` contained in the `TypeRegistry` provided
- Just reflect `Resource` on `State<S>` since now that's possible without introducing new bounds.

---

## Changelog

- `ReflectResource`'s `FromType<T>` implementation no longer requires `T: FromWorld`, but instead now requires `FromReflect`.
- `ReflectResource::insert`, `ReflectResource::apply_or_insert` and `ReflectResource::copy` now take an extra `&TypeRegistry` parameter.

## Migration Guide

- Users of `#[reflect(Resource)]` will need to also implement/derive `FromReflect` (should already be the default).
- Users of `#[reflect(Resource)]` may now want to also add `FromWorld` to the list of reflected traits in case their `FromReflect` implementation may fail.
- Users of `ReflectResource` will now need to pass a `&TypeRegistry` to its `insert`, `apply_or_insert` and `copy` methods.