### PR TITLE
Allow non-sRGB views of internal camera textures

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -512,6 +512,8 @@ pub fn prepare_view_targets(
                             view_formats: match main_texture_format {
                                 TextureFormat::Bgra8Unorm => &[TextureFormat::Bgra8UnormSrgb],
                                 TextureFormat::Rgba8Unorm => &[TextureFormat::Rgba8UnormSrgb],
+                                TextureFormat::Bgra8UnormSrgb => &[TextureFormat::Bgra8Unorm],
+                                TextureFormat::Rgba8UnormSrgb => &[TextureFormat::Rgba8Unorm],
                                 _ => &[],
                             },
                         };


### PR DESCRIPTION
# Objective

- Compute shaders can be a more performant way to implement full-screen post-processing passes, but they cannot use sRGB textures as output storage textures, so a non-sRGB view has to be created first.

## Solution

- Allow non-sRGB views for the camera internal textures.
