### PR TITLE
Faster query construction

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -293,7 +293,7 @@ pub(crate) struct ArchetypeSwapRemoveResult {
 /// Internal metadata for a [`Component`] within a given [`Archetype`].
 ///
 /// [`Component`]: crate::component::Component
-struct ArchetypeComponentInfo {
+pub struct ArchetypeComponentInfo {
     storage_type: StorageType,
     archetype_component_id: ArchetypeComponentId,
 }
@@ -609,7 +609,7 @@ pub struct Archetypes {
     pub(crate) archetypes: Vec<Archetype>,
     archetype_component_count: usize,
     by_components: bevy_utils::HashMap<ArchetypeComponents, ArchetypeId>,
-    component_to_archetypes:
+    pub component_to_archetypes:
         bevy_utils::HashMap<ComponentId, bevy_utils::HashMap<ArchetypeId, ArchetypeComponentInfo>>,
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -741,35 +741,46 @@ impl Archetypes {
                 *archetype_component_count += sparse_set_components.len();
                 let sparse_set_archetype_components =
                     (sparse_start..*archetype_component_count).map(ArchetypeComponentId);
-                archetypes.push(Archetype::new(
-                    id,
-                    table_id,
-                    table_components.clone().into_iter().zip(table_archetype_components),
-                    sparse_set_components.clone()
-                        .into_iter()
-                        .zip(sparse_set_archetype_components),
-                ));
 
-                for component_id in &table_components {
+                // dirty clones (because I couldn't make it just borrow for some reason)
+                for (component_id, archetype_component_id) in table_components
+                    .clone()
+                    .into_iter()
+                    .zip(table_archetype_components.clone())
+                {
                     let map = component_to_archetypes
-                        .entry(*component_id)
+                        .entry(component_id)
                         .or_insert(bevy_utils::HashMap::new());
 
                     map.entry(id).or_insert(ArchetypeComponentInfo {
                         storage_type: StorageType::Table,
-                        archetype_component_id: ArchetypeComponentId(0),
+                        archetype_component_id,
                     });
                 }
-                for component_id in &sparse_set_components {
+
+                for (component_id, archetype_component_id) in sparse_set_components
+                    .clone()
+                    .into_iter()
+                    .zip(sparse_set_archetype_components.clone())
+                {
                     let map = component_to_archetypes
-                        .entry(*component_id)
+                        .entry(component_id)
                         .or_insert(bevy_utils::HashMap::new());
 
                     map.entry(id).or_insert(ArchetypeComponentInfo {
                         storage_type: StorageType::SparseSet,
-                        archetype_component_id: ArchetypeComponentId(0),
+                        archetype_component_id,
                     });
                 }
+
+                archetypes.push(Archetype::new(
+                    id,
+                    table_id,
+                    table_components.into_iter().zip(table_archetype_components),
+                    sparse_set_components
+                        .into_iter()
+                        .zip(sparse_set_archetype_components),
+                ));
                 id
             })
     }

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -263,11 +263,13 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
     pub fn update_archetypes_unsafe_world_cell(&mut self, world: UnsafeWorldCell) {
         self.validate_world(world.id());
         let archetypes = world.archetypes();
-        let old_generation =
-            std::mem::replace(&mut self.archetype_generation, archetypes.generation());
+        let access = self.component_access.access.clone();
 
-        for archetype in &archetypes[old_generation..] {
-            self.new_archetype(archetype);
+        for component_id in access.reads_and_writes() {
+            let matching_archetypes = &archetypes.component_to_archetypes[&component_id];
+            for &archetype_id in matching_archetypes.keys() {
+                self.new_archetype(&archetypes[archetype_id]);
+            }
         }
     }
 


### PR DESCRIPTION
# Objective

Speed up the creation and updating of archetypes that match a query. 

## Solution

Instead of iterating over all (added) archetypes to find the few that match, this uses a component-to-archetype hashmap to speed up the process.

This is part of https://github.com/bevyengine/bevy/discussions/6493 and https://github.com/orgs/bevyengine/projects/15?pane=issue&itemId=49039260.