### PR TITLE
Allow access to the `CachedTexture` through `PostProcessWrite`

### DIFF
--- a/crates/bevy_render/src/view/mod.rs
+++ b/crates/bevy_render/src/view/mod.rs
@@ -204,6 +204,8 @@ pub struct ViewTarget {
 pub struct PostProcessWrite<'a> {
     pub source: &'a TextureView,
     pub destination: &'a TextureView,
+    pub source_texture: &'a CachedTexture,
+    pub destination_texture: &'a CachedTexture,
 }
 
 impl ViewTarget {
@@ -329,12 +331,16 @@ impl ViewTarget {
             PostProcessWrite {
                 source: &self.main_textures.a.texture.default_view,
                 destination: &self.main_textures.b.texture.default_view,
+                source_texture: &self.main_textures.a.texture,
+                destination_texture: &self.main_textures.b.texture,
             }
         } else {
             self.main_textures.a.mark_as_cleared();
             PostProcessWrite {
                 source: &self.main_textures.b.texture.default_view,
                 destination: &self.main_textures.a.texture.default_view,
+                source_texture: &self.main_textures.b.texture,
+                destination_texture: &self.main_textures.a.texture,
             }
         }
     }


### PR DESCRIPTION
# Objective

- Compute shaders cannot write to sRGB storage textures, so in order to implement a post-processing pass with a compute shader, a non-sRGB view must be created first.
- `PostProcessWrite` doesn't allow accessing the underlying `Textures`, so creating views currently requires using `ViewTarget::main_texture` or `ViewTarget::main_texture_other`.

## Solution

- Store references to the whole `CachedTexture`s inside `PostProcessWrite`.

---

## Changelog

### Changed

Allow accessing the source and destination `CachedTexture`s through `PostProcessWrite`.