### PR TITLE
Remove downcast-rs as a dependency from bevy_ecs

### DIFF
--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -25,7 +25,6 @@ bevy_ecs_macros = { path = "macros", version = "0.14.0-dev" }
 concurrent-queue = "2.4.0"
 fixedbitset = "0.4.2"
 rustc-hash = "1.1"
-downcast-rs = "1.2"
 serde = "1"
 thiserror = "1.0"
 


### PR DESCRIPTION
# Objective
`downcast-rs` is not used within bevy_ecs. This is probably a remnant from before Schedule v3 landed, since stages needed the downcasting.

## Solution
Remove it.