### PR TITLE
compute shader game of life example: use R32Float instead of Rgba8Unorm

### DIFF
--- a/assets/shaders/game_of_life.wgsl
+++ b/assets/shaders/game_of_life.wgsl
@@ -1,4 +1,4 @@
-@group(0) @binding(0) var texture: texture_storage_2d<rgba8unorm, read_write>;
+@group(0) @binding(0) var texture: texture_storage_2d<r32float, read_write>;
 
 fn hash(value: u32) -> u32 {
     var state = value;

--- a/examples/shader/compute_shader_game_of_life.rs
+++ b/examples/shader/compute_shader_game_of_life.rs
@@ -48,7 +48,7 @@ fn setup(mut commands: Commands, mut images: ResMut<Assets<Image>>) {
         },
         TextureDimension::D2,
         &[0, 0, 0, 255],
-        TextureFormat::Rgba8Unorm,
+        TextureFormat::R32Float,
         RenderAssetUsages::RENDER_WORLD,
     );
     image.texture_descriptor.usage =
@@ -97,7 +97,7 @@ impl Plugin for GameOfLifeComputePlugin {
 
 #[derive(Resource, Clone, Deref, ExtractResource, AsBindGroup)]
 struct GameOfLifeImage {
-    #[storage_texture(0, image_format = Rgba8Unorm, access = ReadWrite)]
+    #[storage_texture(0, image_format = R32Float, access = ReadWrite)]
     texture: Handle<Image>,
 }
 


### PR DESCRIPTION
# Objective

- Fixes #9670 
- Avoid a crash in CI due to
```
thread 'Compute Task Pool (0)' panicked at /Users/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/wgpu-0.19.1/src/backend/wgpu_core.rs:3009:5:
wgpu error: Validation Error

Caused by:
    In Device::create_bind_group
    The adapter does not support read access for storages texture of format Rgba8Unorm
```

## Solution

- Use an `R32Float` texture instead of an `Rgba8Unorm` as it's a tier 1 texture format https://github.com/gpuweb/gpuweb/issues/3838 and is more supported
- This should also improve support for webgpu in the next wgpu version
