### PR TITLE
Define a prelude for bevy_color, and add it to bevy_internal

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ default = [
   "animation",
   "bevy_asset",
   "bevy_audio",
+  "bevy_color",
   "bevy_gilrs",
   "bevy_scene",
   "bevy_winit",
@@ -90,6 +91,9 @@ bevy_asset = ["bevy_internal/bevy_asset"]
 
 # Provides audio functionality
 bevy_audio = ["bevy_internal/bevy_audio"]
+
+# Provides shared color types and operations
+bevy_color = ["bevy_internal/bevy_color"]
 
 # Provides cameras and other basic render pipeline features
 bevy_core_pipeline = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ default = [
 dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
 
 # Provides animation functionality
-bevy_animation = ["bevy_internal/bevy_animation"]
+bevy_animation = ["bevy_internal/bevy_animation", "bevy_color"]
 
 # Provides asset functionality
 bevy_asset = ["bevy_internal/bevy_asset"]
@@ -120,7 +120,7 @@ bevy_pbr = [
 ]
 
 # Provides rendering functionality
-bevy_render = ["bevy_internal/bevy_render"]
+bevy_render = ["bevy_internal/bevy_render", "bevy_color"]
 
 # Provides scene functionality
 bevy_scene = ["bevy_internal/bevy_scene", "bevy_asset"]
@@ -137,13 +137,14 @@ bevy_ui = [
   "bevy_core_pipeline",
   "bevy_text",
   "bevy_sprite",
+  "bevy_color",
 ]
 
 # winit window and input backend
 bevy_winit = ["bevy_internal/bevy_winit"]
 
 # Adds support for rendering gizmos
-bevy_gizmos = ["bevy_internal/bevy_gizmos"]
+bevy_gizmos = ["bevy_internal/bevy_gizmos", "bevy_color"]
 
 # Tracing support, saving a file in Chrome Tracing format
 trace_chrome = ["trace", "bevy_internal/trace_chrome"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,12 @@ bevy_render = ["bevy_internal/bevy_render", "bevy_color"]
 bevy_scene = ["bevy_internal/bevy_scene", "bevy_asset"]
 
 # Provides sprite functionality
-bevy_sprite = ["bevy_internal/bevy_sprite", "bevy_render", "bevy_core_pipeline"]
+bevy_sprite = [
+  "bevy_internal/bevy_sprite",
+  "bevy_render",
+  "bevy_core_pipeline",
+  "bevy_color",
+]
 
 # Provides text functionality
 bevy_text = ["bevy_internal/bevy_text", "bevy_asset", "bevy_sprite"]

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -95,6 +95,21 @@ mod test_colors;
 mod testing;
 mod xyza;
 
+/// Commonly used color types and traits.
+pub mod prelude {
+    pub use crate::color::*;
+    pub use crate::color_ops::*;
+    pub use crate::hsla::*;
+    pub use crate::hsva::*;
+    pub use crate::hwba::*;
+    pub use crate::laba::*;
+    pub use crate::lcha::*;
+    pub use crate::linear_rgba::*;
+    pub use crate::oklaba::*;
+    pub use crate::srgba::*;
+    pub use crate::xyza::*;
+}
+
 pub use color::*;
 pub use color_ops::*;
 pub use color_range::*;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -185,6 +185,7 @@ bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 bevy_animation = { path = "../bevy_animation", optional = true, version = "0.14.0-dev" }
 bevy_asset = { path = "../bevy_asset", optional = true, version = "0.14.0-dev" }
 bevy_audio = { path = "../bevy_audio", optional = true, version = "0.14.0-dev" }
+bevy_color = { path = "../bevy_color", optional = true, version = "0.14.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", optional = true, version = "0.14.0-dev" }
 bevy_gltf = { path = "../bevy_gltf", optional = true, version = "0.14.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", optional = true, version = "0.14.0-dev" }

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -27,6 +27,12 @@ pub mod core {
     pub use bevy_core::*;
 }
 
+#[cfg(feature = "bevy_color")]
+pub mod color {
+    //! Shared color types and operations.
+    pub use bevy_color::*;
+}
+
 pub mod diagnostic {
     //! Useful diagnostic plugins and types for bevy apps.
     pub use bevy_diagnostic::*;

--- a/crates/bevy_internal/src/prelude.rs
+++ b/crates/bevy_internal/src/prelude.rs
@@ -20,6 +20,10 @@ pub use crate::audio::prelude::*;
 pub use crate::animation::prelude::*;
 
 #[doc(hidden)]
+#[cfg(feature = "bevy_color")]
+pub use crate::color::prelude::*;
+
+#[doc(hidden)]
 #[cfg(feature = "bevy_core_pipeline")]
 pub use crate::core_pipeline::prelude::*;
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -16,6 +16,7 @@ The default feature set enables most of the expected features of a game engine, 
 |bevy_animation|Provides animation functionality|
 |bevy_asset|Provides asset functionality|
 |bevy_audio|Provides audio functionality|
+|bevy_color|Provides shared color types and operations|
 |bevy_core_pipeline|Provides cameras and other basic render pipeline features|
 |bevy_debug_stepping|Enable stepping-based debugging of Bevy systems|
 |bevy_gilrs|Adds gamepad support|


### PR DESCRIPTION
# Objective

As we start to migrate to `bevy_color` in earnest (#12056), we should make it visible to Bevy users, and usable in examples.

## Solution

1. Add a prelude to `bevy_color`: I've only excluded the rarely used `ColorRange` type and the testing-focused color distance module. I definitely think that some color spaces are less useful than others to end users, but at the same time the types used there are very unlikely to conflict with user-facing types.
2. Add `bevy_color` to `bevy_internal` as an optional crate.
3. Re-export `bevy_color`'s prelude as part of `bevy::prelude`.