### PR TITLE
Gate bevy_utils web-time re-export

### DIFF
--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -14,7 +14,6 @@ detailed_trace = []
 [dependencies]
 ahash = "0.8.7"
 tracing = { version = "0.1", default-features = false, features = ["std"] }
-web-time = { version = "0.2" }
 uuid = { version = "1.1", features = ["v4", "serde"] }
 hashbrown = { version = "0.14", features = ["serde"] }
 bevy_utils_proc_macros = { version = "0.14.0-dev", path = "macros" }
@@ -28,6 +27,7 @@ smallvec = { version = "1.11", features = ["serde", "union", "const_generics"] }
 static_assertions = "1.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+web-time = "0.2"
 getrandom = { version = "0.2.0", features = ["js"] }
 
 [lints]

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -34,12 +34,12 @@ pub use hashbrown;
 pub use parallel_queue::*;
 pub use petgraph;
 pub use smallvec;
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 pub use thiserror;
 pub use tracing;
 #[cfg(target_arch = "wasm32")]
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
-#[cfg(not(target_arch = "wasm32"))]
-pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 
 #[allow(missing_docs)]
 pub mod nonmax {

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -34,10 +34,11 @@ pub use hashbrown;
 pub use parallel_queue::*;
 pub use petgraph;
 pub use smallvec;
-#[cfg(not(target_arch = "wasm32"))]
-pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 pub use thiserror;
 pub use tracing;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 #[cfg(target_arch = "wasm32")]
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -36,7 +36,10 @@ pub use petgraph;
 pub use smallvec;
 pub use thiserror;
 pub use tracing;
+#[cfg(target = "wasm32")]
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
+#[cfg(not(target = "wasm32"))]
+pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 
 #[allow(missing_docs)]
 pub mod nonmax {

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -36,9 +36,9 @@ pub use petgraph;
 pub use smallvec;
 pub use thiserror;
 pub use tracing;
-#[cfg(target = "wasm32")]
+#[cfg(target_arch = "wasm32")]
 pub use web_time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
-#[cfg(not(target = "wasm32"))]
+#[cfg(not(target_arch = "wasm32"))]
 pub use std::time::{Duration, Instant, SystemTime, SystemTimeError, TryFromFloatSecsError};
 
 #[allow(missing_docs)]


### PR DESCRIPTION
# Objective

Reduce non-required dependencies

# Solution
Gate bevy_utils re-export of web-time behind wasm32 target and re-export from `std::time` on non wasm target
