### PR TITLE
Make sysinfo diagnostic plugin optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,11 +77,15 @@ default = [
   "tonemapping_luts",
   "default_font",
   "webgl2",
+  "sysinfo_plugin",
   "bevy_debug_stepping",
 ]
 
 # Force dynamic linking, which improves iterative compile times
 dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
+
+# Enables sysinfo diagnostic plugin
+sysinfo_plugin = ["bevy_internal/sysinfo_plugin"]
 
 # Provides animation functionality
 bevy_animation = ["bevy_internal/bevy_animation", "bevy_color"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ default = [
 # Force dynamic linking, which improves iterative compile times
 dynamic_linking = ["dep:bevy_dylib", "bevy_internal/dynamic_linking"]
 
-# Enables sysinfo diagnostic plugin
+# Enables system information diagnostic plugin
 sysinfo_plugin = ["bevy_internal/sysinfo_plugin"]
 
 # Provides animation functionality

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -11,6 +11,8 @@ keywords = ["bevy"]
 [features]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
+sysinfo_plugin = []
+default-features = ["sysinfo_plugin"]
 
 [dependencies]
 # bevy
@@ -26,13 +28,13 @@ const-fnv1a-hash = "1.1.0"
 # MacOS
 [target.'cfg(all(target_os="macos"))'.dependencies]
 # Some features of sysinfo are not supported by apple. This will disable those features on apple devices
-sysinfo = { version = "0.30.0", default-features = false, features = [
+sysinfo = { version = "0.30.0", optional = true, default-features = false, features = [
   "apple-app-store",
 ] }
 
 # Only include when not bevy_dynamic_plugin and on linux/windows/android
 [target.'cfg(any(target_os = "linux", target_os = "windows", target_os = "android"))'.dependencies]
-sysinfo = { version = "0.30.0", default-features = false }
+sysinfo = { version = "0.30.0", optional = true, default-features = false }
 
 [lints]
 workspace = true

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
 sysinfo_plugin = []
-features = ["sysinfo_plugin"]
+features = []
 
 [dependencies]
 # bevy

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["bevy"]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
 sysinfo_plugin = []
-default-features = ["sysinfo_plugin"]
+features = ["sysinfo_plugin"]
 
 [dependencies]
 # bevy

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [features]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
-sysinfo_plugin = []
+sysinfo_plugin = ["sysinfo"]
 features = []
 
 [dependencies]

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -9,22 +9,27 @@ mod diagnostic;
 mod entity_count_diagnostics_plugin;
 mod frame_time_diagnostics_plugin;
 mod log_diagnostics_plugin;
+#[cfg(feature = "sysinfo_plugin")]
 mod system_information_diagnostics_plugin;
 
-use bevy_app::prelude::*;
 pub use diagnostic::*;
+
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
+#[cfg(feature = "sysinfo_plugin")]
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
+
+use bevy_app::prelude::*;
 
 /// Adds core diagnostics resources to an App.
 #[derive(Default)]
 pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
-    fn build(&self, app: &mut App) {
-        app.init_resource::<DiagnosticsStore>().add_systems(
+    fn build(&self, _app: &mut App) {
+        #[cfg(feature = "sysinfo_plugin")]
+        _app.init_resource::<DiagnosticsStore>().add_systems(
             Startup,
             system_information_diagnostics_plugin::internal::log_system_info,
         );

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -25,6 +25,8 @@ trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 detailed_trace = ["bevy_utils/detailed_trace"]
 
+sysinfo_plugin = ["bevy_diagnostics/sysinfo_plugin"]
+
 # Image format support for texture loading (PNG and HDR are enabled by default)
 exr = ["bevy_render/exr"]
 hdr = ["bevy_render/hdr"]

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -25,7 +25,7 @@ trace_tracy_memory = ["bevy_log/trace_tracy_memory"]
 wgpu_trace = ["bevy_render/wgpu_trace"]
 detailed_trace = ["bevy_utils/detailed_trace"]
 
-sysinfo_plugin = ["bevy_diagnostics/sysinfo_plugin"]
+sysinfo_plugin = ["bevy_diagnostic/sysinfo_plugin"]
 
 # Image format support for texture loading (PNG and HDR are enabled by default)
 exr = ["bevy_render/exr"]

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -34,7 +34,7 @@ The default feature set enables most of the expected features of a game engine, 
 |ktx2|KTX2 compressed texture support|
 |multi-threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
 |png|PNG image format support|
-|sysinfo_plugin|Enables sysinfo diagnostic plugin|
+|sysinfo_plugin|Enables system information diagnostic plugin|
 |tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method on your `Camera2dBundle` or `Camera3dBundle`.|
 |vorbis|OGG/VORBIS audio format support|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -34,6 +34,7 @@ The default feature set enables most of the expected features of a game engine, 
 |ktx2|KTX2 compressed texture support|
 |multi-threaded|Enables multithreaded parallelism in the engine. Disabling it forces all engine tasks to run on a single thread.|
 |png|PNG image format support|
+|sysinfo_plugin|Enables sysinfo diagnostic plugin|
 |tonemapping_luts|Include tonemapping Look Up Tables KTX2 files. If everything is pink, you need to enable this feature or change the `Tonemapping` method on your `Camera2dBundle` or `Camera3dBundle`.|
 |vorbis|OGG/VORBIS audio format support|
 |webgl2|Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.|


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/11929
- make sysinfo plugin optional

## Solution

- added features to allow for conditional compilation

---

## Migration Guide

- For users who disable default features of bevy and wish to enable the diagnostic plugin, add `sysinfo_plugin` to your bevy features list.