### PR TITLE
Add a colon to error message link

### DIFF
--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -66,7 +66,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
             already_diagnosed.insert(entity);
             bevy_log::warn!(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
-                This will cause inconsistent behaviors! See https://bevyengine.org/learn/errors/#b0004",
+                This will cause inconsistent behaviors! See: https://bevyengine.org/learn/errors/#b0004",
                 ty_name = get_short_name(std::any::type_name::<T>()),
                 name = name.map_or("An entity".to_owned(), |s| format!("The {s} entity")),
             );


### PR DESCRIPTION
# Objective

- #12165 recently added links to Bevy errors in error messages.
- The links were in the form of `See: https://bevyengine.org/learn/errors/#b000N`
- B0004 does not have the colon separating `See` and the link, unlike the rest of the error messages

## Solution

- Add a colon, for consistency :)