### PR TITLE
Update cargo deny

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,15 @@ deny = [
   { name = "glam", deny-multiple-versions = true },
   { name = "raw-window-handle", deny-multiple-versions = true },
 ]
+# To avoid https://github.com/bevyengine/bevy/issues/11917
+# = raw-window-handle v0.5.2
+#       └── ndk v0.7.0
+#           ├── cpal v0.15.2`
+#           │   └── rodio v0.17.3
+#           │       └── bevy_audio v0.14.0-dev
+skip-tree = [
+  { crate = "cpal@0.15.2", reason = "Waiting for new releases: https://github.com/bevyengine/bevy/issues/11917#issuecomment-1953629729" },
+]
 
 [sources]
 unknown-registry = "deny"

--- a/deny.toml
+++ b/deny.toml
@@ -1,69 +1,67 @@
+[graph]
 all-features = true
 
 [advisories]
-db-path = "~/.cargo/advisory-db"
-db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "deny"
-yanked = "deny"
-notice = "deny"
+version = 2
 ignore = []
 
 [licenses]
-unlicensed = "deny"
-copyleft = "deny"
-default = "deny"
+version = 2
 allow = [
-  "MIT",
-  "MIT-0",
-  "Apache-2.0",
-  "BSD-3-Clause",
-  "ISC",
-  "Zlib",
-  "0BSD",
-  "BSD-2-Clause",
-  "CC0-1.0",
+    "0BSD",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "CC0-1.0",
+    "ISC",
+    "MIT",
+    "MIT-0",
+    "Unlicense",
+    "Zlib",
 ]
+
 exceptions = [
-  { name = "unicode-ident", allow = [
-    "Unicode-DFS-2016",
-  ] },
-  { name = "symphonia-bundle-flac", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-bundle-mp3", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-codec-aac", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-codec-adpcm", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-codec-pcm", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-codec-vorbis", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-core", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-format-isomp4", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-format-wav", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-metadata", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia-utils-xiph", allow = [
-    "MPL-2.0",
-  ] },
-  { name = "symphonia", allow = [
-    "MPL-2.0",
-  ] },
+    { name = "unicode-ident", allow = [
+        "Unicode-DFS-2016",
+    ] },
+    { name = "symphonia", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-bundle-flac", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-bundle-mp3", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-codec-aac", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-codec-adpcm", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-codec-pcm", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-codec-vorbis", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-core", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-format-isomp4", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-format-riff", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-metadata", allow = [
+        "MPL-2.0",
+    ] },
+    { name = "symphonia-utils-xiph", allow = [
+        "MPL-2.0",
+    ] },
 ]
 
 [bans]
@@ -71,10 +69,10 @@ multiple-versions = "warn"
 wildcards = "deny"
 # Certain crates that we don't want multiple versions of in the dependency tree
 deny = [
-  { name = "ahash", deny-multiple-versions = true },
-  { name = "android-activity", deny-multiple-versions = true },
-  { name = "glam", deny-multiple-versions = true },
-  { name = "raw-window-handle", deny-multiple-versions = true },
+    { name = "ahash", deny-multiple-versions = true },
+    { name = "android-activity", deny-multiple-versions = true },
+    { name = "glam", deny-multiple-versions = true },
+    { name = "raw-window-handle", deny-multiple-versions = true },
 ]
 
 [sources]

--- a/deny.toml
+++ b/deny.toml
@@ -8,60 +8,60 @@ ignore = []
 [licenses]
 version = 2
 allow = [
-    "0BSD",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-2-Clause",
-    "BSD-3-Clause",
-    "BSL-1.0",
-    "CC0-1.0",
-    "ISC",
-    "MIT",
-    "MIT-0",
-    "Unlicense",
-    "Zlib",
+  "0BSD",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "BSL-1.0",
+  "CC0-1.0",
+  "ISC",
+  "MIT",
+  "MIT-0",
+  "Unlicense",
+  "Zlib",
 ]
 
 exceptions = [
-    { name = "unicode-ident", allow = [
-        "Unicode-DFS-2016",
-    ] },
-    { name = "symphonia", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-bundle-flac", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-bundle-mp3", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-codec-aac", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-codec-adpcm", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-codec-pcm", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-codec-vorbis", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-core", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-format-isomp4", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-format-riff", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-metadata", allow = [
-        "MPL-2.0",
-    ] },
-    { name = "symphonia-utils-xiph", allow = [
-        "MPL-2.0",
-    ] },
+  { name = "unicode-ident", allow = [
+    "Unicode-DFS-2016",
+  ] },
+  { name = "symphonia", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-bundle-flac", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-bundle-mp3", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-aac", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-adpcm", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-pcm", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-codec-vorbis", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-core", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-format-isomp4", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-format-riff", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-metadata", allow = [
+    "MPL-2.0",
+  ] },
+  { name = "symphonia-utils-xiph", allow = [
+    "MPL-2.0",
+  ] },
 ]
 
 [bans]
@@ -69,10 +69,10 @@ multiple-versions = "warn"
 wildcards = "deny"
 # Certain crates that we don't want multiple versions of in the dependency tree
 deny = [
-    { name = "ahash", deny-multiple-versions = true },
-    { name = "android-activity", deny-multiple-versions = true },
-    { name = "glam", deny-multiple-versions = true },
-    { name = "raw-window-handle", deny-multiple-versions = true },
+  { name = "ahash", deny-multiple-versions = true },
+  { name = "android-activity", deny-multiple-versions = true },
+  { name = "glam", deny-multiple-versions = true },
+  { name = "raw-window-handle", deny-multiple-versions = true },
 ]
 
 [sources]


### PR DESCRIPTION
# Objective

Cargo-deny has being updated and now some keys are being deprecated.
Fix these warnings:
<details>

```rs
warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:6:1
  │
6 │ vulnerability = "deny"
  │ ^^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:7:1
  │
7 │ unmaintained = "deny"
  │ ^^^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
  ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:9:1
  │
9 │ notice = "deny"
  │ ^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:13:1
   │
13 │ unlicensed = "deny"
   │ ^^^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:14:1
   │
14 │ copyleft = "deny"
   │ ^^^^^^^^

warning[deprecated]: this key will be removed in a future update, see https://github.com/EmbarkStudios/cargo-deny/pull/611 for details
   ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:15:1
   │
15 │ default = "deny"
   │ ^^^^^^^

warning[deprecated]: this key has been moved to [graph]
  ┌─ /Users/ameknite/code/rust/repos/bevy/deny.toml:1:1
  │
1 │ all-features = true
  │ ^^^^^^^^^^^^
```
</details>

This also fix ci by temporarily skipping the check for cpal dependencies.
https://github.com/bevyengine/bevy/issues/11917#issuecomment-1953629729



## Solution

- Remove keys deprecated.
- Update the list of licenses allowed. (All these licenses are already being use for some dependencies)
- Skip cpal dependencies to avoid falining in CI, while we wait for new releases https://github.com/bevyengine/bevy/issues/11917#issuecomment-1953629729

