### PR TITLE
Add a way to define and enforce legal state transitions

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -514,7 +514,10 @@ pub fn derive_component(input: TokenStream) -> TokenStream {
     component::derive_component(input)
 }
 
-#[proc_macro_derive(States)]
+#[proc_macro_derive(States, attributes(transition_to))]
 pub fn derive_states(input: TokenStream) -> TokenStream {
-    states::derive_states(input)
+    let ast = parse_macro_input!(input as DeriveInput);
+    states::derive_states(ast)
+        .unwrap_or_else(syn::Error::into_compile_error)
+        .into()
 }

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -24,7 +24,7 @@ pub fn derive_states(ast: DeriveInput) -> syn::Result<TokenStream> {
     Ok(quote! {
         impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
             #[inline]
-            fn can_transit_to(self, target: Self) -> bool {
+            fn can_transit_to(&self, target: &Self) -> bool {
                 #can_transit_to_impl
             }
         }

--- a/crates/bevy_ecs/macros/src/states.rs
+++ b/crates/bevy_ecs/macros/src/states.rs
@@ -1,11 +1,18 @@
-use proc_macro::TokenStream;
+use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
-use syn::{parse_macro_input, DeriveInput};
+use syn::{
+    parenthesized, parse::Parse, punctuated::Punctuated, token::Paren, AttrStyle, DataEnum,
+    DeriveInput, Ident, MetaList, Token, Variant,
+};
 
 use crate::bevy_ecs_path;
 
-pub fn derive_states(input: TokenStream) -> TokenStream {
-    let ast = parse_macro_input!(input as DeriveInput);
+pub fn derive_states(ast: DeriveInput) -> syn::Result<TokenStream> {
+    let can_transit_to_impl = match &ast.data {
+        syn::Data::Enum(data) => impl_can_transit_to_for_enum(&ast.ident, data)?,
+        syn::Data::Struct(_) | syn::Data::Union(_) => quote! { true },
+    };
+
     let generics = ast.generics;
     let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
 
@@ -14,8 +21,103 @@ pub fn derive_states(input: TokenStream) -> TokenStream {
     trait_path.segments.push(format_ident!("States").into());
     let struct_name = &ast.ident;
 
-    quote! {
-        impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {}
+    Ok(quote! {
+        impl #impl_generics #trait_path for #struct_name #ty_generics #where_clause {
+            #[inline]
+            fn can_transit_to(self, target: Self) -> bool {
+                #can_transit_to_impl
+            }
+        }
+    })
+}
+
+const TRANSITION_TO: &str = "transition_to";
+
+fn impl_can_transit_to_for_enum(enum_name: &Ident, data: &DataEnum) -> syn::Result<TokenStream> {
+    let match_branches = data
+        .variants
+        .iter()
+        .map(|variant| {
+            let variant_ident = &variant.ident;
+            let transitions = extract_transition_attributes_for_variant(variant)?;
+
+            Ok(match transitions {
+                Some(TransitionTo { inverted, targets }) => {
+                    let value = if inverted.is_some() {
+                        quote!(false)
+                    } else {
+                        quote!(true)
+                    };
+                    let targets = targets.iter();
+                    quote! {
+                        #( ( #enum_name::#variant_ident, #enum_name::#targets ) => #value, )*
+                        ( #enum_name::#variant_ident, _ ) => !#value,
+                    }
+                }
+
+                // The default behaviour is to allow the transition.
+                None => quote! {
+                    ( #enum_name::#variant_ident, _ ) => true,
+                },
+            })
+        })
+        .collect::<syn::Result<TokenStream>>()?;
+
+    Ok(quote! {
+        match (self, target) {
+            #match_branches
+        }
+    })
+}
+
+fn extract_transition_attributes_for_variant(
+    variant: &Variant,
+) -> syn::Result<Option<TransitionTo>> {
+    let mut transitions = variant
+        .attrs
+        .iter()
+        .filter(|attr| matches!(attr.style, AttrStyle::Outer))
+        .filter_map(|attr| match &attr.meta {
+            syn::Meta::List(MetaList { path, tokens, .. }) if path.is_ident(TRANSITION_TO) => {
+                Some(syn::parse2(tokens.clone()))
+            }
+            _ => None,
+        });
+
+    let first = transitions.next().transpose();
+
+    if transitions.next().is_some() {
+        return Err(syn::Error::new_spanned(
+            variant,
+            format!("only one `{TRANSITION_TO}` attribute is allowed per variant"),
+        ));
     }
-    .into()
+
+    first
+}
+
+mod kw {
+    syn::custom_keyword!(not);
+}
+
+struct TransitionTo {
+    inverted: Option<(kw::not, Paren)>,
+    targets: Punctuated<Ident, Token![,]>,
+}
+
+impl Parse for TransitionTo {
+    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+        Ok(if input.peek(kw::not) {
+            let content;
+            TransitionTo {
+                inverted: Some((input.parse()?, parenthesized!(content in input))),
+                targets: content.parse_terminated(Ident::parse, Token![,])?,
+            }
+        } else {
+            TransitionTo {
+                inverted: None,
+                targets: input.parse_terminated(Ident::parse, Token![,])?,
+            }
+        })
+    }
 }

--- a/crates/bevy_ecs/src/schedule/state.rs
+++ b/crates/bevy_ecs/src/schedule/state.rs
@@ -47,7 +47,7 @@ pub trait States: 'static + Send + Sync + Clone + PartialEq + Eq + Hash + Debug 
     ///
     /// The default implementation returns always `true`.
     #[inline]
-    fn can_transit_to(self, target: Self) -> bool {
+    fn can_transit_to(&self, target: &Self) -> bool {
         let _ = target;
         true
     }
@@ -267,17 +267,17 @@ mod tests {
         }
 
         use MyState::*;
-        assert!(!MyState::A.can_transit_to(A));
-        assert!(MyState::A.can_transit_to(B));
-        assert!(!MyState::A.can_transit_to(C));
+        assert!(!MyState::A.can_transit_to(&A));
+        assert!(MyState::A.can_transit_to(&B));
+        assert!(!MyState::A.can_transit_to(&C));
 
-        assert!(MyState::B.can_transit_to(A));
-        assert!(MyState::B.can_transit_to(B));
-        assert!(MyState::B.can_transit_to(C));
+        assert!(MyState::B.can_transit_to(&A));
+        assert!(MyState::B.can_transit_to(&B));
+        assert!(MyState::B.can_transit_to(&C));
 
-        assert!(MyState::C.can_transit_to(A));
-        assert!(MyState::C.can_transit_to(B));
-        assert!(!MyState::C.can_transit_to(C));
+        assert!(MyState::C.can_transit_to(&A));
+        assert!(MyState::C.can_transit_to(&B));
+        assert!(!MyState::C.can_transit_to(&C));
     }
 
     /// Check that the default implementation of [`States`] allow all transition.
@@ -291,16 +291,16 @@ mod tests {
         }
 
         use MyState::*;
-        assert!(MyState::A.can_transit_to(A));
-        assert!(MyState::A.can_transit_to(B));
-        assert!(MyState::A.can_transit_to(C));
+        assert!(MyState::A.can_transit_to(&A));
+        assert!(MyState::A.can_transit_to(&B));
+        assert!(MyState::A.can_transit_to(&C));
 
-        assert!(MyState::B.can_transit_to(A));
-        assert!(MyState::B.can_transit_to(B));
-        assert!(MyState::B.can_transit_to(C));
+        assert!(MyState::B.can_transit_to(&A));
+        assert!(MyState::B.can_transit_to(&B));
+        assert!(MyState::B.can_transit_to(&C));
 
-        assert!(MyState::C.can_transit_to(A));
-        assert!(MyState::C.can_transit_to(B));
-        assert!(MyState::C.can_transit_to(C));
+        assert!(MyState::C.can_transit_to(&A));
+        assert!(MyState::C.can_transit_to(&B));
+        assert!(MyState::C.can_transit_to(&C));
     }
 }


### PR DESCRIPTION
# Objective

- Fix #12177

## Solution

- Add a `States::can_transit_to(&self, target: &Self) -> bool` method to define when a transition from a state to another is allowed.
- Add a `transition_to` attribute to `derive(States)` that defines which transitions are valid.
- Check if the transition is valid in `apply_state_transition` and emit a warning if the transition is not valid.
- The default behavior matches the current behavior, so it doesn't introduce breaking changes.

---

## Changelog

- Add a `States::can_transit_to` method to determine if a given state transition is valid.
- `derive(States)` accepts a `transition_to` attribute to determine the allowed transitions for the state.
  - **Limitation**: it's work only for enum type with only unit variants (i.e. with no fields).
```rust
#[derive(States, Clone, PartialEq, Eq, Hash, Debug)]
enum MyState {
    // `A` to `A` and `A` to `C` are not allowed (all others transitions are allowed)
    #[transition_to(not(A, C))]
    A,
    // By default all transition are allowed
    B,
    // `C` to `A` and `C` to `B` are allowed (all others transitions are not allowed)
    #[transition_to(A, B)]
    C,
}

use MyState::*;
assert!(!MyState::A.can_transit_to(&A));
assert!(MyState::A.can_transit_to(&B));
assert!(!MyState::A.can_transit_to(&C));

assert!(MyState::B.can_transit_to(&A));
assert!(MyState::B.can_transit_to(&B));
assert!(MyState::B.can_transit_to(&C));

assert!(MyState::C.can_transit_to(&A));
assert!(MyState::C.can_transit_to(&B));
assert!(!MyState::C.can_transit_to(&C));
```
