### PR TITLE
minor oklab/oklch doc nitpicks

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -29,9 +29,9 @@ pub enum Color {
     Laba(Laba),
     /// A color in the LCH color space with alpha.
     Lcha(Lcha),
-    /// A color in the Oklaba color space with alpha.
+    /// A color in the Oklab color space with alpha.
     Oklaba(Oklaba),
-    /// A color in the Oklcha color space with alpha.
+    /// A color in the Oklch color space with alpha.
     Oklcha(Oklcha),
     /// A color in the XYZ color space with alpha.
     Xyza(Xyza),

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -10,6 +10,7 @@
 //! - [`Laba`] (lightness, a-axis, b-axis, alpha)
 //! - [`Lcha`] (lightness, chroma, hue, alpha)
 //! - [`Oklaba`] (lightness, a-axis, b-axis, alpha)
+//! - [`Oklcha`] (lightness, chroma, hue, alpha)
 //! - [`Xyza`] (x-axis, y-axis, z-axis, alpha)
 //!
 //! Each of these color spaces is represented as a distinct Rust type.
@@ -39,7 +40,7 @@
 //! and an analog of lightness in the form of value. In contrast, HWB instead uses whiteness and blackness
 //! parameters, which can be used to lighten and darken a particular hue respectively.
 //!
-//! Oklab and Okclch are perceptually uniform color spaces that are designed to be used for tasks such
+//! Oklab and Oklch are perceptually uniform color spaces that are designed to be used for tasks such
 //! as image processing. They are not as widely used as the other color spaces, but are useful
 //! for tasks such as color correction and image analysis, where it is important to be able
 //! to do things like change color saturation without causing hue shifts.

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -5,7 +5,7 @@ use crate::{
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
-/// Color in Oklaba color space, with alpha
+/// Color in Oklab color space, with alpha
 #[doc = include_str!("../docs/conversion.md")]
 /// <div>
 #[doc = include_str!("../docs/diagrams/model_graph.svg")]


### PR DESCRIPTION
# Objective

Just some mild annoyances:
- The `Color::Oklaba`, `Color::Oklcha` and `oklaba::Oklaba` doc comments were inconsistent with the others
- The crate-level docs didn't include `Oklch` in the list of representations and misspelt it in a later paragraph

## Solution

- Fix 'em