### PR TITLE
texture transform: use 2 vec4 (4 Vec2) instead of a mat3x3 (Mat3)

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -614,7 +614,7 @@ pub struct StandardMaterialUniform {
     pub uv_transform_y_axis: Vec2,
     /// The translation of the transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is [0, 0].
     pub uv_transform_translation: Vec2,
-    /// Needed for alignement, otherwise some versions of DX12 crash
+    /// Needed for alignment, otherwise some versions of DX12 crash
     pub padding: Vec2,
     /// Linear perceptual roughness, clamped to [0.089, 1.0] in the shader
     /// Defaults to minimum of 0.089

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -1,6 +1,6 @@
 use bevy_asset::Asset;
 use bevy_color::Alpha;
-use bevy_math::{Affine2, Mat3, Vec4};
+use bevy_math::{Affine2, Vec2, Vec4};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::{
     mesh::MeshVertexBufferLayoutRef, render_asset::RenderAssets, render_resource::*,
@@ -608,8 +608,13 @@ pub struct StandardMaterialUniform {
     pub emissive: Vec4,
     /// Color white light takes after travelling through the attenuation distance underneath the material surface
     pub attenuation_color: Vec4,
-    /// The transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is identity.
-    pub uv_transform: Mat3,
+    /// The x-axis of the mat2 of the transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is [1, 0].
+    pub uv_transform_x_axis: Vec2,
+    /// The y-axis of the mat2 of the transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is [0, 1].
+    pub uv_transform_y_axis: Vec2,
+    /// The translation of the transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is [0, 0].
+    pub uv_transform_translation: Vec2,
+    pub padding: Vec2,
     /// Linear perceptual roughness, clamped to [0.089, 1.0] in the shader
     /// Defaults to minimum of 0.089
     pub roughness: f32,
@@ -746,7 +751,10 @@ impl AsBindGroupShaderType<StandardMaterialUniform> for StandardMaterial {
             lightmap_exposure: self.lightmap_exposure,
             max_relief_mapping_search_steps: self.parallax_mapping_method.max_steps(),
             deferred_lighting_pass_id: self.deferred_lighting_pass_id as u32,
-            uv_transform: self.uv_transform.into(),
+            uv_transform_x_axis: self.uv_transform.matrix2.x_axis,
+            uv_transform_y_axis: self.uv_transform.matrix2.y_axis,
+            uv_transform_translation: self.uv_transform.translation,
+            padding: Vec2::ZERO,
         }
     }
 }

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -614,6 +614,7 @@ pub struct StandardMaterialUniform {
     pub uv_transform_y_axis: Vec2,
     /// The translation of the transform applied to the UVs corresponding to ATTRIBUTE_UV_0 on the mesh before sampling. Default is [0, 0].
     pub uv_transform_translation: Vec2,
+    /// Needed for alignement, otherwise some versions of DX12 crash
     pub padding: Vec2,
     /// Linear perceptual roughness, clamped to [0.089, 1.0] in the shader
     /// Defaults to minimum of 0.089

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -74,8 +74,8 @@ fn pbr_input_from_standard_material(
 
 #ifdef VERTEX_UVS
     let uv_transform = mat3x3<f32>(
-        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.xy, 0.0),
-        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.zw, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axes.xy, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axes.zw, 0.0),
         vec3<f32>(pbr_bindings::material.uv_transform_translation.xy, 1.0),
     );
     var uv = (uv_transform * vec3(in.uv, 1.0)).xy;

--- a/crates/bevy_pbr/src/render/pbr_fragment.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_fragment.wgsl
@@ -73,7 +73,11 @@ fn pbr_input_from_standard_material(
     let NdotV = max(dot(pbr_input.N, pbr_input.V), 0.0001);
 
 #ifdef VERTEX_UVS
-    let uv_transform = pbr_bindings::material.uv_transform;
+    let uv_transform = mat3x3<f32>(
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.xy, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.zw, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_translation.xy, 1.0),
+    );
     var uv = (uv_transform * vec3(in.uv, 1.0)).xy;
 
 #ifdef VERTEX_TANGENTS

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -19,8 +19,8 @@ fn prepass_alpha_discard(in: VertexOutput) {
 
 #ifdef VERTEX_UVS
     let uv_transform = mat3x3<f32>(
-        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.xy, 0.0),
-        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.zw, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axes.xy, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axes.zw, 0.0),
         vec3<f32>(pbr_bindings::material.uv_transform_translation.xy, 1.0),
     );
     let uv = (uv_transform * vec3(in.uv, 1.0)).xy;

--- a/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_prepass_functions.wgsl
@@ -18,7 +18,11 @@ fn prepass_alpha_discard(in: VertexOutput) {
     var output_color: vec4<f32> = pbr_bindings::material.base_color;
 
 #ifdef VERTEX_UVS
-    let uv_transform = pbr_bindings::material.uv_transform;
+    let uv_transform = mat3x3<f32>(
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.xy, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_xy_axys.zw, 0.0),
+        vec3<f32>(pbr_bindings::material.uv_transform_translation.xy, 1.0),
+    );
     let uv = (uv_transform * vec3(in.uv, 1.0)).xy;
     if (pbr_bindings::material.flags & pbr_types::STANDARD_MATERIAL_FLAGS_BASE_COLOR_TEXTURE_BIT) != 0u {
         output_color = output_color * textureSampleBias(pbr_bindings::base_color_texture, pbr_bindings::base_color_sampler, uv, view.mip_bias);

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -6,7 +6,8 @@ struct StandardMaterial {
     base_color: vec4<f32>,
     emissive: vec4<f32>,
     attenuation_color: vec4<f32>,
-    uv_transform: mat3x3<f32>,
+    uv_transform_xy_axys: vec4<f32>,
+    uv_transform_translation: vec4<f32>,
     perceptual_roughness: f32,
     metallic: f32,
     reflectance: f32,
@@ -78,7 +79,8 @@ fn standard_material_new() -> StandardMaterial {
     material.max_relief_mapping_search_steps = 5u;
     material.deferred_lighting_pass_id = 1u;
     // scale 1, translation 0, rotation 0
-    material.uv_transform = mat3x3<f32>(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0);
+    material.uv_transform_xy_axys = vec4<f32>(1.0, 0.0, 0.0, 0.1);
+    material.uv_transform_translation = vec4<f32>(0.0, 0.0, 0.0, 0.0);
 
     return material;
 }

--- a/crates/bevy_pbr/src/render/pbr_types.wgsl
+++ b/crates/bevy_pbr/src/render/pbr_types.wgsl
@@ -6,7 +6,7 @@ struct StandardMaterial {
     base_color: vec4<f32>,
     emissive: vec4<f32>,
     attenuation_color: vec4<f32>,
-    uv_transform_xy_axys: vec4<f32>,
+    uv_transform_xy_axes: vec4<f32>,
     uv_transform_translation: vec4<f32>,
     perceptual_roughness: f32,
     metallic: f32,
@@ -79,7 +79,7 @@ fn standard_material_new() -> StandardMaterial {
     material.max_relief_mapping_search_steps = 5u;
     material.deferred_lighting_pass_id = 1u;
     // scale 1, translation 0, rotation 0
-    material.uv_transform_xy_axys = vec4<f32>(1.0, 0.0, 0.0, 0.1);
+    material.uv_transform_xy_axes = vec4<f32>(1.0, 0.0, 0.0, 0.1);
     material.uv_transform_translation = vec4<f32>(0.0, 0.0, 0.0, 0.0);
 
     return material;


### PR DESCRIPTION
# Objective

- Work on all platforms after KHR_texture_transform support #11904 
- Initial PR didn't work on WebGL2 (fixed in #12110) and DX12 in some specific case (only observed in CI)

```
2024-02-29T22:06:45.647912Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default    
thread 'Compute Task Pool (1)' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\backend\wgpu_core.rs:3009:5:
wgpu error: Validation Error

Caused by:
    In Queue::write_buffer_with
    Creation of a resource failed for a reason other than running out of memory.


note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Encountered a panic in system `bevy_pbr::render::light::prepare_lights`!
2024-02-29T22:06:45.666035Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default    
thread 'Compute Task Pool (0)' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\backend\wgpu_core.rs:3009:5:
wgpu error: Validation Error

Caused by:
    In Queue::write_buffer
    Creation of a resource failed for a reason other than running out of memory.


Encountered a panic in system `bevy_render::globals::prepare_globals_buffer`!
2024-02-29T22:06:45.666245Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default    
thread 'Compute Task Pool (0)' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\backend\wgpu_core.rs:3009:5:
wgpu error: Validation Error

Caused by:
    In Queue::write_buffer_with
    Creation of a resource failed for a reason other than running out of memory.


Encountered a panic in system `bevy_render::view::prepare_view_uniforms`!
2024-02-29T22:06:45.666459Z ERROR wgpu::backend::wgpu_core: Handling wgpu errors as fatal by default    
thread 'Compute Task Pool (0)' panicked at C:\Users\runneradmin\.cargo\registry\src\index.crates.io-6f17d22bba15001f\wgpu-0.19.1\src\backend\wgpu_core.rs:3009:5:
wgpu error: Validation Error

Caused by:
    In Device::create_buffer
    Creation of a resource failed for a reason other than running out of memory.
...
```

## Solution

- Replace the `Mat3` by four `Vec2` which should be smaller, including some padding
- Rebuild the `mat3x3` from those vectors
- This works on Metal, WebGL2 and DX12 in CI