### PR TITLE
Add basic light gizmos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2669,6 +2669,17 @@ description = "A scene showcasing 3D gizmos"
 category = "Gizmos"
 wasm = true
 
+[[example]]
+name = "light_gizmos"
+path = "examples/gizmos/light_gizmos.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.light_gizmos]
+name = "Light Gizmos"
+description = "A scene showcasing light gizmos"
+category = "Gizmos"
+wasm = true
+
 [profile.wasm-release]
 inherits = "release"
 opt-level = "z"

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -32,6 +32,7 @@ pub mod circles;
 pub mod config;
 pub mod gizmos;
 pub mod grid;
+pub mod light;
 pub mod primitives;
 
 #[cfg(feature = "bevy_sprite")]
@@ -87,6 +88,8 @@ use config::{
 use gizmos::GizmoStorage;
 use std::{any::TypeId, mem};
 
+use crate::light::LightGizmoPlugin;
+
 const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
 
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
@@ -108,7 +111,8 @@ impl Plugin for GizmoPlugin {
             .init_resource::<LineGizmoHandles>()
             // We insert the Resource GizmoConfigStore into the world implicitly here if it does not exist.
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
-            .add_plugins(AabbGizmoPlugin);
+            .add_plugins(AabbGizmoPlugin)
+            .add_plugins(LightGizmoPlugin);
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
             return;

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -47,6 +47,7 @@ pub mod prelude {
         aabb::{AabbGizmoConfigGroup, ShowAabbGizmo},
         config::{DefaultGizmoConfigGroup, GizmoConfig, GizmoConfigGroup, GizmoConfigStore},
         gizmos::Gizmos,
+        light::{LightGizmoColor, LightGizmoConfigGroup, ShowLightGizmo},
         primitives::{dim2::GizmoPrimitive2d, dim3::GizmoPrimitive3d},
         AppGizmoBuilder,
     };
@@ -86,9 +87,8 @@ use config::{
     DefaultGizmoConfigGroup, GizmoConfig, GizmoConfigGroup, GizmoConfigStore, GizmoMeshConfig,
 };
 use gizmos::GizmoStorage;
+use light::LightGizmoPlugin;
 use std::{any::TypeId, mem};
-
-use crate::light::LightGizmoPlugin;
 
 const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
 

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -1,4 +1,4 @@
-//! A module adding debug visualization of f [`PointLight`]s, [`SpotLight`]s and [`DirectionalLight`]s.
+//! A module adding debug visualization of [`PointLight`]s, [`SpotLight`]s and [`DirectionalLight`]s.
 
 use std::f32::consts::PI;
 

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -75,7 +75,6 @@ fn spot_light_gizmo(
         .segments(16);
 
     // Offset the tip of the cone to the light position.
-    gizmos.sphere(translation, Quat::IDENTITY, 0.01, LinearRgba::GREEN);
     for angle in [spot_light.inner_angle, spot_light.outer_angle] {
         let height = spot_light.range * angle.cos();
         let position = translation + rotation * Vec3::NEG_Z * height / 2.0;
@@ -203,7 +202,7 @@ impl Default for LightGizmoConfigGroup {
 #[derive(Component, Reflect, Default, Debug)]
 #[reflect(Component, Default)]
 pub struct ShowLightGizmo {
-    /// Default color strategy for this light gizmo. if none, use the one provided by [`LightGizmoConfigGroup`].
+    /// Default color strategy for this light gizmo. if [`None`], use the one provided by [`LightGizmoConfigGroup`].
     ///
     /// Defaults to [`None`].
     color: Option<LightGizmoColor>,
@@ -237,7 +236,7 @@ fn draw_lights(
             entity,
             light_gizmo.color,
             light.color,
-            gizmos.config_ext.point_light_color,
+            gizmos.config_ext.spot_light_color,
         );
         spot_light_gizmo(transform, light, color, &mut gizmos);
     }
@@ -246,7 +245,7 @@ fn draw_lights(
             entity,
             light_gizmo.color,
             light.color,
-            gizmos.config_ext.point_light_color,
+            gizmos.config_ext.directional_light_color,
         );
         directional_light_gizmo(transform, color, &mut gizmos);
     }

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -1,0 +1,181 @@
+//! A module adding debug visualization of f [`PointLight`]s, [`SpotLight`]s and [`DirectionalLight`]s.
+
+use std::f32::consts::PI;
+
+use crate::{self as bevy_gizmos, primitives::dim3::GizmoPrimitive3d};
+
+use bevy_app::{Plugin, PostUpdate};
+use bevy_color::LinearRgba;
+use bevy_ecs::{
+    component::Component,
+    query::{With, Without},
+    reflect::ReflectComponent,
+    schedule::IntoSystemConfigs,
+    system::{Query, Res},
+};
+use bevy_math::{
+    primitives::{Cone, Sphere},
+    Quat, Vec3,
+};
+use bevy_pbr::{DirectionalLight, PointLight, SpotLight};
+use bevy_reflect::{std_traits::ReflectDefault, Reflect};
+use bevy_transform::{components::GlobalTransform, TransformSystem};
+
+use crate::{
+    config::{GizmoConfigGroup, GizmoConfigStore},
+    gizmos::Gizmos,
+    AppGizmoBuilder,
+};
+
+fn draw_gizmos<'a, P, S, D>(
+    point_lights: P,
+    spot_lights: S,
+    directional_lights: D,
+    gizmos: &mut Gizmos<LightGizmoConfigGroup>,
+) where
+    P: 'a + IntoIterator<Item = (&'a PointLight, &'a GlobalTransform)>,
+    S: 'a + IntoIterator<Item = (&'a SpotLight, &'a GlobalTransform)>,
+    D: 'a + IntoIterator<Item = (&'a DirectionalLight, &'a GlobalTransform)>,
+{
+    // Standard sphere for the radius, axis sphere for the range.
+    for (point_light, transform) in point_lights {
+        let position = transform.translation();
+        gizmos
+            .primitive_3d(
+                Sphere {
+                    radius: point_light.radius,
+                },
+                position,
+                Quat::IDENTITY,
+                point_light.color,
+            )
+            .segments(16);
+        gizmos
+            .sphere(
+                position,
+                Quat::IDENTITY,
+                point_light.range,
+                point_light.color,
+            )
+            .circle_segments(32);
+    }
+
+    // A sphere for the radius, two cones for the inner and outer angles, plus two 3d arcs crossing the
+    // farthest point of effect of the spot light along its direction.
+    for (spot_light, transform) in spot_lights {
+        let (_, rotation, translation) = transform.to_scale_rotation_translation();
+        gizmos
+            .primitive_3d(
+                Sphere {
+                    radius: spot_light.radius,
+                },
+                translation,
+                Quat::IDENTITY,
+                spot_light.color,
+            )
+            .segments(16);
+
+        // Offset the tip of the cone to the light position.
+        gizmos.sphere(translation, Quat::IDENTITY, 0.01, LinearRgba::GREEN);
+        for angle in [spot_light.inner_angle, spot_light.outer_angle] {
+            let height = spot_light.range * angle.cos();
+            let position = translation + rotation * Vec3::NEG_Z * height / 2.0;
+            gizmos
+                .primitive_3d(
+                    Cone {
+                        radius: spot_light.range * angle.sin(),
+                        height,
+                    },
+                    position,
+                    rotation * Quat::from_rotation_x(PI / 2.0),
+                    spot_light.color,
+                )
+                .height_segments(4)
+                .base_segments(32);
+        }
+
+        for arc_rotation in [
+            Quat::from_rotation_y(PI / 2.0 - spot_light.outer_angle),
+            Quat::from_euler(
+                bevy_math::EulerRot::XZY,
+                0.0,
+                PI / 2.0,
+                PI / 2.0 - spot_light.outer_angle,
+            ),
+        ] {
+            gizmos
+                .arc_3d(
+                    2.0 * spot_light.outer_angle,
+                    spot_light.range,
+                    translation,
+                    rotation * arc_rotation,
+                    spot_light.color,
+                )
+                .segments(16);
+        }
+    }
+
+    // An arrow alongside the directional light direction.
+    for (directional_light, transform) in directional_lights {
+        let (_, rotation, translation) = transform.to_scale_rotation_translation();
+        gizmos
+            .arrow(
+                translation,
+                translation + rotation * Vec3::NEG_Z,
+                directional_light.color,
+            )
+            .with_tip_length(0.3);
+    }
+}
+
+/// A [`Plugin`] that provides visualization of [`PointLight`]s, [`SpotLight`]s
+/// and [`DirectionalLight`]s for debugging.
+pub struct LightGizmoPlugin;
+
+impl Plugin for LightGizmoPlugin {
+    fn build(&self, app: &mut bevy_app::App) {
+        app.register_type::<LightGizmoConfigGroup>()
+            .init_gizmo_group::<LightGizmoConfigGroup>()
+            .add_systems(
+                PostUpdate,
+                (
+                    draw_lights,
+                    draw_all_lights.run_if(|config: Res<GizmoConfigStore>| {
+                        config.config::<LightGizmoConfigGroup>().1.draw_all
+                    }),
+                )
+                    .after(TransformSystem::TransformPropagate),
+            );
+    }
+}
+
+/// The [`GizmoConfigGroup`] used to configure the visualization of lights.
+#[derive(Clone, Default, Reflect, GizmoConfigGroup)]
+pub struct LightGizmoConfigGroup {
+    /// Draw a gizmo for all lights if true.
+    pub draw_all: bool,
+}
+
+/// Add this [`Component`] to an entity to draw any of its lights components
+/// ([`PointLight`], [`SpotLight`] and [`DirectionalLight`]).
+#[derive(Component, Reflect, Default, Debug)]
+#[reflect(Component, Default)]
+pub struct ShowLightGizmo;
+
+fn draw_lights(
+    point_query: Query<(&PointLight, &GlobalTransform), With<ShowLightGizmo>>,
+    spot_query: Query<(&SpotLight, &GlobalTransform), With<ShowLightGizmo>>,
+    directional_query: Query<(&DirectionalLight, &GlobalTransform), With<ShowLightGizmo>>,
+    mut gizmos: Gizmos<LightGizmoConfigGroup>,
+) {
+    draw_gizmos(&point_query, &spot_query, &directional_query, &mut gizmos);
+}
+
+fn draw_all_lights(
+    point_query: Query<(&PointLight, &GlobalTransform), Without<ShowLightGizmo>>,
+    spot_query: Query<(&SpotLight, &GlobalTransform), Without<ShowLightGizmo>>,
+    directional_query: Query<(&DirectionalLight, &GlobalTransform), Without<ShowLightGizmo>>,
+    mut gizmos: Gizmos<LightGizmoConfigGroup>,
+) {
+    draw_gizmos(&point_query, &spot_query, &directional_query, &mut gizmos);
+}

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -205,7 +205,7 @@ pub struct ShowLightGizmo {
     /// Default color strategy for this light gizmo. if [`None`], use the one provided by [`LightGizmoConfigGroup`].
     ///
     /// Defaults to [`None`].
-    color: Option<LightGizmoColor>,
+    pub color: Option<LightGizmoColor>,
 }
 
 fn draw_lights(

--- a/crates/bevy_gizmos/src/light.rs
+++ b/crates/bevy_gizmos/src/light.rs
@@ -7,7 +7,7 @@ use crate::{self as bevy_gizmos, primitives::dim3::GizmoPrimitive3d};
 use bevy_app::{Plugin, PostUpdate};
 use bevy_color::{
     palettes::basic::{BLUE, GREEN, RED},
-    Color, LinearRgba, Oklcha,
+    Color, Oklcha,
 };
 use bevy_ecs::{
     component::Component,

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -610,13 +610,34 @@ pub struct Cone3dBuilder<'a, 'w, 's, T: GizmoConfigGroup> {
     color: Color,
 
     // Number of segments used to approximate the cone geometry
-    segments: usize,
+    base_segments: usize,
+
+    height_segments: usize,
 }
 
 impl<T: GizmoConfigGroup> Cone3dBuilder<'_, '_, '_, T> {
-    /// Set the number of segments used to approximate the cone geometry.
+    /// Set the number of segments used to approximate the cone geometry for its base and height.
     pub fn segments(mut self, segments: usize) -> Self {
-        self.segments = segments;
+        self.base_segments = segments;
+        self.height_segments = segments;
+        self
+    }
+
+    /// Set the number of segments to approximate the height of the cone geometry.
+    ///
+    /// `segments` should be a multiple of the value passed to [`Self::height_segments`]
+    /// for the height to connect properly with the base.
+    pub fn base_segments(mut self, segments: usize) -> Self {
+        self.base_segments = segments;
+        self
+    }
+
+    /// Set the number of segments to approximate the height of the cone geometry.
+    ///
+    /// `segments` should be a divider of the value passed to [`Self::base_segments`]
+    /// for the height to connect properly with the base.
+    pub fn height_segments(mut self, segments: usize) -> Self {
+        self.height_segments = segments;
         self
     }
 }
@@ -638,7 +659,8 @@ impl<'w, 's, T: GizmoConfigGroup> GizmoPrimitive3d<Cone> for Gizmos<'w, 's, T> {
             position,
             rotation,
             color,
-            segments: DEFAULT_NUMBER_SEGMENTS,
+            base_segments: DEFAULT_NUMBER_SEGMENTS,
+            height_segments: DEFAULT_NUMBER_SEGMENTS,
         }
     }
 }
@@ -656,7 +678,8 @@ impl<T: GizmoConfigGroup> Drop for Cone3dBuilder<'_, '_, '_, T> {
             position,
             rotation,
             color,
-            segments,
+            base_segments,
+            height_segments,
         } = self;
 
         let half_height = *height * 0.5;
@@ -665,7 +688,7 @@ impl<T: GizmoConfigGroup> Drop for Cone3dBuilder<'_, '_, '_, T> {
         draw_circle_3d(
             gizmos,
             *radius,
-            *segments,
+            *base_segments,
             *rotation,
             *position - *rotation * Vec3::Y * half_height,
             *color,
@@ -673,7 +696,7 @@ impl<T: GizmoConfigGroup> Drop for Cone3dBuilder<'_, '_, '_, T> {
 
         // connect the base circle with the tip of the cone
         let end = Vec3::Y * half_height;
-        circle_coordinates(*radius, *segments)
+        circle_coordinates(*radius, *height_segments)
             .map(|p| Vec3::new(p.x, -half_height, p.y))
             .map(move |p| [p, end])
             .map(|ps| ps.map(rotate_then_translate_3d(*rotation, *position)))

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -609,9 +609,10 @@ pub struct Cone3dBuilder<'a, 'w, 's, T: GizmoConfigGroup> {
     // Color of the cone
     color: Color,
 
-    // Number of segments used to approximate the cone geometry
+    // Number of segments used to approximate the cone base geometry
     base_segments: usize,
 
+    // Number of segments used to approximate the cone height geometry
     height_segments: usize,
 }
 

--- a/crates/bevy_gizmos/src/primitives/dim3.rs
+++ b/crates/bevy_gizmos/src/primitives/dim3.rs
@@ -634,7 +634,7 @@ impl<T: GizmoConfigGroup> Cone3dBuilder<'_, '_, '_, T> {
 
     /// Set the number of segments to approximate the height of the cone geometry.
     ///
-    /// `segments` should be a divider of the value passed to [`Self::base_segments`]
+    /// `segments` should be a divisor of the value passed to [`Self::base_segments`]
     /// for the height to connect properly with the base.
     pub fn height_segments(mut self, segments: usize) -> Self {
         self.height_segments = segments;

--- a/examples/README.md
+++ b/examples/README.md
@@ -265,6 +265,7 @@ Example | Description
 --- | ---
 [2D Gizmos](../examples/gizmos/2d_gizmos.rs) | A scene showcasing 2D gizmos
 [3D Gizmos](../examples/gizmos/3d_gizmos.rs) | A scene showcasing 3D gizmos
+[Light Gizmos](../examples/gizmos/light_gizmos.rs) | A scene showcasing light gizmos
 
 ## Input
 

--- a/examples/gizmos/light_gizmos.rs
+++ b/examples/gizmos/light_gizmos.rs
@@ -1,0 +1,190 @@
+//! This example demonstrates how to visualize lights properties through the gizmo API.
+
+use std::f32::consts::{FRAC_PI_2, PI};
+
+use bevy::{
+    color::palettes::css::{DARK_CYAN, GOLD, GRAY, PURPLE},
+    gizmos::light::{LightGizmoColor, LightGizmoConfigGroup},
+    prelude::*,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_systems(Startup, setup)
+        .add_systems(Update, rotate_camera)
+        .add_systems(Update, update_config)
+        .run();
+}
+
+#[derive(Component)]
+struct GizmoColorText;
+
+fn gizmo_color_text(config: &LightGizmoConfigGroup) -> String {
+    match config.color {
+        LightGizmoColor::Manual(color) => format!("Manual {}", Srgba::from(color).to_hex()),
+        LightGizmoColor::Varied => "Random from entity".to_owned(),
+        LightGizmoColor::MatchLightColor => "Match light color".to_owned(),
+        LightGizmoColor::ByLightType => {
+            format!(
+                "Point {}, Spot {}, Directional {}",
+                Srgba::from(config.point_light_color).to_hex(),
+                Srgba::from(config.spot_light_color).to_hex(),
+                Srgba::from(config.directional_light_color).to_hex()
+            )
+        }
+    }
+}
+
+fn setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<StandardMaterial>>,
+    mut config_store: ResMut<GizmoConfigStore>,
+) {
+    // Circular base.
+    commands.spawn(PbrBundle {
+        mesh: meshes.add(Circle::new(4.0)),
+        material: materials.add(Color::WHITE),
+        transform: Transform::from_rotation(Quat::from_rotation_x(-FRAC_PI_2)),
+        ..default()
+    });
+
+    // Cubes.
+    {
+        let mesh = meshes.add(Cuboid::new(1.0, 1.0, 1.0));
+        let material = materials.add(Color::srgb_u8(124, 144, 255));
+        for x in [-2.0, 0.0, 2.0] {
+            commands.spawn(PbrBundle {
+                mesh: mesh.clone(),
+                material: material.clone(),
+                transform: Transform::from_xyz(x, 0.5, 0.0),
+                ..default()
+            });
+        }
+    }
+
+    // Lights.
+    {
+        commands.spawn(PointLightBundle {
+            point_light: PointLight {
+                shadows_enabled: true,
+                range: 2.0,
+                color: DARK_CYAN.into(),
+                ..default()
+            },
+            transform: Transform::from_xyz(0.0, 1.5, 0.0),
+            ..default()
+        });
+        commands.spawn(SpotLightBundle {
+            spot_light: SpotLight {
+                shadows_enabled: true,
+                range: 3.5,
+                color: PURPLE.into(),
+                outer_angle: PI / 4.0,
+                inner_angle: PI / 4.0 * 0.8,
+                ..default()
+            },
+            transform: Transform::from_xyz(4.0, 2.0, 0.0).looking_at(Vec3::X * 1.5, Vec3::Y),
+            ..default()
+        });
+        commands.spawn(DirectionalLightBundle {
+            directional_light: DirectionalLight {
+                color: GOLD.into(),
+                illuminance: DirectionalLight::default().illuminance * 0.05,
+                shadows_enabled: true,
+                ..default()
+            },
+            transform: Transform::from_xyz(-4.0, 2.0, 0.0).looking_at(Vec3::NEG_X * 1.5, Vec3::Y),
+            ..default()
+        });
+    }
+
+    // Camera.
+    commands.spawn(Camera3dBundle {
+        transform: Transform::from_xyz(-2.5, 4.5, 9.0).looking_at(Vec3::ZERO, Vec3::Y),
+        ..default()
+    });
+
+    // Example instructions and gizmo config.
+    {
+        let text_style = TextStyle {
+            font_size: 20.0,
+            ..default()
+        };
+        commands.spawn(
+            TextBundle::from_section(
+                "Press 'D' to toggle drawing gizmos on top of everything else in the scene\n\
+            Hold 'Left' or 'Right' to change the line width of the gizmos\n\
+            Press 'A' to toggle drawing of the light gizmos\n\
+            Press 'C' to cycle between the light gizmos coloring modes",
+                text_style.clone(),
+            )
+            .with_style(Style {
+                position_type: PositionType::Absolute,
+                top: Val::Px(12.0),
+                left: Val::Px(12.0),
+                ..default()
+            }),
+        );
+
+        let (_, light_config) = config_store.config_mut::<LightGizmoConfigGroup>();
+        light_config.draw_all = true;
+        light_config.color = LightGizmoColor::MatchLightColor;
+
+        commands.spawn((
+            TextBundle::from_sections([
+                TextSection::new("Gizmo color mode: ", text_style.clone()),
+                TextSection::new(gizmo_color_text(light_config), text_style),
+            ])
+            .with_style(Style {
+                position_type: PositionType::Absolute,
+                bottom: Val::Px(12.0),
+                left: Val::Px(12.0),
+                ..default()
+            }),
+            GizmoColorText,
+        ));
+    }
+}
+
+fn rotate_camera(mut query: Query<&mut Transform, With<Camera>>, time: Res<Time>) {
+    let mut transform = query.single_mut();
+
+    transform.rotate_around(Vec3::ZERO, Quat::from_rotation_y(time.delta_seconds() / 2.));
+}
+
+fn update_config(
+    mut config_store: ResMut<GizmoConfigStore>,
+    keyboard: Res<ButtonInput<KeyCode>>,
+    time: Res<Time>,
+    mut color_text_query: Query<&mut Text, With<GizmoColorText>>,
+) {
+    if keyboard.just_pressed(KeyCode::KeyD) {
+        for (_, config, _) in config_store.iter_mut() {
+            config.depth_bias = if config.depth_bias == 0. { -1. } else { 0. };
+        }
+    }
+
+    let (config, light_config) = config_store.config_mut::<LightGizmoConfigGroup>();
+    if keyboard.pressed(KeyCode::ArrowRight) {
+        config.line_width += 5. * time.delta_seconds();
+        config.line_width = config.line_width.clamp(0., 50.);
+    }
+    if keyboard.pressed(KeyCode::ArrowLeft) {
+        config.line_width -= 5. * time.delta_seconds();
+        config.line_width = config.line_width.clamp(0., 50.);
+    }
+    if keyboard.just_pressed(KeyCode::KeyA) {
+        config.enabled ^= true;
+    }
+    if keyboard.just_pressed(KeyCode::KeyC) {
+        light_config.color = match light_config.color {
+            LightGizmoColor::Manual(_) => LightGizmoColor::Varied,
+            LightGizmoColor::Varied => LightGizmoColor::MatchLightColor,
+            LightGizmoColor::MatchLightColor => LightGizmoColor::ByLightType,
+            LightGizmoColor::ByLightType => LightGizmoColor::Manual(GRAY.into()),
+        };
+        color_text_query.single_mut().sections[1].value = gizmo_color_text(light_config);
+    }
+}


### PR DESCRIPTION
# Objective

- Part of #9400.
- Add light gizmos for `SpotLight`, `PointLight` and `DirectionalLight`.

## Solution

- Add a `ShowLightGizmo` and its related gizmo group and plugin, that shows a gizmo for all lights of an entities when inserted on it. Light display can also be toggled globally through the gizmo config in the same way it can already be done for `Aabb`s.
- Add distinct segment setters for height and base one `Cone3dBuilder`. This allow having a properly rounded base without too much edges along the height. The doc comments explain how to ensure height and base connect when setting different values.

Gizmo for the three light types without radius with the depth bias set to -1:
![without-radius](https://github.com/bevyengine/bevy/assets/18357657/699d0154-f367-4727-9b09-8b458d96a0e2)

With Radius:
![with-radius](https://github.com/bevyengine/bevy/assets/18357657/f3af003e-dbba-427a-a305-c5cc1676e340)

Possible future improvements:
- Add a billboarded sprite with a distinct sprite for each light type.
- Display the intensity of the light somehow (no idea how to represent that apart from some text).

---

## Changelog

### Added

- The new `ShowLightGizmo`, part of the `LightGizmoPlugin` and configurable globally with `LightGizmoConfigGroup`, allows drawing gizmo for `PointLight`, `SpotLight` and `DirectionalLight`. The gizmos color behavior can be controlled with the `LightGizmoColor` member of `ShowLightGizmo` and `LightGizmoConfigGroup`.
- The cone gizmo builder (`Cone3dBuilder`) now allows setting a differing number of segments for the base and height.
