### PR TITLE
Explicitly run `+nightly` for `-Zcheck-cfg` pass in ci.

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,4 +1,4 @@
-    //! CI script used for Bevy.
+//! CI script used for Bevy.
 
 use xshell::{cmd, Shell};
 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -161,7 +161,7 @@ fn main() {
     if what_to_run.contains(Check::CFG_CHECK) {
         // Check cfg and imports
         std::env::set_var("RUSTFLAGS", "-D warnings");
-        cmd!(sh, "cargo check +nightly -Zcheck-cfg --workspace")
+        cmd!(sh, "cargo +nightly check -Zcheck-cfg --workspace")
             .run()
             .expect("Please fix failing cfg checks in output above.");
     }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,4 +1,4 @@
-//! CI script used for Bevy.
+    //! CI script used for Bevy.
 
 use xshell::{cmd, Shell};
 
@@ -161,7 +161,7 @@ fn main() {
     if what_to_run.contains(Check::CFG_CHECK) {
         // Check cfg and imports
         std::env::set_var("RUSTFLAGS", "-D warnings");
-        cmd!(sh, "cargo check -Zcheck-cfg --workspace")
+        cmd!(sh, "cargo check +nightly -Zcheck-cfg --workspace")
             .run()
             .expect("Please fix failing cfg checks in output above.");
     }


### PR DESCRIPTION
# Objective

Getting this error running ci locally.

```
$ cargo check -Zcheck-cfg --workspace
error: the `-Z` flag is only accepted on the nightly channel of Cargo, but this is the `stable` channel
See https://doc.rust-lang.org/book/appendix-07-nightly-rust.html for more information about Rust release channels.
thread 'main' panicked at tools\ci\src\main.rs:166:14:
Please fix failing cfg checks in output above.: command exited with non-zero code `cargo check -Zcheck-cfg --workspace`: 101
```

## Solution

- Add `+nightly` flag to the `check-cfg` pass.

---

Obviously we shouldn't be running `nightly` Cargo, but at least now local running of `cargo run -p ci` will pass.