### PR TITLE
Add `size` and `physical_size` to `window`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTDOCFLAGS: --html-in-header header.html
+  NIGHTLY_TOOLCHAIN: nightly
 
 # Sets the permissions to allow deploying to Github pages.
 permissions:
@@ -32,8 +33,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
 
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
@@ -47,7 +49,7 @@ jobs:
           echo "<meta name=\"robots\" content=\"noindex\">" > header.html
 
       - name: Build docs
-        run: cargo doc --all-features --no-deps -p bevy
+        run: cargo doc --all-features --no-deps -p bevy -Zunstable-options -Zrustdoc-scrape-examples
 
       #  This adds the following:
       #   - A top level redirect to the bevy crate documentation

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -628,10 +628,7 @@ impl NormalizedRenderTarget {
                 .into_iter()
                 .find(|(entity, _)| *entity == window_ref.entity())
                 .map(|(_, window)| RenderTargetInfo {
-                    physical_size: UVec2::new(
-                        window.resolution.physical_width(),
-                        window.resolution.physical_height(),
-                    ),
+                    physical_size: window.physical_size(),
                     scale_factor: window.resolution.scale_factor(),
                 }),
             NormalizedRenderTarget::Image(image_handle) => {

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -460,7 +460,7 @@ pub fn resolve_outlines_system(
 ) {
     let viewport_size = primary_window
         .get_single()
-        .map(|window| Vec2::new(window.resolution.width(), window.resolution.height()))
+        .map(|window| window.size())
         .unwrap_or(Vec2::ZERO)
         / ui_scale.0;
 

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -383,7 +383,7 @@ pub fn extract_ui_material_nodes<M: UiMaterial>(
 ) {
     let ui_logical_viewport_size = windows
         .get_single()
-        .map(|window| Vec2::new(window.resolution.width(), window.resolution.height()))
+        .map(|window| window.size())
         .unwrap_or(Vec2::ZERO)
         // The logical window resolution returned by `Window` only takes into account the window scale factor and not `UiScale`,
         // so we have to divide by `UiScale` to get the size of the UI viewport.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -313,7 +313,7 @@ impl Window {
         self.resolution.height()
     }
 
-    /// The window's client size in logical pixels, with x being width and y being height.
+    /// The window's client size in logical pixels
     ///
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
@@ -337,7 +337,7 @@ impl Window {
         self.resolution.physical_height()
     }
 
-    /// The window's client size in physical pixels, with x being width and y being height.
+    /// The window's client size in physical pixels
     ///
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
@@ -680,7 +680,7 @@ impl WindowResolution {
         self.physical_height() as f32 / self.scale_factor()
     }
 
-    /// The window's client size in logical pixels, with x being width and y being height.
+    /// The window's client size in logical pixels
     #[inline]
     pub fn size(&self) -> Vec2 {
         Vec2::new(self.width(), self.height())
@@ -698,7 +698,7 @@ impl WindowResolution {
         self.physical_height
     }
 
-    /// The window's client size in physical pixels, with x being width and y being height.
+    /// The window's client size in physical pixels
     #[inline]
     pub fn physical_size(&self) -> UVec2 {
         UVec2::new(self.physical_width, self.physical_height)

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -2,7 +2,7 @@ use bevy_ecs::{
     entity::{Entity, EntityMapper, MapEntities},
     prelude::{Component, ReflectComponent},
 };
-use bevy_math::{DVec2, IVec2, Vec2};
+use bevy_math::{DVec2, IVec2, UVec2, Vec2};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 
 #[cfg(feature = "serialize")]
@@ -318,7 +318,7 @@ impl Window {
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn size(&self) -> Vec2 {
-        Vec2::new(self.resolution.width(), self.resolution.height())
+        self.resolution.size()
     }
 
     /// The window's client area width in physical pixels.
@@ -342,10 +342,7 @@ impl Window {
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn physical_size(&self) -> bevy_math::UVec2 {
-        bevy_math::UVec2::new(
-            self.resolution.physical_width(),
-            self.resolution.physical_height(),
-        )
+        self.resolution.physical_size()
     }
 
     /// The window's scale factor.
@@ -683,6 +680,12 @@ impl WindowResolution {
         self.physical_height() as f32 / self.scale_factor()
     }
 
+    /// The window's client size in logical pixels, with x being width and y being height.
+    #[inline]
+    pub fn size(&self) -> Vec2 {
+        Vec2::new(self.width(), self.height())
+    }
+
     /// The window's client area width in physical pixels.
     #[inline]
     pub fn physical_width(&self) -> u32 {
@@ -693,6 +696,12 @@ impl WindowResolution {
     #[inline]
     pub fn physical_height(&self) -> u32 {
         self.physical_height
+    }
+
+    // The window's client size in physical pixels, with x being width and y being height.
+    #[inline]
+    pub fn physical_size(&self) -> UVec2 {
+        UVec2::new(self.physical_width, self.physical_height)
     }
 
     /// The ratio of physical pixels to logical pixels.

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -315,7 +315,7 @@ impl Window {
 
     /// The window's client size in logical pixels, with x being width and y being height.
     ///
-    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
+    /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn size(&self) -> Vec2 {
         Vec2::new(self.resolution.width(), self.resolution.height())
@@ -339,7 +339,7 @@ impl Window {
 
     /// The window's client size in physical pixels, with x being width and y being height.
     ///
-    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
+    /// See [`WindowResolution`] for an explanation about logical/physical sizes.
     #[inline]
     pub fn physical_size(&self) -> bevy_math::UVec2 {
         bevy_math::UVec2::new(

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -329,6 +329,28 @@ impl Window {
         self.resolution.physical_height()
     }
 
+    /// The window's client area size in logical pixels.
+    ///
+    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
+    #[inline]
+    pub fn size(&self) -> Vec2 {
+        Vec2::new(
+            self.resolution.width(),
+            self.resolution.height()
+        )
+    }
+
+    /// The window's client area size in physical pixels.
+    ///
+    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
+    #[inline]
+    pub fn physical_size(&self) -> bevy_math::UVec2 {
+        bevy_math::UVec2::new(
+            self.resolution.physical_width(),
+            self.resolution.physical_height()
+        )
+    }
+
     /// The window's scale factor.
     ///
     /// Ratio of physical size to logical size, see [`WindowResolution`].

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -313,6 +313,17 @@ impl Window {
         self.resolution.height()
     }
 
+    /// The window's client size in logical pixels, with x being width and y being height.
+    ///
+    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
+    #[inline]
+    pub fn size(&self) -> Vec2 {
+        Vec2::new(
+            self.resolution.width(),
+            self.resolution.height()
+        )
+    }
+
     /// The window's client area width in physical pixels.
     ///
     /// See [`WindowResolution`] for an explanation about logical/physical sizes.
@@ -329,18 +340,7 @@ impl Window {
         self.resolution.physical_height()
     }
 
-    /// The window's client area size in logical pixels.
-    ///
-    /// See ['WindowResolution'] for an explanation about logical/physical sizes.
-    #[inline]
-    pub fn size(&self) -> Vec2 {
-        Vec2::new(
-            self.resolution.width(),
-            self.resolution.height()
-        )
-    }
-
-    /// The window's client area size in physical pixels.
+    /// The window's client size in physical pixels, with x being width and y being height.
     ///
     /// See ['WindowResolution'] for an explanation about logical/physical sizes.
     #[inline]

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -698,7 +698,7 @@ impl WindowResolution {
         self.physical_height
     }
 
-    // The window's client size in physical pixels, with x being width and y being height.
+    /// The window's client size in physical pixels, with x being width and y being height.
     #[inline]
     pub fn physical_size(&self) -> UVec2 {
         UVec2::new(self.physical_width, self.physical_height)

--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -318,10 +318,7 @@ impl Window {
     /// See ['WindowResolution'] for an explanation about logical/physical sizes.
     #[inline]
     pub fn size(&self) -> Vec2 {
-        Vec2::new(
-            self.resolution.width(),
-            self.resolution.height()
-        )
+        Vec2::new(self.resolution.width(), self.resolution.height())
     }
 
     /// The window's client area width in physical pixels.
@@ -347,7 +344,7 @@ impl Window {
     pub fn physical_size(&self) -> bevy_math::UVec2 {
         bevy_math::UVec2::new(
             self.resolution.physical_width(),
-            self.resolution.physical_height()
+            self.resolution.physical_height(),
         )
     }
 

--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -186,7 +186,7 @@ fn set_camera_viewports(
     // A resize_event is sent when the window is first created, allowing us to reuse this system for initial setup.
     for resize_event in resize_events.read() {
         let window = windows.get(resize_event.window).unwrap();
-        let size = UVec2::new(window.physical_width(), window.physical_height()) / 2;
+        let size = window.physical_size() / 2;
 
         for (camera_position, mut camera) in &mut query {
             camera.viewport = Some(Viewport {

--- a/examples/games/contributors.rs
+++ b/examples/games/contributors.rs
@@ -242,7 +242,7 @@ fn collisions(
     mut query: Query<(&mut Velocity, &mut Transform), With<Contributor>>,
 ) {
     let window = windows.single();
-    let window_size = Vec2::new(window.width(), window.height());
+    let window_size = window.size();
 
     let collision_area = Aabb2d::new(Vec2::ZERO, (window_size - SPRITE_SIZE) / 2.);
 

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -368,11 +368,7 @@ fn spawn_birds(
     let bird_x = (primary_window_resolution.width() / -2.) + HALF_BIRD_SIZE;
     let bird_y = (primary_window_resolution.height() / 2.) - HALF_BIRD_SIZE;
 
-    let half_extents = 0.5
-        * Vec2::new(
-            primary_window_resolution.width(),
-            primary_window_resolution.height(),
-        );
+    let half_extents = 0.5 * primary_window_resolution.size();
 
     let color = counter.color;
     let current_count = counter.count;

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -509,7 +509,7 @@ fn handle_collision(half_extents: Vec2, translation: &Vec3, velocity: &mut Vec3)
 fn collision_system(windows: Query<&Window>, mut bird_query: Query<(&mut Bird, &Transform)>) {
     let window = windows.single();
 
-    let half_extents = 0.5 * Vec2::new(window.width(), window.height());
+    let half_extents = 0.5 * window.size();
 
     for (mut bird, transform) in &mut bird_query {
         handle_collision(half_extents, &transform.translation, &mut bird.velocity);


### PR DESCRIPTION
This is an implementation within `bevy_window::window` that fixes #12229. 

# Objective

Fixes #12229, allow users to retrieve the window's size and physical size as Vectors without having to manually construct them using `height()` and `width()` or `physical_height()` and `physical_width()` 

## Solution

As suggested in #12229, created two public functions within `window`: `size() -> Vec` and `physical_size() -> UVec` that return the needed Vectors ready-to-go.

### Discussion

My first FOSS PRQ ever, so bear with me a bit. I'm new to this.

- I replaced instances of ```Vec2::new(window.width(), window.height());``` or `UVec2::new(window.physical_width(), window.physical_height());` within bevy examples be replaced with their `size()`/`physical_size()` counterparts?
- Discussion within #12229 still holds: should these also be added to WindowResolution?