### PR TITLE
Quality-of-life updates for running CI locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'linux'
       - name: Build & run tests
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- test
+        run: cargo run -p ci -- test --keep-going
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -65,7 +65,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- lints
+        run: cargo run -p ci -- lints --keep-going
 
   miri:
     runs-on: macos-14
@@ -122,7 +122,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- compile
+        run: cargo run -p ci -- compile --keep-going
 
   build-wasm:
     runs-on: ubuntu-latest
@@ -265,7 +265,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doc
+        run: cargo run -p ci -- doc --keep-going
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
@@ -424,4 +424,4 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Build and check cfg typos
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- cfg-check
+        run: cargo run -p ci -- cfg-check --keep-going

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         if: runner.os == 'linux'
       - name: Build & run tests
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- test --keep-going
+        run: cargo run -p ci -- test
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
@@ -65,7 +65,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: CI job
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- lints --keep-going
+        run: cargo run -p ci -- lints
 
   miri:
     runs-on: macos-14
@@ -122,7 +122,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
       - name: Check Compile
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- compile --keep-going
+        run: cargo run -p ci -- compile
 
   build-wasm:
     runs-on: ubuntu-latest
@@ -265,7 +265,7 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Build and check doc
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- doc --keep-going
+        run: cargo run -p ci -- doc
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
@@ -424,4 +424,4 @@ jobs:
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
       - name: Build and check cfg typos
         # See tools/ci/src/main.rs for the commands this runs
-        run: cargo run -p ci -- cfg-check --keep-going
+        run: cargo run -p ci -- cfg-check

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,9 +1,9 @@
 //! CI script used for Bevy.
 
+use bitflags::bitflags;
 use core::panic;
 use std::collections::BTreeMap;
 use xshell::{cmd, Cmd, Shell};
-use bitflags::bitflags;
 
 bitflags! {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -31,9 +31,9 @@ bitflags! {
 // None of the CI tests require any information at runtime other than the options that have been set,
 // which is why all of these are 'static; we could easily update this to use more flexible types.
 struct CITest<'a> {
-    command: Cmd<'a>, // The command to execute
-    failure_message: &'static str, // The message to display if it fails
-    subdir: Option<&'static str>, // The subdirectory path to run the command within
+    command: Cmd<'a>,                            // The command to execute
+    failure_message: &'static str,               // The message to display if it fails
+    subdir: Option<&'static str>,                // The subdirectory path to run the command within
     env_vars: Vec<(&'static str, &'static str)>, // Environment variables that need to be set before the command runs
 }
 
@@ -135,7 +135,7 @@ fn main() {
         // - See crates/bevy_ecs_compile_fail_tests/README.md
 
         // (These must be cloned because of move semantics in `cmd!`)
-        let args_clone = args.clone(); 
+        let args_clone = args.clone();
 
         test_suite.insert(Check::COMPILE_FAIL, vec![CITest {
             command: cmd!(sh, "cargo test {args_clone...}"),
@@ -333,7 +333,7 @@ fn main() {
             for (k, v) in ci_test.env_vars {
                 std::env::set_var(k, v);
             }
-            
+
             // If the CI test is to be executed in a subdirectory, we move there before running the command
             let _hook = ci_test.subdir.map(|path| sh.push_dir(path));
 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -345,7 +345,7 @@ fn main() {
                     &mut failed_checks,
                     &mut failure_message,
                     &flags,
-                )
+                );
             }
             // ^ This must run while `_hook` is in scope; it is dropped at the end of the inner loop iteration.
         }
@@ -353,7 +353,7 @@ fn main() {
 
     if !failed_checks.is_empty() {
         panic!(
-            "One or more CI checks failed.\n
+            "One or more CI checks failed.\n\
             {failure_message}"
         );
     }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,11 +1,12 @@
 //! CI script used for Bevy.
 
-use xshell::{cmd, Shell};
-
+use core::panic;
+use std::collections::BTreeMap;
+use xshell::{cmd, Cmd, Shell};
 use bitflags::bitflags;
 
 bitflags! {
-    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
     struct Check: u32 {
         const FORMAT = 0b00000001;
         const CLIPPY = 0b00000010;
@@ -18,6 +19,22 @@ bitflags! {
         const COMPILE_CHECK = 0b100000000;
         const CFG_CHECK = 0b1000000000;
     }
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    struct Flag: u32 {
+        const KEEP_GOING = 0b00000001;
+    }
+}
+
+// None of the CI tests require any information at runtime other than the options that have been set,
+// which is why all of these are 'static; we could easily update this to use more flexible types.
+struct CITest<'a> {
+    command: Cmd<'a>, // The command to execute
+    failure_message: &'static str, // The message to display if it fails
+    subdir: Option<&'static str>, // The subdirectory path to run the command within
+    env_vars: Vec<(&'static str, &'static str)>, // Environment variables that need to be set before the command runs
 }
 
 fn main() {
@@ -44,125 +61,300 @@ fn main() {
         ("doc-test", Check::DOC_TEST),
     ];
 
-    let what_to_run = if let Some(arg) = std::env::args().nth(1).as_deref() {
-        if let Some((_, check)) = arguments.iter().find(|(str, _)| *str == arg) {
-            *check
-        } else {
-            println!(
-                "Invalid argument: {arg:?}.\nEnter one of: {}.",
-                arguments[1..]
-                    .iter()
-                    .map(|(s, _)| s)
-                    .fold(arguments[0].0.to_owned(), |c, v| c + ", " + v)
-            );
-            return;
+    let flag_arguments = [("--keep-going", Flag::KEEP_GOING)];
+
+    let (mut checks, mut flags) = (Check::empty(), Flag::empty());
+    for arg in std::env::args().skip(1) {
+        if let Some((_, flag)) = flag_arguments.iter().find(|(flag_arg, _)| *flag_arg == arg) {
+            flags.insert(*flag);
+            continue;
         }
-    } else {
-        Check::all()
-    };
+        if let Some((_, check)) = arguments.iter().find(|(check_arg, _)| *check_arg == arg) {
+            checks.insert(*check);
+            continue;
+        }
+        println!(
+            "Invalid argument: {arg:?}.\nEnter one of: {}.",
+            arguments[1..]
+                .iter()
+                .map(|(s, _)| s)
+                .fold(arguments[0].0.to_owned(), |c, v| c + ", " + v)
+        );
+        return;
+    }
+
+    // If no checks are specified, run every check
+    if checks.is_empty() {
+        checks = Check::all();
+    }
 
     let sh = Shell::new().unwrap();
 
-    if what_to_run.contains(Check::FORMAT) {
+    // Each check contains a 'battery' (vector) that can include more than one command, but almost all of them
+    // just contain a single command.
+    let mut test_suite: BTreeMap<Check, Vec<CITest>> = BTreeMap::new();
+
+    if checks.contains(Check::FORMAT) {
         // See if any code needs to be formatted
-        cmd!(sh, "cargo fmt --all -- --check")
-            .run()
-            .expect("Please run 'cargo fmt --all' to format your code.");
+        test_suite.insert(
+            Check::FORMAT,
+            vec![CITest {
+                command: cmd!(sh, "cargo fmt --all -- --check"),
+                failure_message: "Please run 'cargo fmt --all' to format your code.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::CLIPPY) {
+    if checks.contains(Check::CLIPPY) {
         // See if clippy has any complaints.
         // - Type complexity must be ignored because we use huge templates for queries
-        cmd!(
-            sh,
-            "cargo clippy --workspace --all-targets --all-features -- -Dwarnings"
-        )
-        .run()
-        .expect("Please fix clippy errors in output above.");
+        test_suite.insert(
+            Check::CLIPPY,
+            vec![CITest {
+                command: cmd!(
+                    sh,
+                    "cargo clippy --workspace --all-targets --all-features -- -Dwarnings"
+                ),
+                failure_message: "Please fix clippy errors in output above.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::COMPILE_FAIL) {
-        {
-            // ECS Compile Fail Tests
-            // Run UI tests (they do not get executed with the workspace tests)
-            // - See crates/bevy_ecs_compile_fail_tests/README.md
-            let _subdir = sh.push_dir("crates/bevy_ecs_compile_fail_tests");
-            cmd!(sh, "cargo test --target-dir ../../target")
-                .run()
-                .expect("Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.");
+    if checks.contains(Check::COMPILE_FAIL) {
+        let mut args = vec!["--target-dir", "../../target"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--no-fail-fast");
         }
-        {
-            // Reflect Compile Fail Tests
-            // Run tests (they do not get executed with the workspace tests)
-            // - See crates/bevy_reflect_compile_fail_tests/README.md
-            let _subdir = sh.push_dir("crates/bevy_reflect_compile_fail_tests");
-            cmd!(sh, "cargo test --target-dir ../../target")
-                .run()
-                .expect("Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.");
-        }
-        {
-            // Macro Compile Fail Tests
-            // Run tests (they do not get executed with the workspace tests)
-            // - See crates/bevy_macros_compile_fail_tests/README.md
-            let _subdir = sh.push_dir("crates/bevy_macros_compile_fail_tests");
-            cmd!(sh, "cargo test --target-dir ../../target")
-                .run()
-                .expect("Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.");
-        }
+
+        // ECS Compile Fail Tests
+        // Run UI tests (they do not get executed with the workspace tests)
+        // - See crates/bevy_ecs_compile_fail_tests/README.md
+
+        // (These must be cloned because of move semantics in `cmd!`)
+        let args_clone = args.clone(); 
+
+        test_suite.insert(Check::COMPILE_FAIL, vec![CITest {
+            command: cmd!(sh, "cargo test {args_clone...}"),
+            failure_message: "Compiler errors of the ECS compile fail tests seem to be different than expected! Check locally and compare rust versions.",
+            subdir: Some("crates/bevy_ecs_compile_fail_tests"),
+            env_vars: vec![],
+        }]);
+
+        // Reflect Compile Fail Tests
+        // Run tests (they do not get executed with the workspace tests)
+        // - See crates/bevy_reflect_compile_fail_tests/README.md
+        let args_clone = args.clone();
+
+        test_suite.entry(Check::COMPILE_FAIL).and_modify(|tests| tests.push( CITest {
+            command: cmd!(sh, "cargo test {args_clone...}"),
+            failure_message: "Compiler errors of the Reflect compile fail tests seem to be different than expected! Check locally and compare rust versions.",
+            subdir: Some("crates/bevy_reflect_compile_fail_tests"),
+            env_vars: vec![],
+        }));
+
+        // Macro Compile Fail Tests
+        // Run tests (they do not get executed with the workspace tests)
+        // - See crates/bevy_macros_compile_fail_tests/README.md
+        let args_clone = args.clone();
+
+        test_suite.entry(Check::COMPILE_FAIL).and_modify(|tests| tests.push( CITest {
+            command: cmd!(sh, "cargo test {args_clone...}"),
+            failure_message: "Compiler errors of the macros compile fail tests seem to be different than expected! Check locally and compare rust versions.",
+            subdir: Some("crates/bevy_macros_compile_fail_tests"),
+            env_vars: vec![],
+        }));
     }
 
-    if what_to_run.contains(Check::TEST) {
+    if checks.contains(Check::TEST) {
         // Run tests (except doc tests and without building examples)
-        cmd!(sh, "cargo test --workspace --lib --bins --tests --benches")
-            .run()
-            .expect("Please fix failing tests in output above.");
+        let mut args = vec!["--workspace", "--lib", "--bins", "--tests", "--benches"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--no-fail-fast");
+        }
+
+        test_suite.insert(
+            Check::TEST,
+            vec![CITest {
+                command: cmd!(sh, "cargo test {args...}"),
+                failure_message: "Please fix failing tests in output above.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::DOC_TEST) {
+    if checks.contains(Check::DOC_TEST) {
         // Run doc tests
-        cmd!(sh, "cargo test --workspace --doc")
-            .run()
-            .expect("Please fix failing doc-tests in output above.");
+        let mut args = vec!["--workspace", "--doc"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--no-fail-fast");
+        }
+
+        test_suite.insert(
+            Check::DOC_TEST,
+            vec![CITest {
+                command: cmd!(sh, "cargo test {args...}"),
+                failure_message: "Please fix failing doc-tests in output above.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::DOC_CHECK) {
+    if checks.contains(Check::DOC_CHECK) {
         // Check that building docs work and does not emit warnings
-        std::env::set_var("RUSTDOCFLAGS", "-D warnings");
-        cmd!(
-            sh,
-            "cargo doc --workspace --all-features --no-deps --document-private-items"
-        )
-        .run()
-        .expect("Please fix doc warnings in output above.");
+        // std::env::set_var("RUSTDOCFLAGS", "-D warnings");
+
+        let mut args = vec![
+            "--workspace",
+            "--all-features",
+            "--no-deps",
+            "--document-private-items",
+        ];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::DOC_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo doc {args...}"),
+                failure_message: "Please fix doc warnings in output above.",
+                subdir: None,
+                env_vars: vec![("RUSTDOCFLAGS", "-D warnings")],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::BENCH_CHECK) {
-        let _subdir = sh.push_dir("benches");
+    if checks.contains(Check::BENCH_CHECK) {
         // Check that benches are building
-        cmd!(sh, "cargo check --benches --target-dir ../target")
-            .run()
-            .expect("Failed to check the benches.");
+        let mut args = vec!["--benches", "--target-dir", "../target"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::BENCH_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo check {args...}"),
+                failure_message: "Failed to check the benches.",
+                subdir: Some("benches"),
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::EXAMPLE_CHECK) {
+    if checks.contains(Check::EXAMPLE_CHECK) {
         // Build examples and check they compile
-        cmd!(sh, "cargo check --workspace --examples")
-            .run()
-            .expect("Please fix compiler errors for examples in output above.");
+        let mut args = vec!["--workspace", "--examples"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::EXAMPLE_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo check {args...}"),
+                failure_message: "Please fix compiler errors for examples in output above.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::COMPILE_CHECK) {
+    if checks.contains(Check::COMPILE_CHECK) {
         // Build bevy and check that it compiles
-        cmd!(sh, "cargo check --workspace")
-            .run()
-            .expect("Please fix compiler errors in output above.");
+        let mut args = vec!["--workspace"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::COMPILE_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo check {args...}"),
+                failure_message: "Please fix compiler errors in output above.",
+                subdir: None,
+                env_vars: vec![],
+            }],
+        );
     }
 
-    if what_to_run.contains(Check::CFG_CHECK) {
+    if checks.contains(Check::CFG_CHECK) {
         // Check cfg and imports
-        std::env::set_var("RUSTFLAGS", "-D warnings");
-        cmd!(sh, "cargo check -Zcheck-cfg --workspace")
-            .run()
-            .expect("Please fix failing cfg checks in output above.");
+        let mut args = vec!["Zcheck-cfg", "--workspace"];
+        if flags.contains(Flag::KEEP_GOING) {
+            args.push("--keep-going");
+        }
+
+        test_suite.insert(
+            Check::CFG_CHECK,
+            vec![CITest {
+                command: cmd!(sh, "cargo +nightly check {args...}"),
+                failure_message: "Please fix failing cfg checks in output above.",
+                subdir: None,
+                env_vars: vec![("RUSTFLAGS", "-D warnings")],
+            }],
+        );
+    }
+
+    // Actually run the tests:
+
+    let mut failed_checks: Check = Check::empty();
+    let mut failure_message: String = String::new();
+
+    // In KEEP_GOING-mode, we save all errors until the end; otherwise, we just
+    // panic with the given message for test failure.
+    fn fail(
+        current_check: Check,
+        failure_message: &'static str,
+        failed_checks: &mut Check,
+        existing_fail_message: &mut String,
+        flags: &Flag,
+    ) {
+        if flags.contains(Flag::KEEP_GOING) {
+            failed_checks.insert(current_check);
+            if !existing_fail_message.is_empty() {
+                existing_fail_message.push('\n');
+            }
+            existing_fail_message.push_str(failure_message);
+        } else {
+            panic!("{failure_message}");
+        }
+    }
+
+    for (check, battery) in test_suite.into_iter() {
+        for ci_test in battery {
+            // Ensure that necessary environment variables are set
+            for (k, v) in ci_test.env_vars {
+                std::env::set_var(k, v);
+            }
+            
+            // If the CI test is to be executed in a subdirectory, we move there before running the command
+            let _hook = ci_test.subdir.map(|path| sh.push_dir(path));
+
+            // Actually run the test
+            if ci_test.command.run().is_err() {
+                fail(
+                    check,
+                    ci_test.failure_message,
+                    &mut failed_checks,
+                    &mut failure_message,
+                    &flags,
+                )
+            }
+            // ^ This must run while `_hook` is in scope; it is dropped at the end of the inner loop iteration.
+        }
+    }
+
+    if !failed_checks.is_empty() {
+        panic!(
+            "One or more CI checks failed.\n
+            {failure_message}"
+        );
     }
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -3,6 +3,7 @@
 use bitflags::bitflags;
 use core::panic;
 use std::collections::BTreeMap;
+use std::ffi::OsString;
 use xshell::{cmd, Cmd, Shell};
 
 bitflags! {
@@ -35,6 +36,42 @@ struct CITest<'a> {
     failure_message: &'static str,               // The message to display if it fails
     subdir: Option<&'static str>,                // The subdirectory path to run the command within
     env_vars: Vec<(&'static str, &'static str)>, // Environment variables that need to be set before the command runs
+}
+
+// This is a struct that exists to store the old environment variables during a command execution.
+// When `set_env_vars` is called, the thread's environment variables are set according to its parameters
+// and stored in a `StdEnvHook`. When the hook leaves scope, its Drop implementation resets the variables.
+struct EnvHook {
+    var_cache: Vec<(&'static str, Option<OsString>)>,
+}
+
+// Note that `std::env::var_os` can return `None` for reasons other than the environment variable not being
+// present; however, the `EnvHook` Drop implementation will erase those keys. Therefore, be sure that your
+// input is well-formed prior to calling this function (or changing environment variables in the test suite).
+// See documentation of `std::env::var_os`.
+#[must_use]
+fn set_env_vars(env_vars: &[(&'static str, &'static str)]) -> EnvHook {
+    let mut old_vars = vec![];
+    for (k, v) in env_vars {
+        old_vars.push((*k, std::env::var_os(k)));
+        std::env::set_var(k, v);
+    }
+
+    EnvHook {
+        var_cache: old_vars,
+    }
+}
+
+impl Drop for EnvHook {
+    fn drop(&mut self) {
+        for (k, v) in self.var_cache.iter() {
+            if let Some(v) = v {
+                std::env::set_var(k, v);
+            } else {
+                std::env::remove_var(k);
+            }
+        }
+    }
 }
 
 fn main() {
@@ -329,13 +366,11 @@ fn main() {
 
     for (check, battery) in test_suite.into_iter() {
         for ci_test in battery {
-            // Ensure that necessary environment variables are set
-            for (k, v) in ci_test.env_vars {
-                std::env::set_var(k, v);
-            }
+            // Ensure that necessary environment variables are set during command execution
+            let _vars_hook = set_env_vars(&ci_test.env_vars);
 
             // If the CI test is to be executed in a subdirectory, we move there before running the command
-            let _hook = ci_test.subdir.map(|path| sh.push_dir(path));
+            let _subdir_hook = ci_test.subdir.map(|path| sh.push_dir(path));
 
             // Actually run the test
             if ci_test.command.run().is_err() {
@@ -347,7 +382,7 @@ fn main() {
                     &flags,
                 );
             }
-            // ^ This must run while `_hook` is in scope; it is dropped at the end of the inner loop iteration.
+            // ^ This must run while `_vars_hook` and `_subdir_hook` are in scope; they are dropped on loop iteration.
         }
     }
 


### PR DESCRIPTION
# Objective

- Make running CI locally relatively less painful by allowing continuation after failure
- Fix #12206 

## Solution

Previously, `ci` would halt after encounting a failure (or shortly thereafter). For instance, if you ran `cargo run -p ci` and a single test within a CI check failed somewhere in the middle, you would never even reach many of the other tests within the check and certainly none of the CI checks that came afterward. This was annoying; if I am fixing issues with CI tests, I want to just see all of the issues up-front instead of having to rerun CI every time I fix something to see the next error. 

Furthermore, it is not infrequent (because of subtle configuration/system differences) to encounter spurious CI failures locally; previously, when these occurred, they would make the process of running CI largely pointless, since you would have to push your branch in order to see your actual CI failures from the automated testing service. 

Now, when running `ci` locally, we have a couple new tools to ameliorate these and provide a smoother experience:
- Firstly, there is a new optional flag `--keep-going` that can be passed while calling `ci` (e.g. `cargo run -p ci -- doc --keep-going`). It has the following effects:
    - It causes the `--keep-going` flag to be passed to the script's `cargo doc` and `cargo check` invocations, so that they do not stop when they encounter an error in a single module; instead, they keep going (!) and find errors subsequently.
    - It causes the `--no-fail-fast` flag to be passed to the script's `cargo test` invocations, to similar effect.
    - Finally, it causes `ci` itself not to abort after a single check fails; instead, it will run every check that was invoked.

Thus, for instance, `cargo run -p ci -- --keep-going` will run every CI check even if it encounters intermediate failures, and every such check will itself be run to completion.

- Secondly, we now allow multiple ordinary arguments to be passed to `ci`. For instance, `cargo -p ci -- doc test` now executes both the 'doc' checks and the 'test' checks. This allows the caller to run the tests they care about with fewer invocations of `ci`.

As of this PR, automated testing will remain unchanged. 

---

## Changelog

- tools/ci/src/main.rs refactored into staging and execution steps, since the previous control flow did not naturally support continuing after failure.
- Added "--keep-going" flag to `ci`.
- Added support for invoking `ci` with multiple arguments.

---

## Discussion

### Design considerations

I had originally split this into separate flags that controlled:
1. whether `--keep-going`/`--no-fail-fast` would be passed to the constituent commands
2. whether `ci` would continue after a component test failed

However, I decided to merge these two behaviors, since I think that, if you're in the business of seeing all the errors, you'll probably want to actually see all of the errors. One slightly annoying thing, however, about the new behavior with `--keep-going`, is that you will sometimes find yourself wishing that the script would pause or something, since it tends to fill the screen with a lot of junk. I have found that sending stdout to /dev/null helps quite a bit, but I don't think `cargo fmt` or `cargo clippy` actually write to stderr, so you need to be cognizant of that (and perhaps invoke the lints separately). 

~~Next, I'll mention that I feel somewhat strongly that the current behavior of `ci` for automated testing should remain the same, since its job is more like detecting that errors exist rather than finding all of them.~~ (I was convinced this could have value.) Orthogonally, there is the question of whether or not we might want to make this (or something similar) actually the default behavior and make the automated test script invoke some optional flags — it doesn't have to type with its hands, after all. I'm not against that, but I don't really want to rock the boat much more with this PR, since anyone who looks at the diff might already be a little incensed.