### PR TITLE
Replace init_component_info with register_component_hooks

### DIFF
--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -155,9 +155,8 @@ pub trait Component: Send + Sync + 'static {
     /// This must be either [`TableStorage`] or [`SparseStorage`].
     type Storage: ComponentStorage;
 
-    /// Called when registering this component, allowing mutable access to it's [`ComponentInfo`].
-    /// This is currently used for registering hooks.
-    fn init_component_info(_info: &mut ComponentInfo) {}
+    /// Called when registering this component, allowing mutable access to it's [`ComponentHooks`].
+    fn register_component_hooks(_hooks: &mut ComponentHooks) {}
 }
 
 /// Marker type for components stored in a [`Table`](crate::storage::Table).
@@ -580,7 +579,7 @@ impl Components {
                 storages,
                 ComponentDescriptor::new::<T>(),
             );
-            T::init_component_info(&mut components[index.index()]);
+            T::register_component_hooks(&mut components[index.index()].hooks);
             index
         })
     }

--- a/examples/ecs/component_hooks.rs
+++ b/examples/ecs/component_hooks.rs
@@ -1,6 +1,6 @@
 //! This examples illustrates the different ways you can employ component lifecycle hooks
 
-use bevy::ecs::component::{ComponentInfo, TableStorage};
+use bevy::ecs::component::{ComponentHooks, TableStorage};
 use bevy::prelude::*;
 use std::collections::HashMap;
 
@@ -11,8 +11,8 @@ impl Component for MyComponent {
     type Storage = TableStorage;
 
     /// Hooks can also be registered during component initialisation by
-    /// implementing `init_component_info`
-    fn init_component_info(_info: &mut ComponentInfo) {
+    /// implementing `register_component_hooks`
+    fn register_component_hooks(_hooks: &mut ComponentHooks) {
         // Register hooks...
     }
 }


### PR DESCRIPTION
# Objective

- Fix mismatch between the `Component` trait method and the `World` method.

## Solution

- Replace init_component_info with register_component_hooks.