### PR TITLE
Update `wgpu` to v0.19.3 and unpin `web-sys`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,8 +144,6 @@ jobs:
           target: wasm32-unknown-unknown
       - name: Check wasm
         run: cargo check --target wasm32-unknown-unknown
-        env:
-          RUSTFLAGS: --cfg=web_sys_unstable_apis
 
   markdownlint:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -303,7 +303,7 @@ pbr_transmission_textures = ["bevy_internal/pbr_transmission_textures"]
 # Enable some limitations to be able to use WebGL2. Please refer to the [WebGL2 and WebGPU](https://github.com/bevyengine/bevy/tree/latest/examples#webgl2-and-webgpu) section of the examples README for more information on how to run Wasm builds with WebGPU.
 webgl2 = ["bevy_internal/webgl"]
 
-# Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU. Requires the `RUSTFLAGS` environment variable to be set to `--cfg=web_sys_unstable_apis` when building.
+# Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.
 webgpu = ["bevy_internal/webgpu"]
 
 # Enables the built-in asset processor for processed assets.

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -16,7 +16,7 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
 bytemuck = "1"
 serde = "1.0"
 thiserror = "1.0"
-wgpu = { version = "0.19.1", default-features = false }
+wgpu = { version = "0.19.3", default-features = false }
 encase = { version = "0.7", default-features = false }
 
 [lints]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -66,7 +66,7 @@ image = { version = "0.24", default-features = false }
 codespan-reporting = "0.11.0"
 # `fragile-send-sync-non-atomic-wasm` feature means we can't use WASM threads for rendering
 # It is enabled for now to avoid having to do a significant overhaul of the renderer just for wasm
-wgpu = { version = "0.19.1", default-features = false, features = [
+wgpu = { version = "0.19.3", default-features = false, features = [
   "wgsl",
   "dx12",
   "metal",
@@ -107,9 +107,7 @@ naga_oil = { version = "0.13", default-features = false, features = [
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 naga_oil = "0.13"
 js-sys = "0.3"
-# web-sys doesn't follow semver for the WebGPU APIs as they are unstable
-# Make sure that WebGPU builds work when changing this!
-web-sys = { version = "=0.3.67", features = [
+web-sys = { version = "0.3.67", features = [
   'Blob',
   'Document',
   'Element',

--- a/docs-template/EXAMPLE_README.md.tpl
+++ b/docs-template/EXAMPLE_README.md.tpl
@@ -239,13 +239,6 @@ ruby -run -ehttpd examples/wasm
 Bevy support for WebGPU is being worked on, but is currently experimental.
 
 To build for WebGPU, you'll need to enable the `webgpu` feature. This will override the `webgl2` feature, and builds with the `webgpu` feature enabled won't be able to run on browsers that don't support WebGPU.
-WebGPU depends on unstable APIs so you will also need to pass the `web_sys_unstable_apis` flag to your builds. For example:
-
-```sh
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build ...
-```
-
-Check `wasm-bindgen` [docs on Unstable APIs](https://rustwasm.github.io/wasm-bindgen/web-sys/unstable-apis.html) for more details.
 
 Bevy has an helper to build its examples:
 

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -83,7 +83,7 @@ The default feature set enables most of the expected features of a game engine, 
 |trace_tracy_memory|Tracing support, with memory profiling, exposing a port for Tracy|
 |wav|WAV audio format support|
 |wayland|Wayland display server support|
-|webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU. Requires the `RUSTFLAGS` environment variable to be set to `--cfg=web_sys_unstable_apis` when building.|
+|webgpu|Enable support for WebGPU in Wasm. When enabled, this feature will override the `webgl2` feature and you won't be able to run Wasm builds with WebGL2, only with WebGPU.|
 |webp|WebP image format support|
 |wgpu_trace|Save a trace of all wgpu calls|
 |zlib|For KTX2 supercompression|

--- a/examples/README.md
+++ b/examples/README.md
@@ -583,13 +583,6 @@ ruby -run -ehttpd examples/wasm
 Bevy support for WebGPU is being worked on, but is currently experimental.
 
 To build for WebGPU, you'll need to enable the `webgpu` feature. This will override the `webgl2` feature, and builds with the `webgpu` feature enabled won't be able to run on browsers that don't support WebGPU.
-WebGPU depends on unstable APIs so you will also need to pass the `web_sys_unstable_apis` flag to your builds. For example:
-
-```sh
-RUSTFLAGS=--cfg=web_sys_unstable_apis cargo build ...
-```
-
-Check `wasm-bindgen` [docs on Unstable APIs](https://rustwasm.github.io/wasm-bindgen/web-sys/unstable-apis.html) for more details.
 
 Bevy has an helper to build its examples:
 

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
             parameters.push("--features");
             parameters.push(&features_string);
         }
-        let mut cmd = cmd!(
+        let cmd = cmd!(
             sh,
             "cargo build {parameters...} --profile release --target wasm32-unknown-unknown --example {example}"
         );

--- a/tools/build-wasm-example/src/main.rs
+++ b/tools/build-wasm-example/src/main.rs
@@ -77,9 +77,6 @@ fn main() {
             sh,
             "cargo build {parameters...} --profile release --target wasm32-unknown-unknown --example {example}"
         );
-        if matches!(cli.api, WebApi::Webgpu) {
-            cmd = cmd.env("RUSTFLAGS", "--cfg=web_sys_unstable_apis");
-        }
         cmd.run().expect("Error building example");
 
         cmd!(


### PR DESCRIPTION
# Objective

This PR unpins `web-sys` so that unrelated projects that have `bevy_render` in their workspace can finally update their `web-sys`.
More details in and fixes #12246.

## Solution

* Update `wgpu` from 0.19.1 to 0.19.3.
* Remove the `web-sys` pin.
* Update docs and wasm helper to remove the now-stale `--cfg=web_sys_unstable_apis` Rust flag.

---

## Changelog

Updated `wgpu` to v0.19.3 and removed `web-sys` pin.
