### PR TITLE
update comment on `emissive` field of `StandardMaterial` struct to mention large color channel values

### DIFF
--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -57,8 +57,8 @@ pub struct StandardMaterial {
     ///
     /// The default emissive color is [`Color::BLACK`], which doesn't add anything to the material color.
     ///
-    /// To increase emissive strength, channel values for [`emissive`]
-    /// colors can exceed `1.0``. For instance, a [base_color] of
+    /// To increase emissive strength, channel values for `emissive`
+    /// colors can exceed `1.0`. For instance, a `base_color` of
     /// `Color::linear_rgb(1.0, 0.0, 0.0)` represents the brightest
     /// red for objects that reflect light, but an emissive color
     /// like `Color::linear_rgb(1000.0, 0.0, 0.0)` can be used to create

--- a/crates/bevy_pbr/src/pbr_material.rs
+++ b/crates/bevy_pbr/src/pbr_material.rs
@@ -57,7 +57,16 @@ pub struct StandardMaterial {
     ///
     /// The default emissive color is [`Color::BLACK`], which doesn't add anything to the material color.
     ///
-    /// Note that **an emissive material won't light up surrounding areas like a light source**,
+    /// To increase emissive strength, channel values for [`emissive`]
+    /// colors can exceed `1.0``. For instance, a [base_color] of
+    /// `Color::linear_rgb(1.0, 0.0, 0.0)` represents the brightest
+    /// red for objects that reflect light, but an emissive color
+    /// like `Color::linear_rgb(1000.0, 0.0, 0.0)` can be used to create
+    /// intensely bright red emissive effects.
+    ///
+    /// Increasing the emissive strength of the color will impact visual effects
+    /// like bloom, but it's important to note that **an emissive material won't
+    /// light up surrounding areas like a light source**,
     /// it just adds a value to the color seen on screen.
     pub emissive: Color,
 


### PR DESCRIPTION
# Objective

- Describe the objective or issue this PR addresses.

Improve docs around emissive colors --

I couldn't figure out how to increase the emissive strength of materials, asking on discord @alice-i-cecile told me that color channel values can go above `1.0` in the case of the `emissive` field. I would have never figured this out on my own, because [the docs for emissive](https://docs.rs/bevy/latest/bevy/prelude/struct.StandardMaterial.html#structfield.emissive) don't mention this possibility, and indeed if you follow the link in the `emissive` doc [to the `Color` type](https://docs.rs/bevy/latest/bevy/render/color/enum.Color.html#variants), you are told that values should be in `[0.0, 1.0]`.


## Solution

- Describe the solution used to achieve the objective above.

Just added a note on the possibility of large color channel values with example.
