### PR TITLE
Document instability of Entity's internal representation

### DIFF
--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -83,8 +83,8 @@ type IdCursor = isize;
 ///
 /// # Stability warning
 /// For all intents and purposes, `Entity` should be treated as an opaque identifier. The internal bit
-/// representation is liable to change from release to release as are the behaviors or performance 
-/// characteristics of any of its trait implementations (i.e. `Ord`, `Hash`, etc.). This means that changes in 
+/// representation is liable to change from release to release as are the behaviors or performance
+/// characteristics of any of its trait implementations (i.e. `Ord`, `Hash`, etc.). This means that changes in
 /// `Entity`'s representation, though made readable through various functions on the type, are not considered
 /// breaking changes under [SemVer].
 ///

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -83,10 +83,12 @@ type IdCursor = isize;
 ///
 /// # Stability warning
 /// For all intents and purposes, `Entity` should be treated as an opaque identifier. The internal bit
-/// representation is liable to change from release to release, ignoring [SemVer], as are the behaviors or
-/// performance characteristics of any of its trait implementations (i.e. `Ord`, `Hash`, etc.).
+/// representation is liable to change from release to release as are the behaviors or performance 
+/// characteristics of any of its trait implementations (i.e. `Ord`, `Hash`, etc.). This means that changes in 
+/// `Entity`'s representation, though made readable through various functions on the type, are not considered
+/// breaking changes under [SemVer].
 ///
-/// In particular, directly serializing with `Serialize` and `Deserialize` make zero guarentee of long
+/// In particular, directly serializing with `Serialize` and `Deserialize` make zero guarantee of long
 /// term wire format compatibility. Changes in behavior will cause serialized `Entity` values persisted
 /// to long term storage (i.e. disk, databases, etc.) will fail to deserialize upon being updated.
 ///
@@ -136,6 +138,7 @@ type IdCursor = isize;
 /// [`EntityCommands`]: crate::system::EntityCommands
 /// [`Query::get`]: crate::system::Query::get
 /// [`World`]: crate::world::World
+/// [SemVer]: https://semver.org/
 #[derive(Clone, Copy)]
 #[cfg_attr(feature = "bevy_reflect", derive(Reflect))]
 #[cfg_attr(

--- a/crates/bevy_ecs/src/entity/mod.rs
+++ b/crates/bevy_ecs/src/entity/mod.rs
@@ -81,6 +81,15 @@ type IdCursor = isize;
 ///
 /// [generational index]: https://lucassardois.medium.com/generational-indices-guide-8e3c5f7fd594
 ///
+/// # Stability warning
+/// For all intents and purposes, `Entity` should be treated as an opaque identifier. The internal bit
+/// representation is liable to change from release to release, ignoring [SemVer], as are the behaviors or
+/// performance characteristics of any of its trait implementations (i.e. `Ord`, `Hash`, etc.).
+///
+/// In particular, directly serializing with `Serialize` and `Deserialize` make zero guarentee of long
+/// term wire format compatibility. Changes in behavior will cause serialized `Entity` values persisted
+/// to long term storage (i.e. disk, databases, etc.) will fail to deserialize upon being updated.
+///
 /// # Usage
 ///
 /// This data type is returned by iterating a `Query` that has `Entity` as part of its query fetch type parameter ([learn more]).


### PR DESCRIPTION
# Objective
bevy_ecs has been developed with a de facto assumption that `Entity` is to be treated as an opaque identifier by external users, and that its internal representation is readable but in no way guaranteed to be stable between versions of bevy_ecs.

This hasn't been clear to users, and the functions on the type that expose its guts speak a different story.

## Solution
Explicitly document the lack of stability here and define internal representation changes as a non-breaking change under SemVer. Give it the same treatment that the standard lib gives `TypeId`.