### PR TITLE
Batching: replace GpuArrayBufferIndex::index with a u32

### DIFF
--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -88,7 +88,7 @@ pub fn batch_and_prepare_render_phase<I: CachedRenderPipelinePhaseItem, F: GetBa
         let (buffer_data, compare_data) = F::get_batch_data(&system_param_item, item.entity())?;
         let buffer_index = gpu_array_buffer.push(buffer_data);
 
-        let index = buffer_index.index.get();
+        let index = buffer_index.index;
         *item.batch_range_mut() = index..index + 1;
         *item.dynamic_offset_mut() = buffer_index.dynamic_offset;
 

--- a/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/batched_uniform_buffer.rs
@@ -81,7 +81,7 @@ impl<T: GpuArrayBufferable> BatchedUniformBuffer<T> {
 
     pub fn push(&mut self, component: T) -> GpuArrayBufferIndex<T> {
         let result = GpuArrayBufferIndex {
-            index: NonMaxU32::new(self.temp.0.len() as u32).unwrap(),
+            index: self.temp.0.len() as u32,
             dynamic_offset: NonMaxU32::new(self.current_offset),
             element_type: PhantomData,
         };

--- a/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
+++ b/crates/bevy_render/src/render_resource/gpu_array_buffer.rs
@@ -57,7 +57,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
             GpuArrayBuffer::Uniform(buffer) => buffer.push(value),
             GpuArrayBuffer::Storage(buffer) => {
                 let buffer = buffer.get_mut();
-                let index = NonMaxU32::new(buffer.len() as u32).unwrap();
+                let index = buffer.len() as u32;
                 buffer.push(value);
                 GpuArrayBufferIndex {
                     index,
@@ -109,7 +109,7 @@ impl<T: GpuArrayBufferable> GpuArrayBuffer<T> {
 #[derive(Component, Clone)]
 pub struct GpuArrayBufferIndex<T: GpuArrayBufferable> {
     /// The index to use in a shader into the array.
-    pub index: NonMaxU32,
+    pub index: u32,
     /// The dynamic offset to use when setting the bind group in a pass.
     /// Only used on platforms that don't support storage buffers.
     pub dynamic_offset: Option<NonMaxU32>,


### PR DESCRIPTION
# Objective
While mucking around with batch_and_prepare systems, it became apparent that `GpuArrayBufferIndex::index` doesn't need to be a NonMaxU32.

## Solution
Replace it with a normal u32. 

This likely has some potential perf benefit by avoiding panics and the NOT operations, but I haven't been able to find any substantial gains, so this is primarily for code quality.

---

## Changelog
Changed: `GpuArrayBufferIndex::index` is now a u32.

## Migration Guide
`GpuArrayBuferIndex::index` is now a u32 instead of a `NonMaxU32`. Remove any calls to `NonMaxU32::get` on the member.