### PR TITLE
Update engine_style_guide with guideline to link to the error code when using bevy engine error codes

### DIFF
--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -14,6 +14,7 @@ For more advice on contributing to the engine, see the [relevant section](../../
    4. Use \`variable_name\` code blocks in comments to signify that you're referring to specific types and variables.
    5. Start comments with capital letters. End them with a period if they are sentence-like.
 3. Use comments to organize long and complex stretches of code that can't sensibly be refactored into separate functions.
+4. When using [Bevy error codes](https://bevyengine.org/learn/errors/) include a link to the relevant error on the Bevy website in the returned error message `... See: https://bevyengine.org/learn/errors/#b0003`
 
 ## Rust API guidelines
 

--- a/.github/contributing/engine_style_guide.md
+++ b/.github/contributing/engine_style_guide.md
@@ -14,7 +14,7 @@ For more advice on contributing to the engine, see the [relevant section](../../
    4. Use \`variable_name\` code blocks in comments to signify that you're referring to specific types and variables.
    5. Start comments with capital letters. End them with a period if they are sentence-like.
 3. Use comments to organize long and complex stretches of code that can't sensibly be refactored into separate functions.
-4. When using [Bevy error codes](https://bevyengine.org/learn/errors/) include a link to the relevant error on the Bevy website in the returned error message `... See: https://bevyengine.org/learn/errors/#b0003`
+4. When using [Bevy error codes](https://bevyengine.org/learn/errors/) include a link to the relevant error on the Bevy website in the returned error message `... See: https://bevyengine.org/learn/errors/#b0003`.
 
 ## Rust API guidelines
 


### PR DESCRIPTION
# Objective

- https://github.com/bevyengine/bevy/pull/12165 created the expectation that returned bevy errors will include a link to the relevant bevy error. That expectation is not formally established in the contributing guidelines which will lead to it not being upheld in future PRs that use the bevy error codes. This PR adds it to engine_style_guide.md to establish that convention officially