### PR TITLE
Replace bevy_log's tracing reexport with bevy_utils'

### DIFF
--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_asset = { path = "../bevy_asset", version = "0.14.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -14,14 +14,13 @@ use bevy_core::Name;
 use bevy_ecs::entity::MapEntities;
 use bevy_ecs::prelude::*;
 use bevy_ecs::reflect::ReflectMapEntities;
-use bevy_log::error;
 use bevy_math::{FloatExt, Quat, Vec3};
 use bevy_reflect::Reflect;
 use bevy_render::mesh::morph::MorphWeights;
 use bevy_time::Time;
 use bevy_transform::{prelude::Transform, TransformSystem};
 use bevy_utils::hashbrown::HashMap;
-use bevy_utils::{NoOpHash, Uuid};
+use bevy_utils::{tracing::error, NoOpHash, Uuid};
 use sha1_smol::Sha1;
 
 #[allow(missing_docs)]

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -21,7 +21,6 @@ watch = []
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_asset_macros = { path = "macros", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
@@ -53,6 +52,7 @@ notify-debouncer-full = { version = "0.3.1", optional = true }
 
 [dev-dependencies]
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
+bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 
 [lints]
 workspace = true

--- a/crates/bevy_asset/src/io/android.rs
+++ b/crates/bevy_asset/src/io/android.rs
@@ -1,7 +1,7 @@
 use crate::io::{
     get_meta_path, AssetReader, AssetReaderError, EmptyPathStream, PathStream, Reader, VecReader,
 };
-use bevy_log::error;
+use bevy_utils::tracing::error;
 use bevy_utils::BoxedFuture;
 use std::{ffi::CString, path::Path};
 

--- a/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
+++ b/crates/bevy_asset/src/io/embedded/embedded_watcher.rs
@@ -3,7 +3,7 @@ use crate::io::{
     memory::Dir,
     AssetSourceEvent, AssetWatcher,
 };
-use bevy_log::warn;
+use bevy_utils::tracing::warn;
 use bevy_utils::{Duration, HashMap};
 use notify_debouncer_full::{notify::RecommendedWatcher, Debouncer, FileIdMap};
 use parking_lot::RwLock;

--- a/crates/bevy_asset/src/io/file/file_watcher.rs
+++ b/crates/bevy_asset/src/io/file/file_watcher.rs
@@ -1,6 +1,6 @@
 use crate::io::{AssetSourceEvent, AssetWatcher};
 use crate::path::normalize_path;
-use bevy_log::error;
+use bevy_utils::tracing::error;
 use bevy_utils::Duration;
 use crossbeam_channel::Sender;
 use notify_debouncer_full::{

--- a/crates/bevy_asset/src/io/file/mod.rs
+++ b/crates/bevy_asset/src/io/file/mod.rs
@@ -6,7 +6,7 @@ mod file_asset;
 #[cfg(not(feature = "multi-threaded"))]
 mod sync_file_asset;
 
-use bevy_log::error;
+use bevy_utils::tracing::error;
 #[cfg(feature = "file_watcher")]
 pub use file_watcher::*;
 

--- a/crates/bevy_asset/src/io/processor_gated.rs
+++ b/crates/bevy_asset/src/io/processor_gated.rs
@@ -4,7 +4,7 @@ use crate::{
     AssetPath,
 };
 use async_lock::RwLockReadGuardArc;
-use bevy_log::trace;
+use bevy_utils::tracing::trace;
 use bevy_utils::BoxedFuture;
 use futures_io::AsyncRead;
 use std::{path::Path, pin::Pin, sync::Arc};

--- a/crates/bevy_asset/src/io/source.rs
+++ b/crates/bevy_asset/src/io/source.rs
@@ -6,7 +6,7 @@ use crate::{
     processor::AssetProcessorData,
 };
 use bevy_ecs::system::Resource;
-use bevy_log::{error, warn};
+use bevy_utils::tracing::{error, warn};
 use bevy_utils::{CowArc, Duration, HashMap};
 use std::{fmt::Display, hash::Hash, sync::Arc};
 use thiserror::Error;

--- a/crates/bevy_asset/src/io/wasm.rs
+++ b/crates/bevy_asset/src/io/wasm.rs
@@ -1,7 +1,7 @@
 use crate::io::{
     get_meta_path, AssetReader, AssetReaderError, EmptyPathStream, PathStream, Reader, VecReader,
 };
-use bevy_log::error;
+use bevy_utils::tracing::error;
 use bevy_utils::BoxedFuture;
 use js_sys::{Uint8Array, JSON};
 use std::path::{Path, PathBuf};

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -55,9 +55,8 @@ use bevy_ecs::{
     system::Resource,
     world::FromWorld,
 };
-use bevy_log::error;
 use bevy_reflect::{FromReflect, GetTypeRegistration, Reflect, TypePath};
-use bevy_utils::HashSet;
+use bevy_utils::{tracing::error, HashSet};
 use std::{any::TypeId, sync::Arc};
 
 #[cfg(all(feature = "file_watcher", not(feature = "multi-threaded")))]

--- a/crates/bevy_asset/src/meta.rs
+++ b/crates/bevy_asset/src/meta.rs
@@ -1,6 +1,6 @@
 use crate::{self as bevy_asset, DeserializeMetaError, VisitAssetDependencies};
 use crate::{loader::AssetLoader, processor::Process, Asset, AssetPath};
-use bevy_log::error;
+use bevy_utils::tracing::error;
 use downcast_rs::{impl_downcast, Downcast};
 use ron::ser::PrettyConfig;
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_asset/src/processor/log.rs
+++ b/crates/bevy_asset/src/processor/log.rs
@@ -1,6 +1,6 @@
 use crate::AssetPath;
 use async_fs::File;
-use bevy_log::error;
+use bevy_utils::tracing::error;
 use bevy_utils::HashSet;
 use futures_lite::{AsyncReadExt, AsyncWriteExt};
 use std::path::PathBuf;

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -17,8 +17,8 @@ use crate::{
     MissingAssetLoaderForExtensionError,
 };
 use bevy_ecs::prelude::*;
-use bevy_log::{debug, error, trace, warn};
 use bevy_tasks::IoTaskPool;
+use bevy_utils::tracing::{debug, error, trace, warn};
 use bevy_utils::{BoxedFuture, HashMap, HashSet};
 use futures_io::ErrorKind;
 use futures_lite::{AsyncReadExt, AsyncWriteExt, StreamExt};

--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -5,7 +5,7 @@ use crate::{
     UntypedAssetId, UntypedHandle,
 };
 use bevy_ecs::world::World;
-use bevy_log::warn;
+use bevy_utils::tracing::warn;
 use bevy_utils::{Entry, HashMap, HashSet, TypeIdMap};
 use crossbeam_channel::Sender;
 use std::{

--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -3,8 +3,8 @@ use crate::{
     path::AssetPath,
 };
 use async_broadcast::RecvError;
-use bevy_log::{error, warn};
 use bevy_tasks::IoTaskPool;
+use bevy_utils::tracing::{error, warn};
 use bevy_utils::{HashMap, TypeIdMap};
 use std::{any::TypeId, sync::Arc};
 use thiserror::Error;

--- a/crates/bevy_asset/src/server/mod.rs
+++ b/crates/bevy_asset/src/server/mod.rs
@@ -18,8 +18,8 @@ use crate::{
     UntypedAssetLoadFailedEvent, UntypedHandle,
 };
 use bevy_ecs::prelude::*;
-use bevy_log::{error, info};
 use bevy_tasks::IoTaskPool;
+use bevy_utils::tracing::{error, info};
 use bevy_utils::{CowArc, HashSet};
 use crossbeam_channel::{Receiver, Sender};
 use futures_lite::StreamExt;

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -27,7 +27,6 @@ bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.14.0-dev" }
 bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev" }
 bevy_render = { path = "../bevy_render", version = "0.14.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }

--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -14,6 +14,8 @@ use bevy_render::renderer::RenderDevice;
 use bevy_render::texture::{CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_render::view::{ViewTarget, ViewUniform};
 use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
+#[cfg(not(feature = "tonemapping_luts"))]
+use bevy_utils::tracing::error;
 
 mod node;
 
@@ -199,7 +201,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             Tonemapping::AcesFitted => shader_defs.push("TONEMAP_METHOD_ACES_FITTED".into()),
             Tonemapping::AgX => {
                 #[cfg(not(feature = "tonemapping_luts"))]
-                bevy_log::error!(
+                error!(
                     "AgX tonemapping requires the `tonemapping_luts` feature.
                     Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
                     or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."
@@ -211,7 +213,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             }
             Tonemapping::TonyMcMapface => {
                 #[cfg(not(feature = "tonemapping_luts"))]
-                bevy_log::error!(
+                error!(
                     "TonyMcMapFace tonemapping requires the `tonemapping_luts` feature.
                     Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
                     or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."
@@ -220,7 +222,7 @@ impl SpecializedRenderPipeline for TonemappingPipeline {
             }
             Tonemapping::BlenderFilmic => {
                 #[cfg(not(feature = "tonemapping_luts"))]
-                bevy_log::error!(
+                error!(
                     "BlenderFilmic tonemapping requires the `tonemapping_luts` feature.
                     Either enable the `tonemapping_luts` feature for bevy in `Cargo.toml` (recommended),
                     or use a different `Tonemapping` method in your `Camera2dBundle`/`Camera3dBundle`."

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -19,7 +19,6 @@ features = []
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 

--- a/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/log_diagnostics_plugin.rs
@@ -1,8 +1,8 @@
 use super::{Diagnostic, DiagnosticPath, DiagnosticsStore};
 use bevy_app::prelude::*;
 use bevy_ecs::prelude::*;
-use bevy_log::{debug, info};
 use bevy_time::{Real, Time, Timer, TimerMode};
+use bevy_utils::tracing::{debug, info};
 use bevy_utils::Duration;
 
 /// An App Plugin that logs diagnostics to the console.

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -40,7 +40,7 @@ impl SystemInformationDiagnosticsPlugin {
 ))]
 pub mod internal {
     use bevy_ecs::{prelude::ResMut, system::Local};
-    use bevy_log::info;
+    use bevy_utils::tracing::info;
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 
     use crate::{Diagnostic, Diagnostics, DiagnosticsStore};
@@ -136,7 +136,7 @@ pub mod internal {
 )))]
 pub mod internal {
     pub(crate) fn setup_system() {
-        bevy_log::warn!("This platform and/or configuration is not supported!");
+        bevy_utils::tracing::warn!("This platform and/or configuration is not supported!");
     }
 
     pub(crate) fn diagnostic_system() {

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -13,7 +13,6 @@ keywords = ["bevy"]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
 

--- a/crates/bevy_gilrs/src/rumble.rs
+++ b/crates/bevy_gilrs/src/rumble.rs
@@ -4,8 +4,8 @@ use bevy_ecs::prelude::{EventReader, Res, ResMut, Resource};
 #[cfg(target_arch = "wasm32")]
 use bevy_ecs::system::NonSendMut;
 use bevy_input::gamepad::{GamepadRumbleIntensity, GamepadRumbleRequest};
-use bevy_log::{debug, warn};
 use bevy_time::{Real, Time};
+use bevy_utils::tracing::{debug, warn};
 use bevy_utils::{synccell::SyncCell, Duration, HashMap};
 use gilrs::{
     ff::{self, BaseEffect, BaseEffectType, Repeat, Replay},

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -27,7 +27,6 @@ bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.14.0-dev" }
 bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_gizmos_macros = { path = "macros", version = "0.14.0-dev" }
 
 [lints]

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -96,7 +96,9 @@ impl Plugin for GizmoPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         // Gizmos cannot work without either a 3D or 2D renderer.
         #[cfg(all(not(feature = "bevy_pbr"), not(feature = "bevy_sprite")))]
-        bevy_log::error!("bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one.");
+        bevy_utils::tracing::error!(
+            "bevy_gizmos requires either bevy_pbr or bevy_sprite. Please enable one."
+        );
 
         load_internal_asset!(app, LINE_SHADER_HANDLE, "lines.wgsl", Shader::from_wgsl);
 

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -22,7 +22,6 @@ bevy_core = { path = "../bevy_core", version = "0.14.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_pbr = { path = "../bevy_pbr", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [

--- a/crates/bevy_gltf/src/loader.rs
+++ b/crates/bevy_gltf/src/loader.rs
@@ -9,7 +9,6 @@ use bevy_core_pipeline::prelude::Camera3dBundle;
 use bevy_ecs::entity::EntityHashMap;
 use bevy_ecs::{entity::Entity, world::World};
 use bevy_hierarchy::{BuildWorldChildren, WorldChildBuilder};
-use bevy_log::{error, info_span, warn};
 use bevy_math::{Affine2, Mat4, Vec3};
 use bevy_pbr::{
     DirectionalLight, DirectionalLightBundle, PbrBundle, PointLight, PointLightBundle, SpotLight,
@@ -36,6 +35,7 @@ use bevy_scene::Scene;
 #[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::IoTaskPool;
 use bevy_transform::components::Transform;
+use bevy_utils::tracing::{error, info_span, warn};
 use bevy_utils::{
     smallvec::{smallvec, SmallVec},
     HashMap, HashSet,
@@ -474,9 +474,9 @@ async fn load_gltf<'a, 'b, 'c>(
                 let vertex_count_after = mesh.count_vertices();
 
                 if vertex_count_before != vertex_count_after {
-                    bevy_log::debug!("Missing vertex normals in indexed geometry, computing them as flat. Vertex count increased from {} to {}", vertex_count_before, vertex_count_after);
+                    bevy_utils::tracing::debug!("Missing vertex normals in indexed geometry, computing them as flat. Vertex count increased from {} to {}", vertex_count_before, vertex_count_after);
                 } else {
-                    bevy_log::debug!(
+                    bevy_utils::tracing::debug!(
                         "Missing vertex normals in indexed geometry, computing them as flat."
                     );
                 }
@@ -490,7 +490,7 @@ async fn load_gltf<'a, 'b, 'c>(
             } else if mesh.attribute(Mesh::ATTRIBUTE_NORMAL).is_some()
                 && primitive.material().normal_texture().is_some()
             {
-                bevy_log::debug!(
+                bevy_utils::tracing::debug!(
                     "Missing vertex tangents for {}, computing them using the mikktspace algorithm. Consider using a tool such as Blender to pre-compute the tangents.", file_name
                 );
 

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["bevy"]
 [features]
 default = ["bevy_app"]
 trace = []
-bevy_app = ["reflect", "dep:bevy_app", "bevy_core", "bevy_log"]
+bevy_app = ["reflect", "dep:bevy_app", "bevy_core"]
 reflect = ["bevy_ecs/bevy_reflect", "bevy_reflect"]
 
 [dependencies]
@@ -19,7 +19,6 @@ reflect = ["bevy_ecs/bevy_reflect", "bevy_reflect"]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev", optional = true }
 bevy_core = { path = "../bevy_core", version = "0.14.0-dev", optional = true }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev", default-features = false }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev", optional = true }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
 ], optional = true }

--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -64,7 +64,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
         let parent = parent.get();
         if !component_query.contains(parent) && !already_diagnosed.contains(&entity) {
             already_diagnosed.insert(entity);
-            bevy_log::warn!(
+            bevy_utils::tracing::warn!(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
                 This will cause inconsistent behaviors! See: https://bevyengine.org/learn/errors/#b0004",
                 ty_name = get_short_name(std::any::type_name::<T>()),

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -46,7 +46,6 @@ bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_encase_derive = { path = "../bevy_encase_derive", version = "0.14.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_mikktspace = { path = "../bevy_mikktspace", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -20,11 +20,11 @@ use bevy_ecs::{
     reflect::ReflectComponent,
     system::{Commands, Query, Res, ResMut, Resource},
 };
-use bevy_log::warn;
 use bevy_math::{vec2, Dir3, Mat4, Ray3d, Rect, URect, UVec2, UVec4, Vec2, Vec3};
 use bevy_reflect::prelude::*;
 use bevy_render_macros::ExtractComponent;
 use bevy_transform::components::GlobalTransform;
+use bevy_utils::tracing::warn;
 use bevy_utils::{HashMap, HashSet};
 use bevy_window::{
     NormalizedWindowRef, PrimaryWindow, Window, WindowCreated, WindowRef, WindowResized,

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -51,7 +51,7 @@ pub fn extract_resource<R: ExtractResource>(
         } else {
             #[cfg(debug_assertions)]
             if !main_resource.is_added() {
-                bevy_log::warn_once!(
+                bevy_utils::warn_once!(
                     "Removing resource {} from render world not expected, adding using `Commands`.
                 This may decrease performance",
                     std::any::type_name::<R>()

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -17,10 +17,10 @@ use bevy_ecs::system::{
     lifetimeless::{SRes, SResMut},
     SystemParamItem,
 };
-use bevy_log::warn;
 use bevy_math::*;
 use bevy_reflect::Reflect;
 use bevy_utils::tracing::error;
+use bevy_utils::tracing::warn;
 use std::{collections::BTreeMap, hash::Hash, iter::FusedIterator};
 use thiserror::Error;
 use wgpu::{

--- a/crates/bevy_render/src/render_graph/app.rs
+++ b/crates/bevy_render/src/render_graph/app.rs
@@ -1,6 +1,6 @@
 use bevy_app::App;
 use bevy_ecs::world::FromWorld;
-use bevy_log::warn;
+use bevy_utils::tracing::warn;
 
 use super::{IntoRenderNodeArray, Node, RenderGraph, RenderLabel, RenderSubGraph};
 

--- a/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
+++ b/crates/bevy_render/src/render_resource/bind_group_layout_entries.rs
@@ -222,7 +222,7 @@ impl IntoBindGroupLayoutEntryBuilder for BindingType {
 impl IntoBindGroupLayoutEntryBuilder for BindGroupLayoutEntry {
     fn into_bind_group_layout_entry_builder(self) -> BindGroupLayoutEntryBuilder {
         if self.binding != u32::MAX {
-            bevy_log::warn!("The BindGroupLayoutEntries api ignores the binding index when converting a raw wgpu::BindGroupLayoutEntry. You can ignore this warning by setting it to u32::MAX.");
+            bevy_utils::tracing::warn!("The BindGroupLayoutEntries api ignores the binding index when converting a raw wgpu::BindGroupLayoutEntry. You can ignore this warning by setting it to u32::MAX.");
         }
         BindGroupLayoutEntryBuilder {
             ty: self.ty,

--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -276,7 +276,7 @@ pub fn prepare_windows(
                 format!("MSAA {}x", fallback.samples())
             };
 
-            bevy_log::warn!(
+            bevy_utils::tracing::warn!(
                 "MSAA {}x is not supported on this device. Falling back to {}.",
                 msaa.samples(),
                 fallback_str,

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -3,8 +3,8 @@ use std::{borrow::Cow, path::Path, sync::PoisonError};
 use bevy_app::Plugin;
 use bevy_asset::{load_internal_asset, Handle};
 use bevy_ecs::{entity::EntityHashMap, prelude::*};
-use bevy_log::{error, info, info_span};
 use bevy_tasks::AsyncComputeTaskPool;
+use bevy_utils::tracing::{error, info, info_span};
 use std::sync::Mutex;
 use thiserror::Error;
 use wgpu::{

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -19,7 +19,6 @@ bevy_asset = { path = "../bevy_asset", version = "0.14.0-dev" }
 bevy_color = { path = "../bevy_color", version = "0.14.0-dev" }
 bevy_core_pipeline = { path = "../bevy_core_pipeline", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -10,7 +10,6 @@ use bevy_ecs::{
     prelude::*,
     system::{lifetimeless::SRes, SystemParamItem},
 };
-use bevy_log::error;
 use bevy_render::{
     mesh::{Mesh, MeshVertexBufferLayoutRef},
     prelude::Image,
@@ -30,6 +29,7 @@ use bevy_render::{
     Extract, ExtractSchedule, Render, RenderApp, RenderSet,
 };
 use bevy_transform::components::{GlobalTransform, Transform};
+use bevy_utils::tracing::error;
 use bevy_utils::{FloatOrd, HashMap, HashSet};
 use std::hash::Hash;
 use std::marker::PhantomData;

--- a/crates/bevy_sprite/src/texture_atlas_builder.rs
+++ b/crates/bevy_sprite/src/texture_atlas_builder.rs
@@ -1,11 +1,11 @@
 use bevy_asset::AssetId;
-use bevy_log::{debug, error, warn};
 use bevy_math::{URect, UVec2};
 use bevy_render::{
     render_asset::RenderAssetUsages,
     render_resource::{Extent3d, TextureDimension, TextureFormat},
     texture::{Image, TextureFormatPixelInfo},
 };
+use bevy_utils::tracing::{debug, error, warn};
 use bevy_utils::HashMap;
 use rectangle_pack::{
     contains_smallest_box, pack_rects, volume_heuristic, GroupedRectsToPlace, PackedLocation,

--- a/crates/bevy_sprite/src/texture_slice/mod.rs
+++ b/crates/bevy_sprite/src/texture_slice/mod.rs
@@ -86,7 +86,7 @@ impl TextureSlice {
             remaining_columns -= size_y;
         }
         if slices.len() > 1_000 {
-            bevy_log::warn!("One of your tiled textures has generated {} slices. You might want to use higher stretch values to avoid a great performance cost", slices.len());
+            bevy_utils::tracing::warn!("One of your tiled textures has generated {} slices. You might want to use higher stretch values to avoid a great performance cost", slices.len());
         }
         slices
     }

--- a/crates/bevy_sprite/src/texture_slice/slicer.rs
+++ b/crates/bevy_sprite/src/texture_slice/slicer.rs
@@ -207,7 +207,7 @@ impl TextureSlicer {
             || self.border.top >= rect_size.y
             || self.border.bottom >= rect_size.y
         {
-            bevy_log::error!(
+            bevy_utils::tracing::error!(
                 "TextureSlicer::border has out of bounds values. No slicing will be applied"
             );
             return vec![TextureSlice {

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -19,7 +19,6 @@ bevy_derive = { path = "../bevy_derive", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
-bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -25,7 +25,7 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
                 &mut out,
             );
         }
-        bevy_log::info!("Layout tree for camera entity: {entity:?}\n{out}");
+        bevy_utils::tracing::info!("Layout tree for camera entity: {entity:?}\n{out}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -13,10 +13,10 @@ use bevy_ecs::{
     world::Ref,
 };
 use bevy_hierarchy::{Children, Parent};
-use bevy_log::warn;
 use bevy_math::{UVec2, Vec2};
 use bevy_render::camera::{Camera, NormalizedRenderTarget};
 use bevy_transform::components::Transform;
+use bevy_utils::tracing::warn;
 use bevy_utils::{default, HashMap, HashSet};
 use bevy_window::{PrimaryWindow, Window, WindowScaleFactorChanged};
 use std::fmt;


### PR DESCRIPTION
# Objective
Fixes #11298. Make the use of bevy_log vs bevy_utils::tracing more consistent.

## Solution
Replace all uses of bevy_log's logging macros with the reexport from bevy_utils. Remove bevy_log as a dependency where it's no longer needed anymore.

Ideally we should just be using tracing directly, but given that all of these crates are already using bevy_utils, this likely isn't that great of a loss right now.