### PR TITLE
Add nightly hint to config.toml

### DIFF
--- a/.cargo/config_fast_builds.toml
+++ b/.cargo/config_fast_builds.toml
@@ -30,7 +30,7 @@ rustflags = [
 [target.x86_64-pc-windows-msvc]
 linker = "rust-lld.exe" # Use LLD Linker
 rustflags = [
-  "-Zshare-generics=n",
+  "-Zshare-generics=n", # (Nightly)
   "-Zthreads=0",        # (Nightly) Use improved multithreading with the recommended amount of threads.
 ]
 


### PR DESCRIPTION
# Objective

- The build on Windows currently fails on stable when using the `config.toml` as described but commenting out all lines that say "Nightly"

## Solution

- Add a missing nightly specifier for a flag that won't run on stable


