### PR TITLE
fix example lightmaps after color migration

### DIFF
--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,3 +1,5 @@
+use std::ops::Mul;
+
 use crate::color_difference::EuclideanDistance;
 use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza};
 use bevy_math::Vec4;
@@ -367,6 +369,31 @@ pub enum HexColorError {
     /// Invalid character.
     #[error("Invalid hex char")]
     Char(char),
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Srgba {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            red: self.red * rhs,
+            green: self.green * rhs,
+            blue: self.blue * rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl Mul<Srgba> for f32 {
+    type Output = Srgba;
+
+    fn mul(self, rhs: Srgba) -> Srgba {
+        rhs * self
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,4 +1,4 @@
-use std::ops::Mul;
+use std::ops::{Div, Mul};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza};
@@ -393,6 +393,23 @@ impl Mul<Srgba> for f32 {
 
     fn mul(self, rhs: Srgba) -> Srgba {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Srgba {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self {
+        Self {
+            red: self.red / rhs,
+            green: self.green / rhs,
+            blue: self.blue / rhs,
+            alpha: self.alpha,
+        }
     }
 }
 

--- a/examples/3d/lightmaps.rs
+++ b/examples/3d/lightmaps.rs
@@ -36,8 +36,7 @@ fn add_lightmaps_to_meshes(
     let exposure = 250.0;
     for (entity, name, material) in meshes.iter() {
         if &**name == "Light" {
-            materials.get_mut(material).unwrap().emissive =
-                Color::LinearRgba(LinearRgba::WHITE * exposure);
+            materials.get_mut(material).unwrap().emissive = Color::Srgba(Srgba::WHITE * exposure);
             continue;
         }
 


### PR DESCRIPTION
# Objective

- Since #12163 example lightmaps is more dull
<img width="1280" alt="Screenshot 2024-03-02 at 23 04 36" src="https://github.com/bevyengine/bevy/assets/8672791/7736f420-b9c5-4870-93f6-b5b992c4768a">


## Solution

- Use a srgba color, as it was before:
https://github.com/bevyengine/bevy/blob/b24ab2e9fba5b81aba15da97b6551a4e99aad40c/examples/3d/lightmaps.rs#L39
https://github.com/bevyengine/bevy/blob/b24ab2e9fba5b81aba15da97b6551a4e99aad40c/crates/bevy_render/src/color/mod.rs#L132

<img width="1280" alt="Screenshot 2024-03-02 at 23 05 09" src="https://github.com/bevyengine/bevy/assets/8672791/451187ed-8612-456f-ad25-180d5f774188">
