### PR TITLE
Clean up pointer use in BundleSpawner/BundleInserter

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -206,7 +206,7 @@ impl Edges {
                 archetype_id,
                 bundle_status,
             },
-        );
+        )
     }
 
     /// Checks the cache for the target archetype when removing a bundle to the

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -206,7 +206,7 @@ impl Edges {
                 archetype_id,
                 bundle_status,
             },
-        )
+        );
     }
 
     /// Checks the cache for the target archetype when removing a bundle to the

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -904,14 +904,16 @@ impl<'w> BundleSpawner<'w> {
         };
 
         // SAFETY: We have no outstanding mutable references to world as they were dropped
-        unsafe {
-            let mut world = self.world.into_deferred();
-            if archetype.has_on_add() {
-                world.trigger_on_add(entity, bundle_info.iter_components());
-            }
-            if archetype.has_on_insert() {
-                world.trigger_on_insert(entity, bundle_info.iter_components());
-            }
+        let mut deferred_world = unsafe { self.world.into_deferred() };
+        if archetype.has_on_add() {
+            // SAFETY: All components in the bundle are guaranteed to exist in the World
+            // as they must be initialized before creating the BundleInfo.
+            unsafe { deferred_world.trigger_on_add(entity, bundle_info.iter_components()) };
+        }
+        if archetype.has_on_insert() {
+            // SAFETY: All components in the bundle are guaranteed to exist in the World
+            // as they must be initialized before creating the BundleInfo.
+            unsafe { deferred_world.trigger_on_insert(entity, bundle_info.iter_components()) };
         }
 
         location

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -646,7 +646,7 @@ impl<'w> BundleInserter<'w> {
             mut world: DeferredWorld,
         ) {
             if archetype.has_on_add() {
-                // SAFETY: All components in the bundle are guarenteed to exist in the World
+                // SAFETY: All components in the bundle are guaranteed to exist in the World
                 // as they must be initialized before creating the BundleInfo.
                 unsafe {
                     world.trigger_on_add(
@@ -660,7 +660,7 @@ impl<'w> BundleInserter<'w> {
                 }
             }
             if archetype.has_on_insert() {
-                // SAFETY: All components in the bundle are guarenteed to exist in the World
+                // SAFETY: All components in the bundle are guaranteed to exist in the World
                 // as they must be initialized before creating the BundleInfo.
                 unsafe { world.trigger_on_insert(entity, bundle_info.iter_components()) }
             }
@@ -736,7 +736,7 @@ impl<'w> BundleInserter<'w> {
 
                 // SAFETY: We have no outstanding mutable references to world as they were dropped
                 let deferred_world = unsafe { self.world.into_deferred() };
-                trigger_hooks(entity, bundle_info, add_bundle, archetype, deferred_world);
+                trigger_hooks(entity, bundle_info, add_bundle, new_archetype, deferred_world);
 
                 new_location
             }
@@ -745,6 +745,7 @@ impl<'w> BundleInserter<'w> {
                 new_table,
             } => {
                 let new_table = new_table.as_mut();
+                let new_archetype = new_archetype.as_mut();
 
                 let new_location = {
                     // SAFETY: Mutable references do not alias and will be dropped after this block
@@ -758,7 +759,6 @@ impl<'w> BundleInserter<'w> {
                             &mut world.entities,
                         )
                     };
-                    let new_archetype = new_archetype.as_mut();
                     let result = archetype.swap_remove(location.archetype_row);
                     if let Some(swapped_entity) = result.swapped_entity {
                         let swapped_location =
@@ -831,7 +831,7 @@ impl<'w> BundleInserter<'w> {
 
                 // SAFETY: We have no outstanding mutable references to world as they were dropped
                 let deferred_world = unsafe { self.world.into_deferred() };
-                trigger_hooks(entity, bundle_info, add_bundle, archetype, deferred_world);
+                trigger_hooks(entity, bundle_info, add_bundle, new_archetype, deferred_world);
 
                 new_location
             }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -17,9 +17,10 @@ use crate::{
     storage::{SparseSetIndex, SparseSets, Storages, Table, TableRow},
     world::{unsafe_world_cell::UnsafeWorldCell, DeferredWorld},
 };
-use bevy_ptr::OwningPtr;
+use bevy_ptr::{ConstNonNull, OwningPtr};
 use bevy_utils::all_tuples;
 use std::any::TypeId;
+use std::ptr::NonNull;
 
 /// The `Bundle` trait enables insertion and removal of [`Component`]s from an entity.
 ///
@@ -510,10 +511,10 @@ impl BundleInfo {
 // SAFETY: We have exclusive world access so our pointers can't be invalidated externally
 pub(crate) struct BundleInserter<'w> {
     world: UnsafeWorldCell<'w>,
-    bundle_info: *const BundleInfo,
-    add_bundle: *const AddBundle,
-    table: *mut Table,
-    archetype: *mut Archetype,
+    bundle_info: ConstNonNull<BundleInfo>,
+    add_bundle: ConstNonNull<AddBundle>,
+    table: NonNull<Table>,
+    archetype: NonNull<Archetype>,
     result: InsertBundleResult,
     change_tick: Tick,
 }
@@ -521,11 +522,11 @@ pub(crate) struct BundleInserter<'w> {
 pub(crate) enum InsertBundleResult {
     SameArchetype,
     NewArchetypeSameTable {
-        new_archetype: *mut Archetype,
+        new_archetype: NonNull<Archetype>,
     },
     NewArchetypeNewTable {
-        new_archetype: *mut Archetype,
-        new_table: *mut Table,
+        new_archetype: NonNull<Archetype>,
+        new_table: NonNull<Table>,
     },
 }
 
@@ -546,7 +547,7 @@ impl<'w> BundleInserter<'w> {
     /// Creates a new [`BundleInserter`].
     ///
     /// # Safety
-    /// Caller must ensure that `bundle_id` exists in `world.bundles`
+    /// - Caller must ensure that `bundle_id` exists in `world.bundles`.
     #[inline]
     pub(crate) unsafe fn new_with_id(
         world: &'w mut World,
@@ -575,10 +576,10 @@ impl<'w> BundleInserter<'w> {
             let table_id = archetype.table_id();
             let table = &mut world.storages.tables[table_id];
             Self {
-                add_bundle,
-                archetype,
-                bundle_info,
-                table,
+                add_bundle: add_bundle.into(),
+                archetype: archetype.into(),
+                bundle_info: bundle_info.into(),
+                table: table.into(),
                 result: InsertBundleResult::SameArchetype,
                 change_tick,
                 world: world.as_unsafe_world_cell(),
@@ -598,24 +599,26 @@ impl<'w> BundleInserter<'w> {
             if table_id == new_table_id {
                 let table = &mut world.storages.tables[table_id];
                 Self {
-                    add_bundle,
-                    archetype,
-                    bundle_info,
-                    table,
-                    result: InsertBundleResult::NewArchetypeSameTable { new_archetype },
+                    add_bundle: add_bundle.into(),
+                    archetype: archetype.into(),
+                    bundle_info: bundle_info.into(),
+                    table: table.into(),
+                    result: InsertBundleResult::NewArchetypeSameTable {
+                        new_archetype: new_archetype.into(),
+                    },
                     change_tick,
                     world: world.as_unsafe_world_cell(),
                 }
             } else {
                 let (table, new_table) = world.storages.tables.get_2_mut(table_id, new_table_id);
                 Self {
-                    add_bundle,
-                    archetype,
-                    bundle_info,
-                    table,
+                    add_bundle: add_bundle.into(),
+                    archetype: archetype.into(),
+                    bundle_info: bundle_info.into(),
+                    table: table.into(),
                     result: InsertBundleResult::NewArchetypeNewTable {
-                        new_archetype,
-                        new_table,
+                        new_archetype: new_archetype.into(),
+                        new_table: new_table.into(),
                     },
                     change_tick,
                     world: world.as_unsafe_world_cell(),
@@ -623,6 +626,7 @@ impl<'w> BundleInserter<'w> {
             }
         }
     }
+
     /// # Safety
     /// `entity` must currently exist in the source archetype for this inserter. `location`
     /// must be `entity`'s location in the archetype. `T` must match this [`BundleInfo`]'s type
@@ -633,11 +637,15 @@ impl<'w> BundleInserter<'w> {
         location: EntityLocation,
         bundle: T,
     ) -> EntityLocation {
-        // SAFETY: We do not make any structural changes to the archetype graph through self.world so these pointers always remain valid
-        let trigger_hooks = |archetype: &Archetype, mut world: DeferredWorld| {
-            let bundle_info = &*self.bundle_info;
-            let add_bundle = &*self.add_bundle;
-
+        /// # Safety
+        /// Must
+        unsafe fn trigger_hooks(
+            entity: Entity,
+            bundle_info: &BundleInfo,
+            add_bundle: &AddBundle,
+            archetype: &Archetype,
+            mut world: DeferredWorld,
+        ) {
             if archetype.has_on_add() {
                 world.trigger_on_add(
                     entity,
@@ -649,9 +657,15 @@ impl<'w> BundleInserter<'w> {
                 );
             }
             if archetype.has_on_insert() {
-                world.trigger_on_insert(entity, bundle_info.iter_components());
+                unsafe { world.trigger_on_insert(entity, bundle_info.iter_components()) }
             }
-        };
+        }
+
+        let bundle_info = self.bundle_info.as_ref();
+        let add_bundle = self.add_bundle.as_ref();
+        let table = self.table.as_mut();
+        let archetype = self.archetype.as_mut();
+
         match &mut self.result {
             InsertBundleResult::SameArchetype => {
                 {
@@ -660,9 +674,6 @@ impl<'w> BundleInserter<'w> {
                         let world = self.world.world_mut();
                         &mut world.storages.sparse_sets
                     };
-                    let table = &mut *self.table;
-                    let bundle_info = &*self.bundle_info;
-                    let add_bundle = &*self.add_bundle;
 
                     bundle_info.write_components(
                         table,
@@ -676,21 +687,25 @@ impl<'w> BundleInserter<'w> {
                 }
                 // SAFETY: We have no outstanding mutable references to world as they were dropped
                 unsafe {
-                    let archetype = &*self.archetype;
-                    trigger_hooks(archetype, self.world.into_deferred());
+                    trigger_hooks(
+                        entity,
+                        bundle_info,
+                        add_bundle,
+                        archetype,
+                        self.world.into_deferred(),
+                    );
                 }
                 location
             }
             InsertBundleResult::NewArchetypeSameTable { new_archetype } => {
+                let new_archetype = new_archetype.as_mut();
+
                 let new_location = {
                     // SAFETY: Mutable references do not alias and will be dropped after this block
                     let (sparse_sets, entities) = {
                         let world = self.world.world_mut();
                         (&mut world.storages.sparse_sets, &mut world.entities)
                     };
-                    let table = &mut *self.table;
-                    let archetype = &mut *self.archetype;
-                    let new_archetype = &mut **new_archetype;
 
                     let result = archetype.swap_remove(location.archetype_row);
                     if let Some(swapped_entity) = result.swapped_entity {
@@ -709,9 +724,6 @@ impl<'w> BundleInserter<'w> {
                     }
                     let new_location = new_archetype.allocate(entity, result.table_row);
                     entities.set(entity.index(), new_location);
-
-                    let bundle_info = &*self.bundle_info;
-                    let add_bundle = &*self.add_bundle;
                     bundle_info.write_components(
                         table,
                         sparse_sets,
@@ -725,7 +737,15 @@ impl<'w> BundleInserter<'w> {
                 };
 
                 // SAFETY: We have no outstanding mutable references to world as they were dropped
-                unsafe { trigger_hooks(&**new_archetype, self.world.into_deferred()) };
+                unsafe {
+                    trigger_hooks(
+                        entity,
+                        bundle_info,
+                        add_bundle,
+                        archetype,
+                        self.world.into_deferred(),
+                    );
+                }
 
                 new_location
             }
@@ -733,6 +753,8 @@ impl<'w> BundleInserter<'w> {
                 new_archetype,
                 new_table,
             } => {
+                let new_table = new_table.as_mut();
+
                 let new_location = {
                     // SAFETY: Mutable references do not alias and will be dropped after this block
                     let (archetypes_ptr, sparse_sets, entities) = {
@@ -745,10 +767,7 @@ impl<'w> BundleInserter<'w> {
                             &mut world.entities,
                         )
                     };
-                    let table = &mut *self.table;
-                    let new_table = &mut **new_table;
-                    let archetype = &mut *self.archetype;
-                    let new_archetype = &mut **new_archetype;
+                    let new_archetype = new_archetype.as_mut();
                     let result = archetype.swap_remove(location.archetype_row);
                     if let Some(swapped_entity) = result.swapped_entity {
                         let swapped_location =
@@ -775,14 +794,6 @@ impl<'w> BundleInserter<'w> {
                         let swapped_location =
                             // SAFETY: If the swap was successful, swapped_entity must be valid.
                             unsafe { entities.get(swapped_entity).debug_checked_unwrap() };
-                        let swapped_archetype = if archetype.id() == swapped_location.archetype_id {
-                            archetype
-                        } else if new_archetype.id() == swapped_location.archetype_id {
-                            new_archetype
-                        } else {
-                            // SAFETY: the only two borrowed archetypes are above and we just did collision checks
-                            &mut *archetypes_ptr.add(swapped_location.archetype_id.index())
-                        };
 
                         entities.set(
                             swapped_entity.index(),
@@ -793,12 +804,27 @@ impl<'w> BundleInserter<'w> {
                                 table_row: result.table_row,
                             },
                         );
-                        swapped_archetype
-                            .set_entity_table_row(swapped_location.archetype_row, result.table_row);
+
+                        if archetype.id() == swapped_location.archetype_id {
+                            archetype.set_entity_table_row(
+                                swapped_location.archetype_row,
+                                result.table_row,
+                            );
+                        } else if new_archetype.id() == swapped_location.archetype_id {
+                            new_archetype.set_entity_table_row(
+                                swapped_location.archetype_row,
+                                result.table_row,
+                            );
+                        } else {
+                            // SAFETY: the only two borrowed archetypes are above and we just did collision checks
+                            (*archetypes_ptr.add(swapped_location.archetype_id.index()))
+                                .set_entity_table_row(
+                                    swapped_location.archetype_row,
+                                    result.table_row,
+                                );
+                        }
                     }
 
-                    let bundle_info = &*self.bundle_info;
-                    let add_bundle = &*self.add_bundle;
                     bundle_info.write_components(
                         new_table,
                         sparse_sets,
@@ -813,7 +839,15 @@ impl<'w> BundleInserter<'w> {
                 };
 
                 // SAFETY: We have no outstanding mutable references to world as they were dropped
-                unsafe { trigger_hooks(&**new_archetype, self.world.into_deferred()) };
+                unsafe {
+                    trigger_hooks(
+                        entity,
+                        bundle_info,
+                        add_bundle,
+                        archetype,
+                        self.world.into_deferred(),
+                    );
+                }
 
                 new_location
             }
@@ -830,9 +864,9 @@ impl<'w> BundleInserter<'w> {
 // SAFETY: We have exclusive world access so our pointers can't be invalidated externally
 pub(crate) struct BundleSpawner<'w> {
     world: UnsafeWorldCell<'w>,
-    bundle_info: *const BundleInfo,
-    table: *mut Table,
-    archetype: *mut Archetype,
+    bundle_info: ConstNonNull<BundleInfo>,
+    table: NonNull<Table>,
+    archetype: NonNull<Archetype>,
     change_tick: Tick,
 }
 
@@ -866,9 +900,9 @@ impl<'w> BundleSpawner<'w> {
         let archetype = &mut world.archetypes[new_archetype_id];
         let table = &mut world.storages.tables[archetype.table_id()];
         Self {
-            bundle_info,
-            table,
-            archetype,
+            bundle_info: bundle_info.into(),
+            table: table.into(),
+            archetype: archetype.into(),
             change_tick,
             world: world.as_unsafe_world_cell(),
         }
@@ -877,7 +911,7 @@ impl<'w> BundleSpawner<'w> {
     #[inline]
     pub fn reserve_storage(&mut self, additional: usize) {
         // SAFETY: There are no outstanding world references
-        let (archetype, table) = unsafe { (&mut *self.archetype, &mut *self.table) };
+        let (archetype, table) = unsafe { (self.archetype.as_mut(), self.table.as_mut()) };
         archetype.reserve(additional);
         table.reserve(additional);
     }
@@ -890,6 +924,10 @@ impl<'w> BundleSpawner<'w> {
         entity: Entity,
         bundle: T,
     ) -> EntityLocation {
+        let table = self.table.as_mut();
+        let archetype = self.archetype.as_mut();
+        let bundle_info = self.bundle_info.as_ref();
+
         // SAFETY: We do not make any structural changes to the archetype graph through self.world so this pointer always remain valid
         let location = {
             // SAFETY: Mutable references do not alias and will be dropped after this block
@@ -897,11 +935,8 @@ impl<'w> BundleSpawner<'w> {
                 let world = self.world.world_mut();
                 (&mut world.storages.sparse_sets, &mut world.entities)
             };
-            let table = &mut *self.table;
-            let archetype = &mut *self.archetype;
             let table_row = table.allocate(entity);
             let location = archetype.allocate(entity, table_row);
-            let bundle_info = &*self.bundle_info;
             bundle_info.write_components(
                 table,
                 sparse_sets,
@@ -917,8 +952,6 @@ impl<'w> BundleSpawner<'w> {
 
         // SAFETY: We have no outstanding mutable references to world as they were dropped
         unsafe {
-            let archetype = &*self.archetype;
-            let bundle_info = &*self.bundle_info;
             let mut world = self.world.into_deferred();
             if archetype.has_on_add() {
                 world.trigger_on_add(entity, bundle_info.iter_components());

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -75,6 +75,8 @@ impl<T: ?Sized> ConstNonNull<T> {
     /// let ptr = unsafe { ConstNonNull::<u32>::new_unchecked(std::ptr::null()) };
     /// ```
     pub const unsafe fn new_unchecked(ptr: *const T) -> Self {
+        // SAFETY: This function's safety invariants are identical to `NonNull::new_unchecked`
+        // The caller must satisfy all of them.
         unsafe { Self(NonNull::new_unchecked(ptr.cast_mut())) }
     }
 
@@ -120,7 +122,7 @@ impl<T: ?Sized> ConstNonNull<T> {
     }
 }
 
-impl<'a, T: ?Sized> From<NonNull<T>> for ConstNonNull<T> {
+impl<T: ?Sized> From<NonNull<T>> for ConstNonNull<T> {
     fn from(value: NonNull<T>) -> ConstNonNull<T> {
         ConstNonNull(value)
     }
@@ -132,6 +134,11 @@ impl<'a, T: ?Sized> From<&'a T> for ConstNonNull<T> {
     }
 }
 
+impl<'a, T: ?Sized> From<&'a mut T> for ConstNonNull<T> {
+    fn from(value: &'a mut T) -> ConstNonNull<T> {
+        ConstNonNull(NonNull::from(value))
+    }
+}
 /// Type-erased borrow of some unknown type chosen when constructing this type.
 ///
 /// This type tries to act "borrow-like" which means that:

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -33,8 +33,45 @@ mod sealed {
 pub struct ConstNonNull<T: ?Sized>(NonNull<T>);
 
 impl<T: ?Sized> ConstNonNull<T> {
+    /// Returns a shared reference to the value.
+    ///
+    /// # Safety
+    ///
+    /// When calling this method, you have to ensure that all of the following is true:
+    ///
+    /// * The pointer must be properly aligned.
+    ///
+    /// * It must be "dereferenceable" in the sense defined in [the module documentation].
+    ///
+    /// * The pointer must point to an initialized instance of `T`.
+    ///
+    /// * You must enforce Rust's aliasing rules, since the returned lifetime `'a` is
+    ///   arbitrarily chosen and does not necessarily reflect the actual lifetime of the data.
+    ///   In particular, while this reference exists, the memory the pointer points to must
+    ///   not get mutated (except inside `UnsafeCell`).
+    ///
+    /// This applies even if the result of this method is unused!
+    /// (The part about being initialized is not yet fully decided, but until
+    /// it is, the only safe approach is to ensure that they are indeed initialized.)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ptr::NonNull;
+    ///
+    /// let mut x = 0u32;
+    /// let ptr = NonNull::new(&mut x as *mut _).expect("ptr is null!");
+    ///
+    /// let ref_x = unsafe { ptr.as_ref() };
+    /// println!("{ref_x}");
+    /// ```
+    ///
+    /// [the module documentation]: core::ptr#safety
+    #[inline]
     pub unsafe fn as_ref<'a>(&self) -> &'a T {
-        self.0.as_ref()
+        // SAFETY: This function's safety invariants are identical to `NonNull::as_ref`
+        // The caller must satsify all of them.
+        unsafe { self.0.as_ref() }
     }
 }
 

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -70,7 +70,7 @@ impl<T: ?Sized> ConstNonNull<T> {
     #[inline]
     pub unsafe fn as_ref<'a>(&self) -> &'a T {
         // SAFETY: This function's safety invariants are identical to `NonNull::as_ref`
-        // The caller must satsify all of them.
+        // The caller must satisfy all of them.
         unsafe { self.0.as_ref() }
     }
 }


### PR DESCRIPTION
# Objective
Following #10756, we're now using raw pointers in BundleInserter and BundleSpawner. This is primarily to get around the need to split the borrow on the World, but it leaves a lot to be desired in terms of safety guarantees. There's no type level guarantee the code can't dereference a null pointer, and it's restoring them to borrows fairly liberally within the associated functions.

## Solution

 * Replace the pointers with `NonNull` and a new  `bevy_ptr::ConstNonNull` that only allows conversion back to read-only borrows
 * Remove the closure to avoid potentially aliasing through the closure by restructuring the match expression.
 * Move all conversions back into borrows as far up as possible to ensure that the borrow checker is at least locally followed.