### PR TITLE
Implement `Mul` between `f32` and direction types

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -132,6 +132,20 @@ impl std::ops::Neg for Dir2 {
     }
 }
 
+impl std::ops::Mul<f32> for Dir2 {
+    type Output = Vec2;
+    fn mul(self, rhs: f32) -> Self::Output {
+        self.0 * rhs
+    }
+}
+
+impl std::ops::Mul<Dir2> for f32 {
+    type Output = Vec2;
+    fn mul(self, rhs: Dir2) -> Self::Output {
+        self * rhs.0
+    }
+}
+
 #[cfg(feature = "approx")]
 impl approx::AbsDiffEq for Dir2 {
     type Epsilon = f32;
@@ -258,6 +272,13 @@ impl std::ops::Mul<f32> for Dir3 {
     type Output = Vec3;
     fn mul(self, rhs: f32) -> Self::Output {
         self.0 * rhs
+    }
+}
+
+impl std::ops::Mul<Dir3> for f32 {
+    type Output = Vec3;
+    fn mul(self, rhs: Dir3) -> Self::Output {
+        self * rhs.0
     }
 }
 
@@ -405,6 +426,13 @@ impl std::ops::Mul<f32> for Dir3A {
     type Output = Vec3A;
     fn mul(self, rhs: f32) -> Self::Output {
         self.0 * rhs
+    }
+}
+
+impl std::ops::Mul<Dir3A> for f32 {
+    type Output = Vec3A;
+    fn mul(self, rhs: Dir3A) -> Self::Output {
+        self * rhs.0
     }
 }
 


### PR DESCRIPTION
# Objective

Bevy's `Dir3` and `Dir3A` only implement `Mul<f32>` and not vice versa, and `Dir2` can not be multiplied by `f32` at all. They all should implement multiplication both ways, just like Glam's vector types.

## Solution

Implement `Mul<Dir2>`, `Mul<Dir3>`, and `Mul<Dir3A>` for `f32`, and `Mul<f32>` for `Dir2`.