### PR TITLE
Improve error messages for denormalized directions

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -304,7 +304,7 @@ impl std::ops::Mul<Dir3> for Quat {
         assert_is_normalized(
             "`Dir3` is denormalized after rotation.",
             rotated.length_squared(),
-                );
+        );
 
         Dir3(rotated)
     }
@@ -457,7 +457,7 @@ impl std::ops::Mul<Dir3A> for Quat {
         assert_is_normalized(
             "`Dir3A` is denormalized after rotation.",
             rotated.length_squared(),
-                );
+        );
 
         Dir3A(rotated)
     }

--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -279,21 +279,23 @@ impl std::ops::Mul<Dir3> for Quat {
             let length_squared = rotated.length_squared();
             let length_error_squared = (length_squared - 1.0).abs();
 
-            // Warn for slight error, and panic for clear error.
-            if length_error_squared <= LENGTH_WARN_THRESHOLD_SQUARED {
-                eprintln!(
-                    "Dir3 is slightly denormalized after rotation, length {}",
+            // Panic for large error and warn for slight error.
+            if length_error_squared > LENGTH_ERROR_THRESHOLD_SQUARED
+                || length_error_squared.is_nan()
+            {
+                panic!(
+                    "Error: Dir3 is denormalized after rotation, length {}.",
                     length_squared.sqrt()
                 );
-            } else if length_error_squared <= LENGTH_ERROR_THRESHOLD_SQUARED {
-                panic!(
-                    "Dir3 is denormalized after rotation, length {}",
+            } else if length_error_squared > LENGTH_WARN_THRESHOLD_SQUARED {
+                eprintln!(
+                    "Warning: Dir3 is slightly denormalized after rotation, length {}.",
                     length_squared.sqrt()
                 );
             }
         }
 
-        Dir3::new_unchecked(rotated)
+        Dir3(rotated)
     }
 }
 
@@ -443,21 +445,23 @@ impl std::ops::Mul<Dir3A> for Quat {
             let length_squared = rotated.length_squared();
             let length_error_squared = (length_squared - 1.0).abs();
 
-            // Warn for slight error, and panic for clear error.
-            if length_error_squared <= LENGTH_WARN_THRESHOLD_SQUARED {
-                eprintln!(
-                    "Dir3A is slightly denormalized after rotation, length {}",
+            // Panic for large error and warn for slight error.
+            if length_error_squared > LENGTH_ERROR_THRESHOLD_SQUARED
+                || length_error_squared.is_nan()
+            {
+                panic!(
+                    "Error: Dir3A is denormalized after rotation, length {}.",
                     length_squared.sqrt()
                 );
-            } else if length_error_squared <= LENGTH_ERROR_THRESHOLD_SQUARED {
-                panic!(
-                    "Dir3A is denormalized after rotation, length {}",
+            } else if length_error_squared > LENGTH_WARN_THRESHOLD_SQUARED {
+                eprintln!(
+                    "Warning: Dir3A is slightly denormalized after rotation, length {}.",
                     length_squared.sqrt()
                 );
             }
         }
 
-        Dir3A::new_unchecked(rotated)
+        Dir3A(rotated)
     }
 }
 


### PR DESCRIPTION
# Objective

`Dir3` and `Dir3A` can be rotated using `Quat`s. However, if enough floating point error accumulates or (more commonly) the rotation itself is degenerate (like not normalized), the resulting direction can also become denormalized.

Currently, with debug assertions enabled, it panics in these cases with the message `rotated.is_normalized()`. This error message is unclear, doesn't give information about *how* it is denormalized (like is the length too large, NaN, or something else), and is overall not very helpful. Panicking for small-ish error might also be a bit too strict, and has lead to unwanted crashes in crates like `bevy_xpbd` (although it has also helped in finding actual bugs).

The error message should be clearer and give more context, and it shouldn't cause unwanted crashes.

## Solution

Change the `debug_assert!` to a warning for small error with a (squared length) threshold of 2e-4 and a panic for clear error with a threshold of 2e-2. The warnings mention the direction type and the length of the denormalized vector.

Here's what the error and warning look like:

```
Error: `Dir3` is denormalized after rotation. The length is 1.014242.
```

```
Warning: `Dir3A` is denormalized after rotation. The length is 1.0001414.
```

I gave the same treatment to `new_unchecked`:

```
Error: The vector given to `Dir3::new_unchecked` is not normalized. The length is 1.014242.
```

```
Warning: The vector given to `Dir3A::new_unchecked` is not normalized. The length is 1.0001414.
```

---

## Discussion

### Threshold values

The thresholds are somewhat arbitrary. 2e-4 is what Glam uses for the squared length in `is_normalized` (after I corrected it in bitshifter/glam-rs#480), and 2e-2 is just what I thought could be a clear sign of something being critically wrong. I can definitely tune them if there are better thresholds though.

### Logging

`bevy_math` doesn't have `bevy_log`, so we can't use `warn!` or `error!`. This is why I made it use just `eprintln!` and `panic!` for now. Let me know if there's a better way of logging errors in `bevy_math`.