### PR TITLE
Update `Input` to `ButtonInput` in a couple places at keyboard input docs

### DIFF
--- a/crates/bevy_input/src/keyboard.rs
+++ b/crates/bevy_input/src/keyboard.rs
@@ -86,7 +86,7 @@ use bevy_reflect::{ReflectDeserialize, ReflectSerialize};
 /// ## Usage
 ///
 /// The event is consumed inside of the [`keyboard_input_system`]
-/// to update the [`Input<KeyCode>`](ButtonInput<KeyCode>) resource.
+/// to update the [`ButtonInput<KeyCode>`](ButtonInput<KeyCode>) resource.
 #[derive(Event, Debug, Clone, PartialEq, Eq, Reflect)]
 #[reflect(Debug, PartialEq)]
 #[cfg_attr(
@@ -162,7 +162,7 @@ pub enum NativeKeyCode {
 ///
 /// ## Usage
 ///
-/// It is used as the generic `T` value of an [`ButtonInput`] to create a `Res<Input<KeyCode>>`.
+/// It is used as the generic `T` value of an [`ButtonInput`] to create a `Res<ButtonInput<KeyCode>>`.
 ///
 /// Code representing the location of a physical key
 /// This mostly conforms to the UI Events Specification's [`KeyboardEvent.code`] with a few


### PR DESCRIPTION
# Objective

Correct references to `Input` into `ButtonInput` in the keyboard input docs since it was renamed in 0.13.

## Solution

Change the type used in the keyboard input docs from `Input` to `ButtonInput`.
