### PR TITLE
Support closures as ComponentHooks

### DIFF
--- a/crates/bevy_ecs/src/world/deferred_world.rs
+++ b/crates/bevy_ecs/src/world/deferred_world.rs
@@ -271,7 +271,7 @@ impl<'w> DeferredWorld<'w> {
         for component_id in targets {
             // SAFETY: Caller ensures that these components exist
             let hooks = unsafe { self.components().get_info_unchecked(component_id) }.hooks();
-            if let Some(hook) = hooks.on_add {
+            if let Some(hook) = hooks.on_add.as_deref() {
                 hook(DeferredWorld { world: self.world }, entity, component_id);
             }
         }
@@ -290,7 +290,7 @@ impl<'w> DeferredWorld<'w> {
         for component_id in targets {
             // SAFETY: Caller ensures that these components exist
             let hooks = unsafe { self.world.components().get_info_unchecked(component_id) }.hooks();
-            if let Some(hook) = hooks.on_insert {
+            if let Some(hook) = hooks.on_insert.as_deref() {
                 hook(DeferredWorld { world: self.world }, entity, component_id);
             }
         }
@@ -309,7 +309,7 @@ impl<'w> DeferredWorld<'w> {
         for component_id in targets {
             // SAFETY: Caller ensures that these components exist
             let hooks = unsafe { self.world.components().get_info_unchecked(component_id) }.hooks();
-            if let Some(hook) = hooks.on_remove {
+            if let Some(hook) = hooks.on_remove.as_deref() {
                 hook(DeferredWorld { world: self.world }, entity, component_id);
             }
         }


### PR DESCRIPTION
# Objective
Component hooks right now only take raw function pointers instead of allowing those registering it to store some state with them.

## Solution
Store an `Arc<dyn Fn(...)>` instead of a function pointer and make the registration functions generic over the function type being passed in.

Right now this only takes read only closures (`Fn` not `FnMut`), though strictly speaking we could support them as we have mutable access when triggering the hooks, accessing the closure mutably through an Arc would be troublesome if the ComponentInfo was cloned. I tried to keep the traits on `ComponentHooks` and `ComponentInfo` intact as much as I could.

This shouldn't change the performance characteristics of the crate when not using a closure since `&dyn Fn(...)` directly includes the function pointer instead of being a double indirection.

This PR also makes the type alias for ComponentHook private since it's now not part of the public interface of the crate.