### PR TITLE
bevy_ecs: Fix up docs for `World::run_system` and `World::run_system_with_input`

### DIFF
--- a/crates/bevy_ecs/src/system/system_registry.rs
+++ b/crates/bevy_ecs/src/system/system_registry.rs
@@ -164,12 +164,9 @@ impl World {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// #[derive(Resource, Default)]
-    /// struct Counter(u8);
-    ///
-    /// fn increment(mut counter: Local<Counter>) {
-    ///    counter.0 += 1;
-    ///    println!("{}", counter.0);
+    /// fn increment(mut counter: Local<u8>) {
+    ///    *counter += 1;
+    ///    println!("{}", *counter);
     /// }
     ///
     /// let mut world = World::default();
@@ -255,20 +252,17 @@ impl World {
     ///
     /// ```
     /// # use bevy_ecs::prelude::*;
-    /// #[derive(Resource, Default)]
-    /// struct Counter(u8);
-    ///
-    /// fn increment(In(increment_by): In<u8>, mut counter: Local<Counter>) {
-    ///    counter.0 += increment_by;
-    ///    println!("{}", counter.0);
+    /// fn increment(In(increment_by): In<u8>, mut counter: Local<u8>) -> u8 {
+    ///   *counter += increment_by;
+    ///   *counter
     /// }
     ///
     /// let mut world = World::default();
     /// let counter_one = world.register_system(increment);
     /// let counter_two = world.register_system(increment);
-    /// world.run_system_with_input(counter_one, 1); // -> 1
-    /// world.run_system_with_input(counter_one, 20); // -> 21
-    /// world.run_system_with_input(counter_two, 30); // -> 51
+    /// assert_eq!(world.run_system_with_input(counter_one, 1).unwrap(), 1);
+    /// assert_eq!(world.run_system_with_input(counter_one, 20).unwrap(), 21);
+    /// assert_eq!(world.run_system_with_input(counter_two, 30).unwrap(), 30);
     /// ```
     ///
     /// See [`World::run_system`] for more examples.


### PR DESCRIPTION
# Objective

- The doc example for `World::run_system_with_input` mistakenly indicates that systems share state
- Some of the doc example code is unnecessary and/or could be cleaned up

## Solution

Replace the incorrect result value for the correct one in the doc example. I also went with an explicit `assert_eq` check as it presents the same information but can be validated by CI via doc tests.

Also removed some unnecessary code, such as the `Resource` derives on `Counter`. In fact, I just replaced `Counter` with a `u8` in the `Local`. I think it makes the example a little cleaner.

---

## Changelog

- Update docs for `World::run_system` and `World::run_system_with_input`
