### PR TITLE
Update taffy requirement from 0.3.10 to 0.4.0

### DIFF
--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -31,7 +31,7 @@ bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 
 # other
-taffy = { version = "0.3.10" }
+taffy = { version = "0.4.0" }
 serde = { version = "1", features = ["derive"], optional = true }
 bytemuck = { version = "1.5", features = ["derive"] }
 thiserror = "1.0.0"

--- a/crates/bevy_ui/src/layout/convert.rs
+++ b/crates/bevy_ui/src/layout/convert.rs
@@ -1,3 +1,4 @@
+use bevy_utils::default;
 use taffy::style_helpers;
 
 use crate::{
@@ -18,31 +19,31 @@ impl Val {
             Val::Auto => taffy::style::LengthPercentageAuto::Auto,
             Val::Percent(value) => taffy::style::LengthPercentageAuto::Percent(value / 100.),
             Val::Px(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.scale_factor * value)
+                taffy::style::LengthPercentageAuto::Length(context.scale_factor * value)
             }
             Val::VMin(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.min_size * value / 100.)
+                taffy::style::LengthPercentageAuto::Length(context.min_size * value / 100.)
             }
             Val::VMax(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.max_size * value / 100.)
+                taffy::style::LengthPercentageAuto::Length(context.max_size * value / 100.)
             }
             Val::Vw(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.physical_size.x * value / 100.)
+                taffy::style::LengthPercentageAuto::Length(context.physical_size.x * value / 100.)
             }
             Val::Vh(value) => {
-                taffy::style::LengthPercentageAuto::Points(context.physical_size.y * value / 100.)
+                taffy::style::LengthPercentageAuto::Length(context.physical_size.y * value / 100.)
             }
         }
     }
 
     fn into_length_percentage(self, context: &LayoutContext) -> taffy::style::LengthPercentage {
         match self.into_length_percentage_auto(context) {
-            taffy::style::LengthPercentageAuto::Auto => taffy::style::LengthPercentage::Points(0.0),
+            taffy::style::LengthPercentageAuto::Auto => taffy::style::LengthPercentage::Length(0.0),
             taffy::style::LengthPercentageAuto::Percent(value) => {
                 taffy::style::LengthPercentage::Percent(value)
             }
-            taffy::style::LengthPercentageAuto::Points(value) => {
-                taffy::style::LengthPercentage::Points(value)
+            taffy::style::LengthPercentageAuto::Length(value) => {
+                taffy::style::LengthPercentage::Length(value)
             }
         }
     }
@@ -133,6 +134,7 @@ pub fn from_style(context: &LayoutContext, style: &Style) -> taffy::style::Style
             .collect::<Vec<_>>(),
         grid_row: style.grid_row.into(),
         grid_column: style.grid_column.into(),
+        ..default()
     }
 }
 
@@ -478,7 +480,7 @@ mod tests {
         );
         assert_eq!(
             taffy_style.inset.top,
-            taffy::style::LengthPercentageAuto::Points(12.)
+            taffy::style::LengthPercentageAuto::Length(12.)
         );
         assert_eq!(
             taffy_style.inset.bottom,
@@ -513,7 +515,7 @@ mod tests {
         );
         assert_eq!(
             taffy_style.margin.right,
-            taffy::style::LengthPercentageAuto::Points(10.)
+            taffy::style::LengthPercentageAuto::Length(10.)
         );
         assert_eq!(
             taffy_style.margin.top,
@@ -529,7 +531,7 @@ mod tests {
         );
         assert_eq!(
             taffy_style.padding.right,
-            taffy::style::LengthPercentage::Points(21.)
+            taffy::style::LengthPercentage::Length(21.)
         );
         assert_eq!(
             taffy_style.padding.top,
@@ -541,7 +543,7 @@ mod tests {
         );
         assert_eq!(
             taffy_style.border.left,
-            taffy::style::LengthPercentage::Points(14.)
+            taffy::style::LengthPercentage::Length(14.)
         );
         assert_eq!(
             taffy_style.border.right,
@@ -570,18 +572,18 @@ mod tests {
         );
         assert_eq!(
             taffy_style.grid_template_rows,
-            vec![sh::points(10.0), sh::percent(0.5), sh::fr(1.0)]
+            vec![sh::length(10.0), sh::percent(0.5), sh::fr(1.0)]
         );
         assert_eq!(
             taffy_style.grid_template_columns,
-            vec![sh::repeat(5, vec![sh::points(10.0)])]
+            vec![sh::repeat(5, vec![sh::length(10.0)])]
         );
         assert_eq!(
             taffy_style.grid_auto_rows,
             vec![
-                sh::fit_content(taffy::style::LengthPercentage::Points(10.0)),
+                sh::fit_content(taffy::style::LengthPercentage::Length(10.0)),
                 sh::fit_content(taffy::style::LengthPercentage::Percent(0.25)),
-                sh::minmax(sh::points(0.0), sh::fr(2.0)),
+                sh::minmax(sh::length(0.0), sh::fr(2.0)),
             ]
         );
         assert_eq!(
@@ -603,17 +605,17 @@ mod tests {
         use taffy::style::LengthPercentage;
         let context = LayoutContext::new(2.0, bevy_math::Vec2::new(800., 600.));
         let cases = [
-            (Val::Auto, LengthPercentage::Points(0.)),
+            (Val::Auto, LengthPercentage::Length(0.)),
             (Val::Percent(1.), LengthPercentage::Percent(0.01)),
-            (Val::Px(1.), LengthPercentage::Points(2.)),
-            (Val::Vw(1.), LengthPercentage::Points(8.)),
-            (Val::Vh(1.), LengthPercentage::Points(6.)),
-            (Val::VMin(2.), LengthPercentage::Points(12.)),
-            (Val::VMax(2.), LengthPercentage::Points(16.)),
+            (Val::Px(1.), LengthPercentage::Length(2.)),
+            (Val::Vw(1.), LengthPercentage::Length(8.)),
+            (Val::Vh(1.), LengthPercentage::Length(6.)),
+            (Val::VMin(2.), LengthPercentage::Length(12.)),
+            (Val::VMax(2.), LengthPercentage::Length(16.)),
         ];
         for (val, length) in cases {
             assert!(match (val.into_length_percentage(&context), length) {
-                (LengthPercentage::Points(a), LengthPercentage::Points(b))
+                (LengthPercentage::Length(a), LengthPercentage::Length(b))
                 | (LengthPercentage::Percent(a), LengthPercentage::Percent(b)) =>
                     (a - b).abs() < 0.0001,
                 _ => false,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -2,12 +2,11 @@ use crate::UiSurface;
 use bevy_ecs::prelude::Entity;
 use bevy_utils::HashMap;
 use std::fmt::Write;
-use taffy::prelude::Node;
-use taffy::tree::LayoutTree;
+use taffy::{tree::NodeId, TraversePartialTree};
 
 /// Prints a debug representation of the computed layout of the UI layout tree for each window.
 pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
-    let taffy_to_entity: HashMap<Node, Entity> = ui_surface
+    let taffy_to_entity: HashMap<NodeId, Entity> = ui_surface
         .entity_to_taffy
         .iter()
         .map(|(entity, node)| (*node, *entity))
@@ -32,9 +31,9 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
 /// Recursively navigates the layout tree printing each node's information.
 fn print_node(
     ui_surface: &UiSurface,
-    taffy_to_entity: &HashMap<Node, Entity>,
+    taffy_to_entity: &HashMap<NodeId, Entity>,
     entity: Entity,
-    node: Node,
+    node: NodeId,
     has_sibling: bool,
     lines_string: String,
     acc: &mut String,
@@ -43,13 +42,14 @@ fn print_node(
     let layout = tree.layout(node).unwrap();
     let style = tree.style(node).unwrap();
 
-    let num_children = tree.child_count(node).unwrap();
+    let num_children = tree.child_count(node);
 
     let display_variant = match (num_children, style.display) {
         (_, taffy::style::Display::None) => "NONE",
         (0, _) => "LEAF",
         (_, taffy::style::Display::Flex) => "FLEX",
         (_, taffy::style::Display::Grid) => "GRID",
+        (_, taffy::style::Display::Block) => "BLOCK",
     };
 
     let fork_string = if has_sibling {
@@ -59,7 +59,7 @@ fn print_node(
     };
     writeln!(
         acc,
-        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?}) {measured}",
+        "{lines}{fork} {display} [x: {x:<4} y: {y:<4} width: {width:<4} height: {height:<4}] ({entity:?})",
         lines = lines_string,
         fork = fork_string,
         display = display_variant,
@@ -67,7 +67,6 @@ fn print_node(
         y = layout.location.y,
         width = layout.size.width,
         height = layout.size.height,
-        measured = if tree.needs_measure(node) { "measured" } else { "" }
     ).ok();
     let bar = if has_sibling { "│   " } else { "    " };
     let new_string = lines_string + bar;


### PR DESCRIPTION
# Objective

- Update taffy to 0.4.0.
- Closes #12292.

## Solution

- Fix the renamed import paths and renamed types.
- Remove the tests asserts using `needs_measure` since it has been removed.
- Replace use of the `LayoutTree` trait with the corresponding traits it has been split into.
- Replace the use of the remove taffy `MeasureFunc` with a `Box<dyn<Measure>>` as a node context, equivalent to `MeasureFunc::Boxed`.

---

## Changelog

### Changed

- The Taffy dependency has been updated to `0.4.0`. If you are directly using taffy types re-exported from `bevy_ui`, you may need to change some import paths. ([see the corresponding release notes](https://github.com/DioxusLabs/taffy/releases/tag/v0.4.0))
- `UiSurface::try_update_measure` takes a `Box<dyn Measure>` instead of the now removed taffy `MeasureFunc`. 


## Migration Guide

- If you were directly using `UiSurface::try_update_measure`, you should implement the bevy provided `Measure` trait on your measurement struct instead of using the removed `MeasureFunc::Boxed` with the similar taffy provided `Measurable` trait.
