### PR TITLE
remove background color from UI example image

### DIFF
--- a/examples/ui/ui.rs
+++ b/examples/ui/ui.rs
@@ -283,8 +283,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     margin: UiRect::top(Val::VMin(5.)),
                                     ..default()
                                 },
-                                // a `NodeBundle` is transparent by default, so to see the image we have to its color to `WHITE`
-                                background_color: Color::WHITE.into(),
                                 ..default()
                             },
                             UiImage::new(asset_server.load("branding/bevy_logo_dark_big.png")),


### PR DESCRIPTION
# Objective

- After https://github.com/bevyengine/bevy/pull/11165, example `ui` is not pretty as it displays the Bevy logo on a white background, with a comment that is now wrong

## Solution

- Remove the background color
