### PR TITLE
bevy_utils: Add `BuildHasher` parameter to `bevy_utils::Entry` type alias

### DIFF
--- a/crates/bevy_asset/src/server/info.rs
+++ b/crates/bevy_asset/src/server/info.rs
@@ -205,7 +205,7 @@ impl AssetInfos {
             .ok_or(GetOrCreateHandleInternalError::HandleMissingButTypeIdNotSpecified)?;
 
         match handles.entry(type_id) {
-            bevy_utils::hashbrown::hash_map::Entry::Occupied(entry) => {
+            Entry::Occupied(entry) => {
                 let id = *entry.get();
                 // if there is a path_to_id entry, info always exists
                 let info = self.infos.get_mut(&id).unwrap();
@@ -246,7 +246,7 @@ impl AssetInfos {
                 }
             }
             // The entry does not exist, so this is a "fresh" asset load. We must create a new handle
-            bevy_utils::hashbrown::hash_map::Entry::Vacant(entry) => {
+            Entry::Vacant(entry) => {
                 let should_load = match loading_mode {
                     HandleLoadingMode::NotLoading => false,
                     HandleLoadingMode::Request | HandleLoadingMode::Force => true,

--- a/crates/bevy_reflect/src/type_registry.rs
+++ b/crates/bevy_reflect/src/type_registry.rs
@@ -202,8 +202,8 @@ impl TypeRegistry {
         get_registration: impl FnOnce() -> TypeRegistration,
     ) -> bool {
         match self.registrations.entry(type_id) {
-            bevy_utils::hashbrown::hash_map::Entry::Occupied(_) => false,
-            bevy_utils::hashbrown::hash_map::Entry::Vacant(entry) => {
+            bevy_utils::Entry::Occupied(_) => false,
+            bevy_utils::Entry::Vacant(entry) => {
                 let registration = get_registration();
                 Self::update_registration_indices(
                     &registration,

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -64,7 +64,7 @@ pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 pub type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = T> + 'a>>;
 
 /// A shortcut alias for [`hashbrown::hash_map::Entry`].
-pub type Entry<'a, K, V> = hashbrown::hash_map::Entry<'a, K, V, BuildHasherDefault<AHasher>>;
+pub type Entry<'a, K, V, S = BuildHasherDefault<AHasher>> = hashbrown::hash_map::Entry<'a, K, V, S>;
 
 /// A hasher builder that will create a fixed hasher.
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
# Objective

`bevy_utils::Entry` is only useful when using `BuildHasherDefault<AHasher>`. It would be great if we didn't have to write out `bevy_utils::hashbrown::hash_map::Entry` whenever we want to use a different `BuildHasher`, such as when working with `bevy_utils::TypeIdMap`.

## Solution

Give `bevy_utils::Entry` a new optional type parameter for defining a custom `BuildHasher`, such as `NoOpHash`. This parameter defaults to `BuildHasherDefault<AHasher>`— the `BuildHasher` used by `bevy_utils::HashMap`.

---

## Changelog

- Added an optional third type parameter to `bevy_utils::Entry` to specify a custom `BuildHasher`
