### PR TITLE
Fix duplicate dependencies on raw-window-handle

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -25,7 +25,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 rodio = { version = "0.17", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-oboe = { version = "0.5", optional = true }
+oboe = { version = "0.6", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rodio = { version = "0.17", default-features = false, features = [

--- a/deny.toml
+++ b/deny.toml
@@ -74,15 +74,6 @@ deny = [
   { name = "glam", deny-multiple-versions = true },
   { name = "raw-window-handle", deny-multiple-versions = true },
 ]
-# To avoid https://github.com/bevyengine/bevy/issues/11917
-# = raw-window-handle v0.5.2
-#       └── ndk v0.7.0
-#           ├── cpal v0.15.2`
-#           │   └── rodio v0.17.3
-#           │       └── bevy_audio v0.14.0-dev
-skip-tree = [
-  { crate = "cpal@0.15.2", reason = "Waiting for new releases: https://github.com/bevyengine/bevy/issues/11917#issuecomment-1953629729" },
-]
 
 [sources]
 unknown-registry = "deny"


### PR DESCRIPTION
# Objective

cpal has been updated to [0.15.3](https://crates.io/crates/cpal/0.15.3). we can remove the skip to avoid check for cpal 0.15.2 dependencies in deny.toml

cpal now uses ndk 8.0 and Oboe 6.0, so we only have a version for raw-window-handle, version 0.6

## Solution

- Remove temporal fix that skipped the check for the cpal dependency.
- Update oboe to 0.6

Fixes https://github.com/bevyengine/bevy/issues/11917