### PR TITLE
don't depend directly on oboe

### DIFF
--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -25,7 +25,7 @@ bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 rodio = { version = "0.17", default-features = false }
 
 [target.'cfg(target_os = "android")'.dependencies]
-oboe = { version = "0.6", optional = true }
+cpal = { version = "0.15", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 rodio = { version = "0.17", default-features = false, features = [
@@ -45,7 +45,7 @@ symphonia-isomp4 = ["rodio/symphonia-isomp4"]
 symphonia-vorbis = ["rodio/symphonia-vorbis"]
 symphonia-wav = ["rodio/symphonia-wav"]
 # Enable using a shared stdlib for cxx on Android.
-android_shared_stdcxx = ["oboe/shared-stdcxx"]
+android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

- Avoid version mismatch
- When cpal updates oboe in a patch release, this breaks android support for Bevy

## Solution

- Use the same version of oboe as cpal by relying on it to re-export the feature
