### PR TITLE
Allow retargeting audio sources on a per-source basis

### DIFF
--- a/crates/bevy_audio/src/audio.rs
+++ b/crates/bevy_audio/src/audio.rs
@@ -1,4 +1,4 @@
-use crate::{AudioSource, Decodable};
+use crate::{AudioSource, Decodable, AudioTarget};
 use bevy_asset::{Asset, Handle};
 use bevy_derive::Deref;
 use bevy_ecs::prelude::*;

--- a/crates/bevy_audio/src/audio_source.rs
+++ b/crates/bevy_audio/src/audio_source.rs
@@ -1,3 +1,5 @@
+use bevy_ecs::component::Component;
+use rodio::OutputStreamHandle;
 use bevy_asset::{
     io::{AsyncReadExt, Reader},
     Asset, AssetLoader, LoadContext,
@@ -25,6 +27,14 @@ impl AsRef<[u8]> for AudioSource {
     fn as_ref(&self) -> &[u8] {
         &self.bytes
     }
+}
+
+/// Set the target for an [`AudioSource`][crate::AudioSource]. Audio produced by this source will be rerouted
+/// to the designated stream instead of the global stream.
+#[derive(Component)]
+pub struct AudioTarget {
+    /// The handle to the output stream, which will be used to send audio to the mixer.
+    pub output_stream: OutputStreamHandle,
 }
 
 /// Loads files as [`AudioSource`] [`Assets`](bevy_asset::Assets)


### PR DESCRIPTION
# Objective

Right now, there is no way to send audio anywhere other than `rodio`'s global mixer. `rodio` allows users to create mixers directly, meaning that users can create mixers with an output, add extra effects on it, and then add the mixer itself as an audio source. In the current version of `rodio` `OutputStream`/`OutputStreamHandle` don't have a way to create them from anything other than a CPAL device (meaning that alone, this PR only allows users to target specific devices per-audio-source) but https://github.com/RustAudio/rodio/pull/547 is intended to fix that, and ultimately this would allow users to specify scoped effects.

## Solution

Added a new component that allows specifying per-source output handles. While out of scope of this PR, it may eventually be useful to add some kind of proper interface for adding sub-mixers and effects. Not to integrate a DSP framework directly, but just to specify a few basic effects using `rodio`'s built-in effects plus a way for crates like `bevy_fundsp` to build a complex signal processing interface. Once the `rodio` PR lands, I might make a new PR proposing a way to expose this functionality.

This still doesn't provide a way to expose the global stream handle, meaning that even if the `rodio` PR lands then external modules still don't have a way to send data to the global mixer, but it lays the groundwork for more complex audio handling.

---

## Changelog

### Added

New component, `AudioTarget`. This component allows marking sources to be played via a specific `OutputStreamHandle` instead of the global one.
