### PR TITLE
Fix docs for atlas + slicing support

### DIFF
--- a/crates/bevy_sprite/src/bundle.rs
+++ b/crates/bevy_sprite/src/bundle.rs
@@ -13,11 +13,9 @@ use bevy_transform::components::{GlobalTransform, Transform};
 ///
 /// # Extra behaviours
 ///
-/// You may add the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](crate::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw specific sections of the texture
-///
-/// Note that `ImageScaleMode` is currently not compatible with `TextureAtlas`.
+/// - [`TextureAtlas`] to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug, Default)]
 pub struct SpriteBundle {
     /// Specifies the rendering properties of the sprite, such as color tint and flip.

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -79,11 +79,9 @@ impl Default for NodeBundle {
 ///
 /// # Extra behaviours
 ///
-/// You may add the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw specific sections of the texture
-///
-/// Note that `ImageScaleMode` is currently not compatible with `TextureAtlas`.
+/// - [`TextureAtlas`] to draw a specific section of the texture
 #[derive(Bundle, Debug, Default)]
 pub struct ImageBundle {
     /// Describes the logical size of the node
@@ -298,11 +296,9 @@ where
 ///
 /// # Extra behaviours
 ///
-/// You may add the following components to enable additional behaviours:
+/// You may add one or both of the following components to enable additional behaviours:
 /// - [`ImageScaleMode`](bevy_sprite::ImageScaleMode) to enable either slicing or tiling of the texture
-/// - [`TextureAtlas`] to draw specific section of the texture
-///
-/// Note that `ImageScaleMode` is currently not compatible with `TextureAtlas`.
+/// - [`TextureAtlas`] to draw a specific section of the texture
 #[derive(Bundle, Clone, Debug)]
 pub struct ButtonBundle {
     /// Describes the logical size of the node


### PR DESCRIPTION
# Objective

The docs say that atlas and slicing are incompatible, but they are now compatible after https://github.com/bevyengine/bevy/pull/12059.

## Solution

Update the docs.
