### PR TITLE
Fix "dark grey" colors becoming lighter in various examples

### DIFF
--- a/examples/3d/split_screen.rs
+++ b/examples/3d/split_screen.rs
@@ -3,8 +3,7 @@
 use std::f32::consts::PI;
 
 use bevy::{
-    color::palettes::css::DARK_GRAY, pbr::CascadeShadowConfigBuilder, prelude::*,
-    render::camera::Viewport, window::WindowResized,
+    pbr::CascadeShadowConfigBuilder, prelude::*, render::camera::Viewport, window::WindowResized,
 };
 
 fn main() {
@@ -147,7 +146,7 @@ fn setup(
                         ..default()
                     },
                     border_color: Color::WHITE.into(),
-                    image: UiImage::default().with_color(DARK_GRAY.into()),
+                    image: UiImage::default().with_color(Color::srgb(0.25, 0.25, 0.25)),
                     ..default()
                 },
             ))

--- a/examples/ui/borders.rs
+++ b/examples/ui/borders.rs
@@ -23,7 +23,7 @@ fn setup(mut commands: Commands) {
                 align_content: AlignContent::FlexStart,
                 ..Default::default()
             },
-            background_color: DARK_GRAY.into(),
+            background_color: Color::srgb(0.25, 0.25, 0.25).into(),
             ..Default::default()
         })
         .id();

--- a/examples/ui/flex_layout.rs
+++ b/examples/ui/flex_layout.rs
@@ -1,5 +1,5 @@
 //! Demonstrates how the `AlignItems` and `JustifyContent` properties can be composed to layout text.
-use bevy::{color::palettes::css::DARK_GRAY, prelude::*};
+use bevy::prelude::*;
 
 const ALIGN_ITEMS_COLOR: Color = Color::srgb(1., 0.066, 0.349);
 const JUSTIFY_CONTENT_COLOR: Color = Color::srgb(0.102, 0.522, 1.);
@@ -134,7 +134,7 @@ fn spawn_child_node(
                 height: Val::Percent(100.),
                 ..Default::default()
             },
-            background_color: BackgroundColor(DARK_GRAY.into()),
+            background_color: BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
             ..Default::default()
         })
         .with_children(|builder| {

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -87,7 +87,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                         column_gap: Val::Px(12.0),
                         ..default()
                     },
-                    background_color: BackgroundColor(DARK_GRAY.into()),
+                    background_color: BackgroundColor(Color::srgb(0.25, 0.25, 0.25)),
                     ..default()
                 })
                 .with_children(|builder| {

--- a/examples/ui/overflow.rs
+++ b/examples/ui/overflow.rs
@@ -61,7 +61,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
                                     margin: UiRect::bottom(Val::Px(25.)),
                                     ..Default::default()
                                 },
-                                background_color: DARK_GRAY.into(),
+                                background_color: Color::srgb(0.25, 0.25, 0.25).into(),
                                 ..Default::default()
                             })
                             .with_children(|parent| {

--- a/examples/ui/overflow_debug.rs
+++ b/examples/ui/overflow_debug.rs
@@ -1,7 +1,5 @@
 //! Tests how different transforms behave when clipped with `Overflow::Hidden`
-use bevy::{
-    color::palettes::css::DARK_GRAY, input::common_conditions::input_just_pressed, prelude::*,
-};
+use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 use std::f32::consts::{FRAC_PI_2, PI, TAU};
 
 const CONTAINER_SIZE: f32 = 150.0;
@@ -198,7 +196,7 @@ fn spawn_container(
                     overflow: Overflow::clip(),
                     ..default()
                 },
-                background_color: DARK_GRAY.into(),
+                background_color: Color::srgb(0.25, 0.25, 0.25).into(),
                 ..default()
             },
             Container(0),


### PR DESCRIPTION
# Objective

Fixes #12226

Prior to the `bevy_color` port, `DARK GRAY` used to mean "dark grey." But it is now lighter than `GRAY`, matching the css4 spec.

## Solution

Change usages of `css::DARK_GRAY` to `Color::srgb(0.25, 0.25, 0.25)` to restore the examples to their former colors.

With one exception: `display_and_visibility`. I think the new color is an improvement.

## Note

A lot of these examples could use nicer colors. I'm not trying to revamp everything here.

The css4 palette is truly a horror. See #12176 and #12080 for some discussion about alternatives.