### PR TITLE
split check_light_mesh_visibility

### DIFF
--- a/crates/bevy_render/src/texture/image_loader.rs
+++ b/crates/bevy_render/src/texture/image_loader.rs
@@ -91,13 +91,14 @@ impl AssetLoader for ImageLoader {
         settings: &'a ImageLoaderSettings,
         load_context: &'a mut LoadContext<'_>,
     ) -> Result<Image, Self::Error> {
-        // use the file extension for the image type
-        let ext = load_context.path().extension().unwrap().to_str().unwrap();
-
         let mut bytes = Vec::new();
         reader.read_to_end(&mut bytes).await?;
         let image_type = match settings.format {
-            ImageFormatSetting::FromExtension => ImageType::Extension(ext),
+            ImageFormatSetting::FromExtension => {
+                // use the file extension for the image type
+                let ext = load_context.path().extension().unwrap().to_str().unwrap();
+                ImageType::Extension(ext)
+            }
             ImageFormatSetting::Format(format) => ImageType::Format(format),
         };
         Ok(Image::from_buffer(


### PR DESCRIPTION
# Objective

- Part of #12349 
- Split check_light_mesh_visibility into check_directional_light_mesh_visibility and check_spot_point_light_mesh_visibility

## Solution

- Moved shrink_entities to outside of check_light_mesh_visibility and split function according to light type
- Updated lib.rs accordingly

## Motivation

- Part of the refactoring effort focusing on decreasing the complexity of light.rs splitting it's contents into more manageable size 
- Refactored the check_light_mesh_visibility system: Making one system for handling directional lights, and one that handles point and spot lights
- Suggested by @superdump 

