### PR TITLE
Beautify example showcase site URLs

### DIFF
--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -696,15 +696,10 @@ fn parse_examples() -> Vec<Example> {
                     .as_str()
                     .unwrap()
                     .replace(['(', ')'], "")
+                    .to_lowercase()
                     .split_whitespace()
-                    .map(|piece| piece.to_lowercase())
-                    .fold(String::new(), |accumulator, next_piece| {
-                        if accumulator.is_empty() {
-                            next_piece
-                        } else {
-                            format!("{}-{}", accumulator, next_piece)
-                        }
-                    }),
+                    .collect::<Vec<_>>()
+                    .join("-"),
                 wasm: metadata["wasm"].as_bool().unwrap(),
                 required_features: val
                     .get("required-features")

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -506,6 +506,9 @@ title = \"{}\"
 template = \"example{}.html\"
 weight = {}
 description = \"{}\"
+# This creates redirection pages
+# for the old URLs which used
+# uppercase letters and whitespace.
 aliases = [\"/examples{}/{}/{}\"]
 
 [extra]

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -464,7 +464,7 @@ header_message = \"Examples (WebGL2)\"
                 if !to_show.wasm {
                     continue;
                 }
-                let category_path = root_path.join(&to_show.category);
+                let category_path = root_path.join(&to_show.category.replace(['(', ')'], "").replace(' ', "-").to_lowercase());
 
                 if !categories.contains_key(&to_show.category) {
                     let _ = fs::create_dir_all(&category_path);
@@ -500,6 +500,7 @@ title = \"{}\"
 template = \"example{}.html\"
 weight = {}
 description = \"{}\"
+aliases = [\"/examples{}/{}/{}\"]
 
 [extra]
 technical_name = \"{}\"
@@ -516,6 +517,12 @@ header_message = \"Examples ({})\"
                             },
                             categories.get(&to_show.category).unwrap(),
                             to_show.description.replace('"', "'"),
+                            match api {
+                                WebApi::Webgpu => "-webgpu",
+                                WebApi::Webgl2 => "",
+                            },
+                            to_show.category,
+                            &to_show.technical_name.replace('_', "-"),
                             &to_show.technical_name.replace('_', "-"),
                             match api {
                                 WebApi::Webgpu => "-webgpu",

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -692,7 +692,19 @@ fn parse_examples() -> Vec<Example> {
                 path: val["path"].as_str().unwrap().to_string(),
                 name: metadata["name"].as_str().unwrap().to_string(),
                 description: metadata["description"].as_str().unwrap().to_string(),
-                category: metadata["category"].as_str().unwrap().to_string(),
+                category: metadata["category"]
+                    .as_str()
+                    .unwrap()
+                    .replace(['(', ')'], "")
+                    .split_whitespace()
+                    .map(|piece| piece.to_lowercase())
+                    .fold(String::new(), |accumulator, next_piece| {
+                        if accumulator.is_empty() {
+                            next_piece
+                        } else {
+                            format!("{}-{}", accumulator, next_piece)
+                        }
+                    }),
                 wasm: metadata["wasm"].as_bool().unwrap(),
                 required_features: val
                     .get("required-features")

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -697,9 +697,7 @@ fn parse_examples() -> Vec<Example> {
                     .unwrap()
                     .replace(['(', ')'], "")
                     .to_lowercase()
-                    .split_whitespace()
-                    .collect::<Vec<_>>()
-                    .join("-"),
+                    .replace([' '], "-"),
                 wasm: metadata["wasm"].as_bool().unwrap(),
                 required_features: val
                     .get("required-features")

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -464,6 +464,12 @@ header_message = \"Examples (WebGL2)\"
                 if !to_show.wasm {
                     continue;
                 }
+
+                // This beautifys the path
+                // to make it a good looking URL
+                // rather than having weird whitespace
+                // and other characters that don't
+                // work well in a URL path.
                 let category_path = root_path.join(
                     &to_show
                         .category

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -692,12 +692,7 @@ fn parse_examples() -> Vec<Example> {
                 path: val["path"].as_str().unwrap().to_string(),
                 name: metadata["name"].as_str().unwrap().to_string(),
                 description: metadata["description"].as_str().unwrap().to_string(),
-                category: metadata["category"]
-                    .as_str()
-                    .unwrap()
-                    .replace(['(', ')'], "")
-                    .to_lowercase()
-                    .replace([' '], "-"),
+                category: metadata["category"].as_str().unwrap().to_string(),
                 wasm: metadata["wasm"].as_bool().unwrap(),
                 required_features: val
                     .get("required-features")

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -464,7 +464,13 @@ header_message = \"Examples (WebGL2)\"
                 if !to_show.wasm {
                     continue;
                 }
-                let category_path = root_path.join(&to_show.category.replace(['(', ')'], "").replace(' ', "-").to_lowercase());
+                let category_path = root_path.join(
+                    &to_show
+                        .category
+                        .replace(['(', ')'], "")
+                        .replace(' ', "-")
+                        .to_lowercase(),
+                );
 
                 if !categories.contains_key(&to_show.category) {
                     let _ = fs::create_dir_all(&category_path);


### PR DESCRIPTION
# Objective

The current example showcase site URLs have white-space and caps in them which looks ugly as an URL.

Fixes https://github.com/bevyengine/bevy-website/issues/736

## Solution

To fix this the example showcase tool now makes the category used for the site sections lowercase, separated by a hyphen rather than white-space, and without parentheses.