### PR TITLE
Use `.register_asset_source()` in `extra_asset_source` example

### DIFF
--- a/examples/asset/extra_source.rs
+++ b/examples/asset/extra_source.rs
@@ -2,7 +2,7 @@
 //! This asset source exists in addition to the default asset source.
 
 use bevy::asset::{
-    io::{AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
+    io::{AssetSourceBuilder, AssetSourceId},
     AssetPath,
 };
 use bevy::prelude::*;

--- a/examples/asset/extra_source.rs
+++ b/examples/asset/extra_source.rs
@@ -9,22 +9,18 @@ use bevy::prelude::*;
 use std::path::Path;
 
 fn main() {
-    let mut app = App::new();
-
-    // We add an extra asset source with the name "example_files" to the
-    // AssetSourceBuilders.
-    // This needs to be done before AssetPlugin finalizes building them
-    let mut sources = app
-        .world
-        .get_resource_or_insert_with::<AssetSourceBuilders>(default);
-    sources.insert(
-        "example_files",
-        AssetSourceBuilder::platform_default("examples/asset/files", None),
-    );
-
-    // DefaultPlugins contains AssetPlugin so it needs to be added to our App
-    // after inserting our new asset source
-    app.add_plugins(DefaultPlugins)
+    App::new()
+        // Add an extra asset source with the name "example_files" to
+        // AssetSourceBuilders.
+        //
+        // This must be done before AssetPlugin finalizes building assets.
+        .register_asset_source(
+            "example_files",
+            AssetSourceBuilder::platform_default("examples/asset/files", None),
+        )
+        // DefaultPlugins contains AssetPlugin so it must be added to our App
+        // after inserting our new asset source.
+        .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
         .run();
 }
@@ -32,7 +28,7 @@ fn main() {
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
 
-    // Now we can load the asset using our new asset source
+    // Now we can load the asset using our new asset source.
     //
     // The actual file path relative to workspace root is
     // "examples/asset/files/bevy_pixel_light.png".


### PR DESCRIPTION
# Objective

Fixes #12347.

## Solution

Use `.register_asset_source()` in `extra_asset_source` example instead of writing part of the app state.