### PR TITLE
Move Aabb gizmos to `bevy_dev_tools`

### DIFF
--- a/crates/bevy_dev_tools/src/aabb.rs
+++ b/crates/bevy_dev_tools/src/aabb.rs
@@ -1,6 +1,4 @@
-//! A module adding debug visualization of [`Aabb`]s.
-
-use crate as bevy_gizmos;
+//! Debug visualization tools of [`Aabb`].
 
 use bevy_app::{Plugin, PostUpdate};
 use bevy_color::{Color, Oklcha};
@@ -12,17 +10,16 @@ use bevy_ecs::{
     schedule::IntoSystemConfigs,
     system::{Query, Res},
 };
+use bevy_gizmos::{
+    config::{GizmoConfigGroup, GizmoConfigStore},
+    gizmos::Gizmos,
+    AppGizmoBuilder,
+};
 use bevy_reflect::{std_traits::ReflectDefault, Reflect};
 use bevy_render::primitives::Aabb;
 use bevy_transform::{
     components::{GlobalTransform, Transform},
     TransformSystem,
-};
-
-use crate::{
-    config::{GizmoConfigGroup, GizmoConfigStore},
-    gizmos::Gizmos,
-    AppGizmoBuilder,
 };
 
 /// A [`Plugin`] that provides visualization of [`Aabb`]s for debugging.

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -1,9 +1,12 @@
 //! This crate provides additional utilities for the [Bevy game engine](https://bevyengine.org),
 //! focused on improving developer experience.
 
-use bevy_app::prelude::*;
+pub mod aabb;
 #[cfg(feature = "bevy_ci_testing")]
 pub mod ci_testing;
+
+use aabb::AabbGizmoPlugin;
+use bevy_app::prelude::*;
 
 /// Enables developer tools in an [`App`]. This plugin is added automatically with `bevy_dev_tools`
 /// feature.
@@ -35,7 +38,9 @@ pub mod ci_testing;
 pub struct DevToolsPlugin;
 
 impl Plugin for DevToolsPlugin {
-    fn build(&self, _app: &mut App) {
+    fn build(&self, app: &mut App) {
+        app.add_plugins(AabbGizmoPlugin);
+
         #[cfg(feature = "bevy_ci_testing")]
         {
             ci_testing::setup_app(_app);

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -25,7 +25,6 @@ pub enum GizmoRenderSystem {
     QueueLineGizmos3d,
 }
 
-pub mod aabb;
 pub mod arcs;
 pub mod arrows;
 pub mod circles;
@@ -44,7 +43,6 @@ mod pipeline_3d;
 pub mod prelude {
     #[doc(hidden)]
     pub use crate::{
-        aabb::{AabbGizmoConfigGroup, ShowAabbGizmo},
         config::{DefaultGizmoConfigGroup, GizmoConfig, GizmoConfigGroup, GizmoConfigStore},
         gizmos::Gizmos,
         light::{LightGizmoColor, LightGizmoConfigGroup, ShowLightGizmo},
@@ -53,7 +51,6 @@ pub mod prelude {
     };
 }
 
-use aabb::AabbGizmoPlugin;
 use bevy_app::{App, Last, Plugin};
 use bevy_asset::{load_internal_asset, Asset, AssetApp, Assets, Handle};
 use bevy_color::LinearRgba;
@@ -113,7 +110,6 @@ impl Plugin for GizmoPlugin {
             .init_resource::<LineGizmoHandles>()
             // We insert the Resource GizmoConfigStore into the world implicitly here if it does not exist.
             .init_gizmo_group::<DefaultGizmoConfigGroup>()
-            .add_plugins(AabbGizmoPlugin)
             .add_plugins(LightGizmoPlugin);
 
         let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {


### PR DESCRIPTION
# Objective

Done as part of #11341 (resolves #11341).

## Solution

Moved the `aabb` module out of `bevy_gizmos` and into `bevy_dev_tools`.