### PR TITLE
Fix `ImageLoader` not being initialized with `webp` or `pnm` features

### DIFF
--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -118,6 +118,8 @@ impl Plugin for ImagePlugin {
             feature = "bmp",
             feature = "basis-universal",
             feature = "ktx2",
+            feature = "webp",
+            feature = "pnm"
         ))]
         app.preregister_asset_loader::<ImageLoader>(IMG_FILE_EXTENSIONS);
     }
@@ -131,6 +133,8 @@ impl Plugin for ImagePlugin {
             feature = "bmp",
             feature = "basis-universal",
             feature = "ktx2",
+            feature = "webp",
+            feature = "pnm"
         ))]
         {
             app.init_asset_loader::<ImageLoader>();


### PR DESCRIPTION
# Objective

Fixes #12353

When only `webp` was selected, `ImageLoader` would not be initialized.

That is, users using `default-features = false` would need to add `png` or `bmp` or something in addition to `webp` in order to use `webp`.

This was also the case for `pnm`. 

## Solution

Add `webp` and `pnm` to the list of features that trigger the initialization of `ImageLoader`.
