### PR TITLE
Add "all-features = true" to docs.rs metadata for most crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2765,3 +2765,4 @@ panic = "abort"
 
 [package.metadata.docs.rs]
 cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+all-features = true

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -34,3 +34,6 @@ web-sys = { version = "0.3", features = ["Window"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -1,4 +1,5 @@
 //! This crate is about everything concerning the highest-level, application layer of a Bevy app.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod app;
 mod main_schedule;

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -59,3 +59,6 @@ bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod io;
 pub mod meta;

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -49,3 +49,6 @@ android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -21,6 +21,7 @@
 //! ```
 
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod audio;
 mod audio_output;

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -35,3 +35,6 @@ crossbeam-channel = "0.5.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,4 +1,5 @@
 //! This crate provides core functionality for Bevy Engine.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod name;
 #[cfg(feature = "serialize")]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -40,3 +40,6 @@ nonmax = "0.5"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_core_pipeline/src/lib.rs
+++ b/crates/bevy_core_pipeline/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod blit;
 pub mod bloom;

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -23,3 +23,6 @@ ron = { version = "0.8.0", optional = true }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -1,5 +1,6 @@
 //! This crate provides additional utilities for the [Bevy game engine](https://bevyengine.org),
 //! focused on improving developer experience.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_app::prelude::*;
 #[cfg(feature = "bevy_ci_testing")]

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -37,3 +37,6 @@ sysinfo = { version = "0.30.0", optional = true, default-features = false }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! This crate provides a straightforward solution for integrating diagnostics in the [Bevy game engine](https://bevyengine.org/).
 //! It allows users to easily add diagnostic functionality to their Bevy applications, enhancing

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -49,3 +49,6 @@ path = "examples/change_detection.rs"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -1,6 +1,7 @@
 // FIXME(11590): remove this once the lint is fixed
 #![allow(unsafe_op_in_unsafe_fn)]
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_ecs cannot safely compile for a 16-bit platform.");

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -32,3 +32,6 @@ bytemuck = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -13,6 +13,7 @@
 //! ```
 //!
 //! See the documentation on [Gizmos](crate::gizmos::Gizmos) for more examples.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// System set label for the systems handling the rendering of gizmos.
 #[derive(SystemSet, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -58,3 +58,6 @@ smallvec = "1.11"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -2,6 +2,7 @@
 //! for loading glTF 2.0 (a standard 3D scene definition format) files in Bevy.
 //!
 //! The [glTF 2.0 specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html) defines the format of the glTF files.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -29,3 +29,6 @@ smallvec = { version = "1.11", features = ["union", "const_generics"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -44,6 +44,7 @@
 //! [plugin]: HierarchyPlugin
 //! [query extension methods]: HierarchyQueryExt
 //! [world]: BuildWorldChildren
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod components;
 pub use components::*;

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -30,3 +30,6 @@ smol_str = "0.2"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -3,6 +3,7 @@
 //! # Supported input devices
 //!
 //! `bevy` currently supports keyboard, mouse, gamepad, and touch inputs.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod axis;
 mod button_input;

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -39,3 +39,6 @@ tracing-wasm = "0.2.1"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -9,6 +9,7 @@
 //!
 //! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
 //! `DefaultPlugins` during app initialization.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "trace")]
 use std::panic;

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -33,3 +33,6 @@ debug_glam_assert = ["glam/debug-glam-assert"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -3,6 +3,7 @@
 //! The commonly used types are vectors like [`Vec2`] and [`Vec3`],
 //! matrices like [`Mat2`], [`Mat3`] and [`Mat4`] and orientation representations
 //! like [`Quat`].
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod affine3;
 mod aspect_ratio;

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -44,3 +44,6 @@ nonmax = "0.5"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod wireframe;
 

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -55,3 +55,6 @@ required-features = ["documentation"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -467,6 +467,7 @@
 //! [orphan rule]: https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type:~:text=But%20we%20can%E2%80%99t,implementation%20to%20use.
 //! [`bevy_reflect_derive/documentation`]: bevy_reflect_derive
 //! [derive `Reflect`]: derive@crate::Reflect
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod array;
 mod fields;

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -121,3 +121,6 @@ wasm-bindgen = "0.2"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(target_pointer_width = "16")]
 compile_error!("bevy_render cannot compile for a 16-bit platform.");

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -38,3 +38,6 @@ rmp-serde = "1.1"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -3,6 +3,7 @@
 //! Scenes are collections of entities and their associated components that can be
 //! instantiated or removed from a world to allow composition. Scenes can be serialized/deserialized,
 //! for example to save part of the world state to a file.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod bundle;
 mod dynamic_scene;

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -27,3 +27,6 @@ web-time = { version = "0.2" }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_tasks/src/lib.rs
+++ b/crates/bevy_tasks/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod slice;
 pub use slice::{ParallelSlice, ParallelSliceMut};

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -39,3 +39,6 @@ approx = "0.5.1"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_text/src/lib.rs
+++ b/crates/bevy_text/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod error;
 mod font;

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -32,3 +32,6 @@ thiserror = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// Common run conditions
 pub mod common_conditions;

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -34,3 +34,6 @@ serialize = ["dep:serde", "bevy_math/serialize"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_transform/src/lib.rs
+++ b/crates/bevy_transform/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod commands;
 /// The basic components of the transform crate

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -41,5 +41,8 @@ smallvec = "1.11"
 [features]
 serialize = ["serde", "smallvec/serde"]
 
+[package.metadata.docs.rs]
+features = ["bevy_text"]
+
 [lints]
 workspace = true

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -42,7 +42,7 @@ smallvec = "1.11"
 serialize = ["serde", "smallvec/serde"]
 
 [package.metadata.docs.rs]
-features = ["bevy_text"]
+all-features = true
 
 [lints]
 workspace = true

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -5,6 +5,7 @@
 //! # Basic usage
 //! Spawn UI elements with [`node_bundles::ButtonBundle`], [`node_bundles::ImageBundle`], [`node_bundles::TextBundle`] and [`node_bundles::NodeBundle`]
 //! This UI is laid out with the Flexbox and CSS Grid layout models (see <https://cssreference.io/flexbox/>)
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod measurement;
 pub mod node_bundles;

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -32,3 +32,6 @@ smol_str = "0.2"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -4,6 +4,7 @@
 //! used by windowing implementors such as `bevy_winit`.
 //! The [`WindowPlugin`] sets up some global window-related parameters and
 //! is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_a11y::Focus;
 

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -51,7 +51,7 @@ web-sys = "0.3"
 crossbeam-channel = "0.5"
 
 [package.metadata.docs.rs]
-features = ["x11"]
+all-features = true
 
 [lints]
 workspace = true

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -4,6 +4,7 @@
 //! [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
 //! The app's [runner](bevy_app::App::runner) is set by `WinitPlugin` and handles the `winit` [`EventLoop`].
 //! See `winit_runner` for details.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod accessibility;
 mod converters;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use bevy_internal::*;
 


### PR DESCRIPTION
# Objective

Fix missing `TextBundle` (and many others) which are present in the main crate as default features but optional in the sub-crate. See:

- https://docs.rs/bevy/0.13.0/bevy/ui/node_bundles/index.html
- https://docs.rs/bevy_ui/0.13.0/bevy_ui/node_bundles/index.html

~~There are probably other instances in other crates that I could track down, but maybe "all-features = true" should be used by default in all sub-crates? Not sure.~~ (There were many.) I only noticed this because rust-analyzer's "open docs" features takes me to the sub-crate, not the main one.

## Solution

Add "all-features = true" to docs.rs metadata for crates that use features.

## Changelog

### Changed

- Unified features documented on docs.rs between main crate and sub-crates

