### PR TITLE
Document ButtonInput behavior regarding window focus

### DIFF
--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -32,8 +32,8 @@ use bevy_ecs::schedule::State;
 /// ## Window focus
 ///
 /// `ButtonInput<KeyCode>` is tied to window focus. For example, if the user holds a button
-/// while the window looses focus, [`ButtonInput::just_released`] will trigger; if the window
-/// regains focus, [`ButtonInput::just_pressed`] will trigger. Currently this happens even if the
+/// while the window loses focus, [`ButtonInput::just_released`] will be triggered. Similarly if the window
+/// regains focus, [`ButtonInput::just_pressed`] will be triggered. Currently this happens even if the
 /// focus switches from one Bevy window to another (for example because a new window was just spawned).
 ///
 /// `ButtonInput<GamepadButton>` is independent of window focus.


### PR DESCRIPTION
# Objective

`ButtonInput<KeyCode>` documentation is currently incorrect/incomplete, see #12273.

## Solution

Fix the documentation.

I think in the future we should also stop triggering `just_pressed`/`just_released` when focus switches between two Bevy windows, as those functions are independent of the window. It could also make sense to add individual `ButtonInput<KeyCode>`s per window.
