### PR TITLE
move ci testing to dev_tools

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ default = [
   "webgl2",
   "sysinfo_plugin",
   "bevy_debug_stepping",
-  "bevy_ci_testing",
 ]
 
 # Force dynamic linking, which improves iterative compile times

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ default = [
   "webgl2",
   "sysinfo_plugin",
   "bevy_debug_stepping",
+  "bevy_ci_testing",
 ]
 
 # Force dynamic linking, which improves iterative compile times

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -16,6 +16,9 @@ bevy_ci_testing = ["serde", "ron"]
 bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
+bevy_render = { path = "../bevy_render", version = "0.14.0-dev" }
+bevy_time = { path = "../bevy_time", version = "0.14.0-dev" }
+bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 
 # other
 serde = { version = "1.0", features = ["derive"], optional = true }

--- a/crates/bevy_dev_tools/src/ci_testing.rs
+++ b/crates/bevy_dev_tools/src/ci_testing.rs
@@ -1,10 +1,17 @@
 //! Utilities for testing in CI environments.
 
 use bevy_app::{App, AppExit, Update};
+use bevy_ecs::{
+    entity::Entity,
+    prelude::Resource,
+    query::With,
+    system::{Local, Query, Res, ResMut},
+};
+use bevy_render::view::screenshot::ScreenshotManager;
+use bevy_time::TimeUpdateStrategy;
+use bevy_utils::{tracing::info, Duration};
+use bevy_window::PrimaryWindow;
 use serde::Deserialize;
-
-use bevy_ecs::prelude::Resource;
-use bevy_utils::tracing::info;
 
 /// A configuration struct for automated CI testing.
 ///
@@ -53,8 +60,34 @@ pub(crate) fn setup_app(app: &mut App) -> &mut App {
         ron::from_str(config).expect("error deserializing CI testing configuration file")
     };
 
+    if let Some(frame_time) = config.frame_time {
+        app.world
+            .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_secs_f32(
+                frame_time,
+            )));
+    }
+
     app.insert_resource(config)
-        .add_systems(Update, ci_testing_exit_after);
+        .add_systems(Update, (ci_testing_exit_after, ci_testing_screenshot_at));
 
     app
+}
+
+fn ci_testing_screenshot_at(
+    mut current_frame: Local<u32>,
+    ci_testing_config: Res<CiTestingConfig>,
+    mut screenshot_manager: ResMut<ScreenshotManager>,
+    main_window: Query<Entity, With<PrimaryWindow>>,
+) {
+    if ci_testing_config
+        .screenshot_frames
+        .contains(&*current_frame)
+    {
+        info!("Taking a screenshot at frame {}.", *current_frame);
+        let path = format!("./screenshot-{}.png", *current_frame);
+        screenshot_manager
+            .save_screenshot_to_disk(main_window.single(), path)
+            .unwrap();
+    }
+    *current_frame += 1;
 }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -113,12 +113,7 @@ webgpu = [
 ]
 
 # enable systems that allow for automated testing on CI
-bevy_ci_testing = [
-  "bevy_dev_tools/bevy_ci_testing",
-  "bevy_time/bevy_ci_testing",
-  "bevy_render?/bevy_ci_testing",
-  "bevy_render?/ci_limits",
-]
+bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing", "bevy_render?/ci_limits"]
 
 # Enable animation support, and glTF animation loading
 animation = ["bevy_animation", "bevy_gltf?/bevy_animation"]

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -19,7 +19,6 @@ webp = ["image/webp"]
 dds = ["ddsfile"]
 pnm = ["image/pnm"]
 multi-threaded = ["bevy_tasks/multi-threaded"]
-bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing"]
 
 shader_format_glsl = ["naga/glsl-in", "naga/wgsl-out", "naga_oil/glsl"]
 shader_format_spirv = ["wgpu/spirv", "naga/spv-in", "naga/spv-out"]
@@ -57,7 +56,6 @@ bevy_transform = { path = "../bevy_transform", version = "0.14.0-dev" }
 bevy_window = { path = "../bevy_window", version = "0.14.0-dev" }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
 bevy_tasks = { path = "../bevy_tasks", version = "0.14.0-dev" }
-bevy_dev_tools = { path = "../bevy_dev_tools", version = "0.14.0-dev", optional = true }
 
 # rendering
 image = { version = "0.24", default-features = false }

--- a/crates/bevy_render/src/view/window/screenshot.rs
+++ b/crates/bevy_render/src/view/window/screenshot.rs
@@ -140,35 +140,7 @@ impl Plugin for ScreenshotPlugin {
         if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
             render_app.init_resource::<SpecializedRenderPipelines<ScreenshotToScreenPipeline>>();
         }
-
-        #[cfg(feature = "bevy_ci_testing")]
-        if app
-            .world
-            .contains_resource::<bevy_dev_tools::ci_testing::CiTestingConfig>()
-        {
-            app.add_systems(bevy_app::Update, ci_testing_screenshot_at);
-        }
     }
-}
-
-#[cfg(feature = "bevy_ci_testing")]
-fn ci_testing_screenshot_at(
-    mut current_frame: Local<u32>,
-    ci_testing_config: Res<bevy_dev_tools::ci_testing::CiTestingConfig>,
-    mut screenshot_manager: ResMut<ScreenshotManager>,
-    main_window: Query<Entity, With<bevy_window::PrimaryWindow>>,
-) {
-    if ci_testing_config
-        .screenshot_frames
-        .contains(&*current_frame)
-    {
-        info!("Taking a screenshot at frame {}.", *current_frame);
-        let path = format!("./screenshot-{}.png", *current_frame);
-        screenshot_manager
-            .save_screenshot_to_disk(main_window.single(), path)
-            .unwrap();
-    }
-    *current_frame += 1;
 }
 
 pub(crate) fn align_byte_size(value: u32) -> u32 {

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["bevy"]
 [features]
 default = []
 serialize = ["serde"]
-bevy_ci_testing = ["bevy_dev_tools/bevy_ci_testing"]
 
 [dependencies]
 # bevy
@@ -23,7 +22,6 @@ bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [
   "bevy",
 ] }
 bevy_utils = { path = "../bevy_utils", version = "0.14.0-dev" }
-bevy_dev_tools = { path = "../bevy_dev_tools", version = "0.14.0-dev", optional = true }
 
 # other
 crossbeam-channel = "0.5.0"

--- a/crates/bevy_time/src/lib.rs
+++ b/crates/bevy_time/src/lib.rs
@@ -64,19 +64,6 @@ impl Plugin for TimePlugin {
                 bevy_ecs::event::reset_event_update_signal_system.after(EventUpdates),
             )
             .add_systems(FixedPostUpdate, signal_event_update_system);
-
-        #[cfg(feature = "bevy_ci_testing")]
-        if let Some(ci_testing_config) = app
-            .world
-            .get_resource::<bevy_dev_tools::ci_testing::CiTestingConfig>()
-        {
-            if let Some(frame_time) = ci_testing_config.frame_time {
-                app.world
-                    .insert_resource(TimeUpdateStrategy::ManualDuration(Duration::from_secs_f32(
-                        frame_time,
-                    )));
-            }
-        }
     }
 }
 


### PR DESCRIPTION
# Objective

- Fix #12356
- better isolation of ci testing tools in dev tools instead of being in various crates

## Solution

- Move the parts doing the work of ci testing to the dev tools
