### PR TITLE
Remove "features" feature

### DIFF
--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["bevy"]
 # Disables diagnostics that are unsupported when Bevy is dynamically linked
 dynamic_linking = []
 sysinfo_plugin = ["sysinfo"]
-features = []
 
 [dependencies]
 # bevy


### PR DESCRIPTION
I think this was meant to be `default = []` which is the default.