### PR TITLE
Fix gizmos panicking given bad output from `GlobalTransform::to_scale_rotation_translation`

### DIFF
--- a/crates/bevy_gizmos/src/gizmos.rs
+++ b/crates/bevy_gizmos/src/gizmos.rs
@@ -337,7 +337,7 @@ impl<'w, 's, T: GizmoConfigGroup> Gizmos<'w, 's, T> {
         SphereBuilder {
             gizmos: self,
             position,
-            rotation,
+            rotation: rotation.normalize(),
             radius,
             color: color.into(),
             circle_segments: DEFAULT_CIRCLE_SEGMENTS,


### PR DESCRIPTION
# Objective

Fixes #12360.

## Solution

Normalize the rotation `Quat` in `sphere`.