### PR TITLE
correctly set up background color in mobile example

### DIFF
--- a/examples/mobile/src/lib.rs
+++ b/examples/mobile/src/lib.rs
@@ -104,18 +104,22 @@ fn setup_scene(
 
     // Test ui
     commands
-        .spawn(ButtonBundle {
-            style: Style {
-                justify_content: JustifyContent::Center,
-                align_items: AlignItems::Center,
-                position_type: PositionType::Absolute,
-                left: Val::Px(50.0),
-                right: Val::Px(50.0),
-                bottom: Val::Px(50.0),
+        .spawn((
+            ButtonBundle {
+                style: Style {
+                    justify_content: JustifyContent::Center,
+                    align_items: AlignItems::Center,
+                    position_type: PositionType::Absolute,
+                    left: Val::Px(50.0),
+                    right: Val::Px(50.0),
+                    bottom: Val::Px(50.0),
+                    ..default()
+                },
+                image: UiImage::default().with_color(Color::NONE),
                 ..default()
             },
-            ..default()
-        })
+            BackgroundColor(Color::WHITE),
+        ))
         .with_children(|b| {
             b.spawn(
                 TextBundle::from_section(


### PR DESCRIPTION
# Objective

- Since #11165, the button in the mobile example doesn't visually react to touches

## Solution

- Correctly set up the background color
