### PR TITLE
Move AssetEvents to Last

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -49,7 +49,7 @@ use crate::{
     io::{embedded::EmbeddedAssetRegistry, AssetSourceBuilder, AssetSourceBuilders, AssetSourceId},
     processor::{AssetProcessor, Process},
 };
-use bevy_app::{App, First, Plugin, PreUpdate};
+use bevy_app::{App, Last, Plugin, PreUpdate};
 use bevy_ecs::{
     reflect::AppTypeRegistry,
     schedule::{IntoSystemConfigs, IntoSystemSetConfigs, SystemSet},
@@ -380,9 +380,8 @@ impl AssetApp for App {
             .add_event::<AssetLoadFailedEvent<A>>()
             .register_type::<Handle<A>>()
             .add_systems(
-                First,
+                Last,
                 Assets::<A>::asset_events
-                    .before(bevy_ecs::event::event_update_system::<AssetEvent<A>>)
                     .run_if(Assets::<A>::asset_events_condition)
                     .in_set(AssetEvents),
             )


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/12380

## Solution

- Before #11986 AssetEvents were scheduled after PostUpdate. That pr moved these into First. This PR moves them into Last which is closer to how they were scheduled before.
