### PR TITLE
don't attempt to set cursor relative position for zero sized nodes

### DIFF
--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -256,6 +256,9 @@ pub fn ui_focus_system(
                 camera_cursor_positions
                     .get(&camera_entity)
                     .and_then(|cursor_position| {
+                        // ensure node size is non-zero in all dimensions, otherwise relative position will be
+                        // +/-inf. if the node is hidden, the visible rect min/max will also be -inf leading to
+                        // false positives for mouse_over (#12395)
                         (node_rect.size().cmpgt(Vec2::ZERO).all())
                             .then_some((*cursor_position - node_rect.min) / node_rect.size())
                     });

--- a/crates/bevy_ui/src/focus.rs
+++ b/crates/bevy_ui/src/focus.rs
@@ -252,9 +252,13 @@ pub fn ui_focus_system(
             // The mouse position relative to the node
             // (0., 0.) is the top-left corner, (1., 1.) is the bottom-right corner
             // Coordinates are relative to the entire node, not just the visible region.
-            let relative_cursor_position = camera_cursor_positions
-                .get(&camera_entity)
-                .map(|cursor_position| (*cursor_position - node_rect.min) / node_rect.size());
+            let relative_cursor_position =
+                camera_cursor_positions
+                    .get(&camera_entity)
+                    .and_then(|cursor_position| {
+                        (node_rect.size().cmpgt(Vec2::ZERO).all())
+                            .then_some((*cursor_position - node_rect.min) / node_rect.size())
+                    });
 
             // If the current cursor position is within the bounds of the node's visible area, consider it for
             // clicking


### PR DESCRIPTION
# Objective

fix #12007

## Solution

when node size is zero on either axis, set `RelativeCursorPosition::normalized` to None.