### PR TITLE
try_insert NoAutomaticBatching

### DIFF
--- a/crates/bevy_pbr/src/render/morph.rs
+++ b/crates/bevy_pbr/src/render/morph.rs
@@ -109,6 +109,6 @@ pub fn no_automatic_morph_batching(
     query: Query<Entity, (With<MeshMorphWeights>, Without<NoAutomaticBatching>)>,
 ) {
     for entity in &query {
-        commands.entity(entity).insert(NoAutomaticBatching);
+        commands.entity(entity).try_insert(NoAutomaticBatching);
     }
 }

--- a/crates/bevy_pbr/src/render/skin.rs
+++ b/crates/bevy_pbr/src/render/skin.rs
@@ -146,6 +146,6 @@ pub fn no_automatic_skin_batching(
     query: Query<Entity, (With<SkinnedMesh>, Without<NoAutomaticBatching>)>,
 ) {
     for entity in &query {
-        commands.entity(entity).insert(NoAutomaticBatching);
+        commands.entity(entity).try_insert(NoAutomaticBatching);
     }
 }


### PR DESCRIPTION
# Objective

fix occasional crash from commands.insert when quickly spawning and despawning skinned/morphed meshes
 
## Solution

use `try_insert` instead of `insert`. if the entity is deleted we don't mind failing to add the `NoAutomaticBatching` marker.
