### PR TITLE
Implement QueryData for &Archetype and EntityLocation

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -808,7 +808,7 @@ unsafe impl WorldQuery for &Archetype {
         (world.entities(), world.archetypes())
     }
 
-    // This could probably be a non-dense query and just get set a Option<&Archetype> fetch value in
+    // This could probably be a non-dense query and just set a Option<&Archetype> fetch value in
     // set_archetypes, but forcing archetypal iteration is likely to be slower in any compound query.
     const IS_DENSE: bool = true;
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -374,6 +374,8 @@ unsafe impl WorldQuery for EntityLocation {
         world.entities()
     }
 
+    // This is set to true to avoid forcing archetypal iteration in compound queries, is likely to be slower
+    // in most practical use case.
     const IS_DENSE: bool = true;
 
     #[inline]

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -33,7 +33,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///   Read-only access to arbitrary components on the queried entity.
 /// - **[`EntityMut`].**
 ///   Mutable access to arbitrary components on the queried entity.
-/// - **[`&Archetype`].**
+/// - **[`&Archetype`](Archetype).**
 ///   Read-only access to the archetype-level metadata of the queried entity.
 /// - **[`Option`].**
 ///   By default, a world query only tests entities that have the matching component types.

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -18,7 +18,7 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///
 /// There are many types that natively implement this trait:
 ///
-/// - **Component references.**
+/// - **Component references. (&T and &mut T)**
 ///   Fetches a component by reference (immutably or mutably).
 /// - **`QueryData` tuples.**
 ///   If every element of a tuple implements `QueryData`, then the tuple itself also implements the same trait.
@@ -33,6 +33,8 @@ use std::{cell::UnsafeCell, marker::PhantomData};
 ///   Read-only access to arbitrary components on the queried entity.
 /// - **[`EntityMut`].**
 ///   Mutable access to arbitrary components on the queried entity.
+/// - **[`&Archetype`].**
+///   Read-only access to the archetype-level metadata of the queried entity.
 /// - **[`Option`].**
 ///   By default, a world query only tests entities that have the matching component types.
 ///   Wrapping it into an `Option` will increase the query search space, and it will return `None` if an entity doesn't satisfy the `WorldQuery`.

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1292,12 +1292,16 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// Besides removing parameters from the query, you can also
     /// make limited changes to the types of parameters.
     ///
-    /// * Can always add/remove `Entity`
+    /// * Can always add/remove [`Entity`]
+    /// * Can always add/remove [`EntityLocation`]
+    /// * Can always add/remove [`&Archetype`]
     /// * `Ref<T>` <-> `&T`
     /// * `&mut T` -> `&T`
     /// * `&mut T` -> `Ref<T>`
     /// * [`EntityMut`](crate::world::EntityMut) -> [`EntityRef`](crate::world::EntityRef)
-    ///    
+    ///  
+    /// [`EntityLocation`]: crate::entity::EntityLocation
+    /// [`&Archetype`]: crate::archetype::Archetype
     pub fn transmute_lens<NewD: QueryData>(&mut self) -> QueryLens<'_, NewD> {
         self.transmute_lens_filtered::<NewD, ()>()
     }


### PR DESCRIPTION
# Objective
Fixes #12392, fixes #12393, and fixes #11387. Implement QueryData for Archetype and EntityLocation.

## Solution
Add impls for both of the types.

---

## Changelog
Added: `&Archetype` now implements `QueryData`
Added: `EntityLocation` now implements `QueryData`