### PR TITLE
Reduce steady-state allocations in ui_stack_system

### DIFF
--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -114,7 +114,11 @@ fn insert_context_hierarchy(
 }
 
 /// Flatten `StackingContext` (z-index based UI node tree) into back-to-front entities list
-fn fill_stack_recursively(cache: &mut Vec<StackingContext>, result: &mut Vec<Entity>, stack: &mut StackingContext) {
+fn fill_stack_recursively(
+    cache: &mut Vec<StackingContext>,
+    result: &mut Vec<Entity>,
+    stack: &mut StackingContext,
+) {
     // Sort entries by ascending z_index, while ensuring that siblings
     // with the same local z_index will keep their ordering. This results
     // in `back-to-front` ordering, low z_index = back; high z_index = front.

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -26,7 +26,9 @@ impl StackingContextCache {
     }
 
     fn push(&mut self, mut context: StackingContext) {
-        context.entries.clear();
+        for entry in context.entries.drain(..) {
+            self.push(entry.stack);
+        }
         self.inner.push(context);
     }
 }

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -76,6 +76,7 @@ pub fn ui_stack_system(
     ui_stack.uinodes.clear();
     ui_stack.uinodes.reserve(total_entry_count);
     fill_stack_recursively(&mut cache, &mut ui_stack.uinodes, &mut global_context);
+    cache.push(global_context);
 
     for (i, entity) in ui_stack.uinodes.iter().enumerate() {
         if let Ok(mut node) = update_query.get_mut(*entity) {

--- a/crates/bevy_ui/src/stack.rs
+++ b/crates/bevy_ui/src/stack.rs
@@ -15,8 +15,9 @@ pub struct UiStack {
     pub uinodes: Vec<Entity>,
 }
 
+/// Caches stacking context buffers for use in [`ui_stack_system`].
 #[derive(Default)]
-pub struct StackingContextCache {
+pub(crate) struct StackingContextCache {
     inner: Vec<StackingContext>,
 }
 
@@ -35,20 +36,20 @@ impl StackingContextCache {
 
 #[derive(Default)]
 struct StackingContext {
-    pub entries: Vec<StackingContextEntry>,
+    entries: Vec<StackingContextEntry>,
 }
 
 struct StackingContextEntry {
-    pub z_index: i32,
-    pub entity: Entity,
-    pub stack: StackingContext,
+    z_index: i32,
+    entity: Entity,
+    stack: StackingContext,
 }
 
 /// Generates the render stack for UI nodes.
 ///
 /// First generate a UI node tree (`StackingContext`) based on z-index.
 /// Then flatten that tree into back-to-front ordered `UiStack`.
-pub fn ui_stack_system(
+pub(crate) fn ui_stack_system(
     mut cache: Local<StackingContextCache>,
     mut ui_stack: ResMut<UiStack>,
     root_node_query: Query<Entity, (With<Node>, Without<Parent>)>,


### PR DESCRIPTION
# Objective

- Reduce allocations on the UI hot path.

## Solution

- Cache buffers used by the `ui_stack_system`.

## Follow-Up

- `sort_by_key` is potentially-allocating. It might be worthwhile to include the child index as part of the sort-key and use unstable sort.
