### PR TITLE
fix deprecations from toml_edit

### DIFF
--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -9,7 +9,9 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-toml_edit = { version = "0.22", default-features = false, features = ["parse"] }
+toml_edit = { version = "0.22.7", default-features = false, features = [
+    "parse",
+] }
 syn = "2.0"
 quote = "1.0"
 rustc-hash = "1.0"

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["bevy"]
 
 [dependencies]
 toml_edit = { version = "0.22.7", default-features = false, features = [
-    "parse",
+  "parse",
 ] }
 syn = "2.0"
 quote = "1.0"

--- a/crates/bevy_macro_utils/src/bevy_manifest.rs
+++ b/crates/bevy_macro_utils/src/bevy_manifest.rs
@@ -2,11 +2,11 @@ extern crate proc_macro;
 
 use proc_macro::TokenStream;
 use std::{env, path::PathBuf};
-use toml_edit::{Document, Item};
+use toml_edit::{DocumentMut, Item};
 
 /// The path to the `Cargo.toml` file for the Bevy project.
 pub struct BevyManifest {
-    manifest: Document,
+    manifest: DocumentMut,
 }
 
 impl Default for BevyManifest {
@@ -25,7 +25,7 @@ impl Default for BevyManifest {
                     let manifest = std::fs::read_to_string(path.clone()).unwrap_or_else(|_| {
                         panic!("Unable to read cargo manifest: {}", path.display())
                     });
-                    manifest.parse::<Document>().unwrap_or_else(|_| {
+                    manifest.parse::<DocumentMut>().unwrap_or_else(|_| {
                         panic!("Failed to parse cargo manifest: {}", path.display())
                     })
                 })

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -10,7 +10,9 @@ license = "MIT OR Apache-2.0"
 workspace = true
 
 [dependencies]
-toml_edit = { version = "0.22", default-features = false, features = ["parse"] }
+toml_edit = { version = "0.22.7", default-features = false, features = [
+    "parse",
+] }
 tera = "1.15"
 serde = { version = "1.0", features = ["derive"] }
 bitflags = "2.3"

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -11,7 +11,7 @@ workspace = true
 
 [dependencies]
 toml_edit = { version = "0.22.7", default-features = false, features = [
-    "parse",
+  "parse",
 ] }
 tera = "1.15"
 serde = { version = "1.0", features = ["derive"] }

--- a/tools/build-templated-pages/src/examples.rs
+++ b/tools/build-templated-pages/src/examples.rs
@@ -3,7 +3,7 @@ use std::{cmp::Ordering, fs::File};
 use hashbrown::HashMap;
 use serde::Serialize;
 use tera::{Context, Tera};
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 use crate::Command;
 
@@ -40,7 +40,7 @@ impl PartialOrd for Example {
 
 fn parse_examples(panic_on_missing: bool) -> Vec<Example> {
     let manifest_file = std::fs::read_to_string("Cargo.toml").unwrap();
-    let manifest = manifest_file.parse::<Document>().unwrap();
+    let manifest = manifest_file.parse::<DocumentMut>().unwrap();
     let metadatas = manifest
         .get("package")
         .unwrap()
@@ -83,7 +83,7 @@ fn parse_examples(panic_on_missing: bool) -> Vec<Example> {
 
 fn parse_categories() -> HashMap<Box<str>, String> {
     let manifest_file = std::fs::read_to_string("Cargo.toml").unwrap();
-    let manifest = manifest_file.parse::<Document>().unwrap();
+    let manifest = manifest_file.parse::<DocumentMut>().unwrap();
     manifest
         .get("package")
         .unwrap()

--- a/tools/build-templated-pages/src/features.rs
+++ b/tools/build-templated-pages/src/features.rs
@@ -2,7 +2,7 @@ use std::{cmp::Ordering, fs::File};
 
 use serde::Serialize;
 use tera::{Context, Tera};
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 
 use crate::Command;
 
@@ -27,7 +27,7 @@ impl PartialOrd for Feature {
 
 fn parse_features(panic_on_missing: bool) -> Vec<Feature> {
     let manifest_file = std::fs::read_to_string("Cargo.toml").unwrap();
-    let manifest = manifest_file.parse::<Document>().unwrap();
+    let manifest = manifest_file.parse::<DocumentMut>().unwrap();
 
     let features = manifest["features"].as_table().unwrap();
     let default: Vec<_> = features

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -13,5 +13,7 @@ workspace = true
 xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }
 ron = "0.8"
-toml_edit = { version = "0.22", default-features = false, features = ["parse"] }
+toml_edit = { version = "0.22.7", default-features = false, features = [
+    "parse",
+] }
 pbr = "1.1"

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -14,6 +14,6 @@ xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }
 ron = "0.8"
 toml_edit = { version = "0.22.7", default-features = false, features = [
-    "parse",
+  "parse",
 ] }
 pbr = "1.1"

--- a/tools/example-showcase/src/main.rs
+++ b/tools/example-showcase/src/main.rs
@@ -14,7 +14,7 @@ use std::{
 
 use clap::{error::ErrorKind, CommandFactory, Parser, ValueEnum};
 use pbr::ProgressBar;
-use toml_edit::Document;
+use toml_edit::DocumentMut;
 use xshell::{cmd, Shell};
 
 #[derive(Parser, Debug)]
@@ -661,7 +661,7 @@ header_message = \"Examples ({})\"
 
 fn parse_examples() -> Vec<Example> {
     let manifest_file = fs::read_to_string("Cargo.toml").unwrap();
-    let manifest = manifest_file.parse::<Document>().unwrap();
+    let manifest = manifest_file.parse::<DocumentMut>().unwrap();
     let metadatas = manifest
         .get("package")
         .unwrap()


### PR DESCRIPTION
# Objective

- `toml_edit` released a new patch that deprecates `Document`
- this warns when Bevy builds, and CI deny warns

## Solution

- fix deprecation warnings
