### PR TITLE
Send GamepadEvent for gamepads connected at startup

### DIFF
--- a/crates/bevy_gilrs/src/gilrs_system.rs
+++ b/crates/bevy_gilrs/src/gilrs_system.rs
@@ -18,17 +18,20 @@ use gilrs::{ev::filter::axis_dpad_to_button, EventType, Filter};
 pub fn gilrs_event_startup_system(
     #[cfg(target_arch = "wasm32")] mut gilrs: NonSendMut<Gilrs>,
     #[cfg(not(target_arch = "wasm32"))] mut gilrs: ResMut<Gilrs>,
-    mut connection_events: EventWriter<GamepadConnectionEvent>,
+    mut events: EventWriter<GamepadEvent>,
 ) {
     for (id, gamepad) in gilrs.0.get().gamepads() {
         let info = GamepadInfo {
             name: gamepad.name().into(),
         };
 
-        connection_events.send(GamepadConnectionEvent {
-            gamepad: convert_gamepad_id(id),
-            connection: GamepadConnection::Connected(info),
-        });
+        events.send(
+            GamepadConnectionEvent {
+                gamepad: convert_gamepad_id(id),
+                connection: GamepadConnection::Connected(info),
+            }
+            .into(),
+        );
     }
 }
 


### PR DESCRIPTION
# Objective

- Fix GamepadEvent::Connection not being sent for devices connected at startup.

## Solution

- GamepadConnectionEvent was being sent directly for gamepads connected at startup, which causes consumers of GamepadEvent to not receive those events.
- Instead send GamepadEvent. The gamepad_event_system splits GamepadEvent up, so consumers of GamepadConnectionEvent will still receive the events.