### PR TITLE
bevy_reflect: Remove `U32Visitor`

### DIFF
--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -942,6 +942,3 @@ pub type DrawPrepass<M> = (
     SetMaterialBindGroup<M, 2>,
     DrawMesh,
 );
-
-#[derive(Debug, Hash, PartialEq, Eq, Clone, SystemSet)]
-struct PrepassLightsViewFlush;

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -240,23 +240,6 @@ impl<'de> Deserialize<'de> for Ident {
     }
 }
 
-struct U32Visitor;
-
-impl<'de> Visitor<'de> for U32Visitor {
-    type Value = u32;
-
-    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-        formatter.write_str("u32")
-    }
-
-    fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
-    where
-        E: Error,
-    {
-        Ok(v)
-    }
-}
-
 /// A general purpose deserializer for reflected types.
 ///
 /// This will return a [`Box<dyn Reflect>`] containing the deserialized data.


### PR DESCRIPTION
# Objective

The `U32Visitor` struct has been unused since its introduction in #6140. It's made itself known now by causing a recent [CI failure](https://github.com/bevyengine/bevy/actions/runs/8243333274/job/22543736624).

## Solution

Remove the unused `U32Visitor` struct.

Also removed `PrepassLightsViewFlush` as it was causing a [similar CI failure](https://github.com/bevyengine/bevy/actions/runs/8243838066/job/22545103746?pr=12433#step:6:269) on this PR.
