### PR TITLE
Fix `z` scale being `0.0` in breakout example

### DIFF
--- a/examples/games/breakout.rs
+++ b/examples/games/breakout.rs
@@ -10,7 +10,7 @@ mod stepping;
 
 // These constants are defined in `Transform` units.
 // Using the default 2D camera they correspond 1:1 with screen pixels.
-const PADDLE_SIZE: Vec3 = Vec3::new(120.0, 20.0, 0.0);
+const PADDLE_SIZE: Vec2 = Vec2::new(120.0, 20.0);
 const GAP_BETWEEN_PADDLE_AND_FLOOR: f32 = 60.0;
 const PADDLE_SPEED: f32 = 500.0;
 // How close can the paddle get to the wall
@@ -202,7 +202,7 @@ fn setup(
         SpriteBundle {
             transform: Transform {
                 translation: Vec3::new(0.0, paddle_y, 0.0),
-                scale: PADDLE_SIZE,
+                scale: PADDLE_SIZE.extend(1.0),
                 ..default()
             },
             sprite: Sprite {


### PR DESCRIPTION
# Objective

Scaling `z` by anything but `1.0` in 2d can only lead to bugs and confusion. See #4149.

## Solution

Use a `Vec2` for the paddle size const, and add a scale of `1.0` later. This matches the way `BRICK_SIZE` is defined.
