### PR TITLE
Fix CI desktop mode patch

### DIFF
--- a/tools/example-showcase/remove-desktop-app-mode.patch
+++ b/tools/example-showcase/remove-desktop-app-mode.patch
@@ -1,10 +1,10 @@
 diff --git a/crates/bevy_winit/src/winit_config.rs b/crates/bevy_winit/src/winit_config.rs
-index b91e25d34..48f19b708 100644
+index f2cb424ec..e68e01de0 100644
 --- a/crates/bevy_winit/src/winit_config.rs
 +++ b/crates/bevy_winit/src/winit_config.rs
-@@ -29,14 +29,7 @@ impl WinitSettings {
-     /// [`Reactive`](UpdateMode::Reactive) if windows have focus,
-     /// [`ReactiveLowPower`](UpdateMode::ReactiveLowPower) otherwise.
+@@ -31,14 +31,7 @@ impl WinitSettings {
+     ///
+     /// Use the [`EventLoopProxy`](crate::EventLoopProxy) to request a redraw from outside bevy.
      pub fn desktop_app() -> Self {
 -        WinitSettings {
 -            focused_mode: UpdateMode::Reactive {


### PR DESCRIPTION
# Objective

The `example-showcase` command is failing to run.

```
 cargo run --release -p example-showcase -- run --screenshot --in-ci                                  
    Updating crates.io index
   Compiling example-showcase v0.14.0-dev (/Users/robparrett/src/bevy/tools/example-showcase)
    Finished release [optimized] target(s) in 2.59s
     Running `target/release/example-showcase run --screenshot --in-ci`
$ git apply --ignore-whitespace tools/example-showcase/remove-desktop-app-mode.patch
error: patch failed: crates/bevy_winit/src/winit_config.rs:29
error: crates/bevy_winit/src/winit_config.rs: patch does not apply
thread 'main' panicked at tools/example-showcase/src/main.rs:203:18:
called `Result::unwrap()` on an `Err` value: command exited with non-zero code `git apply --ignore-whitespace tools/example-showcase/remove-desktop-app-mode.patch`: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

## Solution

Update `remove-desktop-app-mode.patch`.
