### PR TITLE
Expose Winit's `with_skip_taskbar` on window creation

### DIFF
--- a/crates/bevy_window/src/window.rs
+++ b/crates/bevy_window/src/window.rs
@@ -259,6 +259,15 @@ pub struct Window {
     ///
     /// - **Android / Wayland / Web:** Unsupported.
     pub visible: bool,
+    /// Sets whether the window should be shown in the taskbar.
+    ///
+    /// If `true`, the window will not appear in the taskbar.
+    /// If `false`, the window will appear in the taskbar.
+    ///
+    /// ## Platform-specific
+    ///
+    /// - Only supported on Windows.
+    pub skip_taskbar: bool,
 }
 
 impl Default for Window {
@@ -287,6 +296,7 @@ impl Default for Window {
             canvas: None,
             window_theme: None,
             visible: true,
+            skip_taskbar: false,
         }
     }
 }

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -12,6 +12,7 @@ use bevy_window::{CursorGrabMode, Window, WindowMode, WindowPosition, WindowReso
 use winit::{
     dpi::{LogicalSize, PhysicalPosition},
     monitor::MonitorHandle,
+    platform::windows::WindowBuilderExtWindows,
 };
 
 use crate::{
@@ -103,6 +104,11 @@ impl WinitWindows {
             .with_decorations(window.decorations)
             .with_transparent(window.transparent)
             .with_visible(window.visible);
+
+        #[cfg(target_os = "windows")]
+        {
+            winit_window_builder = winit_window_builder.with_skip_taskbar(window.skip_taskbar)
+        }
 
         #[cfg(any(
             target_os = "linux",


### PR DESCRIPTION
# Objective

Resolves #12431

## Solution

Added a `skip_taskbar` field to the `Window` struct (defaults to `false`). Used in `create_windows` if the target OS is Windows.