### PR TITLE
Fix pink colors in examples

### DIFF
--- a/examples/3d/lighting.rs
+++ b/examples/3d/lighting.rs
@@ -99,7 +99,7 @@ fn setup(
         PbrBundle {
             mesh: meshes.add(Cuboid::default()),
             material: materials.add(StandardMaterial {
-                base_color: PINK.into(),
+                base_color: DEEP_PINK.into(),
                 ..default()
             }),
             transform: Transform::from_xyz(0.0, 0.5, 0.0),

--- a/examples/3d/wireframe.rs
+++ b/examples/3d/wireframe.rs
@@ -146,7 +146,7 @@ Color: {:?}
     // Toggle the global wireframe color
     if keyboard_input.just_pressed(KeyCode::KeyX) {
         config.default_color = if config.default_color == WHITE.into() {
-            PINK.into()
+            DEEP_PINK.into()
         } else {
             WHITE.into()
         };

--- a/examples/stress_tests/many_lights.rs
+++ b/examples/stress_tests/many_lights.rs
@@ -4,7 +4,7 @@
 use std::f64::consts::PI;
 
 use bevy::{
-    color::palettes::css::PINK,
+    color::palettes::css::DEEP_PINK,
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     math::{DVec2, DVec3},
     pbr::{ExtractedPointLight, GlobalLightMeta},
@@ -62,7 +62,7 @@ fn setup(
 
     let mesh = meshes.add(Cuboid::default());
     let material = materials.add(StandardMaterial {
-        base_color: PINK.into(),
+        base_color: DEEP_PINK.into(),
         ..default()
     });
 

--- a/examples/ui/grid.rs
+++ b/examples/ui/grid.rs
@@ -109,7 +109,7 @@ fn spawn_layout(mut commands: Commands, asset_server: Res<AssetServer>) {
                     item_rect(builder, CRIMSON);
                     item_rect(builder, ANTIQUE_WHITE);
                     item_rect(builder, YELLOW);
-                    item_rect(builder, PINK);
+                    item_rect(builder, DEEP_PINK);
                     item_rect(builder, YELLOW_GREEN);
                     item_rect(builder, SALMON);
                 });


### PR DESCRIPTION
# Objective

I was wondering why the `lighting` example was still looking quite different lately (specifically, the intensity of the green light on the cube) and noticed that we had one more color change I didn't catch before.

Prior to the `bevy_color` port, `PINK` was actually "deep pink" from the css4 spec.

`palettes::css::PINK` is now correctly a lighter pink color defined by the same spec.

```rust
// Bevy 0.13
pub const PINK: Color = Color::rgb(1.0, 0.08, 0.58);
// Bevy 0.14-dev
pub const PINK: Srgba = Srgba::new(1.0, 0.753, 0.796, 1.0);
pub const DEEP_PINK: Srgba = Srgba::new(1.0, 0.078, 0.576, 1.0);
```

## Solution

Change usages of `css::PINK`  to `DEEP_PINK` to restore the examples to their former colors.