### PR TITLE
update OrthographicProjection/Camera2dBundle default implementations

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -35,11 +35,7 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        let projection = OrthographicProjection {
-            far: 1000.,
-            near: -1000.,
-            ..Default::default()
-        };
+        let projection = OrthographicProjection::default();
         let transform = Transform::default();
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -458,7 +458,7 @@ impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
             scale: 1.0,
-            near: 0.0,
+            near: -1000.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize(1.0),


### PR DESCRIPTION
# Objective

I have seen or heard of at least 3 instances in the last week of people asking for help with things not appearing in their world due to `Camera2dBundle::default()` using a different orthographic projection settings than `OrthographicProjection::default()`.
This causes many issues were objects don't display as expected when updating values inside the projection field (such as `ScalingMode`).
I say unexpected because:
```rust
commands.spawn(Camera2dBundle {
  transform: Transform::from_translation(Vec2::splat(10.0).extend(0.0)),
  ..Default::default()
});
```
```rust
commands.spawn(Camera2dBunde {
  transform: Transform::from_translation(Vec2::splat(10.0).extend(0.0)),
  projection: OrthographicProjection {
    ScalingMode: ScalingMode::WindowSize(200.0),
    ..Default::default()
  }
  ..Default::default()
});
```
Most people would not expect to be required to manually set the `near` / `far` fields after using `Default::default()`.

## Solution

Default `OrthographicProjection.near` to the value of `-1000.0`
This would bring the default orthographic projection into line with what is expected from most 2d cameras. I think OrthographicProjection should treat 2d as first class, and 3d should specify their near value at 0 if they don't want to see behind them.

`Camera2dBundle` could be changed to not override the near/far values in it's default implementation.
`Camera2dBundle::new_with_far()` would need to be discussed? and probably just left alone
`examples/3d/orthographic.rs` should be fine, however we may want to set near back to 0 for this so that one cannot see behind them in a 3d environment?
`examples/3d/pbr.rs` same as other examples
`examples/3d/many_lights.rs` same as other examples

---

## Changelog

### Changed
`OrthographicProjection::default()` now has a near value of `-1000.0` from `0.0` bringing it into parity with expected results when building a `Camera2dBundle`

## Migration Guide

Verify any `OrthographicProjection`s built using `..Default::default()` have your expected `near` field set to the value you would like.