### PR TITLE
Color maths 1

### DIFF
--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -1,6 +1,9 @@
+use std::ops::{Add, Div, Mul, Sub};
+
 use crate::{
     Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Oklaba, Oklcha, Srgba, StandardColor, Xyza,
 };
+use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -38,6 +41,7 @@ pub enum Color {
 }
 
 impl StandardColor for Color {}
+impl Point for Color {}
 
 impl Color {
     /// Return the color as a linear RGBA color.
@@ -379,6 +383,114 @@ impl Alpha for Color {
             Color::Oklaba(x) => x.set_alpha(alpha),
             Color::Oklcha(x) => x.set_alpha(alpha),
             Color::Xyza(x) => x.set_alpha(alpha),
+        }
+    }
+}
+
+/// The colors are added in the color space of lhs
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue (if present) is in `0..360`
+impl Add<Self> for Color {
+    type Output = Color;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match self {
+            Color::Srgba(x) => (x + rhs.into()).into(),
+            Color::LinearRgba(x) => (x + rhs.into()).into(),
+            Color::Hsla(x) => (x + rhs.into()).into(),
+            Color::Hsva(x) => (x + rhs.into()).into(),
+            Color::Hwba(x) => (x + rhs.into()).into(),
+            Color::Laba(x) => (x + rhs.into()).into(),
+            Color::Lcha(x) => (x + rhs.into()).into(),
+            Color::Oklaba(x) => (x + rhs.into()).into(),
+            Color::Oklcha(x) => (x + rhs.into()).into(),
+            Color::Xyza(x) => (x + rhs.into()).into(),
+        }
+    }
+}
+
+/// The colors are subtracted in the color space of lhs
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue (if present) is in `0..360`
+impl Sub<Self> for Color {
+    type Output = Color;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        match self {
+            Color::Srgba(x) => (x - rhs.into()).into(),
+            Color::LinearRgba(x) => (x - rhs.into()).into(),
+            Color::Hsla(x) => (x - rhs.into()).into(),
+            Color::Hsva(x) => (x - rhs.into()).into(),
+            Color::Hwba(x) => (x - rhs.into()).into(),
+            Color::Laba(x) => (x - rhs.into()).into(),
+            Color::Lcha(x) => (x - rhs.into()).into(),
+            Color::Oklaba(x) => (x - rhs.into()).into(),
+            Color::Oklcha(x) => (x - rhs.into()).into(),
+            Color::Xyza(x) => (x - rhs.into()).into(),
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Color {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        match self {
+            Color::Srgba(x) => (x * rhs).into(),
+            Color::LinearRgba(x) => (x * rhs).into(),
+            Color::Hsla(x) => (x * rhs).into(),
+            Color::Hsva(x) => (x * rhs).into(),
+            Color::Hwba(x) => (x * rhs).into(),
+            Color::Laba(x) => (x * rhs).into(),
+            Color::Lcha(x) => (x * rhs).into(),
+            Color::Oklaba(x) => (x * rhs).into(),
+            Color::Oklcha(x) => (x * rhs).into(),
+            Color::Xyza(x) => (x * rhs).into(),
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<Color> for f32 {
+    type Output = Color;
+
+    fn mul(self, rhs: Color) -> Self::Output {
+        rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Color {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        match self {
+            Color::Srgba(x) => (x / rhs).into(),
+            Color::LinearRgba(x) => (x / rhs).into(),
+            Color::Hsla(x) => (x / rhs).into(),
+            Color::Hsva(x) => (x / rhs).into(),
+            Color::Hwba(x) => (x / rhs).into(),
+            Color::Laba(x) => (x / rhs).into(),
+            Color::Lcha(x) => (x / rhs).into(),
+            Color::Oklaba(x) => (x / rhs).into(),
+            Color::Oklcha(x) => (x / rhs).into(),
+            Color::Xyza(x) => (x / rhs).into(),
         }
     }
 }

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -1,9 +1,6 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Div, Mul};
 
-use crate::{
-    Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Oklaba, Oklcha, Srgba, StandardColor, Xyza,
-};
-use bevy_math::cubic_splines::Point;
+use crate::{Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Oklaba, Oklcha, Srgba, Xyza};
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -39,9 +36,6 @@ pub enum Color {
     /// A color in the XYZ color space with alpha.
     Xyza(Xyza),
 }
-
-impl StandardColor for Color {}
-impl Point for Color {}
 
 impl Color {
     /// Return the color as a linear RGBA color.
@@ -383,56 +377,6 @@ impl Alpha for Color {
             Color::Oklaba(x) => x.set_alpha(alpha),
             Color::Oklcha(x) => x.set_alpha(alpha),
             Color::Xyza(x) => x.set_alpha(alpha),
-        }
-    }
-}
-
-/// The colors are added in the color space of lhs
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue (if present) is in `0..360`
-impl Add<Self> for Color {
-    type Output = Color;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        match self {
-            Color::Srgba(x) => (x + rhs.into()).into(),
-            Color::LinearRgba(x) => (x + rhs.into()).into(),
-            Color::Hsla(x) => (x + rhs.into()).into(),
-            Color::Hsva(x) => (x + rhs.into()).into(),
-            Color::Hwba(x) => (x + rhs.into()).into(),
-            Color::Laba(x) => (x + rhs.into()).into(),
-            Color::Lcha(x) => (x + rhs.into()).into(),
-            Color::Oklaba(x) => (x + rhs.into()).into(),
-            Color::Oklcha(x) => (x + rhs.into()).into(),
-            Color::Xyza(x) => (x + rhs.into()).into(),
-        }
-    }
-}
-
-/// The colors are subtracted in the color space of lhs
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue (if present) is in `0..360`
-impl Sub<Self> for Color {
-    type Output = Color;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        match self {
-            Color::Srgba(x) => (x - rhs.into()).into(),
-            Color::LinearRgba(x) => (x - rhs.into()).into(),
-            Color::Hsla(x) => (x - rhs.into()).into(),
-            Color::Hsva(x) => (x - rhs.into()).into(),
-            Color::Hwba(x) => (x - rhs.into()).into(),
-            Color::Laba(x) => (x - rhs.into()).into(),
-            Color::Lcha(x) => (x - rhs.into()).into(),
-            Color::Oklaba(x) => (x - rhs.into()).into(),
-            Color::Oklcha(x) => (x - rhs.into()).into(),
-            Color::Xyza(x) => (x - rhs.into()).into(),
         }
     }
 }

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -1,5 +1,3 @@
-use std::ops::{Div, Mul};
-
 use crate::{Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Oklaba, Oklcha, Srgba, Xyza};
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};

--- a/crates/bevy_color/src/color.rs
+++ b/crates/bevy_color/src/color.rs
@@ -381,64 +381,6 @@ impl Alpha for Color {
     }
 }
 
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Color {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        match self {
-            Color::Srgba(x) => (x * rhs).into(),
-            Color::LinearRgba(x) => (x * rhs).into(),
-            Color::Hsla(x) => (x * rhs).into(),
-            Color::Hsva(x) => (x * rhs).into(),
-            Color::Hwba(x) => (x * rhs).into(),
-            Color::Laba(x) => (x * rhs).into(),
-            Color::Lcha(x) => (x * rhs).into(),
-            Color::Oklaba(x) => (x * rhs).into(),
-            Color::Oklcha(x) => (x * rhs).into(),
-            Color::Xyza(x) => (x * rhs).into(),
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Color> for f32 {
-    type Output = Color;
-
-    fn mul(self, rhs: Color) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Color {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        match self {
-            Color::Srgba(x) => (x / rhs).into(),
-            Color::LinearRgba(x) => (x / rhs).into(),
-            Color::Hsla(x) => (x / rhs).into(),
-            Color::Hsva(x) => (x / rhs).into(),
-            Color::Hwba(x) => (x / rhs).into(),
-            Color::Laba(x) => (x / rhs).into(),
-            Color::Lcha(x) => (x / rhs).into(),
-            Color::Oklaba(x) => (x / rhs).into(),
-            Color::Oklcha(x) => (x / rhs).into(),
-            Color::Xyza(x) => (x / rhs).into(),
-        }
-    }
-}
-
 impl From<Srgba> for Color {
     fn from(value: Srgba) -> Self {
         Self::Srgba(value)

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
@@ -256,6 +256,16 @@ impl Mul<Hsla> for f32 {
 
     fn mul(self, rhs: Hsla) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Hsla {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
@@ -260,6 +260,23 @@ impl Div<f32> for Hsla {
             hue: (self.hue / rhs).rem_euclid(360.),
             lightness: self.lightness / rhs,
             saturation: self.saturation / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Hsla {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            hue: 360. - self.hue,
+            saturation: -self.saturation,
+            lightness: -self.lightness,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,7 +1,6 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
     StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
@@ -172,136 +171,11 @@ impl Luminance for Hsla {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Add<Hsla> for Hsla {
-    type Output = Self;
-
-    fn add(self, rhs: Hsla) -> Self::Output {
-        Self::Output {
-            hue: (self.hue + rhs.hue).rem_euclid(360.),
-            lightness: self.lightness + rhs.lightness,
-            saturation: self.saturation + rhs.saturation,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl AddAssign<Self> for Hsla {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Sub<Hsla> for Hsla {
-    type Output = Self;
-
-    fn sub(self, rhs: Hsla) -> Self::Output {
-        Self::Output {
-            hue: (self.hue - rhs.hue).rem_euclid(360.),
-            lightness: self.lightness - rhs.lightness,
-            saturation: self.saturation - rhs.saturation,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl SubAssign<Self> for Hsla {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Hsla {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue * rhs).rem_euclid(360.),
-            lightness: self.lightness * rhs,
-            saturation: self.saturation * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Hsla> for f32 {
-    type Output = Hsla;
-
-    fn mul(self, rhs: Hsla) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Hsla {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Hsla {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue / rhs).rem_euclid(360.),
-            lightness: self.lightness / rhs,
-            saturation: self.saturation / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Hsla {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            hue: 360. - self.hue,
-            saturation: -self.saturation,
-            lightness: -self.lightness,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Hsla, [hue, saturation, lightness]);
+impl_color_sub!(Hsla, [hue, saturation, lightness]);
+impl_color_mul!(Hsla, [hue, saturation, lightness]);
+impl_color_div!(Hsla, [hue, saturation, lightness]);
+impl_color_neg!(Hsla, [hue, saturation, lightness]);
 
 impl Point for Hsla {}
 

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
@@ -216,6 +216,17 @@ impl Sub<Hsla> for Hsla {
             saturation: self.saturation - rhs.saturation,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl SubAssign<Self> for Hsla {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -370,4 +370,27 @@ mod tests {
             assert_approx_eq!(color.hue, reference.hue, 0.001);
         }
     }
+
+    #[test]
+    fn test_hsla_group() {
+        let value1 = Hsla::hsl(337., 0.7, 0.1);
+        let value2 = Hsla::hsl(21., 0.9, 0.0);
+        let value3 = Hsla::new(142.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Hsla::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba,
@@ -187,6 +187,17 @@ impl Add<Hsla> for Hsla {
             saturation: self.saturation + rhs.saturation,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl AddAssign<Self> for Hsla {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -224,4 +224,27 @@ mod tests {
             assert_approx_eq!(color.hsv.alpha, hsv2.alpha, 0.001);
         }
     }
+
+    #[test]
+    fn test_hsva_group() {
+        let value1 = Hsva::hsv(337., 0.7, 0.1);
+        let value2 = Hsva::hsv(21., 0.9, 0.0);
+        let value3 = Hsva::new(142.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Hsva::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -184,6 +184,23 @@ impl Div<f32> for Hsva {
             hue: (self.hue / rhs).rem_euclid(360.),
             value: self.value / rhs,
             saturation: self.saturation / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Hsva {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            hue: 360. - self.hue,
+            saturation: -self.saturation,
+            value: -self.value,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -111,6 +111,17 @@ impl Add<Hsva> for Hsva {
             saturation: self.saturation + rhs.saturation,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl AddAssign<Self> for Hsva {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -140,6 +140,17 @@ impl Sub<Hsva> for Hsva {
             saturation: self.saturation - rhs.saturation,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl SubAssign<Self> for Hsva {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,7 +1,6 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -96,136 +95,11 @@ impl Alpha for Hsva {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Add<Hsva> for Hsva {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            hue: (self.hue + rhs.hue).rem_euclid(360.),
-            value: self.value + rhs.value,
-            saturation: self.saturation + rhs.saturation,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl AddAssign<Self> for Hsva {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Sub<Hsva> for Hsva {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            hue: (self.hue - rhs.hue).rem_euclid(360.),
-            value: self.value - rhs.value,
-            saturation: self.saturation - rhs.saturation,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl SubAssign<Self> for Hsva {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Hsva {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue * rhs).rem_euclid(360.),
-            value: self.value * rhs,
-            saturation: self.saturation * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Hsva> for f32 {
-    type Output = Hsva;
-
-    fn mul(self, rhs: Hsva) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Hsva {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Hsva {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue / rhs).rem_euclid(360.),
-            value: self.value / rhs,
-            saturation: self.saturation / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Hsva {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            hue: 360. - self.hue,
-            saturation: -self.saturation,
-            value: -self.value,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Hsva, [hue, saturation, value]);
+impl_color_sub!(Hsva, [hue, saturation, value]);
+impl_color_mul!(Hsva, [hue, saturation, value]);
+impl_color_div!(Hsva, [hue, saturation, value]);
+impl_color_neg!(Hsva, [hue, saturation, value]);
 
 impl Point for Hsva {}
 

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -180,6 +180,16 @@ impl Mul<Hsva> for f32 {
 
     fn mul(self, rhs: Hsva) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Hsva {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,7 +2,7 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -115,6 +115,17 @@ impl Add<Hwba> for Hwba {
             blackness: self.blackness + rhs.blackness,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl AddAssign<Self> for Hwba {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,7 +2,7 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -144,6 +144,17 @@ impl Sub<Hwba> for Hwba {
             blackness: self.blackness - rhs.blackness,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl SubAssign<Self> for Hwba {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -257,4 +257,27 @@ mod tests {
             assert_approx_eq!(color.hwb.alpha, hwb2.alpha, 0.001);
         }
     }
+
+    #[test]
+    fn test_hwba_group() {
+        let value1 = Hwba::hwb(337., 0.7, 0.1);
+        let value2 = Hwba::hwb(21., 0.9, 0.0);
+        let value3 = Hwba::new(142.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Hwba::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,7 +2,7 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -186,8 +186,25 @@ impl Div<f32> for Hwba {
     fn div(self, rhs: f32) -> Self::Output {
         Self::Output {
             hue: (self.hue / rhs).rem_euclid(360.),
-            blackness: self.blackness / rhs,
             whiteness: self.whiteness / rhs,
+            blackness: self.blackness / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Hwba {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            hue: 360. - self.hue,
+            whiteness: -self.whiteness,
+            blackness: -self.blackness,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,10 +2,9 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -100,136 +99,11 @@ impl Alpha for Hwba {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Add<Hwba> for Hwba {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            hue: (self.hue + rhs.hue).rem_euclid(360.),
-            whiteness: self.whiteness + rhs.whiteness,
-            blackness: self.blackness + rhs.blackness,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl AddAssign<Self> for Hwba {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Sub<Hwba> for Hwba {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            hue: (self.hue - rhs.hue).rem_euclid(360.),
-            whiteness: self.whiteness - rhs.whiteness,
-            blackness: self.blackness - rhs.blackness,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl SubAssign<Self> for Hwba {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Hwba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue * rhs).rem_euclid(360.),
-            whiteness: self.whiteness * rhs,
-            blackness: self.blackness * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Hwba> for f32 {
-    type Output = Hwba;
-
-    fn mul(self, rhs: Hwba) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Hwba {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Hwba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            hue: (self.hue / rhs).rem_euclid(360.),
-            whiteness: self.whiteness / rhs,
-            blackness: self.blackness / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Hwba {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            hue: 360. - self.hue,
-            whiteness: -self.whiteness,
-            blackness: -self.blackness,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Hwba, [hue, whiteness, blackness]);
+impl_color_sub!(Hwba, [hue, whiteness, blackness]);
+impl_color_mul!(Hwba, [hue, whiteness, blackness]);
+impl_color_div!(Hwba, [hue, whiteness, blackness]);
+impl_color_neg!(Hwba, [hue, whiteness, blackness]);
 
 impl Point for Hwba {}
 

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,7 +2,7 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
@@ -184,6 +184,16 @@ impl Mul<Hwba> for f32 {
 
     fn mul(self, rhs: Hwba) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Hwba {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,7 +1,6 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
     Srgba, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
@@ -143,132 +142,11 @@ impl Luminance for Laba {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Add<Laba> for Laba {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness + rhs.lightness,
-            a: self.a + rhs.a,
-            b: self.b + rhs.b,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl AddAssign<Self> for Laba {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Sub<Laba> for Laba {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness - rhs.lightness,
-            a: self.a - rhs.a,
-            b: self.b - rhs.b,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl SubAssign<Self> for Laba {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Laba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness * rhs,
-            a: self.a * rhs,
-            b: self.b * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Laba> for f32 {
-    type Output = Laba;
-
-    fn mul(self, rhs: Laba) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Laba {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Laba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness / rhs,
-            a: self.a / rhs,
-            b: self.b / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Laba {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            lightness: -self.lightness,
-            a: -self.a,
-            b: -self.b,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Laba, [lightness, a, b]);
+impl_color_sub!(Laba, [lightness, a, b]);
+impl_color_mul!(Laba, [lightness, a, b]);
+impl_color_div!(Laba, [lightness, a, b]);
+impl_color_neg!(Laba, [lightness, a, b]);
 
 impl Point for Laba {}
 

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
@@ -223,6 +223,16 @@ impl Mul<Laba> for f32 {
 
     fn mul(self, rhs: Laba) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Laba {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
@@ -157,6 +157,16 @@ impl Add<Laba> for Laba {
             b: self.b + rhs.b,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl AddAssign<Self> for Laba {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
@@ -184,6 +184,16 @@ impl Sub<Laba> for Laba {
             b: self.b - rhs.b,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl SubAssign<Self> for Laba {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -364,4 +364,31 @@ mod tests {
             assert_approx_eq!(color.lab.alpha, laba.alpha, 0.001);
         }
     }
+
+    #[test]
+    fn test_laba_group() {
+        let value1 = Laba::lab(0.2, -1.2, 1.2);
+        let value2 = Laba::lab(1.5, -0.925, 0.0);
+        let value3 = Laba::new(0.8, 0.25, -0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Laba::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(
+            value1 + (value2 + value3),
+            (value1 + value2) + value3,
+            "laba is not associative"
+        );
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
@@ -228,6 +228,23 @@ impl Div<f32> for Laba {
             lightness: self.lightness / rhs,
             a: self.a / rhs,
             b: self.b / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Laba {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            lightness: -self.lightness,
+            a: -self.a,
+            b: -self.b,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,6 +1,10 @@
+use std::ops::{Add, Div, Mul, Sub};
+
 use crate::{
-    Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    add_alpha_blend, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba,
+    Srgba, StandardColor, Xyza,
 };
+use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -138,6 +142,88 @@ impl Luminance for Laba {
         )
     }
 }
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Add<Laba> for Laba {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness + rhs.lightness,
+            a: self.a + rhs.a,
+            b: self.b + rhs.b,
+            alpha: add_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Sub<Laba> for Laba {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness - rhs.lightness,
+            a: self.a - rhs.a,
+            b: self.b - rhs.b,
+            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Laba {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness * rhs,
+            a: self.a * rhs,
+            b: self.b * rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<Laba> for f32 {
+    type Output = Laba;
+
+    fn mul(self, rhs: Laba) -> Self::Output {
+        rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Laba {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness / rhs,
+            a: self.a / rhs,
+            b: self.b / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl Point for Laba {}
 
 impl From<Laba> for Xyza {
     fn from(

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -326,4 +326,27 @@ mod tests {
             assert_approx_eq!(color.lch.alpha, lcha.alpha, 0.001);
         }
     }
+
+    #[test]
+    fn test_lcha_group() {
+        let value1 = Lcha::lch(0.2, 1.3, 90.);
+        let value2 = Lcha::lch(1.5, 0.9, 128.9);
+        let value3 = Lcha::new(0.8, 0.25, 307., 0.333);
+
+        // the neutral element
+        let transparent_black = Lcha::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba,
@@ -187,6 +187,17 @@ impl Add<Lcha> for Lcha {
             hue: (self.hue + rhs.hue).rem_euclid(360.),
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl AddAssign<Self> for Lcha {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba,
@@ -260,6 +260,23 @@ impl Div<f32> for Lcha {
             lightness: self.lightness / rhs,
             chroma: self.chroma / rhs,
             hue: (self.hue / rhs).rem_euclid(360.),
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Lcha {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            hue: 360. - self.hue,
+            lightness: -self.lightness,
+            chroma: -self.chroma,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba,
@@ -216,6 +216,17 @@ impl Sub<Lcha> for Lcha {
             hue: (self.hue - rhs.hue).rem_euclid(360.),
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl SubAssign<Self> for Lcha {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,8 +1,7 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba,
-    StandardColor, Xyza,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba, StandardColor,
+    Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -172,136 +171,11 @@ impl Luminance for Lcha {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Add<Lcha> for Lcha {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness + rhs.lightness,
-            chroma: self.chroma + rhs.chroma,
-            hue: (self.hue + rhs.hue).rem_euclid(360.),
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl AddAssign<Self> for Lcha {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Sub<Lcha> for Lcha {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness - rhs.lightness,
-            chroma: self.chroma - rhs.chroma,
-            hue: (self.hue - rhs.hue).rem_euclid(360.),
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl SubAssign<Self> for Lcha {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Lcha {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness * rhs,
-            chroma: self.chroma * rhs,
-            hue: (self.hue * rhs).rem_euclid(360.),
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Lcha> for f32 {
-    type Output = Lcha;
-
-    fn mul(self, rhs: Lcha) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Lcha {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Lcha {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness / rhs,
-            chroma: self.chroma / rhs,
-            hue: (self.hue / rhs).rem_euclid(360.),
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Lcha {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            hue: 360. - self.hue,
-            lightness: -self.lightness,
-            chroma: -self.chroma,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Lcha, [lightness, chroma, hue]);
+impl_color_sub!(Lcha, [lightness, chroma, hue]);
+impl_color_mul!(Lcha, [lightness, chroma, hue]);
+impl_color_div!(Lcha, [lightness, chroma, hue]);
+impl_color_neg!(Lcha, [lightness, chroma, hue]);
 
 impl Point for Lcha {}
 

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, sub_alpha_blend, Alpha, Laba, LinearRgba, Luminance, Mix, Srgba,
@@ -256,6 +256,16 @@ impl Mul<Lcha> for f32 {
 
     fn mul(self, rhs: Lcha) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Lcha {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -113,7 +113,7 @@ pub mod prelude {
     pub use crate::xyza::*;
 }
 
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use bevy_math::cubic_splines::Point;
 pub use color::*;
@@ -158,6 +158,7 @@ where
     Self: Div<f32>,
     Self: Mul<f32>,
     f32: Mul<Self>,
+    Self: Neg,
     Self: Point,
 {
 }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -113,7 +113,7 @@ pub mod prelude {
     pub use crate::xyza::*;
 }
 
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use bevy_math::cubic_splines::Point;
 pub use color::*;
@@ -153,6 +153,7 @@ where
     Self: From<Xyza> + Into<Xyza>,
     Self: Alpha,
     Self: Add<Self>,
+    Self: AddAssign<Self>,
     Self: Sub<Self>,
     Self: Div<f32>,
     Self: Mul<f32>,

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -65,7 +65,7 @@
 //! The only exception to this rule is the `alpha` channel which is blended between the two colors.
 //!
 //! When multiplying or dividing a color by a scalar ([`f32`]) or negating a color,
-//! all channels of the color will be multiplied, devided or negated directly.
+//! all channels of the color will be multiplied, divided or negated directly.
 //! The only exception to this rule is the `alpha` channel which is left unchanged.
 //!
 //! Please note that these operations may result in colors that are outside useful ranges, e.g. a negative value in one of the color channels of a [`LinearRgba`] color:
@@ -73,7 +73,7 @@
 //! use bevy_color::LinearRgba;
 //!
 //! let white = LinearRgba::new(1., 1., 1., 1.);
-//! assert_eq!(-white, LinearRgba::new(-1., -1., -1., -1.));
+//! assert_eq!(-white, LinearRgba::new(-1., -1., -1., 1.));
 //! ```
 //!
 //! In addition, there is a [`Color`] enum that can represent any of the color

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -174,7 +174,7 @@ pub(crate) fn sub_alpha_blend(lhs: f32, rhs: f32) -> f32 {
     lhs * (1. - rhs)
 }
 
-/// Implements Add and AddAssign for a given color type
+/// Implements `Add` and `AddAssign` for a given color type
 macro_rules! impl_color_add {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are added directly
@@ -207,7 +207,7 @@ macro_rules! impl_color_add {
     };
 }
 
-/// Implements Sub and SubAssign for a given color type
+/// Implements `Sub` and `SubAssign` for a given color type
 macro_rules! impl_color_sub {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are subtracted directly
@@ -240,7 +240,7 @@ macro_rules! impl_color_sub {
     };
 }
 
-/// Implements Mul and MulAssign for a given color type
+/// Implements `Mul` and `MulAssign` for a given color type
 macro_rules! impl_color_mul {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are scaled directly,
@@ -285,7 +285,7 @@ macro_rules! impl_color_mul {
     };
 }
 
-/// Implements Div and DivAssign for a given color type
+/// Implements `Div` and `DivAssign` for a given color type
 macro_rules! impl_color_div {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are scaled directly,
@@ -318,7 +318,7 @@ macro_rules! impl_color_div {
     };
 }
 
-/// Implements Neg for a given color type
+/// Implements `Neg` for a given color type
 macro_rules! impl_color_neg {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are negated directly,

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -62,7 +62,9 @@
 //! and color range operations.
 //!
 //! When adding or subtracting one color from another, all channels of the colors are added/subtracted directly.
-//! The only exception to this rule is the `alpha` channel which is blended between the two colors.
+//! The only exception to this rule is the `alpha` channel which is blended between the two colors using
+//! - `lhs + rhs * (1. - lhs)` for addition and
+//! - `lhs * (1. - rhs)` for subtraction.
 //!
 //! When multiplying or dividing a color by a scalar ([`f32`]) or negating a color,
 //! all channels of the color will be multiplied, divided or negated directly.

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -113,7 +113,7 @@ pub mod prelude {
     pub use crate::xyza::*;
 }
 
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use bevy_math::cubic_splines::Point;
 pub use color::*;
@@ -155,6 +155,7 @@ where
     Self: Add<Self>,
     Self: AddAssign<Self>,
     Self: Sub<Self>,
+    Self: SubAssign<Self>,
     Self: Div<f32>,
     Self: Mul<f32>,
     f32: Mul<Self>,

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -113,6 +113,9 @@ pub mod prelude {
     pub use crate::xyza::*;
 }
 
+use std::ops::{Add, Div, Mul, Sub};
+
+use bevy_math::cubic_splines::Point;
 pub use color::*;
 pub use color_ops::*;
 pub use color_range::*;
@@ -149,5 +152,19 @@ where
     Self: From<Oklcha> + Into<Oklcha>,
     Self: From<Xyza> + Into<Xyza>,
     Self: Alpha,
+    Self: Add<Self>,
+    Self: Sub<Self>,
+    Self: Div<f32>,
+    Self: Mul<f32>,
+    f32: Mul<Self>,
+    Self: Point,
 {
+}
+
+pub(crate) fn add_alpha_blend(lhs: f32, rhs: f32) -> f32 {
+    lhs + rhs * (1. - lhs)
+}
+
+pub(crate) fn sub_alpha_blend(lhs: f32, rhs: f32) -> f32 {
+    lhs * (1. - rhs)
 }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -113,7 +113,7 @@ pub mod prelude {
     pub use crate::xyza::*;
 }
 
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use bevy_math::cubic_splines::Point;
 pub use color::*;
@@ -157,6 +157,7 @@ where
     Self: Sub<Self>,
     Self: SubAssign<Self>,
     Self: Div<f32>,
+    Self: MulAssign<f32>,
     Self: Mul<f32>,
     f32: Mul<Self>,
     Self: Neg,

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -58,8 +58,23 @@
 //!
 //! # Other Utilities
 //!
-//! The crate also provides a number of color operations, such as blending, color difference,
+//! The crate also provides a number of color operations, such as adding, subtracting,  blending, color difference,
 //! and color range operations.
+//!
+//! When adding or subtracting one color from another, all channels of the colors are added/subtracted directly.
+//! The only exception to this rule is the `alpha` channel which is blended between the two colors.
+//!
+//! When multiplying or dividing a color by a scalar ([`f32`]) or negating a color,
+//! all channels of the color will be multiplied, devided or negated directly.
+//! The only exception to this rule is the `alpha` channel which is left unchanged.
+//!
+//! Please note that these operations may result in colors that are outside useful ranges, e.g. a negative value in one of the color channels of a [`LinearRgba`] color:
+//! ```
+//! use bevy_color::LinearRgba;
+//!
+//! let white = LinearRgba::new(1., 1., 1., 1.);
+//! assert_eq!(-white, LinearRgba::new(-1., -1., -1., -1.));
+//! ```
 //!
 //! In addition, there is a [`Color`] enum that can represent any of the color
 //! types in this crate. This is useful when you need to store a color in a data structure
@@ -166,21 +181,33 @@ where
 {
 }
 
+/// Alpha blending for adding colors
+/// The blending method used is equivalent to the OpenGL blend function `glBlendFunc(GL_ONE, GL_ONE_MINUS_SRC_ALPHA)`.
+/// For more information please see [this article](https://www.ventuz.com/support/help/latest/NodeRenderoptionsAlphaBlending.html) by the Khronos group.
 pub(crate) fn add_alpha_blend(lhs: f32, rhs: f32) -> f32 {
     lhs + rhs * (1. - lhs)
 }
 
+/// Alpha blending for subtracting colors
+/// The blending method used is equivalent to the OpenGL blend function `glBlendFunc(GL_ONE_MINUS_DST_ALPHA, GL_ZERO)`.
+/// For more information please see [this article](https://www.ventuz.com/support/help/latest/NodeRenderoptionsAlphaBlending.html) by the Khronos group.
 pub(crate) fn sub_alpha_blend(lhs: f32, rhs: f32) -> f32 {
     lhs * (1. - rhs)
 }
 
 /// Implements `Add` and `AddAssign` for a given color type
+///
+/// Note that these operations may result in colors outside useful or acceptable ranges.
+/// For more information please refer to the crate docs.
 macro_rules! impl_color_add {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are added directly
         /// but alpha is blended
         ///
         /// Values are not clamped
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Add<$ty> for $ty {
             type Output = Self;
 
@@ -196,6 +223,9 @@ macro_rules! impl_color_add {
         /// but alpha is blended
         ///
         /// Values are not clamped
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::AddAssign<$ty> for $ty {
             fn add_assign(&mut self, other: Self) {
                 *self = $ty {
@@ -208,12 +238,18 @@ macro_rules! impl_color_add {
 }
 
 /// Implements `Sub` and `SubAssign` for a given color type
+///
+/// Note that these operations may result in colors outside useful or acceptable ranges.
+/// For more information please refer to the crate docs.
 macro_rules! impl_color_sub {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are subtracted directly
         /// but alpha is blended
         ///
         /// Values are not clamped
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Sub<$ty> for $ty {
             type Output = Self;
 
@@ -229,6 +265,9 @@ macro_rules! impl_color_sub {
         /// but alpha is blended
         ///
         /// Values are not clamped
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::SubAssign<$ty> for $ty {
             fn sub_assign(&mut self, other: Self) {
                 *self = $ty {
@@ -241,12 +280,18 @@ macro_rules! impl_color_sub {
 }
 
 /// Implements `Mul` and `MulAssign` for a given color type
+///
+/// Note that these operations may result in colors outside useful or acceptable ranges.
+/// For more information please refer to the crate docs.
 macro_rules! impl_color_mul {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are scaled directly,
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Mul<f32> for $ty {
             type Output = Self;
 
@@ -262,6 +307,9 @@ macro_rules! impl_color_mul {
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Mul<$ty> for f32 {
             type Output = $ty;
 
@@ -274,6 +322,9 @@ macro_rules! impl_color_mul {
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::MulAssign<f32> for $ty {
             fn mul_assign(&mut self, other: f32) {
                 *self = $ty {
@@ -286,12 +337,18 @@ macro_rules! impl_color_mul {
 }
 
 /// Implements `Div` and `DivAssign` for a given color type
+///
+/// Note that these operations may result in colors outside useful or acceptable ranges.
+/// For more information please refer to the crate docs.
 macro_rules! impl_color_div {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are scaled directly,
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Div<f32> for $ty {
             type Output = Self;
 
@@ -307,6 +364,9 @@ macro_rules! impl_color_div {
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::DivAssign<f32> for $ty {
             fn div_assign(&mut self, other: f32) {
                 *self = $ty {
@@ -319,12 +379,18 @@ macro_rules! impl_color_div {
 }
 
 /// Implements `Neg` for a given color type
+///
+/// Note that this operation may result in colors outside useful or acceptable ranges.
+/// For more information please refer to the crate docs.
 macro_rules! impl_color_neg {
     ($ty: ident, [$($element: ident),+]) => {
         /// All color channels are negated directly,
         /// but alpha is unchanged.
         ///
         /// Values are not clamped.
+        ///
+        /// Note that this operation may result in colors outside useful or acceptable ranges.
+        /// For more information please refer to the crate docs.
         impl core::ops::Neg for $ty {
             type Output = Self;
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Luminance, Mix,
@@ -308,6 +308,16 @@ impl Mul<LinearRgba> for f32 {
 
     fn mul(self, rhs: LinearRgba) -> LinearRgba {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for LinearRgba {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Luminance, Mix,
@@ -342,6 +342,16 @@ impl Add<Self> for LinearRgba {
             blue: self.blue + rhs.blue,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl AddAssign<Self> for LinearRgba {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,7 +1,6 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Luminance, Mix,
+    add_alpha_blend, color_difference::EuclideanDistance, impl_color_add, impl_color_div,
+    impl_color_mul, impl_color_neg, impl_color_sub, sub_alpha_blend, Alpha, Luminance, Mix,
     StandardColor,
 };
 use bevy_math::{cubic_splines::Point, Vec4};
@@ -282,132 +281,11 @@ impl From<LinearRgba> for wgpu::Color {
     }
 }
 
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for LinearRgba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self {
-        Self {
-            red: self.red * rhs,
-            green: self.green * rhs,
-            blue: self.blue * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<LinearRgba> for f32 {
-    type Output = LinearRgba;
-
-    fn mul(self, rhs: LinearRgba) -> LinearRgba {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for LinearRgba {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for LinearRgba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self {
-        Self {
-            red: self.red / rhs,
-            green: self.green / rhs,
-            blue: self.blue / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Add<Self> for LinearRgba {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            red: self.red + rhs.red,
-            green: self.green + rhs.green,
-            blue: self.blue + rhs.blue,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl AddAssign<Self> for LinearRgba {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Sub<Self> for LinearRgba {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            red: self.red - rhs.red,
-            green: self.green - rhs.green,
-            blue: self.blue - rhs.blue,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl SubAssign<Self> for LinearRgba {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for LinearRgba {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            red: -self.red,
-            green: -self.green,
-            blue: -self.blue,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(LinearRgba, [red, green, blue]);
+impl_color_sub!(LinearRgba, [red, green, blue]);
+impl_color_mul!(LinearRgba, [red, green, blue]);
+impl_color_div!(LinearRgba, [red, green, blue]);
+impl_color_neg!(LinearRgba, [red, green, blue]);
 
 impl Point for LinearRgba {}
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -423,4 +423,27 @@ mod tests {
         let twice_as_light = color.lighter(0.2);
         assert!(lighter2.distance_squared(&twice_as_light) < 0.0001);
     }
+
+    #[test]
+    fn test_linear_rgba_group() {
+        let value1 = LinearRgba::rgb(0.2, 0.7, 0.1);
+        let value2 = LinearRgba::rgb(1.0, 0.9, 0.0);
+        let value3 = LinearRgba::new(0.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = LinearRgba::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Luminance, Mix,
@@ -369,6 +369,16 @@ impl Sub<Self> for LinearRgba {
             blue: self.blue - rhs.blue,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl SubAssign<Self> for LinearRgba {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Luminance, Mix,
@@ -368,6 +368,23 @@ impl Sub<Self> for LinearRgba {
             green: self.green - rhs.green,
             blue: self.blue - rhs.blue,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for LinearRgba {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            red: -self.red,
+            green: -self.green,
+            blue: -self.blue,
+            alpha: self.alpha,
         }
     }
 }

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,8 +1,7 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
-    Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
+    add_alpha_blend, color_difference::EuclideanDistance, impl_color_add, impl_color_div,
+    impl_color_mul, impl_color_neg, impl_color_sub, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, Lcha,
+    LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -135,132 +134,11 @@ impl EuclideanDistance for Oklaba {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Add<Oklaba> for Oklaba {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            l: self.l + rhs.l,
-            a: self.a + rhs.a,
-            b: self.b + rhs.b,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl AddAssign<Self> for Oklaba {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Sub<Oklaba> for Oklaba {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            l: self.l - rhs.l,
-            a: self.a - rhs.a,
-            b: self.b - rhs.b,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl SubAssign<Self> for Oklaba {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Oklaba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            l: self.l * rhs,
-            a: self.a * rhs,
-            b: self.b * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Oklaba> for f32 {
-    type Output = Oklaba;
-
-    fn mul(self, rhs: Oklaba) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Oklaba {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Oklaba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            l: self.l / rhs,
-            a: self.a / rhs,
-            b: self.b / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Oklaba {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            l: -self.l,
-            a: -self.a,
-            b: -self.b,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Oklaba, [l, a, b]);
+impl_color_sub!(Oklaba, [l, a, b]);
+impl_color_mul!(Oklaba, [l, a, b]);
+impl_color_div!(Oklaba, [l, a, b]);
+impl_color_neg!(Oklaba, [l, a, b]);
 
 impl Point for Oklaba {}
 

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -215,6 +215,16 @@ impl Mul<Oklaba> for f32 {
 
     fn mul(self, rhs: Oklaba) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Oklaba {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -149,6 +149,16 @@ impl Add<Oklaba> for Oklaba {
             b: self.b + rhs.b,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl AddAssign<Self> for Oklaba {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -176,6 +176,16 @@ impl Sub<Oklaba> for Oklaba {
             b: self.b - rhs.b,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl SubAssign<Self> for Oklaba {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -220,6 +220,23 @@ impl Div<f32> for Oklaba {
             l: self.l / rhs,
             a: self.a / rhs,
             b: self.b / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Oklaba {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            l: -self.l,
+            a: -self.a,
+            b: -self.b,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,7 +1,10 @@
+use std::ops::{Add, Div, Mul, Sub};
+
 use crate::{
-    color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix,
-    Srgba, StandardColor, Xyza,
+    add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
+    Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
+use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -131,6 +134,88 @@ impl EuclideanDistance for Oklaba {
         (self.l - other.l).powi(2) + (self.a - other.a).powi(2) + (self.b - other.b).powi(2)
     }
 }
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Add<Oklaba> for Oklaba {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            l: self.l + rhs.l,
+            a: self.a + rhs.a,
+            b: self.b + rhs.b,
+            alpha: add_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Sub<Oklaba> for Oklaba {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            l: self.l - rhs.l,
+            a: self.a - rhs.a,
+            b: self.b - rhs.b,
+            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Oklaba {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            l: self.l * rhs,
+            a: self.a * rhs,
+            b: self.b * rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<Oklaba> for f32 {
+    type Output = Oklaba;
+
+    fn mul(self, rhs: Oklaba) -> Self::Output {
+        rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Oklaba {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            l: self.l / rhs,
+            a: self.a / rhs,
+            b: self.b / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl Point for Oklaba {}
 
 #[allow(clippy::excessive_precision)]
 impl From<LinearRgba> for Oklaba {

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -47,7 +47,7 @@ impl Oklaba {
     /// * `l` - Lightness channel. [0.0, 1.0]
     /// * `a` - Green-red channel. [-1.0, 1.0]
     /// * `b` - Blue-yellow channel. [-1.0, 1.0]
-    pub const fn lch(l: f32, a: f32, b: f32) -> Self {
+    pub const fn lab(l: f32, a: f32, b: f32) -> Self {
         Self {
             l,
             a,
@@ -313,5 +313,28 @@ mod tests {
         assert_approx_eq!(oklaba.a, oklaba2.a, 0.001);
         assert_approx_eq!(oklaba.b, oklaba2.b, 0.001);
         assert_approx_eq!(oklaba.alpha, oklaba2.alpha, 0.001);
+    }
+
+    #[test]
+    fn test_oklaba_group() {
+        let value1 = Oklaba::lab(0.2, -0.7, 0.1);
+        let value2 = Oklaba::lab(1.0, -0.9, 0.0);
+        let value3 = Oklaba::new(0.5, 0.25, -0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Oklaba::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
     }
 }

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,8 +1,7 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::{
-    add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
-    Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    add_alpha_blend, color_difference::EuclideanDistance, impl_color_add, impl_color_div,
+    impl_color_mul, impl_color_neg, impl_color_sub, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba, Laba,
+    Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
@@ -177,136 +176,11 @@ impl EuclideanDistance for Oklcha {
     }
 }
 
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Add<Oklcha> for Oklcha {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness + rhs.lightness,
-            chroma: self.chroma + rhs.chroma,
-            hue: (self.hue + rhs.hue).rem_euclid(360.),
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl AddAssign<Self> for Oklcha {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl Sub<Oklcha> for Oklcha {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness - rhs.lightness,
-            chroma: self.chroma - rhs.chroma,
-            hue: (self.hue - rhs.hue).rem_euclid(360.),
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-/// but hue is in `0..360`
-impl SubAssign<Self> for Oklcha {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Oklcha {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness * rhs,
-            chroma: self.chroma * rhs,
-            hue: (self.hue * rhs).rem_euclid(360.),
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Oklcha> for f32 {
-    type Output = Oklcha;
-
-    fn mul(self, rhs: Oklcha) -> Self::Output {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Oklcha {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Oklcha {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self::Output {
-        Self::Output {
-            lightness: self.lightness / rhs,
-            chroma: self.chroma / rhs,
-            hue: (self.hue / rhs).rem_euclid(360.),
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Oklcha {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            hue: 360. - self.hue,
-            lightness: -self.lightness,
-            chroma: -self.chroma,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Oklcha, [lightness, chroma, hue]);
+impl_color_sub!(Oklcha, [lightness, chroma, hue]);
+impl_color_mul!(Oklcha, [lightness, chroma, hue]);
+impl_color_div!(Oklcha, [lightness, chroma, hue]);
+impl_color_neg!(Oklcha, [lightness, chroma, hue]);
 
 impl Point for Oklcha {}
 

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -261,6 +261,16 @@ impl Mul<Oklcha> for f32 {
 
     fn mul(self, rhs: Oklcha) -> Self::Output {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Oklcha {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -192,6 +192,17 @@ impl Add<Oklcha> for Oklcha {
             hue: (self.hue + rhs.hue).rem_euclid(360.),
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl AddAssign<Self> for Oklcha {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -265,6 +265,23 @@ impl Div<f32> for Oklcha {
             lightness: self.lightness / rhs,
             chroma: self.chroma / rhs,
             hue: (self.hue / rhs).rem_euclid(360.),
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Oklcha {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            hue: 360. - self.hue,
+            lightness: -self.lightness,
+            chroma: -self.chroma,
             alpha: self.alpha,
         }
     }

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,7 +1,10 @@
+use std::ops::{Add, Div, Mul, Sub};
+
 use crate::{
-    color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba,
-    Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
+    Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
+use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -173,6 +176,90 @@ impl EuclideanDistance for Oklcha {
             + (self.hue - other.hue).powi(2)
     }
 }
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl Add<Oklcha> for Oklcha {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness + rhs.lightness,
+            chroma: self.chroma + rhs.chroma,
+            hue: (self.hue + rhs.hue).rem_euclid(360.),
+            alpha: add_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl Sub<Oklcha> for Oklcha {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness - rhs.lightness,
+            chroma: self.chroma - rhs.chroma,
+            hue: (self.hue - rhs.hue).rem_euclid(360.),
+            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Oklcha {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness * rhs,
+            chroma: self.chroma * rhs,
+            hue: (self.hue * rhs).rem_euclid(360.),
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<Oklcha> for f32 {
+    type Output = Oklcha;
+
+    fn mul(self, rhs: Oklcha) -> Self::Output {
+        rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Oklcha {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self::Output {
+        Self::Output {
+            lightness: self.lightness / rhs,
+            chroma: self.chroma / rhs,
+            hue: (self.hue / rhs).rem_euclid(360.),
+            alpha: self.alpha,
+        }
+    }
+}
+
+impl Point for Oklcha {}
 
 impl From<Oklaba> for Oklcha {
     fn from(Oklaba { l, a, b, alpha }: Oklaba) -> Self {

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{
     add_alpha_blend, color_difference::EuclideanDistance, sub_alpha_blend, Alpha, Hsla, Hsva, Hwba,
@@ -221,6 +221,17 @@ impl Sub<Oklcha> for Oklcha {
             hue: (self.hue - rhs.hue).rem_euclid(360.),
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+/// but hue is in `0..360`
+impl SubAssign<Self> for Oklcha {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -359,4 +359,27 @@ mod tests {
         assert_approx_eq!(oklcha.hue, oklcha2.hue, 0.001);
         assert_approx_eq!(oklcha.alpha, oklcha2.alpha, 0.001);
     }
+
+    #[test]
+    fn test_oklcha_group() {
+        let value1 = Oklcha::lch(0.2, 0.7, 90.);
+        let value2 = Oklcha::lch(1.0, 0.9, 128.9);
+        let value3 = Oklcha::new(0.5, 0.25, 307., 0.333);
+
+        // the neutral element
+        let transparent_black = Oklcha::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,7 +1,10 @@
-use std::ops::{Div, Mul};
+use std::ops::{Add, Div, Mul, Sub};
 
 use crate::color_difference::EuclideanDistance;
-use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza};
+use crate::{
+    add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza,
+};
+use bevy_math::cubic_splines::Point;
 use bevy_math::Vec4;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
@@ -388,6 +391,10 @@ impl Mul<f32> for Srgba {
     }
 }
 
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
 impl Mul<Srgba> for f32 {
     type Output = Srgba;
 
@@ -412,6 +419,42 @@ impl Div<f32> for Srgba {
         }
     }
 }
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Add<Self> for Srgba {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            red: self.red + rhs.red,
+            green: self.green + rhs.green,
+            blue: self.blue + rhs.blue,
+            alpha: add_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Sub<Self> for Srgba {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            red: self.red - rhs.red,
+            green: self.green - rhs.green,
+            blue: self.blue - rhs.blue,
+            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+impl Point for Srgba {}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{
@@ -434,6 +434,16 @@ impl Add<Self> for Srgba {
             blue: self.blue + rhs.blue,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl AddAssign<Self> for Srgba {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -458,4 +458,27 @@ mod tests {
         assert!(matches!(Srgba::hex("yyy"), Err(HexColorError::Parse(_))));
         assert!(matches!(Srgba::hex("##fff"), Err(HexColorError::Parse(_))));
     }
+
+    #[test]
+    fn test_srgba_group() {
+        let value1 = Srgba::rgb(0.2, 0.7, 0.1);
+        let value2 = Srgba::rgb(1.0, 0.9, 0.0);
+        let value3 = Srgba::new(0.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Srgba::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value2 + value3), (value1 + value2) + value3);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,8 +1,7 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
 use crate::color_difference::EuclideanDistance;
 use crate::{
-    add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza,
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza,
 };
 use bevy_math::cubic_splines::Point;
 use bevy_math::Vec4;
@@ -374,132 +373,11 @@ pub enum HexColorError {
     Char(char),
 }
 
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Srgba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self {
-        Self {
-            red: self.red * rhs,
-            green: self.green * rhs,
-            blue: self.blue * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Srgba> for f32 {
-    type Output = Srgba;
-
-    fn mul(self, rhs: Srgba) -> Srgba {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Srgba {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Srgba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self {
-        Self {
-            red: self.red / rhs,
-            green: self.green / rhs,
-            blue: self.blue / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Add<Self> for Srgba {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            red: self.red + rhs.red,
-            green: self.green + rhs.green,
-            blue: self.blue + rhs.blue,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl AddAssign<Self> for Srgba {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Sub<Self> for Srgba {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            red: self.red - rhs.red,
-            green: self.green - rhs.green,
-            blue: self.blue - rhs.blue,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl SubAssign<Self> for Srgba {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Srgba {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            red: -self.red,
-            green: -self.green,
-            blue: -self.blue,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Srgba, [red, green, blue]);
+impl_color_sub!(Srgba, [red, green, blue]);
+impl_color_mul!(Srgba, [red, green, blue]);
+impl_color_div!(Srgba, [red, green, blue]);
+impl_color_neg!(Srgba, [red, green, blue]);
 
 impl Point for Srgba {}
 

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{
@@ -460,6 +460,23 @@ impl Sub<Self> for Srgba {
             green: self.green - rhs.green,
             blue: self.blue - rhs.blue,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Srgba {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            red: -self.red,
+            green: -self.green,
+            blue: -self.blue,
+            alpha: self.alpha,
         }
     }
 }

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{
@@ -461,6 +461,16 @@ impl Sub<Self> for Srgba {
             blue: self.blue - rhs.blue,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl SubAssign<Self> for Srgba {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{
@@ -400,6 +400,16 @@ impl Mul<Srgba> for f32 {
 
     fn mul(self, rhs: Srgba) -> Srgba {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Srgba {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Sub};
 
 use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
 use bevy_math::cubic_splines::Point;
@@ -197,6 +197,16 @@ impl Add<Self> for Xyza {
             z: self.z + rhs.z,
             alpha: add_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl AddAssign<Self> for Xyza {
+    fn add_assign(&mut self, rhs: Self) {
+        *self = *self + rhs;
     }
 }
 

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
 
 use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
 use bevy_math::cubic_splines::Point;
@@ -224,6 +224,16 @@ impl Sub<Self> for Xyza {
             z: self.z - rhs.z,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
         }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl SubAssign<Self> for Xyza {
+    fn sub_assign(&mut self, rhs: Self) {
+        *self = *self - rhs;
     }
 }
 

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -220,4 +220,27 @@ mod tests {
             assert_approx_eq!(color.xyz.alpha, xyz2.alpha, 0.001);
         }
     }
+
+    #[test]
+    fn test_xyza_group() {
+        let value1 = Xyza::xyz(0.2, 0.7, 0.1);
+        let value2 = Xyza::xyz(1.0, 0.9, 0.0);
+        let value3 = Xyza::new(0.5, 0.25, 0.98, 0.333);
+
+        // the neutral element
+        let transparent_black = Xyza::new(0.0, 0.0, 0.0, 0.0);
+
+        // Test for neutral element
+        assert_eq!(value1 + transparent_black, value1);
+        assert_eq!(transparent_black + value2, value2);
+        assert_eq!(value3 + transparent_black, value3);
+
+        // Test associativity
+        assert_eq!(value1 + (value3 + value2), (value1 + value3) + value2);
+
+        // Test for inverse element
+        assert_eq!((-value1 + value1).with_alpha(0.), transparent_black);
+        assert_eq!((-value2 + value2).with_alpha(0.), transparent_black);
+        assert_eq!((-value3 + value3).with_alpha(0.), transparent_black);
+    }
 }

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,7 @@
-use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor};
+use std::ops::{Add, Div, Mul, Sub};
+
+use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
+use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
 
@@ -133,6 +136,88 @@ impl Mix for Xyza {
         }
     }
 }
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<f32> for Xyza {
+    type Output = Self;
+
+    fn mul(self, rhs: f32) -> Self {
+        Self {
+            x: self.x * rhs,
+            y: self.y * rhs,
+            z: self.z * rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Mul<Xyza> for f32 {
+    type Output = Xyza;
+
+    fn mul(self, rhs: Xyza) -> Xyza {
+        rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl Div<f32> for Xyza {
+    type Output = Self;
+
+    fn div(self, rhs: f32) -> Self {
+        Self {
+            x: self.x / rhs,
+            y: self.y / rhs,
+            z: self.z / rhs,
+            alpha: self.alpha,
+        }
+    }
+}
+
+/// All color channels are added directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Add<Self> for Xyza {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            x: self.x + rhs.x,
+            y: self.y + rhs.y,
+            z: self.z + rhs.z,
+            alpha: add_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are subtracted directly
+/// but alpha is blended
+///
+/// Values are not clamped
+impl Sub<Self> for Xyza {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            x: self.x - rhs.x,
+            y: self.y - rhs.y,
+            z: self.z - rhs.z,
+            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+impl Point for Xyza {}
 
 impl From<LinearRgba> for Xyza {
     fn from(

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,6 +1,7 @@
-use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
-
-use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
+use crate::{
+    add_alpha_blend, impl_color_add, impl_color_div, impl_color_mul, impl_color_neg,
+    impl_color_sub, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor,
+};
 use bevy_math::cubic_splines::Point;
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use serde::{Deserialize, Serialize};
@@ -137,132 +138,11 @@ impl Mix for Xyza {
     }
 }
 
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Xyza {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self {
-        Self {
-            x: self.x * rhs,
-            y: self.y * rhs,
-            z: self.z * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<Xyza> for f32 {
-    type Output = Xyza;
-
-    fn mul(self, rhs: Xyza) -> Xyza {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl MulAssign<f32> for Xyza {
-    fn mul_assign(&mut self, rhs: f32) {
-        *self = *self * rhs;
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Xyza {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self {
-        Self {
-            x: self.x / rhs,
-            y: self.y / rhs,
-            z: self.z / rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Add<Self> for Xyza {
-    type Output = Self;
-
-    fn add(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            x: self.x + rhs.x,
-            y: self.y + rhs.y,
-            z: self.z + rhs.z,
-            alpha: add_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are added directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl AddAssign<Self> for Xyza {
-    fn add_assign(&mut self, rhs: Self) {
-        *self = *self + rhs;
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl Sub<Self> for Xyza {
-    type Output = Self;
-
-    fn sub(self, rhs: Self) -> Self::Output {
-        Self::Output {
-            x: self.x - rhs.x,
-            y: self.y - rhs.y,
-            z: self.z - rhs.z,
-            alpha: sub_alpha_blend(self.alpha, rhs.alpha),
-        }
-    }
-}
-
-/// All color channels are subtracted directly
-/// but alpha is blended
-///
-/// Values are not clamped
-impl SubAssign<Self> for Xyza {
-    fn sub_assign(&mut self, rhs: Self) {
-        *self = *self - rhs;
-    }
-}
-
-/// All color channels are negated directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped
-impl Neg for Xyza {
-    type Output = Self;
-
-    fn neg(self) -> Self::Output {
-        Self::Output {
-            x: -self.x,
-            y: -self.y,
-            z: -self.z,
-            alpha: self.alpha,
-        }
-    }
-}
+impl_color_add!(Xyza, [x, y, z]);
+impl_color_sub!(Xyza, [x, y, z]);
+impl_color_mul!(Xyza, [x, y, z]);
+impl_color_div!(Xyza, [x, y, z]);
+impl_color_neg!(Xyza, [x, y, z]);
 
 impl Point for Xyza {}
 

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Div, Mul, MulAssign, Neg, Sub, SubAssign};
 
 use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
 use bevy_math::cubic_splines::Point;
@@ -163,6 +163,16 @@ impl Mul<Xyza> for f32 {
 
     fn mul(self, rhs: Xyza) -> Xyza {
         rhs * self
+    }
+}
+
+/// All color channels are scaled directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped.
+impl MulAssign<f32> for Xyza {
+    fn mul_assign(&mut self, rhs: f32) {
+        *self = *self * rhs;
     }
 }
 

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Div, Mul, Sub};
+use std::ops::{Add, AddAssign, Div, Mul, Neg, Sub};
 
 use crate::{add_alpha_blend, sub_alpha_blend, Alpha, LinearRgba, Luminance, Mix, StandardColor};
 use bevy_math::cubic_splines::Point;
@@ -223,6 +223,23 @@ impl Sub<Self> for Xyza {
             y: self.y - rhs.y,
             z: self.z - rhs.z,
             alpha: sub_alpha_blend(self.alpha, rhs.alpha),
+        }
+    }
+}
+
+/// All color channels are negated directly,
+/// but alpha is unchanged.
+///
+/// Values are not clamped
+impl Neg for Xyza {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        Self::Output {
+            x: -self.x,
+            y: -self.y,
+            z: -self.z,
+            alpha: self.alpha,
         }
     }
 }


### PR DESCRIPTION
# Objective

- Adds Addition and subtraction as well as scalar multiplication/division for colors, suggestion of #12202 

## Solution

- All of the above operations add/mul/sub/div the color channels of all color types directly (similar to what was already possible for `Srgba`.
- The alpha channel is blended for addition and subtraction according to 
  - `alpha_result = alpha_a + alpha_b * (1 - alpha_a)` for addition and
  - `alpha_result = alpha_a * (1 - alpha_b)` for subtraction
These are common alpha blending functions and ensure that when `alpha_b` and `alpha_a` are in `0..1`, `alpha_result` will be in `0..1` as well.
- For scalar multiplication/division the alpha channel is left unchanged.
- By adding the above operations, `bevy_math::cubic_splines::Point` could also be implemented.

## Additional information
<del>I have added `Add<Color> for Color` and `Sub<Color> for Color` as well but these require a lot of conversion between color spaces which is not optimal. I am not sure whether we should allow adding `Color`s. </del>