### PR TITLE
Fix: deserialize `DynamicEnum` using index

### DIFF
--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1253,7 +1253,6 @@ mod tests {
             ),
         }"#;
 
-        let registry = get_registry();
         let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
         let mut ron_deserializer = ron::de::Deserializer::from_str(input).unwrap();
         let dynamic_output = reflect_deserializer
@@ -1437,30 +1436,19 @@ mod tests {
 
     // Regression test for https://github.com/bevyengine/bevy/issues/12462
     #[test]
-    fn enum_should_be_correct_variant_on_reserialize() {
-        #[derive(Reflect, Default)]
-        enum MyEnum {
-            #[default]
-            Unit,
-            Tuple(String),
-            Struct {
-                value: u32,
-            },
-        }
+    fn should_reserialize() {
+        
+        let registry = get_registry();
+        let input1 = get_my_struct();
 
-        let mut registry = TypeRegistry::default();
-        registry.register::<MyEnum>();
-
-        let value = MyEnum::Tuple("Hello world".to_string());
-
-        let serializer1 = ReflectSerializer::new(&value, &registry);
+        let serializer1 = ReflectSerializer::new(&input1, &registry);
         let serialized1 = ron::ser::to_string(&serializer1).unwrap();
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized1).unwrap();
         let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
-        let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
+        let input2 = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 
-        let serializer2 = ReflectSerializer::new(&*value, &registry);
+        let serializer2 = ReflectSerializer::new(&*input2, &registry);
         let serialized2 = ron::ser::to_string(&serializer2).unwrap();
 
         assert_eq!(serialized1, serialized2);

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1170,12 +1170,11 @@ mod tests {
         registry
     }
 
-    #[test]
-    fn should_deserialize() {
+    fn get_my_struct()->MyStruct{
         let mut map = HashMap::new();
         map.insert(64, 32);
 
-        let expected = MyStruct {
+        MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
             option_value_complex: Some(SomeStruct { foo: 123 }),
@@ -1202,7 +1201,14 @@ mod tests {
                 value: 100,
                 inner_struct: SomeDeserializableStruct { foo: 101 },
             },
-        };
+        }
+    }
+
+    #[test]
+    fn should_deserialize() {
+
+        let expected = get_my_struct();
+        let registry = get_registry();
 
         let input = r#"{
             "bevy_reflect::serde::de::tests::MyStruct": (
@@ -1462,38 +1468,8 @@ mod tests {
 
     #[test]
     fn should_deserialize_non_self_describing_binary() {
-        let mut map = HashMap::new();
-        map.insert(64, 32);
 
-        let expected = MyStruct {
-            primitive_value: 123,
-            option_value: Some(String::from("Hello world!")),
-            option_value_complex: Some(SomeStruct { foo: 123 }),
-            tuple_value: (PI, 1337),
-            list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
-            map_value: map,
-            struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
-            unit_struct: SomeUnitStruct,
-            unit_enum: SomeEnum::Unit,
-            newtype_enum: SomeEnum::NewType(123),
-            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
-            struct_enum: SomeEnum::Struct {
-                foo: String::from("Struct variant value"),
-            },
-            ignored_struct: SomeIgnoredStruct { ignored: 0 },
-            ignored_tuple_struct: SomeIgnoredTupleStruct(0),
-            ignored_struct_variant: SomeIgnoredEnum::Struct {
-                foo: String::default(),
-            },
-            ignored_tuple_variant: SomeIgnoredEnum::Tuple(0.0, 0.0),
-            custom_deserialize: CustomDeserialize {
-                value: 100,
-                inner_struct: SomeDeserializableStruct { foo: 101 },
-            },
-        };
-
+        let expected = get_my_struct();
         let registry = get_registry();
 
         let input = vec![
@@ -1525,38 +1501,8 @@ mod tests {
 
     #[test]
     fn should_deserialize_self_describing_binary() {
-        let mut map = HashMap::new();
-        map.insert(64, 32);
 
-        let expected = MyStruct {
-            primitive_value: 123,
-            option_value: Some(String::from("Hello world!")),
-            option_value_complex: Some(SomeStruct { foo: 123 }),
-            tuple_value: (PI, 1337),
-            list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
-            map_value: map,
-            struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
-            unit_struct: SomeUnitStruct,
-            unit_enum: SomeEnum::Unit,
-            newtype_enum: SomeEnum::NewType(123),
-            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
-            struct_enum: SomeEnum::Struct {
-                foo: String::from("Struct variant value"),
-            },
-            ignored_struct: SomeIgnoredStruct { ignored: 0 },
-            ignored_tuple_struct: SomeIgnoredTupleStruct(0),
-            ignored_struct_variant: SomeIgnoredEnum::Struct {
-                foo: String::default(),
-            },
-            ignored_tuple_variant: SomeIgnoredEnum::Tuple(0.0, 0.0),
-            custom_deserialize: CustomDeserialize {
-                value: 100,
-                inner_struct: SomeDeserializableStruct { foo: 101 },
-            },
-        };
-
+        let expected = get_my_struct();
         let registry = get_registry();
 
         let input = vec![

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1062,7 +1062,7 @@ mod tests {
     use bevy_utils::HashMap;
 
     use crate as bevy_reflect;
-    use crate::serde::{TypedReflectDeserializer, UntypedReflectDeserializer};
+    use crate::serde::{ReflectSerializer, TypedReflectDeserializer, UntypedReflectDeserializer};
     use crate::{DynamicEnum, FromReflect, Reflect, ReflectDeserialize, TypeRegistry};
 
     #[derive(Reflect, Debug, PartialEq)]
@@ -1427,6 +1427,37 @@ mod tests {
             value: String::from("I <3 Enums"),
         });
         assert!(expected.reflect_partial_eq(output.as_ref()).unwrap());
+    }
+
+    // Regression test for https://github.com/bevyengine/bevy/issues/12462
+    #[test]
+    fn enum_should_be_correct_variant_on_reserialize() {
+        #[derive(Reflect, Default)]
+        enum MyEnum {
+            #[default]
+            Unit,
+            Tuple(String),
+            Struct {
+                value: u32,
+            },
+        }
+
+        let mut registry = TypeRegistry::default();
+        registry.register::<MyEnum>();
+
+        let value = MyEnum::Tuple("Hello world".to_string());
+
+        let serializer1 = ReflectSerializer::new(&value, &registry);
+        let serialized1 = ron::ser::to_string(&serializer1).unwrap();
+
+        let mut deserializer = ron::de::Deserializer::from_str(&serialized1).unwrap();
+        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
+
+        let serializer2 = ReflectSerializer::new(&*value, &registry);
+        let serialized2 = ron::ser::to_string(&serializer2).unwrap();
+
+        assert_eq!(serialized1, serialized2);
     }
 
     #[test]

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -1120,7 +1120,7 @@ mod tests {
     #[reflect(Deserialize)]
     struct CustomDeserialize {
         value: usize,
-        #[serde(rename = "renamed")]
+        #[serde(alias = "renamed")]
         inner_struct: SomeDeserializableStruct,
     }
 
@@ -1170,7 +1170,7 @@ mod tests {
         registry
     }
 
-    fn get_my_struct()->MyStruct{
+    fn get_my_struct() -> MyStruct {
         let mut map = HashMap::new();
         map.insert(64, 32);
 
@@ -1206,7 +1206,6 @@ mod tests {
 
     #[test]
     fn should_deserialize() {
-
         let expected = get_my_struct();
         let registry = get_registry();
 
@@ -1437,7 +1436,6 @@ mod tests {
     // Regression test for https://github.com/bevyengine/bevy/issues/12462
     #[test]
     fn should_reserialize() {
-        
         let registry = get_registry();
         let input1 = get_my_struct();
 
@@ -1456,7 +1454,6 @@ mod tests {
 
     #[test]
     fn should_deserialize_non_self_describing_binary() {
-
         let expected = get_my_struct();
         let registry = get_registry();
 
@@ -1489,7 +1486,6 @@ mod tests {
 
     #[test]
     fn should_deserialize_self_describing_binary() {
-
         let expected = get_my_struct();
         let registry = get_registry();
 

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -753,8 +753,12 @@ impl<'a, 'de> Visitor<'de> for EnumVisitor<'a> {
                 )?
                 .into(),
         };
-
-        dynamic_enum.set_variant(variant_info.name(), value);
+        let variant_name = variant_info.name();
+        let variant_index = self
+            .enum_info
+            .index_of(variant_name)
+            .expect("variant should exist");
+        dynamic_enum.set_variant_with_index(variant_index, variant_name, value);
         Ok(dynamic_enum)
     }
 }

--- a/crates/bevy_reflect/src/serde/ser.rs
+++ b/crates/bevy_reflect/src/serde/ser.rs
@@ -574,12 +574,10 @@ mod tests {
         registry
     }
 
-    #[test]
-    fn should_serialize() {
+    fn get_my_struct() -> MyStruct {
         let mut map = HashMap::new();
         map.insert(64, 32);
-
-        let input = MyStruct {
+        MyStruct {
             primitive_value: 123,
             option_value: Some(String::from("Hello world!")),
             option_value_complex: Some(SomeStruct { foo: 123 }),
@@ -606,9 +604,14 @@ mod tests {
                 value: 100,
                 inner_struct: SomeSerializableStruct { foo: 101 },
             },
-        };
+        }
+    }
 
+    #[test]
+    fn should_serialize() {
+        let input = get_my_struct();
         let registry = get_registry();
+
         let serializer = ReflectSerializer::new(&input, &registry);
 
         let config = PrettyConfig::default()
@@ -776,38 +779,7 @@ mod tests {
 
     #[test]
     fn should_serialize_non_self_describing_binary() {
-        let mut map = HashMap::new();
-        map.insert(64, 32);
-
-        let input = MyStruct {
-            primitive_value: 123,
-            option_value: Some(String::from("Hello world!")),
-            option_value_complex: Some(SomeStruct { foo: 123 }),
-            tuple_value: (PI, 1337),
-            list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
-            map_value: map,
-            struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
-            unit_struct: SomeUnitStruct,
-            unit_enum: SomeEnum::Unit,
-            newtype_enum: SomeEnum::NewType(123),
-            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
-            struct_enum: SomeEnum::Struct {
-                foo: String::from("Struct variant value"),
-            },
-            ignored_struct: SomeIgnoredStruct { ignored: 123 },
-            ignored_tuple_struct: SomeIgnoredTupleStruct(123),
-            ignored_struct_variant: SomeIgnoredEnum::Struct {
-                foo: String::from("Struct Variant"),
-            },
-            ignored_tuple_variant: SomeIgnoredEnum::Tuple(1.23, 3.45),
-            custom_serialize: CustomSerialize {
-                value: 100,
-                inner_struct: SomeSerializableStruct { foo: 101 },
-            },
-        };
-
+        let input = get_my_struct();
         let registry = get_registry();
 
         let serializer = ReflectSerializer::new(&input, &registry);
@@ -834,38 +806,7 @@ mod tests {
 
     #[test]
     fn should_serialize_self_describing_binary() {
-        let mut map = HashMap::new();
-        map.insert(64, 32);
-
-        let input = MyStruct {
-            primitive_value: 123,
-            option_value: Some(String::from("Hello world!")),
-            option_value_complex: Some(SomeStruct { foo: 123 }),
-            tuple_value: (PI, 1337),
-            list_value: vec![-2, -1, 0, 1, 2],
-            array_value: [-2, -1, 0, 1, 2],
-            map_value: map,
-            struct_value: SomeStruct { foo: 999999999 },
-            tuple_struct_value: SomeTupleStruct(String::from("Tuple Struct")),
-            unit_struct: SomeUnitStruct,
-            unit_enum: SomeEnum::Unit,
-            newtype_enum: SomeEnum::NewType(123),
-            tuple_enum: SomeEnum::Tuple(1.23, 3.21),
-            struct_enum: SomeEnum::Struct {
-                foo: String::from("Struct variant value"),
-            },
-            ignored_struct: SomeIgnoredStruct { ignored: 123 },
-            ignored_tuple_struct: SomeIgnoredTupleStruct(123),
-            ignored_struct_variant: SomeIgnoredEnum::Struct {
-                foo: String::from("Struct Variant"),
-            },
-            ignored_tuple_variant: SomeIgnoredEnum::Tuple(1.23, 3.45),
-            custom_serialize: CustomSerialize {
-                value: 100,
-                inner_struct: SomeSerializableStruct { foo: 101 },
-            },
-        };
-
+        let input = get_my_struct();
         let registry = get_registry();
 
         let serializer = ReflectSerializer::new(&input, &registry);

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -693,32 +693,6 @@ mod tests {
         assert_eq!(1, dst_world.query::<&Baz>().iter(&dst_world).count());
     }
 
-    // Regression test for https://github.com/bevyengine/bevy/issues/12462
-    #[test]
-    fn should_reserialize() {
-        let mut world = create_world();
-
-        world.spawn(MyComponent {
-            foo: [1, 2, 3],
-            bar: (1.3, 3.7),
-            baz: MyEnum::Tuple("Hello World!".to_string()),
-        });
-
-        let registry = world.resource::<AppTypeRegistry>();
-        let scene = DynamicScene::from_world(&world);
-        let serialized_scene1 = scene.serialize_ron(&registry.0).unwrap();
-
-        let scene_deserializer = SceneDeserializer {
-            type_registry: &registry.0.read(),
-        };
-        let mut deserializer = ron::de::Deserializer::from_str(&serialized_scene1).unwrap();
-        let deserialized_scene = scene_deserializer.deserialize(&mut deserializer).unwrap();
-
-        let serialized_scene2 = deserialized_scene.serialize_ron(&registry.0).unwrap();
-
-        assert_eq!(serialized_scene1, serialized_scene2);
-    }
-
     #[test]
     fn should_roundtrip_with_later_generations_and_obsolete_references() {
         let mut world = create_world();

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -693,6 +693,7 @@ mod tests {
         assert_eq!(1, dst_world.query::<&Baz>().iter(&dst_world).count());
     }
 
+    // Regression test regarding [#12462](https://github.com/bevyengine/bevy/issues/12462)
     #[test]
     fn should_reserialize() {
         let mut world = create_world();

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -693,7 +693,7 @@ mod tests {
         assert_eq!(1, dst_world.query::<&Baz>().iter(&dst_world).count());
     }
 
-    // Regression test regarding [#12462](https://github.com/bevyengine/bevy/issues/12462)
+    // Regression test for https://github.com/bevyengine/bevy/issues/12462
     #[test]
     fn should_reserialize() {
         let mut world = create_world();

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -694,6 +694,31 @@ mod tests {
     }
 
     #[test]
+    fn should_reserialize() {
+        let mut world = create_world();
+
+        world.spawn(MyComponent {
+            foo: [1, 2, 3],
+            bar: (1.3, 3.7),
+            baz: MyEnum::Tuple("Hello World!".to_string()),
+        });
+
+        let registry = world.resource::<AppTypeRegistry>();
+        let scene = DynamicScene::from_world(&world);
+        let serialized_scene1 = scene.serialize_ron(&registry.0).unwrap();
+
+        let scene_deserializer = SceneDeserializer {
+            type_registry: &registry.0.read(),
+        };
+        let mut deserializer = ron::de::Deserializer::from_str(&serialized_scene1).unwrap();
+        let deserialized_scene = scene_deserializer.deserialize(&mut deserializer).unwrap();
+
+        let serialized_scene2 = deserialized_scene.serialize_ron(&registry.0).unwrap();
+
+        assert_eq!(serialized_scene1, serialized_scene2);
+    }
+
+    #[test]
     fn should_roundtrip_with_later_generations_and_obsolete_references() {
         let mut world = create_world();
 


### PR DESCRIPTION
# Objective

- Addresses #12462
- When we serialize an enum, deserialize it, then reserialize it, the correct variant should be selected.

## Solution

- Change `dynamic_enum.set_variant` to `dynamic_enum.set_variant_with_index` in `EnumVisitor`