### PR TITLE
change doc for SphereKind::Ico to reflect that the triangles are equa…

### DIFF
--- a/crates/bevy_render/src/mesh/primitives/dim3/sphere.rs
+++ b/crates/bevy_render/src/mesh/primitives/dim3/sphere.rs
@@ -25,7 +25,7 @@ pub enum IcosphereError {
 /// A type of sphere mesh.
 #[derive(Clone, Copy, Debug)]
 pub enum SphereKind {
-    /// An icosphere, a spherical mesh that consists of equally sized triangles.
+    /// An icosphere, a spherical mesh that consists of similar sized triangles.
     Ico {
         /// The number of subdivisions applied.
         /// The number of faces quadruples with each subdivision.


### PR DESCRIPTION
# Objective
Fixes #12480 
by removing the explicit mention of equally sized triangles from the doc for icospheres