### PR TITLE
order systems in axes example

### DIFF
--- a/examples/gizmos/axes.rs
+++ b/examples/gizmos/axes.rs
@@ -10,7 +10,7 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         .add_systems(Startup, setup)
-        .add_systems(Update, (move_cubes, draw_axes))
+        .add_systems(Update, (move_cubes, draw_axes).chain())
         .run();
 }
 


### PR DESCRIPTION
# Objective

- in example `axes`, the axes are sometime one frame late to follow their mesh

## Solution

- System `move_cubes` modify the transforms, and `draw_axes` query them for the axes
- if their order is not specified, it will be random and sometimes axes are drawn before transforms are updated
- order systems
