### PR TITLE
Make `from_reflect_or_world` also try `ReflectDefault` and improve some comments and panic messages

### DIFF
--- a/crates/bevy_ecs/src/reflect/bundle.rs
+++ b/crates/bevy_ecs/src/reflect/bundle.rs
@@ -9,7 +9,7 @@ use std::any::TypeId;
 use crate::{prelude::Bundle, world::EntityWorldMut};
 use bevy_reflect::{FromReflect, FromType, Reflect, ReflectRef, TypeRegistry};
 
-use super::ReflectComponent;
+use super::{from_reflect_with_fallback, ReflectComponent};
 
 /// A struct used to operate on reflected [`Bundle`] trait of a type.
 ///
@@ -24,7 +24,7 @@ pub struct ReflectBundle(ReflectBundleFns);
 #[derive(Clone)]
 pub struct ReflectBundleFns {
     /// Function pointer implementing [`ReflectBundle::insert()`].
-    pub insert: fn(&mut EntityWorldMut, &dyn Reflect),
+    pub insert: fn(&mut EntityWorldMut, &dyn Reflect, &TypeRegistry),
     /// Function pointer implementing [`ReflectBundle::apply()`].
     pub apply: fn(&mut EntityWorldMut, &dyn Reflect, &TypeRegistry),
     /// Function pointer implementing [`ReflectBundle::apply_or_insert()`].
@@ -46,8 +46,13 @@ impl ReflectBundleFns {
 
 impl ReflectBundle {
     /// Insert a reflected [`Bundle`] into the entity like [`insert()`](EntityWorldMut::insert).
-    pub fn insert(&self, entity: &mut EntityWorldMut, bundle: &dyn Reflect) {
-        (self.0.insert)(entity, bundle);
+    pub fn insert(
+        &self,
+        entity: &mut EntityWorldMut,
+        bundle: &dyn Reflect,
+        registry: &TypeRegistry,
+    ) {
+        (self.0.insert)(entity, bundle, registry);
     }
 
     /// Uses reflection to set the value of this [`Bundle`] type in the entity to the given value.
@@ -114,11 +119,13 @@ impl ReflectBundle {
     }
 }
 
-impl<B: Bundle + Reflect + FromReflect> FromType<B> for ReflectBundle {
+impl<B: Bundle + Reflect> FromType<B> for ReflectBundle {
     fn from_type() -> Self {
         ReflectBundle(ReflectBundleFns {
-            insert: |entity, reflected_bundle| {
-                let bundle = B::from_reflect(reflected_bundle).unwrap();
+            insert: |entity, reflected_bundle, registry| {
+                let bundle = entity.world_scope(|world| {
+                    from_reflect_with_fallback::<B>(reflected_bundle, world, registry)
+                });
                 entity.insert(bundle);
             },
             apply: |entity, reflected_bundle, registry| {

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -253,7 +253,7 @@ impl ReflectComponent {
     }
 }
 
-impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
+impl<C: Component + Reflect> FromType<C> for ReflectComponent {
     fn from_type() -> Self {
         ReflectComponent(ReflectComponentFns {
             insert: |entity, reflected_component, registry| {

--- a/crates/bevy_ecs/src/reflect/component.rs
+++ b/crates/bevy_ecs/src/reflect/component.rs
@@ -57,7 +57,7 @@
 //!
 //! [`get_type_registration`]: bevy_reflect::GetTypeRegistration::get_type_registration
 
-use super::from_reflect_or_world;
+use super::from_reflect_with_fallback;
 use crate::{
     change_detection::Mut,
     component::Component,
@@ -258,7 +258,7 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
         ReflectComponent(ReflectComponentFns {
             insert: |entity, reflected_component, registry| {
                 let component = entity.world_scope(|world| {
-                    from_reflect_or_world::<C>(reflected_component, world, registry)
+                    from_reflect_with_fallback::<C>(reflected_component, world, registry)
                 });
                 entity.insert(component);
             },
@@ -271,7 +271,7 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
                     component.apply(reflected_component);
                 } else {
                     let component = entity.world_scope(|world| {
-                        from_reflect_or_world::<C>(reflected_component, world, registry)
+                        from_reflect_with_fallback::<C>(reflected_component, world, registry)
                     });
                     entity.insert(component);
                 }
@@ -283,7 +283,7 @@ impl<C: Component + Reflect + FromReflect> FromType<C> for ReflectComponent {
             copy: |source_world, destination_world, source_entity, destination_entity, registry| {
                 let source_component = source_world.get::<C>(source_entity).unwrap();
                 let destination_component =
-                    from_reflect_or_world::<C>(source_component, destination_world, registry);
+                    from_reflect_with_fallback::<C>(source_component, destination_world, registry);
                 destination_world
                     .entity_mut(destination_entity)
                     .insert(destination_component);

--- a/crates/bevy_ecs/src/reflect/resource.rs
+++ b/crates/bevy_ecs/src/reflect/resource.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use bevy_reflect::{FromReflect, FromType, Reflect, TypeRegistry};
 
-use super::from_reflect_or_world;
+use super::from_reflect_with_fallback;
 
 /// A struct used to operate on reflected [`Resource`] of a type.
 ///
@@ -180,7 +180,7 @@ impl<R: Resource + FromReflect> FromType<R> for ReflectResource {
     fn from_type() -> Self {
         ReflectResource(ReflectResourceFns {
             insert: |world, reflected_resource, registry| {
-                let resource = from_reflect_or_world::<R>(reflected_resource, world, registry);
+                let resource = from_reflect_with_fallback::<R>(reflected_resource, world, registry);
                 world.insert_resource(resource);
             },
             apply: |world, reflected_resource| {
@@ -191,7 +191,8 @@ impl<R: Resource + FromReflect> FromType<R> for ReflectResource {
                 if let Some(mut resource) = world.get_resource_mut::<R>() {
                     resource.apply(reflected_resource);
                 } else {
-                    let resource = from_reflect_or_world::<R>(reflected_resource, world, registry);
+                    let resource =
+                        from_reflect_with_fallback::<R>(reflected_resource, world, registry);
                     world.insert_resource(resource);
                 }
             },
@@ -212,7 +213,7 @@ impl<R: Resource + FromReflect> FromType<R> for ReflectResource {
             copy: |source_world, destination_world, registry| {
                 let source_resource = source_world.resource::<R>();
                 let destination_resource =
-                    from_reflect_or_world::<R>(source_resource, destination_world, registry);
+                    from_reflect_with_fallback::<R>(source_resource, destination_world, registry);
                 destination_world.insert_resource(destination_resource);
             },
         })


### PR DESCRIPTION
# Objective

- `from_reflect_or_world` is an internal utilty used in the implementations of `ReflectComponent` and `ReflectBundle` to create a `T` given a `&dyn Reflect` by trying to use `FromReflect`, and if that fails it falls back to `ReflectFromWorld`
- reflecting `FromWorld` is not intuitive though: often it is implicitly implemented by deriving `Default` so people might not even be aware of it.
- the panic messages mentioning `ReflectFromWorld` are not directly correlated to what the user would have to do (reflect `FromWorld`)

## Solution

- Also check for `ReflectDefault` in addition to `ReflectFromWorld`.
- Change the panic messages to mention the reflected trait rather than the `Reflect*` types.

---

## Changelog

- `ReflectComponent` and `ReflectBundle` no longer require `T: FromReflect` but instead only `T: Reflect`.
- `ReflectComponent` and `ReflectBundle` will also work with types that only reflected `Default` and not `FromWorld`.

## Migration Guide

- `ReflectBundle::insert` now requires an additional `&TypeRegistry` parameter.