### PR TITLE
Return a static string for Enum::variant_name

### DIFF
--- a/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/impls/enums.rs
@@ -134,7 +134,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
                 }
             }
 
-            fn name_at(&self, #ref_index: usize) -> #FQOption<&str> {
+            fn name_at(&self, #ref_index: usize) -> #FQOption<&'static str> {
                  match self {
                     #(#enum_name_at,)*
                     _ => #FQOption::None,
@@ -154,7 +154,7 @@ pub(crate) fn impl_enum(reflect_enum: &ReflectEnum) -> proc_macro2::TokenStream 
             }
 
             #[inline]
-            fn variant_name(&self) -> &str {
+            fn variant_name(&self) -> &'static str {
                  match self {
                     #(#enum_variant_name,)*
                     _ => unreachable!(),

--- a/crates/bevy_reflect/src/enums/dynamic_enum.rs
+++ b/crates/bevy_reflect/src/enums/dynamic_enum.rs
@@ -72,7 +72,7 @@ impl From<()> for DynamicVariant {
 #[derive(Default, Debug)]
 pub struct DynamicEnum {
     represented_type: Option<&'static TypeInfo>,
-    variant_name: String,
+    variant_name: &'static str,
     variant_index: usize,
     variant: DynamicVariant,
 }
@@ -85,7 +85,7 @@ impl DynamicEnum {
     /// * `variant_name`: The name of the variant to set
     /// * `variant`: The variant data
     ///
-    pub fn new<I: Into<String>, V: Into<DynamicVariant>>(variant_name: I, variant: V) -> Self {
+    pub fn new<I: Into<&'static str>, V: Into<DynamicVariant>>(variant_name: I, variant: V) -> Self {
         Self {
             represented_type: None,
             variant_index: 0,
@@ -102,7 +102,7 @@ impl DynamicEnum {
     /// * `variant_name`: The name of the variant to set
     /// * `variant`: The variant data
     ///
-    pub fn new_with_index<I: Into<String>, V: Into<DynamicVariant>>(
+    pub fn new_with_index<I: Into<&'static str>, V: Into<DynamicVariant>>(
         variant_index: usize,
         variant_name: I,
         variant: V,
@@ -135,13 +135,13 @@ impl DynamicEnum {
     }
 
     /// Set the current enum variant represented by this struct.
-    pub fn set_variant<I: Into<String>, V: Into<DynamicVariant>>(&mut self, name: I, variant: V) {
+    pub fn set_variant<I: Into<&'static str>, V: Into<DynamicVariant>>(&mut self, name: I, variant: V) {
         self.variant_name = name.into();
         self.variant = variant.into();
     }
 
     /// Set the current enum variant represented by this struct along with its variant index.
-    pub fn set_variant_with_index<I: Into<String>, V: Into<DynamicVariant>>(
+    pub fn set_variant_with_index<I: Into<&'static str>, V: Into<DynamicVariant>>(
         &mut self,
         variant_index: usize,
         variant_name: I,
@@ -261,8 +261,8 @@ impl Enum for DynamicEnum {
         }
     }
 
-    fn variant_name(&self) -> &str {
-        &self.variant_name
+    fn variant_name(&self) -> &'static str {
+        self.variant_name
     }
 
     fn variant_index(&self) -> usize {
@@ -281,7 +281,7 @@ impl Enum for DynamicEnum {
         Self {
             represented_type: self.represented_type,
             variant_index: self.variant_index,
-            variant_name: self.variant_name.clone(),
+            variant_name: self.variant_name,
             variant: self.variant.clone(),
         }
     }

--- a/crates/bevy_reflect/src/enums/enum_trait.rs
+++ b/crates/bevy_reflect/src/enums/enum_trait.rs
@@ -113,7 +113,7 @@ pub trait Enum: Reflect {
     /// Returns the number of fields in the current variant.
     fn field_len(&self) -> usize;
     /// The name of the current variant.
-    fn variant_name(&self) -> &str;
+    fn variant_name(&self) -> &'static str;
     /// The index of the current variant.
     fn variant_index(&self) -> usize;
     /// The type of the current variant.

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1032,7 +1032,7 @@ impl<T: FromReflect + TypePath + GetTypeRegistration> Enum for Option<T> {
         None
     }
 
-    fn name_at(&self, _index: usize) -> Option<&str> {
+    fn name_at(&self, _index: usize) -> Option<&'static str> {
         None
     }
 
@@ -1049,7 +1049,7 @@ impl<T: FromReflect + TypePath + GetTypeRegistration> Enum for Option<T> {
     }
 
     #[inline]
-    fn variant_name(&self) -> &str {
+    fn variant_name(&self) -> &'static str {
         match self {
             Some(..) => "Some",
             None => "None",

--- a/crates/bevy_reflect/src/impls/std.rs
+++ b/crates/bevy_reflect/src/impls/std.rs
@@ -1032,7 +1032,7 @@ impl<T: FromReflect + TypePath + GetTypeRegistration> Enum for Option<T> {
         None
     }
 
-    fn name_at(&self, _index: usize) -> Option<&'static str> {
+    fn name_at(&self, _index: usize) -> Option<&str> {
         None
     }
 


### PR DESCRIPTION
# Objective

The `reflect::Enum::variant_name()` should return a static string; the name returned shouldn't depend on the lifetime of the enum itself. I'm using reflection with Enums in a library and I was expecting the `variant_name` function to give me a string that is indenpendent to my object's lifetime

Caveats:
- are there some cases where we wouldn't want to return a `&'static str`?
- we should probably have the same thing for `reflect::Enum::name_at()` but I wasn't able to get it working because of DynamicEnum




## Migration Guide


- `reflect::DynamicEnum` now requires a `&'static str` for the variant_name instead of a String

