### PR TITLE
stop retrying removed assets

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -934,6 +934,10 @@ pub fn prepare_materials<M: Material>(
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (id, material) in queued_assets.into_iter() {
+        if extracted_assets.removed.contains(&id) {
+            continue;
+        }
+
         match prepare_material(
             &material,
             &render_device,

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -402,6 +402,10 @@ pub fn prepare_assets<A: RenderAsset>(
     let mut param = param.into_inner();
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (id, extracted_asset) in queued_assets {
+        if extracted_assets.removed.contains(&id) {
+            continue;
+        }
+
         match extracted_asset.prepare_asset(&mut param) {
             Ok(prepared_asset) => {
                 render_assets.insert(id, prepared_asset);

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -572,6 +572,10 @@ pub fn prepare_materials_2d<M: Material2d>(
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (id, material) in queued_assets {
+        if extracted_assets.removed.contains(&id) {
+            continue;
+        }
+
         match prepare_material2d(
             &material,
             &render_device,

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -691,6 +691,10 @@ pub fn prepare_ui_materials<M: UiMaterial>(
 ) {
     let queued_assets = std::mem::take(&mut prepare_next_frame.assets);
     for (id, material) in queued_assets {
+        if extracted_assets.removed.contains(&id) {
+            continue;
+        }
+
         match prepare_ui_material(
             &material,
             &render_device,


### PR DESCRIPTION
# Objective

assets that don't load before they get removed are retried forever, causing buffer churn and slowdown.

## Solution

stop trying to prepare dead assets.