### PR TITLE
Add `Triangle3d` primitive to `bevy_math::primitives`

### DIFF
--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -376,10 +376,10 @@ impl Triangle2d {
     }
 
     /// Reverse the [`WindingOrder`] of the triangle
-    /// by swapping the second and third vertices
+    /// by swapping the first and last vertices
     #[inline(always)]
     pub fn reverse(&mut self) {
-        self.vertices.swap(1, 2);
+        self.vertices.swap(0, 2);
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim2.rs
+++ b/crates/bevy_math/src/primitives/dim2.rs
@@ -753,9 +753,9 @@ mod tests {
         assert_eq!(cw_triangle.winding_order(), WindingOrder::Clockwise);
 
         let ccw_triangle = Triangle2d::new(
-            Vec2::new(0.0, 2.0),
             Vec2::new(-1.0, -1.0),
             Vec2::new(-0.5, -1.2),
+            Vec2::new(0.0, 2.0),
         );
         assert_eq!(ccw_triangle.winding_order(), WindingOrder::CounterClockwise);
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -643,11 +643,11 @@ pub struct Triangle3d {
 impl Primitive3d for Triangle3d {}
 
 impl Default for Triangle3d {
-    /// Returns the default [`Triangle3d`] with the vertices `[0.5, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]`
+    /// Returns the default [`Triangle3d`] with the vertices `[0.0, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]`
     fn default() -> Self {
         Self {
             vertices: [
-                Vec3::new(0.5, 0.5, 0.0),
+                Vec3::new(0.0, 0.5, 0.0),
                 Vec3::new(-0.5, -0.5, 0.0),
                 Vec3::new(0.5, -0.5, 0.0),
             ],

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -746,9 +746,6 @@ impl Bounded3d for Triangle3d {
         rotation: glam::Quat,
     ) -> crate::bounding::BoundingSphere {
         let [a, b, c] = self.vertices;
-        let a = rotation * a + translation;
-        let b = rotation * b + translation;
-        let c = rotation * c + translation;
 
         let center = (a + b + c) / 3.0;
         let radius = (a - center)
@@ -756,6 +753,7 @@ impl Bounded3d for Triangle3d {
             .max((b - center).length())
             .max((c - center).length());
 
+        let center = rotation * center + translation;
         crate::bounding::BoundingSphere::new(center, radius)
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -709,7 +709,7 @@ impl Triangle3d {
         ab.cross(ac).length() < f32::EPSILON
     }
 
-    /// Reverse the order of the vertices in the triangle
+    /// Reverse the order of the vertices in the triangle.
     #[inline(always)]
     pub fn reverse(&mut self) {
         self.vertices.swap(1, 2);

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -679,7 +679,10 @@ impl Triangle3d {
         ab + bc + ca
     }
 
-    /// Get the normal of the triangle
+    /// Get the normal of the triangle in the direction of the right-hand rule, assuming
+    /// the vertices are ordered in a counter-clockwise direction.
+    /// 
+    /// The normal is computed as the cross product of the vectors `ab` and `ac`.
     #[inline(always)]
     pub fn normal(&self) -> Dir3 {
         let [a, b, c] = self.vertices;

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -681,7 +681,7 @@ impl Triangle3d {
 
     /// Get the normal of the triangle in the direction of the right-hand rule, assuming
     /// the vertices are ordered in a counter-clockwise direction.
-    /// 
+    ///
     /// The normal is computed as the cross product of the vectors `ab` and `ac`.
     #[inline(always)]
     pub fn normal(&self) -> Dir3 {
@@ -689,6 +689,12 @@ impl Triangle3d {
         let ab = b - a;
         let ac = c - a;
         Dir3::new_unchecked(ab.cross(ac).normalize())
+    }
+
+    /// Reverse the order of the vertices in the triangle
+    #[inline(always)]
+    pub fn reverse(&mut self) {
+        self.vertices.swap(1, 2);
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -709,10 +709,10 @@ impl Triangle3d {
         ab.cross(ac).length() < f32::EPSILON
     }
 
-    /// Reverse the order of the vertices in the triangle.
+    /// Reverse the triangle by swapping the first and last vertices.
     #[inline(always)]
     pub fn reverse(&mut self) {
-        self.vertices.swap(1, 2);
+        self.vertices.swap(0, 2);
     }
 
     /// Get the centroid of the triangle.
@@ -757,13 +757,13 @@ impl Bounded3d for Triangle3d {
     }
 
     /// Get the bounding sphere of the triangle.
-    /// 
+    ///
     /// The [`Triangle3d`] implements the minimal bounding sphere calculation. For acute triangles, the circumcenter is used as
     /// the center of the sphere. For the others, the bounding sphere is the minimal sphere
     /// that contains the largest side of the triangle.
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the triangle is degenerate.
     fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
         let [a, b, c] = self.vertices;

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -731,6 +731,7 @@ impl Triangle3d {
         let [a, b, c] = self.vertices;
         let ab = b - a;
         let ac = c - a;
+        // Reference: https://gamedev.stackexchange.com/questions/60630/how-do-i-find-the-circumcenter-of-a-triangle-in-3d
         let m = a
             + ((ac.length_squared() * ab.cross(ac).cross(ab)
                 + ab.length_squared() * ac.cross(ab).cross(ac))

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -636,14 +636,14 @@ impl Torus {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
 pub struct Triangle3d {
-    /// The vertices of the triangle
+    /// The vertices of the triangle.
     pub vertices: [Vec3; 3],
 }
 
 impl Primitive3d for Triangle3d {}
 
 impl Default for Triangle3d {
-    /// Returns the default [`Triangle3d`] with the vertices `[0.0, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]`
+    /// Returns the default [`Triangle3d`] with the vertices `[0.0, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]`.
     fn default() -> Self {
         Self {
             vertices: [
@@ -656,7 +656,7 @@ impl Default for Triangle3d {
 }
 
 impl Triangle3d {
-    /// Create a new [`Triangle3d`] from points `a`, `b`, and `c`
+    /// Create a new [`Triangle3d`] from points `a`, `b`, and `c`.
     #[inline(always)]
     pub fn new(a: Vec3, b: Vec3, c: Vec3) -> Self {
         Self {
@@ -664,7 +664,7 @@ impl Triangle3d {
         }
     }
 
-    /// Get the area of the triangle
+    /// Get the area of the triangle.
     #[inline(always)]
     pub fn area(&self) -> f32 {
         let [a, b, c] = self.vertices;
@@ -673,7 +673,7 @@ impl Triangle3d {
         ab.cross(ac).length() / 2.0
     }
 
-    /// Get the perimeter of the triangle
+    /// Get the perimeter of the triangle.
     #[inline(always)]
     pub fn perimeter(&self) -> f32 {
         let [a, b, c] = self.vertices;
@@ -715,17 +715,17 @@ impl Triangle3d {
         self.vertices.swap(1, 2);
     }
 
-    /// Get the centroid of the triangle
+    /// Get the centroid of the triangle.
     ///
     /// This function finds the geometric center of the triangle by averaging the vertices:
-    /// `centroid = (a + b + c) / 3`
+    /// `centroid = (a + b + c) / 3`.
     #[doc(alias("center", "barycenter", "baricenter"))]
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0
     }
 
-    /// Get the circumcenter of the triangle
+    /// Get the circumcenter of the triangle.
     #[inline(always)]
     pub fn circumcenter(&self) -> Vec3 {
         let [a, b, c] = self.vertices;
@@ -739,7 +739,7 @@ impl Triangle3d {
 }
 
 impl Bounded3d for Triangle3d {
-    /// Get the bounding box of the triangle
+    /// Get the bounding box of the triangle.
     fn aabb_3d(&self, translation: Vec3, rotation: Quat) -> Aabb3d {
         let [a, b, c] = self.vertices;
 
@@ -756,7 +756,15 @@ impl Bounded3d for Triangle3d {
         Aabb3d::new(bounding_center, half_extents)
     }
 
-    /// Get the bounding sphere of the triangle
+    /// Get the bounding sphere of the triangle.
+    /// 
+    /// The [`Triangle3d`] implements the minimal bounding sphere calculation. For acute triangles, the circumcenter is used as
+    /// the center of the sphere. For the others, the bounding sphere is the minimal sphere
+    /// that contains the largest side of the triangle.
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the triangle is degenerate.
     fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
         let [a, b, c] = self.vertices;
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -753,15 +753,11 @@ impl Bounded3d for Triangle3d {
         let bounding_center = (max + min) / 2.0 + translation;
         let half_extents = (max - min) / 2.0;
 
-        crate::bounding::Aabb3d::new(bounding_center, half_extents)
+        Aabb3d::new(bounding_center, half_extents)
     }
 
     /// Get the bounding sphere of the triangle
-    fn bounding_sphere(
-        &self,
-        translation: Vec3,
-        rotation: Quat,
-    ) -> crate::bounding::BoundingSphere {
+    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
         let [a, b, c] = self.vertices;
 
         let side_opposite_to_non_acute = if (b - a).dot(c - a) <= 0.0 {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -699,6 +699,10 @@ impl Triangle3d {
     }
 
     /// Get the centroid of the triangle
+    ///
+    /// This function finds the geometric center of the triangle by averaging the vertices:
+    /// `centroid = (a + b + c) / 3`
+    #[doc(alias("center"))]
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -664,7 +664,7 @@ impl Triangle3d {
         let ab = a.distance(b);
         let bc = b.distance(c);
         let ca = c.distance(a);
-        
+
         let s = (ab + bc + ca) / 2.0;
         (s * (s - ab) * (s - bc) * (s - ca)).sqrt()
     }
@@ -677,6 +677,15 @@ impl Triangle3d {
         let bc = b.distance(c);
         let ca = c.distance(a);
         ab + bc + ca
+    }
+
+    /// Get the normal of the triangle
+    #[inline(always)]
+    pub fn normal(&self) -> Dir3 {
+        let [a, b, c] = self.vertices;
+        let ab = b - a;
+        let ac = c - a;
+        Dir3::new_unchecked(ab.cross(ac).normalize())
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -713,9 +713,9 @@ impl Bounded3d for Triangle3d {
     /// Get the bounding box of the triangle
     fn aabb_3d(&self, translation: Vec3, rotation: glam::Quat) -> crate::bounding::Aabb3d {
         let [a, b, c] = self.vertices;
-        let a = rotation * a + translation;
-        let b = rotation * b + translation;
-        let c = rotation * c + translation;
+        let a = rotation * a;
+        let b = rotation * b;
+        let c = rotation * c;
 
         let min_x = a.x.min(b.x).min(c.x);
         let min_y = a.y.min(b.y).min(c.y);
@@ -728,7 +728,7 @@ impl Bounded3d for Triangle3d {
             (min_x + max_x) / 2.0,
             (min_y + max_y) / 2.0,
             (min_z + max_z) / 2.0,
-        );
+        ) + translation;
 
         let half_extents = Vec3::new(
             (max_x - min_x) / 2.0,

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -696,6 +696,12 @@ impl Triangle3d {
     pub fn reverse(&mut self) {
         self.vertices.swap(1, 2);
     }
+
+    /// Get the centroid of the triangle
+    #[inline(always)]
+    pub fn centroid(&self) -> Vec3 {
+        (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0
+    }
 }
 
 #[cfg(test)]

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -643,7 +643,7 @@ pub struct Triangle3d {
 impl Primitive3d for Triangle3d {}
 
 impl Default for Triangle3d {
-    /// Returns the default [`Triangle3d`] with the vertices `[0.5, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]
+    /// Returns the default [`Triangle3d`] with the vertices `[0.5, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]`
     fn default() -> Self {
         Self {
             vertices: [

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -692,6 +692,18 @@ impl Triangle3d {
         Dir3::new_unchecked(ab.cross(ac).normalize())
     }
 
+    /// Checks if the triangle is degenerate, meaning it has zero area.
+    ///
+    /// A triangle is degenerate if the cross product of the vectors `ab` and `ac` has a length less than `f32::EPSILON`.
+    /// This indicates that the three vertices are collinear or nearly collinear.
+    #[inline(always)]
+    pub fn is_degenerate(&self) -> bool {
+        let [a, b, c] = self.vertices;
+        let ab = b - a;
+        let ac = c - a;
+        ab.cross(ac).length() < f32::EPSILON
+    }
+
     /// Reverse the order of the vertices in the triangle
     #[inline(always)]
     pub fn reverse(&mut self) {

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -719,7 +719,7 @@ impl Triangle3d {
     ///
     /// This function finds the geometric center of the triangle by averaging the vertices:
     /// `centroid = (a + b + c) / 3`
-    #[doc(alias("center", "barycenter"))]
+    #[doc(alias("center", "barycenter", "baricenter"))]
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -706,7 +706,7 @@ impl Triangle3d {
         let [a, b, c] = self.vertices;
         let ab = b - a;
         let ac = c - a;
-        ab.cross(ac).length() < f32::EPSILON
+        ab.cross(ac).length() < 10e-7
     }
 
     /// Reverse the triangle by swapping the first and last vertices.

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -732,11 +732,9 @@ impl Triangle3d {
         let ab = b - a;
         let ac = c - a;
         // Reference: https://gamedev.stackexchange.com/questions/60630/how-do-i-find-the-circumcenter-of-a-triangle-in-3d
-        let m = a
-            + ((ac.length_squared() * ab.cross(ac).cross(ab)
-                + ab.length_squared() * ac.cross(ab).cross(ac))
-                / (2.0 * ab.cross(ac).length_squared()));
-        m
+        let n = ab.cross(ac);
+        a + ((ac.length_squared() * n.cross(ab) + ab.length_squared() * ac.cross(ab).cross(ac))
+            / (2.0 * n.length_squared()))
     }
 }
 

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -702,7 +702,7 @@ impl Triangle3d {
     ///
     /// This function finds the geometric center of the triangle by averaging the vertices:
     /// `centroid = (a + b + c) / 3`
-    #[doc(alias("center"))]
+    #[doc(alias("center", "baricenter", "barycenter"))]
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -643,7 +643,11 @@ impl Default for Triangle3d {
     /// Returns the default [`Triangle3d`] with vertices at the `[-0.5, 0.0, 0.0]`, `[0.5, 0.0, 0.0]`, and `[0.0, 0.5, 0.0]`
     fn default() -> Self {
         Self {
-            vertices: [Vec3::ZERO, Vec3::X, Vec3::Y],
+            vertices: [
+                Vec3::new(-0.5, 0.0, 0.0),
+                Vec3::new(0.5, 0.0, 0.0),
+                Vec3::new(0.0, 0.5, 0.0),
+            ],
         }
     }
 }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -719,7 +719,7 @@ impl Triangle3d {
     ///
     /// This function finds the geometric center of the triangle by averaging the vertices:
     /// `centroid = (a + b + c) / 3`
-    #[doc(alias("center", "baricenter", "barycenter"))]
+    #[doc(alias("center", "barycenter"))]
     #[inline(always)]
     pub fn centroid(&self) -> Vec3 {
         (self.vertices[0] + self.vertices[1] + self.vertices[2]) / 3.0

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -640,13 +640,13 @@ pub struct Triangle3d {
 impl Primitive3d for Triangle3d {}
 
 impl Default for Triangle3d {
-    /// Returns the default [`Triangle3d`] with vertices at the `[-0.5, 0.0, 0.0]`, `[0.5, 0.0, 0.0]`, and `[0.0, 0.5, 0.0]`
+    /// Returns the default [`Triangle3d`] with the vertices `[0.5, 0.5, 0.0]`, `[-0.5, -0.5, 0.0]`, and `[0.5, -0.5, 0.0]
     fn default() -> Self {
         Self {
             vertices: [
-                Vec3::new(-0.5, 0.0, 0.0),
-                Vec3::new(0.5, 0.0, 0.0),
-                Vec3::new(0.0, 0.5, 0.0),
+                Vec3::new(0.5, 0.5, 0.0),
+                Vec3::new(-0.5, -0.5, 0.0),
+                Vec3::new(0.5, -0.5, 0.0),
             ],
         }
     }

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -661,12 +661,9 @@ impl Triangle3d {
     #[inline(always)]
     pub fn area(&self) -> f32 {
         let [a, b, c] = self.vertices;
-        let ab = a.distance(b);
-        let bc = b.distance(c);
-        let ca = c.distance(a);
-
-        let s = (ab + bc + ca) / 2.0;
-        (s * (s - ab) * (s - bc) * (s - ca)).sqrt()
+        let ab = b - a;
+        let ac = c - a;
+        ab.cross(ac).length() / 2.0
     }
 
     /// Get the perimeter of the triangle

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -629,6 +629,57 @@ impl Torus {
     }
 }
 
+/// A 3D triangle primitive.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]
+pub struct Triangle3d {
+    /// The vertices of the triangle
+    pub vertices: [Vec3; 3],
+}
+
+impl Primitive3d for Triangle3d {}
+
+impl Default for Triangle3d {
+    /// Returns the default [`Triangle3d`] with vertices at the `[-0.5, 0.0, 0.0]`, `[0.5, 0.0, 0.0]`, and `[0.0, 0.5, 0.0]`
+    fn default() -> Self {
+        Self {
+            vertices: [Vec3::ZERO, Vec3::X, Vec3::Y],
+        }
+    }
+}
+
+impl Triangle3d {
+    /// Create a new [`Triangle3d`] from points `a`, `b`, and `c`
+    #[inline(always)]
+    pub fn new(a: Vec3, b: Vec3, c: Vec3) -> Self {
+        Self {
+            vertices: [a, b, c],
+        }
+    }
+
+    /// Get the area of the triangle
+    #[inline(always)]
+    pub fn area(&self) -> f32 {
+        let [a, b, c] = self.vertices;
+        let ab = a.distance(b);
+        let bc = b.distance(c);
+        let ca = c.distance(a);
+        
+        let s = (ab + bc + ca) / 2.0;
+        (s * (s - ab) * (s - bc) * (s - ca)).sqrt()
+    }
+
+    /// Get the perimeter of the triangle
+    #[inline(always)]
+    pub fn perimeter(&self) -> f32 {
+        let [a, b, c] = self.vertices;
+        let ab = a.distance(b);
+        let bc = b.distance(c);
+        let ca = c.distance(a);
+        ab + bc + ca
+    }
+}
+
 #[cfg(test)]
 mod tests {
     // Reference values were computed by hand and/or with external tools

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -685,10 +685,7 @@ impl Triangle3d {
     #[inline(always)]
     pub fn perimeter(&self) -> f32 {
         let [a, b, c] = self.vertices;
-        let ab = a.distance(b);
-        let bc = b.distance(c);
-        let ca = c.distance(a);
-        ab + bc + ca
+        a.distance(b) + b.distance(c) + c.distance(a)
     }
 
     /// Get the normal of the triangle in the direction of the right-hand rule, assuming


### PR DESCRIPTION
# Context

[GitHub Discussion Link](https://github.com/bevyengine/bevy/discussions/12506)

# Objective

- **Clarity:** More explicit representation of a common geometric primitive.
- **Convenience:** Provide methods tailored to 3D triangles (area, perimeters, etc.).

## Solution

- Adding the `Triangle3d` primitive into the `bevy_math` crate.

---

## Changelog

### Added

- `Triangle3d` primitive to the `bevy_math` crate

### Changed

- `Triangle2d::reverse`: the first and last vertices are swapped instead of the second and third.