### PR TITLE
make example font_atlas_debug deterministic with a seeded random

### DIFF
--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -2,6 +2,7 @@
 //! Bevy uses `FontAtlas`'s under the hood to optimize text rendering.
 
 use bevy::{color::palettes::basic::YELLOW, prelude::*, text::FontAtlasSets};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 fn main() {
     App::new()
@@ -30,6 +31,9 @@ impl Default for State {
     }
 }
 
+#[derive(Resource, Deref, DerefMut)]
+struct SeededRng(StdRng);
+
 fn atlas_render_system(
     mut commands: Commands,
     mut state: ResMut<State>,
@@ -57,10 +61,15 @@ fn atlas_render_system(
     }
 }
 
-fn text_update_system(mut state: ResMut<State>, time: Res<Time>, mut query: Query<&mut Text>) {
+fn text_update_system(
+    mut state: ResMut<State>,
+    time: Res<Time>,
+    mut query: Query<&mut Text>,
+    mut seeded_rng: ResMut<SeededRng>,
+) {
     if state.timer.tick(time.delta()).finished() {
         for mut text in &mut query {
-            let c = rand::random::<u8>() as char;
+            let c = seeded_rng.gen::<u8>() as char;
             let string = &mut text.sections[0].value;
             if !string.contains(c) {
                 string.push(c);
@@ -95,4 +104,5 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
                 },
             ));
         });
+    commands.insert_resource(SeededRng(StdRng::seed_from_u64(19878367467713)));
 }


### PR DESCRIPTION
# Objective

- Make example font_atlas_debug deterministic so that it's easier to check for regression

## Solution

- Use a seeded random
