### PR TITLE
remove link to inexistent example

### DIFF
--- a/crates/bevy_transform/src/components/transform.rs
+++ b/crates/bevy_transform/src/components/transform.rs
@@ -30,9 +30,7 @@ use std::ops::Mul;
 /// # Examples
 ///
 /// - [`transform`]
-/// - [`global_vs_local_translation`]
 ///
-/// [`global_vs_local_translation`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/global_vs_local_translation.rs
 /// [`transform`]: https://github.com/bevyengine/bevy/blob/latest/examples/transforms/transform.rs
 #[derive(Component, Debug, PartialEq, Clone, Copy, Reflect)]
 #[cfg_attr(feature = "serialize", derive(serde::Serialize, serde::Deserialize))]


### PR DESCRIPTION
# Objective

the example `global_vs_local_translation` was removed in 3600c5a340 but this part of the documentation links to it

## Solution

yeet it