### PR TITLE
feat: derive some common traits on some UI types

### DIFF
--- a/crates/bevy_text/src/text.rs
+++ b/crates/bevy_text/src/text.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::Font;
 
-#[derive(Component, Debug, Clone, Reflect)]
+#[derive(Component, Debug, Clone, Default, Reflect)]
 #[reflect(Component, Default)]
 pub struct Text {
     pub sections: Vec<TextSection>,
@@ -16,16 +16,6 @@ pub struct Text {
     pub justify: JustifyText,
     /// How the text should linebreak when running out of the bounds determined by max_size
     pub linebreak_behavior: BreakLineOn,
-}
-
-impl Default for Text {
-    fn default() -> Self {
-        Self {
-            sections: Default::default(),
-            justify: JustifyText::Left,
-            linebreak_behavior: BreakLineOn::WordBoundary,
-        }
-    }
 }
 
 impl Text {
@@ -219,12 +209,13 @@ impl Default for TextStyle {
 }
 
 /// Determines how lines will be broken when preventing text from running out of bounds.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default, Reflect, Serialize, Deserialize)]
 #[reflect(Serialize, Deserialize)]
 pub enum BreakLineOn {
     /// Uses the [Unicode Line Breaking Algorithm](https://www.unicode.org/reports/tr14/).
     /// Lines will be broken up at the nearest suitable word boundary, usually a space.
     /// This behavior suits most cases, as it keeps words intact across linebreaks.
+    #[default]
     WordBoundary,
     /// Lines will be broken without discrimination on any character that would leave bounds.
     /// This is closer to the behavior one might expect from text in a terminal.

--- a/crates/bevy_ui/src/ui_node.rs
+++ b/crates/bevy_ui/src/ui_node.rs
@@ -23,7 +23,7 @@ use thiserror::Error;
 /// - [`RelativeCursorPosition`](crate::RelativeCursorPosition)
 ///   to obtain the cursor position relative to this node
 /// - [`Interaction`](crate::Interaction) to obtain the interaction state of this node
-#[derive(Component, Debug, Copy, Clone, Reflect)]
+#[derive(Component, Debug, Copy, Clone, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Node {
     /// The order of the node in the UI layout.
@@ -1590,7 +1590,7 @@ pub enum GridPlacementError {
 /// The background color of the node
 ///
 /// This serves as the "fill" color.
-#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 #[cfg_attr(
     feature = "serialize",
@@ -1616,7 +1616,7 @@ impl<T: Into<Color>> From<T> for BackgroundColor {
 }
 
 /// The border color of the UI node.
-#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Copy, Clone, Debug, PartialEq, Reflect)]
 #[reflect(Component, Default)]
 #[cfg_attr(
     feature = "serialize",
@@ -1796,7 +1796,7 @@ pub struct CalculatedClip {
 /// `ZIndex::Local(n)` and `ZIndex::Global(n)` for root nodes.
 ///
 /// Nodes without this component will be treated as if they had a value of `ZIndex::Local(0)`.
-#[derive(Component, Copy, Clone, Debug, Reflect)]
+#[derive(Component, Copy, Clone, Debug, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default)]
 pub enum ZIndex {
     /// Indicates the order in which this node should be rendered relative to its siblings.

--- a/crates/bevy_ui/src/widget/button.rs
+++ b/crates/bevy_ui/src/widget/button.rs
@@ -4,6 +4,6 @@ use bevy_reflect::std_traits::ReflectDefault;
 use bevy_reflect::Reflect;
 
 /// Marker struct for buttons
-#[derive(Component, Debug, Default, Clone, Copy, Reflect)]
+#[derive(Component, Debug, Default, Clone, Copy, PartialEq, Eq, Reflect)]
 #[reflect(Component, Default)]
 pub struct Button;


### PR DESCRIPTION
# Objective

- working with UI components in Bevy, I found myself wanting some of these common traits, like `PartialEq` for comparing simple types

## Solution

- I added only (hopefully) uncontroversial `derive`s for some common UI types

Note that many types, unfortunately, can't have `PartialEq` `derive`d for them, because they contain `f32`s and / or `Vec`s.