### PR TITLE
Compute texture slices after layout

### DIFF
--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -149,17 +149,15 @@ impl Plugin for UiPlugin {
                 // They run independently since `widget::image_node_system` will only ever observe
                 // its own UiImage, and `widget::text_system` & `bevy_text::update_text2d_layout`
                 // will never modify a pre-existing `Image` asset.
+                widget::update_image_content_size_system
+                    .before(UiSystem::Layout)
+                    .in_set(AmbiguousWithTextSystem)
+                    .in_set(AmbiguousWithUpdateText2DLayout),
                 (
-                    widget::update_image_content_size_system
-                        .before(UiSystem::Layout)
-                        .in_set(AmbiguousWithTextSystem)
-                        .in_set(AmbiguousWithUpdateText2DLayout),
-                    (
-                        texture_slice::compute_slices_on_asset_event,
-                        texture_slice::compute_slices_on_image_change,
-                    ),
+                    texture_slice::compute_slices_on_asset_event,
+                    texture_slice::compute_slices_on_image_change,
                 )
-                    .chain(),
+                    .after(UiSystem::Layout),
             ),
         );
 


### PR DESCRIPTION
# Objective

Whenever a nodes size gets changed, its texture slices get updated a frame later. This results in visual glitches when animating the size of a node with a texture slice. See this video:

[Screencast from 17-03-24 14:53:13.webm](https://github.com/bevyengine/bevy/assets/46689298/64e711f7-a1ec-41e3-b119-dc8d7e1a7669)


## Solution

Compute texture slices after the layout system has finished.
