### PR TITLE
Color maths 2

### DIFF
--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,4 +1,9 @@
 use crate::{Alpha, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza};
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +27,14 @@ pub struct Hsla {
 }
 
 impl StandardColor for Hsla {}
+
+impl_componentwise_add!(Hsla, [hue, saturation, lightness, alpha]);
+impl_componentwise_sub!(Hsla, [hue, saturation, lightness, alpha]);
+impl_componentwise_mul!(Hsla, [hue, saturation, lightness, alpha]);
+impl_componentwise_scalar_mul!(Hsla, f32, [hue, saturation, lightness, alpha]);
+impl_componentwise_div!(Hsla, [hue, saturation, lightness, alpha]);
+impl_componentwise_scalar_div!(Hsla, f32, [hue, saturation, lightness, alpha]);
+impl_componentwise_point!(Hsla);
 
 impl Hsla {
     /// Construct a new [`Hsla`] color from components.

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,9 @@
 use crate::{Alpha, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza};
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +27,14 @@ pub struct Hsva {
 }
 
 impl StandardColor for Hsva {}
+
+impl_componentwise_add!(Hsva, [hue, saturation, value, alpha]);
+impl_componentwise_sub!(Hsva, [hue, saturation, value, alpha]);
+impl_componentwise_mul!(Hsva, [hue, saturation, value, alpha]);
+impl_componentwise_scalar_mul!(Hsva, f32, [hue, saturation, value, alpha]);
+impl_componentwise_div!(Hsva, [hue, saturation, value, alpha]);
+impl_componentwise_scalar_div!(Hsva, f32, [hue, saturation, value, alpha]);
+impl_componentwise_point!(Hsva);
 
 impl Hsva {
     /// Construct a new [`Hsva`] color from components.

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -3,6 +3,11 @@
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
 use crate::{Alpha, Lcha, LinearRgba, Srgba, StandardColor, Xyza};
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +31,14 @@ pub struct Hwba {
 }
 
 impl StandardColor for Hwba {}
+
+impl_componentwise_add!(Hwba, [hue, whiteness, blackness, alpha]);
+impl_componentwise_sub!(Hwba, [hue, whiteness, blackness, alpha]);
+impl_componentwise_mul!(Hwba, [hue, whiteness, blackness, alpha]);
+impl_componentwise_scalar_mul!(Hwba, f32, [hue, whiteness, blackness, alpha]);
+impl_componentwise_div!(Hwba, [hue, whiteness, blackness, alpha]);
+impl_componentwise_scalar_div!(Hwba, f32, [hue, whiteness, blackness, alpha]);
+impl_componentwise_point!(Hwba);
 
 impl Hwba {
     /// Construct a new [`Hwba`] color from components.

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,6 +1,11 @@
 use crate::{
     Alpha, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +28,14 @@ pub struct Laba {
 }
 
 impl StandardColor for Laba {}
+
+impl_componentwise_add!(Laba, [lightness, a, b, alpha]);
+impl_componentwise_sub!(Laba, [lightness, a, b, alpha]);
+impl_componentwise_mul!(Laba, [lightness, a, b, alpha]);
+impl_componentwise_scalar_mul!(Laba, f32, [lightness, a, b, alpha]);
+impl_componentwise_div!(Laba, [lightness, a, b, alpha]);
+impl_componentwise_scalar_div!(Laba, f32, [lightness, a, b, alpha]);
+impl_componentwise_point!(Laba);
 
 impl Laba {
     /// Construct a new [`Laba`] color from components.

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,9 @@
 use crate::{Alpha, Laba, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza};
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +26,14 @@ pub struct Lcha {
 }
 
 impl StandardColor for Lcha {}
+
+impl_componentwise_add!(Lcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_sub!(Lcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_mul!(Lcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_scalar_mul!(Lcha, f32, [lightness, chroma, hue, alpha]);
+impl_componentwise_div!(Lcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_scalar_div!(Lcha, f32, [lightness, chroma, hue, alpha]);
+impl_componentwise_point!(Lcha);
 
 impl Lcha {
     /// Construct a new [`Lcha`] color from components.

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,7 +1,11 @@
 use std::ops::{Div, Mul};
 
 use crate::{color_difference::EuclideanDistance, Alpha, Luminance, Mix, StandardColor};
-use bevy_math::Vec4;
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_scalar_div, impl_componentwise_scalar_mul, impl_componentwise_sub,
+};
+use bevy_math::{impl_componentwise_point, Vec4};
 use bevy_reflect::prelude::*;
 use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
@@ -26,6 +30,14 @@ pub struct LinearRgba {
 }
 
 impl StandardColor for LinearRgba {}
+
+impl_componentwise_add!(LinearRgba, [red, green, blue, alpha]);
+impl_componentwise_sub!(LinearRgba, [red, green, blue, alpha]);
+impl_componentwise_mul!(LinearRgba, [red, green, blue, alpha]);
+impl_componentwise_scalar_mul!(LinearRgba, f32, [red, green, blue, alpha]);
+impl_componentwise_div!(LinearRgba, [red, green, blue, alpha]);
+impl_componentwise_scalar_div!(LinearRgba, f32, [red, green, blue, alpha]);
+impl_componentwise_point!(LinearRgba);
 
 impl LinearRgba {
     /// A fully black color with full alpha.

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -2,6 +2,11 @@ use crate::{
     color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix,
     Srgba, StandardColor, Xyza,
 };
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +29,14 @@ pub struct Oklaba {
 }
 
 impl StandardColor for Oklaba {}
+
+impl_componentwise_add!(Oklaba, [l, a, b, alpha]);
+impl_componentwise_sub!(Oklaba, [l, a, b, alpha]);
+impl_componentwise_mul!(Oklaba, [l, a, b, alpha]);
+impl_componentwise_scalar_mul!(Oklaba, f32, [l, a, b, alpha]);
+impl_componentwise_div!(Oklaba, [l, a, b, alpha]);
+impl_componentwise_scalar_div!(Oklaba, f32, [l, a, b, alpha]);
+impl_componentwise_point!(Oklaba);
 
 impl Oklaba {
     /// Construct a new [`Oklaba`] color from components.

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -2,6 +2,11 @@ use crate::{
     color_difference::EuclideanDistance, Alpha, Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba,
     Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -24,6 +29,14 @@ pub struct Oklcha {
 }
 
 impl StandardColor for Oklcha {}
+
+impl_componentwise_add!(Oklcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_sub!(Oklcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_mul!(Oklcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_scalar_mul!(Oklcha, f32, [lightness, chroma, hue, alpha]);
+impl_componentwise_div!(Oklcha, [lightness, chroma, hue, alpha]);
+impl_componentwise_scalar_div!(Oklcha, f32, [lightness, chroma, hue, alpha]);
+impl_componentwise_point!(Oklcha);
 
 impl Oklcha {
     /// Construct a new [`Oklcha`] color from components.

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -2,7 +2,11 @@ use std::ops::{Div, Mul};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor, Xyza};
-use bevy_math::Vec4;
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_scalar_div, impl_componentwise_scalar_mul, impl_componentwise_sub,
+};
+use bevy_math::{impl_componentwise_point, Vec4};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -26,6 +30,14 @@ pub struct Srgba {
 }
 
 impl StandardColor for Srgba {}
+
+impl_componentwise_add!(Srgba, [red, green, blue, alpha]);
+impl_componentwise_sub!(Srgba, [red, green, blue, alpha]);
+impl_componentwise_mul!(Srgba, [red, green, blue, alpha]);
+impl_componentwise_scalar_mul!(Srgba, f32, [red, green, blue, alpha]);
+impl_componentwise_div!(Srgba, [red, green, blue, alpha]);
+impl_componentwise_scalar_div!(Srgba, f32, [red, green, blue, alpha]);
+impl_componentwise_point!(Srgba);
 
 impl Srgba {
     // The standard VGA colors, with alpha set to 1.0.

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,9 @@
 use crate::{Alpha, LinearRgba, Luminance, Mix, StandardColor};
+use bevy_math::{
+    impl_componentwise_add, impl_componentwise_div, impl_componentwise_mul,
+    impl_componentwise_point, impl_componentwise_scalar_div, impl_componentwise_scalar_mul,
+    impl_componentwise_sub,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +26,14 @@ pub struct Xyza {
 }
 
 impl StandardColor for Xyza {}
+
+impl_componentwise_add!(Xyza, [x, y, z, alpha]);
+impl_componentwise_sub!(Xyza, [x, y, z, alpha]);
+impl_componentwise_mul!(Xyza, [x, y, z, alpha]);
+impl_componentwise_scalar_mul!(Xyza, f32, [x, y, z, alpha]);
+impl_componentwise_div!(Xyza, [x, y, z, alpha]);
+impl_componentwise_scalar_div!(Xyza, f32, [x, y, z, alpha]);
+impl_componentwise_point!(Xyza);
 
 impl Xyza {
     /// Construct a new [`Xyza`] color from components.

--- a/crates/bevy_math/src/componentwise_arith.rs
+++ b/crates/bevy_math/src/componentwise_arith.rs
@@ -1,0 +1,143 @@
+//! Provides traits for componentwise arithmetic.
+//!
+//! This may be useful for types where there are no agreed upon standards for operators,
+//! e.g. what would it mean to add two HSL-colors?
+
+use glam::{Vec2, Vec3, Vec4};
+
+/// The componentwise + operator
+pub trait ComponentwiseAdd {
+    /// The componentwise + operator
+    fn componentwise_add(self, rhs: Self) -> Self;
+}
+/// The componentwise - operator
+pub trait ComponentwiseSub {
+    /// The componentwise - operator
+    fn componentwise_sub(self, rhs: Self) -> Self;
+}
+
+/// The componentwise * operator
+///
+/// This should only be used for types where a componentwise multiplication makes sense.
+/// For example, `Vec4` * `Vec4` or `Vec4` * `f32` allow for sensible componentwise multiplication
+/// but `Vec4` * `Quat` does not.
+pub trait ComponentwiseMul<T> {
+    /// The componentwise * operator
+    fn componentwise_mul(self, rhs: T) -> Self;
+}
+/// The componentwise / operator
+///
+/// This should only be used for types where a componentwise division makes sense.
+/// For example, `Vec4` / `Vec4` or `Vec4` / `f32` allow for sensible componentwise division
+/// but `Vec4` / `Quat` does not.
+pub trait ComponentwiseDiv<T> {
+    /// The componentwise / operator
+    fn componentwise_div(self, rhs: T) -> Self;
+}
+
+#[macro_export]
+/// Implements the `ComponentwiseAdd` trait for the type `ty` and its elements.
+macro_rules! impl_componentwise_add {
+    ($ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseAdd for $ty {
+            #[inline]
+            fn componentwise_add(self, rhs: Self) -> Self {
+                $ty {
+                    $($element: self.$element + rhs.$element,)+
+                }
+            }
+        }
+    };
+}
+#[macro_export]
+/// Implements the `ComponentwiseSub` trait for the type `ty` and its elements.
+macro_rules! impl_componentwise_sub {
+    ($ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseSub for $ty {
+            #[inline]
+            fn componentwise_sub(self, rhs: Self) -> Self {
+                $ty {
+                    $($element: self.$element - rhs.$element,)+
+                }
+            }
+        }
+    };
+}
+#[macro_export]
+/// Implements the `ComponentwiseMul<Self>` trait for the type `ty` and its elements.
+macro_rules! impl_componentwise_mul {
+    ($ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseMul<Self> for $ty {
+            #[inline]
+            fn componentwise_mul(self, rhs: Self) -> Self {
+                $ty {
+                    $($element: self.$element * rhs.$element,)+
+                }
+            }
+        }
+    };
+}
+#[macro_export]
+/// Implements the `ComponentwiseMul<scalar_ty>` trait for the type `ty` and its elements and a given scalar type `scalar_ty`.
+macro_rules! impl_componentwise_scalar_mul {
+    ($ty: ident, $scalar_ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseMul<$scalar_ty> for $ty {
+            #[inline]
+            fn componentwise_mul(self, rhs: $scalar_ty) -> Self {
+                $ty {
+                    $($element: self.$element * rhs,)+
+                }
+            }
+        }
+    };
+}
+#[macro_export]
+/// Implements the `ComponentwiseDiv<Self>` trait for the type `ty` and its elements.
+macro_rules! impl_componentwise_div {
+    ($ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseDiv<Self> for $ty {
+            #[inline]
+            fn componentwise_div(self, rhs: Self) -> Self {
+                $ty {
+                    $($element: self.$element / rhs.$element,)+
+                }
+            }
+        }
+    };
+}
+#[macro_export]
+/// Implements the `ComponentwiseDiv<scalar_ty>` trait for the type `ty` and its elements and a given scalar type `scalar_ty`.
+macro_rules! impl_componentwise_scalar_div {
+    ($ty: ident, $scalar_ty: ident, [$($element: ident),+]) => {
+        impl $crate::componentwise_arith::ComponentwiseDiv<$scalar_ty> for $ty {
+            #[inline]
+            fn componentwise_div(self, rhs: $scalar_ty) -> Self {
+                $ty {
+                    $($element: self.$element / rhs,)+
+                }
+            }
+        }
+    };
+}
+
+impl_componentwise_add!(Vec2, [x, y]);
+impl_componentwise_add!(Vec3, [x, y, z]);
+impl_componentwise_add!(Vec4, [x, y, z, w]);
+
+impl_componentwise_sub!(Vec2, [x, y]);
+impl_componentwise_sub!(Vec3, [x, y, z]);
+impl_componentwise_sub!(Vec4, [x, y, z, w]);
+
+impl_componentwise_mul!(Vec2, [x, y]);
+impl_componentwise_mul!(Vec3, [x, y, z]);
+impl_componentwise_mul!(Vec4, [x, y, z, w]);
+impl_componentwise_scalar_mul!(Vec2, f32, [x, y]);
+impl_componentwise_scalar_mul!(Vec3, f32, [x, y, z]);
+impl_componentwise_scalar_mul!(Vec4, f32, [x, y, z, w]);
+
+impl_componentwise_div!(Vec2, [x, y]);
+impl_componentwise_div!(Vec3, [x, y, z]);
+impl_componentwise_div!(Vec4, [x, y, z, w]);
+impl_componentwise_scalar_div!(Vec2, f32, [x, y]);
+impl_componentwise_scalar_div!(Vec3, f32, [x, y, z]);
+impl_componentwise_scalar_div!(Vec4, f32, [x, y, z, w]);

--- a/crates/bevy_math/src/componentwise_arith.rs
+++ b/crates/bevy_math/src/componentwise_arith.rs
@@ -3,8 +3,6 @@
 //! This may be useful for types where there are no agreed upon standards for operators,
 //! e.g. what would it mean to add two HSL-colors?
 
-use glam::{Vec2, Vec3, Vec4};
-
 /// The componentwise + operator
 pub trait ComponentwiseAdd {
     /// The componentwise + operator
@@ -119,25 +117,3 @@ macro_rules! impl_componentwise_scalar_div {
         }
     };
 }
-
-impl_componentwise_add!(Vec2, [x, y]);
-impl_componentwise_add!(Vec3, [x, y, z]);
-impl_componentwise_add!(Vec4, [x, y, z, w]);
-
-impl_componentwise_sub!(Vec2, [x, y]);
-impl_componentwise_sub!(Vec3, [x, y, z]);
-impl_componentwise_sub!(Vec4, [x, y, z, w]);
-
-impl_componentwise_mul!(Vec2, [x, y]);
-impl_componentwise_mul!(Vec3, [x, y, z]);
-impl_componentwise_mul!(Vec4, [x, y, z, w]);
-impl_componentwise_scalar_mul!(Vec2, f32, [x, y]);
-impl_componentwise_scalar_mul!(Vec3, f32, [x, y, z]);
-impl_componentwise_scalar_mul!(Vec4, f32, [x, y, z, w]);
-
-impl_componentwise_div!(Vec2, [x, y]);
-impl_componentwise_div!(Vec3, [x, y, z]);
-impl_componentwise_div!(Vec4, [x, y, z, w]);
-impl_componentwise_scalar_div!(Vec2, f32, [x, y]);
-impl_componentwise_scalar_div!(Vec3, f32, [x, y, z]);
-impl_componentwise_scalar_div!(Vec4, f32, [x, y, z, w]);

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -11,6 +11,7 @@ pub mod bounding;
 pub mod componentwise_arith;
 pub mod cubic_splines;
 mod direction;
+pub mod point;
 pub mod primitives;
 mod ray;
 mod rects;

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -8,6 +8,7 @@
 mod affine3;
 mod aspect_ratio;
 pub mod bounding;
+pub mod componentwise_arith;
 pub mod cubic_splines;
 mod direction;
 pub mod primitives;

--- a/crates/bevy_math/src/point.rs
+++ b/crates/bevy_math/src/point.rs
@@ -1,0 +1,113 @@
+//! Provides interfaces for points in space of any dimension that support the math ops needed for cubic spline
+//! interpolation.
+use std::fmt::Debug;
+
+use glam::{Quat, Vec2, Vec3, Vec3A, Vec4};
+
+/// A point in space of any dimension that supports the math ops needed for cubic spline
+/// interpolation.
+pub trait Point:
+    PointAdd + PointSub + PointMul + PointDiv + Default + Debug + Clone + Copy
+{
+}
+
+/// The + operator that should be used for points on cubic splines.
+pub trait PointAdd {
+    /// The + operator that should be used for points on cubic splines.
+    fn point_add(self, rhs: Self) -> Self;
+}
+
+/// The - operator that should be used for points on cubic splines.
+pub trait PointSub {
+    /// The - operator that should be used for points on cubic splines.
+    fn point_sub(self, rhs: Self) -> Self;
+}
+
+/// The * operator that should be used for points on cubic splines.
+pub trait PointMul {
+    /// The * operator that should be used for points on cubic splines.
+    fn point_mul(self, rhs: f32) -> Self;
+}
+
+/// The / operator that should be used for points on cubic splines.
+pub trait PointDiv {
+    /// The / operator that should be used for points on cubic splines.
+    fn point_div(self, rhs: f32) -> Self;
+}
+
+#[macro_export]
+/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the 
+/// `ComponentwiseAdd`, `ComponentwiseSub`, `ComponentwiseMul` and `ComponentwiseDiv` implementations of that type.
+/// 
+/// Please note that this macro does not implement any componentwise traits or other bounds introduced by `Point`.
+macro_rules! impl_componentwise_point {
+    ($ty: ident) => {
+        impl $crate::point::PointAdd for $ty {
+            #[inline]
+            fn point_add(self, rhs: $ty) -> $ty {
+                $crate::componentwise_arith::ComponentwiseAdd::componentwise_add(self, rhs)
+            }
+        }
+        impl $crate::point::PointSub for $ty {
+            #[inline]
+            fn point_sub(self, rhs: $ty) -> $ty {
+                $crate::componentwise_arith::ComponentwiseSub::componentwise_sub(self, rhs)
+            }
+        }
+        impl $crate::point::PointMul for $ty {
+            #[inline]
+            fn point_mul(self, rhs: f32) -> $ty {
+                $crate::componentwise_arith::ComponentwiseMul::componentwise_mul(self, rhs)
+            }
+        }
+        impl $crate::point::PointDiv for $ty {
+            #[inline]
+            fn point_div(self, rhs: f32) -> $ty {
+                $crate::componentwise_arith::ComponentwiseDiv::componentwise_div(self, rhs)
+            }
+        }
+        impl $crate::point::Point for $ty {}
+    };
+}
+
+#[macro_export]
+/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the 
+/// `std::ops::Add`, `std::ops::Sub`, `std::ops::Mul` and `std::ops::Div` implementations of that type.
+/// 
+/// Please note that this macro does not implement any of the `std::ops::*` traits or other bounds introduced by `Point`.
+macro_rules! impl_std_ops_point {
+    ($ty: ident) => {
+        impl $crate::point::PointAdd for $ty {
+            #[inline]
+            fn point_add(self, rhs: $ty) -> $ty {
+                self + rhs
+            }
+        }
+        impl $crate::point::PointSub for $ty {
+            #[inline]
+            fn point_sub(self, rhs: $ty) -> $ty {
+                self - rhs
+            }
+        }
+        impl $crate::point::PointMul for $ty {
+            #[inline]
+            fn point_mul(self, rhs: f32) -> $ty {
+                self * rhs
+            }
+        }
+        impl $crate::point::PointDiv for $ty {
+            #[inline]
+            fn point_div(self, rhs: f32) -> $ty {
+                self / rhs
+            }
+        }
+        impl $crate::point::Point for $ty {}
+    };
+}
+
+impl_std_ops_point!(Quat);
+impl_std_ops_point!(Vec4);
+impl_std_ops_point!(Vec3);
+impl_std_ops_point!(Vec3A);
+impl_std_ops_point!(Vec2);
+impl_std_ops_point!(f32);

--- a/crates/bevy_math/src/point.rs
+++ b/crates/bevy_math/src/point.rs
@@ -36,9 +36,9 @@ pub trait PointDiv {
 }
 
 #[macro_export]
-/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the 
+/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the
 /// `ComponentwiseAdd`, `ComponentwiseSub`, `ComponentwiseMul` and `ComponentwiseDiv` implementations of that type.
-/// 
+///
 /// Please note that this macro does not implement any componentwise traits or other bounds introduced by `Point`.
 macro_rules! impl_componentwise_point {
     ($ty: ident) => {
@@ -71,9 +71,9 @@ macro_rules! impl_componentwise_point {
 }
 
 #[macro_export]
-/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the 
+/// Implements `PointAdd`, `PointSub`, `PointMul`, `PointDiv` and `Point` for the provided type using the
 /// `std::ops::Add`, `std::ops::Sub`, `std::ops::Mul` and `std::ops::Div` implementations of that type.
-/// 
+///
 /// Please note that this macro does not implement any of the `std::ops::*` traits or other bounds introduced by `Point`.
 macro_rules! impl_std_ops_point {
     ($ty: ident) => {


### PR DESCRIPTION
# Objective

- Adds arithmatic operations for colors so they can be used with splines, suggestion of #12202 and incorporating feedback from #12460 

## Solution

- This PR introduces `ComponentwiseAdd`, `ComponentwiseSub`, `ComponentwiseMul` and `ComponentwiseDiv` traits which may be used to define component wise arithmetic operations for types where there is no agreed upon "standard addition, etc.". These traits are implemented for all colour types excluding `Color`.
- There are also the `PointAdd`, `PointSub`, `PointMul` and `PointDiv` traits which are used in the `Point` trait. Any type implementing all `PointX` traits may be used with splines. 
- I have also added multiple macros for automatically implementing the component wise traits and two macros for implementing the `PointX` traits. These are `impl_componentwise_point!(Type)` and `impl_std_ops_point!(Type)` which implement the `PointX` traits and `Point` using either the component wise or the `std::ops::*` operators respectively.

---

## Changelog

- `Point` has been moved to its own module.

## Additional information

- Arithmetic operations on colors are a controversial topic. Please read over the first PR #12460 trying to implement this if you are concerned about whether we should allow any maths operations on colours (especially sRGB) as your concerns may have already been addressed there :)