### PR TITLE
Fix typo in bevy_internal/Cargo.toml

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -202,7 +202,7 @@ bevy_ui = { path = "../bevy_ui", optional = true, version = "0.14.0-dev" }
 bevy_winit = { path = "../bevy_winit", optional = true, version = "0.14.0-dev" }
 bevy_gilrs = { path = "../bevy_gilrs", optional = true, version = "0.14.0-dev" }
 bevy_gizmos = { path = "../bevy_gizmos", optional = true, version = "0.14.0-dev", default-features = false }
-bevy_dev_tools = { path = "../bevy_dev_tools/", optional = true, version = "0.14.0-dev" }
+bevy_dev_tools = { path = "../bevy_dev_tools", optional = true, version = "0.14.0-dev" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
# Objective

Fixes typo by #11341.
Functionally doesn't change anything other than naming consistency and stop IDE's from screaming at you.


