### PR TITLE
Add setting to enable/disable shadows to MaterialPlugin

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -193,6 +193,8 @@ pub struct MaterialPlugin<M: Material> {
     /// When it is enabled, it will automatically add the [`PrepassPlugin`]
     /// required to make the prepass work on this Material.
     pub prepass_enabled: bool,
+    /// Controls if shadows are enabled for the Material.
+    pub shadows_enabled: bool,
     pub _marker: PhantomData<M>,
 }
 
@@ -200,6 +202,7 @@ impl<M: Material> Default for MaterialPlugin<M> {
     fn default() -> Self {
         Self {
             prepass_enabled: true,
+            shadows_enabled: true,
             _marker: Default::default(),
         }
     }
@@ -231,18 +234,26 @@ where
                         prepare_materials::<M>
                             .in_set(RenderSet::PrepareAssets)
                             .after(prepare_assets::<Image>),
-                        queue_shadows::<M>
-                            .in_set(RenderSet::QueueMeshes)
-                            .after(prepare_materials::<M>),
                         queue_material_meshes::<M>
                             .in_set(RenderSet::QueueMeshes)
                             .after(prepare_materials::<M>),
                     ),
                 );
+
+            if self.shadows_enabled {
+                render_app.add_systems(
+                    Render,
+                    (queue_shadows::<M>
+                        .in_set(RenderSet::QueueMeshes)
+                        .after(prepare_materials::<M>),),
+                );
+            }
         }
 
-        // PrepassPipelinePlugin is required for shadow mapping and the optional PrepassPlugin
-        app.add_plugins(PrepassPipelinePlugin::<M>::default());
+        if self.shadows_enabled || self.prepass_enabled {
+            // PrepassPipelinePlugin is required for shadow mapping and the optional PrepassPlugin
+            app.add_plugins(PrepassPipelinePlugin::<M>::default());
+        }
 
         if self.prepass_enabled {
             app.add_plugins(PrepassPlugin::<M>::default());


### PR DESCRIPTION
# Objective

- Not all materials need shadow, but a queue_shadows system is always added to the `Render` schedule and executed

## Solution

- Make a setting for shadows, it defaults to true

## Changelog

- Added `shadows_enabled` setting to `MaterialPlugin`

## Migration Guide

- `MaterialPlugin` now has a `shadows_enabled` setting, if you didn't spawn the plugin using `::default()` or `..default()`, you'll need to set it. `shadows_enabled: true` is the same behavior as the previous version, and also the default value.