### PR TITLE
Color maths 3

### DIFF
--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hsva, Hwba, Lcha, LinearRgba,
-    Luminance, Mix, Srgba, StandardColor, Xyza,
+    impl_color_linear_convex_space, Alpha, ClampColor, Hsva, Hwba, Lcha, LinearRgba, Luminance,
+    Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -26,7 +26,7 @@ pub struct Hsla {
 
 impl StandardColor for Hsla {}
 
-impl_componentwise_linear_convex_space!(Hsla, [hue, saturation, lightness, alpha]);
+impl_color_linear_convex_space!(Hsla, [hue, saturation, lightness, alpha]);
 
 impl Hsla {
     /// Construct a new [`Hsla`] color from components.

--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -1,5 +1,6 @@
 use crate::{
-    Alpha, ClampColor, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hsva, Hwba, Lcha, LinearRgba,
+    Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -24,6 +25,8 @@ pub struct Hsla {
 }
 
 impl StandardColor for Hsla {}
+
+impl_componentwise_linear_convex_space!(Hsla, [hue, saturation, lightness, alpha]);
 
 impl Hsla {
     /// Construct a new [`Hsla`] color from components.

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,4 +1,7 @@
-use crate::{Alpha, ClampColor, Hwba, Lcha, LinearRgba, Srgba, StandardColor, Xyza};
+use crate::{
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hwba, Lcha, LinearRgba, Srgba,
+    StandardColor, Xyza,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -22,6 +25,8 @@ pub struct Hsva {
 }
 
 impl StandardColor for Hsva {}
+
+impl_componentwise_linear_convex_space!(Hsva, [hue, saturation, value, alpha]);
 
 impl Hsva {
     /// Construct a new [`Hsva`] color from components.

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -1,5 +1,5 @@
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hwba, Lcha, LinearRgba, Srgba,
+    impl_color_linear_convex_space, Alpha, ClampColor, Hwba, Lcha, LinearRgba, Srgba,
     StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
@@ -26,7 +26,7 @@ pub struct Hsva {
 
 impl StandardColor for Hsva {}
 
-impl_componentwise_linear_convex_space!(Hsva, [hue, saturation, value, alpha]);
+impl_color_linear_convex_space!(Hsva, [hue, saturation, value, alpha]);
 
 impl Hsva {
     /// Construct a new [`Hsva`] color from components.

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -2,7 +2,10 @@
 //! in [_HWB - A More Intuitive Hue-Based Color Model_] by _Smith et al_.
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
-use crate::{Alpha, ClampColor, Lcha, LinearRgba, Srgba, StandardColor, Xyza};
+use crate::{
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, Lcha, LinearRgba, Srgba,
+    StandardColor, Xyza,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -26,6 +29,8 @@ pub struct Hwba {
 }
 
 impl StandardColor for Hwba {}
+
+impl_componentwise_linear_convex_space!(Hwba, [hue, whiteness, blackness, alpha]);
 
 impl Hwba {
     /// Construct a new [`Hwba`] color from components.

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -3,8 +3,7 @@
 //!
 //! [_HWB - A More Intuitive Hue-Based Color Model_]: https://web.archive.org/web/20240226005220/http://alvyray.com/Papers/CG/HWB_JGTv208.pdf
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, Lcha, LinearRgba, Srgba,
-    StandardColor, Xyza,
+    impl_color_linear_convex_space, Alpha, ClampColor, Lcha, LinearRgba, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -30,7 +29,7 @@ pub struct Hwba {
 
 impl StandardColor for Hwba {}
 
-impl_componentwise_linear_convex_space!(Hwba, [hue, whiteness, blackness, alpha]);
+impl_color_linear_convex_space!(Hwba, [hue, whiteness, blackness, alpha]);
 
 impl Hwba {
     /// Construct a new [`Hwba`] color from components.

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Alpha, ClampColor, Hsla, Hsva, Hwba, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor,
-    Xyza,
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hsla, Hsva, Hwba, LinearRgba,
+    Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,8 @@ pub struct Laba {
 }
 
 impl StandardColor for Laba {}
+
+impl_componentwise_linear_convex_space!(Laba, [lightness, a, b, alpha]);
 
 impl Laba {
     /// Construct a new [`Laba`] color from components.

--- a/crates/bevy_color/src/laba.rs
+++ b/crates/bevy_color/src/laba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, Hsla, Hsva, Hwba, LinearRgba,
-    Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    impl_color_linear_convex_space, Alpha, ClampColor, Hsla, Hsva, Hwba, LinearRgba, Luminance,
+    Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ pub struct Laba {
 
 impl StandardColor for Laba {}
 
-impl_componentwise_linear_convex_space!(Laba, [lightness, a, b, alpha]);
+impl_color_linear_convex_space!(Laba, [lightness, a, b, alpha]);
 
 impl Laba {
     /// Construct a new [`Laba`] color from components.

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,6 +1,6 @@
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, Laba, LinearRgba, Luminance, Mix,
-    Srgba, StandardColor, Xyza,
+    impl_color_linear_convex_space, Alpha, ClampColor, Laba, LinearRgba, Luminance, Mix, Srgba,
+    StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ pub struct Lcha {
 
 impl StandardColor for Lcha {}
 
-impl_componentwise_linear_convex_space!(Lcha, [lightness, chroma, hue, alpha]);
+impl_color_linear_convex_space!(Lcha, [lightness, chroma, hue, alpha]);
 
 impl Lcha {
     /// Construct a new [`Lcha`] color from components.

--- a/crates/bevy_color/src/lcha.rs
+++ b/crates/bevy_color/src/lcha.rs
@@ -1,4 +1,7 @@
-use crate::{Alpha, ClampColor, Laba, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza};
+use crate::{
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, Laba, LinearRgba, Luminance, Mix,
+    Srgba, StandardColor, Xyza,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +24,8 @@ pub struct Lcha {
 }
 
 impl StandardColor for Lcha {}
+
+impl_componentwise_linear_convex_space!(Lcha, [lightness, chroma, hue, alpha]);
 
 impl Lcha {
     /// Construct a new [`Lcha`] color from components.

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -174,13 +174,13 @@ macro_rules! impl_color_linear_convex_space {
                 }
             }
             #[inline]
-            fn mul(self, rhs: f32) -> Self {
+            fn scale(self, rhs: f32) -> Self {
                 Self {
                     $($element: self.$element * rhs,)+
                 }
             }
             #[inline]
-            fn div(self, rhs: f32) -> Self {
+            fn scale_recip(self, rhs: f32) -> Self {
                 Self {
                     $($element: self.$element / rhs,)+
                 }

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -156,7 +156,7 @@ where
 /// coponentwise arithmetic operations on the provided properties of `T`.
 ///
 /// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` seperately.
-macro_rules! impl_componentwise_linear_convex_space {
+macro_rules! impl_color_linear_convex_space {
     ($ty: ident, [$($element: ident),+]) => {
         impl bevy_math::linear_convex_space::LinearConvexSpace<f32> for $ty {
             #[inline]
@@ -187,4 +187,4 @@ macro_rules! impl_componentwise_linear_convex_space {
     };
 }
 
-pub(crate) use impl_componentwise_linear_convex_space;
+pub(crate) use impl_color_linear_convex_space;

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -158,7 +158,9 @@ where
 /// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` separately.
 macro_rules! impl_color_linear_convex_space {
     ($ty: ident, [$($element: ident),+]) => {
-        impl bevy_math::linear_convex_space::LinearConvexSpace<f32> for $ty {
+        impl bevy_math::linear_convex_space::LinearConvexSpace for $ty {
+            type Scalar = f32;
+
             #[inline]
             fn add(self, rhs: Self) -> Self {
                 Self {

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -151,3 +151,40 @@ where
     Self: Alpha,
 {
 }
+
+/// Implements `LinearConvexSpace<f32>` for a given type `T` using
+/// coponentwise arithmetic operations on the provided properties of `T`.
+///
+/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` seperately.
+macro_rules! impl_componentwise_linear_convex_space {
+    ($ty: ident, [$($element: ident),+]) => {
+        impl bevy_math::linear_convex_space::LinearConvexSpace<f32> for $ty {
+            #[inline]
+            fn add(self, rhs: Self) -> Self {
+                Self {
+                    $($element: self.$element + rhs.$element,)+
+                }
+            }
+            #[inline]
+            fn sub(self, rhs: Self) -> Self {
+                Self {
+                    $($element: self.$element - rhs.$element,)+
+                }
+            }
+            #[inline]
+            fn mul(self, rhs: f32) -> Self {
+                Self {
+                    $($element: self.$element * rhs,)+
+                }
+            }
+            #[inline]
+            fn div(self, rhs: f32) -> Self {
+                Self {
+                    $($element: self.$element / rhs,)+
+                }
+            }
+        }
+    };
+}
+
+pub(crate) use impl_componentwise_linear_convex_space;

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -155,7 +155,7 @@ where
 /// Implements `LinearConvexSpace<f32>` for a given type `T` using
 /// coponentwise arithmetic operations on the provided properties of `T`.
 ///
-/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` seperately.
+/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` separately.
 macro_rules! impl_color_linear_convex_space {
     ($ty: ident, [$($element: ident),+]) => {
         impl bevy_math::linear_convex_space::LinearConvexSpace<f32> for $ty {

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,7 +1,7 @@
 use std::ops::{Div, Mul};
 
 use crate::{
-    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
+    color_difference::EuclideanDistance, impl_color_linear_convex_space, Alpha, ClampColor,
     Luminance, Mix, StandardColor,
 };
 use bevy_math::Vec4;
@@ -30,7 +30,7 @@ pub struct LinearRgba {
 
 impl StandardColor for LinearRgba {}
 
-impl_componentwise_linear_convex_space!(LinearRgba, [red, green, blue, alpha]);
+impl_color_linear_convex_space!(LinearRgba, [red, green, blue, alpha]);
 
 impl LinearRgba {
     /// A fully black color with full alpha.

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -1,7 +1,8 @@
 use std::ops::{Div, Mul};
 
 use crate::{
-    color_difference::EuclideanDistance, Alpha, ClampColor, Luminance, Mix, StandardColor,
+    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
+    Luminance, Mix, StandardColor,
 };
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
@@ -28,6 +29,8 @@ pub struct LinearRgba {
 }
 
 impl StandardColor for LinearRgba {}
+
+impl_componentwise_linear_convex_space!(LinearRgba, [red, green, blue, alpha]);
 
 impl LinearRgba {
     /// A fully black color with full alpha.

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, Alpha, ClampColor, Hsla, Hsva, Hwba, Lcha, LinearRgba,
-    Luminance, Mix, Srgba, StandardColor, Xyza,
+    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
+    Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,8 @@ pub struct Oklaba {
 }
 
 impl StandardColor for Oklaba {}
+
+impl_componentwise_linear_convex_space!(Oklaba, [lightness, a, b, alpha]);
 
 impl Oklaba {
     /// Construct a new [`Oklaba`] color from components.

--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
-    Hsla, Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
+    color_difference::EuclideanDistance, impl_color_linear_convex_space, Alpha, ClampColor, Hsla,
+    Hsva, Hwba, Lcha, LinearRgba, Luminance, Mix, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ pub struct Oklaba {
 
 impl StandardColor for Oklaba {}
 
-impl_componentwise_linear_convex_space!(Oklaba, [lightness, a, b, alpha]);
+impl_color_linear_convex_space!(Oklaba, [lightness, a, b, alpha]);
 
 impl Oklaba {
     /// Construct a new [`Oklaba`] color from components.

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
-    Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    color_difference::EuclideanDistance, impl_color_linear_convex_space, Alpha, ClampColor, Hsla,
+    Hsva, Hwba, Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -25,7 +25,7 @@ pub struct Oklcha {
 
 impl StandardColor for Oklcha {}
 
-impl_componentwise_linear_convex_space!(Oklcha, [lightness, chroma, hue, alpha]);
+impl_color_linear_convex_space!(Oklcha, [lightness, chroma, hue, alpha]);
 
 impl Oklcha {
     /// Construct a new [`Oklcha`] color from components.

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -1,6 +1,6 @@
 use crate::{
-    color_difference::EuclideanDistance, Alpha, ClampColor, Hsla, Hsva, Hwba, Laba, Lcha,
-    LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
+    color_difference::EuclideanDistance, impl_componentwise_linear_convex_space, Alpha, ClampColor,
+    Hsla, Hsva, Hwba, Laba, Lcha, LinearRgba, Luminance, Mix, Oklaba, Srgba, StandardColor, Xyza,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -24,6 +24,8 @@ pub struct Oklcha {
 }
 
 impl StandardColor for Oklcha {}
+
+impl_componentwise_linear_convex_space!(Oklcha, [lightness, chroma, hue, alpha]);
 
 impl Oklcha {
     /// Construct a new [`Oklcha`] color from components.

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,7 +1,10 @@
 use std::ops::{Div, Mul};
 
 use crate::color_difference::EuclideanDistance;
-use crate::{Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor, Xyza};
+use crate::{
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix,
+    StandardColor, Xyza,
+};
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -26,6 +29,8 @@ pub struct Srgba {
 }
 
 impl StandardColor for Srgba {}
+
+impl_componentwise_linear_convex_space!(Srgba, [red, green, blue, alpha]);
 
 impl Srgba {
     // The standard VGA colors, with alpha set to 1.0.

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -2,8 +2,8 @@ use std::ops::{Div, Mul};
 
 use crate::color_difference::EuclideanDistance;
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix,
-    StandardColor, Xyza,
+    impl_color_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor,
+    Xyza,
 };
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
@@ -30,7 +30,7 @@ pub struct Srgba {
 
 impl StandardColor for Srgba {}
 
-impl_componentwise_linear_convex_space!(Srgba, [red, green, blue, alpha]);
+impl_color_linear_convex_space!(Srgba, [red, green, blue, alpha]);
 
 impl Srgba {
     // The standard VGA colors, with alpha set to 1.0.

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,4 +1,7 @@
-use crate::{Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor};
+use crate::{
+    impl_componentwise_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix,
+    StandardColor,
+};
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +24,8 @@ pub struct Xyza {
 }
 
 impl StandardColor for Xyza {}
+
+impl_componentwise_linear_convex_space!(Xyza, [x, y, z, alpha]);
 
 impl Xyza {
     /// Construct a new [`Xyza`] color from components.

--- a/crates/bevy_color/src/xyza.rs
+++ b/crates/bevy_color/src/xyza.rs
@@ -1,6 +1,5 @@
 use crate::{
-    impl_componentwise_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix,
-    StandardColor,
+    impl_color_linear_convex_space, Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor,
 };
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -25,7 +24,7 @@ pub struct Xyza {
 
 impl StandardColor for Xyza {}
 
-impl_componentwise_linear_convex_space!(Xyza, [x, y, z, alpha]);
+impl_color_linear_convex_space!(Xyza, [x, y, z, alpha]);
 
 impl Xyza {
     /// Construct a new [`Xyza`] color from components.

--- a/crates/bevy_math/src/cubic_splines.rs
+++ b/crates/bevy_math/src/cubic_splines.rs
@@ -41,11 +41,11 @@ use crate::linear_convex_space::LinearConvexSpace;
 /// let bezier = CubicBezier::new(points).to_curve();
 /// let positions: Vec<_> = bezier.iter_positions(100).collect();
 /// ```
-pub struct CubicBezier<P: LinearConvexSpace<f32>> {
+pub struct CubicBezier<P: LinearConvexSpace<Scalar = f32>> {
     control_points: Vec<[P; 4]>,
 }
 
-impl<P: LinearConvexSpace<f32>> CubicBezier<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicBezier<P> {
     /// Create a new cubic Bezier curve from sets of control points.
     pub fn new(control_points: impl Into<Vec<[P; 4]>>) -> Self {
         Self {
@@ -53,7 +53,7 @@ impl<P: LinearConvexSpace<f32>> CubicBezier<P> {
         }
     }
 }
-impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicBezier<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicGenerator<P> for CubicBezier<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         // A derivation for this matrix can be found in "General Matrix Representations for B-splines" by Kaihuai Qin.
@@ -112,10 +112,10 @@ impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicBezier<P> {
 /// let hermite = CubicHermite::new(points, tangents).to_curve();
 /// let positions: Vec<_> = hermite.iter_positions(100).collect();
 /// ```
-pub struct CubicHermite<P: LinearConvexSpace<f32>> {
+pub struct CubicHermite<P: LinearConvexSpace<Scalar = f32>> {
     control_points: Vec<(P, P)>,
 }
-impl<P: LinearConvexSpace<f32>> CubicHermite<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicHermite<P> {
     /// Create a new Hermite curve from sets of control points.
     pub fn new(
         control_points: impl IntoIterator<Item = P>,
@@ -126,7 +126,7 @@ impl<P: LinearConvexSpace<f32>> CubicHermite<P> {
         }
     }
 }
-impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicHermite<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicGenerator<P> for CubicHermite<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         let char_matrix = [
@@ -177,12 +177,12 @@ impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicHermite<P> {
 /// let cardinal = CubicCardinalSpline::new(0.3, points).to_curve();
 /// let positions: Vec<_> = cardinal.iter_positions(100).collect();
 /// ```
-pub struct CubicCardinalSpline<P: LinearConvexSpace<f32>> {
+pub struct CubicCardinalSpline<P: LinearConvexSpace<Scalar = f32>> {
     tension: f32,
     control_points: Vec<P>,
 }
 
-impl<P: LinearConvexSpace<f32>> CubicCardinalSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicCardinalSpline<P> {
     /// Build a new Cardinal spline.
     pub fn new(tension: f32, control_points: impl Into<Vec<P>>) -> Self {
         Self {
@@ -199,7 +199,7 @@ impl<P: LinearConvexSpace<f32>> CubicCardinalSpline<P> {
         }
     }
 }
-impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicCardinalSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicGenerator<P> for CubicCardinalSpline<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         let s = self.tension;
@@ -246,10 +246,10 @@ impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicCardinalSpline<P> {
 /// let b_spline = CubicBSpline::new(points).to_curve();
 /// let positions: Vec<_> = b_spline.iter_positions(100).collect();
 /// ```
-pub struct CubicBSpline<P: LinearConvexSpace<f32>> {
+pub struct CubicBSpline<P: LinearConvexSpace<Scalar = f32>> {
     control_points: Vec<P>,
 }
-impl<P: LinearConvexSpace<f32>> CubicBSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicBSpline<P> {
     /// Build a new B-Spline.
     pub fn new(control_points: impl Into<Vec<P>>) -> Self {
         Self {
@@ -257,7 +257,7 @@ impl<P: LinearConvexSpace<f32>> CubicBSpline<P> {
         }
     }
 }
-impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for CubicBSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicGenerator<P> for CubicBSpline<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         // A derivation for this matrix can be found in "General Matrix Representations for B-splines" by Kaihuai Qin.
@@ -363,12 +363,12 @@ pub enum CubicNurbsError {
 ///     .to_curve();
 /// let positions: Vec<_> = nurbs.iter_positions(100).collect();
 /// ```
-pub struct CubicNurbs<P: LinearConvexSpace<f32>> {
+pub struct CubicNurbs<P: LinearConvexSpace<Scalar = f32>> {
     control_points: Vec<P>,
     weights: Vec<f32>,
     knots: Vec<f32>,
 }
-impl<P: LinearConvexSpace<f32>> CubicNurbs<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicNurbs<P> {
     /// Build a Non-Uniform Rational B-Spline.
     ///
     /// If provided, weights must be the same length as the control points. Defaults to equal weights.
@@ -528,7 +528,7 @@ impl<P: LinearConvexSpace<f32>> CubicNurbs<P> {
         ]
     }
 }
-impl<P: LinearConvexSpace<f32>> RationalGenerator<P> for CubicNurbs<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> RationalGenerator<P> for CubicNurbs<P> {
     #[inline]
     fn to_curve(&self) -> RationalCurve<P> {
         let segments = self
@@ -567,10 +567,10 @@ impl<P: LinearConvexSpace<f32>> RationalGenerator<P> for CubicNurbs<P> {
 ///
 /// ### Continuity
 /// The curve is C0 continuous, meaning it has no holes or jumps.
-pub struct LinearSpline<P: LinearConvexSpace<f32>> {
+pub struct LinearSpline<P: LinearConvexSpace<Scalar = f32>> {
     points: Vec<P>,
 }
-impl<P: LinearConvexSpace<f32>> LinearSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> LinearSpline<P> {
     /// Create a new linear spline
     pub fn new(points: impl Into<Vec<P>>) -> Self {
         Self {
@@ -578,7 +578,7 @@ impl<P: LinearConvexSpace<f32>> LinearSpline<P> {
         }
     }
 }
-impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for LinearSpline<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicGenerator<P> for LinearSpline<P> {
     #[inline]
     fn to_curve(&self) -> CubicCurve<P> {
         let segments = self
@@ -597,7 +597,7 @@ impl<P: LinearConvexSpace<f32>> CubicGenerator<P> for LinearSpline<P> {
 }
 
 /// Implement this on cubic splines that can generate a cubic curve from their spline parameters.
-pub trait CubicGenerator<P: LinearConvexSpace<f32>> {
+pub trait CubicGenerator<P: LinearConvexSpace<Scalar = f32>> {
     /// Build a [`CubicCurve`] by computing the interpolation coefficients for each curve segment.
     fn to_curve(&self) -> CubicCurve<P>;
 }
@@ -607,11 +607,11 @@ pub trait CubicGenerator<P: LinearConvexSpace<f32>> {
 ///
 /// Segments can be chained together to form a longer compound curve.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct CubicSegment<P: LinearConvexSpace<f32>> {
+pub struct CubicSegment<P: LinearConvexSpace<Scalar = f32>> {
     coeff: [P; 4],
 }
 
-impl<P: LinearConvexSpace<f32>> CubicSegment<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicSegment<P> {
     /// Instantaneous position of a point at parametric value `t`.
     #[inline]
     pub fn position(&self, t: f32) -> P {
@@ -777,11 +777,11 @@ impl CubicSegment<Vec2> {
 /// Use any struct that implements the [`CubicGenerator`] trait to create a new curve, such as
 /// [`CubicBezier`].
 #[derive(Clone, Debug, PartialEq)]
-pub struct CubicCurve<P: LinearConvexSpace<f32>> {
+pub struct CubicCurve<P: LinearConvexSpace<Scalar = f32>> {
     segments: Vec<CubicSegment<P>>,
 }
 
-impl<P: LinearConvexSpace<f32>> CubicCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> CubicCurve<P> {
     /// Compute the position of a point on the cubic curve at the parametric value `t`.
     ///
     /// Note that `t` varies from `0..=(n_points - 3)`.
@@ -882,13 +882,13 @@ impl<P: LinearConvexSpace<f32>> CubicCurve<P> {
     }
 }
 
-impl<P: LinearConvexSpace<f32>> Extend<CubicSegment<P>> for CubicCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> Extend<CubicSegment<P>> for CubicCurve<P> {
     fn extend<T: IntoIterator<Item = CubicSegment<P>>>(&mut self, iter: T) {
         self.segments.extend(iter);
     }
 }
 
-impl<P: LinearConvexSpace<f32>> IntoIterator for CubicCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> IntoIterator for CubicCurve<P> {
     type IntoIter = <Vec<CubicSegment<P>> as IntoIterator>::IntoIter;
 
     type Item = CubicSegment<P>;
@@ -899,7 +899,7 @@ impl<P: LinearConvexSpace<f32>> IntoIterator for CubicCurve<P> {
 }
 
 /// Implement this on cubic splines that can generate a rational cubic curve from their spline parameters.
-pub trait RationalGenerator<P: LinearConvexSpace<f32>> {
+pub trait RationalGenerator<P: LinearConvexSpace<Scalar = f32>> {
     /// Build a [`RationalCurve`] by computing the interpolation coefficients for each curve segment.
     fn to_curve(&self) -> RationalCurve<P>;
 }
@@ -909,7 +909,7 @@ pub trait RationalGenerator<P: LinearConvexSpace<f32>> {
 ///
 /// Segments can be chained together to form a longer compound curve.
 #[derive(Clone, Debug, Default, PartialEq)]
-pub struct RationalSegment<P: LinearConvexSpace<f32>> {
+pub struct RationalSegment<P: LinearConvexSpace<Scalar = f32>> {
     /// The coefficients matrix of the cubic curve.
     coeff: [P; 4],
     /// The homogeneous weight coefficients.
@@ -918,7 +918,7 @@ pub struct RationalSegment<P: LinearConvexSpace<f32>> {
     knot_span: f32,
 }
 
-impl<P: LinearConvexSpace<f32>> RationalSegment<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> RationalSegment<P> {
     /// Instantaneous position of a point at parametric value `t` in `[0, knot_span)`.
     #[inline]
     pub fn position(&self, t: f32) -> P {
@@ -1059,11 +1059,11 @@ impl<P: LinearConvexSpace<f32>> RationalSegment<P> {
 /// Use any struct that implements the [`RationalGenerator`] trait to create a new curve, such as
 /// [`CubicNurbs`], or convert [`CubicCurve`] using `into/from`.
 #[derive(Clone, Debug, PartialEq)]
-pub struct RationalCurve<P: LinearConvexSpace<f32>> {
+pub struct RationalCurve<P: LinearConvexSpace<Scalar = f32>> {
     segments: Vec<RationalSegment<P>>,
 }
 
-impl<P: LinearConvexSpace<f32>> RationalCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> RationalCurve<P> {
     /// Compute the position of a point on the curve at the parametric value `t`.
     ///
     /// Note that `t` varies from `0..=(n_points - 3)`.
@@ -1183,13 +1183,13 @@ impl<P: LinearConvexSpace<f32>> RationalCurve<P> {
     }
 }
 
-impl<P: LinearConvexSpace<f32>> Extend<RationalSegment<P>> for RationalCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> Extend<RationalSegment<P>> for RationalCurve<P> {
     fn extend<T: IntoIterator<Item = RationalSegment<P>>>(&mut self, iter: T) {
         self.segments.extend(iter);
     }
 }
 
-impl<P: LinearConvexSpace<f32>> IntoIterator for RationalCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> IntoIterator for RationalCurve<P> {
     type IntoIter = <Vec<RationalSegment<P>> as IntoIterator>::IntoIter;
 
     type Item = RationalSegment<P>;
@@ -1199,7 +1199,7 @@ impl<P: LinearConvexSpace<f32>> IntoIterator for RationalCurve<P> {
     }
 }
 
-impl<P: LinearConvexSpace<f32>> From<CubicSegment<P>> for RationalSegment<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> From<CubicSegment<P>> for RationalSegment<P> {
     fn from(value: CubicSegment<P>) -> Self {
         Self {
             coeff: value.coeff,
@@ -1209,7 +1209,7 @@ impl<P: LinearConvexSpace<f32>> From<CubicSegment<P>> for RationalSegment<P> {
     }
 }
 
-impl<P: LinearConvexSpace<f32>> From<CubicCurve<P>> for RationalCurve<P> {
+impl<P: LinearConvexSpace<Scalar = f32>> From<CubicCurve<P>> for RationalCurve<P> {
     fn from(value: CubicCurve<P>) -> Self {
         Self {
             segments: value.segments.into_iter().map(Into::into).collect(),

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -10,6 +10,7 @@ mod aspect_ratio;
 pub mod bounding;
 pub mod cubic_splines;
 mod direction;
+pub mod linear_convex_space;
 pub mod primitives;
 mod ray;
 mod rects;

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -18,10 +18,10 @@ pub trait LinearConvexSpace: Default + Copy + Clone {
     fn add(self, rhs: Self) -> Self;
     /// Subtracts one element in the space from another one.
     fn sub(self, rhs: Self) -> Self;
-    /// Multiplies an element of the space by a scalar.
-    fn mul(self, rhs: Self::Scalar) -> Self;
-    /// Divides an element of the space by a scalar.
-    fn div(self, rhs: Self::Scalar) -> Self;
+    /// Scales an element of the space by a scalar.
+    fn scale(self, rhs: Self::Scalar) -> Self;
+    /// Scales an element of the space by the reciprocal of a scalar, effectifely dividing by that scalar.
+    fn scale_recip(self, rhs: Self::Scalar) -> Self;
 }
 
 #[macro_export]
@@ -43,11 +43,11 @@ macro_rules! impl_linear_convex_space {
                 self - rhs
             }
             #[inline]
-            fn mul(self, rhs: $scalar_ty) -> Self {
+            fn scale(self, rhs: $scalar_ty) -> Self {
                 self * rhs
             }
             #[inline]
-            fn div(self, rhs: $scalar_ty) -> Self {
+            fn scale_recip(self, rhs: $scalar_ty) -> Self {
                 self / rhs
             }
         }

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -11,7 +11,7 @@ use glam::{Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Vec4};
 ///
 /// By implementing this trait, you garantee that the above conditions hold true.
 pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
-    /// Adds two elements of the space
+    /// Adds two elements of the space.
     fn add(self, rhs: Self) -> Self;
     /// Subtracts one element in the space from another one.
     fn sub(self, rhs: Self) -> Self;

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -9,7 +9,7 @@ use glam::{DVec2, DVec3, DVec4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Ve
 ///
 /// The space should also be linear, meaning that `A*t + B*(1 - t)` with any points `A`, `B` and `t` element `0..1` should represent a straight line.
 ///
-/// By implementing this trait, you garantee that the above conditions hold true.
+/// By implementing this trait, you guarantee that the above conditions hold true.
 pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
     /// Adds two elements of the space.
     fn add(self, rhs: Self) -> Self;
@@ -25,7 +25,7 @@ pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
 /// Implements `LinearConvexSpace<Scalar>` for a given type `T` using the
 /// `Add`, `Sub`, `Mul` and `Div` implementations of `T`.
 ///
-/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` seperately.
+/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` separately.
 macro_rules! impl_linear_convex_space {
     ($ty: ident, $scalar_ty: ident) => {
         impl $crate::linear_convex_space::LinearConvexSpace<$scalar_ty> for $ty {

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -10,15 +10,18 @@ use glam::{DVec2, DVec3, DVec4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Ve
 /// The space should also be linear, meaning that `A*t + B*(1 - t)` with any points `A`, `B` and `t` element `0..1` should represent a straight line.
 ///
 /// By implementing this trait, you guarantee that the above conditions hold true.
-pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
+pub trait LinearConvexSpace: Default + Copy + Clone {
+    /// The scalar type to be used with this space.
+    type Scalar: Copy + Clone;
+
     /// Adds two elements of the space.
     fn add(self, rhs: Self) -> Self;
     /// Subtracts one element in the space from another one.
     fn sub(self, rhs: Self) -> Self;
     /// Multiplies an element of the space by a scalar.
-    fn mul(self, rhs: Scalar) -> Self;
+    fn mul(self, rhs: Self::Scalar) -> Self;
     /// Divides an element of the space by a scalar.
-    fn div(self, rhs: Scalar) -> Self;
+    fn div(self, rhs: Self::Scalar) -> Self;
 }
 
 #[macro_export]
@@ -28,7 +31,9 @@ pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
 /// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` separately.
 macro_rules! impl_linear_convex_space {
     ($ty: ident, $scalar_ty: ident) => {
-        impl $crate::linear_convex_space::LinearConvexSpace<$scalar_ty> for $ty {
+        impl $crate::linear_convex_space::LinearConvexSpace for $ty {
+            type Scalar = $scalar_ty;
+
             #[inline]
             fn add(self, rhs: Self) -> Self {
                 self + rhs

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -1,5 +1,5 @@
 //! This module provides the `LinearConvexSpace` trait and some related objects
-use glam::{Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Vec4};
+use glam::{DVec2, DVec3, DVec4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Vec4};
 
 /// A trait providing methods for spanning a linear, convex space.
 ///
@@ -57,6 +57,11 @@ impl_linear_convex_space!(Vec3, f32);
 impl_linear_convex_space!(Vec3A, f32);
 impl_linear_convex_space!(Vec4, f32);
 impl_linear_convex_space!(Quat, f32);
+
+impl_linear_convex_space!(f64, f64);
+impl_linear_convex_space!(DVec2, f64);
+impl_linear_convex_space!(DVec3, f64);
+impl_linear_convex_space!(DVec4, f64);
 
 impl_linear_convex_space!(u32, u32);
 impl_linear_convex_space!(UVec2, u32);

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -3,11 +3,14 @@ use glam::{DVec2, DVec3, DVec4, Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Ve
 
 /// A trait providing methods for spanning a linear, convex space.
 ///
+/// These are a generally useful set of properties, but in particular, are needed to ensure spline interpolation is well-behaved.
 /// A convex space or convex set is a set of points (think points in 3d or 2d space) in which every point on a line between two points A and B in that set
 /// is also a part of that set. For example the set of all points inside a square is a convex set as you can draw a line between any two points in the square and never leave it.
 /// For more information, please see [this wikipedia article](https://en.wikipedia.org/wiki/Convex_set).
 ///
-/// The space should also be linear, meaning that `A*t + B*(1 - t)` with any points `A`, `B` and `t` element `0..1` should represent a straight line.
+/// The space must also be linear,  allowing you to interpolate between any two points `A` and `B` via the parameter
+/// `t`  according to the formula `A*t + B*(1-t)`. This formula produces a new point on the straight line joining `A` and `B`,
+/// no matter what value of `t` between 0 (yielding B) and 1 (yielding A) is selected.
 ///
 /// By implementing this trait, you guarantee that the above conditions hold true.
 pub trait LinearConvexSpace: Default + Copy + Clone {

--- a/crates/bevy_math/src/linear_convex_space.rs
+++ b/crates/bevy_math/src/linear_convex_space.rs
@@ -1,0 +1,64 @@
+//! This module provides the `LinearConvexSpace` trait and some related objects
+use glam::{Quat, UVec2, UVec3, UVec4, Vec2, Vec3, Vec3A, Vec4};
+
+/// A trait providing methods for spanning a linear, convex space.
+///
+/// A convex space or convex set is a set of points (think points in 3d or 2d space) in which every point on a line between two points A and B in that set
+/// is also a part of that set. For example the set of all points inside a square is a convex set as you can draw a line between any two points in the square and never leave it.
+/// For more information, please see [this wikipedia article](https://en.wikipedia.org/wiki/Convex_set).
+///
+/// The space should also be linear, meaning that `A*t + B*(1 - t)` with any points `A`, `B` and `t` element `0..1` should represent a straight line.
+///
+/// By implementing this trait, you garantee that the above conditions hold true.
+pub trait LinearConvexSpace<Scalar>: Default + Copy + Clone {
+    /// Adds two elements of the space
+    fn add(self, rhs: Self) -> Self;
+    /// Subtracts one element in the space from another one.
+    fn sub(self, rhs: Self) -> Self;
+    /// Multiplies an element of the space by a scalar.
+    fn mul(self, rhs: Scalar) -> Self;
+    /// Divides an element of the space by a scalar.
+    fn div(self, rhs: Scalar) -> Self;
+}
+
+#[macro_export]
+/// Implements `LinearConvexSpace<Scalar>` for a given type `T` using the
+/// `Add`, `Sub`, `Mul` and `Div` implementations of `T`.
+///
+/// Please note that you still need to derive the bounds introduced by `LinearConvexSpace` seperately.
+macro_rules! impl_linear_convex_space {
+    ($ty: ident, $scalar_ty: ident) => {
+        impl $crate::linear_convex_space::LinearConvexSpace<$scalar_ty> for $ty {
+            #[inline]
+            fn add(self, rhs: Self) -> Self {
+                self + rhs
+            }
+            #[inline]
+            fn sub(self, rhs: Self) -> Self {
+                self - rhs
+            }
+            #[inline]
+            fn mul(self, rhs: $scalar_ty) -> Self {
+                self * rhs
+            }
+            #[inline]
+            fn div(self, rhs: $scalar_ty) -> Self {
+                self / rhs
+            }
+        }
+    };
+}
+
+pub use impl_linear_convex_space;
+
+impl_linear_convex_space!(f32, f32);
+impl_linear_convex_space!(Vec2, f32);
+impl_linear_convex_space!(Vec3, f32);
+impl_linear_convex_space!(Vec3A, f32);
+impl_linear_convex_space!(Vec4, f32);
+impl_linear_convex_space!(Quat, f32);
+
+impl_linear_convex_space!(u32, u32);
+impl_linear_convex_space!(UVec2, u32);
+impl_linear_convex_space!(UVec3, u32);
+impl_linear_convex_space!(UVec4, u32);


### PR DESCRIPTION
# Objective

- Adds arithmatic operations for colors so they can be used with splines, suggestion of #12202 and incorporating feedback from #12460 and #12534

## Solution

- This PR adds a `LinearConvexSpace` trait as suggested by @alice-i-cecile [in this comment](https://github.com/bevyengine/bevy/pull/12534#issuecomment-2002515053). This trait has everything needed for splines including arithatic operations such as addition or subtraction.
- `LinearConvexSpace` does not implement `std::ops::Add` and friends because those operations are not well defined for some types (such as colors) allthough those types may be used to define a linear convex space.  
- `LinearConvexSpace<Scalar>` is generic over some `Scalar` type so that `LinearConvexSpace` may also be used for `f64` or `u32` based types such as `DVec2`. These types cannot be used with splines but since `LinearConvexSpace` does not suggest only being used with splines, this might be useful in the future, allthough I am happy to remove this if wanted.
- I have added a `impl_linear_convex_space!(Type, Scalar)` macro that will automatically implement `LinearConvexSpace<Scalar> for Type` using the `std::ops::*` traits.
- Color types implement `LinearConvexSpace<f32>` using a macro `impl_color_linear_convex_space` local to `bevy_color`. All operations on color types are componentwise with no special rules for the alpha channel.
---

## Migration Guide

- The `Point` trait from `cubic_splines.rs` has been removed; as such any type that is supposed to be used with splines should implement `LinearConvexSpace<f32>` now. This can be done automatically for any custom type previously used with splines using the `impl_linear_convex_space` macro.

## Additional information

Mathematical operations on colors are a controversial topic. This is not the first PR attempting to add them and there has been lots of feedback and discussions on some previous PRs. If you want more information for the reasoning behind this proposal, please check #12534 out. For more information on why we don't implement `std::ops::Add` etc. for Colors or why arithmetic operations on colors may still be useful, please check out #12460.