### PR TITLE
refactor: separate out `PanicHandlerPlugin`

### DIFF
--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -175,6 +175,7 @@ bevy_ecs = { path = "../bevy_ecs", version = "0.14.0-dev" }
 bevy_hierarchy = { path = "../bevy_hierarchy", version = "0.14.0-dev" }
 bevy_input = { path = "../bevy_input", version = "0.14.0-dev" }
 bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
+bevy_panic_handler = { path = "../bevy_panic_handler", version = "0.14.0-dev" }
 bevy_math = { path = "../bevy_math", version = "0.14.0-dev" }
 bevy_ptr = { path = "../bevy_ptr", version = "0.14.0-dev" }
 bevy_reflect = { path = "../bevy_reflect", version = "0.14.0-dev", features = [

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -1,6 +1,7 @@
 use bevy_app::{Plugin, PluginGroup, PluginGroupBuilder};
 
 /// This plugin group will add all the default plugins for a *Bevy* application:
+/// * [`PanicHandlerPlugin`](crate::panic_handler::PanicHandlerPlugin)
 /// * [`LogPlugin`](crate::log::LogPlugin)
 /// * [`TaskPoolPlugin`](crate::core::TaskPoolPlugin)
 /// * [`TypeRegistrationPlugin`](crate::core::TypeRegistrationPlugin)

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -42,6 +42,7 @@ impl PluginGroup for DefaultPlugins {
     fn build(self) -> PluginGroupBuilder {
         let mut group = PluginGroupBuilder::start::<Self>();
         group = group
+            .add(bevy_panic_handler::PanicHandlerPlugin)
             .add(bevy_log::LogPlugin::default())
             .add(bevy_core::TaskPoolPlugin::default())
             .add(bevy_core::TypeRegistrationPlugin)

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -53,6 +53,11 @@ pub mod log {
     pub use bevy_log::*;
 }
 
+pub mod panic_handler {
+    //! Platform-specific panic handlers
+    pub use bevy_panic_handler::*;
+}
+
 pub mod math {
     //! Math types (Vec3, Mat4, Quat, etc) and helpers.
     pub use bevy_math::*;

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -34,7 +34,6 @@ tracy-client = { version = "0.17.0", optional = true }
 android_log-sys = "0.3.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = "0.1.6"
 tracing-wasm = "0.2.1"
 
 [lints]

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -205,7 +205,6 @@ impl Plugin for LogPlugin {
 
         #[cfg(target_arch = "wasm32")]
         {
-            console_error_panic_hook::set_once();
             finished_subscriber = subscriber.with(tracing_wasm::WASMLayer::new(
                 tracing_wasm::WASMLayerConfig::default(),
             ));

--- a/crates/bevy_panic_handler/Cargo.toml
+++ b/crates/bevy_panic_handler/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "bevy_panic_handler"
+version = "0.14.0-dev"
+edition = "2021"
+description = "Provides panic handlers for Bevy Engine"
+homepage = "https://bevyengine.org"
+repository = "https://github.com/bevyengine/bevy"
+license = "MIT OR Apache-2.0"
+keywords = ["bevy"]
+
+[features]
+
+[dependencies]
+bevy_app = { path = "../bevy_app", version = "0.14.0-dev" }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+console_error_panic_hook = "0.1.6"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+all-features = true

--- a/crates/bevy_panic_handler/src/lib.rs
+++ b/crates/bevy_panic_handler/src/lib.rs
@@ -46,10 +46,9 @@ impl Plugin for PanicHandlerPlugin {
         {
             console_error_panic_hook::set_once();
         }
-
-        #[cfg(target_os = "android")]
+        #[cfg(not(target_arch = "wasm32"))]
         {
-            // TODO - How should panics occur on android?
+            // Use the default target panic hook - Do nothing.
         }
     }
 }

--- a/crates/bevy_panic_handler/src/lib.rs
+++ b/crates/bevy_panic_handler/src/lib.rs
@@ -1,0 +1,55 @@
+//! This crate provides panic handlers for [Bevy](https://bevyengine.org)
+//! apps, and automatically configures platform specifics (i.e. WASM or Android).
+//!
+//! By default, the [`PanicHandlerPlugin`] from this crate is included in Bevy's `DefaultPlugins`.
+//!
+//! For more fine-tuned control over panic behavior, disable the [`PanicHandlerPlugin`] or
+//! `DefaultPlugins` during app initialization.
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+use bevy_app::{App, Plugin};
+
+/// Adds sensible panic handlers to Apps. This plugin is part of the `DefaultPlugins`. Adding
+/// this plugin will setup a panic hook appropriate to your target platform:
+/// * On WASM, uses [`console_error_panic_hook`](https://crates.io/crates/console_error_panic_hook), logging
+/// to the browser console.
+/// * Other platforms are currently not setup.
+///
+/// ```no_run
+/// # use bevy_app::{App, NoopPluginGroup as MinimalPlugins, PluginGroup};
+/// # use bevy_panic_handler::PanicHandlerPlugin;
+/// fn main() {
+///     App::new()
+///         .add_plugins(MinimalPlugins)
+///         .add_plugins(PanicHandlerPlugin)
+///         .run();
+/// }
+/// ```
+///
+/// If you want to setup your own panic handler, you should disable this
+/// plugin from `DefaultPlugins`:
+/// ```no_run
+/// # use bevy_app::{App, NoopPluginGroup as DefaultPlugins, PluginGroup};
+/// # use bevy_panic_handler::PanicHandlerPlugin;
+/// fn main() {
+///     App::new()
+///         .add_plugins(DefaultPlugins.build().disable::<PanicHandlerPlugin>())
+///         .run();
+/// }
+/// ```
+#[derive(Default)]
+pub struct PanicHandlerPlugin;
+
+impl Plugin for PanicHandlerPlugin {
+    fn build(&self, _app: &mut App) {
+        #[cfg(target_arch = "wasm32")]
+        {
+            console_error_panic_hook::set_once();
+        }
+
+        #[cfg(target_os = "android")]
+        {
+            // TODO - How should panics occur on android?
+        }
+    }
+}


### PR DESCRIPTION
# Objective

- Allow configuring of platform-specific panic handlers.
- Remove the silent overwrite of the WASM panic handler
- Closes #12546

## Solution

- Separates the panic handler to a new plugin, `PanicHandlerPlugin`.
- `PanicHandlerPlugin` was added to `DefaultPlugins`.
- Can be disabled on `DefaultPlugins`, in the case someone needs to configure custom panic handlers.

---

## Changelog

### Added
- A `PanicHandlerPlugin` was added to the `DefaultPlugins`, which now sets sensible target-specific panic handlers.

### Changed
- On WASM, the panic stack trace was output to the console through the `BevyLogPlugin`. Since this was separated out into `PanicHandlerPlugin`, you may need to add the new `PanicHandlerPlugin` (included in `DefaultPlugins`).

## Migration Guide

- If you used `MinimalPlugins` with `LogPlugin` for a WASM-target build, you will need to add the new `PanicHandlerPlugin` to set the panic behavior to output to the console. Otherwise, you will see the default panic handler (opaque, `unreachable` errors in the console).
