### PR TITLE
fix: correctly handle UI outline scale

### DIFF
--- a/crates/bevy_dev_tools/src/debug_overlay/mod.rs
+++ b/crates/bevy_dev_tools/src/debug_overlay/mod.rs
@@ -200,7 +200,7 @@ fn outline_roots(
         );
     }
     let window_scale = window.get_single().map_or(1., Window::scale_factor);
-    let scale_factor = window_scale * outline.ui_scale.0;
+    let scale_factor = outline.ui_scale.0;
 
     // We let the line be defined by the window scale alone
     let line_width = outline


### PR DESCRIPTION
# Objective

- The UI outline in the new dev tools does not handle scale correctly when the scale is not 1. It looks like the `GlobalTransform` already handles `scale`. Fix #12566 
- To reproduce make sure your screen scale is not 1 and run `cargo run --example ui --features bevy/bevy_dev_tools`
- I'm not really familiar with Bevy UI internal so please review this carefully.

## Solution
- Dont apply `window_scale` when calculating `LayoutRect` scale
---
#### Question about UI Node with custom scale: 
- How do we expect the outline when the UI Node is spawn with custom transform
Eg: `Transform::from_scale(Vec3::splat(1.5))`. Related discussion in Discord https://discord.com/channels/691052431525675048/743663673393938453/1219575406986788864

Before
![image](https://github.com/bevyengine/bevy/assets/33456881/10a0bd72-d3ce-4d23-803b-2c458a3a34d7)
After 
![image](https://github.com/bevyengine/bevy/assets/33456881/5bb34d71-2d4c-4fb3-9782-abc450ac7c00)
