### PR TITLE
Added an `init_bundle` method to `World`

### DIFF
--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2091,12 +2091,11 @@ impl World {
     /// This is equivalent to calling [`init_component`](Self::init_component) on each component
     /// in the bundle.
     #[inline]
-    pub fn init_bundle<B: Bundle>(&mut self) -> Vec<ComponentId> {
-        let mut ids = Vec::new();
-        B::component_ids(&mut self.components, &mut self.storages, &mut |id| {
-            ids.push(id);
-        });
-        ids
+    pub fn init_bundle<B: Bundle>(&mut self) -> &[ComponentId] {
+        let id = self
+            .bundles
+            .init_info::<B>(&mut self.components, &mut self.storages);
+        self.bundles.get(id).unwrap().components()
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2097,7 +2097,7 @@ impl World {
             .bundles
             .init_info::<B>(&mut self.components, &mut self.storages);
         // SAFETY: We just initialised the bundle so its id should definitely be valid.
-        unsafe { self.bundles.get(id).unwrap_unchecked() }
+        unsafe { self.bundles.get(id).debug_checked_unwrap() }
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2085,6 +2085,19 @@ impl World {
         self.storages.resources.clear();
         self.storages.non_send_resources.clear();
     }
+
+    /// Initializes all of the components in the given [`Bundle`] and returns their ids.
+    ///
+    /// This is equivalent to calling [`init_component`](Self::init_component) on each component
+    /// in the bundle.
+    #[inline]
+    pub fn init_bundle<B: Bundle>(&mut self) -> Vec<ComponentId> {
+        let mut ids = Vec::new();
+        B::component_ids(&mut self.components, &mut self.storages, &mut |id| {
+            ids.push(id);
+        });
+        ids
+    }
 }
 
 impl World {

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2095,7 +2095,8 @@ impl World {
         let id = self
             .bundles
             .init_info::<B>(&mut self.components, &mut self.storages);
-        self.bundles.get(id).unwrap().components()
+        // SAFETY: We just initialised the bundle so its id should definitely be valid.
+        unsafe { self.bundles.get(id).unwrap_unchecked().components() }
     }
 }
 

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -18,7 +18,7 @@ pub use spawn_batch::*;
 
 use crate::{
     archetype::{ArchetypeComponentId, ArchetypeId, ArchetypeRow, Archetypes},
-    bundle::{Bundle, BundleInserter, BundleSpawner, Bundles},
+    bundle::{Bundle, BundleInfo, BundleInserter, BundleSpawner, Bundles},
     change_detection::{MutUntyped, TicksMut},
     component::{
         Component, ComponentDescriptor, ComponentHooks, ComponentId, ComponentInfo, ComponentTicks,
@@ -2086,17 +2086,18 @@ impl World {
         self.storages.non_send_resources.clear();
     }
 
-    /// Initializes all of the components in the given [`Bundle`] and returns their ids.
+    /// Initializes all of the components in the given [`Bundle`] and returns both the component
+    /// ids and the bundle id.
     ///
-    /// This is equivalent to calling [`init_component`](Self::init_component) on each component
-    /// in the bundle.
+    /// This is largely equivalent to calling [`init_component`](Self::init_component) on each
+    /// component in the bundle.
     #[inline]
-    pub fn init_bundle<B: Bundle>(&mut self) -> &[ComponentId] {
+    pub fn init_bundle<B: Bundle>(&mut self) -> &BundleInfo {
         let id = self
             .bundles
             .init_info::<B>(&mut self.components, &mut self.storages);
         // SAFETY: We just initialised the bundle so its id should definitely be valid.
-        unsafe { self.bundles.get(id).unwrap_unchecked().components() }
+        unsafe { self.bundles.get(id).unwrap_unchecked() }
     }
 }
 


### PR DESCRIPTION
# Objective
Make it easy to get the ids of all the components in a bundle (and initialise any components not yet initialised). This is fairly similar to the `Bundle::get_component_ids()` method added in the observers PR however that will return none for any non-initialised components. This is exactly the API space covered by `Bundle::component_ids()` however that isn't possible to call outside of `bevy_ecs` as it requires `&mut Components` and `&mut Storages`.

## Solution
Added `World.init_bundle<B: Bundle>()` which similarly to `init_component` and `init_resource`, initialises all components in the bundle and returns a vector of their component ids.

---

## Changelog
Added the method `init_bundle` to `World` as a counterpart to `init_component` and `init_resource`.
