### PR TITLE
Split apart `AssetSourceBuilder`'s `build_sources` and `build`

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -166,7 +166,11 @@ impl Plugin for AssetPlugin {
             match self.mode {
                 AssetMode::Unprocessed => {
                     let mut builders = app.world.resource_mut::<AssetSourceBuilders>();
-                    let sources = builders.build_sources(watch, false);
+                    let sources = if watch {
+                        builders.build_sources_and_watch_for_unprocessed_changes()
+                    } else {
+                        builders.build_sources()
+                    };
                     let meta_check = app
                         .world
                         .get_resource::<AssetMetaCheck>()
@@ -185,7 +189,11 @@ impl Plugin for AssetPlugin {
                     {
                         let mut builders = app.world.resource_mut::<AssetSourceBuilders>();
                         let processor = AssetProcessor::new(&mut builders);
-                        let mut sources = builders.build_sources(false, watch);
+                        let mut sources = if watch {
+                            builders.build_sources_and_watch_for_processed_changes()
+                        } else {
+                            builders.build_sources()
+                        };
                         sources.gate_on_processor(processor.data.clone());
                         // the main asset server shares loaders with the processor asset server
                         app.insert_resource(AssetServer::new_with_loaders(
@@ -201,7 +209,11 @@ impl Plugin for AssetPlugin {
                     #[cfg(not(feature = "asset_processor"))]
                     {
                         let mut builders = app.world.resource_mut::<AssetSourceBuilders>();
-                        let sources = builders.build_sources(false, watch);
+                        let sources = if watch {
+                            builders.build_sources_and_watch_for_processed_changes()
+                        } else {
+                            builders.build_sources()
+                        };
                         app.insert_resource(AssetServer::new_with_meta_check(
                             sources,
                             AssetServerMode::Processed,

--- a/crates/bevy_asset/src/processor/mod.rs
+++ b/crates/bevy_asset/src/processor/mod.rs
@@ -73,9 +73,11 @@ pub struct AssetProcessorData {
 impl AssetProcessor {
     /// Creates a new [`AssetProcessor`] instance.
     pub fn new(source: &mut AssetSourceBuilders) -> Self {
-        let data = Arc::new(AssetProcessorData::new(source.build_sources(true, false)));
+        let data = Arc::new(AssetProcessorData::new(
+            source.build_sources_and_watch_for_unprocessed_changes(),
+        ));
         // The asset processor uses its own asset server with its own id space
-        let mut sources = source.build_sources(false, false);
+        let mut sources = source.build_sources();
         sources.gate_on_processor(data.clone());
         let server = AssetServer::new_with_meta_check(
             sources,


### PR DESCRIPTION
# Objective

- Remove 'watch' and 'watch_processed' flag parameters to increase readability.

## Solution

- Split the 'build' and 'build_sources' functions into functions where each parameter is either true or false and give them fitting names.

---

## Notes

The case where both 'watch' and 'watch_processed' are true is not used and is thus not included.