### PR TITLE
Fix `Oklab` and `Oklch` color space inconsistency

### DIFF
--- a/crates/bevy_color/src/oklaba.rs
+++ b/crates/bevy_color/src/oklaba.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize, Reflect)]
 #[reflect(PartialEq, Serialize, Deserialize, Default)]
 pub struct Oklaba {
-    /// The 'l' channel. [0.0, 1.0]
+    /// The 'lightness' channel. [0.0, 1.0]
     pub lightness: f32,
     /// The 'a' channel. [-1.0, 1.0]
     pub a: f32,
@@ -59,7 +59,7 @@ impl Oklaba {
         }
     }
 
-    /// Return a copy of this color with the 'l' channel set to the given value.
+    /// Return a copy of this color with the 'lightness' channel set to the given value.
     pub const fn with_lightness(self, lightness: f32) -> Self {
         Self { lightness, ..self }
     }

--- a/crates/bevy_color/src/oklcha.rs
+++ b/crates/bevy_color/src/oklcha.rs
@@ -56,17 +56,17 @@ impl Oklcha {
     }
 
     /// Return a copy of this color with the 'lightness' channel set to the given value.
-    pub const fn with_l(self, lightness: f32) -> Self {
+    pub const fn with_lightness(self, lightness: f32) -> Self {
         Self { lightness, ..self }
     }
 
     /// Return a copy of this color with the 'chroma' channel set to the given value.
-    pub const fn with_c(self, chroma: f32) -> Self {
+    pub const fn with_chroma(self, chroma: f32) -> Self {
         Self { chroma, ..self }
     }
 
     /// Return a copy of this color with the 'hue' channel set to the given value.
-    pub const fn with_h(self, hue: f32) -> Self {
+    pub const fn with_hue(self, hue: f32) -> Self {
         Self { hue, ..self }
     }
 


### PR DESCRIPTION
# Objective

Fixes #12224.

## Solution

- Expand `with_` methods for the `Oklch` to their full names.
- Expand `l` to `lightness` in `Oklaba` comments.

## Migration Guide

The following methods have been renamed for the `Oklch` color space:
- `with_l` -> `with_lightness`.
- `with_c` -> `with_chroma`.
- `with_h` -> `with_hue`.
