### PR TITLE
Make SystemInfo a Resource

### DIFF
--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -28,11 +28,13 @@ use bevy_app::prelude::*;
 pub struct DiagnosticsPlugin;
 
 impl Plugin for DiagnosticsPlugin {
-    fn build(&self, _app: &mut App) {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<DiagnosticsStore>();
+
         #[cfg(feature = "sysinfo_plugin")]
-        _app.init_resource::<DiagnosticsStore>().add_systems(
+        app.add_systems(
             Startup,
-            system_information_diagnostics_plugin::internal::log_system_info,
+            system_information_diagnostics_plugin::internal::setup_system_info_resource,
         );
     }
 }

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -18,9 +18,8 @@ pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
-use system_information_diagnostics_plugin::SystemInfo;
 #[cfg(feature = "sysinfo_plugin")]
-pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
+pub use system_information_diagnostics_plugin::{SystemInfo, SystemInformationDiagnosticsPlugin};
 
 use bevy_app::prelude::*;
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -18,6 +18,7 @@ pub use diagnostic::*;
 pub use entity_count_diagnostics_plugin::EntityCountDiagnosticsPlugin;
 pub use frame_time_diagnostics_plugin::FrameTimeDiagnosticsPlugin;
 pub use log_diagnostics_plugin::LogDiagnosticsPlugin;
+use system_information_diagnostics_plugin::SystemInfo;
 #[cfg(feature = "sysinfo_plugin")]
 pub use system_information_diagnostics_plugin::SystemInformationDiagnosticsPlugin;
 
@@ -32,10 +33,7 @@ impl Plugin for DiagnosticsPlugin {
         app.init_resource::<DiagnosticsStore>();
 
         #[cfg(feature = "sysinfo_plugin")]
-        app.add_systems(
-            Startup,
-            system_information_diagnostics_plugin::internal::setup_system_info_resource,
-        );
+        app.init_resource::<SystemInfo>();
     }
 }
 

--- a/crates/bevy_diagnostic/src/lib.rs
+++ b/crates/bevy_diagnostic/src/lib.rs
@@ -33,7 +33,7 @@ impl Plugin for DiagnosticsPlugin {
         app.init_resource::<DiagnosticsStore>();
 
         #[cfg(feature = "sysinfo_plugin")]
-        app.init_resource::<SystemInfo>();
+        app.init_resource::<system_information_diagnostics_plugin::SystemInfo>();
     }
 }
 

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -148,7 +148,7 @@ pub mod internal {
         // no-op
     }
 
-    pub(crate) fn log_system_info() {
+    pub(crate) fn setup_system_info_resource() {
         // no-op
     }
 }

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -99,9 +99,8 @@ pub mod internal {
         });
     }
 
-    impl FromWorld for SystemInfo {
-        // This doesn't need the world but it makes easier to initialize at app creation
-        fn from_world(_world: &mut bevy_ecs::world::World) -> Self {
+    impl Default for SystemInfo {
+        fn default() -> Self {
             let sys = System::new_with_specifics(
                 RefreshKind::new()
                     .with_cpu(CpuRefreshKind::new())
@@ -148,8 +147,8 @@ pub mod internal {
         // no-op
     }
 
-    impl bevy_ecs::world::FromWorld for super::SystemInfo {
-        fn from_world(world: &mut bevy_ecs::world::World) -> Self {
+    impl Default for super::SystemInfo {
+        fn default() -> Self {
             let unknown = "Unknown".to_string();
             Self {
                 os: unknown.clone(),

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -148,7 +148,7 @@ pub mod internal {
         // no-op
     }
 
-    impl FromWorld for SystemInfo {
+    impl bevy_ecs::world::FromWorld for SystemInfo {
         fn from_world(world: &mut bevy_ecs::world::World) -> Self {
             Self {
                 os: "Unknown",

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -51,7 +51,7 @@ pub struct SystemInfo {
     not(feature = "dynamic_linking")
 ))]
 pub mod internal {
-    use bevy_ecs::{prelude::ResMut, system::Local, world::FromWorld};
+    use bevy_ecs::{prelude::ResMut, system::Local};
     use bevy_utils::tracing::info;
     use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind, System};
 

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -31,13 +31,13 @@ impl SystemInformationDiagnosticsPlugin {
     pub const MEM_USAGE: DiagnosticPath = DiagnosticPath::const_new("system/mem_usage");
 }
 
-#[derive(Debug, Resource)]
 /// A resource that stores diagnostic information about the system.
 /// This information can be useful for debugging and profiling purposes.
 ///
 /// # See also
 ///
 /// [`SystemInformationDiagnosticsPlugin`](crate::SystemInformationDiagnosticsPlugin) for more information.
+#[derive(Debug, Resource)]
 pub struct SystemInfo {
     pub os: String,
     pub kernel: String,

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -150,12 +150,13 @@ pub mod internal {
 
     impl bevy_ecs::world::FromWorld for super::SystemInfo {
         fn from_world(world: &mut bevy_ecs::world::World) -> Self {
+            let unknown = "Unknown".to_string();
             Self {
-                os: "Unknown",
-                kernel: "Unknown",
-                cpu: "Unknown",
-                core_count: "Unknown",
-                memory: "Unknown",
+                os: unknown.clone(),
+                kernel: unknown.clone(),
+                cpu: unknown.clone(),
+                core_count: unknown.clone(),
+                memory: unknown.clone(),
             }
         }
     }

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -148,7 +148,7 @@ pub mod internal {
         // no-op
     }
 
-    impl bevy_ecs::world::FromWorld for SystemInfo {
+    impl bevy_ecs::world::FromWorld for super::SystemInfo {
         fn from_world(world: &mut bevy_ecs::world::World) -> Self {
             Self {
                 os: "Unknown",

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -36,7 +36,7 @@ impl SystemInformationDiagnosticsPlugin {
 ///
 /// # See also
 ///
-/// [`SystemInformationDiagnosticsPlugin`](crate::SystemInformationDiagnosticsPlugin) for more information.
+/// [`SystemInformationDiagnosticsPlugin`] for more information.
 #[derive(Debug, Resource)]
 pub struct SystemInfo {
     pub os: String,

--- a/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
+++ b/crates/bevy_diagnostic/src/system_information_diagnostics_plugin.rs
@@ -32,6 +32,12 @@ impl SystemInformationDiagnosticsPlugin {
 }
 
 #[derive(Debug, Resource)]
+/// A resource that stores diagnostic information about the system.
+/// This information can be useful for debugging and profiling purposes.
+///
+/// # See also
+///
+/// [`SystemInformationDiagnosticsPlugin`](crate::SystemInformationDiagnosticsPlugin) for more information.
 pub struct SystemInfo {
     pub os: String,
     pub kernel: String,


### PR DESCRIPTION
# Objective

We already collect a lot of system information on startup when possible but we don't make this information available. With the upcoming work on a diagnostic overlay it would be useful to be able to display this information.

## Solution

Make the already existing SystemInfo a Resource

---

## Changelog

Added `SystemInfo` Resource
