### PR TITLE
Always spawn fps_overlay on top of everything

### DIFF
--- a/crates/bevy_dev_tools/src/fps_overlay.rs
+++ b/crates/bevy_dev_tools/src/fps_overlay.rs
@@ -10,8 +10,13 @@ use bevy_ecs::{
     schedule::{common_conditions::resource_changed, IntoSystemConfigs},
     system::{Commands, Query, Res, Resource},
 };
+use bevy_hierarchy::BuildChildren;
 use bevy_text::{Font, Text, TextSection, TextStyle};
-use bevy_ui::node_bundles::TextBundle;
+use bevy_ui::{
+    node_bundles::{NodeBundle, TextBundle},
+    PositionType, Style, ZIndex,
+};
+use bevy_utils::default;
 
 /// A plugin that adds an FPS overlay to the Bevy application.
 ///
@@ -67,13 +72,26 @@ impl Default for FpsOverlayConfig {
 struct FpsText;
 
 fn setup(mut commands: Commands, overlay_config: Res<FpsOverlayConfig>) {
-    commands.spawn((
-        TextBundle::from_sections([
-            TextSection::new("FPS: ", overlay_config.text_config.clone()),
-            TextSection::from_style(overlay_config.text_config.clone()),
-        ]),
-        FpsText,
-    ));
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                // We need to make sure the overlay doesn't affect the position of other UI nodes
+                position_type: PositionType::Absolute,
+                ..default()
+            },
+            // Render overlay on top of everything
+            z_index: ZIndex::Global(i32::MAX),
+            ..default()
+        })
+        .with_children(|c| {
+            c.spawn((
+                TextBundle::from_sections([
+                    TextSection::new("FPS: ", overlay_config.text_config.clone()),
+                    TextSection::from_style(overlay_config.text_config.clone()),
+                ]),
+                FpsText,
+            ));
+        });
 }
 
 fn update_text(diagnostic: Res<DiagnosticsStore>, mut query: Query<&mut Text, With<FpsText>>) {

--- a/examples/dev_tools/fps_overlay.rs
+++ b/examples/dev_tools/fps_overlay.rs
@@ -28,30 +28,33 @@ fn main() {
 }
 
 fn setup(mut commands: Commands) {
-    // We need to spawn camera to see overlay
+    // We need to spawn a camera (2d or 3d) to see the overlay
     commands.spawn(Camera2dBundle::default());
-    commands.spawn(
-        TextBundle::from_sections([
-            TextSection::new(
-                "Press 1 to change color of the overlay.",
-                TextStyle {
-                    font_size: 25.0,
-                    ..default()
-                },
-            ),
-            TextSection::new(
-                "\nPress 2 to change size of the overlay",
-                TextStyle {
-                    font_size: 25.0,
-                    ..default()
-                },
-            ),
-        ])
-        .with_style(Style {
-            justify_self: JustifySelf::Center,
+
+    // Instruction text
+    commands
+        .spawn(NodeBundle {
+            style: Style {
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
+                align_items: AlignItems::Center,
+                justify_content: JustifyContent::Center,
+                ..default()
+            },
             ..default()
-        }),
-    );
+        })
+        .with_children(|c| {
+            c.spawn(TextBundle::from_section(
+                concat!(
+                    "Press 1 to change color of the overlay.\n",
+                    "Press 2 to change size of the overlay."
+                ),
+                TextStyle {
+                    font_size: 25.0,
+                    ..default()
+                },
+            ));
+        });
 }
 
 fn customize_config(input: Res<ButtonInput<KeyCode>>, mut overlay: ResMut<FpsOverlayConfig>) {


### PR DESCRIPTION
# Objective

- Currently the fps_overlay affects any other ui node spawned. This should not happen

## Solution

- Use position absolute and a ZIndex of `i32::MAX`