### PR TITLE
UI: allow border radius to be optional for images and background

### DIFF
--- a/crates/bevy_ui/src/render/mod.rs
+++ b/crates/bevy_ui/src/render/mod.rs
@@ -193,7 +193,7 @@ pub fn extract_uinode_background_colors(
             Option<&CalculatedClip>,
             Option<&TargetCamera>,
             &BackgroundColor,
-            &BorderRadius,
+            Option<&BorderRadius>,
         )>,
     >,
 ) {
@@ -224,8 +224,11 @@ pub fn extract_uinode_background_colors(
             continue;
         }
 
-        let border_radius =
-            resolve_border_radius(border_radius, uinode.size(), viewport_size, ui_scale.0);
+        let border_radius = if let Some(border_radius) = border_radius {
+            resolve_border_radius(border_radius, uinode.size(), viewport_size, ui_scale.0)
+        } else {
+            [0.; 4]
+        };
 
         extracted_uinodes.uinodes.insert(
             entity,
@@ -268,7 +271,7 @@ pub fn extract_uinode_images(
             &UiImage,
             Option<&TextureAtlas>,
             Option<&ComputedTextureSlices>,
-            &BorderRadius,
+            Option<&BorderRadius>,
         )>,
     >,
 ) {
@@ -323,8 +326,11 @@ pub fn extract_uinode_images(
             ),
         };
 
-        let border_radius =
-            resolve_border_radius(border_radius, uinode.size(), viewport_size, ui_scale.0);
+        let border_radius = if let Some(border_radius) = border_radius {
+            resolve_border_radius(border_radius, uinode.size(), viewport_size, ui_scale.0)
+        } else {
+            [0.; 4]
+        };
 
         extracted_uinodes.uinodes.insert(
             commands.spawn_empty().id(),


### PR DESCRIPTION
# Objective

- #12500 broke images and background colors in UI. Try examples `overflow`, `ui_scaling` or `ut_texture_atlas`

## Solution

- Makes the component `BorderRadius` optional in the query, as it's not always present. Use `[0.; 4]` as border radius in the extracted node when none was found
