### PR TITLE
Adding explanation to seeded rng used in examples

### DIFF
--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -50,7 +50,8 @@ fn setup(
 
     // cubes
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
     let cube_mesh = meshes.add(Cuboid::new(0.5, 0.5, 0.5));
     let blue = materials.add(Color::srgb_u8(124, 144, 255));

--- a/examples/3d/spotlight.rs
+++ b/examples/3d/spotlight.rs
@@ -48,6 +48,8 @@ fn setup(
     ));
 
     // cubes
+
+    // Make it deterministic for testing purposes.
     let mut rng = StdRng::seed_from_u64(19878367467713);
     let cube_mesh = meshes.add(Cuboid::new(0.5, 0.5, 0.5));
     let blue = materials.add(Color::srgb_u8(124, 144, 255));

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -122,6 +122,7 @@ fn setup(
 
     let mesh = meshes.add(mesh);
 
+    // Make it deterministic for testing purposes.
     let mut rng = StdRng::seed_from_u64(42);
 
     for i in -5..5 {

--- a/examples/animation/custom_skinned_mesh.rs
+++ b/examples/animation/custom_skinned_mesh.rs
@@ -123,7 +123,8 @@ fn setup(
 
     let mesh = meshes.add(mesh);
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(42);
 
     for i in -5..5 {

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -26,6 +26,7 @@ fn setup(mut commands: Commands) {
 
     let (tx, rx) = bounded::<u32>(10);
     std::thread::spawn(move || {
+        // Make it deterministic for testing purposes.
         let mut rng = StdRng::seed_from_u64(19878367467713);
         loop {
             // Everything here happens in another thread

--- a/examples/async_tasks/external_source_external_thread.rs
+++ b/examples/async_tasks/external_source_external_thread.rs
@@ -27,7 +27,8 @@ fn setup(mut commands: Commands) {
 
     let (tx, rx) = bounded::<u32>(10);
     std::thread::spawn(move || {
-        // Make it deterministic for testing purposes.
+        // We're seeding the PRNG here to make this example deterministic for testing purposes.
+        // This isn't strictly required in practical use unless you need your app to be deterministic.
         let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
         loop {
             // Everything here happens in another thread

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -45,7 +45,8 @@ fn generate_bodies(
     let color_range = 0.5..1.0;
     let vel_range = -0.5..0.5;
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
     for _ in 0..NUM_BODIES {
         let radius: f32 = rng.gen_range(0.1..0.7);

--- a/examples/ecs/iter_combinations.rs
+++ b/examples/ecs/iter_combinations.rs
@@ -44,6 +44,7 @@ fn generate_bodies(
     let color_range = 0.5..1.0;
     let vel_range = -0.5..0.5;
 
+    // Make it deterministic for testing purposes.
     let mut rng = StdRng::seed_from_u64(19878367467713);
     for _ in 0..NUM_BODIES {
         let radius: f32 = rng.gen_range(0.1..0.7);

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -10,6 +10,8 @@ struct Velocity(Vec2);
 fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     let texture = asset_server.load("branding/icon.png");
+
+    // Make it deterministic for testing purposes.
     let mut rng = StdRng::seed_from_u64(19878367467713);
     for _ in 0..128 {
         commands.spawn((

--- a/examples/ecs/parallel_query.rs
+++ b/examples/ecs/parallel_query.rs
@@ -12,7 +12,8 @@ fn spawn_system(mut commands: Commands, asset_server: Res<AssetServer>) {
     commands.spawn(Camera2dBundle::default());
     let texture = asset_server.load("branding/icon.png");
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
     for _ in 0..128 {
         commands.spawn((

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -109,7 +109,7 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMut<Game>) {
     let mut rng = if std::env::var("GITHUB_ACTIONS") == Ok("true".to_string()) {
-        // Make the game play out the same way every time, this is useful for testing purposes.
+        // Make it deterministic for testing purposes.
         StdRng::seed_from_u64(19878367467713)
     } else {
         StdRng::from_entropy()

--- a/examples/games/alien_cake_addict.rs
+++ b/examples/games/alien_cake_addict.rs
@@ -110,7 +110,8 @@ fn setup_cameras(mut commands: Commands, mut game: ResMut<Game>) {
 
 fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut game: ResMut<Game>) {
     let mut rng = if std::env::var("GITHUB_ACTIONS") == Ok("true".to_string()) {
-        // Make it deterministic for testing purposes.
+        // We're seeding the PRNG here to make this example deterministic for testing purposes.
+        // This isn't strictly required in practical use unless you need your app to be deterministic.
         ChaCha8Rng::seed_from_u64(19878367467713)
     } else {
         ChaCha8Rng::from_entropy()

--- a/examples/gizmos/axes.rs
+++ b/examples/gizmos/axes.rs
@@ -41,6 +41,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // Make it deterministic for testing purposes.
     let mut rng = StdRng::seed_from_u64(19878367467713);
 
     // Lights...

--- a/examples/gizmos/axes.rs
+++ b/examples/gizmos/axes.rs
@@ -42,7 +42,8 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut rng = ChaCha8Rng::seed_from_u64(19878367467713);
 
     // Lights...

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -221,6 +221,7 @@ fn setup(
         quad: meshes
             .add(Rectangle::from_size(Vec2::splat(BIRD_TEXTURE_SIZE as f32)))
             .into(),
+        // Make it deterministic for testing purposes.
         color_rng: StdRng::seed_from_u64(42),
         material_rng: StdRng::seed_from_u64(42),
         velocity_rng: StdRng::seed_from_u64(42),
@@ -304,6 +305,7 @@ fn mouse_handler(
     mut wave: Local<usize>,
 ) {
     if rng.is_none() {
+        // Make it deterministic for testing purposes.
         *rng = Some(StdRng::seed_from_u64(42));
     }
     let rng = rng.as_mut().unwrap();
@@ -537,6 +539,7 @@ fn counter_system(
 }
 
 fn init_textures(textures: &mut Vec<Handle<Image>>, args: &Args, images: &mut Assets<Image>) {
+    // Make it deterministic for testing purposes.
     let mut color_rng = StdRng::seed_from_u64(42);
     while textures.len() < args.material_texture_count {
         let pixel = [color_rng.gen(), color_rng.gen(), color_rng.gen(), 255];
@@ -572,6 +575,7 @@ fn init_materials(
         texture: textures.first().cloned(),
     }));
 
+    // Make it deterministic for testing purposes.
     let mut color_rng = StdRng::seed_from_u64(42);
     let mut texture_rng = StdRng::seed_from_u64(42);
     materials.extend(

--- a/examples/stress_tests/bevymark.rs
+++ b/examples/stress_tests/bevymark.rs
@@ -222,7 +222,8 @@ fn setup(
         quad: meshes
             .add(Rectangle::from_size(Vec2::splat(BIRD_TEXTURE_SIZE as f32)))
             .into(),
-        // Make it deterministic for testing purposes.
+        // We're seeding the PRNG here to make this example deterministic for testing purposes.
+        // This isn't strictly required in practical use unless you need your app to be deterministic.
         color_rng: ChaCha8Rng::seed_from_u64(42),
         material_rng: ChaCha8Rng::seed_from_u64(42),
         velocity_rng: ChaCha8Rng::seed_from_u64(42),
@@ -306,7 +307,8 @@ fn mouse_handler(
     mut wave: Local<usize>,
 ) {
     if rng.is_none() {
-        // Make it deterministic for testing purposes.
+        // We're seeding the PRNG here to make this example deterministic for testing purposes.
+        // This isn't strictly required in practical use unless you need your app to be deterministic.
         *rng = Some(ChaCha8Rng::seed_from_u64(42));
     }
     let rng = rng.as_mut().unwrap();
@@ -540,7 +542,8 @@ fn counter_system(
 }
 
 fn init_textures(textures: &mut Vec<Handle<Image>>, args: &Args, images: &mut Assets<Image>) {
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut color_rng = ChaCha8Rng::seed_from_u64(42);
     while textures.len() < args.material_texture_count {
         let pixel = [color_rng.gen(), color_rng.gen(), color_rng.gen(), 255];
@@ -576,7 +579,8 @@ fn init_materials(
         texture: textures.first().cloned(),
     }));
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut color_rng = ChaCha8Rng::seed_from_u64(42);
     let mut texture_rng = ChaCha8Rng::seed_from_u64(42);
     materials.extend(

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -123,6 +123,7 @@ fn setup(
     let material_textures = init_textures(args, images);
     let materials = init_materials(args, &material_textures, material_assets);
 
+    // Make it deterministic for testing purposes.
     let mut material_rng = StdRng::seed_from_u64(42);
     match args.layout {
         Layout::Sphere => {
@@ -202,6 +203,7 @@ fn setup(
 }
 
 fn init_textures(args: &Args, images: &mut Assets<Image>) -> Vec<Handle<Image>> {
+    // Make it deterministic for testing purposes.
     let mut color_rng = StdRng::seed_from_u64(42);
     let color_bytes: Vec<u8> = (0..(args.material_texture_count * 4))
         .map(|i| if (i % 4) == 3 { 255 } else { color_rng.gen() })
@@ -246,6 +248,7 @@ fn init_materials(
         ..default()
     }));
 
+    // Make it deterministic for testing purposes.
     let mut color_rng = StdRng::seed_from_u64(42);
     let mut texture_rng = StdRng::seed_from_u64(42);
     materials.extend(

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -124,7 +124,8 @@ fn setup(
     let material_textures = init_textures(args, images);
     let materials = init_materials(args, &material_textures, material_assets);
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut material_rng = ChaCha8Rng::seed_from_u64(42);
     match args.layout {
         Layout::Sphere => {
@@ -204,7 +205,8 @@ fn setup(
 }
 
 fn init_textures(args: &Args, images: &mut Assets<Image>) -> Vec<Handle<Image>> {
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut color_rng = ChaCha8Rng::seed_from_u64(42);
     let color_bytes: Vec<u8> = (0..(args.material_texture_count * 4))
         .map(|i| if (i % 4) == 3 { 255 } else { color_rng.gen() })
@@ -249,7 +251,8 @@ fn init_materials(
         ..default()
     }));
 
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut color_rng = ChaCha8Rng::seed_from_u64(42);
     let mut texture_rng = ChaCha8Rng::seed_from_u64(42);
     materials.extend(

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -54,7 +54,8 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     let mut seeded_rng = ChaCha8Rng::seed_from_u64(19878367467712);
 
     // A camera looking at the origin

--- a/examples/transforms/align.rs
+++ b/examples/transforms/align.rs
@@ -53,6 +53,7 @@ fn setup(
     mut meshes: ResMut<Assets<Mesh>>,
     mut materials: ResMut<Assets<StandardMaterial>>,
 ) {
+    // Make it deterministic for testing purposes.
     let mut seeded_rng = StdRng::seed_from_u64(19878367467712);
 
     // A camera looking at the origin

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -104,5 +104,6 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
                 },
             ));
         });
+    // Make it deterministic for testing purposes.
     commands.insert_resource(SeededRng(StdRng::seed_from_u64(19878367467713)));
 }

--- a/examples/ui/font_atlas_debug.rs
+++ b/examples/ui/font_atlas_debug.rs
@@ -105,6 +105,7 @@ fn setup(mut commands: Commands, asset_server: Res<AssetServer>, mut state: ResM
                 },
             ));
         });
-    // Make it deterministic for testing purposes.
+    // We're seeding the PRNG here to make this example deterministic for testing purposes.
+    // This isn't strictly required in practical use unless you need your app to be deterministic.
     commands.insert_resource(SeededRng(ChaCha8Rng::seed_from_u64(19878367467713)));
 }


### PR DESCRIPTION
# Objective

- Fixes #12544

## Solution

- Added/updated a universally worded comment to all seeded rng instances in our examples.