### PR TITLE
Add a from Dir2 impl for Vec2

### DIFF
--- a/crates/bevy_math/src/direction.rs
+++ b/crates/bevy_math/src/direction.rs
@@ -151,6 +151,12 @@ impl TryFrom<Vec2> for Dir2 {
     }
 }
 
+impl From<Dir2> for Vec2 {
+    fn from(value: Dir2) -> Self {
+        value.as_vec2()
+    }
+}
+
 impl std::ops::Deref for Dir2 {
     type Target = Vec2;
     fn deref(&self) -> &Self::Target {


### PR DESCRIPTION
# Objective

Allow converting from `Dir2` to `Vec2` in generic code. Fixes #12529 

## Solution

Added a `From<Dir2>` impl for `Vec2`