### PR TITLE
UI: don't multiply color channels by alpha

### DIFF
--- a/crates/bevy_ui/src/render/ui.wgsl
+++ b/crates/bevy_ui/src/render/ui.wgsl
@@ -300,12 +300,12 @@ fn draw(in: VertexOutput) -> vec4<f32> {
         // is present, otherwise an outline about the external boundary would be drawn even without 
         // a border.
         let t = 1. - select(step(0.0, border_distance), smoothstep(0.0, fborder, border_distance), external_distance < internal_distance);
-        return vec4(color.rgb * t * color.a, t * color.a);
+        return color.rgba * t;
     }
 
     // The item is a rectangle, draw normally with anti-aliasing at the edges.
     let t = 1. - smoothstep(0.0, fexternal, external_distance);
-    return vec4(color.rgb * t * color.a, t * color.a);
+    return color.rgba * t;
 }
 
 @fragment


### PR DESCRIPTION
# Objective

- since #12500, text is a little bit more gray in UI

## Solution

- don't multiply color by alpha. I think this was done in the original PR (#8973) for shadows which were not added in #12500
