### PR TITLE
more robust gpu image use

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/mod.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/mod.rs
@@ -3,7 +3,6 @@ use bevy_app::prelude::*;
 use bevy_asset::{load_internal_asset, Assets, Handle};
 use bevy_ecs::prelude::*;
 use bevy_reflect::Reflect;
-use bevy_render::camera::Camera;
 use bevy_render::extract_component::{ExtractComponent, ExtractComponentPlugin};
 use bevy_render::extract_resource::{ExtractResource, ExtractResourcePlugin};
 use bevy_render::render_asset::{RenderAssetUsages, RenderAssets};
@@ -13,6 +12,7 @@ use bevy_render::render_resource::binding_types::{
 use bevy_render::renderer::RenderDevice;
 use bevy_render::texture::{CompressedImageFormats, Image, ImageSampler, ImageType};
 use bevy_render::view::{ViewTarget, ViewUniform};
+use bevy_render::{camera::Camera, texture::FallbackImage};
 use bevy_render::{render_resource::*, Render, RenderApp, RenderSet};
 #[cfg(not(feature = "tonemapping_luts"))]
 use bevy_utils::tracing::error;
@@ -320,6 +320,7 @@ pub fn get_lut_bindings<'a>(
     images: &'a RenderAssets<Image>,
     tonemapping_luts: &'a TonemappingLuts,
     tonemapping: &Tonemapping,
+    fallback_image: &'a FallbackImage,
 ) -> (&'a TextureView, &'a Sampler) {
     let image = match tonemapping {
         // AgX lut texture used when tonemapping doesn't need a texture since it's very small (32x32x32)
@@ -332,7 +333,7 @@ pub fn get_lut_bindings<'a>(
         Tonemapping::TonyMcMapface => &tonemapping_luts.tony_mc_mapface,
         Tonemapping::BlenderFilmic => &tonemapping_luts.blender_filmic,
     };
-    let lut_image = images.get(image).unwrap();
+    let lut_image = images.get(image).unwrap_or(&fallback_image.d3);
     (&lut_image.texture_view, &lut_image.sampler)
 }
 

--- a/crates/bevy_core_pipeline/src/tonemapping/node.rs
+++ b/crates/bevy_core_pipeline/src/tonemapping/node.rs
@@ -11,7 +11,7 @@ use bevy_render::{
         RenderPassColorAttachment, RenderPassDescriptor, StoreOp, TextureViewId,
     },
     renderer::RenderContext,
-    texture::Image,
+    texture::{FallbackImage, Image},
     view::{ViewTarget, ViewUniformOffset, ViewUniforms},
 };
 
@@ -19,7 +19,7 @@ use super::{get_lut_bindings, Tonemapping};
 
 #[derive(Default)]
 pub struct TonemappingNode {
-    cached_bind_group: Mutex<Option<(BufferId, TextureViewId, BindGroup)>>,
+    cached_bind_group: Mutex<Option<(BufferId, TextureViewId, TextureViewId, BindGroup)>>,
     last_tonemapping: Mutex<Option<Tonemapping>>,
 }
 
@@ -43,6 +43,7 @@ impl ViewNode for TonemappingNode {
         let pipeline_cache = world.resource::<PipelineCache>();
         let tonemapping_pipeline = world.resource::<TonemappingPipeline>();
         let gpu_images = world.get_resource::<RenderAssets<Image>>().unwrap();
+        let fallback_image = world.resource::<FallbackImage>();
         let view_uniforms_resource = world.resource::<ViewUniforms>();
         let view_uniforms = &view_uniforms_resource.uniforms;
         let view_uniforms_id = view_uniforms.buffer().unwrap().id();
@@ -72,9 +73,10 @@ impl ViewNode for TonemappingNode {
 
         let mut cached_bind_group = self.cached_bind_group.lock().unwrap();
         let bind_group = match &mut *cached_bind_group {
-            Some((buffer_id, texture_id, bind_group))
+            Some((buffer_id, texture_id, lut_id, bind_group))
                 if view_uniforms_id == *buffer_id
                     && source.id() == *texture_id
+                    && *lut_id != fallback_image.d3.texture_view.id()
                     && !tonemapping_changed =>
             {
                 bind_group
@@ -82,7 +84,8 @@ impl ViewNode for TonemappingNode {
             cached_bind_group => {
                 let tonemapping_luts = world.resource::<TonemappingLuts>();
 
-                let lut_bindings = get_lut_bindings(gpu_images, tonemapping_luts, tonemapping);
+                let lut_bindings =
+                    get_lut_bindings(gpu_images, tonemapping_luts, tonemapping, fallback_image);
 
                 let bind_group = render_context.render_device().create_bind_group(
                     None,
@@ -96,8 +99,12 @@ impl ViewNode for TonemappingNode {
                     )),
                 );
 
-                let (_, _, bind_group) =
-                    cached_bind_group.insert((view_uniforms_id, source.id(), bind_group));
+                let (_, _, _, bind_group) = cached_bind_group.insert((
+                    view_uniforms_id,
+                    source.id(),
+                    lut_bindings.0.id(),
+                    bind_group,
+                ));
                 bind_group
             }
         };

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -496,7 +496,8 @@ pub fn prepare_mesh_view_bind_groups(
                 None => {}
             }
 
-            let lut_bindings = get_lut_bindings(&images, &tonemapping_luts, tonemapping);
+            let lut_bindings =
+                get_lut_bindings(&images, &tonemapping_luts, tonemapping, &fallback_image);
             entries = entries.extend_with_indices(((18, lut_bindings.0), (19, lut_bindings.1)));
 
             // When using WebGL, we can't have a depth texture with multisampling

--- a/crates/bevy_render/src/mesh/mesh/mod.rs
+++ b/crates/bevy_render/src/mesh/mesh/mod.rs
@@ -1390,6 +1390,16 @@ impl RenderAsset for Mesh {
             Self::Param,
         >,
     ) -> Result<Self::PreparedAsset, PrepareAssetError<Self>> {
+        let morph_targets = match self.morph_targets.as_ref() {
+            Some(mt) => {
+                let Some(target_image) = images.get(mt) else {
+                    return Err(PrepareAssetError::RetryNextUpdate(self));
+                };
+                Some(target_image.texture_view.clone())
+            }
+            None => None,
+        };
+
         let vertex_buffer_data = self.get_vertex_buffer_data();
         let vertex_buffer = render_device.create_buffer_with_data(&BufferInitDescriptor {
             usage: BufferUsages::VERTEX,
@@ -1420,9 +1430,7 @@ impl RenderAsset for Mesh {
             buffer_info,
             primitive_topology: self.primitive_topology(),
             layout: mesh_vertex_buffer_layout,
-            morph_targets: self
-                .morph_targets
-                .and_then(|mt| images.get(&mt).map(|i| i.texture_view.clone())),
+            morph_targets,
         })
     }
 }


### PR DESCRIPTION
# Objective

make morph targets and tonemapping more tolerant of delayed image loading.

neither of these actually fail currently unless using a bespoke loader (and even then it would be rare), but i am working on adding throttling for asset gpu uploads (as a stopgap until we can do proper asset streaming) and they break with that.

## Solution

when a mesh with morph targets is uploaded to the gpu, the prepare function uploads the morph target texture if it's available, otherwise it uploads without morph targets. this is generally fine as long as morph targets are typically loaded from bytes (in gltf loader), but may fail for a custom loader if the asset server async-loads the target texture and the texture is not available yet. the mesh fails to render and doesn't update when the image is loaded
-> if morph targets are specified but not ready yet, retry mesh upload next frame

tonemapping `unwrap`s on the lookup table image. this is never a problem since the image is added via `include_bytes!`, but could be a problem in future with asset gpu throttling/streaming.
-> if the lookup texture is not yet available, use a fallback
-> in the node, check if the fallback was used before caching the bind group