### PR TITLE
Corrected use of visibility to drive rendering on unsupported platforms

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -388,7 +388,10 @@ fn handle_winit_event(
 
             if should_update {
                 let (_, winit_windows, _, _) = event_writer_system_state.get_mut(&mut app.world);
-                let visible = winit_windows.windows.values().any(|window| window.is_visible().unwrap_or(false));
+                let visible = winit_windows
+                    .windows
+                    .values()
+                    .any(|window| window.is_visible().unwrap_or(false));
                 if visible && runner_state.active != ActiveState::WillSuspend {
                     for window in winit_windows.windows.values() {
                         window.request_redraw();
@@ -409,15 +412,13 @@ fn handle_winit_event(
                     // per winit's docs on [Window::is_visible](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.is_visible),
                     // we cannot use the visibility to drive rendering on these platforms
                     // so we cannot discern whether to beneficially use `Poll` or not?
-                    if runner_state.active != ActiveState::Suspended && !cfg!(any(
+                    #[cfg(not(any(
                         target_arch = "wasm32",
                         target_os = "android",
                         target_os = "ios",
-                        all(
-                            target_os = "linux",
-                            any(feature = "x11", feature = "wayland")
-                        )
-                    )) {
+                        all(target_os = "linux", any(feature = "x11", feature = "wayland"))
+                    )))]
+                    if runner_state.active != ActiveState::Suspended {
                         event_loop.set_control_flow(ControlFlow::Poll);
                     }
                 }


### PR DESCRIPTION
# Objective

Resolves an issue on Chrome where CPU usage spikes while the tab is inactive.

Looks related to #12126, but actually it's actually a different bug.

## Solution

The root issue is that `window.request_redraw()` fails to provoke the `WindowEvent::RedrawRequested` event we expect when another tab in Chrome has focus. This breaks the event loop, and causes winit to hound bevy_winit's runner with `StartCause::ResumeTimeReached` events repeatedly in response to an aging `ControlFlow::WaitUntil` end time.

Upon investigation, the winit docs on [Window::is_visible](https://docs.rs/winit/latest/winit/window/struct.Window.html#method.is_visible) mention:
> None means it couldn’t be determined, so it is not recommended to use this to drive your rendering backend.

This suggests to me that we cannot rely on window visibility to determine if we can `request_redraw` on these platforms, and we should just run the inner update immediately.

This PR changes the check from bevy's `Window::visible` to winit's `Window::is_visible()`, and defaults it to `false` in the aforementioned `None` cases. This means that we are always firing the inner update during `AboutToWait` on these platforms, which should be the correct place from what I can tell. This needs to be further tested on those platforms mentioned:
- Web
- iOS
- Android
- X11
- Wayland

Something that needs to be hashed out is the original `ControlFlow::Poll` behavior. It seems to me that we should only need to set `Poll` once, and the current behavior gets around the `ControlFlow` set during inner update. I could not ascertain the scenarios where it would be useful to set it in the manner we were before, overriding the new `Wait`/`WaitUntil` each time, and I believe we should remove it entirely. For now I gated just those platforms with visibility concerns, which feels wrong.