### PR TITLE
Improve output of example showcase patches CI workflow

### DIFF
--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - main
 
-
 concurrency:
   group: ${{github.workflow}}-${{github.ref}}
   cancel-in-progress: ${{github.event_name == 'pull_request'}}
@@ -305,8 +304,10 @@ jobs:
         uses: ./.github/actions/install-linux-deps
       - name: Apply patches
         run: |
+          CODE=0
           for patch in tools/example-showcase/*.patch; do
-            git apply --ignore-whitespace $patch
+            git apply --ignore-whitespace $patch || { echo "::error::$patch failed to apply."; CODE=1; }
           done
+          exit $CODE
       - name: Build with patches
         run: cargo build

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -297,8 +297,6 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-check-showcase-patches-${{ hashFiles('**/Cargo.toml') }}
       - uses: dtolnay/rust-toolchain@stable
-      - name: Installs cargo-udeps
-        run: cargo install --force cargo-udeps
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Apply patches

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -304,6 +304,7 @@ jobs:
         run: |
           CODE=0
           for patch in tools/example-showcase/*.patch; do
+            # Try applying the patch, logging an error if it fails.
             git apply --ignore-whitespace $patch || { echo "::error::$patch failed to apply."; CODE=1; }
           done
           exit $CODE

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -283,7 +283,6 @@ jobs:
         run: cargo udeps
 
   check-example-showcase-patches-still-work:
-    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -283,6 +283,7 @@ jobs:
         run: cargo udeps
 
   check-example-showcase-patches-still-work:
+    if: ${{ github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
# Objective

Fixes #12539

Improve [this CI output](https://github.com/bevyengine/bevy/actions/runs/8367408952/job/22909715870#step:7:11).

## Solution

- Don't stop after the first failure.
- Print the filename of the patch(es) that failed.
- Clean up an unused package install while we're at it.

Tested over here: https://github.com/rparrett/bevy/pull/20