### PR TITLE
Change orthographic projection near default to -1000

### DIFF
--- a/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
+++ b/crates/bevy_core_pipeline/src/core_2d/camera_2d.rs
@@ -22,10 +22,6 @@ pub struct Camera2d;
 pub struct Camera2dBundle {
     pub camera: Camera,
     pub camera_render_graph: CameraRenderGraph,
-    /// Note: default value for `OrthographicProjection.near` is `0.0`
-    /// which makes objects on the screen plane invisible to 2D camera.
-    /// `Camera2dBundle::default()` sets `near` to negative value,
-    /// so be careful when initializing this field manually.
     pub projection: OrthographicProjection,
     pub visible_entities: VisibleEntities,
     pub frustum: Frustum,
@@ -39,11 +35,7 @@ pub struct Camera2dBundle {
 
 impl Default for Camera2dBundle {
     fn default() -> Self {
-        let projection = OrthographicProjection {
-            far: 1000.,
-            near: -1000.,
-            ..Default::default()
-        };
+        let projection = OrthographicProjection::default();
         let transform = Transform::default();
         let frustum = projection.compute_frustum(&GlobalTransform::from(transform));
         Self {
@@ -74,6 +66,7 @@ impl Camera2dBundle {
         // the camera's translation by far and use a right handed coordinate system
         let projection = OrthographicProjection {
             far,
+            near: 0.0,
             ..Default::default()
         };
         let transform = Transform::from_xyz(0.0, 0.0, far - 0.1);

--- a/crates/bevy_render/src/camera/projection.rs
+++ b/crates/bevy_render/src/camera/projection.rs
@@ -327,7 +327,7 @@ pub struct OrthographicProjection {
     ///
     /// Objects closer than this will not be rendered.
     ///
-    /// Defaults to `0.0`
+    /// Defaults to `-1000.0`
     pub near: f32,
     /// The distance of the far clipping plane in world units.
     ///
@@ -458,7 +458,7 @@ impl Default for OrthographicProjection {
     fn default() -> Self {
         OrthographicProjection {
             scale: 1.0,
-            near: 0.0,
+            near: -1000.0,
             far: 1000.0,
             viewport_origin: Vec2::new(0.5, 0.5),
             scaling_mode: ScalingMode::WindowSize(1.0),


### PR DESCRIPTION
# Objective

Fix an issue where `Camera2dBundle` and `OrthographicProjection` have different defaults for the projection's `near` value. This causes confusion when a user starts with:
```
commands.spawn(Camera2dBundle {
   ..default()
});
```
and decides they need to modify just one field of the projection:
```
commands.spawn(Camera2dBundle {
   projection: OrthographicProjection {
      scaling_mode: my_scaling_mode,
      ..default()
   },
   ..default()
});
```
Since the user never mentioned the `near` field, it is surprising that the `near` field changes (from `-1000.` to `0.`).

This issue was the inspiration for https://github.com/bevyengine/bevy/pull/11115.

Fixes #12267

## Solution

This behaviour was introduced in #9310, which changed `Camera2dBundle::default()` to cover the region `z=-1000.` to `z=1000.` (so that sprites with negative Z are visible) and place the camera at the origin. This PR changes `OrthographicProjection` to have the same defaults as `Camera2dBundle`.

At the time, `Camera2dBundle::new_with_far` was not touched, since that would be a breaking change for that function, since that function is fairly explicit about the near/far range. This PR keeps `near=0` in that function.

---

## Changelog

- Changed default value for `near` plane for `OrthographicProjection`.
