### PR TITLE
Fix Ci failing over dead code in tests

### DIFF
--- a/crates/bevy_asset/src/server/loaders.rs
+++ b/crates/bevy_asset/src/server/loaders.rs
@@ -307,12 +307,16 @@ mod tests {
 
     use super::*;
 
+    // The compiler notices these fields are never read and raises a dead_code lint which kill CI.
+    #[allow(dead_code)]
     #[derive(Asset, TypePath, Debug)]
     struct A(usize);
 
+    #[allow(dead_code)]
     #[derive(Asset, TypePath, Debug)]
     struct B(usize);
 
+    #[allow(dead_code)]
     #[derive(Asset, TypePath, Debug)]
     struct C(usize);
 

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -84,6 +84,7 @@ mod tests {
     #[derive(Component, Debug, PartialEq, Eq, Clone, Copy)]
     struct C;
 
+    #[allow(dead_code)]
     #[derive(Default)]
     struct NonSendA(usize, PhantomData<*mut ()>);
 
@@ -102,6 +103,8 @@ mod tests {
         }
     }
 
+    // TODO: The compiler says the Debug and Clone are removed during dead code analysis. Investigate.
+    #[allow(dead_code)]
     #[derive(Component, Clone, Debug)]
     #[component(storage = "SparseSet")]
     struct DropCkSparse(DropCk);
@@ -1724,9 +1727,12 @@ mod tests {
         );
     }
 
+    // These fields are never read so we get a dead code lint here.
+    #[allow(dead_code)]
     #[derive(Component)]
     struct ComponentA(u32);
 
+    #[allow(dead_code)]
     #[derive(Component)]
     struct ComponentB(u32);
 

--- a/crates/bevy_ecs/src/system/commands/mod.rs
+++ b/crates/bevy_ecs/src/system/commands/mod.rs
@@ -1092,6 +1092,7 @@ mod tests {
         Arc,
     };
 
+    #[allow(dead_code)]
     #[derive(Component)]
     #[component(storage = "SparseSet")]
     struct SparseDropCk(DropCk);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -844,7 +844,9 @@ mod tests {
         let mut world = World::default();
 
         world.insert_resource(SystemRan::No);
+        #[allow(dead_code)]
         struct NotSend1(std::rc::Rc<i32>);
+        #[allow(dead_code)]
         struct NotSend2(std::rc::Rc<i32>);
         world.insert_non_send_resource(NotSend1(std::rc::Rc::new(0)));
 
@@ -867,7 +869,9 @@ mod tests {
         let mut world = World::default();
 
         world.insert_resource(SystemRan::No);
+        #[allow(dead_code)]
         struct NotSend1(std::rc::Rc<i32>);
+        #[allow(dead_code)]
         struct NotSend2(std::rc::Rc<i32>);
 
         world.insert_non_send_resource(NotSend1(std::rc::Rc::new(1)));

--- a/crates/bevy_ecs/src/system/system_param.rs
+++ b/crates/bevy_ecs/src/system/system_param.rs
@@ -1578,6 +1578,7 @@ mod tests {
     // Compile test for https://github.com/bevyengine/bevy/pull/7001.
     #[test]
     fn system_param_const_generics() {
+        #[allow(dead_code)]
         #[derive(SystemParam)]
         pub struct ConstGenericParam<'w, const I: usize>(Res<'w, R<I>>);
 
@@ -1635,6 +1636,7 @@ mod tests {
         #[derive(SystemParam)]
         pub struct UnitParam;
 
+        #[allow(dead_code)]
         #[derive(SystemParam)]
         pub struct TupleParam<'w, 's, R: Resource, L: FromWorld + Send + 'static>(
             Res<'w, R>,
@@ -1651,6 +1653,7 @@ mod tests {
         #[derive(Resource)]
         struct PrivateResource;
 
+        #[allow(dead_code)]
         #[derive(SystemParam)]
         pub struct EncapsulatedParam<'w>(Res<'w, PrivateResource>);
 

--- a/crates/bevy_ecs/src/world/command_queue.rs
+++ b/crates/bevy_ecs/src/world/command_queue.rs
@@ -344,6 +344,7 @@ mod test {
     // This has an arbitrary value `String` stored to ensure
     // when then command gets pushed, the `bytes` vector gets
     // some data added to it.
+    #[allow(dead_code)]
     struct PanicCommand(String);
     impl Command for PanicCommand {
         fn apply(self, _: &mut World) {
@@ -392,6 +393,7 @@ mod test {
         assert_is_send(SpawnCommand);
     }
 
+    #[allow(dead_code)]
     struct CommandWithPadding(u8, u16);
     impl Command for CommandWithPadding {
         fn apply(self, _: &mut World) {}

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_exact_sized_iterator_safety.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Changed<Foo>: ArchetypeFilter` i
   --> tests/ui/query_exact_sized_iterator_safety.rs:8:28
    |
 8  |     is_exact_size_iterator(query.iter());
-   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Changed<Foo>`
+   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Changed<Foo>`, which is required by `QueryIter<'_, '_, &Foo, bevy_ecs::query::Changed<Foo>>: ExactSizeIterator`
    |     |
    |     required by a bound introduced by this call
    |
@@ -27,7 +27,7 @@ error[E0277]: the trait bound `bevy_ecs::query::Added<Foo>: ArchetypeFilter` is 
   --> tests/ui/query_exact_sized_iterator_safety.rs:13:28
    |
 13 |     is_exact_size_iterator(query.iter());
-   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Added<Foo>`
+   |     ---------------------- ^^^^^^^^^^^^ the trait `ArchetypeFilter` is not implemented for `bevy_ecs::query::Added<Foo>`, which is required by `QueryIter<'_, '_, &Foo, bevy_ecs::query::Added<Foo>>: ExactSizeIterator`
    |     |
    |     required by a bound introduced by this call
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_combinations_mut_iterator_safety.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
   --> tests/ui/query_iter_combinations_mut_iterator_safety.rs:10:17
    |
 10 |     is_iterator(iter)
-   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
+   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`, which is required by `QueryCombinationIter<'_, '_, &mut A, (), _>: Iterator`
    |     |
    |     required by a bound introduced by this call
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/query_iter_many_mut_iterator_safety.stderr
@@ -2,7 +2,7 @@ error[E0277]: the trait bound `&mut A: ReadOnlyQueryData` is not satisfied
   --> tests/ui/query_iter_many_mut_iterator_safety.rs:10:17
    |
 10 |     is_iterator(iter)
-   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`
+   |     ----------- ^^^^ the trait `ReadOnlyQueryData` is not implemented for `&mut A`, which is required by `QueryManyIter<'_, '_, &mut A, (), std::array::IntoIter<bevy_ecs::entity::Entity, 1>>: Iterator`
    |     |
    |     required by a bound introduced by this call
    |

--- a/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
+++ b/crates/bevy_ecs_compile_fail_tests/tests/ui/system_param_derive_readonly.stderr
@@ -10,7 +10,7 @@ error[E0277]: the trait bound `&'static mut Foo: ReadOnlyQueryData` is not satis
   --> tests/ui/system_param_derive_readonly.rs:18:23
    |
 18 |     assert_readonly::<Mutable>();
-   |                       ^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`
+   |                       ^^^^^^^ the trait `ReadOnlyQueryData` is not implemented for `&'static mut Foo`, which is required by `Mutable<'_, '_>: ReadOnlySystemParam`
    |
    = help: the following other types implement trait `ReadOnlyQueryData`:
              bevy_ecs::change_detection::Ref<'__w, T>

--- a/crates/bevy_hierarchy/src/child_builder.rs
+++ b/crates/bevy_hierarchy/src/child_builder.rs
@@ -851,6 +851,7 @@ mod tests {
         );
     }
 
+    #[allow(dead_code)]
     #[derive(Component)]
     struct C(u32);
 

--- a/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
+++ b/crates/bevy_macros_compile_fail_tests/tests/deref_mut_derive/missing_deref.fail.stderr
@@ -7,6 +7,14 @@ error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
 
+error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
+ --> tests/deref_mut_derive/missing_deref.fail.rs:3:10
+  |
+3 | #[derive(DerefMut)]
+  |          ^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
+  |
+  = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
+
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:7:8
   |
@@ -15,14 +23,6 @@ error[E0277]: the trait bound `Struct: Deref` is not satisfied
   |
 note: required by a bound in `DerefMut`
  --> $RUST/core/src/ops/deref.rs
-
-error[E0277]: the trait bound `TupleStruct: Deref` is not satisfied
- --> tests/deref_mut_derive/missing_deref.fail.rs:3:10
-  |
-3 | #[derive(DerefMut)]
-  |          ^^^^^^^^ the trait `Deref` is not implemented for `TupleStruct`
-  |
-  = note: this error originates in the derive macro `DerefMut` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `Struct: Deref` is not satisfied
  --> tests/deref_mut_derive/missing_deref.fail.rs:6:10

--- a/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
+++ b/crates/bevy_reflect_compile_fail_tests/tests/reflect_derive/generics.fail.stderr
@@ -26,7 +26,7 @@ error[E0277]: the trait bound `NoReflect: GetTypeRegistration` is not satisfied
   --> tests/reflect_derive/generics.fail.rs:14:36
    |
 14 |     let mut foo: Box<dyn Struct> = Box::new(Foo::<NoReflect> { a: NoReflect(42.0) });
-   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetTypeRegistration` is not implemented for `NoReflect`
+   |                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `GetTypeRegistration` is not implemented for `NoReflect`, which is required by `Foo<NoReflect>: bevy_reflect::Struct`
    |
    = help: the following other types implement trait `GetTypeRegistration`:
              bool

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -107,7 +107,7 @@ impl WinitWindows {
         #[cfg(target_os = "windows")]
         {
             use winit::platform::windows::WindowBuilderExtWindows;
-            winit_window_builder = winit_window_builder.with_skip_taskbar(window.skip_taskbar)
+            winit_window_builder = winit_window_builder.with_skip_taskbar(window.skip_taskbar);
         }
 
         #[cfg(any(


### PR DESCRIPTION
# Objective

Fix Pr CI failing over dead code in tests and main branch CI failing over a missing semicolon. Fixes #12620.

## Solution

Add dead_code annotations and a semicolon.