### PR TITLE
Add path function to ProcessContext

### DIFF
--- a/crates/bevy_asset/src/processor/process.rs
+++ b/crates/bevy_asset/src/processor/process.rs
@@ -364,6 +364,12 @@ impl<'a> ProcessContext<'a> {
         Ok(loaded_asset)
     }
 
+    /// The path of the asset being processed.
+    #[inline]
+    pub fn path(&self) -> &AssetPath<'static> {
+        self.path
+    }
+
     /// The source bytes of the asset being processed.
     #[inline]
     pub fn asset_bytes(&self) -> &[u8] {


### PR DESCRIPTION
# Objective

- It can be useful to have access to the path of the current asset being processed, for example if you want to need a second file that is relative to the current file being processed.

## Solution

- I added a `path()` function to the `ProcessContext`
