### PR TITLE
check sampler type in as_bind_group derives

### DIFF
--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -953,8 +953,8 @@ impl<M: Material> RenderAsset for PreparedMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
-            Err(e) => {
-                Err(PrepareAssetError::AsBindGroupError(e))
+            Err(other) => {
+                Err(PrepareAssetError::AsBindGroupError(other))
             }
         }
     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -953,8 +953,8 @@ impl<M: Material> RenderAsset for PreparedMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
-            Err(other) => {
-                Err(PrepareAssetError::AsBindGroupError(other))
+            Err(e) => {
+                Err(PrepareAssetError::AsBindGroupError(e))
             }
         }
     }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -953,6 +953,9 @@ impl<M: Material> RenderAsset for PreparedMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
+            Err(other) => {
+                Err(PrepareAssetError::AsBindGroupError(other))
+            }
         }
     }
 }

--- a/crates/bevy_pbr/src/material.rs
+++ b/crates/bevy_pbr/src/material.rs
@@ -953,9 +953,7 @@ impl<M: Material> RenderAsset for PreparedMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
-            Err(other) => {
-                Err(PrepareAssetError::AsBindGroupError(other))
-            }
+            Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
         }
     }
 }

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -395,7 +395,7 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                                             format!("{:?}", #expected_samplers),
                                         ));
                                     }
-                                    image.sampler.clone()                                    
+                                    image.sampler.clone()
                                 } else {
                                     #fallback_image.sampler.clone()
                                 }

--- a/crates/bevy_render/macros/src/as_bind_group.rs
+++ b/crates/bevy_render/macros/src/as_bind_group.rs
@@ -355,6 +355,20 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
 
                     let fallback_image = get_fallback_image(&render_path, *dimension);
 
+                    let expected_samplers = match sampler_binding_type {
+                        SamplerBindingType::Filtering => {
+                            quote!( [#render_path::render_resource::TextureSampleType::Float { filterable: true }] )
+                        }
+                        SamplerBindingType::NonFiltering => quote!([
+                            #render_path::render_resource::TextureSampleType::Float { filterable: false },
+                            #render_path::render_resource::TextureSampleType::Sint,
+                            #render_path::render_resource::TextureSampleType::Uint,
+                        ]),
+                        SamplerBindingType::Comparison => {
+                            quote!( [#render_path::render_resource::TextureSampleType::Depth] )
+                        }
+                    };
+
                     // insert fallible texture-based entries at 0 so that if we fail here, we exit before allocating any buffers
                     binding_impls.insert(0, quote! {
                         (
@@ -362,7 +376,26 @@ pub fn derive_as_bind_group(ast: syn::DeriveInput) -> Result<TokenStream> {
                             #render_path::render_resource::OwnedBindingResource::Sampler({
                                 let handle: Option<&#asset_path::Handle<#render_path::texture::Image>> = (&self.#field_name).into();
                                 if let Some(handle) = handle {
-                                    images.get(handle).ok_or_else(|| #render_path::render_resource::AsBindGroupError::RetryNextUpdate)?.sampler.clone()
+                                    let image = images.get(handle).ok_or_else(|| #render_path::render_resource::AsBindGroupError::RetryNextUpdate)?;
+
+                                    let Some(sample_type) = image.texture_format.sample_type(None, None) else {
+                                        return Err(#render_path::render_resource::AsBindGroupError::InvalidSamplerType(
+                                            #binding_index,
+                                            "None".to_string(),
+                                            format!("{:?}", #expected_samplers),
+                                        ));
+                                    };
+
+                                    let valid = #expected_samplers.contains(&sample_type);
+
+                                    if !valid {
+                                        return Err(#render_path::render_resource::AsBindGroupError::InvalidSamplerType(
+                                            #binding_index,
+                                            format!("{:?}", sample_type),
+                                            format!("{:?}", #expected_samplers),
+                                        ));
+                                    }
+                                    image.sampler.clone()                                    
                                 } else {
                                     #fallback_image.sampler.clone()
                                 }

--- a/crates/bevy_render/src/render_asset.rs
+++ b/crates/bevy_render/src/render_asset.rs
@@ -1,4 +1,6 @@
-use crate::{render_resource::AsBindGroupError, ExtractSchedule, MainWorld, Render, RenderApp, RenderSet};
+use crate::{
+    render_resource::AsBindGroupError, ExtractSchedule, MainWorld, Render, RenderApp, RenderSet,
+};
 use bevy_app::{App, Plugin, SubApp};
 use bevy_asset::{Asset, AssetEvent, AssetId, Assets};
 use bevy_ecs::{
@@ -9,7 +11,10 @@ use bevy_ecs::{
 };
 use bevy_reflect::{Reflect, ReflectDeserialize, ReflectSerialize};
 use bevy_render_macros::ExtractResource;
-use bevy_utils::{tracing::{debug, error}, HashMap, HashSet};
+use bevy_utils::{
+    tracing::{debug, error},
+    HashMap, HashSet,
+};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 use thiserror::Error;
@@ -362,7 +367,10 @@ pub fn prepare_assets<A: RenderAsset>(
                 prepare_next_frame.assets.push((id, extracted_asset));
             }
             Err(PrepareAssetError::AsBindGroupError(e)) => {
-                error!("{} Bind group construction failed: {e}", std::any::type_name::<A>()) ;
+                error!(
+                    "{} Bind group construction failed: {e}",
+                    std::any::type_name::<A>()
+                );
             }
         }
     }
@@ -397,7 +405,10 @@ pub fn prepare_assets<A: RenderAsset>(
                 prepare_next_frame.assets.push((id, extracted_asset));
             }
             Err(PrepareAssetError::AsBindGroupError(e)) => {
-                error!("{} Bind group construction failed: {e}", std::any::type_name::<A>()) ;
+                error!(
+                    "{} Bind group construction failed: {e}",
+                    std::any::type_name::<A>()
+                );
             }
         }
     }

--- a/crates/bevy_render/src/render_resource/bind_group.rs
+++ b/crates/bevy_render/src/render_resource/bind_group.rs
@@ -352,6 +352,8 @@ pub enum AsBindGroupError {
     /// The bind group could not be generated. Try again next frame.
     #[error("The bind group could not be generated")]
     RetryNextUpdate,
+    #[error("At binding index{0}, the provided image sampler `{1}` does not match the required sampler type(s) `{2}`.")]
+    InvalidSamplerType(u32, String, String),
 }
 
 /// A prepared bind group returned as a result of [`AsBindGroup::as_bind_group`].

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -615,9 +615,7 @@ impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
-            Err(other) => {
-                Err(PrepareAssetError::AsBindGroupError(other))
-            }
+            Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
         }
     }
 }

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -615,6 +615,9 @@ impl<M: Material2d> RenderAsset for PreparedMaterial2d<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
+            Err(other) => {
+                Err(PrepareAssetError::AsBindGroupError(other))
+            }
         }
     }
 }

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -624,6 +624,9 @@ impl<M: UiMaterial> RenderAsset for PreparedUiMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
+            Err(other) => {
+                Err(PrepareAssetError::AsBindGroupError(other))
+            }
         }
     }
 }

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -624,9 +624,7 @@ impl<M: UiMaterial> RenderAsset for PreparedUiMaterial<M> {
             Err(AsBindGroupError::RetryNextUpdate) => {
                 Err(PrepareAssetError::RetryNextUpdate(material))
             }
-            Err(other) => {
-                Err(PrepareAssetError::AsBindGroupError(other))
-            }
+            Err(other) => Err(PrepareAssetError::AsBindGroupError(other)),
         }
     }
 }


### PR DESCRIPTION
# Objective

currently if we use an image with the wrong sampler type in a material, wgpu panics with an invalid texture format. turn this into a warning and fail more gracefully.

## Solution

the expected sampler type is specified in the AsBindGroup derive, so we can just check the image sampler is what it should be.

i am not totally sure about the mapping of image sampler type to #[sampler(type)], i assumed:

```
    "filtering" => [ TextureSampleType::Float { filterable: true } ],
    "non_filtering" => [
        TextureSampleType::Float { filterable: false },
        TextureSampleType::Sint,
        TextureSampleType::Uint,
    ],
    "comparison" => [ TextureSampleType::Depth ],
```