### PR TITLE
Interpolating hues should use rem_euclid.

### DIFF
--- a/crates/bevy_color/src/hsla.rs
+++ b/crates/bevy_color/src/hsla.rs
@@ -105,16 +105,8 @@ impl Mix for Hsla {
     #[inline]
     fn mix(&self, other: &Self, factor: f32) -> Self {
         let n_factor = 1.0 - factor;
-        // TODO: Refactor this into EuclideanModulo::lerp_modulo
-        let shortest_angle = ((((other.hue - self.hue) % 360.) + 540.) % 360.) - 180.;
-        let mut hue = self.hue + shortest_angle * factor;
-        if hue < 0. {
-            hue += 360.;
-        } else if hue >= 360. {
-            hue -= 360.;
-        }
         Self {
-            hue,
+            hue: crate::color_ops::lerp_hue(self.hue, other.hue, factor),
             saturation: self.saturation * n_factor + other.saturation * factor,
             lightness: self.lightness * n_factor + other.lightness * factor,
             alpha: self.alpha * n_factor + other.alpha * factor,

--- a/crates/bevy_color/src/hsva.rs
+++ b/crates/bevy_color/src/hsva.rs
@@ -73,16 +73,8 @@ impl Mix for Hsva {
     #[inline]
     fn mix(&self, other: &Self, factor: f32) -> Self {
         let n_factor = 1.0 - factor;
-        // TODO: Refactor this into EuclideanModulo::lerp_modulo
-        let shortest_angle = ((((other.hue - self.hue) % 360.) + 540.) % 360.) - 180.;
-        let mut hue = self.hue + shortest_angle * factor;
-        if hue < 0. {
-            hue += 360.;
-        } else if hue >= 360. {
-            hue -= 360.;
-        }
         Self {
-            hue,
+            hue: crate::color_ops::lerp_hue(self.hue, other.hue, factor),
             saturation: self.saturation * n_factor + other.saturation * factor,
             value: self.value * n_factor + other.value * factor,
             alpha: self.alpha * n_factor + other.alpha * factor,

--- a/crates/bevy_color/src/hwba.rs
+++ b/crates/bevy_color/src/hwba.rs
@@ -77,16 +77,8 @@ impl Mix for Hwba {
     #[inline]
     fn mix(&self, other: &Self, factor: f32) -> Self {
         let n_factor = 1.0 - factor;
-        // TODO: Refactor this into EuclideanModulo::lerp_modulo
-        let shortest_angle = ((((other.hue - self.hue) % 360.) + 540.) % 360.) - 180.;
-        let mut hue = self.hue + shortest_angle * factor;
-        if hue < 0. {
-            hue += 360.;
-        } else if hue >= 360. {
-            hue -= 360.;
-        }
         Self {
-            hue,
+            hue: crate::color_ops::lerp_hue(self.hue, other.hue, factor),
             whiteness: self.whiteness * n_factor + other.whiteness * factor,
             blackness: self.blackness * n_factor + other.blackness * factor,
             alpha: self.alpha * n_factor + other.alpha * factor,


### PR DESCRIPTION
Also, added additional tests for the hue interpolation.

Fixes #12632
Fixes #12631
