### PR TITLE
Make `feature(doc_auto_cfg)` work

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,7 +49,10 @@ jobs:
           echo "<meta name=\"robots\" content=\"noindex\">" > header.html
 
       - name: Build docs
-        run: cargo doc --all-features --no-deps -p bevy -Zunstable-options -Zrustdoc-scrape-examples
+        env:
+          # needs to be in sync with [package.metadata.docs.rs]
+          RUSTDOCFLAGS:  -Zunstable-options -Zrustdoc-scrape-examples --cfg=docsrs
+        run: cargo doc --all-features --no-deps -p bevy
 
       #  This adds the following:
       #   - A top level redirect to the bevy crate documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -51,8 +51,8 @@ jobs:
       - name: Build docs
         env:
           # needs to be in sync with [package.metadata.docs.rs]
-          RUSTDOCFLAGS:  -Zunstable-options -Zrustdoc-scrape-examples --cfg=docsrs
-        run: cargo doc --all-features --no-deps -p bevy
+          RUSTDOCFLAGS:  -Zunstable-options --cfg=docsrs
+        run: cargo doc --all-features --no-deps -p bevy -Zunstable-options -Zrustdoc-scrape-examples
 
       #  This adds the following:
       #   - A top level redirect to the bevy crate documentation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2820,10 +2820,6 @@ lto = "fat"
 panic = "abort"
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2820,5 +2820,10 @@ lto = "fat"
 panic = "abort"
 
 [package.metadata.docs.rs]
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -20,10 +20,5 @@ accesskit = "0.12"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_a11y/Cargo.toml
+++ b/crates/bevy_a11y/Cargo.toml
@@ -18,3 +18,12 @@ accesskit = "0.12"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_a11y/src/lib.rs
+++ b/crates/bevy_a11y/src/lib.rs
@@ -1,6 +1,7 @@
-//! Accessibility for Bevy
-
 #![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+//! Accessibility for Bevy
 
 use std::sync::{
     atomic::{AtomicBool, Ordering},

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -42,10 +42,5 @@ uuid = { version = "1.7", features = ["v4"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_animation/Cargo.toml
+++ b/crates/bevy_animation/Cargo.toml
@@ -40,3 +40,12 @@ uuid = { version = "1.7", features = ["v4"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_animation/src/lib.rs
+++ b/crates/bevy_animation/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Animation for the game engine Bevy
 
 mod animatable;

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -36,10 +36,5 @@ web-sys = { version = "0.3", features = ["Window"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_app/Cargo.toml
+++ b/crates/bevy_app/Cargo.toml
@@ -36,4 +36,10 @@ web-sys = { version = "0.3", features = ["Window"] }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_app/src/lib.rs
+++ b/crates/bevy_app/src/lib.rs
@@ -1,5 +1,6 @@
-//! This crate is about everything concerning the highest-level, application layer of a Bevy app.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+//! This crate is about everything concerning the highest-level, application layer of a Bevy app.
 
 mod app;
 mod main_schedule;

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -61,4 +61,10 @@ bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_asset/Cargo.toml
+++ b/crates/bevy_asset/Cargo.toml
@@ -61,10 +61,5 @@ bevy_log = { path = "../bevy_log", version = "0.14.0-dev" }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_asset/macros/Cargo.toml
+++ b/crates/bevy_asset/macros/Cargo.toml
@@ -22,10 +22,5 @@ quote = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_asset/macros/Cargo.toml
+++ b/crates/bevy_asset/macros/Cargo.toml
@@ -20,3 +20,12 @@ quote = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_asset/macros/src/lib.rs
+++ b/crates/bevy_asset/macros/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_macro_utils::BevyManifest;
 use proc_macro::{Span, TokenStream};

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -52,10 +52,5 @@ android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_audio/Cargo.toml
+++ b/crates/bevy_audio/Cargo.toml
@@ -52,4 +52,10 @@ android_shared_stdcxx = ["cpal/oboe-shared-stdcxx"]
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_audio/src/lib.rs
+++ b/crates/bevy_audio/src/lib.rs
@@ -1,3 +1,6 @@
+#![forbid(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Audio support for the game engine Bevy
 //!
 //! ```no_run
@@ -19,8 +22,6 @@
 //!     });
 //! }
 //! ```
-#![forbid(unsafe_code)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod audio;
 mod audio_output;

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -21,3 +21,12 @@ encase = { version = "0.7", default-features = false }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -23,10 +23,5 @@ encase = { version = "0.7", default-features = false }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_color/src/lib.rs
+++ b/crates/bevy_color/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Representations of colors in various color spaces.
 //!
 //! This crate provides a number of color representations, including:

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -37,4 +37,10 @@ crossbeam-channel = "0.5.0"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_core/Cargo.toml
+++ b/crates/bevy_core/Cargo.toml
@@ -37,10 +37,5 @@ crossbeam-channel = "0.5.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -1,5 +1,6 @@
-//! This crate provides core functionality for Bevy Engine.
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+//! This crate provides core functionality for Bevy Engine.
 
 mod name;
 #[cfg(feature = "serialize")]

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -42,10 +42,5 @@ nonmax = "0.5"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_core_pipeline/Cargo.toml
+++ b/crates/bevy_core_pipeline/Cargo.toml
@@ -42,4 +42,10 @@ nonmax = "0.5"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -21,10 +21,5 @@ syn = { version = "2.0", features = ["full"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_derive/Cargo.toml
+++ b/crates/bevy_derive/Cargo.toml
@@ -19,3 +19,12 @@ syn = { version = "2.0", features = ["full"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_derive/src/lib.rs
+++ b/crates/bevy_derive/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;
 

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -43,4 +43,10 @@ ron = { version = "0.8.0", optional = true }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_dev_tools/Cargo.toml
+++ b/crates/bevy_dev_tools/Cargo.toml
@@ -43,10 +43,5 @@ ron = { version = "0.8.0", optional = true }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_dev_tools/src/lib.rs
+++ b/crates/bevy_dev_tools/src/lib.rs
@@ -1,6 +1,7 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This crate provides additional utilities for the [Bevy game engine](https://bevyengine.org),
 //! focused on improving developer experience.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_app::prelude::*;
 

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -38,4 +38,10 @@ sysinfo = { version = "0.30.0", optional = true, default-features = false }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_diagnostic/Cargo.toml
+++ b/crates/bevy_diagnostic/Cargo.toml
@@ -38,10 +38,5 @@ sysinfo = { version = "0.30.0", optional = true, default-features = false }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -18,10 +18,5 @@ bevy_internal = { path = "../bevy_internal", version = "0.14.0-dev", default-fea
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_dylib/Cargo.toml
+++ b/crates/bevy_dylib/Cargo.toml
@@ -16,3 +16,12 @@ bevy_internal = { path = "../bevy_internal", version = "0.14.0-dev", default-fea
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -51,4 +51,5 @@
 
 // Force linking of the main bevy crate
 #[allow(unused_imports)]
+#[allow(clippy::single_component_path_imports)]
 use bevy_internal;

--- a/crates/bevy_dylib/src/lib.rs
+++ b/crates/bevy_dylib/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::single_component_path_imports)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Forces dynamic linking of Bevy.
 //!

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -18,3 +18,12 @@ thiserror = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_dynamic_plugin/Cargo.toml
+++ b/crates/bevy_dynamic_plugin/Cargo.toml
@@ -20,10 +20,5 @@ thiserror = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_dynamic_plugin/src/lib.rs
+++ b/crates/bevy_dynamic_plugin/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Bevy's dynamic plugin loading functionality.
 //!
 //! This crate allows loading dynamic libraries (`.dylib`, `.so`) that export a single

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -51,10 +51,5 @@ path = "examples/change_detection.rs"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ecs/Cargo.toml
+++ b/crates/bevy_ecs/Cargo.toml
@@ -51,4 +51,10 @@ path = "examples/change_detection.rs"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -19,10 +19,5 @@ proc-macro2 = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ecs/macros/Cargo.toml
+++ b/crates/bevy_ecs/macros/Cargo.toml
@@ -17,3 +17,12 @@ proc-macro2 = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 extern crate proc_macro;
 

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -17,3 +17,12 @@ encase_derive_impl = "0.7"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -19,10 +19,5 @@ encase_derive_impl = "0.7"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_encase_derive/src/lib.rs
+++ b/crates/bevy_encase_derive/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_macro_utils::BevyManifest;
 use encase_derive_impl::{implement, syn};

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -24,10 +24,5 @@ thiserror = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_gilrs/Cargo.toml
+++ b/crates/bevy_gilrs/Cargo.toml
@@ -22,3 +22,12 @@ thiserror = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_gilrs/src/lib.rs
+++ b/crates/bevy_gilrs/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Systems and type definitions for gamepad handling in Bevy.
 //!
 //! This crate is built on top of [GilRs](gilrs), a library

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -34,10 +34,5 @@ bytemuck = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_gizmos/Cargo.toml
+++ b/crates/bevy_gizmos/Cargo.toml
@@ -34,4 +34,10 @@ bytemuck = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -23,10 +23,5 @@ quote = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_gizmos/macros/Cargo.toml
+++ b/crates/bevy_gizmos/macros/Cargo.toml
@@ -11,8 +11,6 @@ keywords = ["bevy"]
 [lib]
 proc-macro = true
 
-[lints]
-workspace = true
 
 [dependencies]
 bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.14.0-dev" }
@@ -20,3 +18,15 @@ bevy_macro_utils = { path = "../../bevy_macro_utils", version = "0.14.0-dev" }
 syn = "2.0"
 proc-macro2 = "1.0"
 quote = "1.0"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_gizmos/macros/src/lib.rs
+++ b/crates/bevy_gizmos/macros/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Derive implementations for `bevy_gizmos`.
 
 use bevy_macro_utils::BevyManifest;

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This crate adds an immediate mode drawing api to Bevy for visual debugging.
 //!
 //! # Example
@@ -13,7 +15,6 @@
 //! ```
 //!
 //! See the documentation on [Gizmos](crate::gizmos::Gizmos) for more examples.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 /// System set label for the systems handling the rendering of gizmos.
 #[derive(SystemSet, Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -60,4 +60,10 @@ smallvec = "1.11"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_gltf/Cargo.toml
+++ b/crates/bevy_gltf/Cargo.toml
@@ -60,10 +60,5 @@ smallvec = "1.11"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_gltf/src/lib.rs
+++ b/crates/bevy_gltf/src/lib.rs
@@ -1,8 +1,9 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Plugin providing an [`AssetLoader`](bevy_asset::AssetLoader) and type definitions
 //! for loading glTF 2.0 (a standard 3D scene definition format) files in Bevy.
 //!
 //! The [glTF 2.0 specification](https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html) defines the format of the glTF files.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "bevy_animation")]
 use bevy_animation::AnimationClip;

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -31,10 +31,5 @@ smallvec = { version = "1.11", features = ["union", "const_generics"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_hierarchy/Cargo.toml
+++ b/crates/bevy_hierarchy/Cargo.toml
@@ -31,4 +31,10 @@ smallvec = { version = "1.11", features = ["union", "const_generics"] }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_hierarchy/src/lib.rs
+++ b/crates/bevy_hierarchy/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Parent-child relationships for Bevy entities.
 //!
 //! You should use the tools in this crate
@@ -44,7 +46,6 @@
 //! [plugin]: HierarchyPlugin
 //! [query extension methods]: HierarchyQueryExt
 //! [world]: BuildWorldChildren
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod components;
 pub use components::*;

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -32,4 +32,10 @@ smol_str = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_input/Cargo.toml
+++ b/crates/bevy_input/Cargo.toml
@@ -32,10 +32,5 @@ smol_str = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_input/src/lib.rs
+++ b/crates/bevy_input/src/lib.rs
@@ -1,9 +1,10 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Input functionality for the [Bevy game engine](https://bevyengine.org/).
 //!
 //! # Supported input devices
 //!
 //! `bevy` currently supports keyboard, mouse, gamepad, and touch inputs.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod axis;
 mod button_input;

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -209,10 +209,5 @@ bevy_dev_tools = { path = "../bevy_dev_tools", optional = true, version = "0.14.
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -207,3 +207,12 @@ bevy_dev_tools = { path = "../bevy_dev_tools", optional = true, version = "0.14.
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_internal/src/lib.rs
+++ b/crates/bevy_internal/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This module is separated into its own crate to enable simple dynamic linking for Bevy, and should not be used directly
 
 /// `use bevy::prelude::*;` to import common components, bundles, and plugins.

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -40,4 +40,10 @@ tracing-wasm = "0.2.1"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_log/Cargo.toml
+++ b/crates/bevy_log/Cargo.toml
@@ -40,10 +40,5 @@ tracing-wasm = "0.2.1"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_log/src/lib.rs
+++ b/crates/bevy_log/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This crate provides logging functions and configuration for [Bevy](https://bevyengine.org)
 //! apps, and automatically configures platform specific log handlers (i.e. WASM or Android).
 //!
@@ -9,7 +11,6 @@
 //!
 //! For more fine-tuned control over logging behavior, set up the [`LogPlugin`] or
 //! `DefaultPlugins` during app initialization.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[cfg(feature = "trace")]
 use std::panic;

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -19,3 +19,12 @@ proc-macro2 = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_macro_utils/Cargo.toml
+++ b/crates/bevy_macro_utils/Cargo.toml
@@ -21,10 +21,5 @@ proc-macro2 = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_macro_utils/src/lib.rs
+++ b/crates/bevy_macro_utils/src/lib.rs
@@ -1,4 +1,6 @@
 #![deny(unsafe_code)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! A collection of helper types and functions for working on macros within the Bevy ecosystem.
 
 extern crate proc_macro;

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -45,10 +45,5 @@ rand = ["dep:rand"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -45,4 +45,10 @@ rand = ["dep:rand"]
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -1,9 +1,10 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Provides math types and functionality for the Bevy game engine.
 //!
 //! The commonly used types are vectors like [`Vec2`] and [`Vec3`],
 //! matrices like [`Mat2`], [`Mat3`] and [`Mat4`] and orientation representations
 //! like [`Quat`].
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod affine3;
 mod aspect_ratio;

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -24,10 +24,5 @@ name = "generate"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -22,3 +22,12 @@ name = "generate"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_mikktspace/src/lib.rs
+++ b/crates/bevy_mikktspace/src/lib.rs
@@ -6,6 +6,7 @@
 )]
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use glam::{Vec2, Vec3};
 

--- a/crates/bevy_panic_handler/Cargo.toml
+++ b/crates/bevy_panic_handler/Cargo.toml
@@ -20,4 +20,10 @@ console_error_panic_hook = "0.1.6"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_panic_handler/Cargo.toml
+++ b/crates/bevy_panic_handler/Cargo.toml
@@ -20,10 +20,5 @@ console_error_panic_hook = "0.1.6"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_panic_handler/src/lib.rs
+++ b/crates/bevy_panic_handler/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This crate provides panic handlers for [Bevy](https://bevyengine.org)
 //! apps, and automatically configures platform specifics (i.e. WASM or Android).
 //!
@@ -5,7 +7,6 @@
 //!
 //! For more fine-tuned control over panic behavior, disable the [`PanicHandlerPlugin`] or
 //! `DefaultPlugins` during app initialization.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_app::{App, Plugin};
 

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -46,4 +46,10 @@ nonmax = "0.5"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_pbr/Cargo.toml
+++ b/crates/bevy_pbr/Cargo.toml
@@ -46,10 +46,5 @@ nonmax = "0.5"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -14,10 +14,5 @@ keywords = ["bevy", "no_std"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ptr/Cargo.toml
+++ b/crates/bevy_ptr/Cargo.toml
@@ -12,3 +12,12 @@ keywords = ["bevy", "no_std"]
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_ptr/src/lib.rs
+++ b/crates/bevy_ptr/src/lib.rs
@@ -1,5 +1,6 @@
 #![doc = include_str!("../README.md")]
 #![no_std]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use core::fmt::{self, Formatter, Pointer};
 use core::{

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -59,4 +59,10 @@ required-features = ["documentation"]
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -59,10 +59,5 @@ required-features = ["documentation"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -28,10 +28,5 @@ uuid = { version = "1.1", features = ["v4"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
+++ b/crates/bevy_reflect/bevy_reflect_derive/Cargo.toml
@@ -26,3 +26,12 @@ uuid = { version = "1.1", features = ["v4"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
+++ b/crates/bevy_reflect/bevy_reflect_derive/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! This crate contains macros used by Bevy's `Reflect` API.
 //!
 //! The main export of this crate is the derive macro for [`Reflect`]. This allows

--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Reflection in Rust.
 //!
@@ -467,7 +468,6 @@
 //! [orphan rule]: https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type:~:text=But%20we%20can%E2%80%99t,implementation%20to%20use.
 //! [`bevy_reflect_derive/documentation`]: bevy_reflect_derive
 //! [derive `Reflect`]: derive@crate::Reflect
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod array;
 mod fields;

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -122,4 +122,10 @@ wasm-bindgen = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -122,10 +122,5 @@ wasm-bindgen = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -22,10 +22,5 @@ quote = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_render/macros/Cargo.toml
+++ b/crates/bevy_render/macros/Cargo.toml
@@ -20,3 +20,12 @@ quote = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod as_bind_group;
 mod extract_component;

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -40,10 +40,5 @@ rmp-serde = "1.1"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_scene/Cargo.toml
+++ b/crates/bevy_scene/Cargo.toml
@@ -40,4 +40,10 @@ rmp-serde = "1.1"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_scene/src/lib.rs
+++ b/crates/bevy_scene/src/lib.rs
@@ -1,9 +1,10 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! Provides scene definition, instantiation and serialization/deserialization.
 //!
 //! Scenes are collections of entities and their associated components that can be
 //! instantiated or removed from a world to allow composition. Scenes can be serialized/deserialized,
 //! for example to save part of the world state to a file.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 mod bundle;
 mod dynamic_scene;

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -41,10 +41,5 @@ radsort = "0.1"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_sprite/Cargo.toml
+++ b/crates/bevy_sprite/Cargo.toml
@@ -39,3 +39,12 @@ radsort = "0.1"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_sprite/src/lib.rs
+++ b/crates/bevy_sprite/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! Provides 2D sprite rendering functionality.
 mod bundle;

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -29,4 +29,10 @@ web-time = { version = "0.2" }
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_tasks/Cargo.toml
+++ b/crates/bevy_tasks/Cargo.toml
@@ -29,10 +29,5 @@ web-time = { version = "0.2" }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -41,10 +41,5 @@ approx = "0.5.1"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_text/Cargo.toml
+++ b/crates/bevy_text/Cargo.toml
@@ -41,4 +41,10 @@ approx = "0.5.1"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -32,4 +32,10 @@ thiserror = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_time/Cargo.toml
+++ b/crates/bevy_time/Cargo.toml
@@ -32,10 +32,5 @@ thiserror = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -36,4 +36,10 @@ serialize = ["dep:serde", "bevy_math/serialize"]
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_transform/Cargo.toml
+++ b/crates/bevy_transform/Cargo.toml
@@ -36,10 +36,5 @@ serialize = ["dep:serde", "bevy_math/serialize"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -46,10 +46,5 @@ serialize = ["serde", "smallvec/serde"]
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -41,8 +41,15 @@ smallvec = "1.11"
 [features]
 serialize = ["serde", "smallvec/serde"]
 
-[package.metadata.docs.rs]
-all-features = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -1,11 +1,11 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! This crate contains Bevy's UI system, which can be used to create UI for both 2D and 3D games
 //! # Basic usage
 //! Spawn UI elements with [`node_bundles::ButtonBundle`], [`node_bundles::ImageBundle`], [`node_bundles::TextBundle`] and [`node_bundles::NodeBundle`]
 //! This UI is laid out with the Flexbox and CSS Grid layout models (see <https://cssreference.io/flexbox/>)
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod measurement;
 pub mod node_bundles;

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -27,3 +27,12 @@ getrandom = { version = "0.2.0", features = ["js"] }
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_utils/Cargo.toml
+++ b/crates/bevy_utils/Cargo.toml
@@ -29,10 +29,5 @@ getrandom = { version = "0.2.0", features = ["js"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_utils/macros/Cargo.toml
+++ b/crates/bevy_utils/macros/Cargo.toml
@@ -15,3 +15,12 @@ proc-macro2 = "1.0"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_utils/macros/Cargo.toml
+++ b/crates/bevy_utils/macros/Cargo.toml
@@ -17,10 +17,5 @@ proc-macro2 = "1.0"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_utils/macros/src/lib.rs
+++ b/crates/bevy_utils/macros/src/lib.rs
@@ -1,5 +1,6 @@
 // FIXME(3492): remove once docs are ready
 #![allow(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use proc_macro::TokenStream;
 use quote::{format_ident, quote};

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! General utilities for first-party [Bevy] engine crates.
 //!
 //! [Bevy]: https://bevyengine.org/

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -34,10 +34,5 @@ smol_str = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_window/Cargo.toml
+++ b/crates/bevy_window/Cargo.toml
@@ -34,4 +34,10 @@ smol_str = "0.2"
 workspace = true
 
 [package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
 all-features = true

--- a/crates/bevy_window/src/lib.rs
+++ b/crates/bevy_window/src/lib.rs
@@ -1,10 +1,11 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! `bevy_window` provides a platform-agnostic interface for windowing in Bevy.
 //!
 //! This crate contains types for window management and events,
 //! used by windowing implementors such as `bevy_winit`.
 //! The [`WindowPlugin`] sets up some global window-related parameters and
 //! is part of the [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use bevy_a11y::Focus;
 

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -50,8 +50,15 @@ wasm-bindgen = { version = "0.2" }
 web-sys = "0.3"
 crossbeam-channel = "0.5"
 
-[package.metadata.docs.rs]
-all-features = true
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -55,10 +55,5 @@ crossbeam-channel = "0.5"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -1,10 +1,11 @@
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
 //! `bevy_winit` provides utilities to handle window creation and the eventloop through [`winit`]
 //!
 //! Most commonly, the [`WinitPlugin`] is used as part of
 //! [`DefaultPlugins`](https://docs.rs/bevy/latest/bevy/struct.DefaultPlugins.html).
 //! The app's [runner](bevy_app::App::runner) is set by `WinitPlugin` and handles the `winit` [`EventLoop`].
 //! See `winit_runner` for details.
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub mod accessibility;
 mod converters;

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -6,8 +6,18 @@ description = "Bevy's error codes"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
 
 [dependencies]
 bevy = { path = ".." }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/errors/Cargo.toml
+++ b/errors/Cargo.toml
@@ -14,10 +14,5 @@ bevy = { path = ".." }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -34,3 +34,12 @@ label = "Bevy Example"
 
 [lints]
 workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/examples/mobile/Cargo.toml
+++ b/examples/mobile/Cargo.toml
@@ -36,10 +36,5 @@ label = "Bevy Example"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::single_component_path_imports)]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 //! [![](https://bevyengine.org/assets/bevy_logo_docs.svg)](https://bevyengine.org)
 //!

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -6,8 +6,6 @@ description = "handle templated pages in Bevy repository"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
 
 [dependencies]
 toml_edit = { version = "0.22.7", default-features = false, features = [
@@ -17,3 +15,15 @@ tera = "1.15"
 serde = { version = "1.0", features = ["derive"] }
 bitflags = "2.3"
 hashbrown = { version = "0.14", features = ["serde"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/tools/build-templated-pages/Cargo.toml
+++ b/tools/build-templated-pages/Cargo.toml
@@ -20,10 +20,5 @@ hashbrown = { version = "0.14", features = ["serde"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -6,9 +6,19 @@ description = "Build an example for wasm"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
 
 [dependencies]
 xshell = "0.2"
 clap = { version = "4.0", features = ["derive"] }
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/tools/build-wasm-example/Cargo.toml
+++ b/tools/build-wasm-example/Cargo.toml
@@ -15,10 +15,5 @@ clap = { version = "4.0", features = ["derive"] }
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -14,10 +14,5 @@ bitflags = "2.3"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -6,9 +6,18 @@ description = "CI script for Bevy"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
-
 [dependencies]
 xshell = "0.2"
 bitflags = "2.3"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -20,10 +20,5 @@ pbr = "1.1"
 workspace = true
 
 [package.metadata.docs.rs]
-rustdoc-args = [
-  "-Zunstable-options",
-  "-Zrustdoc-scrape-examples",
-  "--cfg",
-  "docsrs",
-]
+rustdoc-args = ["-Zunstable-options", "--cfg", "docsrs"]
 all-features = true

--- a/tools/example-showcase/Cargo.toml
+++ b/tools/example-showcase/Cargo.toml
@@ -6,8 +6,6 @@ description = "Run examples"
 publish = false
 license = "MIT OR Apache-2.0"
 
-[lints]
-workspace = true
 
 [dependencies]
 xshell = "0.2"
@@ -17,3 +15,15 @@ toml_edit = { version = "0.22.7", default-features = false, features = [
   "parse",
 ] }
 pbr = "1.1"
+
+[lints]
+workspace = true
+
+[package.metadata.docs.rs]
+rustdoc-args = [
+  "-Zunstable-options",
+  "-Zrustdoc-scrape-examples",
+  "--cfg",
+  "docsrs",
+]
+all-features = true


### PR DESCRIPTION
# Objective

- In #12366 `![cfg_attr(docsrs, feature(doc_auto_cfg))] `was added. But to apply it it needs `--cfg=docsrs` in rustdoc-args.


## Solution

- Apply `--cfg=docsrs` to all crates and CI.

I also added `[package.metadata.docs.rs]` to all crates to avoid adding code behind a feature and forget adding the metadata.

Before:

![Screenshot 2024-03-22 at 00 51 57](https://github.com/bevyengine/bevy/assets/104745335/6a9dfdaa-8710-4784-852b-5f9b74e3522c)

After:
![Screenshot 2024-03-22 at 00 51 32](https://github.com/bevyengine/bevy/assets/104745335/c5bd6d8e-8ddb-45b3-b844-5ecf9f88961c)

