### PR TITLE
Improve ci - install binaries instead of compiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -305,9 +305,9 @@ jobs:
       # This currently report a lot of false positives
       # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
       # - name: Installs cargo-deadlinks
-          # uses: taiki-e/install-action@v2
-          # with:
-          #   tool: cargo-deadlinks
+      #   uses: taiki-e/install-action@v2
+      #   with:
+      #    tool: cargo-deadlinks
       # - name: Checks dead links
       #   run: cargo deadlinks --dir target/doc/bevy
       #   continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install taplo
-        run: cargo install taplo-cli --locked
+        uses: taiki-e/install-action@v2
+        with:
+          tool: taplo-cli
       - name: Run Taplo
         id: taplo
         run: taplo fmt --check --diff
@@ -303,7 +305,9 @@ jobs:
       # This currently report a lot of false positives
       # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
       # - name: Installs cargo-deadlinks
-      #   run: cargo install --force cargo-deadlinks
+          # uses: taiki-e/install-action@v2
+          # with:
+          #   tool: cargo-deadlinks
       # - name: Checks dead links
       #   run: cargo deadlinks --dir target/doc/bevy
       #   continue-on-error: true

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -50,7 +50,9 @@ jobs:
         run: rustup target add aarch64-linux-android armv7-linux-androideabi
 
       - name: Install Cargo APK
-        run: cargo install --force cargo-apk
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-apk
 
       - name: Build app for Android
         run: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME cargo apk build --package bevy_mobile_example

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -26,7 +26,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-deny
       - name: Check for security advisories and unmaintained crates
         run: cargo deny check advisories
 
@@ -36,7 +38,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-deny
       - name: Check for banned and duplicated dependencies
         run: cargo deny check bans
 
@@ -46,7 +50,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-deny
       - name: Check for unauthorized licenses
         run: cargo deny check licenses
 
@@ -56,6 +62,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Install cargo-deny
-        run: cargo install cargo-deny
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-deny
       - name: Checked for unauthorized crate sources
         run: cargo deny check sources

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-release
 
       - name: Setup post-release version bump
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,9 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install cargo-release
-        run: cargo install cargo-release
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-release
 
       - name: Setup release
         run: |

--- a/.github/workflows/validation-jobs.yml
+++ b/.github/workflows/validation-jobs.yml
@@ -62,7 +62,9 @@ jobs:
         run: rustup target add aarch64-linux-android armv7-linux-androideabi
 
       - name: Install Cargo APK
-        run: cargo install --force cargo-apk
+        uses: taiki-e/install-action
+        with:
+          tool: cargo-apk
 
       - name: Build APK
         run: ANDROID_NDK_ROOT=$ANDROID_NDK_LATEST_HOME cargo apk build --package bevy_mobile_example
@@ -199,7 +201,9 @@ jobs:
           sudo apt install -y xvfb libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
 
       - name: Install wasm-bindgen
-        run: cargo install --force wasm-bindgen-cli
+        uses: taiki-e/install-action
+        with:
+          tool: wasm-bindgen-cli
 
       - name: Setup playwright
         run: |
@@ -278,7 +282,9 @@ jobs:
         with:
           toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
       - name: Installs cargo-udeps
-        run: cargo install --force cargo-udeps
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-udeps
       - name: Install Linux dependencies
         uses: ./.github/actions/install-linux-deps
       - name: Run cargo udeps


### PR DESCRIPTION
# Objective

Reduce time compiling crates in CI.

## Solution

- Install binaries using https://github.com/taiki-e/install-action/tree/v2/

install-actions uses github releases to find the binaries.
Uses [cargo-binstall](https://github.com/cargo-bins/cargo-binstall) as a fallback
