### PR TITLE
Implement maths and `Animatable` for `Srgba`

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use bevy_color::{ClampColor, Laba, LinearRgba, Oklaba, Xyza};
+use bevy_color::{ClampColor, Laba, LinearRgba, Oklaba, Srgba, Xyza};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -96,6 +96,7 @@ impl_float_animatable!(DVec4, f64);
 impl_color_animatable!(LinearRgba);
 impl_color_animatable!(Laba);
 impl_color_animatable!(Oklaba);
+impl_color_animatable!(Srgba);
 impl_color_animatable!(Xyza);
 
 // Vec3 is special cased to use Vec3A internally for blending

--- a/crates/bevy_color/src/srgba.rs
+++ b/crates/bevy_color/src/srgba.rs
@@ -1,7 +1,7 @@
-use std::ops::{Div, Mul};
-
 use crate::color_difference::EuclideanDistance;
-use crate::{Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor, Xyza};
+use crate::{
+    impl_componentwise_point, Alpha, ClampColor, LinearRgba, Luminance, Mix, StandardColor, Xyza,
+};
 use bevy_math::Vec4;
 use bevy_reflect::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -26,6 +26,8 @@ pub struct Srgba {
 }
 
 impl StandardColor for Srgba {}
+
+impl_componentwise_point!(Srgba, [red, green, blue, alpha]);
 
 impl Srgba {
     // The standard VGA colors, with alpha set to 1.0.
@@ -387,48 +389,6 @@ pub enum HexColorError {
     /// Invalid character.
     #[error("Invalid hex char")]
     Char(char),
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Mul<f32> for Srgba {
-    type Output = Self;
-
-    fn mul(self, rhs: f32) -> Self {
-        Self {
-            red: self.red * rhs,
-            green: self.green * rhs,
-            blue: self.blue * rhs,
-            alpha: self.alpha,
-        }
-    }
-}
-
-impl Mul<Srgba> for f32 {
-    type Output = Srgba;
-
-    fn mul(self, rhs: Srgba) -> Srgba {
-        rhs * self
-    }
-}
-
-/// All color channels are scaled directly,
-/// but alpha is unchanged.
-///
-/// Values are not clamped.
-impl Div<f32> for Srgba {
-    type Output = Self;
-
-    fn div(self, rhs: f32) -> Self {
-        Self {
-            red: self.red / rhs,
-            green: self.green / rhs,
-            blue: self.blue / rhs,
-            alpha: self.alpha,
-        }
-    }
 }
 
 #[cfg(test)]

--- a/examples/animation/color_animation.rs
+++ b/examples/animation/color_animation.rs
@@ -37,7 +37,7 @@ fn main() {
 fn setup(mut commands: Commands) {
     commands.spawn(Camera2dBundle::default());
 
-    // The color spaces `Oklaba`, `Laba`, `LinearRgba` and `Xyza` all are either perceptually or physically linear.
+    // The color spaces `Oklaba`, `Laba`, `LinearRgba`, `Srgba` and `Xyza` all are either perceptually or physically linear.
     // This property allows us to define curves, e.g. bezier curves through these spaces.
 
     // Define the control points for the curve.


### PR DESCRIPTION
# Objective

- Implements maths and `Animatable` for `Srgba` as suggested [here](https://github.com/bevyengine/bevy/issues/12617#issuecomment-2013494774).

## Solution

- Implements `Animatable` and maths for `Srgba` just like their implemented for other colors.

---

## Changelog

- Updated the example to mention `Srgba`.

## Migration Guide

- The previously existing implementation of mul/div for `Srgba` did not modify `alpha` but these operations do modify `alpha` now. Users need to be aware of this change.
