### PR TITLE
ChangeDetection as Components

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,6 +8,8 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
+use bevy_ecs_macros::Component;
+use crate::component::Component;
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -474,6 +476,16 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
         }
     }
 }
+
+// TODO: add docs
+#[derive(Component, Clone)]
+pub(crate) struct ChangeTicks<T: Component>{
+    /// The [`Tick`] indicating when the component was added.
+    pub(crate) added: Tick,
+    /// The [`Tick`] indicating when the component was last changed.
+    pub(crate) changed: Tick,
+}
+
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -284,7 +284,7 @@ impl ComponentSparseSet {
             self.entities.swap_remove(dense_index.as_usize());
             let is_last = dense_index.as_usize() == self.dense.len() - 1;
             // SAFETY: dense_index was just removed from `sparse`, which ensures that it is valid
-            let (value, _) = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
+            let value = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
             if !is_last {
                 let swapped_entity = self.entities[dense_index.as_usize()];
                 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
# Objective

- Remove all special casing for ComponentTicks in storage and add ChangeTicks<T: Component> as an engine provided component.
- Add Component hooks that automatically add or remove the ticks if the component is added/removed. This can be done via hooks or be the only hard-coded part of this.

- Update Archetype change logic:
   - either when `insert::<T: Bundle>` is called, we actually call `insert::<(T::Bundle, T::Bundle::ChangeTicks)>`
   - or inside the bundle insertion logic, we do extra logic to spawn the ChangeTick entities

- Update Mut to fetch both &mut T and &mut ChangeTicks<T>.
- Add an associated type to Component that changes WriteFetch to retrieve &mut T when change detection is disabled, and Mut<T> when it isn't. Update the derive macro to enable/disable this behavior.
- Update change detection fetches/filters to rely on Component<Write=Mut<Self>>

## Solution

- Describe the solution used to achieve the objective above.

---

## Changelog

> This section is optional. If this was a trivial fix, or has no externally-visible impact, you can delete this section.

- What changed as a result of this PR?
- If applicable, organize changes under "Added", "Changed", or "Fixed" sub-headings
- Stick to one or two sentences. If more detail is needed for a particular change, consider adding it to the "Solution" section
  - If you can't summarize the work, your change may be unreasonably large / unrelated. Consider splitting your PR to make it easier to review and merge!

## Migration Guide

> This section is optional. If there are no breaking changes, you can delete this section.

- If this PR is a breaking change (relative to the last release of Bevy), describe how a user might need to migrate their code to support these changes
- Simply adding new functionality is not a breaking change.
- Fixing behavior that was definitely a bug, rather than a questionable design choice is not a breaking change.
