### PR TITLE
Removed Into<AssedId<T>> for Handle<T> as mentioned in #12600

### DIFF
--- a/crates/bevy_asset/src/handle.rs
+++ b/crates/bevy_asset/src/handle.rs
@@ -249,24 +249,10 @@ impl<A: Asset> PartialEq for Handle<A> {
 
 impl<A: Asset> Eq for Handle<A> {}
 
-impl<A: Asset> From<Handle<A>> for AssetId<A> {
-    #[inline]
-    fn from(value: Handle<A>) -> Self {
-        value.id()
-    }
-}
-
 impl<A: Asset> From<&Handle<A>> for AssetId<A> {
     #[inline]
     fn from(value: &Handle<A>) -> Self {
         value.id()
-    }
-}
-
-impl<A: Asset> From<Handle<A>> for UntypedAssetId {
-    #[inline]
-    fn from(value: Handle<A>) -> Self {
-        value.id().into()
     }
 }
 
@@ -426,13 +412,6 @@ impl PartialOrd for UntypedHandle {
         } else {
             None
         }
-    }
-}
-
-impl From<UntypedHandle> for UntypedAssetId {
-    #[inline]
-    fn from(value: UntypedHandle) -> Self {
-        value.id()
     }
 }
 

--- a/crates/bevy_asset/src/io/embedded/mod.rs
+++ b/crates/bevy_asset/src/io/embedded/mod.rs
@@ -254,7 +254,7 @@ pub fn watched_path(_source_file_path: &'static str, _asset_path: &'static str) 
 macro_rules! load_internal_asset {
     ($app: ident, $handle: expr, $path_str: expr, $loader: expr) => {{
         let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
-        assets.insert($handle, ($loader)(
+        assets.insert($handle.id(), ($loader)(
             include_str!($path_str),
             std::path::Path::new(file!())
                 .parent()
@@ -266,7 +266,7 @@ macro_rules! load_internal_asset {
     // we can't support params without variadic arguments, so internal assets with additional params can't be hot-reloaded
     ($app: ident, $handle: ident, $path_str: expr, $loader: expr $(, $param:expr)+) => {{
         let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
-        assets.insert($handle, ($loader)(
+        assets.insert($handle.id(), ($loader)(
             include_str!($path_str),
             std::path::Path::new(file!())
                 .parent()
@@ -284,7 +284,7 @@ macro_rules! load_internal_binary_asset {
     ($app: ident, $handle: expr, $path_str: expr, $loader: expr) => {{
         let mut assets = $app.world.resource_mut::<$crate::Assets<_>>();
         assets.insert(
-            $handle,
+            $handle.id(),
             ($loader)(
                 include_bytes!($path_str).as_ref(),
                 std::path::Path::new(file!())

--- a/crates/bevy_asset/src/reflect.rs
+++ b/crates/bevy_asset/src/reflect.rs
@@ -149,7 +149,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
                 let mut assets = world.resource_mut::<Assets<A>>();
                 let value: A = FromReflect::from_reflect(value)
                     .expect("could not call `FromReflect::from_reflect` in `ReflectAsset::set`");
-                assets.insert(handle.typed_debug_checked(), value);
+                assets.insert(&handle.typed_debug_checked(), value);
             },
             len: |world| {
                 let assets = world.resource::<Assets<A>>();
@@ -161,7 +161,7 @@ impl<A: Asset + FromReflect> FromType<A> for ReflectAsset {
             },
             remove: |world, handle| {
                 let mut assets = world.resource_mut::<Assets<A>>();
-                let value = assets.remove(handle.typed_debug_checked());
+                let value = assets.remove(&handle.typed_debug_checked());
                 value.map(|value| Box::new(value) as Box<dyn Reflect>)
             },
         }

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -328,7 +328,7 @@ impl Plugin for PbrPlugin {
         }
 
         app.world.resource_mut::<Assets<StandardMaterial>>().insert(
-            Handle::<StandardMaterial>::default(),
+            &Handle::<StandardMaterial>::default(),
             StandardMaterial {
                 base_color: Color::srgb(1.0, 0.0, 0.5),
                 unlit: true,

--- a/crates/bevy_render/src/texture/mod.rs
+++ b/crates/bevy_render/src/texture/mod.rs
@@ -90,7 +90,7 @@ impl Plugin for ImagePlugin {
             .register_asset_reflect::<Image>();
         app.world
             .resource_mut::<Assets<Image>>()
-            .insert(Handle::default(), Image::default());
+            .insert(&Handle::default(), Image::default());
         #[cfg(feature = "basis-universal")]
         if let Some(processor) = app
             .world

--- a/crates/bevy_scene/src/scene_spawner.rs
+++ b/crates/bevy_scene/src/scene_spawner.rs
@@ -482,7 +482,7 @@ mod tests {
 
         let scene_id = world.resource_mut::<Assets<DynamicScene>>().add(scene);
         let instance_id = scene_spawner
-            .spawn_dynamic_sync(&mut world, scene_id)
+            .spawn_dynamic_sync(&mut world, &scene_id)
             .unwrap();
 
         // verify we spawned exactly one new entity with our expected component

--- a/crates/bevy_sprite/src/mesh2d/color_material.rs
+++ b/crates/bevy_sprite/src/mesh2d/color_material.rs
@@ -25,7 +25,7 @@ impl Plugin for ColorMaterialPlugin {
             .register_asset_reflect::<ColorMaterial>();
 
         app.world.resource_mut::<Assets<ColorMaterial>>().insert(
-            Handle::<ColorMaterial>::default(),
+            &Handle::<ColorMaterial>::default(),
             ColorMaterial {
                 color: Color::srgb(1.0, 0.0, 1.0),
                 ..Default::default()

--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -274,7 +274,7 @@ impl Plugin for ColoredMesh2dPlugin {
         // Load our custom shader
         let mut shaders = app.world.resource_mut::<Assets<Shader>>();
         shaders.insert(
-            COLORED_MESH2D_SHADER_HANDLE,
+            &COLORED_MESH2D_SHADER_HANDLE,
             Shader::from_wgsl(COLORED_MESH2D_SHADER, file!()),
         );
 

--- a/examples/shader/array_texture.rs
+++ b/examples/shader/array_texture.rs
@@ -54,7 +54,7 @@ fn create_array_texture(
     mut materials: ResMut<Assets<ArrayTextureMaterial>>,
 ) {
     if loading_texture.is_loaded
-        || asset_server.load_state(loading_texture.handle.clone()) != LoadState::Loaded
+        || asset_server.load_state(loading_texture.handle.id()) != LoadState::Loaded
     {
         return;
     }


### PR DESCRIPTION
Fixes #12600 

## Solution

Removed Into<AssetId<T>> for Handle<T> as proposed in Issue conversation, fixed dependent code

## Migration guide

If you use passing Handle by value as AssetId, you should pass reference or call .id() method on it
Before (0.13):
`assets.insert(handle, value);`
After (0.14):
`assets.insert(&handle, value);`
or
`assets.insert(handle.id(), value);`