### PR TITLE
Update safety comment for bundle removal

### DIFF
--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -977,6 +977,8 @@ impl Bundles {
     }
 
     /// Initializes a new [`BundleInfo`] for a statically known type.
+    ///
+    /// Also initializes all the components in the bundle.
     pub(crate) fn init_info<T: Bundle>(
         &mut self,
         components: &mut Components,
@@ -999,6 +1001,7 @@ impl Bundles {
         id
     }
 
+    /// SAFETY: a `BundleInfo` with the given `BundleId` must have been initialized
     pub(crate) unsafe fn get_unchecked(&self, id: BundleId) -> &BundleInfo {
         self.bundle_infos.get_unchecked(id.0)
     }

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -1001,7 +1001,8 @@ impl Bundles {
         id
     }
 
-    /// SAFETY: a `BundleInfo` with the given `BundleId` must have been initialized
+    /// # Safety
+    /// A `BundleInfo` with the given `BundleId` must have been initialized for this instance of `Bundles`.
     pub(crate) unsafe fn get_unchecked(&self, id: BundleId) -> &BundleInfo {
         self.bundle_infos.get_unchecked(id.0)
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1032,14 +1032,14 @@ impl<'w> EntityWorldMut<'w> {
     /// Remove the components of `bundle` from `entity`.
     ///
     /// SAFETY:
-    /// - A `bundle_info` with the corresponding bundle_id must have been initialized
-    /// - The components in `bundle_info` must exist.
+    /// - A Bundle with the corresponding bundle_id must have been initialized.
+    /// - The components in BundleInfo must exist on the entity.
     #[allow(clippy::too_many_arguments)]
     unsafe fn remove_bundle(&mut self, bundle: BundleId) -> EntityLocation {
         let entity = self.entity;
         let world = &mut self.world;
         let location = self.location;
-        // SAFETY: the bundle_info exists because it was initialized
+        // SAFETY: the caller guarantees that the BundleInfo for this id has been initialized.
         let bundle_info = world.bundles.get_unchecked(bundle);
 
         // SAFETY: `archetype_id` exists because it is referenced in `location` which is valid

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1032,8 +1032,7 @@ impl<'w> EntityWorldMut<'w> {
     /// Remove the components of `bundle` from `entity`.
     ///
     /// SAFETY:
-    /// - A Bundle with the corresponding bundle_id must have been initialized.
-    /// - The components in BundleInfo must exist on the entity.
+    /// - A `BundleInfo` with the corresponding `BundleId` must have been initialized.
     #[allow(clippy::too_many_arguments)]
     unsafe fn remove_bundle(&mut self, bundle: BundleId) -> EntityLocation {
         let entity = self.entity;
@@ -1043,13 +1042,14 @@ impl<'w> EntityWorldMut<'w> {
         let bundle_info = world.bundles.get_unchecked(bundle);
 
         // SAFETY: `archetype_id` exists because it is referenced in `location` which is valid
-        // and components in `bundle_info` must exist due to this functions safety invariants.
+        // and components in `bundle_info` must exist due to this function's safety invariants.
         let new_archetype_id = remove_bundle_from_archetype(
             &mut world.archetypes,
             &mut world.storages,
             &world.components,
             location.archetype_id,
             bundle_info,
+            // components from the bundle that are not present on the entity are ignored
             true,
         )
         .expect("intersections should always return a result");
@@ -1120,8 +1120,7 @@ impl<'w> EntityWorldMut<'w> {
         let components = &mut self.world.components;
         let bundle_info = self.world.bundles.init_info::<T>(components, storages);
 
-        // SAFETY: Components exist in `bundle_info` because `Bundles::init_info`
-        // initializes a: EntityLocation `BundleInfo` containing all components of the bundle type `T`.
+        // SAFETY: the `BundleInfo` is initialized above
         self.location = unsafe { self.remove_bundle(bundle_info) };
 
         self
@@ -1147,8 +1146,7 @@ impl<'w> EntityWorldMut<'w> {
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 
-        // SAFETY: Components exist in `remove_bundle` because `Bundles::init_dynamic_info`
-        // initializes a `BundleInfo` containing all components in the to_remove Bundle.
+        // SAFETY: the `BundleInfo` for the components to remove is initialized above
         self.location = unsafe { self.remove_bundle(remove_bundle) };
         self
     }

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1031,12 +1031,15 @@ impl<'w> EntityWorldMut<'w> {
 
     /// Remove the components of `bundle` from `entity`.
     ///
-    /// SAFETY: The components in `bundle_info` must exist.
+    /// SAFETY:
+    /// - A `bundle_info` with the corresponding bundle_id must have been initialized
+    /// - The components in `bundle_info` must exist.
     #[allow(clippy::too_many_arguments)]
     unsafe fn remove_bundle(&mut self, bundle: BundleId) -> EntityLocation {
         let entity = self.entity;
         let world = &mut self.world;
         let location = self.location;
+        // SAFETY: the bundle_info exists because it was initialized
         let bundle_info = world.bundles.get_unchecked(bundle);
 
         // SAFETY: `archetype_id` exists because it is referenced in `location` which is valid


### PR DESCRIPTION
# Objective

- Tiny PR to clarify that `self.world.bundles.init_info::<T>` must have been called so that the BundleInfo is present in the World
