### PR TITLE
Add triangle_math tests and fix Triangle3d::bounding_sphere bug

### DIFF
--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1004,9 +1004,8 @@ mod tests {
             epsilon = 10e-9
         );
         assert_eq!(default_triangle.normal(), Ok(Dir3::Z), "incorrect normal");
-        assert_eq!(
+        assert!(
             default_triangle.is_degenerate(),
-            false,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1052,9 +1051,8 @@ mod tests {
 
         // Degenerate triangle tests
         let zero_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::ZERO, Vec3::ZERO);
-        assert_eq!(
+        assert!(
             zero_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1081,9 +1079,8 @@ mod tests {
         );
 
         let dup_degenerate_triangle = Triangle3d::new(Vec3::ZERO, Vec3::X, Vec3::X);
-        assert_eq!(
+        assert!(
             dup_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(
@@ -1117,9 +1114,8 @@ mod tests {
         );
 
         let common_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
-        assert_eq!(
+        assert!(
             common_degenerate_triangle.is_degenerate(),
-            true,
             "incorrect degenerate check"
         );
         assert_eq!(

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -813,8 +813,9 @@ impl Bounded3d for Triangle3d {
         };
 
         if let Some((p1, p2)) = side_opposite_to_non_acute {
-            let (segment, _) = Segment3d::from_points(p1, p2);
-            segment.bounding_sphere(translation, rotation)
+            let mid_point = (p1 + p2) / 2.0;
+            let radius = mid_point.distance(p1);
+            BoundingSphere::new(mid_point + translation, radius)
         } else {
             let circumcenter = self.circumcenter();
             let radius = circumcenter.distance(a);

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -793,7 +793,7 @@ impl Bounded3d for Triangle3d {
     /// The [`Triangle3d`] implements the minimal bounding sphere calculation. For acute triangles, the circumcenter is used as
     /// the center of the sphere. For the others, the bounding sphere is the minimal sphere
     /// that contains the largest side of the triangle.
-    fn bounding_sphere(&self, translation: Vec3, rotation: Quat) -> BoundingSphere {
+    fn bounding_sphere(&self, translation: Vec3, _rotation: Quat) -> BoundingSphere {
         if self.is_degenerate() {
             let (p1, p2) = self.largest_side();
             let mid_point = (p1 + p2) / 2.0;

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -798,7 +798,7 @@ impl Bounded3d for Triangle3d {
             let (p1, p2) = self.largest_side();
             let mid_point = (p1 + p2) / 2.0;
             let (segment, _) = Segment3d::from_points(p1, p2);
-            return segment.bounding_sphere(mid_point, rotation);
+            return segment.bounding_sphere(translation + mid_point, rotation);
         }
 
         let [a, b, c] = self.vertices;

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -797,8 +797,7 @@ impl Bounded3d for Triangle3d {
         if self.is_degenerate() {
             let (p1, p2) = self.largest_side();
             let mid_point = (p1 + p2) / 2.0;
-            let (segment, _) = Segment3d::from_points(p1, p2);
-            return segment.bounding_sphere(translation + mid_point, rotation);
+            return BoundingSphere::new(mid_point + translation, mid_point.distance(p1));
         }
 
         let [a, b, c] = self.vertices;
@@ -1066,9 +1065,9 @@ mod tests {
             "incorrect largest side"
         );
 
-        // let bs = zero_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY); // DIVISION BY ZERO
-        // assert_eq!(bs.center, Vec3::ZERO, "incorrect bounding sphere center");
-        // assert_eq!(bs.sphere.radius, 0.0, "incorrect bounding sphere radius");
+        let bs = zero_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY);
+        assert_eq!(bs.center, Vec3::ZERO, "incorrect bounding sphere center");
+        assert_eq!(bs.sphere.radius, 0.0, "incorrect bounding sphere radius");
 
         let br = zero_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(br.center(), Vec3::ZERO, "incorrect bounding box center");

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1005,7 +1005,7 @@ mod tests {
         );
         assert_eq!(default_triangle.normal(), Ok(Dir3::Z), "incorrect normal");
         assert!(
-            default_triangle.is_degenerate(),
+            !default_triangle.is_degenerate(),
             "incorrect degenerate check"
         );
         assert_eq!(

--- a/crates/bevy_math/src/primitives/dim3.rs
+++ b/crates/bevy_math/src/primitives/dim3.rs
@@ -1113,26 +1113,26 @@ mod tests {
             "incorrect bounding box half extents"
         );
 
-        let common_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
+        let collinear_degenerate_triangle = Triangle3d::new(Vec3::NEG_X, Vec3::ZERO, Vec3::X);
         assert!(
-            common_degenerate_triangle.is_degenerate(),
+            collinear_degenerate_triangle.is_degenerate(),
             "incorrect degenerate check"
         );
         assert_eq!(
-            common_degenerate_triangle.normal(),
+            collinear_degenerate_triangle.normal(),
             Err(InvalidDirectionError::Zero),
             "incorrect normal"
         );
         assert_eq!(
-            common_degenerate_triangle.largest_side(),
+            collinear_degenerate_triangle.largest_side(),
             (Vec3::NEG_X, Vec3::X),
             "incorrect largest side"
         );
 
-        let bs = common_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY);
+        let bs = collinear_degenerate_triangle.bounding_sphere(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(bs.center, Vec3::ZERO, "incorrect bounding sphere center");
         assert_eq!(bs.sphere.radius, 1.0, "incorrect bounding sphere radius");
-        let br = common_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
+        let br = collinear_degenerate_triangle.aabb_3d(Vec3::ZERO, Quat::IDENTITY);
         assert_eq!(br.center(), Vec3::ZERO, "incorrect bounding box center");
         assert_eq!(
             br.half_size(),


### PR DESCRIPTION
# Objective

To test and fix the `Triangle3d` methods.

## Solution

- Fixes an issue with the `Triangle3d::bounding_sphere` method, which was not translating the sphere to the largest side mid-point.
- Add tests for the `Triangle3d` math.

---

## Changelog

### Changed

- Add `Triangle3d` tests
- Fix `Triangle3d::bounding_sphere` bug for degenerate triangles