### PR TITLE
Clarify documentation regarding just_released and just_pressed inputs

### DIFF
--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -114,12 +114,14 @@ where
         self.just_released.extend(self.pressed.drain());
     }
 
-    /// Returns `true` if the `input` has just been pressed.
+    /// Returns `true` if the `input` has been pressed during the current frame.
+    ///
+    /// Note: This function does not imply information regarding the current or previous state of [`ButtonInput::pressed`].
     pub fn just_pressed(&self, input: T) -> bool {
         self.just_pressed.contains(&input)
     }
 
-    /// Returns `true` if any item in `inputs` has just been pressed.
+    /// Returns `true` if any item in `inputs` has been pressed during the current frame.
     pub fn any_just_pressed(&self, inputs: impl IntoIterator<Item = T>) -> bool {
         inputs.into_iter().any(|it| self.just_pressed(it))
     }
@@ -131,7 +133,9 @@ where
         self.just_pressed.remove(&input)
     }
 
-    /// Returns `true` if the `input` has just been released.
+    /// Returns `true` if the `input` has been released during the current frame.
+    ///
+    /// Note: This function does not imply information regarding the current or previous state of [`ButtonInput::pressed`].
     pub fn just_released(&self, input: T) -> bool {
         self.just_released.contains(&input)
     }
@@ -178,11 +182,15 @@ where
     }
 
     /// An iterator visiting every just pressed input in arbitrary order.
+    ///
+    /// Note: Returned elements do not imply information regarding the current or previous state of [`ButtonInput::pressed`].
     pub fn get_just_pressed(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_pressed.iter()
     }
 
     /// An iterator visiting every just released input in arbitrary order.
+    ///
+    /// Note: Returned elements do not imply information regarding the current or previous state of [`ButtonInput::pressed`].
     pub fn get_just_released(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_released.iter()
     }

--- a/crates/bevy_input/src/button_input.rs
+++ b/crates/bevy_input/src/button_input.rs
@@ -116,7 +116,7 @@ where
 
     /// Returns `true` if the `input` has been pressed during the current frame.
     ///
-    /// Note: This function does not imply information regarding the current or previous state of [`ButtonInput::pressed`].
+    /// Note: This function does not imply information regarding the current state of [`ButtonInput::pressed`] or [`ButtonInput::just_released`].
     pub fn just_pressed(&self, input: T) -> bool {
         self.just_pressed.contains(&input)
     }
@@ -135,7 +135,7 @@ where
 
     /// Returns `true` if the `input` has been released during the current frame.
     ///
-    /// Note: This function does not imply information regarding the current or previous state of [`ButtonInput::pressed`].
+    /// Note: This function does not imply information regarding the current state of [`ButtonInput::pressed`] or [`ButtonInput::just_pressed`].
     pub fn just_released(&self, input: T) -> bool {
         self.just_released.contains(&input)
     }
@@ -183,14 +183,14 @@ where
 
     /// An iterator visiting every just pressed input in arbitrary order.
     ///
-    /// Note: Returned elements do not imply information regarding the current or previous state of [`ButtonInput::pressed`].
+    /// Note: Returned elements do not imply information regarding the current state of [`ButtonInput::pressed`] or [`ButtonInput::just_released`].
     pub fn get_just_pressed(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_pressed.iter()
     }
 
     /// An iterator visiting every just released input in arbitrary order.
     ///
-    /// Note: Returned elements do not imply information regarding the current or previous state of [`ButtonInput::pressed`].
+    /// Note: Returned elements do not imply information regarding the current state of [`ButtonInput::pressed`] or [`ButtonInput::just_pressed`].
     pub fn get_just_released(&self) -> impl ExactSizeIterator<Item = &T> {
         self.just_released.iter()
     }


### PR DESCRIPTION
# Objective

- Clarify that `ButtonInput::just_release` and `ButtonInput::just_pressed` don't imply information about the state of `ButtonInput::pressed` or their counterparts.

