### PR TITLE
WIP: Change Detection as components

### DIFF
--- a/crates/bevy_ecs/macros/src/lib.rs
+++ b/crates/bevy_ecs/macros/src/lib.rs
@@ -72,6 +72,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         .map(|field| &field.ty)
         .collect::<Vec<_>>();
 
+    let mut change_ticks = Vec::new();
     let mut field_component_ids = Vec::new();
     let mut field_get_components = Vec::new();
     let mut field_from_components = Vec::new();
@@ -83,6 +84,9 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
     {
         match field_kind {
             BundleFieldKind::Component => {
+                change_ticks.push(quote! {
+                <#field_type as #ecs_path::bundle::Bundle>::ChangeTicks
+                });
                 field_component_ids.push(quote! {
                 <#field_type as #ecs_path::bundle::Bundle>::component_ids(components, storages, &mut *ids);
                 });
@@ -124,6 +128,7 @@ pub fn derive_bundle(input: TokenStream) -> TokenStream {
         // - `Bundle::get_components` is exactly once for each member. Rely's on the Component -> Bundle implementation to properly pass
         //   the correct `StorageType` into the callback.
         unsafe impl #impl_generics #ecs_path::bundle::Bundle for #struct_name #ty_generics #where_clause {
+            type ChangeTicks = (#(#change_ticks,)*);
             fn component_ids(
                 components: &mut #ecs_path::component::Components,
                 storages: &mut #ecs_path::storage::Storages,

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -146,13 +146,13 @@ impl BundleComponentStatus for AddBundle {
     #[inline]
     unsafe fn get_component_status(&self, index: usize) -> ComponentStatus {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        unsafe { *self.bundle_status.get_unchecked(index).component }
+        unsafe { self.bundle_status.get_unchecked(index).component }
     }
 
     #[inline]
     unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
-        unsafe { *self.bundle_status.get_unchecked(index).change_component }
+        unsafe { self.bundle_status.get_unchecked(index).change_component }
     }
 }
 

--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -115,7 +115,7 @@ pub(crate) enum ComponentStatus {
 
 pub(crate) struct ComponentChangeStatus {
     pub(crate) component: ComponentStatus,
-    pub(crate) change_component: ComponentStatus,
+    pub(crate) change_component: Option<ComponentStatus>,
 }
 
 pub(crate) struct AddBundle {
@@ -136,10 +136,12 @@ pub(crate) trait BundleComponentStatus {
 
     /// Returns the Bundle's change detection component status for the given "bundle index"
     ///
+    /// Returns None if the component does not have change detection enabled.
+    ///
     /// # Safety
     /// Callers must ensure that index is always a valid bundle index for the
     /// Bundle associated with this [`BundleComponentStatus`]
-    unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus;
+    unsafe fn get_component_change_status(&self, index: usize) -> Option<ComponentStatus>;
 }
 
 impl BundleComponentStatus for AddBundle {
@@ -150,7 +152,7 @@ impl BundleComponentStatus for AddBundle {
     }
 
     #[inline]
-    unsafe fn get_component_change_status(&self, index: usize) -> ComponentStatus {
+    unsafe fn get_component_change_status(&self, index: usize) -> Option<ComponentStatus> {
         // SAFETY: caller has ensured index is a valid bundle index for this bundle
         unsafe { self.bundle_status.get_unchecked(index).change_component }
     }
@@ -166,9 +168,10 @@ impl BundleComponentStatus for SpawnBundleStatus {
     }
 
     #[inline]
-    unsafe fn get_component_change_status(&self, _index: usize) -> ComponentStatus {
+    unsafe fn get_component_change_status(&self, _index: usize) -> Option<ComponentStatus> {
+        // TODO: be able to handle components with no change detection!!
         // Change detection added during a spawn call are always treated as added
-        ComponentStatus::Added
+        Some(ComponentStatus::Added)
     }
 }
 

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -506,15 +506,12 @@ impl BundleInfo {
             // handle the change detection component in a separate loop to maintain the order
             // between the component and its change detection component
             let change_component_id = component_change_id.change_ticks_component;
+            // TODO: can we avoid this check and re-use the main component's Status?
             let change_component_status = if current_archetype.contains(change_component_id) {
                 ComponentStatus::Mutated
             } else {
-                // SAFETY: component_id exists
-                let component_info = unsafe { components.get_info_unchecked(component_id) };
-                match component_info.storage_type() {
-                    StorageType::Table => new_table_components.push(component_id),
-                    StorageType::SparseSet => new_sparse_set_components.push(component_id),
-                }
+                // tick components are always stored in tables
+                new_table_components.push(change_component_id);
                 ComponentStatus::Added
             };
             bundle_status.push(ComponentChangeStatus {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -865,7 +865,7 @@ impl<'w> BundleInserter<'w> {
                     bundle_info
                         .iter_components()
                         .zip(add_bundle.bundle_status.iter())
-                        .filter(|(_, &status)| status.component == ComponentStatus::Added)
+                        .filter(|(_, &ref status)| status.component == ComponentStatus::Added)
                         .map(|(id, _)| id),
                 );
             }
@@ -1063,7 +1063,7 @@ impl Bundles {
                 change_component_ids.push(id);
             });
             // it is guaranteed that each component_id has a corresponding change_component_id
-            let mut component_change_ids = component_ids
+            let component_change_ids = component_ids
                 .into_iter()
                 .zip(change_component_ids.into_iter())
                 .map(|(component_id, change_component_id)| {

--- a/crates/bevy_ecs/src/bundle.rs
+++ b/crates/bevy_ecs/src/bundle.rs
@@ -228,7 +228,7 @@ macro_rules! tuple_impl {
         // - `Bundle::get_components` is called exactly once for each member. Relies on the above implementation to pass the correct
         //   `StorageType` into the callback.
         unsafe impl<$($name: Bundle),*> Bundle for ($($name,)*) {
-            type ChangeTicks: ($($name::ChangeTicks,)*);
+            type ChangeTicks = ($($name::ChangeTicks,)*);
 
             #[allow(unused_variables)]
             fn component_ids(components: &mut Components, storages: &mut Storages, ids: &mut impl FnMut(ComponentId)){
@@ -865,7 +865,7 @@ impl<'w> BundleInserter<'w> {
                     bundle_info
                         .iter_components()
                         .zip(add_bundle.bundle_status.iter())
-                        .filter(|(_, &status)| status == ComponentStatus::Added)
+                        .filter(|(_, &status)| status.component == ComponentStatus::Added)
                         .map(|(id, _)| id),
                 );
             }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -368,7 +368,7 @@ macro_rules! impl_methods {
             /// # impl Vec2 { pub const ZERO: Self = Self; }
             /// # #[derive(Component)] pub struct Transform { translation: Vec2 }
             /// // When run, zeroes the translation of every entity.
-            /// fn reset_positions(mut transforms: Query<&mut Transform>) {
+            /// fn reset_positions(mut transforms: Query<Mut<Transform>>) {
             ///     for transform in &mut transforms {
             ///         // We pinky promise not to modify `t` within the closure.
             ///         // Breaking this promise will result in logic errors, but will never cause undefined behavior.

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -8,6 +8,8 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
+use bevy_ecs_macros::Component;
+use crate::component::Component;
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -474,6 +476,16 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
         }
     }
 }
+
+// TODO: add docs
+#[derive(Component, Clone)]
+pub(crate) struct ChangeTicks<T: Component>{
+    /// The [`Tick`] indicating when the component was added.
+    pub(crate) added: Tick,
+    /// The [`Tick`] indicating when the component was last changed.
+    pub(crate) changed: Tick,
+}
+
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -9,7 +9,7 @@ use crate::{
 use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use bevy_ecs_macros::Component;
+use crate as bevy_ecs;
 use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
@@ -480,7 +480,8 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 
 // TODO: add docs
 #[derive(Component, Clone)]
-pub(crate) struct ChangeTicks<T: Component>{
+#[component(change_detection = false)]
+pub struct ChangeTicks<T: Component>{
     ticks: ComponentTicks,
     _marker: PhantomData<T>,
 }

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -529,7 +529,7 @@ pub struct ChangeTicks<T: Component>{
 pub struct ComponentChangeId {
     pub(crate) component: ComponentId,
     // TODO: make this optional is change detection is disabled for this component?
-    pub(crate) change_ticks_component: ComponentId,
+    pub(crate) change_ticks_component: Option<ComponentId>,
 }
 
 

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,17 +1,17 @@
 //! Types that detect when their internal data mutate.
 
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
+use crate as bevy_ecs;
+use crate::component::{Component, ComponentId, ComponentTicks};
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
     system::Resource,
 };
 use bevy_ptr::{Ptr, UnsafeCellDeref};
+use std::cell::UnsafeCell;
+use std::marker::PhantomData;
 use std::mem;
 use std::ops::{Deref, DerefMut};
-use crate as bevy_ecs;
-use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -518,11 +518,10 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 // TODO: add docs
 #[derive(Component, Clone)]
 #[component(change_detection = false)]
-pub struct ChangeTicks<T: Component>{
+pub struct ChangeTicks<T: Component> {
     ticks: ComponentTicks,
     _marker: PhantomData<T>,
 }
-
 
 /// Stores the component's [`ComponentId`] as well as the id of the component storing the change ticks.
 #[derive(Copy, Clone, Hash, Debug, Ord, PartialOrd, Eq, PartialEq)]
@@ -531,7 +530,6 @@ pub struct ComponentChangeId {
     // TODO: make this optional is change detection is disabled for this component?
     pub(crate) change_ticks_component: Option<ComponentId>,
 }
-
 
 /// Shared borrow of a [`Resource`].
 ///

--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -1,5 +1,6 @@
 //! Types that detect when their internal data mutate.
 
+use std::marker::PhantomData;
 use crate::{
     component::{Tick, TickCells},
     ptr::PtrMut,
@@ -9,7 +10,7 @@ use bevy_ptr::{Ptr, UnsafeCellDeref};
 use std::mem;
 use std::ops::{Deref, DerefMut};
 use bevy_ecs_macros::Component;
-use crate::component::Component;
+use crate::component::{Component, ComponentId, ComponentTicks};
 
 /// The (arbitrarily chosen) minimum number of world tick increments between `check_tick` scans.
 ///
@@ -480,10 +481,17 @@ impl<'w> From<TicksMut<'w>> for Ticks<'w> {
 // TODO: add docs
 #[derive(Component, Clone)]
 pub(crate) struct ChangeTicks<T: Component>{
-    /// The [`Tick`] indicating when the component was added.
-    pub(crate) added: Tick,
-    /// The [`Tick`] indicating when the component was last changed.
-    pub(crate) changed: Tick,
+    ticks: ComponentTicks,
+    _marker: PhantomData<T>,
+}
+
+
+/// Stores the component's [`ComponentId`] as well as the id of the component storing the change ticks.
+#[derive(Copy, Clone, Hash, Debug, Ord, PartialOrd, Eq, PartialEq)]
+pub(crate) struct ComponentChangeId {
+    pub(crate) component: ComponentId,
+    // TODO: make this optional is change detection is disabled for this component?
+    pub(crate) change_ticks_component: ComponentId,
 }
 
 

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -595,7 +595,7 @@ impl Components {
             storage_type: StorageType::Table,
             is_send_and_sync: true,
             type_id: None,
-            layout: Layout::new::<ChangeTicks<()>>(),
+            layout: Layout::new::<ComponentTicks>(),
             drop: None,
         };
         let change_detection_id = Components::init_component_inner(&mut self.components, storages, change_ticks_descriptor, None);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -59,7 +59,7 @@ mod tests {
     use crate::prelude::Or;
     use crate::{
         bundle::Bundle,
-        change_detection::Ref,
+        change_detection::{Ref},
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -56,10 +56,11 @@ pub mod prelude {
 #[cfg(test)]
 mod tests {
     use crate as bevy_ecs;
+    use crate::change_detection::ChangeTicks;
     use crate::prelude::Or;
     use crate::{
         bundle::Bundle,
-        change_detection::{Ref},
+        change_detection::Ref,
         component::{Component, ComponentId},
         entity::Entity,
         query::{Added, Changed, FilteredAccess, QueryFilter, With, Without},
@@ -76,7 +77,6 @@ mod tests {
             Arc, Mutex,
         },
     };
-    use crate::change_detection::ChangeTicks;
 
     #[derive(Component, Resource, Debug, PartialEq, Eq, Clone, Copy)]
     struct A(usize);
@@ -1377,7 +1377,10 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        let b_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<B>>())
+            .unwrap();
         expected.add_write(a_id);
         expected.add_read(b_tick_id);
         assert!(
@@ -1393,8 +1396,14 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let a_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
-        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        let a_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<A>>())
+            .unwrap();
+        let b_tick_id = world
+            .components
+            .get_id(TypeId::of::<ChangeTicks<B>>())
+            .unwrap();
         expected.add_write(a_id);
         expected.add_write(a_tick_id);
         expected.add_read(b_tick_id);

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -76,6 +76,7 @@ mod tests {
             Arc, Mutex,
         },
     };
+    use crate::change_detection::ChangeTicks;
 
     #[derive(Component, Resource, Debug, PartialEq, Eq, Clone, Copy)]
     struct A(usize);
@@ -903,7 +904,7 @@ mod tests {
 
         world.clear_trackers();
 
-        for (i, mut a) in world.query::<&mut A>().iter_mut(&mut world).enumerate() {
+        for (i, mut a) in world.query::<Mut<A>>().iter_mut(&mut world).enumerate() {
             if i % 2 == 0 {
                 a.0 += 1;
             }
@@ -983,7 +984,7 @@ mod tests {
         world.clear_trackers();
 
         for (i, mut a) in world
-            .query::<&mut SparseStored>()
+            .query::<Mut<SparseStored>>()
             .iter_mut(&mut world)
             .enumerate()
         {
@@ -1376,9 +1377,27 @@ mod tests {
 
         let mut expected = FilteredAccess::<ComponentId>::default();
         let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
-        let b_id = world.components.get_id(TypeId::of::<B>()).unwrap();
+        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
         expected.add_write(a_id);
-        expected.add_read(b_id);
+        expected.add_read(b_tick_id);
+        assert!(
+            query.component_access.eq(&expected),
+            "ComponentId access from query fetch and query filter should be combined"
+        );
+    }
+
+    #[test]
+    fn filtered_query_access_mut() {
+        let mut world = World::new();
+        let query = world.query_filtered::<Mut<A>, Changed<B>>();
+
+        let mut expected = FilteredAccess::<ComponentId>::default();
+        let a_id = world.components.get_id(TypeId::of::<A>()).unwrap();
+        let a_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<A>>()).unwrap();
+        let b_tick_id = world.components.get_id(TypeId::of::<ChangeTicks<B>>()).unwrap();
+        expected.add_write(a_id);
+        expected.add_write(a_tick_id);
+        expected.add_read(b_tick_id);
         assert!(
             query.component_access.eq(&expected),
             "ComponentId access from query fetch and query filter should be combined"

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1206,10 +1206,13 @@ unsafe impl<T: Component> WorldQuery for &mut T {
     }
 
     fn init_state(world: &mut World) -> ComponentId {
+        // TODO: find something better than a runtime panic..
+        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.init_component::<T>()
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
+        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.component_id::<T>()
     }
 

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -941,7 +941,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         // SAFETY: if change detection is enabled, the change ticks are present in the same table
         let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
         fetch.tick_data = Some(change_column.get_data_slice().into());
-        // Self::set_tick_data(fetch, component_id.change_ticks_component, table);
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
@@ -960,7 +959,7 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         // SAFETY: if change detection is enabled, the change ticks are present in the same table
         let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
         fetch.tick_data = Some(change_column.get_data_slice().into());
-        
+
         let column = table.get_column(component_id.component).debug_checked_unwrap();
         fetch.table_data = Some(column.get_data_slice().into());
     }
@@ -1062,13 +1061,6 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
     }
 }
 
-impl<'w, T: Component> Ref<'w, T> {
-    unsafe fn set_tick_data(fetch: &mut RefFetch<'w, T>, change_component_id: ComponentId, table: &'w Table) {
-        // SAFETY: if change detection is enabled, the change ticks are present in the same table
-        let change_column = table.get_column(change_component_id).debug_checked_unwrap();
-        fetch.tick_data = Some(change_column.get_data_slice().into());
-    }
-}
 
 /// SAFETY: `Self` is the same as `Self::ReadOnly`
 unsafe impl<'__w, T: Component> QueryData for Ref<'__w, T> {

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -938,7 +938,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         _archetype: &'w Archetype,
         table: &'w Table,
     ) {
-        Self::set_tick_data(fetch, component_id.change_ticks_component, table);
+        // SAFETY: if change detection is enabled, the change ticks are present in the same table
+        let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
+        fetch.tick_data = Some(change_column.get_data_slice().into());
+        // Self::set_tick_data(fetch, component_id.change_ticks_component, table);
         if Self::IS_DENSE {
             // SAFETY: `set_archetype`'s safety rules are a super set of the `set_table`'s ones.
             unsafe {
@@ -954,7 +957,10 @@ unsafe impl<'__w, T: Component> WorldQuery for Ref<'__w, T> {
         &component_id: &ComponentChangeId,
         table: &'w Table,
     ) {
-        Self::set_tick_data(fetch, component_id.change_ticks_component, table);
+        // SAFETY: if change detection is enabled, the change ticks are present in the same table
+        let change_column = table.get_column(component_id.change_ticks_component).debug_checked_unwrap();
+        fetch.tick_data = Some(change_column.get_data_slice().into());
+        
         let column = table.get_column(component_id.component).debug_checked_unwrap();
         fetch.table_data = Some(column.get_data_slice().into());
     }

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1199,7 +1199,7 @@ unsafe impl<T: Component> WorldQuery for &mut T {
     ) {
         assert!(
             !access.access().has_read(component_id),
-            "&{} conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",
+            "&mut {} conflicts with a previous access in this query. Mutable component access must be unique.",
             std::any::type_name::<T>(),
         );
         access.add_write(component_id);
@@ -1207,12 +1207,12 @@ unsafe impl<T: Component> WorldQuery for &mut T {
 
     fn init_state(world: &mut World) -> ComponentId {
         // TODO: find something better than a runtime panic..
-        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
+        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.init_component::<T>()
     }
 
     fn get_state(world: &World) -> Option<Self::State> {
-        assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
+        // assert!(!T::CHANGE_DETECTION, "Can fetch &mut T only for components without change detection");
         world.component_id::<T>()
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -853,13 +853,17 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
             panic!("$state_name<{}> conflicts with a previous access in this query. Shared access cannot coincide with exclusive access.",std::any::type_name::<T>());
         }
         access.add_read(id);
+        // TODO: should we also restrict access to the actual component? i'm confused
+        //  i think this access is mostly just to find which archetypes match
     }
 
     fn init_state(world: &mut World) -> ComponentId {
         let component_id = world.init_component::<T>();
-        // TODO: deal with the change ticks not existing
         let component_info = world.components.get_info(component_id).unwrap();
-        let change_component_id = component_info.change_detection_id().unwrap();
+        // TODO: is panicking the best solution here?
+        let change_component_id = component_info.change_detection_id().expect(
+            "Component change detection is not enabled for this component!"
+        );
         change_component_id
     }
 

--- a/crates/bevy_ecs/src/query/filter.rs
+++ b/crates/bevy_ecs/src/query/filter.rs
@@ -1,3 +1,4 @@
+use crate::component::ComponentTicks;
 use crate::{
     archetype::Archetype,
     component::{Component, ComponentId, StorageType, Tick},
@@ -9,7 +10,6 @@ use crate::{
 use bevy_ptr::{ThinSlicePtr, UnsafeCellDeref};
 use bevy_utils::all_tuples;
 use std::{cell::UnsafeCell, marker::PhantomData};
-use crate::component::ComponentTicks;
 
 /// Types that filter the results of a [`Query`].
 ///
@@ -653,7 +653,9 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
         let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
         // SAFETY: The caller ensures `table_row` is in range.
         let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref().added.is_newer_than(fetch.last_run, fetch.this_run)
+        tick.deref()
+            .added
+            .is_newer_than(fetch.last_run, fetch.this_run)
     }
 
     #[inline]
@@ -674,9 +676,10 @@ unsafe impl<T: Component> WorldQuery for Added<T> {
 
     fn get_state(world: &World) -> Option<ComponentId> {
         let component_id = world.component_id::<T>()?;
-        world.components.get_info(component_id).and_then(|info| {
-            info.change_detection_id()
-        })
+        world
+            .components
+            .get_info(component_id)
+            .and_then(|info| info.change_detection_id())
     }
 
     fn matches_component_set(
@@ -844,7 +847,9 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         let table = unsafe { fetch.table_ticks.debug_checked_unwrap() };
         // SAFETY: The caller ensures `table_row` is in range.
         let tick = unsafe { table.get(table_row.as_usize()) };
-        tick.deref().changed.is_newer_than(fetch.last_run, fetch.this_run)
+        tick.deref()
+            .changed
+            .is_newer_than(fetch.last_run, fetch.this_run)
     }
 
     #[inline]
@@ -861,17 +866,18 @@ unsafe impl<T: Component> WorldQuery for Changed<T> {
         let component_id = world.init_component::<T>();
         let component_info = world.components.get_info(component_id).unwrap();
         // TODO: is panicking the best solution here?
-        let change_component_id = component_info.change_detection_id().expect(
-            "Component change detection is not enabled for this component!"
-        );
+        let change_component_id = component_info
+            .change_detection_id()
+            .expect("Component change detection is not enabled for this component!");
         change_component_id
     }
 
     fn get_state(world: &World) -> Option<ComponentId> {
         let component_id = world.component_id::<T>()?;
-        world.components.get_info(component_id).and_then(|info| {
-            info.change_detection_id()
-        })
+        world
+            .components
+            .get_info(component_id)
+            .and_then(|info| info.change_detection_id())
     }
 
     fn matches_component_set(

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -78,6 +78,7 @@ mod tests {
     use crate::{self as bevy_ecs, component::Component, world::World};
     use std::any::type_name;
     use std::collections::HashSet;
+    use crate::change_detection::Mut;
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy)]
     struct A(usize);
@@ -347,7 +348,7 @@ mod tests {
             .collect::<HashSet<_>>()
         );
 
-        let mut query = world.query_filtered::<&mut A, Without<B>>();
+        let mut query = world.query_filtered::<Mut<A>, Without<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;
@@ -395,7 +396,7 @@ mod tests {
 
         let mut query_changed = world.query_filtered::<&A, Changed<A>>();
 
-        let mut query = world.query_filtered::<&mut A, With<B>>();
+        let mut query = world.query_filtered::<Mut<A>, With<B>>();
         let mut combinations = query.iter_combinations_mut(&mut world);
         while let Some([mut a, mut b, mut c]) = combinations.fetch_next() {
             a.0 += 10;

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -783,13 +783,13 @@ mod tests {
         let mut world = World::new();
         world.spawn((A(1), B(1)));
 
-        fn propagate_system(mut query: Query<(&A, &mut B), Changed<A>>) {
+        fn propagate_system(mut query: Query<(&A, Mut<B>), Changed<A>>) {
             query.par_iter_mut().for_each(|(a, mut b)| {
                 b.0 = a.0;
             });
         }
 
-        fn modify_system(mut query: Query<&mut A>) {
+        fn modify_system(mut query: Query<Mut<A>>) {
             for mut a in &mut query {
                 a.0 = 2;
             }

--- a/crates/bevy_ecs/src/query/mod.rs
+++ b/crates/bevy_ecs/src/query/mod.rs
@@ -71,6 +71,7 @@ impl<T> DebugCheckedUnwrap for Option<T> {
 mod tests {
     use bevy_ecs_macros::{QueryData, QueryFilter};
 
+    use crate::change_detection::Mut;
     use crate::prelude::{AnyOf, Changed, Entity, Or, QueryState, With, Without};
     use crate::query::{ArchetypeFilter, Has, QueryCombinationIter, ReadOnlyQueryData};
     use crate::schedule::{IntoSystemConfigs, Schedule};
@@ -78,7 +79,6 @@ mod tests {
     use crate::{self as bevy_ecs, component::Component, world::World};
     use std::any::type_name;
     use std::collections::HashSet;
-    use crate::change_detection::Mut;
 
     #[derive(Component, Debug, Hash, Eq, PartialEq, Clone, Copy)]
     struct A(usize);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -1,11 +1,11 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Tick, TickCells},
+    component::{ComponentId, ComponentInfo},
     entity::Entity,
     storage::{Column, TableRow},
 };
 use bevy_ptr::{OwningPtr, Ptr};
 use nonmax::NonMaxUsize;
-use std::{cell::UnsafeCell, hash::Hash, marker::PhantomData};
+use std::{hash::Hash, marker::PhantomData};
 
 type EntityIndex = u32;
 
@@ -550,12 +550,6 @@ impl SparseSets {
     pub(crate) fn clear_entities(&mut self) {
         for set in self.sets.values_mut() {
             set.clear();
-        }
-    }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for set in self.sets.values_mut() {
-            set.check_change_ticks(change_tick);
         }
     }
 }

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -164,11 +164,7 @@ impl ComponentSparseSet {
     /// # Safety
     /// The `value` pointer must point to a valid address that matches the [`Layout`](std::alloc::Layout)
     /// inside the [`ComponentInfo`] given when constructing this sparse set.
-    pub(crate) unsafe fn insert(
-        &mut self,
-        entity: Entity,
-        value: OwningPtr<'_>,
-    ) {
+    pub(crate) unsafe fn insert(&mut self, entity: Entity, value: OwningPtr<'_>) {
         if let Some(&dense_index) = self.sparse.get(entity.index()) {
             #[cfg(debug_assertions)]
             assert_eq!(entity, self.entities[dense_index.as_usize()]);

--- a/crates/bevy_ecs/src/storage/sparse_set.rs
+++ b/crates/bevy_ecs/src/storage/sparse_set.rs
@@ -284,7 +284,7 @@ impl ComponentSparseSet {
             self.entities.swap_remove(dense_index.as_usize());
             let is_last = dense_index.as_usize() == self.dense.len() - 1;
             // SAFETY: dense_index was just removed from `sparse`, which ensures that it is valid
-            let (value, _) = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
+            let value = unsafe { self.dense.swap_remove_and_forget_unchecked(dense_index) };
             if !is_last {
                 let swapped_entity = self.entities[dense_index.as_usize()];
                 #[cfg(not(debug_assertions))]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,10 +1,10 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, ComponentTicks, Components, Tick, TickCells},
+    component::{ComponentId, ComponentInfo, Components, Tick},
     entity::Entity,
     query::DebugCheckedUnwrap,
     storage::{blob_vec::BlobVec, ImmutableSparseSet, SparseSet},
 };
-use bevy_ptr::{OwningPtr, Ptr, PtrMut, UnsafeCellDeref};
+use bevy_ptr::{OwningPtr, Ptr, PtrMut};
 use bevy_utils::HashMap;
 use std::alloc::Layout;
 use std::{
@@ -301,7 +301,7 @@ impl Column {
     ///
     /// Returns `None` if `row` is out of bounds.
     #[inline]
-    pub fn get(&self, row: TableRow) -> Option<(Ptr<'_>)> {
+    pub fn get(&self, row: TableRow) -> Option<Ptr<'_>> {
         (row.as_usize() < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -175,7 +175,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn initialize(&mut self, row: TableRow, data: OwningPtr<'_>, tick: Tick) {
+    pub(crate) unsafe fn initialize(&mut self, row: TableRow, data: OwningPtr<'_>) {
         debug_assert!(row.as_usize() < self.len());
         self.data.initialize_unchecked(row.as_usize(), data);
     }
@@ -186,7 +186,7 @@ impl Column {
     /// # Safety
     /// Assumes data has already been allocated for the given row.
     #[inline]
-    pub(crate) unsafe fn replace(&mut self, row: TableRow, data: OwningPtr<'_>, change_tick: Tick) {
+    pub(crate) unsafe fn replace(&mut self, row: TableRow, data: OwningPtr<'_>) {
         debug_assert!(row.as_usize() < self.len());
         self.data.replace_unchecked(row.as_usize(), data);
     }
@@ -266,7 +266,7 @@ impl Column {
     ///
     /// # Safety
     /// `ptr` must point to valid data of this column's component type
-    pub(crate) unsafe fn push(&mut self, ptr: OwningPtr<'_>, ticks: ComponentTicks) {
+    pub(crate) unsafe fn push(&mut self, ptr: OwningPtr<'_>) {
         self.data.push(ptr);
     }
 

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -305,9 +305,7 @@ impl Column {
         (row.as_usize() < self.data.len())
             // SAFETY: The row is length checked before fetching the pointer. This is being
             // accessed through a read-only reference to the column.
-            .then(|| unsafe {
-                self.data.get_unchecked(row.as_usize())
-            })
+            .then(|| unsafe { self.data.get_unchecked(row.as_usize()) })
     }
 
     /// Fetches a read-only reference to the data at `row`.
@@ -364,7 +362,6 @@ impl Column {
     pub fn clear(&mut self) {
         self.data.clear();
     }
-
 }
 
 /// A builder type for constructing [`Table`]s.
@@ -633,7 +630,6 @@ impl Table {
         self.entities.is_empty()
     }
 
-
     /// Iterates over the [`Column`]s of the [`Table`].
     pub fn iter(&self) -> impl Iterator<Item = &Column> {
         self.columns.values()
@@ -771,7 +767,7 @@ mod tests {
     use crate::ptr::OwningPtr;
     use crate::storage::Storages;
     use crate::{
-        component::{Components},
+        component::Components,
         entity::Entity,
         storage::{TableBuilder, TableRow},
     };
@@ -794,10 +790,10 @@ mod tests {
                 let row = table.allocate(*entity);
                 let value: W<TableRow> = W(row);
                 OwningPtr::make(value, |value_ptr| {
-                    table.get_column_mut(component_id).unwrap().initialize(
-                        row,
-                        value_ptr,
-                    );
+                    table
+                        .get_column_mut(component_id)
+                        .unwrap()
+                        .initialize(row, value_ptr);
                 });
             };
         }

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -633,11 +633,6 @@ impl Table {
         self.entities.is_empty()
     }
 
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for column in self.columns.values_mut() {
-            column.check_change_ticks(change_tick);
-        }
-    }
 
     /// Iterates over the [`Column`]s of the [`Table`].
     pub fn iter(&self) -> impl Iterator<Item = &Column> {
@@ -751,12 +746,6 @@ impl Tables {
             table.clear();
         }
     }
-
-    pub(crate) fn check_change_ticks(&mut self, change_tick: Tick) {
-        for table in &mut self.tables {
-            table.check_change_ticks(change_tick);
-        }
-    }
 }
 
 impl Index<TableId> for Tables {
@@ -782,7 +771,7 @@ mod tests {
     use crate::ptr::OwningPtr;
     use crate::storage::Storages;
     use crate::{
-        component::{Components, Tick},
+        component::{Components},
         entity::Entity,
         storage::{TableBuilder, TableRow},
     };
@@ -808,7 +797,6 @@ mod tests {
                     table.get_column_mut(component_id).unwrap().initialize(
                         row,
                         value_ptr,
-                        Tick::new(0),
                     );
                 });
             };

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -1,5 +1,5 @@
 use crate::{
-    component::{ComponentId, ComponentInfo, Components, Tick},
+    component::{ComponentId, ComponentInfo, Components},
     entity::Entity,
     query::DebugCheckedUnwrap,
     storage::{blob_vec::BlobVec, ImmutableSparseSet, SparseSet},

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -985,7 +985,7 @@ mod tests {
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().to_vec();
+                let mut bundle_components = bundle_info.components().collect::<Vec<_>>();
                 bundle_components.sort();
                 for component_id in &bundle_components {
                     assert!(

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -985,7 +985,8 @@ mod tests {
                     .get_id(TypeId::of::<(W<i32>, W<bool>)>())
                     .expect("Bundle used to spawn entity should exist");
                 let bundle_info = bundles.get(bundle_id).unwrap();
-                let mut bundle_components = bundle_info.components().collect::<Vec<_>>();
+                // get all components, including the change detection components
+                let mut bundle_components = bundle_info.iter_all_components().collect::<Vec<_>>();
                 bundle_components.sort();
                 for component_id in &bundle_components {
                     assert!(

--- a/crates/bevy_ecs/src/system/query.rs
+++ b/crates/bevy_ecs/src/system/query.rs
@@ -1334,9 +1334,11 @@ impl<'w, 's, D: QueryData, F: QueryFilter> Query<'w, 's, D, F> {
     /// make limited changes to the types of parameters.
     ///
     /// * Can always add/remove `Entity`
-    /// * `Ref<T>` <-> `&T`
+    /// * `Ref<T>` -> `&T`
     /// * `&mut T` -> `&T`
-    /// * `&mut T` -> `Ref<T>`
+    /// * `Mut<T>` -> `&mut T`
+    /// * `Mut<T>` -> Ref<T>
+    /// * `Ref<T>/Mut<T>` -> Changed<T>/Added<T>
     /// * [`EntityMut`](crate::world::EntityMut) -> [`EntityRef`](crate::world::EntityRef)
     ///    
     pub fn transmute_lens<NewD: QueryData>(&mut self) -> QueryLens<'_, NewD> {

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,9 +1141,10 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_all_components().any(|comp| comp == *c))
+            .filter(|c| !retained_bundle_info.iter_components().any(|comp| comp == *c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
+
 
         // SAFETY: Components exist in `remove_bundle` because `Bundles::init_dynamic_info`
         // initializes a `BundleInfo` containing all components in the to_remove Bundle.

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1074,6 +1074,7 @@ impl<'w> EntityWorldMut<'w> {
         }
 
         let old_archetype = &world.archetypes[location.archetype_id];
+        // TODO: should we also send RemovedComponent for ChangeTicks components?
         for component_id in bundle_info.iter_components() {
             if old_archetype.contains(component_id) {
                 world.removed_components.send(component_id, entity);
@@ -1140,7 +1141,7 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.components().contains(c))
+            .filter(|c| !retained_bundle_info.iter_all_components().contains(c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -2257,7 +2257,7 @@ unsafe fn remove_bundle_from_archetype(
             let current_archetype = &mut archetypes[archetype_id];
             let mut removed_table_components = Vec::new();
             let mut removed_sparse_set_components = Vec::new();
-            for component_id in bundle_info.components().iter().cloned() {
+            for component_id in bundle_info.iter_all_components() {
                 if current_archetype.contains(component_id) {
                     // SAFETY: bundle components were already initialized by bundles.get_info
                     let component_info = unsafe { components.get_info_unchecked(component_id) };

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,7 +1141,7 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_all_components().contains(c))
+            .filter(|c| !retained_bundle_info.iter_all_components().any(|comp| comp == *c))
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
 

--- a/crates/bevy_ecs/src/world/entity_ref.rs
+++ b/crates/bevy_ecs/src/world/entity_ref.rs
@@ -1141,10 +1141,13 @@ impl<'w> EntityWorldMut<'w> {
 
         let to_remove = &old_archetype
             .components()
-            .filter(|c| !retained_bundle_info.iter_components().any(|comp| comp == *c))
+            .filter(|c| {
+                !retained_bundle_info
+                    .iter_components()
+                    .any(|comp| comp == *c)
+            })
             .collect::<Vec<_>>();
         let remove_bundle = self.world.bundles.init_dynamic_info(components, to_remove);
-
 
         // SAFETY: Components exist in `remove_bundle` because `Bundles::init_dynamic_info`
         // initializes a `BundleInfo` containing all components in the to_remove Bundle.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2443,6 +2443,7 @@ mod tests {
 
     // For bevy_ecs_macros
     use crate as bevy_ecs;
+    use crate::change_detection::ChangeTicks;
 
     type ID = u8;
 
@@ -2707,36 +2708,40 @@ mod tests {
                 .collect()
         }
 
+        let foo_ticks_id = TypeId::of::<ChangeTicks<Foo>>();
         let foo_id = TypeId::of::<Foo>();
+        let bar_ticks_id = TypeId::of::<ChangeTicks<Bar>>();
         let bar_id = TypeId::of::<Bar>();
+        let baz_ticks_id = TypeId::of::<ChangeTicks<Baz>>();
         let baz_id = TypeId::of::<Baz>();
+        // note that the change detection component is registered before the component
         assert_eq!(
             to_type_ids(world.inspect_entity(ent0)),
-            [Some(foo_id), Some(bar_id), Some(baz_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(bar_ticks_id), Some(bar_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent1)),
-            [Some(foo_id), Some(bar_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(bar_ticks_id), Some(bar_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent2)),
-            [Some(bar_id), Some(baz_id)].into()
+            [Some(bar_ticks_id), Some(bar_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent3)),
-            [Some(foo_id), Some(baz_id)].into()
+            [Some(foo_ticks_id), Some(foo_id), Some(baz_ticks_id), Some(baz_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent4)),
-            [Some(foo_id)].into()
+            [Some(foo_ticks_id), Some(foo_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent5)),
-            [Some(bar_id)].into()
+            [Some(bar_ticks_id), Some(bar_id)].into()
         );
         assert_eq!(
             to_type_ids(world.inspect_entity(ent6)),
-            [Some(baz_id)].into()
+            [Some(baz_ticks_id), Some(baz_id)].into()
         );
     }
 

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -966,9 +966,15 @@ unsafe fn get_component_and_ticks(
     };
 
     // TODO: handle case where component has change detection disabled
-    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let change_component_id = world
+        .components()
+        .get_info_unchecked(component_id)
+        .change_detection_id()
+        .unwrap();
     let column = world.fetch_table(location, change_component_id)?;
-    let component_ticks = column.get_data_slice::<ComponentTicks>().get(location.table_row.as_usize())?;
+    let component_ticks = column
+        .get_data_slice::<ComponentTicks>()
+        .get(location.table_row.as_usize())?;
     Some((ptr, component_ticks))
 }
 
@@ -989,7 +995,16 @@ unsafe fn get_ticks(
     entity: Entity,
     location: EntityLocation,
 ) -> Option<ComponentTicks> {
-    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let change_component_id = world
+        .components()
+        .get_info_unchecked(component_id)
+        .change_detection_id()
+        .unwrap();
     let column = world.fetch_table(location, change_component_id)?;
-    Some(column.get_data_slice::<ComponentTicks>().get(location.table_row.as_usize())?.read())
+    Some(
+        column
+            .get_data_slice::<ComponentTicks>()
+            .get(location.table_row.as_usize())?
+            .read(),
+    )
 }

--- a/crates/bevy_ecs/src/world/unsafe_world_cell.rs
+++ b/crates/bevy_ecs/src/world/unsafe_world_cell.rs
@@ -971,6 +971,11 @@ unsafe fn get_component_and_ticks(
         }
         StorageType::SparseSet => world.fetch_sparse_set(component_id)?.get_with_ticks(entity),
     }
+    // TODO: handle case where component has change detection disabled
+    let change_component_id = world.components().get_info_unchecked(component_id).change_detection_id().unwrap();
+    let column = world.fetch_table(location, change_component_id)?;
+    let ticks = column.get_data_unchecked(location.table_row);
+
 }
 
 /// Get an untyped pointer to the [`ComponentTicks`] on a particular [`Entity`]


### PR DESCRIPTION
# Objective

This PR aims to be a proof-of-concept for the issue: https://github.com/bevyengine/bevy/issues/4882 

The general idea is to remove the extra `ComponentTicks` information that is included directly in the `Column` storage type, which now only includes a dense array containing the actual component values.
Instead, the change detection values for a given component `C` are stored inside a separate component `ChangeTicks<C>`.


The implementation is currently pretty ad-hoc, and doesn't make use of new tools such as Observers, which maybe could be used for something like this? I don't know if there's other use cases of 'companion component' in the bevy codebase currently.

## Disabling Change Detection

This potentially opens the door to removing the change detection data for components that don't need it: the main change required would simply be to remove (or not spawn) the `ChangedTicks<C>` component. This could be useful to opt-out of change detection for performance results (for example for some ZSTs).

I don't have this fully working currently, but some general ideas are already there. Currently it is only configurable at compile time with an associated constant on the `Component` type that can get set with the derive macro.
But it might be possible to make it configurable at runtime, and then the only change would be insert/remove the `ChangedTicks<C>` component.


## Solution

Here's a general outline:

1) Remove the `added_tick` and `change_tick` information that was stored in the `Column` storage type

2) Add an associated constant `CHANGE_DETECTION` to the `Component` type to enable/disable change detection for this type. (currently I just use this to disable change detection on the ChangedTicks<C> component, which would trigger an infinite recursion. But there might be other ways to achieve this; I'm not a fan of the associated constant, especially if we want runtime-configuration in the future).

3) Update component initialization to also register a sister component `ChangeTicks<C>` if C::CHANGE_DETECTION is true. Update `ComponentInfo` to contain a link to the change detection component's `ComponentId`. Enable it work for dynamic component registration as well.

4) Add a `B::ChangeTicks` associated type to `Bundle`, which defines the corresponding change tick components for the bundle. For example `(C1, C2)::ChangeTicks = (ChangedTicks<C1>, ChangedTicks<C2>)`. Update the `Bundle` derive macro to also generate the appropriate `ChangeTicks` associated type.

TODO: I don't really know what to do if some of the components have change detection disabled. For example if I have a bundle (A, B, C) and B has change detection disabled, what should the corresponding ChangeTick type be? Maybe (ChangeTicks<A>, (), ChangeTicks<B>) ?

5) Update the archetype edge logic (add bundle, insert bundle, remove bundle) to take into account the additional `B::ChangeTick` that needs to be added. (e.g. when we insert C, we actually also insert ChangeTicks<C> if C::CHANGE_DETECTION is enabled.)

6) Update the different fetch/filter types to account for change detection. Currently I just changed things just so that I could get the tests to pass, but it's probably not the behaviour that we want
- `&C` only fetches the component data, not the ticks data
- `Ref<C>` fetches the `C` and `ChangeTicks<C>` columns and panics if change detection is not enabled
- `&mut C` only fetches the component data, not the ticks data. This is a big footgun because modifying a component under these conditions doesn't update the ticks.
- `Mut<C>` fetches the `C` and `ChangeTicks<C>` and currently panics if change detection is not enabled
- `Added<C>` and `Changed<C>` now only fetch the changed ticks `ChangeTicks<C>`. This is different from the previous behaviour, where the actual storage from the component had to be accessed. This means that `&C` cannot be transmuted to `Changed<C>` anymore because they don't share the same accesses.


## TODO

- Currently, even if C is a SparseSet component, I store `ChangeTicks<C>` as dense storage.
I don't know if this a good design; I think it means that iterating through all `Changed<C>` or `Added<C>` is faster, but it might also slow down adding/removing a `C` component to an entity, which is not what we want.
- Change `&mut C` to fetch `&mut C` if component detection is disabled, `Mut<C>` if not. Is it possible to decide this at runtime? Maybe it could always return `Mut<C>`, and `Mut<C>` doesn't contain any change detection information if it is disabled.
- Add tests for compile-time disabling of change detection for a component
- Investigate runtime toggling of change detection for a component