### PR TITLE
fix: rewrite winit loop

### DIFF
--- a/crates/bevy_winit/Cargo.toml
+++ b/crates/bevy_winit/Cargo.toml
@@ -36,6 +36,7 @@ accesskit_winit = { version = "0.17", default-features = false, features = [
   "rwh_06",
 ] }
 approx = { version = "0.5", default-features = false }
+cfg-if = "1.0"
 raw-window-handle = "0.6"
 serde = { version = "1.0", features = ["derive"], optional = true }
 

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -197,25 +197,6 @@ impl WinitAppRunnerState {
         self.redraw_requested = false;
         self.window_event_received = false;
         self.device_event_received = false;
-        self.wait_elapsed = false;
-    }
-}
-
-#[derive(PartialEq, Eq)]
-enum ActiveState {
-    NotYetStarted,
-    Active,
-    Suspended,
-    WillSuspend,
-}
-
-impl ActiveState {
-    #[inline]
-    fn should_run(&self) -> bool {
-        match self {
-            ActiveState::NotYetStarted | ActiveState::Suspended => false,
-            ActiveState::Active | ActiveState::WillSuspend => true,
-        }
     }
 }
 
@@ -230,6 +211,25 @@ impl Default for WinitAppRunnerState {
             last_update: Instant::now(),
             // 3 seems to be enough, 5 is a safe margin
             startup_forced_updates: 5,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Debug)]
+enum ActiveState {
+    NotYetStarted,
+    Active,
+    Suspended,
+    WillSuspend,
+    WillResume,
+}
+
+impl ActiveState {
+    #[inline]
+    fn should_run(&self) -> bool {
+        match self {
+            Self::NotYetStarted | Self::Suspended => false,
+            Self::Active | Self::WillSuspend | Self::WillResume => true,
         }
     }
 }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -344,12 +344,12 @@ fn handle_winit_event(
             app.cleanup();
         }
         runner_state.redraw_requested = true;
+    }
 
-        if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
-            if app_exit_event_reader.read(app_exit_events).last().is_some() {
-                event_loop.exit();
-                return;
-            }
+    if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
+        if app_exit_event_reader.read(app_exit_events).last().is_some() {
+            event_loop.exit();
+            return;
         }
     }
 
@@ -403,7 +403,6 @@ fn handle_winit_event(
                         focused_windows_state,
                         event_loop,
                         create_window,
-                        app_exit_event_reader,
                         redraw_event_reader,
                         winit_events,
                     );
@@ -630,7 +629,6 @@ fn handle_winit_event(
                         focused_windows_state,
                         event_loop,
                         create_window,
-                        app_exit_event_reader,
                         redraw_event_reader,
                         winit_events,
                     );
@@ -730,7 +728,6 @@ fn run_app_update_if_should(
     focused_windows_state: &mut SystemState<(Res<WinitSettings>, Query<&Window>)>,
     event_loop: &EventLoopWindowTarget<UserEvent>,
     create_window: &mut SystemState<CreateWindowParams<Added<Window>>>,
-    app_exit_event_reader: &mut ManualEventReader<AppExit>,
     redraw_event_reader: &mut ManualEventReader<RequestRedraw>,
     winit_events: &mut Vec<WinitEvent>,
 ) {
@@ -785,12 +782,6 @@ fn run_app_update_if_should(
         if let Some(app_redraw_events) = app.world.get_resource::<Events<RequestRedraw>>() {
             if redraw_event_reader.read(app_redraw_events).last().is_some() {
                 runner_state.redraw_requested = true;
-            }
-        }
-
-        if let Some(app_exit_events) = app.world.get_resource::<Events<AppExit>>() {
-            if app_exit_event_reader.read(app_exit_events).last().is_some() {
-                event_loop.exit();
             }
         }
     }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -469,15 +469,14 @@ fn handle_winit_event(
             }
 
             if should_update {
-                let visible = windows.iter().any(|window| window.visible);
-                let (_, winit_windows, _, _) = event_writer_system_state.get_mut(&mut app.world);
-                if visible && runner_state.active != ActiveState::WillSuspend {
+                if runner_state.redraw_requested && runner_state.active != ActiveState::Suspended {
+                    let (_, winit_windows, _, _) =
+                        event_writer_system_state.get_mut(&mut app.world);
                     for window in winit_windows.windows.values() {
                         window.request_redraw();
                     }
-                } else {
-                    // there are no windows, or they are not visible.
-                    // Winit won't send events on some platforms, so trigger an update manually.
+                } else if runner_state.wait_elapsed {
+                    // Not redrawing, but the timeout elapsed.
                     run_app_update_if_should(
                         runner_state,
                         app,

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -477,11 +477,7 @@ fn handle_winit_event(
                     }
                 } else if runner_state.wait_elapsed {
                     // Not redrawing, but the timeout elapsed.
-                    run_app_update_if_should(
-                        runner_state,
-                        app,
-                        winit_events,
-                    );
+                    run_app_update_if_should(runner_state, app, winit_events);
                 }
             }
 
@@ -524,7 +520,6 @@ fn handle_winit_event(
                             if runner_state.wait_elapsed && current != next {
                                 event_loop.set_control_flow(ControlFlow::WaitUntil(next));
                             }
-
                         } else {
                             event_loop.set_control_flow(ControlFlow::WaitUntil(next));
                         }
@@ -743,11 +738,7 @@ fn handle_winit_event(
                     winit_events.send(WindowDestroyed { window });
                 }
                 WindowEvent::RedrawRequested => {
-                    run_app_update_if_should(
-                        runner_state,
-                        app,
-                        winit_events,
-                    );
+                    run_app_update_if_should(runner_state, app, winit_events);
                 }
                 _ => {}
             }

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -495,7 +495,7 @@ fn handle_winit_event(
                         )))]
                         {
                             let (_, windows) = focused_windows_state.get(&app.world);
-                            let visible = windows.iter().any(|(_, window)| window.visible);
+                            let visible = windows.iter().any(|window| window.visible);
 
                             match event_loop.control_flow() {
                                 ControlFlow::Poll if visible => {

--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -353,6 +353,11 @@ fn handle_winit_event(
         }
     }
 
+    // create any new windows
+    // (even if app did not update, some may have been created by plugin setup)
+    create_windows(event_loop, create_window.get_mut(&mut app.world));
+    create_window.apply(&mut app.world);
+
     match event {
         Event::AboutToWait => {
             if let Some(app_redraw_events) = app.world.get_resource::<Events<RequestRedraw>>() {
@@ -462,7 +467,6 @@ fn handle_winit_event(
                         app,
                         focused_windows_state,
                         event_loop,
-                        create_window,
                         winit_events,
                     );
                     if runner_state.active != ActiveState::Suspended {
@@ -687,7 +691,6 @@ fn handle_winit_event(
                         app,
                         focused_windows_state,
                         event_loop,
-                        create_window,
                         winit_events,
                     );
                 }
@@ -739,7 +742,6 @@ fn run_app_update_if_should(
     app: &mut App,
     focused_windows_state: &mut SystemState<(Res<WinitSettings>, Query<&Window>)>,
     event_loop: &EventLoopWindowTarget<UserEvent>,
-    create_window: &mut SystemState<CreateWindowParams<Added<Window>>>,
     winit_events: &mut Vec<WinitEvent>,
 ) {
     runner_state.reset_on_update();
@@ -777,11 +779,6 @@ fn run_app_update_if_should(
             }
         }
     }
-
-    // create any new windows
-    // (even if app did not update, some may have been created by plugin setup)
-    create_windows(event_loop, create_window.get_mut(&mut app.world));
-    create_window.apply(&mut app.world);
 }
 
 fn react_to_resize(

--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -44,10 +44,10 @@ impl WinitSettings {
     /// Returns the current [`UpdateMode`].
     ///
     /// **Note:** The output depends on whether the window has focus or not.
-    pub fn update_mode(&self, focused: bool) -> &UpdateMode {
+    pub fn update_mode(&self, focused: bool) -> UpdateMode {
         match focused {
-            true => &self.focused_mode,
-            false => &self.unfocused_mode,
+            true => self.focused_mode,
+            false => self.unfocused_mode,
         }
     }
 }
@@ -63,7 +63,7 @@ impl Default for WinitSettings {
 /// **Note:** This setting is independent of VSync. VSync is controlled by a window's
 /// [`PresentMode`](bevy_window::PresentMode) setting. If an app can update faster than the refresh
 /// rate, but VSync is enabled, the update rate will be indirectly limited by the renderer.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum UpdateMode {
     /// The [`App`](bevy_app::App) will update over and over, as fast as it possibly can, until an
     /// [`AppExit`](bevy_app::AppExit) event appears.

--- a/examples/window/low_power.rs
+++ b/examples/window/low_power.rs
@@ -9,6 +9,7 @@ use bevy::{
     window::{PresentMode, RequestRedraw, WindowPlugin},
     winit::WinitSettings,
 };
+use bevy_internal::winit::EventLoopProxy;
 
 fn main() {
     App::new()
@@ -55,8 +56,8 @@ enum ExampleMode {
 /// Update winit based on the current `ExampleMode`
 fn update_winit(
     mode: Res<ExampleMode>,
-    mut event: EventWriter<RequestRedraw>,
     mut winit_config: ResMut<WinitSettings>,
+    event_loop_proxy: NonSend<EventLoopProxy>,
 ) {
     use ExampleMode::*;
     *winit_config = match *mode {
@@ -85,7 +86,9 @@ fn update_winit(
             // frame regardless of any user input. For example, your application might use
             // `WinitSettings::desktop_app()` to reduce power use, but UI animations need to play even
             // when there are no inputs, so you send redraw requests while the animation is playing.
-            event.send(RequestRedraw);
+            // Note that in this example the RequestRedraw winit event will make the app run in the same 
+            // was as continuous
+            let _ = event_loop_proxy.send_event(RequestRedraw);
             WinitSettings::desktop_app()
         }
     };


### PR DESCRIPTION
# Objective

- Simplifies/clarifies the winit loop.
- Fixes #12612.

## Solution

The Winit loop runs following this flow:
* NewEvents
* Any number of other events, that can be 0, including RequestRedraw
* AboutToWait

Bevy also uses the UpdateMode, to define how the next loop has to run. It can be essentially:
* Continuous, using ControlFlow::Wait for windowed apps, and ControlFlow::Poll for windowless apps
* Reactive/ReactiveLowPower, using ControlFlow::WaitUntil with a specific wait delay

The changes are made to follow this pattern, so that 
* NewEvents define if the WaitUntil has been canceled because we received a Winit event.
* AboutToWait:
  * checks if the window has to be redrawn
  * otherwise calls app.update() if the WaitUntil timeout has elapsed
  * updates the ControlFlow accordingly

To make the code more logical:
* AboutToWait checks if any Bevy's RequestRedraw event has been emitted
* create_windows is run every cycle, at the beginning of the loop
* the ActiveState (that could be renamed ActivityState) is updated in AboutToWait, symmetrically for WillSuspend/WillResume
* the AppExit events are checked every loop cycle, to exit the app early