### PR TITLE
Make dynamic_linking a no-op on wasm targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -325,8 +325,10 @@ bevy_debug_stepping = ["bevy_internal/bevy_debug_stepping"]
 ios_simulator = ["bevy_internal/ios_simulator"]
 
 [dependencies]
-bevy_dylib = { path = "crates/bevy_dylib", version = "0.14.0-dev", default-features = false, optional = true }
 bevy_internal = { path = "crates/bevy_internal", version = "0.14.0-dev", default-features = false }
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+bevy_dylib = { path = "crates/bevy_dylib", version = "0.14.0-dev", default-features = false, optional = true }
 
 [dev-dependencies]
 rand = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -327,6 +327,7 @@ ios_simulator = ["bevy_internal/ios_simulator"]
 [dependencies]
 bevy_internal = { path = "crates/bevy_internal", version = "0.14.0-dev", default-features = false }
 
+# WASM does not support dynamic linking.
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.14.0-dev", default-features = false, optional = true }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,6 @@
 
 pub use bevy_internal::*;
 
-#[cfg(feature = "dynamic_linking")]
+#[cfg(all(feature = "dynamic_linking", not(target_family = "wasm")))]
 #[allow(unused_imports)]
 use bevy_dylib;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@
 
 pub use bevy_internal::*;
 
+// WASM does not support dynamic linking.
 #[cfg(all(feature = "dynamic_linking", not(target_family = "wasm")))]
 #[allow(unused_imports)]
 use bevy_dylib;


### PR DESCRIPTION
# Objective
Resolve #10054.

## Solution
Make dynamic linking a no-op by omitting it from the dependency tree on wasm targets.

To test this, try `cargo build --lib --target wasm32-unknown-unknown --features bevy/dynamic_linking` with and without this PR.

Might need to update the book on the website to explain this when this makes it into a release.

Co-Authored By: @daxpedda 