### PR TITLE
Implement minimal GPU culling for cameras.

### DIFF
--- a/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
+++ b/crates/bevy_core_pipeline/src/tonemapping/tonemapping_shared.wgsl
@@ -7,8 +7,8 @@
     @group(0) @binding(3) var dt_lut_texture: texture_3d<f32>;
     @group(0) @binding(4) var dt_lut_sampler: sampler;
 #else
-    @group(0) @binding(18) var dt_lut_texture: texture_3d<f32>;
-    @group(0) @binding(19) var dt_lut_sampler: sampler;
+    @group(0) @binding(19) var dt_lut_texture: texture_3d<f32>;
+    @group(0) @binding(20) var dt_lut_sampler: sampler;
 #endif
 
 fn sample_current_lut(p: vec3<f32>) -> vec3<f32> {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -434,6 +434,7 @@ impl<const I: usize, P: PhaseItem> RenderCommand<P> for SetLineGizmoBindGroup<I>
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: ROQueryItem<'w, Self::ViewQuery>,
         uniform_index: Option<ROQueryItem<'w, Self::ItemQuery>>,
         bind_group: SystemParamItem<'w, '_, Self::Param>,
@@ -460,6 +461,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineGizmo {
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: ROQueryItem<'w, Self::ViewQuery>,
         handle: Option<ROQueryItem<'w, Self::ItemQuery>>,
         line_gizmos: SystemParamItem<'w, '_, Self::Param>,
@@ -506,6 +508,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawLineJointGizmo {
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: ROQueryItem<'w, Self::ViewQuery>,
         handle: Option<ROQueryItem<'w, Self::ItemQuery>>,
         line_gizmos: SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_pbr/src/deferred/mod.rs
+++ b/crates/bevy_pbr/src/deferred/mod.rs
@@ -301,6 +301,10 @@ impl SpecializedRenderPipeline for DeferredLightingLayout {
             shader_defs.push("MOTION_VECTOR_PREPASS".into());
         }
 
+        if key.contains(MeshPipelineKey::INDIRECT) {
+            shader_defs.push("INDIRECT".into());
+        }
+
         // Always true, since we're in the deferred lighting pipeline
         shader_defs.push("DEFERRED_PREPASS".into());
 

--- a/crates/bevy_pbr/src/lib.rs
+++ b/crates/bevy_pbr/src/lib.rs
@@ -62,6 +62,8 @@ pub mod graph {
         /// Label for the screen space ambient occlusion render node.
         ScreenSpaceAmbientOcclusion,
         DeferredLightingPass,
+        /// Label for the GPU culling node.
+        GpuCull,
     }
 }
 
@@ -267,6 +269,7 @@ impl Plugin for PbrPlugin {
                 ExtractComponentPlugin::<ShadowFilteringMethod>::default(),
                 LightmapPlugin,
                 LightProbePlugin,
+                GpuCullPlugin,
             ))
             .configure_sets(
                 PostUpdate,

--- a/crates/bevy_pbr/src/prepass/mod.rs
+++ b/crates/bevy_pbr/src/prepass/mod.rs
@@ -412,6 +412,10 @@ where
             shader_defs.push("MOTION_VECTOR_PREPASS".into());
         }
 
+        if key.mesh_key.contains(MeshPipelineKey::INDIRECT) {
+            shader_defs.push("INDIRECT".into());
+        }
+
         if key.mesh_key.intersects(
             MeshPipelineKey::NORMAL_PREPASS
                 | MeshPipelineKey::MOTION_VECTOR_PREPASS
@@ -902,6 +906,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetPrepassViewBindGroup<
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         (view_uniform_offset, previous_view_projection_uniform_offset): (
             &'_ ViewUniformOffset,
             Option<&'_ PreviousViewProjectionUniformOffset>,

--- a/crates/bevy_pbr/src/render/cull.rs
+++ b/crates/bevy_pbr/src/render/cull.rs
@@ -1,0 +1,228 @@
+//! GPU culling.
+
+use bevy_app::{App, Plugin};
+use bevy_asset::{load_internal_asset, Handle};
+use bevy_core_pipeline::core_3d::graph::{Core3d, Node3d};
+use bevy_ecs::{
+    component::Component,
+    entity::Entity,
+    query::{QueryItem, With},
+    schedule::IntoSystemConfigs as _,
+    system::{lifetimeless::Read, Commands, Query, Res, ResMut, Resource},
+    world::{FromWorld, World},
+};
+use bevy_render::{
+    indirect::{
+        GpuIndirectInstanceDescriptor, GpuIndirectParameters, IndirectBuffers, MeshIndirectUniform,
+    },
+    render_graph::{NodeRunError, RenderGraphApp, RenderGraphContext, ViewNode, ViewNodeRunner},
+    render_resource::{
+        binding_types::{storage_buffer, storage_buffer_read_only, uniform_buffer},
+        BindGroupEntries, BindGroupLayout, CachedComputePipelineId, ComputePassDescriptor,
+        ComputePipelineDescriptor, DynamicBindGroupLayoutEntries, GpuArrayBuffer, PipelineCache,
+        Shader, ShaderStages, SpecializedComputePipeline, SpecializedComputePipelines,
+    },
+    renderer::{RenderContext, RenderDevice},
+    view::{GpuCulling, ViewTarget, ViewUniform, ViewUniformOffset, ViewUniforms},
+    Render, RenderApp, RenderSet,
+};
+use bevy_utils::tracing::warn;
+
+use crate::{graph::NodePbr, MeshUniform};
+
+const WORKGROUP_SIZE: usize = 64;
+
+pub const CULL_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(10372890860177113771);
+
+pub struct GpuCullPlugin;
+
+#[derive(Default)]
+pub struct GpuCullNode;
+
+#[derive(Resource)]
+pub struct CullingPipeline {
+    culling_bind_group_layout: BindGroupLayout,
+}
+
+#[derive(Component)]
+pub struct ViewCullingPipeline(CachedComputePipelineId);
+
+impl Plugin for GpuCullPlugin {
+    fn build(&self, app: &mut App) {
+        load_internal_asset!(app, CULL_SHADER_HANDLE, "cull.wgsl", Shader::from_wgsl);
+
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app.add_systems(Render, prepare_culling_pipelines.in_set(RenderSet::Prepare));
+    }
+
+    fn finish(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app
+            .add_render_graph_node::<ViewNodeRunner<GpuCullNode>>(Core3d, NodePbr::GpuCull)
+            .add_render_graph_edges(
+                Core3d,
+                (
+                    Node3d::StartMainPass,
+                    NodePbr::GpuCull,
+                    Node3d::MainOpaquePass,
+                ),
+            )
+            .init_resource::<CullingPipeline>()
+            .init_resource::<SpecializedComputePipelines<CullingPipeline>>();
+    }
+}
+
+impl ViewNode for GpuCullNode {
+    type ViewQuery = (Entity, Read<ViewUniformOffset>, Read<ViewCullingPipeline>);
+
+    fn run<'w>(
+        &self,
+        _: &mut RenderGraphContext,
+        render_context: &mut RenderContext<'w>,
+        (view_entity, view_uniform_offset, view_culling_pipeline): QueryItem<'w, Self::ViewQuery>,
+        world: &'w World,
+    ) -> Result<(), NodeRunError> {
+        let pipeline_cache = world.resource::<PipelineCache>();
+        let culling_pipeline = world.resource::<CullingPipeline>();
+        let indirect_buffers = world.resource::<IndirectBuffers>();
+        let mesh_uniforms_buffer = world.resource::<GpuArrayBuffer<MeshUniform>>();
+        let view_uniforms = world.resource::<ViewUniforms>();
+
+        let Some(view_culling_pipeline) =
+            pipeline_cache.get_compute_pipeline(view_culling_pipeline.0)
+        else {
+            warn!("View culling pipeline wasn't present");
+            return Ok(());
+        };
+
+        let Some(view_instance_buffers) = indirect_buffers.view_instances.get(&view_entity) else {
+            warn!("Failed to find view instance buffers");
+            return Ok(());
+        };
+
+        let Some(view_uniforms_buffer) = view_uniforms.uniforms.binding() else {
+            warn!("View uniforms buffer wasn't uploaded");
+            return Ok(());
+        };
+
+        let Some(mesh_uniforms_buffer) = mesh_uniforms_buffer.binding() else {
+            warn!("Mesh uniforms buffer wasn't uploaded");
+            return Ok(());
+        };
+
+        let Some(mesh_indirect_uniforms_buffer) = indirect_buffers.mesh_indirect_uniform.buffer()
+        else {
+            warn!("Failed to find mesh indirect uniforms buffer");
+            return Ok(());
+        };
+
+        let Some(indirect_parameters_buffer) = indirect_buffers.params.buffer() else {
+            warn!("Failed to find indirect parameters buffer");
+            return Ok(());
+        };
+
+        let (Some(instances_buffer), Some(descriptors_buffer)) = (
+            view_instance_buffers.instances.buffer(),
+            view_instance_buffers.descriptors.buffer(),
+        ) else {
+            warn!("View instance buffers weren't uploaded");
+            return Ok(());
+        };
+
+        // TODO: Do this in a separate pass and cache them.
+        let cull_bind_group = render_context.render_device().create_bind_group(
+            "cull_bind_group",
+            &culling_pipeline.culling_bind_group_layout,
+            &BindGroupEntries::sequential((
+                view_uniforms_buffer,
+                mesh_uniforms_buffer,
+                instances_buffer.as_entire_binding(),
+                descriptors_buffer.as_entire_binding(),
+                mesh_indirect_uniforms_buffer.as_entire_binding(),
+                indirect_parameters_buffer.as_entire_binding(),
+            )),
+        );
+
+        let mut compute_pass =
+            render_context
+                .command_encoder()
+                .begin_compute_pass(&ComputePassDescriptor {
+                    label: Some("cull"),
+                    timestamp_writes: None,
+                });
+
+        compute_pass.set_pipeline(view_culling_pipeline);
+        compute_pass.set_bind_group(0, &cull_bind_group, &[view_uniform_offset.offset]);
+        let workgroup_count = div_round_up(view_instance_buffers.descriptors.len(), WORKGROUP_SIZE);
+        compute_pass.dispatch_workgroups(workgroup_count as u32, 1, 1);
+
+        Ok(())
+    }
+}
+
+impl SpecializedComputePipeline for CullingPipeline {
+    type Key = ();
+
+    fn specialize(&self, _: Self::Key) -> ComputePipelineDescriptor {
+        ComputePipelineDescriptor {
+            label: Some("cull".into()),
+            layout: vec![self.culling_bind_group_layout.clone()],
+            push_constant_ranges: vec![],
+            shader: CULL_SHADER_HANDLE,
+            shader_defs: vec![],
+            entry_point: "main".into(),
+        }
+    }
+}
+
+impl FromWorld for CullingPipeline {
+    fn from_world(render_world: &mut World) -> Self {
+        let render_device = render_world.resource::<RenderDevice>();
+
+        let culling_bind_group_layout_entries = DynamicBindGroupLayoutEntries::sequential(
+            ShaderStages::COMPUTE,
+            (
+                uniform_buffer::<ViewUniform>(/*has_dynamic_offset=*/ true),
+                GpuArrayBuffer::<MeshUniform>::binding_layout(render_device),
+                storage_buffer::<u32>(/*has_dynamic_offset=*/ false),
+                storage_buffer_read_only::<GpuIndirectInstanceDescriptor>(
+                    /*has_dynamic_offset=*/ false,
+                ),
+                storage_buffer_read_only::<MeshIndirectUniform>(/*has_dynamic_offset=*/ false),
+                storage_buffer::<GpuIndirectParameters>(/*has_dynamic_offset=*/ false),
+            ),
+        );
+
+        let culling_bind_group_layout = render_device
+            .create_bind_group_layout("cull_bind_group_layout", &culling_bind_group_layout_entries);
+
+        CullingPipeline {
+            culling_bind_group_layout,
+        }
+    }
+}
+
+pub fn prepare_culling_pipelines(
+    mut commands: Commands,
+    pipeline_cache: Res<PipelineCache>,
+    mut pipelines: ResMut<SpecializedComputePipelines<CullingPipeline>>,
+    culling_pipeline: Res<CullingPipeline>,
+    view_query: Query<Entity, (With<ViewTarget>, With<GpuCulling>)>,
+) {
+    for entity in view_query.iter() {
+        let culling_pipeline_id = pipelines.specialize(&pipeline_cache, &culling_pipeline, ());
+        commands
+            .entity(entity)
+            .insert(ViewCullingPipeline(culling_pipeline_id));
+    }
+}
+
+fn div_round_up(a: usize, b: usize) -> usize {
+    (a + b - 1) / b
+}

--- a/crates/bevy_pbr/src/render/cull.wgsl
+++ b/crates/bevy_pbr/src/render/cull.wgsl
@@ -1,0 +1,71 @@
+#import bevy_pbr::mesh_types::Mesh
+#import bevy_render::view::View
+#import bevy_render::maths
+
+struct IndirectParameters {
+    vertex_count: u32,
+    instance_count: atomic<u32>,
+    first_index_or_vertex: u32,
+    first_vertex_or_instance: u32,
+    first_instance: u32,
+}
+
+struct IndirectInstanceDescriptor {
+    parameters_index: u32,
+    instance_index: u32,
+}
+
+struct MeshIndirect {
+    aabb_center: vec3<f32>,
+    aabb_half_extents: vec3<f32>,
+}
+
+@group(0) @binding(0) var<uniform> view: View;
+@group(0) @binding(1) var<storage> meshes: array<Mesh>;
+@group(0) @binding(2) var<storage, read_write> indirect_instances: array<u32>;
+@group(0) @binding(3) var<storage> indirect_descriptors: array<IndirectInstanceDescriptor>;
+@group(0) @binding(4) var<storage> indirect_meshes: array<MeshIndirect>;
+@group(0) @binding(5) var<storage, read_write> indirect_parameters: array<IndirectParameters>;
+
+fn transform_radius(transform: mat4x4<f32>, half_extents: vec3<f32>) -> f32 {
+    return length(maths::mat4x4_to_mat3x3(transform) * half_extents);
+}
+
+fn view_frustum_intersects_sphere(sphere_center: vec3<f32>, sphere_radius: f32) -> bool {
+    let center = vec4<f32>(sphere_center, 1.0);
+    for (var i = 0; i < 5; i += 1) {
+        if (dot(view.frustum[i], center) + sphere_radius <= 0.0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+@compute
+@workgroup_size(64)
+fn main(@builtin(global_invocation_id) global_invocation_id: vec3<u32>) {
+    let mesh_instance_index = global_invocation_id.x;
+    if (mesh_instance_index >= arrayLength(&indirect_descriptors)) {
+        return;
+    }
+
+    let indirect_descriptor = indirect_descriptors[mesh_instance_index];
+    let instance_index = indirect_descriptor.instance_index;
+
+    let indirect_data_index = meshes[instance_index].indirect_data_index;
+    let mesh_indirect = indirect_meshes[indirect_data_index];
+
+    let model = maths::affine3_to_square(meshes[instance_index].model);
+
+    let sphere_center = (model * vec4(mesh_indirect.aabb_center, 1.0)).xyz;
+    let sphere_radius = transform_radius(model, mesh_indirect.aabb_half_extents);
+    if (!view_frustum_intersects_sphere(sphere_center, sphere_radius)) {
+        return;
+    }
+
+    let parameters_index = indirect_descriptor.parameters_index;
+    let instance_handle = atomicAdd(&indirect_parameters[parameters_index].instance_count, 1u) +
+        indirect_parameters[parameters_index].first_instance;
+
+    indirect_instances[instance_handle] = indirect_descriptor.instance_index;
+}

--- a/crates/bevy_pbr/src/render/mesh.wgsl
+++ b/crates/bevy_pbr/src/render/mesh.wgsl
@@ -31,6 +31,10 @@ fn morph_vertex(vertex_in: Vertex) -> Vertex {
 fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     var out: VertexOutput;
 
+    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
+    // See https://github.com/gfx-rs/naga/issues/2416 .
+    let instance_index = mesh_functions::get_mesh_instance_index(vertex_no_morph.instance_index);
+
 #ifdef MORPH_TARGETS
     var vertex = morph_vertex(vertex_no_morph);
 #else
@@ -40,9 +44,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #ifdef SKINNED
     var model = skinning::skin_model(vertex.joint_indices, vertex.joint_weights);
 #else
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416 .
-    var model = mesh_functions::get_model_matrix(vertex_no_morph.instance_index);
+    var model = mesh_functions::get_model_matrix(instance_index);
 #endif
 
 #ifdef VERTEX_NORMALS
@@ -51,9 +53,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #else
     out.world_normal = mesh_functions::mesh_normal_local_to_world(
         vertex.normal,
-        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-        // See https://github.com/gfx-rs/naga/issues/2416
-        vertex_no_morph.instance_index
+        instance_index
     );
 #endif
 #endif
@@ -75,9 +75,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
     out.world_tangent = mesh_functions::mesh_tangent_local_to_world(
         model,
         vertex.tangent,
-        // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-        // See https://github.com/gfx-rs/naga/issues/2416
-        vertex_no_morph.instance_index
+        instance_index
     );
 #endif
 
@@ -86,9 +84,7 @@ fn vertex(vertex_no_morph: Vertex) -> VertexOutput {
 #endif
 
 #ifdef VERTEX_OUTPUT_INSTANCE_INDEX
-    // Use vertex_no_morph.instance_index instead of vertex.instance_index to work around a wgpu dx12 bug.
-    // See https://github.com/gfx-rs/naga/issues/2416
-    out.instance_index = vertex_no_morph.instance_index;
+    out.instance_index = instance_index;
 #endif
 
     return out;

--- a/crates/bevy_pbr/src/render/mesh_functions.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_functions.wgsl
@@ -1,7 +1,7 @@
 #define_import_path bevy_pbr::mesh_functions
 
 #import bevy_pbr::{
-    mesh_view_bindings::view,
+    mesh_view_bindings::{view, instance_indices},
     mesh_bindings::mesh,
     mesh_types::MESH_FLAGS_SIGN_DETERMINANT_MODEL_3X3_BIT,
     view_transformations::position_world_to_clip,
@@ -82,4 +82,12 @@ fn mesh_tangent_local_to_world(model: mat4x4<f32>, vertex_tangent: vec4<f32>, in
     } else {
         return vertex_tangent;
     }
+}
+
+fn get_mesh_instance_index(instance_index: u32) -> u32 {
+#ifdef INDIRECT
+    return instance_indices[instance_index];
+#else
+    return instance_index;
+#endif
 }

--- a/crates/bevy_pbr/src/render/mesh_types.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_types.wgsl
@@ -12,6 +12,7 @@ struct Mesh {
     // Use bevy_pbr::mesh_functions::mat2x4_f32_to_mat3x3_unpack to unpack
     inverse_transpose_model_a: mat2x4<f32>,
     inverse_transpose_model_b: f32,
+    indirect_data_index: u32,
     // 'flags' is a bit field indicating various options. u32 is 32 bits so we have up to 32 options.
     flags: u32,
     lightmap_uv_rect: vec2<u32>,

--- a/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.wgsl
@@ -8,6 +8,7 @@
 
 @group(0) @binding(0) var<uniform> view: View;
 @group(0) @binding(1) var<uniform> lights: types::Lights;
+
 #ifdef NO_CUBE_ARRAY_TEXTURES_SUPPORT
 @group(0) @binding(2) var point_shadow_textures: texture_depth_cube;
 #else
@@ -37,56 +38,60 @@
 
 @group(0) @binding(12) var screen_space_ambient_occlusion_texture: texture_2d<f32>;
 
-#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
-@group(0) @binding(13) var diffuse_environment_maps: binding_array<texture_cube<f32>, 8u>;
-@group(0) @binding(14) var specular_environment_maps: binding_array<texture_cube<f32>, 8u>;
-#else
-@group(0) @binding(13) var diffuse_environment_map: texture_cube<f32>;
-@group(0) @binding(14) var specular_environment_map: texture_cube<f32>;
+#ifdef INDIRECT
+@group(0) @binding(13) var<storage> instance_indices: array<u32>;
 #endif
-@group(0) @binding(15) var environment_map_sampler: sampler;
+
+#ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
+@group(0) @binding(14) var diffuse_environment_maps: binding_array<texture_cube<f32>, 8u>;
+@group(0) @binding(15) var specular_environment_maps: binding_array<texture_cube<f32>, 8u>;
+#else
+@group(0) @binding(14) var diffuse_environment_map: texture_cube<f32>;
+@group(0) @binding(15) var specular_environment_map: texture_cube<f32>;
+#endif
+@group(0) @binding(16) var environment_map_sampler: sampler;
 
 #ifdef IRRADIANCE_VOLUMES_ARE_USABLE
 #ifdef MULTIPLE_LIGHT_PROBES_IN_ARRAY
-@group(0) @binding(16) var irradiance_volumes: binding_array<texture_3d<f32>, 8u>;
+@group(0) @binding(17) var irradiance_volumes: binding_array<texture_3d<f32>, 8u>;
 #else
-@group(0) @binding(16) var irradiance_volume: texture_3d<f32>;
+@group(0) @binding(17) var irradiance_volume: texture_3d<f32>;
 #endif
-@group(0) @binding(17) var irradiance_volume_sampler: sampler;
+@group(0) @binding(18) var irradiance_volume_sampler: sampler;
 #endif
 
 // NB: If you change these, make sure to update `tonemapping_shared.wgsl` too.
-@group(0) @binding(18) var dt_lut_texture: texture_3d<f32>;
-@group(0) @binding(19) var dt_lut_sampler: sampler;
+@group(0) @binding(19) var dt_lut_texture: texture_3d<f32>;
+@group(0) @binding(20) var dt_lut_sampler: sampler;
 
 #ifdef MULTISAMPLED
 #ifdef DEPTH_PREPASS
-@group(0) @binding(20) var depth_prepass_texture: texture_depth_multisampled_2d;
+@group(0) @binding(21) var depth_prepass_texture: texture_depth_multisampled_2d;
 #endif // DEPTH_PREPASS
 #ifdef NORMAL_PREPASS
-@group(0) @binding(21) var normal_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(22) var normal_prepass_texture: texture_multisampled_2d<f32>;
 #endif // NORMAL_PREPASS
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(22) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
+@group(0) @binding(23) var motion_vector_prepass_texture: texture_multisampled_2d<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 #else // MULTISAMPLED
 
 #ifdef DEPTH_PREPASS
-@group(0) @binding(20) var depth_prepass_texture: texture_depth_2d;
+@group(0) @binding(21) var depth_prepass_texture: texture_depth_2d;
 #endif // DEPTH_PREPASS
 #ifdef NORMAL_PREPASS
-@group(0) @binding(21) var normal_prepass_texture: texture_2d<f32>;
+@group(0) @binding(22) var normal_prepass_texture: texture_2d<f32>;
 #endif // NORMAL_PREPASS
 #ifdef MOTION_VECTOR_PREPASS
-@group(0) @binding(22) var motion_vector_prepass_texture: texture_2d<f32>;
+@group(0) @binding(23) var motion_vector_prepass_texture: texture_2d<f32>;
 #endif // MOTION_VECTOR_PREPASS
 
 #endif // MULTISAMPLED
 
 #ifdef DEFERRED_PREPASS
-@group(0) @binding(23) var deferred_prepass_texture: texture_2d<u32>;
+@group(0) @binding(24) var deferred_prepass_texture: texture_2d<u32>;
 #endif // DEFERRED_PREPASS
 
-@group(0) @binding(24) var view_transmission_texture: texture_2d<f32>;
-@group(0) @binding(25) var view_transmission_sampler: sampler;
+@group(0) @binding(25) var view_transmission_texture: texture_2d<f32>;
+@group(0) @binding(26) var view_transmission_sampler: sampler;

--- a/crates/bevy_pbr/src/render/mod.rs
+++ b/crates/bevy_pbr/src/render/mod.rs
@@ -1,3 +1,4 @@
+mod cull;
 mod fog;
 mod light;
 pub(crate) mod mesh;
@@ -6,6 +7,7 @@ mod mesh_view_bindings;
 mod morph;
 mod skin;
 
+pub use cull::*;
 pub use fog::*;
 pub use light::*;
 pub use mesh::*;

--- a/crates/bevy_render/src/batching/mod.rs
+++ b/crates/bevy_render/src/batching/mod.rs
@@ -55,7 +55,7 @@ impl<T: PartialEq> BatchMeta<T> {
 
 /// A trait to support getting data used for batching draw commands via phase
 /// items.
-pub trait GetBatchData {
+pub trait GetBatchData: Sized {
     type Param: SystemParam + 'static;
     /// Data used for comparison between phase items. If the pipeline id, draw
     /// function id, per-instance data buffer dynamic offset and this data
@@ -77,11 +77,11 @@ pub trait GetBatchData {
 /// Batch the items in a render phase. This means comparing metadata needed to draw each phase item
 /// and trying to combine the draws into a batch.
 pub fn batch_and_prepare_render_phase<I: CachedRenderPipelinePhaseItem, F: GetBatchData>(
-    gpu_array_buffer: ResMut<GpuArrayBuffer<F::BufferData>>,
+    data_buffer: ResMut<GpuArrayBuffer<F::BufferData>>,
     mut views: Query<&mut RenderPhase<I>>,
     param: StaticSystemParam<F::Param>,
 ) {
-    let gpu_array_buffer = gpu_array_buffer.into_inner();
+    let gpu_array_buffer = data_buffer.into_inner();
     let system_param_item = param.into_inner();
 
     let mut process_item = |item: &mut I| {

--- a/crates/bevy_render/src/indirect.rs
+++ b/crates/bevy_render/src/indirect.rs
@@ -1,0 +1,144 @@
+//! Logic for indirect rendering.
+//!
+//! Currently, indirect rendering is enabled whenever GPU culling is enabled.
+
+use std::{any::TypeId, ops::Range};
+
+use bevy_app::{App, Plugin};
+use bevy_ecs::{
+    entity::EntityHashMap,
+    schedule::IntoSystemConfigs as _,
+    system::{Res, ResMut, Resource},
+};
+use bevy_encase_derive::ShaderType;
+use bevy_math::{Vec3, Vec3A};
+use bevy_utils::HashMap;
+use bytemuck::{Pod, Zeroable};
+use wgpu::BufferUsages;
+
+use crate::{
+    primitives::Aabb,
+    render_resource::{binding_types, BindGroupLayoutEntryBuilder, BufferVec},
+    renderer::{RenderDevice, RenderQueue},
+    Render, RenderApp, RenderSet,
+};
+
+pub struct IndirectRenderPlugin;
+
+/// This covers both the indexed indirect and regular indirect parameters.
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+#[repr(C)]
+pub struct GpuIndirectParameters {
+    pub vertex_count: u32,
+    pub instance_count: u32,
+    pub extra_0: u32,
+    pub extra_1: u32,
+    pub first_instance: u32,
+}
+
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+#[repr(C)]
+pub struct GpuIndirectInstanceDescriptor {
+    pub parameters_index: u32,
+    pub instance_index: u32,
+}
+
+#[derive(Resource)]
+pub struct IndirectBuffers {
+    pub params: BufferVec<GpuIndirectParameters>,
+    pub mesh_indirect_uniform: BufferVec<MeshIndirectUniform>,
+    pub view_instances: EntityHashMap<ViewIndirectInstances>,
+}
+
+pub struct ViewIndirectInstances {
+    pub instances: BufferVec<u32>,
+    pub instance_count: u32,
+    /// These represent the culling work units.
+    pub descriptors: BufferVec<GpuIndirectInstanceDescriptor>,
+    ///  The `TypeId` here is the type ID of a `PhaseItem`.
+    pub phase_item_ranges: HashMap<TypeId, Range<u32>>,
+}
+
+#[derive(Clone)]
+pub struct RenderMeshIndirectInstance {
+    pub aabb: Aabb,
+}
+
+#[derive(Clone, Copy, Pod, Zeroable, ShaderType)]
+#[repr(C)]
+pub struct MeshIndirectUniform {
+    pub aabb_center: Vec3,
+    pub pad0: u32,
+    pub aabb_half_extents: Vec3,
+    pub pad1: u32,
+}
+
+impl Plugin for IndirectRenderPlugin {
+    fn build(&self, app: &mut App) {
+        let Ok(render_app) = app.get_sub_app_mut(RenderApp) else {
+            return;
+        };
+
+        render_app.init_resource::<IndirectBuffers>().add_systems(
+            Render,
+            write_indirect_buffers.in_set(RenderSet::PrepareResourcesFlush),
+        );
+    }
+}
+
+impl Default for IndirectBuffers {
+    fn default() -> Self {
+        IndirectBuffers {
+            params: BufferVec::new(BufferUsages::STORAGE | BufferUsages::INDIRECT),
+            view_instances: EntityHashMap::default(),
+            mesh_indirect_uniform: BufferVec::new(BufferUsages::STORAGE),
+        }
+    }
+}
+
+impl ViewIndirectInstances {
+    pub fn new() -> ViewIndirectInstances {
+        ViewIndirectInstances {
+            instances: BufferVec::new(BufferUsages::STORAGE),
+            instance_count: 0,
+            descriptors: BufferVec::new(BufferUsages::STORAGE),
+            phase_item_ranges: HashMap::new(),
+        }
+    }
+}
+
+impl Default for ViewIndirectInstances {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn write_indirect_buffers(
+    render_device: Res<RenderDevice>,
+    render_queue: Res<RenderQueue>,
+    mut indirect_buffers: ResMut<IndirectBuffers>,
+) {
+    indirect_buffers
+        .params
+        .write_buffer(&render_device, &render_queue);
+    indirect_buffers
+        .mesh_indirect_uniform
+        .write_buffer(&render_device, &render_queue);
+
+    for view_instance in indirect_buffers.view_instances.values_mut() {
+        view_instance
+            .instances
+            .reserve(view_instance.instance_count as usize, &render_device);
+        view_instance
+            .descriptors
+            .write_buffer(&render_device, &render_queue);
+    }
+}
+
+pub fn get_bind_group_layout_entry(read_only: bool) -> BindGroupLayoutEntryBuilder {
+    if read_only {
+        binding_types::storage_buffer_read_only::<u32>(/*has_dynamic_offset=*/ false)
+    } else {
+        binding_types::storage_buffer::<u32>(/*has_dynamic_offset=*/ false)
+    }
+}

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -18,6 +18,7 @@ mod extract_param;
 pub mod extract_resource;
 pub mod globals;
 pub mod gpu_component_array_buffer;
+pub mod indirect;
 pub mod mesh;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod pipelined_rendering;
@@ -55,6 +56,7 @@ pub use extract_param::Extract;
 use bevy_hierarchy::ValidParentCheckPlugin;
 use bevy_window::{PrimaryWindow, RawHandleWrapper};
 use globals::GlobalsPlugin;
+use indirect::IndirectRenderPlugin;
 use renderer::{RenderAdapter, RenderAdapterInfo, RenderDevice, RenderQueue};
 
 use crate::deterministic::DeterministicRenderingConfig;
@@ -327,6 +329,7 @@ impl Plugin for RenderPlugin {
             MeshPlugin,
             GlobalsPlugin,
             MorphPlugin,
+            IndirectRenderPlugin,
         ));
 
         app.register_type::<alpha::AlphaMode>()

--- a/crates/bevy_render/src/maths.wgsl
+++ b/crates/bevy_render/src/maths.wgsl
@@ -17,6 +17,10 @@ fn affine3_to_square(affine: mat3x4<f32>) -> mat4x4<f32> {
     ));
 }
 
+fn mat4x4_to_mat3x3(m: mat4x4<f32>) -> mat3x3<f32> {
+    return mat3x3<f32>(m[0].xyz, m[1].xyz, m[2].xyz);
+}
+
 fn mat2x4_f32_to_mat3x3_unpack(
     a: mat2x4<f32>,
     b: f32,

--- a/crates/bevy_render/src/render_phase/mod.rs
+++ b/crates/bevy_render/src/render_phase/mod.rs
@@ -115,7 +115,7 @@ impl<I: PhaseItem> RenderPhase<I> {
                 index += 1;
             } else {
                 let draw_function = draw_functions.get_mut(item.draw_function()).unwrap();
-                draw_function.draw(world, render_pass, view, item);
+                draw_function.draw(world, render_pass, view, item, index);
                 index += batch_range.len();
             }
         }
@@ -201,6 +201,7 @@ impl<P: CachedRenderPipelinePhaseItem> RenderCommand<P> for SetItemPipeline {
     #[inline]
     fn render<'w>(
         item: &P,
+        _index: usize,
         _view: (),
         _entity: Option<()>,
         pipeline_cache: SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_sprite/src/mesh2d/material.rs
+++ b/crates/bevy_sprite/src/mesh2d/material.rs
@@ -338,6 +338,7 @@ impl<P: PhaseItem, M: Material2d, const I: usize> RenderCommand<P>
     #[inline]
     fn render<'w>(
         item: &P,
+        _index: usize,
         _view: (),
         _item_query: Option<()>,
         (materials, material_instances): SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_sprite/src/mesh2d/mesh.rs
+++ b/crates/bevy_sprite/src/mesh2d/mesh.rs
@@ -624,6 +624,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dViewBindGroup<I
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         (view_uniform, mesh2d_view_bind_group): ROQueryItem<'w, Self::ViewQuery>,
         _view: Option<()>,
         _param: SystemParamItem<'w, '_, Self::Param>,
@@ -644,6 +645,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetMesh2dBindGroup<I> {
     #[inline]
     fn render<'w>(
         item: &P,
+        _index: usize,
         _view: (),
         _item_query: Option<()>,
         mesh2d_bind_group: SystemParamItem<'w, '_, Self::Param>,
@@ -673,6 +675,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMesh2d {
     #[inline]
     fn render<'w>(
         item: &P,
+        _index: usize,
         _view: (),
         _item_query: Option<()>,
         (meshes, render_mesh2d_instances): SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_sprite/src/render/mod.rs
+++ b/crates/bevy_sprite/src/render/mod.rs
@@ -752,6 +752,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteViewBindGroup<I
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         view_uniform: &'_ ViewUniformOffset,
         _entity: Option<()>,
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,
@@ -773,6 +774,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetSpriteTextureBindGrou
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         batch: Option<&'_ SpriteBatch>,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
@@ -803,6 +805,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawSpriteBatch {
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         batch: Option<&'_ SpriteBatch>,
         sprite_meta: SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_ui/src/render/render_pass.rs
+++ b/crates/bevy_ui/src/render/render_pass.rs
@@ -161,6 +161,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUiViewBindGroup<I> {
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         view_uniform: &'w ViewUniformOffset,
         _entity: Option<()>,
         ui_meta: SystemParamItem<'w, '_, Self::Param>,
@@ -183,6 +184,7 @@ impl<P: PhaseItem, const I: usize> RenderCommand<P> for SetUiTextureBindGroup<I>
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         batch: Option<&'w UiBatch>,
         image_bind_groups: SystemParamItem<'w, '_, Self::Param>,
@@ -206,6 +208,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawUiNode {
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         batch: Option<&'w UiBatch>,
         ui_meta: SystemParamItem<'w, '_, Self::Param>,

--- a/crates/bevy_ui/src/render/ui_material_pipeline.rs
+++ b/crates/bevy_ui/src/render/ui_material_pipeline.rs
@@ -268,6 +268,7 @@ impl<P: PhaseItem, M: UiMaterial, const I: usize> RenderCommand<P> for SetMatUiV
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         view_uniform: &'w ViewUniformOffset,
         _entity: Option<()>,
         ui_meta: SystemParamItem<'w, '_, Self::Param>,
@@ -292,6 +293,7 @@ impl<P: PhaseItem, M: UiMaterial, const I: usize> RenderCommand<P>
 
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         material_handle: Option<ROQueryItem<'_, Self::ItemQuery>>,
         materials: SystemParamItem<'w, '_, Self::Param>,
@@ -317,6 +319,7 @@ impl<P: PhaseItem, M: UiMaterial> RenderCommand<P> for DrawUiMaterialNode<M> {
     #[inline]
     fn render<'w>(
         _item: &P,
+        _index: usize,
         _view: (),
         batch: Option<&'w UiMaterialBatch<M>>,
         ui_meta: SystemParamItem<'w, '_, Self::Param>,

--- a/examples/3d/3d_shapes.rs
+++ b/examples/3d/3d_shapes.rs
@@ -9,6 +9,7 @@ use bevy::{
     render::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
+        view::GpuCulling,
     },
 };
 
@@ -83,10 +84,13 @@ fn setup(
         ..default()
     });
 
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 6., 12.0).looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
-        ..default()
-    });
+    commands
+        .spawn(Camera3dBundle {
+            transform: Transform::from_xyz(0.0, 6., 12.0)
+                .looking_at(Vec3::new(0., 1., 0.), Vec3::Y),
+            ..default()
+        })
+        .insert(GpuCulling);
 }
 
 fn rotate(mut query: Query<&mut Transform, With<Shape>>, time: Res<Time>) {

--- a/examples/shader/shader_instancing.rs
+++ b/examples/shader/shader_instancing.rs
@@ -240,6 +240,7 @@ impl<P: PhaseItem> RenderCommand<P> for DrawMeshInstanced {
     #[inline]
     fn render<'w>(
         item: &P,
+        _index: usize,
         _view: (),
         instance_buffer: Option<&'w InstanceBuffer>,
         (meshes, render_mesh_instances): SystemParamItem<'w, '_, Self::Param>,

--- a/examples/stress_tests/many_cubes.rs
+++ b/examples/stress_tests/many_cubes.rs
@@ -18,7 +18,7 @@ use bevy::{
     render::{
         render_asset::RenderAssetUsages,
         render_resource::{Extent3d, TextureDimension, TextureFormat},
-        view::NoFrustumCulling,
+        view::{GpuCulling, NoFrustumCulling},
     },
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
@@ -47,6 +47,10 @@ struct Args {
     /// whether to disable frustum culling, for stress testing purposes
     #[argh(switch)]
     no_frustum_culling: bool,
+
+    /// whether to use GPU culling
+    #[argh(switch)]
+    gpu_culling: bool,
 }
 
 #[derive(Default, Clone)]
@@ -148,7 +152,10 @@ fn setup(
             }
 
             // camera
-            commands.spawn(Camera3dBundle::default());
+            let mut camera = commands.spawn(Camera3dBundle::default());
+            if args.gpu_culling {
+                camera.insert(GpuCulling);
+            }
         }
         _ => {
             // NOTE: This pattern is good for demonstrating that frustum culling is working correctly

--- a/examples/stress_tests/many_foxes.rs
+++ b/examples/stress_tests/many_foxes.rs
@@ -9,6 +9,7 @@ use bevy::{
     diagnostic::{FrameTimeDiagnosticsPlugin, LogDiagnosticsPlugin},
     pbr::CascadeShadowConfigBuilder,
     prelude::*,
+    render::view::GpuCulling,
     window::{PresentMode, WindowResolution},
     winit::{UpdateMode, WinitSettings},
 };
@@ -23,6 +24,10 @@ struct Args {
     /// total number of foxes.
     #[argh(option, default = "1000")]
     count: usize,
+
+    /// whether to use GPU culling
+    #[argh(switch)]
+    gpu_culling: bool,
 }
 
 #[derive(Resource)]
@@ -65,6 +70,7 @@ fn main() {
             moving: true,
             sync: args.sync,
         })
+        .insert_resource(args)
         .add_systems(Startup, setup)
         .add_systems(
             Update,
@@ -113,6 +119,7 @@ fn setup(
     mut materials: ResMut<Assets<StandardMaterial>>,
     mut animation_graphs: ResMut<Assets<AnimationGraph>>,
     foxes: Res<Foxes>,
+    args: Res<Args>,
 ) {
     warn!(include_str!("warning_string.txt"));
 
@@ -194,11 +201,14 @@ fn setup(
         radius * 0.5 * zoom,
         radius * 1.5 * zoom,
     );
-    commands.spawn(Camera3dBundle {
+    let mut camera = commands.spawn(Camera3dBundle {
         transform: Transform::from_translation(translation)
             .looking_at(0.2 * Vec3::new(translation.x, 0.0, translation.z), Vec3::Y),
         ..default()
     });
+    if args.gpu_culling {
+        camera.insert(GpuCulling);
+    }
 
     // Plane
     commands.spawn(PbrBundle {


### PR DESCRIPTION
This commit introduces a new component, `GpuCulling`, which, when present on a camera, skips the CPU visibility check in favor of doing the frustum culling on the GPU. This trades off potentially-increased CPU work and drawcalls in favor of cheaper culling and doesn't improve the performance of any workloads that I know of today. However, it opens the door to significant optimizations in the future by taking the necessary first step toward *GPU-driven rendering*.

Enabling GPU culling for a view puts the rendering for that view into *indirect mode*. In indirect mode, CPU-level visibility checks are skipped, and all renderable entities are considered potentially visible. Bevy's batching logic still runs as usual, but it doesn't directly generate mesh instance indices. Instead, it generates *instance handles*, which are indices into an array of real instance indices. Before any rendering is done, for each view, a compute shader, `cull.wgsl`, maps instance handles to instance indices, discarding any instance handles that represent meshes that are outside the visible frustum. Draws are then done using the *indirect draw* feature of `wgpu`, which instructs the GPU to read the number of actual instances from the output of that compute shader.

Essentially, GPU culling works by adding a new level of indirection between the CPU's notion of instances (known as instance handles) and the GPU's notion of instances.

A new `--gpu-culling` flag has been added to the `many_foxes`, `many_cubes`, and `3d_shapes` examples.

Potential follow-ups include:

* Split up `RenderMeshInstances` into CPU-driven and GPU-driven parts. The former, which contain fields like the transform, won't be initialized at all in when GPU culling is enabled. Instead, the transform will be directly written to the GPU in `extract_meshes`, like `extract_skins` does for joint matrices.

* Implement GPU culling for shadow maps.

  - Following that, we can treat all cascades as one as far as the CPU is concerned, simply replaying the final draw commands with different view uniforms, which should reduce the CPU overhead considerably.

* Retain bins from frame to frame so that they don't have to be rebuilt. This is a longer term project that will build on top of #12453 and several of the tasks in #12590, such as main-world pipeline specialization.

* Implement [two-phase occlusion culling] on top of the new indirect mode. This allows us to move beyond simple frustum culling.

This PR needs a bit more polish before it's ready to go, so I'm marking it as a draft. Everything seems to work though.

[two-phase occlusion culling]: https://medium.com/@mil_kru/two-pass-occlusion-culling-4100edcad501