### PR TITLE
Remove redundant doc_auto_config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,6 @@
     html_logo_url = "https://bevyengine.org/assets/icon.png",
     html_favicon_url = "https://bevyengine.org/assets/icon.png"
 )]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub use bevy_internal::*;
 


### PR DESCRIPTION
# Objective
CI on main has been failing for the following reason:
```
error[E0636]: the feature `doc_auto_cfg` has already been declared
  --> src/lib.rs:48:29
   |
48 | #![cfg_attr(docsrs, feature(doc_auto_cfg))]
   |                             ^^^^^^^^^^^^
```

## Solution
Remove the redundant attribute.