### PR TITLE
ignore lost surface error on exit for xwayland

### DIFF
--- a/crates/bevy_render/src/view/window/mod.rs
+++ b/crates/bevy_render/src/view/window/mod.rs
@@ -331,6 +331,14 @@ pub fn prepare_windows(
                         of your Linux GPU driver, so it can be safely ignored."
                     );
                 }
+                #[cfg(target_os = "linux")]
+                Err(wgpu::SurfaceError::Lost) => {
+                    bevy_utils::tracing::trace!(
+                        "The swap chain was lost. If you are using XWayland and the app \
+                        is exiting this is normal, ignore it while it is properly fixed."
+                    );
+                    continue;
+                }
                 Err(err) => {
                     panic!("Couldn't get swap chain texture, operation unrecoverable: {err}");
                 }


### PR DESCRIPTION
# Objective

Hack that stops the panic from #11734 but doesn't fix underlying issue of trying to prepare window after swapchain has been destroyed.

## Solution

Just stops trying to configure it and logs it incase the error happens before exiting.

Now it will just log an X error instead of panicking, letting the app clean up properly.

A real fix would be ideal but not sure why it's doing this to begin with.

```
ERROR winit::platform_impl::platform: X11 error: XError {
    description: "BadWindow (invalid Window parameter)",
    error_code: 3,
    request_code: 146,
    minor_code: 1,
}
```

---

## Changelog
no cl no fun