### PR TITLE
Add iOS to synchronous_pipeline_compilation docs

### DIFF
--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -88,7 +88,7 @@ use std::{
 pub struct RenderPlugin {
     pub render_creation: RenderCreation,
     /// If `true`, disables asynchronous pipeline compilation.
-    /// This has no effect on macOS, Wasm, or without the `multi-threaded` feature.
+    /// This has no effect on macOS, Wasm, iOS, or without the `multi-threaded` feature.
     pub synchronous_pipeline_compilation: bool,
 }
 


### PR DESCRIPTION
iOS uses Metal, so it has the same limitation as macOS, presumably.