### PR TITLE
0.13.1 Root Node `style.position_type` not set to `Position::Absolute` regression warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -324,6 +324,11 @@ bevy_debug_stepping = ["bevy_internal/bevy_debug_stepping"]
 # Enable support for the ios_simulator by downgrading some rendering capabilities
 ios_simulator = ["bevy_internal/ios_simulator"]
 
+# Ignore regression warning for root node's not behaving like 0.13 unless position_type is set to absolute
+ignore_regression_warning_root_node_position_type_not_absolute = [
+  "bevy_internal/ignore_regression_warning_root_node_position_type_not_absolute",
+]
+
 [dependencies]
 bevy_dylib = { path = "crates/bevy_dylib", version = "0.14.0-dev", default-features = false, optional = true }
 bevy_internal = { path = "crates/bevy_internal", version = "0.14.0-dev", default-features = false }

--- a/crates/bevy_internal/Cargo.toml
+++ b/crates/bevy_internal/Cargo.toml
@@ -165,6 +165,11 @@ bevy_dev_tools = ["dep:bevy_dev_tools"]
 # Enable support for the ios_simulator by downgrading some rendering capabilities
 ios_simulator = ["bevy_pbr?/ios_simulator", "bevy_render?/ios_simulator"]
 
+# Ignore regression warning for root node's not behaving like 0.13 unless position_type is set to absolute
+ignore_regression_warning_root_node_position_type_not_absolute = [
+  "bevy_ui/ignore_regression_warning_root_node_position_type_not_absolute",
+]
+
 [dependencies]
 # bevy
 bevy_a11y = { path = "../bevy_a11y", version = "0.14.0-dev" }

--- a/crates/bevy_ui/Cargo.toml
+++ b/crates/bevy_ui/Cargo.toml
@@ -41,6 +41,8 @@ smallvec = "1.11"
 [features]
 serialize = ["serde", "smallvec/serde"]
 
+# Ignore regression warning for root node's not behaving like 0.13 unless position_type is set to absolute
+ignore_regression_warning_root_node_position_type_not_absolute = []
 
 [lints]
 workspace = true

--- a/docs/cargo_features.md
+++ b/docs/cargo_features.md
@@ -62,6 +62,7 @@ The default feature set enables most of the expected features of a game engine, 
 |file_watcher|Enables watching the filesystem for Bevy Asset hot-reloading|
 |flac|FLAC audio format support|
 |glam_assert|Enable assertions to check the validity of parameters passed to glam|
+|ignore_regression_warning_root_node_position_type_not_absolute|Ignore regression warning for root node's not behaving like 0.13 unless position_type is set to absolute|
 |ios_simulator|Enable support for the ios_simulator by downgrading some rendering capabilities|
 |jpeg|JPEG image format support|
 |minimp3|MP3 audio format support (through minimp3)|


### PR DESCRIPTION
# Objective

To provide users with a warning about a detected [regression with likely undesired behavior](https://github.com/bevyengine/bevy/issues/12624) and how to work around it for the remainder of 13.x.

## Solution

- Use the existing root node query to check if any root nodes `style.position_type` is not set to `Position::Absolute` and trigger a warn_once with details.
- Adds a feature flag that disables the check if in the unlikely event a user does not want to use `Position::Absolute` for their root nodes. (IMO this is probably highly unlikely and I can axe this part if desired, but I figured I'd include it just in case.)

---

## Changelog

- Adds a warning when a root node is detected to not have `style.position_type` set to `Position::Absolute` potentially causing undesired behavior from a regression introduced in #12255
- Adds a feature `ignore_regression_warning_root_node_position_type_not_absolute` that disables the check.

## Migration Guide

- All Root Nodes should have their `style.position_type` set to `Position::Absolute`. 
- If you are expecting the parent viewport style to provide the currently seen `Grid` behavior, then it is advised to create a common root node parent with both `Position::Absolute` and `Display::Grid` (width and height set to `Val::Percent(100.)`) and assign your other root nodes as it's children.
- The parent viewport style should not be relied on to provide `Display::Grid` as it might change in 0.14 with the potential upgrade to the dependency taffy and support for `Display::Block` (TBD)

