### PR TITLE
add `ExtractEventPlugin` for extracting events to the render world

### DIFF
--- a/crates/bevy_render/macros/src/extract_event.rs
+++ b/crates/bevy_render/macros/src/extract_event.rs
@@ -1,0 +1,26 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, parse_quote, DeriveInput, Path};
+
+pub fn derive_extract_event(input: TokenStream) -> TokenStream {
+    let mut ast = parse_macro_input!(input as DeriveInput);
+    let bevy_render_path: Path = crate::bevy_render_path();
+
+    ast.generics
+        .make_where_clause()
+        .predicates
+        .push(parse_quote! { Self: Clone });
+
+    let struct_name = &ast.ident;
+    let (impl_generics, type_generics, where_clause) = &ast.generics.split_for_impl();
+
+    TokenStream::from(quote! {
+        impl #impl_generics #bevy_render_path::extract_event::ExtractEvent for #struct_name #type_generics #where_clause {
+            type Source = Self;
+
+            fn extract_event(source: &Self::Source) -> Self {
+                source.clone()
+            }
+        }
+    })
+}

--- a/crates/bevy_render/macros/src/lib.rs
+++ b/crates/bevy_render/macros/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod as_bind_group;
 mod extract_component;
+mod extract_event;
 mod extract_resource;
 
 use bevy_macro_utils::{derive_label, BevyManifest};
@@ -20,6 +21,11 @@ pub(crate) fn bevy_render_path() -> syn::Path {
 #[proc_macro_derive(ExtractResource)]
 pub fn derive_extract_resource(input: TokenStream) -> TokenStream {
     extract_resource::derive_extract_resource(input)
+}
+
+#[proc_macro_derive(ExtractEvent)]
+pub fn derive_extract_event(input: TokenStream) -> TokenStream {
+    extract_event::derive_extract_event(input)
 }
 
 /// Implements `ExtractComponent` trait for a component.

--- a/crates/bevy_render/src/extract_event.rs
+++ b/crates/bevy_render/src/extract_event.rs
@@ -1,0 +1,48 @@
+use std::marker::PhantomData;
+
+use bevy_app::{App, Plugin};
+use bevy_ecs::prelude::*;
+pub use bevy_render_macros::ExtractResource;
+
+/// Describes how an event gets extracted for rendering.
+///
+/// Therefore the event is transferred from the "main world" into the "render world"
+/// in the [`ExtractSchedule`] step.
+pub trait ExtractEvent {
+    type Source: Event;
+
+    /// Defines how the event is transferred into the "render world".
+    fn extract_event(source: &Self::Source) -> Self;
+}
+
+/// This plugin extracts events into the "render world".
+///
+/// The event `E::Source` is automatically added to the app and event `E` is added to the render app.
+pub struct ExtractEventPlugin<E: Event + ExtractEvent>(PhantomData<E>);
+
+impl<E: Event + ExtractEvent> Default for ExtractEventPlugin<E> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<E: Event + ExtractEvent> Plugin for ExtractEventPlugin<E> {
+    fn build(&self, app: &mut App) {
+        app.add_event::<E::Source>();
+        if let Ok(render_app) = app.get_sub_app_mut(RenderApp) {
+            render_app.add_event::<E>();
+            render_app.add_systems(ExtractSchedule, extract_event::<E>);
+        }
+    }
+}
+
+/// This system extracts the events of the corresponding [`Event`] type
+pub fn extract_event<T: Event + ExtractEvent>(
+    mut reader: Local<ManualEventReader<T::Source>>,
+    incoming: Extract<Res<Events<T::Source>>>,
+    mut outgoing: ResMut<Events<T>>,
+) {
+    for source in reader.read(&incoming) {
+        outgoing.send(T::extract_event(source));
+    }
+}

--- a/crates/bevy_render/src/extract_event.rs
+++ b/crates/bevy_render/src/extract_event.rs
@@ -1,8 +1,10 @@
 use std::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
-use bevy_ecs::prelude::*;
+use bevy_ecs::{event::ManualEventReader, prelude::*};
 pub use bevy_render_macros::ExtractResource;
+
+use crate::{Extract, ExtractSchedule, RenderApp};
 
 /// Describes how an event gets extracted for rendering.
 ///

--- a/crates/bevy_render/src/extract_event.rs
+++ b/crates/bevy_render/src/extract_event.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use bevy_app::{App, Plugin};
 use bevy_ecs::{event::ManualEventReader, prelude::*};
-pub use bevy_render_macros::ExtractResource;
+pub use bevy_render_macros::ExtractEvent;
 
 use crate::{Extract, ExtractSchedule, RenderApp};
 

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -11,7 +11,7 @@ use crate::{Extract, ExtractSchedule, RenderApp};
 /// Therefore the resource is transferred from the "main world" into the "render world"
 /// in the [`ExtractSchedule`] step.
 ///
-/// See also [`crate::extract_event::ExtractEvent`] for extracting events.
+/// See also [`ExtractEvent`](crate::extract_event::ExtractEvent) for extracting events.
 pub trait ExtractResource: Resource {
     type Source: Resource;
 
@@ -24,7 +24,7 @@ pub trait ExtractResource: Resource {
 /// Therefore it sets up the[`ExtractSchedule`] step
 /// for the specified [`Resource`].
 ///
-/// See also [`crate::extract_event::ExtractEventPlugin`] for extracting events.
+/// See also [`ExtractEventPlugin`](crate::extract_event::ExtractEventPlugin) for extracting events.
 pub struct ExtractResourcePlugin<R: ExtractResource>(PhantomData<R>);
 
 impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {

--- a/crates/bevy_render/src/extract_resource.rs
+++ b/crates/bevy_render/src/extract_resource.rs
@@ -10,6 +10,8 @@ use crate::{Extract, ExtractSchedule, RenderApp};
 ///
 /// Therefore the resource is transferred from the "main world" into the "render world"
 /// in the [`ExtractSchedule`] step.
+///
+/// See also [`crate::extract_event::ExtractEvent`] for extracting events.
 pub trait ExtractResource: Resource {
     type Source: Resource;
 
@@ -21,6 +23,8 @@ pub trait ExtractResource: Resource {
 ///
 /// Therefore it sets up the[`ExtractSchedule`] step
 /// for the specified [`Resource`].
+///
+/// See also [`crate::extract_event::ExtractEventPlugin`] for extracting events.
 pub struct ExtractResourcePlugin<R: ExtractResource>(PhantomData<R>);
 
 impl<R: ExtractResource> Default for ExtractResourcePlugin<R> {

--- a/crates/bevy_render/src/lib.rs
+++ b/crates/bevy_render/src/lib.rs
@@ -13,6 +13,7 @@ pub mod camera;
 pub mod deterministic;
 pub mod diagnostic;
 pub mod extract_component;
+pub mod extract_event;
 pub mod extract_instances;
 mod extract_param;
 pub mod extract_resource;


### PR DESCRIPTION
# Objective

Sometimes I'd like to render/compute something in response to something happening in the main world. Using events seemed like a good way of doing this. 

Currently (as far as I know) you have to use a resource or component to do this sort of thing.

## Solution

I added an `ExtractEvent` trait along with a plugin and system which is all almost identical to the `ExtractResource` counterparts except it "clones" the individual events rather than the whole resource. 

Just like `ExtractResource` it can be automatically derived for any event type that implements `Clone` by using the macro.

---

## Changelog

- added `ExtractEvent` trait, `ExtractEventPlugin` and `extract_event` system.
- added `ExtractEvent` derive macro.

