### PR TITLE
Support window-independent scaling for text

### DIFF
--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -777,10 +777,8 @@ pub fn camera_system<T: CameraProjection + Component>(
                     camera_projection.update(size.x, size.y);
                     camera.computed.projection_matrix = camera_projection.get_projection_matrix();
                 }
-            } else {
-                if let Some(info) = camera.computed.target_info.as_mut() {
-                    info.scale_factor_changed = false;
-                }
+            } else if let Some(info) = camera.computed.target_info.as_mut() {
+                info.scale_factor_changed = false;
             }
         }
 

--- a/crates/bevy_render/src/camera/camera.rs
+++ b/crates/bevy_render/src/camera/camera.rs
@@ -749,7 +749,7 @@ pub fn camera_system<T: CameraProjection + Component>(
                 // Without this, the viewport will take a smaller portion of the window moved to
                 // a higher DPI monitor.
                 if normalized_target.is_changed(&scale_factor_changed_window_ids, &HashSet::new()) {
-                    if let Some(mut info) = new_computed_target_info.as_mut() {
+                    if let Some(info) = new_computed_target_info.as_mut() {
                         info.scale_factor_changed = true;
                     }
 

--- a/crates/bevy_text/src/pipeline.rs
+++ b/crates/bevy_text/src/pipeline.rs
@@ -31,6 +31,23 @@ pub struct TextLayoutInfo {
     pub logical_size: Vec2,
 }
 
+#[derive(Component, Clone, Debug, Reflect)]
+#[reflect(Component)]
+pub struct TextScalingInfo {
+    pub scale_factor: f32,
+    pub scale_factor_changed: bool,
+}
+
+impl Default for TextScalingInfo {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            scale_factor: 1.0,
+            scale_factor_changed: false,
+        }
+    }
+}
+
 impl TextPipeline {
     pub fn get_or_insert_font_id(&mut self, handle: &Handle<Font>, font: &Font) -> FontId {
         let brush = &mut self.brush;

--- a/crates/bevy_ui/src/lib.rs
+++ b/crates/bevy_ui/src/lib.rs
@@ -182,14 +182,18 @@ impl Plugin for UiPlugin {
 fn build_text_interop(app: &mut App) {
     use crate::widget::TextFlags;
     use bevy_text::TextLayoutInfo;
+    use bevy_text::TextScalingInfo;
 
     app.register_type::<TextLayoutInfo>()
-        .register_type::<TextFlags>();
+        .register_type::<TextFlags>()
+        .register_type::<TextScalingInfo>();
 
     app.add_systems(
         PostUpdate,
         (
             widget::measure_text_system
+                // For spawning target camera on child nodes by update_target_camera to take effect.
+                .after(apply_deferred)
                 .before(UiSystem::Layout)
                 // Potential conflict: `Assets<Image>`
                 // In practice, they run independently since `bevy_render::camera_update_system`

--- a/crates/bevy_ui/src/node_bundles.rs
+++ b/crates/bevy_ui/src/node_bundles.rs
@@ -15,7 +15,9 @@ use bevy_ecs::bundle::Bundle;
 use bevy_render::view::{InheritedVisibility, ViewVisibility, Visibility};
 use bevy_sprite::TextureAtlas;
 #[cfg(feature = "bevy_text")]
-use bevy_text::{BreakLineOn, JustifyText, Text, TextLayoutInfo, TextSection, TextStyle};
+use bevy_text::{
+    BreakLineOn, JustifyText, Text, TextLayoutInfo, TextScalingInfo, TextSection, TextStyle,
+};
 use bevy_transform::prelude::{GlobalTransform, Transform};
 
 /// The basic UI node.
@@ -212,6 +214,7 @@ pub struct TextBundle {
     pub z_index: ZIndex,
     /// The background color that will fill the containing node
     pub background_color: BackgroundColor,
+    pub text_scaling_info: TextScalingInfo,
 }
 
 #[cfg(feature = "bevy_text")]
@@ -233,6 +236,7 @@ impl Default for TextBundle {
             z_index: Default::default(),
             // Transparent background
             background_color: BackgroundColor(Color::NONE),
+            text_scaling_info: TextScalingInfo::default(),
         }
     }
 }

--- a/crates/bevy_ui/src/widget/text.rs
+++ b/crates/bevy_ui/src/widget/text.rs
@@ -5,7 +5,7 @@ use bevy_ecs::{
     prelude::{Component, DetectChanges},
     query::With,
     reflect::ReflectComponent,
-    system::{Local, Query, Res, ResMut},
+    system::{Query, Res, ResMut},
     world::{Mut, Ref},
 };
 use bevy_math::Vec2;
@@ -16,7 +16,6 @@ use bevy_text::{
     scale_value, BreakLineOn, Font, FontAtlasSets, Text, TextError, TextLayoutInfo,
     TextMeasureInfo, TextPipeline, TextScalingInfo, TextSettings, YAxisOrientation,
 };
-use bevy_window::{PrimaryWindow, Window};
 use taffy::style::AvailableSpace;
 
 /// Text system flags


### PR DESCRIPTION
Fixes https://github.com/bevyengine/bevy/issues/11375. However, I've got no glue how to handle `Text2d` because currently `TargetCamera` is only for UI nodes.

I doubt we need to apply the scale factor to `Text2d` at all, as an overall scale of 2D/3D elements should be controlled by a camera's zoom only (meanwhile UI elements need to take into account the scale factor).