### PR TITLE
Remove duplicate cfg(wasm32) attribute

### DIFF
--- a/crates/bevy_core/src/lib.rs
+++ b/crates/bevy_core/src/lib.rs
@@ -30,7 +30,6 @@ use std::ops::Range;
 use std::path::{Path, PathBuf};
 
 #[cfg(not(target_arch = "wasm32"))]
-#[cfg(not(target_arch = "wasm32"))]
 use bevy_tasks::tick_global_task_pools_on_main_thread;
 
 /// Registration of default types to the [`TypeRegistry`](bevy_reflect::TypeRegistry) resource.


### PR DESCRIPTION
# Objective

- Duplicate cfg attribute 

## Solution

- Removed duplicate code. 

---
