### PR TITLE
Fix `Ord` and `PartialOrd` differing for `FloatOrd` and optimize implementation

### DIFF
--- a/crates/bevy_utils/src/float_ord.rs
+++ b/crates/bevy_utils/src/float_ord.rs
@@ -13,28 +13,47 @@ use std::{
 ///
 /// Wrapping a float with `FloatOrd` breaks conformance with the standard
 /// by sorting `NaN` as less than all other numbers and equal to any other `NaN`.
-#[derive(Debug, Copy, Clone, PartialOrd)]
+#[derive(Debug, Copy, Clone)]
 pub struct FloatOrd(pub f32);
 
-#[allow(clippy::derive_ord_xor_partial_ord)]
+impl PartialOrd for FloatOrd {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+
+    fn lt(&self, other: &Self) -> bool {
+        !other.le(self)
+    }
+    // If `self` is NaN, it is equal to another NaN and less than all other floats, so return true.
+    // If `self` isn't NaN and `other` is, the float comparison returns false, which match the `FloatOrd` ordering.
+    // Otherwise, a standard float comparison happens.
+    fn le(&self, other: &Self) -> bool {
+        self.0.is_nan() || self.0 <= other.0
+    }
+    fn gt(&self, other: &Self) -> bool {
+        !self.le(other)
+    }
+    fn ge(&self, other: &Self) -> bool {
+        other.le(self)
+    }
+}
+
 impl Ord for FloatOrd {
     fn cmp(&self, other: &Self) -> Ordering {
-        self.0.partial_cmp(&other.0).unwrap_or_else(|| {
-            if self.0.is_nan() && !other.0.is_nan() {
-                Ordering::Less
-            } else if !self.0.is_nan() && other.0.is_nan() {
-                Ordering::Greater
-            } else {
-                Ordering::Equal
-            }
-        })
+        if self > other {
+            Ordering::Greater
+        } else if self < other {
+            Ordering::Less
+        } else {
+            Ordering::Equal
+        }
     }
 }
 
 impl PartialEq for FloatOrd {
     fn eq(&self, other: &Self) -> bool {
-        if self.0.is_nan() && other.0.is_nan() {
-            true
+        if self.0.is_nan() {
+            other.0.is_nan()
         } else {
             self.0 == other.0
         }
@@ -62,5 +81,39 @@ impl Neg for FloatOrd {
 
     fn neg(self) -> Self::Output {
         FloatOrd(-self.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn float_ord_eq() {
+        let nan = FloatOrd(f32::NAN);
+        let num = FloatOrd(0.0);
+
+        assert_eq!(nan, nan);
+
+        assert_ne!(nan, num);
+        assert_ne!(num, nan);
+
+        assert_eq!(num, num);
+    }
+
+    #[test]
+    fn float_ord_cmp() {
+        let nan = FloatOrd(f32::NAN);
+        let zero = FloatOrd(0.0);
+        let one = FloatOrd(1.0);
+
+        assert_eq!(nan.cmp(&nan), Ordering::Equal);
+
+        assert_eq!(nan.cmp(&zero), Ordering::Less);
+        assert_eq!(zero.cmp(&nan), Ordering::Greater);
+
+        assert_eq!(zero.cmp(&zero), Ordering::Equal);
+        assert_eq!(one.cmp(&zero), Ordering::Greater);
+        assert_eq!(zero.cmp(&one), Ordering::Less);
     }
 }

--- a/crates/bevy_utils/src/float_ord.rs
+++ b/crates/bevy_utils/src/float_ord.rs
@@ -39,6 +39,7 @@ impl PartialOrd for FloatOrd {
 }
 
 impl Ord for FloatOrd {
+    #[allow(clippy::comparison_chain)]
     fn cmp(&self, other: &Self) -> Ordering {
         if self > other {
             Ordering::Greater


### PR DESCRIPTION
# Objective

- `FloatOrd` currently has a different comparison behavior between its derived `PartialOrd` impl and manually implemented `Ord` impl (The [`Ord` doc](https://doc.rust-lang.org/std/cmp/trait.Ord.html) says this is a logic error). This might be a problem for some `std` containers/algorithms if they rely on both matching, and a footgun for Bevy users. 

## Solution

- Replace the `PartialEq` and `Ord` impls of `FloatOrd` with some equivalent ones producing [better assembly.](https://godbolt.org/z/jaWbjnMKx)
- Manually derive `PartialOrd` with the same behavior as `Ord`, implement the comparison operators.
- Add some tests.

I first tried using a match-based implementation similar to the `PartialOrd` impl [of the std](https://doc.rust-lang.org/src/core/cmp.rs.html#1457) (with added NaN ordering) but I couldn't get it to produce non-branching assembly. The current implementation is based on [the one from the `ordered_float` crate](https://github.com/reem/rust-ordered-float/blob/3641f59e314030b2ffa3e6321c0d51f8ce50b385/src/lib.rs#L121), adapted since it uses a different ordering. Should this be mentionned somewhere in the code?

---

## Changelog

### Fixed

- `FloatOrd` now uses the same ordering for its `PartialOrd` and `Ord` implementations.

## Migration Guide

- If you were depending on the `PartialOrd` behaviour of `FloatOrd`, it has changed from matching `f32` to matching `FloatOrd`'s `Ord` ordering, never returning `None`.
