### PR TITLE
Cleanup UI surface mappings - Follow up for #12698

### DIFF
--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -13,13 +13,13 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
         .map(|(entity, node)| (*node, *entity))
         .collect();
     let mut camera_tree_output_map = HashMap::<Entity, Vec<String>>::new();
-    for (&(camera_entity, _), root_node_pair) in ui_surface.camera_and_root_node_pair.iter() {
+    for (&(camera_entity, _), &implicit_viewport_node) in ui_surface.camera_root_to_viewport_taffy.iter() {
         let mut out = String::new();
         print_node(
             ui_surface,
             &taffy_to_entity,
             camera_entity,
-            root_node_pair.implicit_viewport_node,
+            implicit_viewport_node,
             false,
             String::new(),
             &mut out,

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -12,6 +12,7 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
         .iter()
         .map(|(entity, node)| (*node, *entity))
         .collect();
+    let mut camera_tree_output_map = HashMap::<Entity, Vec<String>>::new();
     for (&(camera_entity, _), root_node_pair) in ui_surface.camera_and_root_node_pair.iter() {
         let mut out = String::new();
         print_node(
@@ -23,7 +24,14 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
             String::new(),
             &mut out,
         );
-        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity:?}\n{out}");
+        camera_tree_output_map
+            .entry(camera_entity)
+            .or_default()
+            .push(out);
+    }
+    for (camera_entity, tree_strings) in camera_tree_output_map.into_iter() {
+        let output = tree_strings.join("\n");
+        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity:?}\n{output}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/debug.rs
+++ b/crates/bevy_ui/src/layout/debug.rs
@@ -12,20 +12,18 @@ pub fn print_ui_layout_tree(ui_surface: &UiSurface) {
         .iter()
         .map(|(entity, node)| (*node, *entity))
         .collect();
-    for (&entity, roots) in &ui_surface.camera_roots {
+    for (&(camera_entity, _), root_node_pair) in ui_surface.camera_and_root_node_pair.iter() {
         let mut out = String::new();
-        for root in roots {
-            print_node(
-                ui_surface,
-                &taffy_to_entity,
-                entity,
-                root.implicit_viewport_node,
-                false,
-                String::new(),
-                &mut out,
-            );
-        }
-        bevy_utils::tracing::info!("Layout tree for camera entity: {entity:?}\n{out}");
+        print_node(
+            ui_surface,
+            &taffy_to_entity,
+            camera_entity,
+            root_node_pair.implicit_viewport_node,
+            false,
+            String::new(),
+            &mut out,
+        );
+        bevy_utils::tracing::info!("Layout tree for camera entity: {camera_entity:?}\n{out}");
     }
 }
 

--- a/crates/bevy_ui/src/layout/mod.rs
+++ b/crates/bevy_ui/src/layout/mod.rs
@@ -41,28 +41,20 @@ impl LayoutContext {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct RootNodePair {
-    // The implicit "viewport" node created by Bevy
-    implicit_viewport_node: taffy::node::Node,
-    // The root (parentless) node specified by the user
-    user_root_node: taffy::node::Node,
-}
-
 type EntityTupleHashMap<V> = hashbrown::HashMap<(Entity, Entity), V, EntityHash>;
 
 #[derive(Resource)]
 pub struct UiSurface {
     entity_to_taffy: EntityHashMap<taffy::node::Node>,
-    /// `HashMap<(Camera Entity, RootNode Entity), RootNodePair>`
-    camera_and_root_node_pair: EntityTupleHashMap<RootNodePair>,
+    /// `HashMap<(Camera Entity, Root (parentless) Entity), implicit Viewport>`
+    camera_root_to_viewport_taffy: EntityTupleHashMap<taffy::node::Node>,
     taffy: Taffy,
 }
 
 fn _assert_send_sync_ui_surface_impl_safe() {
     fn _assert_send_sync<T: Send + Sync>() {}
     _assert_send_sync::<EntityHashMap<taffy::node::Node>>();
-    _assert_send_sync::<EntityTupleHashMap<RootNodePair>>();
+    _assert_send_sync::<EntityTupleHashMap<taffy::node::Node>>();
     _assert_send_sync::<Taffy>();
     _assert_send_sync::<UiSurface>();
 }
@@ -71,7 +63,10 @@ impl fmt::Debug for UiSurface {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("UiSurface")
             .field("entity_to_taffy", &self.entity_to_taffy)
-            .field("camera_and_root_node_pair", &self.camera_and_root_node_pair)
+            .field(
+                "camera_root_to_viewport_taffy",
+                &self.camera_root_to_viewport_taffy,
+            )
             .finish()
     }
 }
@@ -82,7 +77,7 @@ impl Default for UiSurface {
         taffy.disable_rounding();
         Self {
             entity_to_taffy: Default::default(),
-            camera_and_root_node_pair: Default::default(),
+            camera_root_to_viewport_taffy: Default::default(),
             taffy,
         }
     }
@@ -171,40 +166,34 @@ without UI components as a child of an entity with UI components, results may be
         };
 
         for entity in children {
-            let root_node_pair = self
-                .camera_and_root_node_pair
-                .entry((camera_id, entity))
-                .or_insert_with(|| {
-                    let implicit_viewport_node =
-                        self.taffy.new_leaf(viewport_style.clone()).unwrap();
-                    let user_root_node = *self.entity_to_taffy.get(&entity).expect(
-                        "root node was not inserted yet or was removed from entity_to_taffy map",
-                    );
-                    RootNodePair {
-                        implicit_viewport_node,
-                        user_root_node,
-                    }
-                });
+            let user_root_node = *self
+                .entity_to_taffy
+                .get(&entity)
+                .expect("root node was not inserted yet or was removed from entity_to_taffy map");
 
-            if let Some(previous_parent) = self.taffy.parent(root_node_pair.user_root_node) {
+            let implicit_viewport_node = *self
+                .camera_root_to_viewport_taffy
+                .entry((camera_id, entity))
+                .or_insert_with(|| self.taffy.new_leaf(viewport_style.clone()).unwrap());
+
+            if let Some(previous_parent) = self.taffy.parent(user_root_node) {
                 // remove the root node from the previous implicit node's children
                 self.taffy
-                    .remove_child(previous_parent, root_node_pair.user_root_node)
+                    .remove_child(previous_parent, user_root_node)
                     .unwrap();
             }
 
             self.taffy
-                .add_child(
-                    root_node_pair.implicit_viewport_node,
-                    root_node_pair.user_root_node,
-                )
+                .add_child(implicit_viewport_node, user_root_node)
                 .unwrap();
         }
     }
 
     /// Compute the layout for each window entity's corresponding root node in the layout.
     pub fn compute_camera_layout(&mut self, camera: Entity, render_target_resolution: UVec2) {
-        for (&(camera_entity, _), root_node_pair) in self.camera_and_root_node_pair.iter() {
+        for (&(camera_entity, _), &implicit_viewport_node) in
+            self.camera_root_to_viewport_taffy.iter()
+        {
             if camera_entity != camera {
                 continue;
             }
@@ -215,46 +204,44 @@ without UI components as a child of an entity with UI components, results may be
             };
 
             self.taffy
-                .compute_layout(root_node_pair.implicit_viewport_node, available_space)
+                .compute_layout(implicit_viewport_node, available_space)
                 .unwrap();
         }
     }
 
-    /// Removes specified camera entities by disassociating them from their associated `RootNodePair`
-    /// in the internal map, and subsequently removes the `RootNodePair.implicit_viewport_node`
+    /// Removes specified camera entities by disassociating them from their associated `implicit_viewport_node`
+    /// in the internal map, and subsequently removes the `implicit_viewport_node`
     /// from the `taffy` layout engine for each.
     pub fn remove_camera_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
-            self.camera_and_root_node_pair
-                .retain(|&(camera_entity, _), root_node_pair| {
+            self.camera_root_to_viewport_taffy.retain(
+                |&(camera_entity, _), implicit_viewport_node| {
                     if camera_entity != entity {
                         true
                     } else {
-                        self.taffy
-                            .remove(root_node_pair.implicit_viewport_node)
-                            .unwrap();
+                        self.taffy.remove(*implicit_viewport_node).unwrap();
                         false
                     }
-                });
+                },
+            );
         }
     }
 
     /// Removes the specified entities from the internal map while
-    /// removing their `RootNodePair.implicit_viewport_node` from taffy,
+    /// removing their `implicit_viewport_node` from taffy,
     /// and then subsequently removes their entry from `entity_to_taffy` and associated node from taffy
     pub fn remove_entities(&mut self, entities: impl IntoIterator<Item = Entity>) {
         for entity in entities {
-            self.camera_and_root_node_pair
-                .retain(|&(_, root_node_entity), root_node_pair| {
+            self.camera_root_to_viewport_taffy.retain(
+                |&(_, root_node_entity), implicit_viewport_node| {
                     if root_node_entity != entity {
                         true
                     } else {
-                        self.taffy
-                            .remove(root_node_pair.implicit_viewport_node)
-                            .unwrap();
+                        self.taffy.remove(*implicit_viewport_node).unwrap();
                         false
                     }
-                });
+                },
+            );
             if let Some(node) = self.entity_to_taffy.remove(&entity) {
                 self.taffy.remove(node).unwrap();
             }
@@ -724,7 +711,7 @@ mod tests {
 
         // no UI entities in world, none in UiSurface
         let ui_surface = world.resource::<UiSurface>();
-        assert!(ui_surface.camera_and_root_node_pair.is_empty());
+        assert!(ui_surface.camera_root_to_viewport_taffy.is_empty());
 
         // respawn camera
         let camera_entity = world.spawn(Camera2dBundle::default()).id();
@@ -733,26 +720,26 @@ mod tests {
             .spawn((NodeBundle::default(), TargetCamera(camera_entity)))
             .id();
 
-        // `ui_layout_system` should create a  keypair (`camera_entity`, `root_node_entity`) in `UiSurface::camera_and_root_node_pair`
+        // `ui_layout_system` should create a  keypair (`camera_entity`, `root_node_entity`) in `UiSurface::camera_root_to_viewport_taffy`
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(ui_surface
-            .camera_and_root_node_pair
+            .camera_root_to_viewport_taffy
             .contains_key(&(camera_entity, ui_entity)));
-        assert_eq!(ui_surface.camera_and_root_node_pair.len(), 1);
+        assert_eq!(ui_surface.camera_root_to_viewport_taffy.len(), 1);
 
         world.despawn(ui_entity);
         world.despawn(camera_entity);
 
-        // `ui_layout_system` should remove (`camera_entity`, _) from `UiSurface::camera_and_root_node_pair`
+        // `ui_layout_system` should remove (`camera_entity`, _) from `UiSurface::camera_root_to_viewport_taffy`
         ui_schedule.run(&mut world);
 
         let ui_surface = world.resource::<UiSurface>();
         assert!(!ui_surface
-            .camera_and_root_node_pair
+            .camera_root_to_viewport_taffy
             .contains_key(&(camera_entity, ui_entity)));
-        assert!(ui_surface.camera_and_root_node_pair.is_empty());
+        assert!(ui_surface.camera_root_to_viewport_taffy.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Draft PR: ~~I still need to review some potential performance tradeoffs and whether bringing back the `RootNodePair` structure to collapse it even further is an option or not.~~ See comment https://github.com/bevyengine/bevy/pull/12719#discussion_r1544043219

---

# Objective

- Follow up to https://github.com/bevyengine/bevy/pull/12698 ([comment](https://github.com/bevyengine/bevy/pull/12698#issuecomment-2018553579))
- Reduce redundant internal map usages in `UiSurface`


## Solution

- By using a tuple as a key in the `EntityHashMap<(Entity, Entity), taffy::node::Node>`, we reduce the redundancy and complexity of the internal mappings.

