### PR TITLE
2D top-down camera example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3086,6 +3086,17 @@ path = "examples/dev_tools/fps_overlay.rs"
 doc-scrape-examples = true
 required-features = ["bevy_dev_tools"]
 
+[[example]]
+name = "2d_top_down_camera"
+path = "examples/camera/2d_top_down_camera.rs"
+doc-scrape-examples = true
+
+[package.metadata.example.2d_top_down_camera]
+name = "2D top-down camera"
+description = "A 2D top-down camera smoothly following player movements"
+category = "Camera"
+wasm = true
+
 [package.metadata.example.fps_overlay]
 name = "FPS overlay"
 description = "Demonstrates FPS overlay"

--- a/examples/README.md
+++ b/examples/README.md
@@ -45,6 +45,7 @@ git checkout v0.4.0
   - [Assets](#assets)
   - [Async Tasks](#async-tasks)
   - [Audio](#audio)
+  - [Camera](#camera)
   - [Dev tools](#dev-tools)
   - [Diagnostics](#diagnostics)
   - [ECS (Entity Component System)](#ecs-entity-component-system)
@@ -239,6 +240,12 @@ Example | Description
 [Soundtrack](../examples/audio/soundtrack.rs) | Shows how to play different soundtracks based on game state
 [Spatial Audio 2D](../examples/audio/spatial_audio_2d.rs) | Shows how to play spatial audio, and moving the emitter in 2D
 [Spatial Audio 3D](../examples/audio/spatial_audio_3d.rs) | Shows how to play spatial audio, and moving the emitter in 3D
+
+## Camera
+
+Example | Description
+--- | ---
+[2D top-down camera](../examples/camera/2d_top_down_camera.rs) | A 2D top-down camera smoothly following player movements
 
 ## Dev tools
 

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -27,7 +27,7 @@ struct Player;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins.set(LogPlugin {
-            filter: "info,wgpu_core=warn,wgpu_hal=warn,2d_top_down=debug".into(),
+            filter: "info,wgpu_core=warn,wgpu_hal=warn,2d_top_down_camera=debug".into(),
             level: Level::INFO,
             ..default()
         }))

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -1,0 +1,175 @@
+//! Shows how to create a 2D top-down camera to smoothly follow the player.
+
+// Init state, camera and plane
+// Cube character movement on a plane: Transform
+// Update position on time with delta seconds
+// Camera Position: follow player
+// 1. Query player
+// 2. Query Camera mut
+// 3. Update cam position based on player movement
+// 4. Optimize for smooth movement with smooth damp
+// 5. Level Boundaries: show damp effect on boundaries
+// 6. Colliders: to better showcase camera movements (optional)
+
+use bevy::log::{Level, LogPlugin};
+use bevy::math::{vec2, vec3};
+use bevy::prelude::*;
+use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
+
+static MOVE_SPEED: f32 = 10.;
+
+#[derive(Component, Debug)]
+struct Player;
+
+#[derive(Bundle, Debug)]
+struct PlayerBundle {
+    player: Player,
+    sprite_bundle: SpriteBundle,
+}
+
+fn main() {
+    let default_plugins = DefaultPlugins.set(LogPlugin {
+        filter: "info,wgpu_core=warn,wgpu_hal=warn,2d_top_down=debug".into(),
+        level: Level::INFO,
+        update_subscriber: None,
+    });
+
+    App::new()
+        .add_plugins(default_plugins)
+        .add_systems(Startup, (scene_setup, camera_setup).chain())
+        .add_systems(Update, (update_camera, move_player))
+        .run();
+}
+
+fn scene_setup(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // World where we move the player
+    commands.spawn(MaterialMesh2dBundle {
+        mesh: Mesh2dHandle(meshes.add(Rectangle::new(1000.0, 1000.0))),
+        material: materials.add(Color::srgb(0.3, 0.5, 0.3)),
+        ..default()
+    });
+
+    // Player
+    commands.spawn(PlayerBundle {
+        player: Player,
+        sprite_bundle: SpriteBundle {
+            transform: Transform {
+                scale: vec3(50., 50., 1.),
+                translation: vec3(0., 0., 2.),
+                ..default()
+            },
+            sprite: Sprite {
+                color: Color::BLACK,
+                ..default()
+            },
+            ..default()
+        },
+    });
+
+    debug!("Scene setup finished");
+}
+
+fn camera_setup(mut commands: Commands) {
+    let camera = Camera2dBundle {
+        transform: Transform::from_xyz(0., 0., 1.),
+        ..default()
+    };
+
+    commands.spawn(camera);
+
+    debug!("Camera setup finished");
+}
+
+fn update_camera(
+    mut camera: Query<&mut Transform, (With<Camera2d>, Without<Player>)>,
+    player: Query<&Transform, (With<Player>, Without<Camera2d>)>,
+    time: Res<Time>,
+) {
+    let Ok(mut camera) = camera.get_single_mut() else {
+        debug!("Camera2d not found");
+        return;
+    };
+
+    let Ok(player) = player.get_single() else {
+        debug!("Player not found");
+        return;
+    };
+
+    let Vec3 { x, y, .. } = player.translation;
+    let direction = Vec3::new(x, y, camera.translation.z);
+
+    let smooth_damp = smooth_damp(
+        camera.translation,
+        direction,
+        Vec3::ZERO,
+        0.2,
+        f32::INFINITY,
+        time.delta_seconds(),
+    );
+
+    camera.translation = smooth_damp;
+}
+
+fn move_player(
+    mut player: Query<&mut Transform, With<Player>>,
+    time: Res<Time>,
+    _kb_input: Res<ButtonInput<KeyCode>>,
+) {
+    let Ok(mut player) = player.get_single_mut() else {
+        debug!("Player not found");
+        return;
+    };
+
+    let move_delta = vec2(1., 1.) * MOVE_SPEED * time.delta_seconds();
+    player.translation += move_delta.extend(0.);
+}
+
+/// Update a vector `Vec3` towards a target over time (`delta_time`).
+/// The smoothness is achieved with a spring-damper like function.
+///
+/// Algorithm based on Game Programming Gems vol.4,
+/// chapter 1.10 "Critically Damped Ease-In/Ease-Out Smoothing".
+pub fn smooth_damp(
+    from: Vec3,
+    to: Vec3,
+    mut velocity: Vec3,
+    mut smoothness: f32,
+    max_speed: f32,
+    delta_time: f32,
+) -> Vec3 {
+    // The desired smoothness clamped to the minimum value.
+    smoothness = f32::max(0.0001, smoothness);
+    // Corresponds to the spring's natural frequency
+    let omega = 2. / smoothness;
+
+    let x = omega * delta_time;
+    // Approximation
+    let exp = 1. / (1. + x + 0.48 * x * x + 0.235 * x * x * x);
+
+    let mut distance_x = from.x - to.x;
+    let mut distance_y = from.y - to.y;
+    let mut distance_z = from.z - to.z;
+
+    let max_distance = max_speed * smoothness;
+    distance_x = f32::min(f32::max(-max_distance, distance_x), max_distance);
+    distance_y = f32::min(f32::max(-max_distance, distance_y), max_distance);
+    distance_z = f32::min(f32::max(-max_distance, distance_z), max_distance);
+
+    let temp_x = (velocity.x + omega * distance_x) * delta_time;
+    let temp_y = (velocity.y + omega * distance_y) * delta_time;
+    let temp_z = (velocity.z + omega * distance_z) * delta_time;
+
+    velocity.x = (velocity.x - omega * temp_x) * exp;
+    velocity.y = (velocity.y - omega * temp_y) * exp;
+    velocity.z = (velocity.z - omega * temp_z) * exp;
+
+    let x = to.x + (distance_x + temp_x) * exp;
+    let y = to.y + (distance_y + temp_y) * exp;
+    let z = to.z + (distance_z + temp_z) * exp;
+
+    Vec3::new(x, y, z)
+}

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -157,6 +157,9 @@ fn move_player(
         direction.x = 1.;
     }
 
-    let move_delta = direction * PLAYER_SPEED * time.delta_seconds();
+    // Progressively update the player's position over time. Normalize the
+    // direction vector to prevent it from exceeding a magnitude of 1 when
+    // moving diagonally.
+    let move_delta = direction.normalize_or_zero() * PLAYER_SPEED * time.delta_seconds();
     player.translation += move_delta.extend(0.);
 }

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -13,7 +13,7 @@ use bevy::core_pipeline::bloom::BloomSettings;
 use bevy::log::{Level, LogPlugin};
 use bevy::math::{vec2, vec3};
 use bevy::prelude::*;
-use bevy::sprite::{Material2d, MaterialMesh2dBundle, Mesh2dHandle};
+use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
 
 /// Player movement speed factor.
 const PLAYER_SPEED: f32 = 100.;
@@ -32,7 +32,10 @@ fn main() {
             ..default()
         }))
         .insert_resource(ClearColor(Color::BLACK))
-        .add_systems(Startup, (setup_scene, setup_camera).chain())
+        .add_systems(
+            Startup,
+            (setup_scene, setup_instructions, setup_camera).chain(),
+        )
         .add_systems(Update, (move_player, update_camera).chain())
         .run();
 }
@@ -64,6 +67,21 @@ fn setup_scene(
     ));
 
     debug!("Scene setup finished");
+}
+
+fn setup_instructions(mut commands: Commands) {
+    commands.spawn(
+        TextBundle::from_section(
+            "Move the light with ZQSD or WASD.\nThe camera will smoothly track the light.",
+            TextStyle::default(),
+        )
+        .with_style(Style {
+            position_type: PositionType::Absolute,
+            bottom: Val::Px(12.0),
+            left: Val::Px(12.0),
+            ..default()
+        }),
+    );
 }
 
 fn setup_camera(mut commands: Commands) {

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -10,7 +10,6 @@
 //! | `D`                  | Move right    |
 
 use bevy::core_pipeline::bloom::BloomSettings;
-use bevy::log::{Level, LogPlugin};
 use bevy::math::{vec2, vec3};
 use bevy::prelude::*;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
@@ -26,11 +25,7 @@ struct Player;
 
 fn main() {
     App::new()
-        .add_plugins(DefaultPlugins.set(LogPlugin {
-            filter: "info,wgpu_core=warn,wgpu_hal=warn,2d_top_down_camera=debug".into(),
-            level: Level::INFO,
-            ..default()
-        }))
+        .add_plugins(DefaultPlugins)
         .insert_resource(ClearColor(Color::BLACK))
         .add_systems(
             Startup,
@@ -65,8 +60,6 @@ fn setup_scene(
             ..default()
         },
     ));
-
-    debug!("Scene setup finished");
 }
 
 fn setup_instructions(mut commands: Commands) {
@@ -96,8 +89,6 @@ fn setup_camera(mut commands: Commands) {
         },
         BloomSettings::NATURAL,
     ));
-
-    debug!("Camera setup finished");
 }
 
 /// Update the camera position by tracking the player.
@@ -107,12 +98,10 @@ fn update_camera(
     time: Res<Time>,
 ) {
     let Ok(mut camera) = camera.get_single_mut() else {
-        debug!("Camera2d not found");
         return;
     };
 
     let Ok(player) = player.get_single() else {
-        debug!("Player not found");
         return;
     };
 
@@ -135,7 +124,6 @@ fn move_player(
     kb_input: Res<ButtonInput<KeyCode>>,
 ) {
     let Ok(mut player) = player.get_single_mut() else {
-        debug!("Player not found");
         return;
     };
 

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -10,7 +10,7 @@
 //! | `D`                  | Move right    |
 
 use bevy::core_pipeline::bloom::BloomSettings;
-use bevy::math::{vec2, vec3};
+use bevy::math::vec3;
 use bevy::prelude::*;
 use bevy::sprite::{MaterialMesh2dBundle, Mesh2dHandle};
 
@@ -26,11 +26,7 @@ struct Player;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .insert_resource(ClearColor(Color::BLACK))
-        .add_systems(
-            Startup,
-            (setup_scene, setup_instructions, setup_camera).chain(),
-        )
+        .add_systems(Startup, (setup_scene, setup_instructions, setup_camera))
         .add_systems(Update, (move_player, update_camera).chain())
         .run();
 }
@@ -52,7 +48,7 @@ fn setup_scene(
         Player,
         MaterialMesh2dBundle {
             mesh: meshes.add(Circle::new(25.)).into(),
-            material: materials.add(Color::srgb(6.25, 9.4, 9.1)),
+            material: materials.add(Color::srgb(6.25, 9.4, 9.1)), // RGB values exceed 1 to achieve a bright color for the bloom effect
             transform: Transform {
                 translation: vec3(0., 0., 2.),
                 ..default()
@@ -80,9 +76,8 @@ fn setup_instructions(mut commands: Commands) {
 fn setup_camera(mut commands: Commands) {
     commands.spawn((
         Camera2dBundle {
-            transform: Transform::from_xyz(0., 0., 1.),
             camera: Camera {
-                hdr: true,
+                hdr: true, // HDR is required for the bloom effect
                 ..default()
             },
             ..default()
@@ -110,8 +105,9 @@ fn update_camera(
 
     // Applies a smooth effect to camera movement using interpolation between
     // the camera position and the player position on the x and y axes.
-    // Here we use the in-game time (in seconds), to get the elapsed time since
-    // the previous time update. This avoids jittery when tracking the player.
+    // Here we use the in-game time, to get the elapsed time (in seconds)
+    // since the previous update. This avoids jittery movement when tracking
+    // the player.
     camera.translation = camera
         .translation
         .lerp(direction, time.delta_seconds() * CAM_LERP_FACTOR);
@@ -127,22 +123,22 @@ fn move_player(
         return;
     };
 
-    let mut direction = vec2(0., 0.);
+    let mut direction = Vec2::ZERO;
 
     if kb_input.pressed(KeyCode::KeyW) {
-        direction.y = 1.;
+        direction.y += 1.;
     }
 
     if kb_input.pressed(KeyCode::KeyS) {
-        direction.y = -1.;
+        direction.y -= 1.;
     }
 
     if kb_input.pressed(KeyCode::KeyA) {
-        direction.x = -1.;
+        direction.x -= 1.;
     }
 
     if kb_input.pressed(KeyCode::KeyD) {
-        direction.x = 1.;
+        direction.x += 1.;
     }
 
     // Progressively update the player's position over time. Normalize the

--- a/examples/camera/2d_top_down_camera.rs
+++ b/examples/camera/2d_top_down_camera.rs
@@ -6,8 +6,11 @@ use bevy::math::{vec2, vec3};
 use bevy::prelude::*;
 use bevy::sprite::{Material2d, MaterialMesh2dBundle, Mesh2dHandle};
 
-static MOVE_SPEED: f32 = 100.;
-static LERP_FACTOR: f32 = 2.;
+/// Player movement speed factor.
+const PLAYER_SPEED: f32 = 100.;
+
+/// Camera lerp factor.
+const CAM_LERP_FACTOR: f32 = 2.;
 
 #[derive(Component)]
 struct Player;
@@ -29,7 +32,7 @@ fn main() {
         .add_plugins(default_plugins)
         .insert_resource(ClearColor(Color::BLACK))
         .add_systems(Startup, (scene_setup, camera_setup).chain())
-        .add_systems(Update, (update_camera, move_player))
+        .add_systems(Update, (move_player, update_camera).chain())
         .run();
 }
 
@@ -98,7 +101,7 @@ fn update_camera(
     // Move camera with a smooth effect
     camera.translation = camera
         .translation
-        .lerp(direction, time.delta_seconds() * LERP_FACTOR);
+        .lerp(direction, time.delta_seconds() * CAM_LERP_FACTOR);
 }
 
 fn move_player(
@@ -129,6 +132,6 @@ fn move_player(
         direction.x = 1.;
     }
 
-    let move_delta = direction * MOVE_SPEED * time.delta_seconds();
+    let move_delta = direction * PLAYER_SPEED * time.delta_seconds();
     player.translation += move_delta.extend(0.);
 }


### PR DESCRIPTION
# Objective

This PR addresses the 2D part of #12658. I plan to separate the examples and make one PR per camera example.

## Solution

Added a new top-down example composed of:

- [x] Player keyboard movements
- [x] UI for keyboard instructions
- [x] Colors and bloom effect to see the movement of the player
- [x] Camera smooth movement towards the player (lerp)

## Testing

```bash
cargo run --features="wayland,bevy/dynamic_linking" --example 2d_top_down_camera
```


https://github.com/bevyengine/bevy/assets/10638479/95db0587-e5e0-4f55-be11-97444b795793

