### PR TITLE
bevy_reflect: Rename `UntypedReflectDeserializer` to `ReflectDeserializer`

### DIFF
--- a/crates/bevy_reflect/src/lib.rs
+++ b/crates/bevy_reflect/src/lib.rs
@@ -334,7 +334,7 @@
 //! The way it works is by moving the serialization logic into common serializers and deserializers:
 //! * [`ReflectSerializer`]
 //! * [`TypedReflectSerializer`]
-//! * [`UntypedReflectDeserializer`]
+//! * [`ReflectDeserializer`]
 //! * [`TypedReflectDeserializer`]
 //!
 //! All of these structs require a reference to the [registry] so that [type information] can be retrieved,
@@ -347,7 +347,7 @@
 //! and the value is the serialized data.
 //! The `TypedReflectSerializer` will simply output the serialized data.
 //!
-//! The `UntypedReflectDeserializer` can be used to deserialize this map and return a `Box<dyn Reflect>`,
+//! The `ReflectDeserializer` can be used to deserialize this map and return a `Box<dyn Reflect>`,
 //! where the underlying type will be a dynamic type representing some concrete type (except for value types).
 //!
 //! Again, it's important to remember that dynamic types may need to be converted to their concrete counterparts
@@ -357,7 +357,7 @@
 //! ```
 //! # use serde::de::DeserializeSeed;
 //! # use bevy_reflect::{
-//! #     serde::{ReflectSerializer, UntypedReflectDeserializer},
+//! #     serde::{ReflectSerializer, ReflectDeserializer},
 //! #     Reflect, FromReflect, TypeRegistry
 //! # };
 //! #[derive(Reflect, PartialEq, Debug)]
@@ -378,7 +378,7 @@
 //! let serialized_value: String = ron::to_string(&reflect_serializer).unwrap();
 //!
 //! // Deserialize
-//! let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+//! let reflect_deserializer = ReflectDeserializer::new(&registry);
 //! let deserialized_value: Box<dyn Reflect> = reflect_deserializer.deserialize(
 //!   &mut ron::Deserializer::from_str(&serialized_value).unwrap()
 //! ).unwrap();
@@ -460,7 +460,7 @@
 //! [`serde`]: ::serde
 //! [`ReflectSerializer`]: serde::ReflectSerializer
 //! [`TypedReflectSerializer`]: serde::TypedReflectSerializer
-//! [`UntypedReflectDeserializer`]: serde::UntypedReflectDeserializer
+//! [`ReflectDeserializer`]: serde::ReflectDeserializer
 //! [`TypedReflectDeserializer`]: serde::TypedReflectDeserializer
 //! [registry]: TypeRegistry
 //! [type information]: TypeInfo
@@ -610,7 +610,7 @@ mod tests {
     use super::prelude::*;
     use super::*;
     use crate as bevy_reflect;
-    use crate::serde::{ReflectSerializer, UntypedReflectDeserializer};
+    use crate::serde::{ReflectDeserializer, ReflectSerializer};
     use crate::utility::GenericTypePathCell;
 
     #[test]
@@ -1223,7 +1223,7 @@ mod tests {
         let serialized = to_string_pretty(&serializer, PrettyConfig::default()).unwrap();
 
         let mut deserializer = Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let dynamic_struct = value.take::<DynamicStruct>().unwrap();
 
@@ -2383,7 +2383,7 @@ bevy_reflect::tests::Test {
             registry.register::<Quat>();
             registry.register::<f32>();
 
-            let de = UntypedReflectDeserializer::new(&registry);
+            let de = ReflectDeserializer::new(&registry);
 
             let mut deserializer =
                 Deserializer::from_str(data).expect("Failed to acquire deserializer");
@@ -2440,7 +2440,7 @@ bevy_reflect::tests::Test {
             registry.add_registration(Vec3::get_type_registration());
             registry.add_registration(f32::get_type_registration());
 
-            let de = UntypedReflectDeserializer::new(&registry);
+            let de = ReflectDeserializer::new(&registry);
 
             let mut deserializer =
                 Deserializer::from_str(data).expect("Failed to acquire deserializer");

--- a/crates/bevy_reflect/src/serde/de.rs
+++ b/crates/bevy_reflect/src/serde/de.rs
@@ -240,6 +240,54 @@ impl<'de> Deserialize<'de> for Ident {
     }
 }
 
+/// A deserializer for type registrations.
+///
+/// This will return a [`&TypeRegistration`] corresponding to the given type.
+/// This deserializer expects a string containing the _full_ [type path] of the
+/// type to find the `TypeRegistration` of.
+///
+/// [`&TypeRegistration`]: TypeRegistration
+/// [type path]: crate::TypePath::type_path
+pub struct TypeRegistrationDeserializer<'a> {
+    registry: &'a TypeRegistry,
+}
+
+impl<'a> TypeRegistrationDeserializer<'a> {
+    pub fn new(registry: &'a TypeRegistry) -> Self {
+        Self { registry }
+    }
+}
+
+impl<'a, 'de> DeserializeSeed<'de> for TypeRegistrationDeserializer<'a> {
+    type Value = &'a TypeRegistration;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct TypeRegistrationVisitor<'a>(&'a TypeRegistry);
+
+        impl<'de, 'a> Visitor<'de> for TypeRegistrationVisitor<'a> {
+            type Value = &'a TypeRegistration;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("string containing `type` entry for the reflected value")
+            }
+
+            fn visit_str<E>(self, type_path: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                self.0.get_with_type_path(type_path).ok_or_else(|| {
+                    Error::custom(format_args!("No registration found for `{type_path}`"))
+                })
+            }
+        }
+
+        deserializer.deserialize_str(TypeRegistrationVisitor(self.registry))
+    }
+}
+
 /// A general purpose deserializer for reflected types.
 ///
 /// This is the deserializer counterpart to [`ReflectSerializer`].
@@ -336,89 +384,42 @@ impl<'a, 'de> DeserializeSeed<'de> for ReflectDeserializer<'a> {
     where
         D: serde::Deserializer<'de>,
     {
+        struct UntypedReflectDeserializerVisitor<'a> {
+            registry: &'a TypeRegistry,
+        }
+
+        impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
+            type Value = Box<dyn Reflect>;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter
+                    .write_str("map containing `type` and `value` entries for the reflected value")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: MapAccess<'de>,
+            {
+                let registration = map
+                    .next_key_seed(TypeRegistrationDeserializer::new(self.registry))?
+                    .ok_or_else(|| Error::invalid_length(0, &"a single entry"))?;
+
+                let value = map.next_value_seed(TypedReflectDeserializer {
+                    registration,
+                    registry: self.registry,
+                })?;
+
+                if map.next_key::<IgnoredAny>()?.is_some() {
+                    return Err(Error::invalid_length(2, &"a single entry"));
+                }
+
+                Ok(value)
+            }
+        }
+
         deserializer.deserialize_map(UntypedReflectDeserializerVisitor {
             registry: self.registry,
         })
-    }
-}
-
-/// A deserializer for type registrations.
-///
-/// This will return a [`&TypeRegistration`] corresponding to the given type.
-/// This deserializer expects a string containing the _full_ [type path] of the
-/// type to find the `TypeRegistration` of.
-///
-/// [`&TypeRegistration`]: TypeRegistration
-/// [type path]: crate::TypePath::type_path
-pub struct TypeRegistrationDeserializer<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a> TypeRegistrationDeserializer<'a> {
-    pub fn new(registry: &'a TypeRegistry) -> Self {
-        Self { registry }
-    }
-}
-
-impl<'a, 'de> DeserializeSeed<'de> for TypeRegistrationDeserializer<'a> {
-    type Value = &'a TypeRegistration;
-
-    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        struct TypeRegistrationVisitor<'a>(&'a TypeRegistry);
-
-        impl<'de, 'a> Visitor<'de> for TypeRegistrationVisitor<'a> {
-            type Value = &'a TypeRegistration;
-
-            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-                formatter.write_str("string containing `type` entry for the reflected value")
-            }
-
-            fn visit_str<E>(self, type_path: &str) -> Result<Self::Value, E>
-            where
-                E: Error,
-            {
-                self.0.get_with_type_path(type_path).ok_or_else(|| {
-                    Error::custom(format_args!("No registration found for `{type_path}`"))
-                })
-            }
-        }
-
-        deserializer.deserialize_str(TypeRegistrationVisitor(self.registry))
-    }
-}
-
-struct UntypedReflectDeserializerVisitor<'a> {
-    registry: &'a TypeRegistry,
-}
-
-impl<'a, 'de> Visitor<'de> for UntypedReflectDeserializerVisitor<'a> {
-    type Value = Box<dyn Reflect>;
-
-    fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
-        formatter.write_str("map containing `type` and `value` entries for the reflected value")
-    }
-
-    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
-    where
-        A: MapAccess<'de>,
-    {
-        let registration = map
-            .next_key_seed(TypeRegistrationDeserializer::new(self.registry))?
-            .ok_or_else(|| Error::invalid_length(0, &"a single entry"))?;
-
-        let value = map.next_value_seed(TypedReflectDeserializer {
-            registration,
-            registry: self.registry,
-        })?;
-
-        if map.next_key::<IgnoredAny>()?.is_some() {
-            return Err(Error::invalid_length(2, &"a single entry"));
-        }
-
-        Ok(value)
     }
 }
 

--- a/crates/bevy_reflect/src/serde/mod.rs
+++ b/crates/bevy_reflect/src/serde/mod.rs
@@ -10,7 +10,7 @@ pub use type_data::*;
 mod tests {
     use crate::{self as bevy_reflect, DynamicTupleStruct, Struct};
     use crate::{
-        serde::{ReflectSerializer, UntypedReflectDeserializer},
+        serde::{ReflectDeserializer, ReflectSerializer},
         type_registry::TypeRegistry,
         DynamicStruct, FromReflect, Reflect,
     };
@@ -52,7 +52,7 @@ mod tests {
             ron::ser::to_string_pretty(&serializer, ron::ser::PrettyConfig::default()).unwrap();
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let deserialized = value.take::<DynamicStruct>().unwrap();
 
@@ -111,7 +111,7 @@ mod tests {
             ron::ser::to_string_pretty(&serializer, ron::ser::PrettyConfig::default()).unwrap();
 
         let mut deserializer = ron::de::Deserializer::from_str(&serialized).unwrap();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
         let value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
         let deserialized = value.take::<DynamicTupleStruct>().unwrap();
 
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(expected, result);
 
         let mut deserializer = ron::de::Deserializer::from_str(&result).unwrap();
-        let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+        let reflect_deserializer = ReflectDeserializer::new(&registry);
 
         let expected = value.clone_value();
         let result = reflect_deserializer

--- a/crates/bevy_reflect/src/type_path.rs
+++ b/crates/bevy_reflect/src/type_path.rs
@@ -72,7 +72,7 @@ use std::fmt;
 /// ```
 ///
 /// [utility]: crate::utility
-/// [(de)serialization]: crate::serde::UntypedReflectDeserializer
+/// [(de)serialization]: crate::serde::ReflectDeserializer
 /// [`Reflect`]: crate::Reflect
 /// [`type_path`]: TypePath::type_path
 /// [`short_type_path`]: TypePath::short_type_path

--- a/crates/bevy_scene/src/serde.rs
+++ b/crates/bevy_scene/src/serde.rs
@@ -4,7 +4,7 @@ use crate::{DynamicEntity, DynamicScene};
 use bevy_ecs::entity::Entity;
 use bevy_reflect::serde::{TypedReflectDeserializer, TypedReflectSerializer};
 use bevy_reflect::{
-    serde::{TypeRegistrationDeserializer, UntypedReflectDeserializer},
+    serde::{ReflectDeserializer, TypeRegistrationDeserializer},
     Reflect, TypeRegistry, TypeRegistryArc,
 };
 use bevy_utils::HashSet;
@@ -460,9 +460,7 @@ impl<'a, 'de> Visitor<'de> for SceneMapVisitor<'a> {
         A: SeqAccess<'de>,
     {
         let mut dynamic_properties = Vec::new();
-        while let Some(entity) =
-            seq.next_element_seed(UntypedReflectDeserializer::new(self.registry))?
-        {
+        while let Some(entity) = seq.next_element_seed(ReflectDeserializer::new(self.registry))? {
             dynamic_properties.push(entity);
         }
 

--- a/examples/reflection/reflection.rs
+++ b/examples/reflection/reflection.rs
@@ -7,7 +7,7 @@
 use bevy::{
     prelude::*,
     reflect::{
-        serde::{ReflectSerializer, UntypedReflectDeserializer},
+        serde::{ReflectDeserializer, ReflectSerializer},
         DynamicStruct,
     },
 };
@@ -90,7 +90,7 @@ fn setup(type_registry: Res<AppTypeRegistry>) {
     info!("{}\n", ron_string);
 
     // Dynamic properties can be deserialized
-    let reflect_deserializer = UntypedReflectDeserializer::new(&type_registry);
+    let reflect_deserializer = ReflectDeserializer::new(&type_registry);
     let mut deserializer = ron::de::Deserializer::from_str(&ron_string).unwrap();
     let reflect_value = reflect_deserializer.deserialize(&mut deserializer).unwrap();
 


### PR DESCRIPTION
# Objective

We have `ReflectSerializer` and `TypedReflectSerializer`. The former is the one users will most often use since the latter takes a bit more effort to deserialize.

However, our deserializers are named `UntypedReflectDeserializer` and `TypedReflectDeserializer`. There is no obvious indication that `UntypedReflectDeserializer` must be used with `ReflectSerializer` since the names don't quite match up.

## Solution

Rename `UntypedReflectDeserializer` back to `ReflectDeserializer` (initially changed as part of #5723).

Also update the docs for both deserializers (as they were pretty out of date) and include doc examples.

I also updated the docs for the serializers, too, just so that everything is consistent.

---

## Changelog

- Renamed `UntypedReflectDeserializer` to `ReflectDeserializer`
- Updated docs for `ReflectDeserializer`, `TypedReflectDeserializer`, `ReflectSerializer`, and `TypedReflectSerializer`

## Migration Guide

`UntypedReflectDeserializer` has been renamed to `ReflectDeserializer`. Usages will need to be updated accordingly.

```diff
- let reflect_deserializer = UntypedReflectDeserializer::new(&registry);
+ let reflect_deserializer = ReflectDeserializer::new(&registry);
```