### PR TITLE
Add Debug to Has Query type

### DIFF
--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1408,6 +1408,7 @@ unsafe impl<T: ReadOnlyQueryData> ReadOnlyQueryData for Option<T> {}
 /// }
 /// # bevy_ecs::system::assert_is_system(alphabet_entity_system);
 /// ```
+#[derive(Debug)]
 pub struct Has<T>(PhantomData<T>);
 
 /// SAFETY:

--- a/crates/bevy_ecs/src/query/fetch.rs
+++ b/crates/bevy_ecs/src/query/fetch.rs
@@ -1408,8 +1408,13 @@ unsafe impl<T: ReadOnlyQueryData> ReadOnlyQueryData for Option<T> {}
 /// }
 /// # bevy_ecs::system::assert_is_system(alphabet_entity_system);
 /// ```
-#[derive(Debug)]
 pub struct Has<T>(PhantomData<T>);
+
+impl<T> std::fmt::Debug for Has<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
+        write!(f, "Has<{}>", std::any::type_name::<T>())
+    }
+}
 
 /// SAFETY:
 /// `update_component_access` and `update_archetype_component_access` do nothing.


### PR DESCRIPTION
# Objective

Pretty minor change to add `Debug` to `Has`.

This is helpful for users (Like me) who have the [`missing_debug_implementations`](https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/builtin/static.MISSING_DEBUG_IMPLEMENTATIONS.html) lint turned on.

## Solution

Simple `#[derive(Debug)]`

## Changelog
* Has now implemented `Debug`