### PR TITLE
Added a `pipe_map_some` method to the `bevy_ecs::IntoSystem` trait (#12718)

### DIFF
--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -338,15 +338,15 @@ where
 ///
 /// fn main() {
 ///     let mut world = World::default();
-///     // pipe_map the `parse_message_system`'s output into the `check_system`s input
-///     let mut pipe_mapped_system = parse_message_system.pipe_map(triple);
-///     pipe_mapped_system.initialize(&mut world);
+///     // pipe_map_some the `parse_message_system`'s output into the `check_system`s input
+///     let mut pipe_map_some_system = parse_message_system.pipe_map_some(triple);
+///     pipe_map_some_system.initialize(&mut world);
 ///
 ///     world.insert_resource(Message("not a usize".to_string()));
-///     assert_eq!(pipe_mapped_system.run((), &mut world), 0);
+///     assert_eq!(pipe_map_some_system.run((), &mut world), 0);
 ///
 ///     world.insert_resource(Message("14".to_string()));
-///     assert_eq!(pipe_mapped_system.run((), &mut world), 42);
+///     assert_eq!(pipe_map_some_system.run((), &mut world), 42);
 /// }
 ///
 /// #[derive(Resource)]
@@ -360,12 +360,12 @@ where
 ///     parsed * 3
 /// }
 /// ```
-pub type PipeMapSystem<SystemA, SystemB> = CombinatorSystem<PipeMap, SystemA, SystemB>;
+pub type PipeMapSomeSystem<SystemA, SystemB> = CombinatorSystem<PipeMapSome, SystemA, SystemB>;
 
 #[doc(hidden)]
-pub struct PipeMap;
+pub struct PipeMapSome;
 
-impl<A, B> Combine<A, B> for PipeMap
+impl<A, B> Combine<A, B> for PipeMapSome
 where
     A: System<Out = Option<B::In>>,
     B: System,

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -318,7 +318,7 @@ where
 }
 
 /// A [`System`] created by piping the unwrapped output of the first system into the input of the second.
-/// If the outpuf of the first system is [`None`], the seconds system is nnot executed.
+/// If the output of the first system is [`None`], the seconds system is not executed.
 ///
 /// This can be repeated indefinitely. If not [`None`], the unwrapped output is consumed by the receiving system.
 ///

--- a/crates/bevy_ecs/src/system/combinator.rs
+++ b/crates/bevy_ecs/src/system/combinator.rs
@@ -369,7 +369,7 @@ impl<A, B> Combine<A, B> for PipeMap
 where
     A: System<Out = Option<B::In>>,
     B: System,
-    B::Out: Default
+    B::Out: Default,
 {
     type In = A::In;
     type Out = B::Out;

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -173,15 +173,18 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     /// The second system must have [`In<T>`](crate::system::In) as its first parameter,
     /// where `Option<T>` is the return type of the first system.
     /// The seconnd system must return a type that implements [`Default`].
-    fn pipe_map<B, Final, MarkerB, T>(self, system: B) -> PipeMapSystem<Self::System, B::System>
+    fn pipe_map_some<B, Final, MarkerB, T>(
+        self,
+        system: B,
+    ) -> PipeMapSomeSystem<Self::System, B::System>
     where
         B: IntoSystem<T, Final, MarkerB>,
         Final: Default,
     {
         let system_a = IntoSystem::into_system(self);
         let system_b = IntoSystem::into_system(system);
-        let name = format!("PipeMap({}, {})", system_a.name(), system_b.name());
-        PipeMapSystem::new(system_a, system_b, Cow::Owned(name))
+        let name = format!("PipeMapSome({}, {})", system_a.name(), system_b.name());
+        PipeMapSomeSystem::new(system_a, system_b, Cow::Owned(name))
     }
 
     /// Pass the output of this system into the passed function `f`, creating a new system that

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -168,6 +168,21 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
         PipeSystem::new(system_a, system_b, Cow::Owned(name))
     }
 
+    /// Unwrap the output of this system `A` if it is not [`None`] into a second system `B`, creating a new compound system.
+    ///
+    /// The second system must have [`In<T>`](crate::system::In) as its first parameter,
+    /// where `Option<T>` is the return type of the first system.
+    /// The seconnd system must also return an [`Option`]
+    fn pipe_map<B, Final, MarkerB, T>(self, system: B) -> PipeMapSystem<Self::System, B::System>
+    where
+        B: IntoSystem<T, Final, MarkerB>
+    {
+        let system_a = IntoSystem::into_system(self);
+        let system_b = IntoSystem::into_system(system);
+        let name = format!("PipeMap({}, {})", system_a.name(), system_b.name());
+        PipeMapSystem::new(system_a, system_b, Cow::Owned(name))
+    }
+
     /// Pass the output of this system into the passed function `f`, creating a new system that
     /// outputs the value returned from the function.
     ///

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -172,10 +172,11 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     ///
     /// The second system must have [`In<T>`](crate::system::In) as its first parameter,
     /// where `Option<T>` is the return type of the first system.
-    /// The seconnd system must also return an [`Option`]
+    /// The seconnd system must return a type that implements [`Default`].
     fn pipe_map<B, Final, MarkerB, T>(self, system: B) -> PipeMapSystem<Self::System, B::System>
     where
-        B: IntoSystem<T, Final, MarkerB>
+        B: IntoSystem<T, Final, MarkerB>,
+        Final: Default
     {
         let system_a = IntoSystem::into_system(self);
         let system_b = IntoSystem::into_system(system);

--- a/crates/bevy_ecs/src/system/mod.rs
+++ b/crates/bevy_ecs/src/system/mod.rs
@@ -176,7 +176,7 @@ pub trait IntoSystem<In, Out, Marker>: Sized {
     fn pipe_map<B, Final, MarkerB, T>(self, system: B) -> PipeMapSystem<Self::System, B::System>
     where
         B: IntoSystem<T, Final, MarkerB>,
-        Final: Default
+        Final: Default,
     {
         let system_a = IntoSystem::into_system(self);
         let system_b = IntoSystem::into_system(system);

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -77,5 +77,5 @@ fn warning_pipe_system(message: Res<OptionalWarning>) -> Result<(), String> {
 
 // This system takes a usize input and prints the parsed value .
 fn simple_handler_system(In(value): In<usize>) {
-    println!("[simple] parsed message: {value}")
+    println!("[simple] parsed message: {value}");
 }

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -26,11 +26,11 @@ fn main() {
                 parse_error_message_system.map(error),
                 parse_message_system.map(drop),
                 // `Result::ok` converts the `Result` to an `Option`.
-                // `pipe_map` unwraps the option passed to simple_handler_system, and would skip
+                // `pipe_map_some` unwraps the option passed to simple_handler_system, and would skip
                 // running simple_handler_system if the passed option was None.
                 parse_message_system
                     .map(Result::ok)
-                    .pipe_map(simple_handler_system),
+                    .pipe_map_some(simple_handler_system),
             ),
         )
         .run();

--- a/examples/ecs/system_piping.rs
+++ b/examples/ecs/system_piping.rs
@@ -25,6 +25,12 @@ fn main() {
                 warning_pipe_system.map(warn),
                 parse_error_message_system.map(error),
                 parse_message_system.map(drop),
+                // `Result::ok` converts the `Result` to an `Option`.
+                // `pipe_map` unwraps the option passed to simple_handler_system, and would skip
+                // running simple_handler_system if the passed option was None.
+                parse_message_system
+                    .map(Result::ok)
+                    .pipe_map(simple_handler_system),
             ),
         )
         .run();
@@ -67,4 +73,9 @@ fn data_pipe_system(message: Res<Message>) -> String {
 // not see the warning message printed.
 fn warning_pipe_system(message: Res<OptionalWarning>) -> Result<(), String> {
     message.0.clone()
+}
+
+// This system takes a usize input and prints the parsed value .
+fn simple_handler_system(In(value): In<usize>) {
+    println!("[simple] parsed message: {value}")
 }


### PR DESCRIPTION
# Objective

- #12718

A composition of a system that returns an `Option` with a second system that returns a type that implements `Default`. This composition skips the second system when the output of the first system is `None`. The composition runs the second system with the unwrapped output of the first system when that output is not `None`.

## Solution

- A `pipe_map_some` method analogous to the `pipe` method
