### PR TITLE
Add `World::run_system_set` to run only the systems in a `SystemSet`

### DIFF
--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -27,7 +27,15 @@ pub(super) trait SystemExecutor: Send + Sync {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        skip_systems: Option<&FixedBitSet>,
+    );
+
+    /// Similar to `run`, but potentially skips systems based on the provided bitset.
+    /// This is separated from `run` to avoid the performance hit of checking the bitset
+    fn run_with_skip(
+        &mut self,
+        schedule: &mut SystemSchedule,
+        world: &mut World,
+        skip_systems: Option<&FixedBitSet>
     );
     fn set_apply_final_deferred(&mut self, value: bool);
 }

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -23,11 +23,7 @@ pub(super) trait SystemExecutor: Send + Sync {
     ///
     /// `skip_systems` can be provided to skip certain systems; the bit `i` corresponds to the
     /// system at index `i` in the [`SystemSchedule`]'s `system_ids`
-    fn run(
-        &mut self,
-        schedule: &mut SystemSchedule,
-        world: &mut World,
-    );
+    fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World);
 
     /// Similar to `run`, but potentially skips systems based on the provided bitset.
     /// This is separated from `run` to avoid the performance hit of checking the bitset
@@ -35,7 +31,7 @@ pub(super) trait SystemExecutor: Send + Sync {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        skip_systems: Option<&FixedBitSet>
+        skip_systems: Option<&FixedBitSet>,
     );
     fn set_apply_final_deferred(&mut self, value: bool);
 }

--- a/crates/bevy_ecs/src/schedule/executor/mod.rs
+++ b/crates/bevy_ecs/src/schedule/executor/mod.rs
@@ -18,6 +18,11 @@ use crate::{
 pub(super) trait SystemExecutor: Send + Sync {
     fn kind(&self) -> ExecutorKind;
     fn init(&mut self, schedule: &SystemSchedule);
+
+    /// Run the schedule in the order defined by the [`SystemSchedule`]
+    ///
+    /// `skip_systems` can be provided to skip certain systems; the bit `i` corresponds to the
+    /// system at index `i` in the [`SystemSchedule`]'s `system_ids`
     fn run(
         &mut self,
         schedule: &mut SystemSchedule,

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -188,11 +188,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         state.num_dependencies_remaining = Vec::with_capacity(sys_count);
     }
 
-    fn run(
-        &mut self,
-        schedule: &mut SystemSchedule,
-        world: &mut World,
-    ) {
+    fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         let state = self.state.get_mut().unwrap();
         // reset counts
         state.num_systems = schedule.systems.len();
@@ -262,7 +258,12 @@ impl SystemExecutor for MultiThreadedExecutor {
         state.completed_systems.clear();
     }
 
-    fn run_with_skip(&mut self, schedule: &mut SystemSchedule, world: &mut World, skip_systems: Option<&FixedBitSet>) {
+    fn run_with_skip(
+        &mut self,
+        schedule: &mut SystemSchedule,
+        world: &mut World,
+        skip_systems: Option<&FixedBitSet>,
+    ) {
         let state = self.state.get_mut().unwrap();
         // reset counts
         state.num_systems = schedule.systems.len();

--- a/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/multi_threaded.rs
@@ -192,7 +192,7 @@ impl SystemExecutor for MultiThreadedExecutor {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        _skip_systems: Option<&FixedBitSet>,
+        skip_systems: Option<&FixedBitSet>,
     ) {
         let state = self.state.get_mut().unwrap();
         // reset counts
@@ -214,10 +214,8 @@ impl SystemExecutor for MultiThreadedExecutor {
             }
         }
 
-        // If stepping is enabled, make sure we skip those systems that should
-        // not be run.
-        #[cfg(feature = "bevy_debug_stepping")]
-        if let Some(skipped_systems) = _skip_systems {
+        // skip the systems that should not be run.
+        if let Some(skipped_systems) = skip_systems {
             debug_assert_eq!(skipped_systems.len(), state.completed_systems.len());
             // mark skipped systems as completed
             state.completed_systems |= skipped_systems;

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -38,14 +38,7 @@ impl SystemExecutor for SimpleExecutor {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        skip_systems: Option<&FixedBitSet>,
     ) {
-        // skip the systems that should not be run.
-        if let Some(skipped_systems) = skip_systems {
-            // mark skipped systems as completed
-            self.completed_systems |= skipped_systems;
-        }
-
         for system_index in 0..schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
@@ -103,6 +96,15 @@ impl SystemExecutor for SimpleExecutor {
 
         self.evaluated_sets.clear();
         self.completed_systems.clear();
+    }
+
+    fn run_with_skip(&mut self, schedule: &mut SystemSchedule, world: &mut World, skip_systems: Option<&FixedBitSet>) {
+        // skip the systems that should not be run.
+        if let Some(skipped_systems) = skip_systems {
+            // mark skipped systems as completed
+            self.completed_systems |= skipped_systems;
+        }
+        self.run(schedule, world)
     }
 
     fn set_apply_final_deferred(&mut self, _: bool) {

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -105,7 +105,7 @@ impl SystemExecutor for SimpleExecutor {
             // mark skipped systems as completed
             self.completed_systems |= skipped_systems;
         }
-        self.run(schedule, world)
+        self.run(schedule, world);
     }
 
     fn set_apply_final_deferred(&mut self, _: bool) {

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -38,12 +38,10 @@ impl SystemExecutor for SimpleExecutor {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        _skip_systems: Option<&FixedBitSet>,
+        skip_systems: Option<&FixedBitSet>,
     ) {
-        // If stepping is enabled, make sure we skip those systems that should
-        // not be run.
-        #[cfg(feature = "bevy_debug_stepping")]
-        if let Some(skipped_systems) = _skip_systems {
+        // skip the systems that should not be run.
+        if let Some(skipped_systems) = skip_systems {
             // mark skipped systems as completed
             self.completed_systems |= skipped_systems;
         }

--- a/crates/bevy_ecs/src/schedule/executor/simple.rs
+++ b/crates/bevy_ecs/src/schedule/executor/simple.rs
@@ -34,11 +34,7 @@ impl SystemExecutor for SimpleExecutor {
         self.completed_systems = FixedBitSet::with_capacity(sys_count);
     }
 
-    fn run(
-        &mut self,
-        schedule: &mut SystemSchedule,
-        world: &mut World,
-    ) {
+    fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         for system_index in 0..schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
@@ -98,7 +94,12 @@ impl SystemExecutor for SimpleExecutor {
         self.completed_systems.clear();
     }
 
-    fn run_with_skip(&mut self, schedule: &mut SystemSchedule, world: &mut World, skip_systems: Option<&FixedBitSet>) {
+    fn run_with_skip(
+        &mut self,
+        schedule: &mut SystemSchedule,
+        world: &mut World,
+        skip_systems: Option<&FixedBitSet>,
+    ) {
         // skip the systems that should not be run.
         if let Some(skipped_systems) = skip_systems {
             // mark skipped systems as completed

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -40,11 +40,7 @@ impl SystemExecutor for SingleThreadedExecutor {
         self.unapplied_systems = FixedBitSet::with_capacity(sys_count);
     }
 
-    fn run(
-        &mut self,
-        schedule: &mut SystemSchedule,
-        world: &mut World,
-    ) {
+    fn run(&mut self, schedule: &mut SystemSchedule, world: &mut World) {
         for system_index in 0..schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
@@ -118,7 +114,12 @@ impl SystemExecutor for SingleThreadedExecutor {
         self.completed_systems.clear();
     }
 
-    fn run_with_skip(&mut self, schedule: &mut SystemSchedule, world: &mut World, skip_systems: Option<&FixedBitSet>) {
+    fn run_with_skip(
+        &mut self,
+        schedule: &mut SystemSchedule,
+        world: &mut World,
+        skip_systems: Option<&FixedBitSet>,
+    ) {
         // skip the systems that should not be run.
         if let Some(skipped_systems) = skip_systems {
             // mark skipped systems as completed

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -44,12 +44,10 @@ impl SystemExecutor for SingleThreadedExecutor {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        _skip_systems: Option<&FixedBitSet>,
+        skip_systems: Option<&FixedBitSet>,
     ) {
-        // If stepping is enabled, make sure we skip those systems that should
-        // not be run.
-        #[cfg(feature = "bevy_debug_stepping")]
-        if let Some(skipped_systems) = _skip_systems {
+        // skip the systems that should not be run.
+        if let Some(skipped_systems) = skip_systems {
             // mark skipped systems as completed
             self.completed_systems |= skipped_systems;
         }

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -44,14 +44,7 @@ impl SystemExecutor for SingleThreadedExecutor {
         &mut self,
         schedule: &mut SystemSchedule,
         world: &mut World,
-        skip_systems: Option<&FixedBitSet>,
     ) {
-        // skip the systems that should not be run.
-        if let Some(skipped_systems) = skip_systems {
-            // mark skipped systems as completed
-            self.completed_systems |= skipped_systems;
-        }
-
         for system_index in 0..schedule.systems.len() {
             #[cfg(feature = "trace")]
             let name = schedule.systems[system_index].name();
@@ -123,6 +116,15 @@ impl SystemExecutor for SingleThreadedExecutor {
         }
         self.evaluated_sets.clear();
         self.completed_systems.clear();
+    }
+
+    fn run_with_skip(&mut self, schedule: &mut SystemSchedule, world: &mut World, skip_systems: Option<&FixedBitSet>) {
+        // skip the systems that should not be run.
+        if let Some(skipped_systems) = skip_systems {
+            // mark skipped systems as completed
+            self.completed_systems |= skipped_systems;
+        }
+        self.run(schedule, world)
     }
 
     fn set_apply_final_deferred(&mut self, apply_final_deferred: bool) {

--- a/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
+++ b/crates/bevy_ecs/src/schedule/executor/single_threaded.rs
@@ -125,7 +125,7 @@ impl SystemExecutor for SingleThreadedExecutor {
             // mark skipped systems as completed
             self.completed_systems |= skipped_systems;
         }
-        self.run(schedule, world)
+        self.run(schedule, world);
     }
 
     fn set_apply_final_deferred(&mut self, apply_final_deferred: bool) {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -330,7 +330,7 @@ impl Schedule {
             .unwrap_or_else(|e| panic!("Error when initializing schedule {:?}: {e}", self.label));
 
         #[cfg(not(feature = "bevy_debug_stepping"))]
-        self.executor.run(&mut self.executable, world, None);
+        self.executor.run(&mut self.executable, world);
 
         #[cfg(feature = "bevy_debug_stepping")]
         {
@@ -340,7 +340,7 @@ impl Schedule {
             };
 
             self.executor
-                .run(&mut self.executable, world, skip_systems.as_ref());
+                .run_with_skip(&mut self.executable, world, skip_systems.as_ref());
         }
     }
 
@@ -384,7 +384,7 @@ impl Schedule {
 
         #[cfg(not(feature = "bevy_debug_stepping"))]
         self.executor
-            .run(&mut self.executable, world, skipped.as_ref());
+            .run_with_skip(&mut self.executable, world, skipped.as_ref());
 
         #[cfg(feature = "bevy_debug_stepping")]
         {
@@ -399,7 +399,7 @@ impl Schedule {
                 (None, None) => None,
             };
             self.executor
-                .run(&mut self.executable, world, to_skip.as_ref());
+                .run_with_skip(&mut self.executable, world, to_skip.as_ref());
         }
     }
 

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -356,9 +356,6 @@ impl Schedule {
         self.initialize(world)
             .unwrap_or_else(|e| panic!("Error when initializing schedule {:?}: {e}", self.label));
 
-        #[cfg(not(feature = "bevy_debug_stepping"))]
-        self.executor.run(&mut self.executable, world, skipped);
-
         let skipped = self
             .graph
             .system_set_ids
@@ -386,6 +383,9 @@ impl Schedule {
                     });
                 skipped_system_indices
             });
+
+        #[cfg(not(feature = "bevy_debug_stepping"))]
+        self.executor.run(&mut self.executable, world, skipped.as_ref());
 
         #[cfg(feature = "bevy_debug_stepping")]
         {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -385,7 +385,8 @@ impl Schedule {
             });
 
         #[cfg(not(feature = "bevy_debug_stepping"))]
-        self.executor.run(&mut self.executable, world, skipped.as_ref());
+        self.executor
+            .run(&mut self.executable, world, skipped.as_ref());
 
         #[cfg(feature = "bevy_debug_stepping")]
         {

--- a/crates/bevy_ecs/src/schedule/schedule.rs
+++ b/crates/bevy_ecs/src/schedule/schedule.rs
@@ -216,8 +216,6 @@ pub struct Schedule {
 #[derive(ScheduleLabel, Hash, PartialEq, Eq, Debug, Clone)]
 struct DefaultSchedule;
 
-// type BuildSkipBitSet = Box<dyn FnOnce(Schedule) -> FixedBitSet>;
-
 impl Default for Schedule {
     /// Creates a schedule with a default label. Only use in situations where
     /// you don't care about the [`ScheduleLabel`]. Inserting a default schedule
@@ -404,59 +402,6 @@ impl Schedule {
                 .run(&mut self.executable, world, to_skip.as_ref());
         }
     }
-
-    // pub(crate) fn run_system_set(&mut self, world: &mut World, system_set: impl SystemSet) {
-    //     self.run_with_skipped(world, self.graph.system_set_ids.get(&system_set.intern()).copied().map(|system_set_node_id| {
-    //         Box::new(move |sched: &Schedule| -> FixedBitSet {
-    //             // for each system in the graph, skip it if it's not in the system_set
-    //             let mut skipped_system_ids = FixedBitSet::with_capacity(self.graph.systems.len());
-    //             sched.graph().systems().for_each(|(system_node_id, _, _)| {
-    //                 if !sched.graph().hierarchy().graph().contains_edge(system_set_node_id, system_node_id) {
-    //                     skipped_system_ids.insert(system_node_id.index());
-    //                 }
-    //             });
-    //             // convert from system ids to system indices
-    //             let mut skipped_system_indices = FixedBitSet::with_capacity(self.systems_len());
-    //             self.executable.system_ids.iter().enumerate().for_each(|(index, system_id)| {
-    //                 if skipped_system_ids.contains(system_id.index()) {
-    //                     skipped_system_indices.insert(index);
-    //                 }
-    //             });
-    //             skipped_system_indices
-    //         })
-    //     }));
-    // }
-
-    // /// Runs all systems in this schedule for which the `filter` function returns true
-    // pub(crate) fn run_with_skipped(&mut self, world: &mut World, to_skip: Option<BuildSkipBitSet>) {
-    //     #[cfg(feature = "trace")]
-    //         let _span = info_span!("schedule", name = ?self.label).entered();
-    //
-    //     world.check_change_ticks();
-    //     self.initialize(world)
-    //         .unwrap_or_else(|e| panic!("Error when initializing schedule {:?}: {e}", self.label));
-    //
-    //     #[cfg(not(feature = "bevy_debug_stepping"))]
-    //     self.executor.run(&mut self.executable, world, skipped);
-    //
-    //     // after the executable schedule is initialized, create a bitset of systems to skip
-    //     let skipped = to_skip.map(|f| f(self));
-    //     #[cfg(feature = "bevy_debug_stepping")]
-    //     {
-    //         let skip_systems = match world.get_resource_mut::<Stepping>() {
-    //             None => None,
-    //             Some(mut stepping) => stepping.skipped_systems(self),
-    //         };
-    //         let to_skip = match (skip_systems, skipped) {
-    //             (Some(skip_systems), Some(skipped)) => Some(&skip_systems | &skipped),
-    //             (Some(skip_systems), None) => Some(skip_systems),
-    //             (None, Some(skipped)) => Some(skipped),
-    //             (None, None) => None,
-    //         };
-    //         self.executor
-    //             .run(&mut self.executable, world, to_skip.as_ref());
-    //     }
-    // }
 
     /// Initializes any newly-added systems and conditions, rebuilds the executable schedule,
     /// and re-initializes the executor.

--- a/crates/bevy_ecs/src/world/mod.rs
+++ b/crates/bevy_ecs/src/world/mod.rs
@@ -2373,8 +2373,6 @@ impl World {
     /// The [`Schedule`] is fetched from the [`Schedules`] resource of the world by its label,
     /// and system state is cached.
     ///
-    /// For simple testing use cases, call [`Schedule::run(&mut world)`](Schedule::run) instead.
-    ///
     /// # Panics
     ///
     /// If the requested schedule does not exist.
@@ -2385,7 +2383,7 @@ impl World {
     ) {
         self.schedule_scope(schedule_label, |world, sched| {
             sched.run_system_set(world, system_set);
-        })
+        });
     }
 
     /// Ignore system order ambiguities caused by conflicts on [`Component`]s of type `T`.


### PR DESCRIPTION
# Objective

Fixes https://github.com/bevyengine/bevy/issues/12717 
As explained in the issue, it would be convenient to be able to run only the systems that are inside a `SystemSet`. (for example for benchmarking, I would like to only run a specific `SystemSet` of my `App`.



## Solution

- The idea is to re-use the work started from system stepping, which made it possible to provide a `FixedBitSet` of systems that need to be fixed when running the schedule.
- Add a separate function `run_system_set` which computes the bitset of systems to skip from the graph:
  - run a BFS on the graph to find the NodeId of every system that needs to be run
  - convert that FixedBitSet into a FixedBitSet of the **index** of every system that needs to be skipped in the final `SystemSchedule`
- Added some unit tests to check that the code works as expected
  
TODO:
- ideally I would have created a function `run_with_skip` that takes a closure `Box<dyn Fn(&Schedule) -> FixedBitSet>` as input that defines which systems we want to skip from the schedule, but I wasn't able to get it working (my `closure` wasn't `dyn Fn` apparently? I would appreciate help there
- clean PR + doctests
- maybe add more doctests on the schedule_graph code? it was a bit hard to follow what was going on there because that code is not very documented

---

## Changelog

### Added
- A function `World::run_system_set` to run once the systems that are part of a given `SystemSet`
