### PR TITLE
Add entity id to hierarchy propagation error message

### DIFF
--- a/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
+++ b/crates/bevy_hierarchy/src/valid_parent_check_plugin.rs
@@ -68,7 +68,7 @@ pub fn check_hierarchy_component_has_valid_parent<T: Component>(
                 "warning[B0004]: {name} with the {ty_name} component has a parent without {ty_name}.\n\
                 This will cause inconsistent behaviors! See: https://bevyengine.org/learn/errors/#b0004",
                 ty_name = get_short_name(std::any::type_name::<T>()),
-                name = name.map_or("An entity".to_owned(), |s| format!("The {s} entity")),
+                name = name.map_or(format!("Entity {}", entity), |s| format!("The {s} entity")),
             );
         }
     }


### PR DESCRIPTION
# Objective

- Fixes https://github.com/bevyengine/bevy/issues/12731


## Solution

- Use the `Name` component if present, else default to `Entity 0v1` instead of `An entity`
