### PR TITLE
Add the annulus shape to the `2d_shapes` example

### DIFF
--- a/examples/2d/2d_shapes.rs
+++ b/examples/2d/2d_shapes.rs
@@ -24,6 +24,7 @@ fn setup(
     let shapes = [
         Mesh2dHandle(meshes.add(Circle { radius: 50.0 })),
         Mesh2dHandle(meshes.add(Ellipse::new(25.0, 50.0))),
+        Mesh2dHandle(meshes.add(Annulus::new(25.0, 50.0))),
         Mesh2dHandle(meshes.add(Capsule2d::new(25.0, 50.0))),
         Mesh2dHandle(meshes.add(Rectangle::new(50.0, 100.0))),
         Mesh2dHandle(meshes.add(RegularPolygon::new(50.0, 6))),


### PR DESCRIPTION
# Objective

- Depends on #12734.

Since adding the `Annulus` primitive shape (#12706, #12734), the `2d_shapes` example has become outdated.

## Solution

This PR adds the annulus shape to the `2d_shapes` example:

![image](https://github.com/bevyengine/bevy/assets/37378746/e620362d-bec6-4660-bf6e-d70babff8179)

---

## Changelog

### Added

- `Annulus` shape to the `2d_shapes` example

(as an added bonus, the example now features Newton's [ROYGBIV](https://en.wikipedia.org/wiki/ROYGBIV) rainbow palette ^^)
