### PR TITLE
Fix unhandled null characters in Android logs

### DIFF
--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -40,16 +40,6 @@ impl Visit for StringRecorder {
     }
 }
 
-impl core::fmt::Display for StringRecorder {
-    fn fmt(&self, mut f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if !self.0.is_empty() {
-            write!(&mut f, " {}", self.0)
-        } else {
-            Ok(())
-        }
-    }
-}
-
 impl core::default::Default for StringRecorder {
     fn default() -> Self {
         StringRecorder::new()
@@ -82,7 +72,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
                 .as_bytes()
                 .into_iter()
                 .copied()
-                .filter(|byte| byte != 0)
+                .filter(|byte| *byte != 0)
                 .collect();
             CString::new(bytes).unwrap()
         }
@@ -102,7 +92,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
         unsafe {
             android_log_sys::__android_log_write(
                 priority as android_log_sys::c_int,
-                sanitize(recorder).as_ptr(),
+                sanitize(&recorder.0).as_ptr(),
                 sanitize(meta.tag()).as_ptr(),
             );
         }

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -81,6 +81,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
             let mut bytes: Vec<u8> = string
                 .as_bytes()
                 .into_iter()
+                .copied()
                 .filter(|byte| byte != 0)
                 .collect();
             CString::new(bytes).unwrap()
@@ -89,7 +90,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
         let mut recorder = StringRecorder::new();
         event.record(&mut recorder);
         let meta = event.metadata();
-        let priority = match meta.level() {
+        let priority = match *meta.level() {
             Level::TRACE => android_log_sys::LogPriority::VERBOSE,
             Level::DEBUG => android_log_sys::LogPriority::DEBUG,
             Level::INFO => android_log_sys::LogPriority::INFO,

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -77,7 +77,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
     }
 
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        fn sanitize(string: &str) -> CStirng {
+        fn sanitize(string: &str) -> CString {
             let mut bytes: Vec<u8> = string
                 .as_bytes()
                 .into_iter()

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -92,8 +92,8 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
         unsafe {
             android_log_sys::__android_log_write(
                 priority as android_log_sys::c_int,
+                sanitize(meta.name()).as_ptr(),
                 sanitize(&recorder.0).as_ptr(),
-                sanitize(meta.tag()).as_ptr(),
             );
         }
     }

--- a/crates/bevy_log/src/android_tracing.rs
+++ b/crates/bevy_log/src/android_tracing.rs
@@ -90,7 +90,7 @@ impl<S: Subscriber + for<'a> LookupSpan<'a>> Layer<S> for AndroidLayer {
         };
         let message = CString::new(recorder).expect("message contained null character.");
         let tag = CString::new(meta.name()).expect("tag contained null character.");
-        // SAFETY: Called only on Android platforms. priority is guarented to be in range of c_int.
+        // SAFETY: Called only on Android platforms. priority is guaranteed to be in range of c_int.
         // The provided tag and message are null terminated properly.
         unsafe {
             android_log_sys::__android_log_write(


### PR DESCRIPTION
# Objective
Fix #12728.  Fix unsoundnesss from unhandled null characters in Android logs.

## Solution
Use `CString` instead of using formatted Strings. Properly document the safety invariants of the FFI call.