### PR TITLE
Math tests fix

### DIFF
--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -23,6 +23,7 @@ approx = "0.5"
 # Supply rngs for examples and tests
 rand = "0.8"
 rand_chacha = "0.3"
+bevy_math = { path = ".", version = "0.14.0-dev", features = ["approx"] }
 
 [features]
 default = ["rand"]

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -23,6 +23,7 @@ approx = "0.5"
 # Supply rngs for examples and tests
 rand = "0.8"
 rand_chacha = "0.3"
+# Enable the approx feature when testing.
 bevy_math = { path = ".", version = "0.14.0-dev", features = ["approx"] }
 
 [features]


### PR DESCRIPTION
# Objective

Fixes `cargo test -p bevy_math` as in #12729.

## Solution

As described in [message](https://github.com/bevyengine/bevy/issues/12729#issuecomment-2022197944)
Added workaround `bevy_math = { path = ".", version = "0.14.0-dev", features = ["approx"] }` to `bevy_math`'s `dev-dependencies`
