### PR TITLE
Clean up WinitWindows::remove_window

### DIFF
--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -281,7 +281,7 @@ impl WinitWindows {
     /// This should mostly just be called when the window is closing.
     pub fn remove_window(&mut self, entity: Entity) -> Option<winit::window::Window> {
         let winit_id = self.entity_to_winit.remove(&entity)?;
-        // Don't remove from `winit_to_window_id` so we know the window used to exist.
+        self.winit_to_entity.remove(&winit_id);
         self.windows.remove(&winit_id)
     }
 }


### PR DESCRIPTION
# Objective

- Avoid unbounded HashMap growth for opening/closing windows.

## Solution

- Remove map entry in `WinitWindows::remove_window`.

## Migration Guide

- `WinitWindows::get_window_entity` now returns `None` after a window is closed, instead of a dead entity.

---

## Comments

The comment this PR replaces was added in https://github.com/bevyengine/bevy/pull/3575. Since `get_window_entity` now returns an `Entity` instead of a `WindowId`, this no longer seems useful. Note that `get_window_entity` is only used [here](https://github.com/bevyengine/bevy/blob/56bcbb097552b45e3ff48c48947ed8ee4e2c24b1/crates/bevy_winit/src/lib.rs#L436), immediately followed by a warning if the entity returned doesn't exist.
