### PR TITLE
fix example mesh2d_manual in wasm/webgl2

### DIFF
--- a/examples/2d/mesh2d_manual.rs
+++ b/examples/2d/mesh2d_manual.rs
@@ -16,8 +16,9 @@ use bevy::{
         render_resource::{
             BlendState, ColorTargetState, ColorWrites, Face, FragmentState, FrontFace,
             MultisampleState, PipelineCache, PolygonMode, PrimitiveState, PrimitiveTopology,
-            RenderPipelineDescriptor, SpecializedRenderPipeline, SpecializedRenderPipelines,
-            TextureFormat, VertexBufferLayout, VertexFormat, VertexState, VertexStepMode,
+            PushConstantRange, RenderPipelineDescriptor, ShaderStages, SpecializedRenderPipeline,
+            SpecializedRenderPipelines, TextureFormat, VertexBufferLayout, VertexFormat,
+            VertexState, VertexStepMode,
         },
         texture::BevyDefault,
         view::{ExtractedView, ViewTarget, VisibleEntities},
@@ -157,6 +158,18 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
             false => TextureFormat::bevy_default(),
         };
 
+        let mut push_constant_ranges = Vec::with_capacity(1);
+        if cfg!(all(
+            feature = "webgl2",
+            target_arch = "wasm32",
+            not(feature = "webgpu")
+        )) {
+            push_constant_ranges.push(PushConstantRange {
+                stages: ShaderStages::VERTEX,
+                range: 0..4,
+            });
+        }
+
         RenderPipelineDescriptor {
             vertex: VertexState {
                 // Use our custom shader
@@ -184,7 +197,7 @@ impl SpecializedRenderPipeline for ColoredMesh2dPipeline {
                 // Bind group 1 is the mesh uniform
                 self.mesh2d_pipeline.mesh_layout.clone(),
             ],
-            push_constant_ranges: Vec::new(),
+            push_constant_ranges,
             primitive: PrimitiveState {
                 front_face: FrontFace::Ccw,
                 cull_mode: Some(Face::Back),


### PR DESCRIPTION
# Objective

- Example `mesh2d_manual` crashes in wasm/webgl2, as reported in https://github.com/bevyengine/bevy-website/issues/1123#issuecomment-2019479670
```
wgpu error: Validation Error

Caused by:
    In a RenderPass
      note: encoder = `<CommandBuffer-(0, 1, Gl)>`
    In a set_push_constant command
    Provided push constant is for stage(s) ShaderStages(VERTEX), however the pipeline layout has no push constant range for the stage(s) ShaderStages(VERTEX)
```

## Solution

- Properly declare the push constant as in https://github.com/bevyengine/bevy/blob/4508077297a92295d8b6fb6b07a63b547deac1e0/crates/bevy_sprite/src/mesh2d/mesh.rs#L514-L524
