### PR TITLE
Implement `From<Vec2>` for `AspectRatio`

### DIFF
--- a/crates/bevy_math/src/aspect_ratio.rs
+++ b/crates/bevy_math/src/aspect_ratio.rs
@@ -1,5 +1,7 @@
 //! Provides a simple aspect ratio struct to help with calculations.
 
+use crate::Vec2;
+
 /// An `AspectRatio` is the ratio of width to height.
 pub struct AspectRatio(f32);
 
@@ -14,6 +16,13 @@ impl AspectRatio {
     #[inline]
     pub fn from_pixels(x: u32, y: u32) -> Self {
         Self::new(x as f32, y as f32)
+    }
+}
+
+impl From<Vec2> for AspectRatio {
+    #[inline]
+    fn from(value: Vec2) -> Self {
+        Self::new(value.x, value.y)
     }
 }
 


### PR DESCRIPTION
# Objective
Since it is common to store a pair of width and height as `Vec2`, it would be useful to have an easy way to instantiate `AspectRatio` from `Vec2`.

## Solution
Add `impl From<Vec2> for AspectRatio`.

---

## Changelog
- Added `impl From<Vec2> for AspectRatio`
