### PR TITLE
Update glam version requirement from 0.25 to 0.27

### DIFF
--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 license = "MIT OR Apache-2.0"
 
 [dev-dependencies]
-glam = "0.25"
+glam = "0.27"
 rand = "0.8"
 rand_chacha = "0.3"
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/crates/bevy_color/Cargo.toml
+++ b/crates/bevy_color/Cargo.toml
@@ -17,7 +17,7 @@ bytemuck = { version = "1", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"], optional = true }
 thiserror = "1.0"
 wgpu-types = { version = "0.19", default-features = false, optional = true }
-encase = { version = "0.7", default-features = false }
+encase = { version = "0.8", default-features = false }
 
 [features]
 serialize = ["serde"]

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -319,7 +319,7 @@ impl encase::ShaderType for LinearRgba {
         encase::private::Metadata {
             alignment,
             has_uniform_min_alignment: false,
-            is_pod: false,
+            is_pod: true,
             min_size: size,
             extra: (),
         }

--- a/crates/bevy_color/src/linear_rgba.rs
+++ b/crates/bevy_color/src/linear_rgba.rs
@@ -319,6 +319,7 @@ impl encase::ShaderType for LinearRgba {
         encase::private::Metadata {
             alignment,
             has_uniform_min_alignment: false,
+            is_pod: false,
             min_size: size,
             extra: (),
         }

--- a/crates/bevy_encase_derive/Cargo.toml
+++ b/crates/bevy_encase_derive/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 bevy_macro_utils = { path = "../bevy_macro_utils", version = "0.14.0-dev" }
-encase_derive_impl = "0.7"
+encase_derive_impl = "0.8"
 
 [lints]
 workspace = true

--- a/crates/bevy_math/Cargo.toml
+++ b/crates/bevy_math/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT OR Apache-2.0"
 keywords = ["bevy"]
 
 [dependencies]
-glam = { version = "0.25", features = ["bytemuck"] }
+glam = { version = "0.27", features = ["bytemuck"] }
 thiserror = "1.0"
 serde = { version = "1", features = ["derive"], optional = true }
 libm = { version = "0.2", optional = true }

--- a/crates/bevy_mikktspace/Cargo.toml
+++ b/crates/bevy_mikktspace/Cargo.toml
@@ -15,7 +15,7 @@ license = "Zlib AND (MIT OR Apache-2.0)"
 keywords = ["bevy", "3D", "graphics", "algorithm", "tangent"]
 
 [dependencies]
-glam = "0.25"
+glam = "0.27"
 
 [[example]]
 name = "generate"

--- a/crates/bevy_reflect/Cargo.toml
+++ b/crates/bevy_reflect/Cargo.toml
@@ -37,7 +37,7 @@ thiserror = "1.0"
 serde = "1"
 smallvec = { version = "1.11", optional = true }
 
-glam = { version = "0.25", features = ["serde"], optional = true }
+glam = { version = "0.27", features = ["serde"], optional = true }
 petgraph = { version = "0.6", features = ["serde-1"], optional = true }
 smol_str = { version = "0.2.0", optional = true }
 uuid = { version = "1.0", optional = true, features = ["v4", "serde"] }

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -93,7 +93,7 @@ flate2 = { version = "1.0.22", optional = true }
 ruzstd = { version = "0.6.0", optional = true }
 # For transcoding of UASTC/ETC1S universal formats, and for .basis file support
 basis-universal = { version = "0.3.0", optional = true }
-encase = { version = "0.7", features = ["glam"] }
+encase = { version = "0.8", features = ["glam"] }
 # For wgpu profiling using tracing. Use `RUST_LOG=info` to also capture the wgpu spans.
 profiling = { version = "1", features = [
   "profile-with-tracing",

--- a/crates/bevy_render/Cargo.toml
+++ b/crates/bevy_render/Cargo.toml
@@ -85,7 +85,7 @@ bytemuck = { version = "1.5", features = ["derive", "must_cast"] }
 downcast-rs = "1.2.0"
 thiserror = "1.0"
 futures-lite = "2.0.1"
-hexasphere = "10.0"
+hexasphere = "12.0"
 ddsfile = { version = "0.5.2", optional = true }
 ktx2 = { version = "0.3.0", optional = true }
 # For ktx2 supercompression

--- a/crates/bevy_render/src/render_resource/uniform_buffer.rs
+++ b/crates/bevy_render/src/render_resource/uniform_buffer.rs
@@ -386,6 +386,11 @@ impl<'a> BufferMut for QueueWriteBufferViewWrapper<'a> {
     fn write<const N: usize>(&mut self, offset: usize, val: &[u8; N]) {
         self.buffer_view.write(offset, val);
     }
+
+    #[inline]
+    fn write_slice(&mut self, offset: usize, val: &[u8]) {
+        self.buffer_view.write_slice(offset, val);
+    }
 }
 
 impl<'a, T: ShaderType + WriteInto> IntoBinding<'a> for &'a DynamicUniformBuffer<T> {


### PR DESCRIPTION
# Objective

- Update glam version requirement to latest version.

## Solution

- Updated `glam` version requirement from 0.25 to 0.27.
- Updated `encase` and `encase_derive_impl` version requirement from 0.7 to 0.8.
- Updated `hexasphere` version requirement from 10.0 to 12.0.
- Breaking changes from glam changelog:
  - [0.26.0] Minimum Supported Rust Version bumped to 1.68.2 for impl From<bool> for {f32,f64} support.
  - [0.27.0] Changed implementation of vector fract method to match the Rust implementation instead of the GLSL implementation, that is self - self.trunc() instead of self - self.floor().

---

## Migration Guide

- When using `glam` exports, keep in mind that `vector` `fract()` method now matches Rust implementation (that is `self - self.trunc()` instead of `self - self.floor()`). If you want to use the GLSL implementation you should now use `fract_gl()`.