### PR TITLE
Check CI against Rust beta each week

### DIFF
--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -85,11 +85,12 @@ jobs:
       - name: Create issue
         run: |
           previous_issue_number=$(gh issue list \
-            --title "$TITLE" \
+            --search "$TITLE in:title" \
             --json number \
             --jq '.[0].number')
           if [[ -n $previous_issue_number ]]; then
-            echo "issue already exists: $previous_issue_number"
+            gh issue comment $previous_issue_number \
+              --body "Weekly pipeline still fails: $FAILED_RUN" 
           else
             gh issue create \
               --title "$TITLE" \
@@ -101,8 +102,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           TITLE: Main branch fails to compile on Rust beta.
           LABELS: C-Bug,S-Needs-Triage
-          BODY: |
+          FAILED_RUN: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          BODY: | 
             ## Weekly CI run has failed.
-            [The offending run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-
-
+            [The offending run.]($FAILED_RUN)

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -1,0 +1,142 @@
+name: Weekly beta compile test
+
+on:
+  schedule:
+    # New versions of rust release on Thursdays. We test on Wednesdays to get at least a day's warning before all our CI breaks again.
+    # https://forge.rust-lang.org/release/process.html#release-day-thursday
+    - cron:  '0 12 * * 3'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  NIGHTLY_TOOLCHAIN: nightly
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+        if: runner.os == 'linux'
+      - name: Build & run tests
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- test
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0 -D warnings"
+
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+        with:
+          components: rustfmt, clippy
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: CI job
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- lints
+
+  miri:
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
+          components: miri
+      - name: CI job
+        # To run the tests one item at a time for troubleshooting, use
+        # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
+        run: cargo miri test -p bevy_ecs
+        env:
+          # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
+          RUSTFLAGS: -Zrandomize-layout
+          # https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
+          # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
+          # -Zmiri-permissive-provenance disables warnings against int2ptr casts (since those are used by once_cell)
+          # -Zmiri-ignore-leaks is necessary because a bunch of tests don't join all threads before finishing.
+          MIRIFLAGS: -Zmiri-ignore-leaks -Zmiri-disable-isolation -Zmiri-permissive-provenance
+
+  check-compiles:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: ci
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+        with:
+          toolchain: stable
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
+      - name: Check Compile
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- compile
+
+  build-wasm:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+        with:
+          target: wasm32-unknown-unknown
+      - name: Check wasm
+        run: cargo check --target wasm32-unknown-unknown
+
+  check-doc:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@beta
+      - name: Install alsa and udev
+        run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
+      - name: Build and check doc
+        # See tools/ci/src/main.rs for the commands this runs
+        run: cargo run -p ci -- doc
+        env:
+          CARGO_INCREMENTAL: 0
+          RUSTFLAGS: "-C debuginfo=0"
+      # This currently report a lot of false positives
+      # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
+      # - name: Installs cargo-deadlinks
+      #   run: cargo install --force cargo-deadlinks
+      # - name: Checks dead links
+      #   run: cargo deadlinks --dir target/doc/bevy
+      #   continue-on-error: true
+
+  open-issue:
+    name: Warn that weekly CI fails
+    runs-on: ubuntu-latest
+    needs: [build, ci, miri, check-compiles, build-wasm, check-doc]
+    permissions:
+      issues: write
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+      - name: Create issue
+        run: |
+          gh issue create \
+            --title "$TITLE" \
+            --label "$LABELS" \
+            --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: Master branch fails to compile on Rust beta.
+          LABELS: C-Bug,S-Needs-Triage
+          BODY: |
+            ## Weekly CI run has failed.
+            [The offending run.](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+
+

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -72,13 +72,6 @@ jobs:
         env:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0"
-      # This currently report a lot of false positives
-      # Enable it again once it's fixed - https://github.com/bevyengine/bevy/issues/1983
-      # - name: Installs cargo-deadlinks
-      #   run: cargo install --force cargo-deadlinks
-      # - name: Checks dead links
-      #   run: cargo deadlinks --dir target/doc/bevy
-      #   continue-on-error: true
 
   open-issue:
     name: Warn that weekly CI fails
@@ -91,14 +84,22 @@ jobs:
     steps:
       - name: Create issue
         run: |
-          gh issue create \
+          previous_issue_number=$(gh issue list \
             --title "$TITLE" \
-            --label "$LABELS" \
-            --body "$BODY"
+            --json number \
+            --jq '.[0].number')
+          if [[ -n $previous_issue_number ]]; then
+            echo "issue already exists: $previous_issue_number"
+          else
+            gh issue create \
+              --title "$TITLE" \
+              --label "$LABELS" \
+              --body "$BODY"
+          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          TITLE: Master branch fails to compile on Rust beta.
+          TITLE: Main branch fails to compile on Rust beta.
           LABELS: C-Bug,S-Needs-Triage
           BODY: |
             ## Weekly CI run has failed.

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -2,9 +2,9 @@ name: Weekly beta compile test
 
 on:
   schedule:
-    # New versions of rust release on Thursdays. We test on Wednesdays to get at least a day's warning before all our CI breaks again.
+    # New versions of rust release on Thursdays. We test on Mondays to get at least 3 days of warning before all our CI breaks again.
     # https://forge.rust-lang.org/release/process.html#release-day-thursday
-    - cron:  '0 12 * * 3'
+    - cron:  '0 12 * * 1'
   workflow_dispatch:
 
 env:
@@ -12,7 +12,7 @@ env:
   NIGHTLY_TOOLCHAIN: nightly
 
 jobs:
-  build:
+  test:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
@@ -31,7 +31,7 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-C debuginfo=0 -D warnings"
 
-  ci:
+  lint:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -41,31 +41,9 @@ jobs:
           components: rustfmt, clippy
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-      - name: CI job
+      - name: Run lints
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- lints
-
-  miri:
-    runs-on: macos-14
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ env.NIGHTLY_TOOLCHAIN }}
-          components: miri
-      - name: CI job
-        # To run the tests one item at a time for troubleshooting, use
-        # cargo --quiet test --lib -- --list | sed 's/: test$//' | MIRIFLAGS="-Zmiri-disable-isolation -Zmiri-permissive-provenance -Zmiri-disable-weak-memory-emulation" xargs -n1 cargo miri test -p bevy_ecs --lib -- --exact
-        run: cargo miri test -p bevy_ecs
-        env:
-          # -Zrandomize-layout makes sure we dont rely on the layout of anything that might change
-          RUSTFLAGS: -Zrandomize-layout
-          # https://github.com/rust-lang/miri#miri--z-flags-and-environment-variables
-          # -Zmiri-disable-isolation is needed because our executor uses `fastrand` which accesses system time.
-          # -Zmiri-permissive-provenance disables warnings against int2ptr casts (since those are used by once_cell)
-          # -Zmiri-ignore-leaks is necessary because a bunch of tests don't join all threads before finishing.
-          MIRIFLAGS: -Zmiri-ignore-leaks -Zmiri-disable-isolation -Zmiri-permissive-provenance
 
   check-compiles:
     runs-on: ubuntu-latest
@@ -74,25 +52,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@beta
-        with:
-          toolchain: stable
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev
-      - name: Check Compile
+      - name: Check compile test
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- compile
-
-  build-wasm:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    needs: build
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@beta
-        with:
-          target: wasm32-unknown-unknown
-      - name: Check wasm
-        run: cargo check --target wasm32-unknown-unknown
 
   check-doc:
     runs-on: ubuntu-latest
@@ -102,7 +66,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@beta
       - name: Install alsa and udev
         run: sudo apt-get update; sudo apt-get install --no-install-recommends libasound2-dev libudev-dev libwayland-dev libxkbcommon-dev
-      - name: Build and check doc
+      - name: Build and check docs
         # See tools/ci/src/main.rs for the commands this runs
         run: cargo run -p ci -- doc
         env:
@@ -119,9 +83,10 @@ jobs:
   open-issue:
     name: Warn that weekly CI fails
     runs-on: ubuntu-latest
-    needs: [build, ci, miri, check-compiles, build-wasm, check-doc]
+    needs: [test, lint, check-compiles, check-doc]
     permissions:
       issues: write
+    # Use always() so the job doesn't get canceled if any other jobs fail 
     if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
       - name: Create issue


### PR DESCRIPTION
# Objective

Get an early warning if any new rust lints will break CI. Closes #12625

## Solution

Test the main branch against the Rust beta every week.

## Additional Possibilities
The action currently creates an issue if anything fails. The issue could use a label like `C-Weekly` but somebody with the ability to create issue labels would have to add it.

Another possibility would be to use discord webhooks. That would need somebody with the access to create webhooks on discord and somebody with the rights to connect that webhook to this repo,