### PR TITLE
Fix `Triangle2d`/`Triangle3d` interior sampling to correctly follow triangle

### DIFF
--- a/crates/bevy_math/src/shape_sampling.rs
+++ b/crates/bevy_math/src/shape_sampling.rs
@@ -159,9 +159,9 @@ fn sample_triangle_interior<P: NormedVectorSpace, R: Rng + ?Sized>(
     if u + v > 1. {
         let u1 = 1. - v;
         let v1 = 1. - u;
-        ab * u1 + ac * v1
+        a + (ab * u1 + ac * v1)
     } else {
-        ab * u + ac * v
+        a + (ab * u + ac * v)
     }
 }
 

--- a/crates/bevy_math/src/shape_sampling.rs
+++ b/crates/bevy_math/src/shape_sampling.rs
@@ -148,6 +148,8 @@ fn sample_triangle_interior<P: NormedVectorSpace, R: Rng + ?Sized>(
     rng: &mut R,
 ) -> P {
     let [a, b, c] = vertices;
+    let ab = b - a;
+    let ac = c - a;
 
     // Generate random points on a parallelipiped and reflect so that
     // we can use the points that lie outside the triangle
@@ -157,9 +159,9 @@ fn sample_triangle_interior<P: NormedVectorSpace, R: Rng + ?Sized>(
     if u + v > 1. {
         let u1 = 1. - v;
         let v1 = 1. - u;
-        a.lerp(b, u1) + a.lerp(c, v1)
+        a + (ab * u1 + ac * v1)
     } else {
-        a.lerp(b, u) + a.lerp(c, v)
+        a + (ab * u + ac * v)
     }
 }
 

--- a/crates/bevy_math/src/shape_sampling.rs
+++ b/crates/bevy_math/src/shape_sampling.rs
@@ -148,8 +148,6 @@ fn sample_triangle_interior<P: NormedVectorSpace, R: Rng + ?Sized>(
     rng: &mut R,
 ) -> P {
     let [a, b, c] = vertices;
-    let ab = b - a;
-    let ac = c - a;
 
     // Generate random points on a parallelipiped and reflect so that
     // we can use the points that lie outside the triangle
@@ -159,9 +157,9 @@ fn sample_triangle_interior<P: NormedVectorSpace, R: Rng + ?Sized>(
     if u + v > 1. {
         let u1 = 1. - v;
         let v1 = 1. - u;
-        a + (ab * u1 + ac * v1)
+        a.lerp(b, u1) + a.lerp(c, v1)
     } else {
-        a + (ab * u + ac * v)
+        a.lerp(b, u) + a.lerp(c, v)
     }
 }
 


### PR DESCRIPTION
# Objective

When I wrote #12747 I neglected to translate random samples from triangles back to the point where they originated, so they would be sampled near the origin instead of at the actual triangle location.

## Solution

Translate by the first vertex location so that the samples follow the actual triangle. 