### PR TITLE
Normalization anchor for sprite slice in dimensions of this slice

### DIFF
--- a/crates/bevy_sprite/src/texture_slice/computed_slices.rs
+++ b/crates/bevy_sprite/src/texture_slice/computed_slices.rs
@@ -53,9 +53,20 @@ impl ComputedTextureSlices {
                 flip_x,
                 flip_y,
                 image_handle_id: handle.id(),
-                anchor: sprite.anchor.as_vec(),
+                anchor: Self::redepend_anchor_from_sprite_to_slice(sprite, slice),
             }
         })
+    }
+
+    fn redepend_anchor_from_sprite_to_slice(sprite: &Sprite, slice: &TextureSlice) -> Vec2 {
+        let sprite_size = sprite
+            .custom_size
+            .unwrap_or(sprite.rect.unwrap_or_default().size());
+        if sprite_size != Vec2::ZERO {
+            sprite.anchor.as_vec() * sprite_size / slice.draw_size
+        } else {
+            sprite.anchor.as_vec()
+        }
     }
 }
 

--- a/crates/bevy_sprite/src/texture_slice/computed_slices.rs
+++ b/crates/bevy_sprite/src/texture_slice/computed_slices.rs
@@ -62,10 +62,10 @@ impl ComputedTextureSlices {
         let sprite_size = sprite
             .custom_size
             .unwrap_or(sprite.rect.unwrap_or_default().size());
-        if sprite_size != Vec2::ZERO {
-            sprite.anchor.as_vec() * sprite_size / slice.draw_size
-        } else {
+        if sprite_size == Vec2::ZERO {
             sprite.anchor.as_vec()
+        } else {
+            sprite.anchor.as_vec() * sprite_size / slice.draw_size
         }
     }
 }


### PR DESCRIPTION
# Objective

Fixes #12408 .
Fixes #12680.

## Solution

- Recaclulated anchor from dimensions of sprite to dimension of each part of it (each part contains its own anchor)


