### PR TITLE
Moves intern and label modules into bevy_ecs

### DIFF
--- a/crates/bevy_app/src/app.rs
+++ b/crates/bevy_app/src/app.rs
@@ -3,24 +3,25 @@ use crate::{
 };
 pub use bevy_derive::AppLabel;
 use bevy_ecs::{
+    intern::Interned,
     prelude::*,
     schedule::{ScheduleBuildSettings, ScheduleLabel},
     system::SystemId,
 };
 #[cfg(feature = "trace")]
 use bevy_utils::tracing::info_span;
-use bevy_utils::{intern::Interned, tracing::debug, HashMap};
+use bevy_utils::{tracing::debug, HashMap};
 use std::fmt::Debug;
 use std::panic::{catch_unwind, resume_unwind, AssertUnwindSafe};
 use thiserror::Error;
 
-bevy_utils::define_label!(
+bevy_ecs::define_label!(
     /// A strongly-typed class of labels used to identify an [`App`].
     AppLabel,
     APP_LABEL_INTERNER
 );
 
-pub use bevy_utils::label::DynEq;
+pub use bevy_ecs::label::DynEq;
 
 /// A shorthand for `Interned<dyn AppLabel>`.
 pub type InternedAppLabel = Interned<dyn AppLabel>;

--- a/crates/bevy_ecs/src/intern.rs
+++ b/crates/bevy_ecs/src/intern.rs
@@ -11,7 +11,7 @@ use std::{
     sync::{OnceLock, PoisonError, RwLock},
 };
 
-use crate::HashSet;
+use bevy_utils::HashSet;
 
 /// An interned value. Will stay valid until the end of the program and will not drop.
 ///
@@ -26,7 +26,7 @@ use crate::HashSet;
 // NOTE: This type must NEVER implement Borrow since it does not obey that trait's invariants.
 ///
 /// ```
-/// # use bevy_utils::intern::*;
+/// # use bevy_ecs::intern::*;
 /// #[derive(PartialEq, Eq, Hash, Debug)]
 /// struct Value(i32);
 /// impl Internable for Value {

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -63,7 +63,7 @@ where
 /// # Example
 ///
 /// ```
-/// # use bevy_utils::define_label;
+/// # use bevy_ecs::define_label;
 /// define_label!(
 ///     /// Documentation of label trait
 ///     MyNewLabelTrait,
@@ -125,7 +125,7 @@ macro_rules! define_label {
             /// Feeds this value into the given [`Hasher`].
             fn dyn_hash(&self, state: &mut dyn ::std::hash::Hasher);
 
-            /// Returns an [`Interned`](bevy_utils::intern::Interned) value corresponding to `self`.
+            /// Returns an [`Interned`](bevy_ecs::intern::Interned) value corresponding to `self`.
             fn intern(&self) -> $crate::intern::Interned<dyn $label_trait_name>
             where Self: Sized {
                 $interner_name.intern(self)

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -125,7 +125,7 @@ macro_rules! define_label {
             /// Feeds this value into the given [`Hasher`].
             fn dyn_hash(&self, state: &mut dyn ::std::hash::Hasher);
 
-            /// Returns an [`Interned`](crate::intern::Interned) value corresponding to `self`.
+            /// Returns an [`Interned`] value corresponding to `self`.
             fn intern(&self) -> $crate::intern::Interned<dyn $label_trait_name>
             where Self: Sized {
                 $interner_name.intern(self)

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -175,7 +175,7 @@ macro_rules! define_label {
 
             fn ref_eq(&self, other: &Self) -> bool {
                 if self.as_dyn_eq().type_id() == other.as_dyn_eq().type_id() {
-                    (self as *const Self as *const ()) == (other as *const Self as *const ())
+                    (self as *const Self).cast::<()>() == (other as *const Self).cast::<()>()
                 } else {
                     false
                 }
@@ -184,7 +184,7 @@ macro_rules! define_label {
             fn ref_hash<H: ::std::hash::Hasher>(&self, state: &mut H) {
                 use ::std::hash::Hash;
                 self.as_dyn_eq().type_id().hash(state);
-                (self as *const Self as *const ()).hash(state);
+                (self as *const Self).cast::<()>().hash(state);
             }
         }
 

--- a/crates/bevy_ecs/src/label.rs
+++ b/crates/bevy_ecs/src/label.rs
@@ -125,7 +125,7 @@ macro_rules! define_label {
             /// Feeds this value into the given [`Hasher`].
             fn dyn_hash(&self, state: &mut dyn ::std::hash::Hasher);
 
-            /// Returns an [`Interned`](bevy_ecs::intern::Interned) value corresponding to `self`.
+            /// Returns an [`Interned`](crate::intern::Interned) value corresponding to `self`.
             fn intern(&self) -> $crate::intern::Interned<dyn $label_trait_name>
             where Self: Sized {
                 $interner_name.intern(self)

--- a/crates/bevy_ecs/src/lib.rs
+++ b/crates/bevy_ecs/src/lib.rs
@@ -18,6 +18,8 @@ pub mod component;
 pub mod entity;
 pub mod event;
 pub mod identifier;
+pub mod intern;
+pub mod label;
 pub mod query;
 #[cfg(feature = "bevy_reflect")]
 pub mod reflect;

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -3,14 +3,16 @@ use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 use std::marker::PhantomData;
 
+pub use crate::label::DynEq;
 pub use bevy_ecs_macros::{ScheduleLabel, SystemSet};
-use bevy_utils::define_label;
-use bevy_utils::intern::Interned;
-pub use bevy_utils::label::DynEq;
 
-use crate::system::{
-    ExclusiveFunctionSystem, ExclusiveSystemParamFunction, FunctionSystem,
-    IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
+use crate::{
+    define_label,
+    intern::Interned,
+    system::{
+        ExclusiveFunctionSystem, ExclusiveSystemParamFunction, FunctionSystem,
+        IsExclusiveFunctionSystem, IsFunctionSystem, SystemParamFunction,
+    },
 };
 
 define_label!(

--- a/crates/bevy_ecs/src/schedule/set.rs
+++ b/crates/bevy_ecs/src/schedule/set.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 define_label!(
-    /// A strongly-typed class of labels used to identify an [`Schedule`].
+    /// A strongly-typed class of labels used to identify a [`Schedule`](crate::schedule::Schedule).
     ScheduleLabel,
     SCHEDULE_LABEL_INTERNER
 );

--- a/crates/bevy_render/src/render_graph/graph.rs
+++ b/crates/bevy_render/src/render_graph/graph.rs
@@ -5,8 +5,8 @@ use crate::{
     },
     renderer::RenderContext,
 };
-use bevy_ecs::{prelude::World, system::Resource};
-use bevy_utils::{define_label, intern::Interned, HashMap};
+use bevy_ecs::{define_label, intern::Interned, prelude::World, system::Resource};
+use bevy_utils::HashMap;
 use std::fmt::Debug;
 
 use super::{EdgeExistence, InternedRenderLabel, IntoRenderNodeArray};

--- a/crates/bevy_render/src/render_graph/node.rs
+++ b/crates/bevy_render/src/render_graph/node.rs
@@ -5,12 +5,14 @@ use crate::{
     },
     renderer::RenderContext,
 };
+pub use bevy_ecs::label::DynEq;
 use bevy_ecs::{
+    define_label,
+    intern::Interned,
     query::{QueryItem, QueryState, ReadOnlyQueryData},
     world::{FromWorld, World},
 };
-pub use bevy_utils::label::DynEq;
-use bevy_utils::{all_tuples_with_size, define_label, intern::Interned};
+use bevy_utils::all_tuples_with_size;
 use downcast_rs::{impl_downcast, Downcast};
 use std::fmt::Debug;
 use thiserror::Error;

--- a/crates/bevy_utils/src/lib.rs
+++ b/crates/bevy_utils/src/lib.rs
@@ -16,7 +16,6 @@ pub mod prelude {
 }
 
 pub mod futures;
-pub mod label;
 mod short_names;
 pub use short_names::get_short_name;
 pub mod synccell;
@@ -24,7 +23,6 @@ pub mod syncunsafecell;
 
 mod cow_arc;
 mod default;
-pub mod intern;
 mod once;
 mod parallel_queue;
 


### PR DESCRIPTION
# Objective

- Attempts to solve two items from https://github.com/bevyengine/bevy/issues/11478.

## Solution

- Moved `intern` module from `bevy_utils` into `bevy_ecs` crate and updated all relevant imports.
- Moved `label` module from `bevy_utils` into `bevy_ecs` crate and updated all relevant imports.

---

## Migration Guide

- Replace `bevy_utils::define_label` imports with `bevy_ecs::define_label` imports.
- Replace `bevy_utils::label::DynEq` imports with `bevy_ecs::label::DynEq` imports.
- Replace `bevy_utils::label::DynHash` imports with `bevy_ecs::label::DynHash` imports.
- Replace `bevy_utils::intern::Interned` imports with `bevy_ecs::intern::Interned` imports.
- Replace `bevy_utils::intern::Internable` imports with `bevy_ecs::intern::Internable` imports.
- Replace `bevy_utils::intern::Interner` imports with `bevy_ecs::intern::Interner` imports.
