### PR TITLE
Fix ambiguities causing a crash

### DIFF
--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -130,7 +130,6 @@ impl Plugin for GizmoPlugin {
 
         render_app.add_systems(ExtractSchedule, extract_gizmo_data);
 
-
         #[cfg(feature = "bevy_sprite")]
         if app.is_plugin_added::<bevy_sprite::SpritePlugin>() {
             app.add_plugins(pipeline_2d::LineGizmo2dPlugin);

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -95,10 +95,7 @@ const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(74148126892380
 
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
 ///
-/// Requires to be loaded after [PbrPlugin] or [SpritePlugin].
-///
-/// [PbrPlugin]: bevy_pbr::PbrPlugin
-/// [SpritePlugin]: bevy_sprite::SpritePlugin
+/// Requires to be loaded after [`PbrPlugin`](bevy_pbr::PbrPlugin) or [`SpritePlugin`](bevy_sprite::SpritePlugin).
 pub struct GizmoPlugin;
 
 impl Plugin for GizmoPlugin {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -94,6 +94,11 @@ use std::{any::TypeId, mem};
 const LINE_SHADER_HANDLE: Handle<Shader> = Handle::weak_from_u128(7414812689238026784);
 
 /// A [`Plugin`] that provides an immediate mode drawing api for visual debugging.
+///
+/// Requires to be loaded after [PbrPlugin] or [SpritePlugin].
+///
+/// [PbrPlugin]: bevy_pbr::PbrPlugin
+/// [SpritePlugin]: bevy_sprite::SpritePlugin
 pub struct GizmoPlugin;
 
 impl Plugin for GizmoPlugin {
@@ -128,10 +133,19 @@ impl Plugin for GizmoPlugin {
 
         render_app.add_systems(ExtractSchedule, extract_gizmo_data);
 
+
         #[cfg(feature = "bevy_sprite")]
-        app.add_plugins(pipeline_2d::LineGizmo2dPlugin);
+        if app.is_plugin_added::<bevy_sprite::SpritePlugin>() {
+            app.add_plugins(pipeline_2d::LineGizmo2dPlugin);
+        } else {
+            bevy_utils::tracing::warn!("bevy_sprite feature is enabled but bevy_sprite::SpritePlugin was not detected. Are you sure you loaded GizmoPlugin after SpritePlugin?")
+        }
         #[cfg(feature = "bevy_pbr")]
-        app.add_plugins(pipeline_3d::LineGizmo3dPlugin);
+        if app.is_plugin_added::<bevy_pbr::PbrPlugin>() {
+            app.add_plugins(pipeline_3d::LineGizmo3dPlugin);
+        } else {
+            bevy_utils::tracing::warn!("bevy_pbr feature is enabled but bevy_pbr::PbrPlugin was not detected. Are you sure you loaded GizmoPlugin after PbrPlugin?")
+        }
     }
 
     fn finish(&self, app: &mut bevy_app::App) {

--- a/crates/bevy_gizmos/src/lib.rs
+++ b/crates/bevy_gizmos/src/lib.rs
@@ -134,13 +134,13 @@ impl Plugin for GizmoPlugin {
         if app.is_plugin_added::<bevy_sprite::SpritePlugin>() {
             app.add_plugins(pipeline_2d::LineGizmo2dPlugin);
         } else {
-            bevy_utils::tracing::warn!("bevy_sprite feature is enabled but bevy_sprite::SpritePlugin was not detected. Are you sure you loaded GizmoPlugin after SpritePlugin?")
+            bevy_utils::tracing::warn!("bevy_sprite feature is enabled but bevy_sprite::SpritePlugin was not detected. Are you sure you loaded GizmoPlugin after SpritePlugin?");
         }
         #[cfg(feature = "bevy_pbr")]
         if app.is_plugin_added::<bevy_pbr::PbrPlugin>() {
             app.add_plugins(pipeline_3d::LineGizmo3dPlugin);
         } else {
-            bevy_utils::tracing::warn!("bevy_pbr feature is enabled but bevy_pbr::PbrPlugin was not detected. Are you sure you loaded GizmoPlugin after PbrPlugin?")
+            bevy_utils::tracing::warn!("bevy_pbr feature is enabled but bevy_pbr::PbrPlugin was not detected. Are you sure you loaded GizmoPlugin after PbrPlugin?");
         }
     }
 

--- a/crates/bevy_gizmos/src/pipeline_2d.rs
+++ b/crates/bevy_gizmos/src/pipeline_2d.rs
@@ -36,7 +36,12 @@ impl Plugin for LineGizmo2dPlugin {
             .init_resource::<SpecializedRenderPipelines<LineGizmoPipeline>>()
             .configure_sets(
                 Render,
-                GizmoRenderSystem::QueueLineGizmos2d.in_set(RenderSet::Queue),
+                GizmoRenderSystem::QueueLineGizmos2d
+                    .in_set(RenderSet::Queue)
+                    .ambiguous_with(bevy_sprite::queue_sprites)
+                    .ambiguous_with(
+                        bevy_sprite::queue_material2d_meshes::<bevy_sprite::ColorMaterial>,
+                    ),
             )
             .add_systems(
                 Render,

--- a/crates/bevy_gizmos/src/pipeline_3d.rs
+++ b/crates/bevy_gizmos/src/pipeline_3d.rs
@@ -38,7 +38,9 @@ impl Plugin for LineGizmo3dPlugin {
             .init_resource::<SpecializedRenderPipelines<LineGizmoPipeline>>()
             .configure_sets(
                 Render,
-                GizmoRenderSystem::QueueLineGizmos3d.in_set(RenderSet::Queue),
+                GizmoRenderSystem::QueueLineGizmos3d
+                    .in_set(RenderSet::Queue)
+                    .ambiguous_with(bevy_pbr::queue_material_meshes::<bevy_pbr::StandardMaterial>),
             )
             .add_systems(
                 Render,

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -153,35 +153,12 @@ impl Plugin for IgnoreAmbiguitiesPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         // bevy_ui owns the Transform and cannot be animated
         #[cfg(all(feature = "bevy_animation", feature = "bevy_ui"))]
-        app.ignore_ambiguity(
-            bevy_app::PostUpdate,
-            bevy_animation::advance_animations,
-            bevy_ui::ui_layout_system,
-        );
-
-        #[cfg(feature = "bevy_render")]
-        if let Ok(render_app) = app.get_sub_app_mut(bevy_render::RenderApp) {
-            #[cfg(all(feature = "bevy_gizmos", feature = "bevy_sprite"))]
-            {
-                render_app.ignore_ambiguity(
-                    bevy_render::Render,
-                    bevy_gizmos::GizmoRenderSystem::QueueLineGizmos2d,
-                    bevy_sprite::queue_sprites,
-                );
-                render_app.ignore_ambiguity(
-                    bevy_render::Render,
-                    bevy_gizmos::GizmoRenderSystem::QueueLineGizmos2d,
-                    bevy_sprite::queue_material2d_meshes::<bevy_sprite::ColorMaterial>,
-                );
-            }
-            #[cfg(all(feature = "bevy_gizmos", feature = "bevy_pbr"))]
-            {
-                render_app.ignore_ambiguity(
-                    bevy_render::Render,
-                    bevy_gizmos::GizmoRenderSystem::QueueLineGizmos3d,
-                    bevy_pbr::queue_material_meshes::<bevy_pbr::StandardMaterial>,
-                );
-            }
+        if app.is_plugin_added::<bevy_animation::AnimationPlugin>() && app.is_plugin_added::<bevy_ui::UiPlugin>() {
+            app.ignore_ambiguity(
+                bevy_app::PostUpdate,
+                bevy_animation::advance_animations,
+                bevy_ui::ui_layout_system,
+            );
         }
     }
 }

--- a/crates/bevy_internal/src/default_plugins.rs
+++ b/crates/bevy_internal/src/default_plugins.rs
@@ -153,7 +153,9 @@ impl Plugin for IgnoreAmbiguitiesPlugin {
     fn build(&self, app: &mut bevy_app::App) {
         // bevy_ui owns the Transform and cannot be animated
         #[cfg(all(feature = "bevy_animation", feature = "bevy_ui"))]
-        if app.is_plugin_added::<bevy_animation::AnimationPlugin>() && app.is_plugin_added::<bevy_ui::UiPlugin>() {
+        if app.is_plugin_added::<bevy_animation::AnimationPlugin>()
+            && app.is_plugin_added::<bevy_ui::UiPlugin>()
+        {
             app.ignore_ambiguity(
                 bevy_app::PostUpdate,
                 bevy_animation::advance_animations,


### PR DESCRIPTION
# Objective

- Disabling some plugins causes a crash due to ambiguities relying in feature flags and not checking if both plugins are enabled causing code like this to crash:

`app.add_plugins(DefaultPlugins.build().disable::<AnimationPlugin>())`

## Solution

- Check if plugins were added before ambiguities.
- Move bevy_gizmos ambiguities from bevy_internal to bevy_gizmos since they already depend on them.
