### PR TITLE
Move accessibility setup to accessibility module

### DIFF
--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -60,7 +60,7 @@ pub(crate) fn prepare_accessibility_for_window(
     let accesskit_window_id = NodeId(entity.to_bits());
     let handler = WinitActionHandler::default();
     let adapter = Adapter::with_action_handler(
-        &winit_window,
+        winit_window,
         move || {
             accessibility_requested.set(true);
             TreeUpdate {

--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -8,7 +8,7 @@ use std::{
 use accesskit_winit::Adapter;
 use bevy_a11y::{
     accesskit::{
-        ActionHandler, ActionRequest, NodeBuilder, NodeClassSet, NodeId, Role, Tree, TreeUpdate
+        ActionHandler, ActionRequest, NodeBuilder, NodeClassSet, NodeId, Role, Tree, TreeUpdate,
     },
     AccessibilityNode, AccessibilityRequested, AccessibilitySystem, Focus,
 };

--- a/crates/bevy_winit/src/winit_windows.rs
+++ b/crates/bevy_winit/src/winit_windows.rs
@@ -1,8 +1,4 @@
-use accesskit_winit::Adapter;
-use bevy_a11y::{
-    accesskit::{NodeBuilder, NodeClassSet, NodeId, Role, Tree, TreeUpdate},
-    AccessibilityRequested,
-};
+use bevy_a11y::AccessibilityRequested;
 use bevy_ecs::entity::Entity;
 
 use bevy_ecs::entity::EntityHashMap;
@@ -15,7 +11,7 @@ use winit::{
 };
 
 use crate::{
-    accessibility::{AccessKitAdapters, WinitActionHandler, WinitActionHandlers},
+    accessibility::{prepare_accessibility_for_window, AccessKitAdapters, WinitActionHandlers},
     converters::{convert_enabled_buttons, convert_window_level, convert_window_theme},
 };
 
@@ -212,28 +208,14 @@ impl WinitWindows {
 
         let winit_window = winit_window_builder.build(event_loop).unwrap();
         let name = window.title.clone();
-
-        let mut root_builder = NodeBuilder::new(Role::Window);
-        root_builder.set_name(name.into_boxed_str());
-        let root = root_builder.build(&mut NodeClassSet::lock_global());
-
-        let accesskit_window_id = NodeId(entity.to_bits());
-        let handler = WinitActionHandler::default();
-        let accessibility_requested = accessibility_requested.clone();
-        let adapter = Adapter::with_action_handler(
+        prepare_accessibility_for_window(
             &winit_window,
-            move || {
-                accessibility_requested.set(true);
-                TreeUpdate {
-                    nodes: vec![(accesskit_window_id, root)],
-                    tree: Some(Tree::new(accesskit_window_id)),
-                    focus: accesskit_window_id,
-                }
-            },
-            Box::new(handler.clone()),
+            entity,
+            name,
+            accessibility_requested.clone(),
+            adapters,
+            handlers,
         );
-        adapters.insert(entity, adapter);
-        handlers.insert(entity, handler);
 
         // Do not set the grab mode on window creation if it's none. It can fail on mobile.
         if window.cursor.grab_mode != CursorGrabMode::None {


### PR DESCRIPTION
# Objective

- Reduce the size of `create_windows` and isolate accessibility setup logic.

## Solution

- Move accessibility setup for new windows to the `accessibility` module.

## Comments

This is a small refactor, no behavior changes.