### PR TITLE
Add Clone to WinitSettings

### DIFF
--- a/crates/bevy_winit/src/winit_config.rs
+++ b/crates/bevy_winit/src/winit_config.rs
@@ -2,7 +2,7 @@ use bevy_ecs::system::Resource;
 use bevy_utils::Duration;
 
 /// Settings for the [`WinitPlugin`](super::WinitPlugin).
-#[derive(Debug, Resource)]
+#[derive(Debug, Resource, Clone)]
 pub struct WinitSettings {
     /// Determines how frequently the application can update when it has focus.
     pub focused_mode: UpdateMode,


### PR DESCRIPTION
# Objective

- Allow cloning `WinitSettings`. I use this in [bevy_worldswap](https://github.com/UkoeHB/bevy_worldswap) when synchronizing secondary app window state.

## Solution

- Add `Clone` to `WinitSettings`.

---

## Changelog

- Added `Clone` to `WinitSettings`.
