### PR TITLE
Synchronize system states to world changes in the winit loop

### DIFF
--- a/crates/bevy_winit/src/lib.rs
+++ b/crates/bevy_winit/src/lib.rs
@@ -341,14 +341,14 @@ fn handle_winit_event(
     let _span = bevy_utils::tracing::info_span!("winit event_handler").entered();
 
     // Reinitialize system states if the world changed.
-    if !create_window.matches_world(app.world.id()) {
-        *create_window = SystemState::new(&mut app.world);
+    if !create_window.matches_world(app.world().id()) {
+        *create_window = SystemState::new(app.world_mut());
     }
-    if !event_writer_system_state.matches_world(app.world.id()) {
-        *event_writer_system_state = SystemState::new(&mut app.world);
+    if !event_writer_system_state.matches_world(app.world().id()) {
+        *event_writer_system_state = SystemState::new(app.world_mut());
     }
-    if !focused_windows_state.matches_world(app.world.id()) {
-        *focused_windows_state = SystemState::new(&mut app.world);
+    if !focused_windows_state.matches_world(app.world().id()) {
+        *focused_windows_state = SystemState::new(app.world_mut());
     }
 
     if app.plugins_state() != PluginsState::Cleaned {
@@ -781,9 +781,9 @@ fn run_app_update_if_should(
         app.update();
 
         // Reinitialize system states if the world changed.
-        if !create_window.matches_world(app.world.id()) {
-            *create_window = SystemState::new(&mut app.world);
-            *focused_windows_state = SystemState::new(&mut app.world);
+        if !create_window.matches_world(app.world().id()) {
+            *create_window = SystemState::new(app.world_mut());
+            *focused_windows_state = SystemState::new(app.world_mut());
         }
 
         // decide when to run the next update


### PR DESCRIPTION
# Objective

- If the `World` is changed at runtime, system states used in the winit loop need to be updated otherwise accessing them will panic.

## Solution

- Reinitialize system states used in the winit loop if their reference world changes.
