### PR TITLE
Avoid reallocations of access buffers when updating archetypes

### DIFF
--- a/crates/bevy_ecs/src/archetype.rs
+++ b/crates/bevy_ecs/src/archetype.rs
@@ -769,7 +769,7 @@ impl Archetypes {
 
     /// Returns a read-only iterator over all archetypes.
     #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = &Archetype> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &Archetype> {
         self.archetypes.iter()
     }
 

--- a/crates/bevy_ecs/src/query/state.rs
+++ b/crates/bevy_ecs/src/query/state.rs
@@ -140,7 +140,9 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         access: &mut Access<ArchetypeComponentId>,
     ) -> Self {
         let mut state = Self::new_uninitialized(world);
-        for archetype in world.archetypes.iter() {
+        // Iterate in reverse to avoid reallocating the backing stores for accesses if there are a
+        // large number of archetypes and components.
+        for archetype in world.archetypes.iter().rev() {
             if state.new_archetype_internal(archetype) {
                 state.update_archetype_component_access(archetype, access);
             }
@@ -323,7 +325,9 @@ impl<D: QueryData, F: QueryFilter> QueryState<D, F> {
         let old_generation =
             std::mem::replace(&mut self.archetype_generation, archetypes.generation());
 
-        for archetype in &archetypes[old_generation..] {
+        // Iterate in reverse to avoid reallocating the backing stores for accesses if there are a
+        // large number of new archetypes and components.
+        for archetype in archetypes[old_generation..].iter().rev() {
             self.new_archetype_internal(archetype);
         }
     }

--- a/crates/bevy_ecs/src/system/function_system.rs
+++ b/crates/bevy_ecs/src/system/function_system.rs
@@ -288,7 +288,9 @@ impl<Param: SystemParam> SystemState<Param> {
         let old_generation =
             std::mem::replace(&mut self.archetype_generation, archetypes.generation());
 
-        for archetype in &archetypes[old_generation..] {
+        // Iterate in reverse to avoid reallocating the backing stores for accesses if there are a
+        // large number of new archetypes and components.
+        for archetype in archetypes[old_generation..].iter().rev() {
             Param::new_archetype(&mut self.param_state, archetype, &mut self.meta);
         }
     }


### PR DESCRIPTION
# Objective
The current process for updating archetypes iterates from low to high. As `ArchetypeComponentId` currently monotonically increases with `ArchetypeId`, the inserted IDs also monotonically increase when being added to the system's archetype-component access. This potentially results in multiple reallocations if a large number of new archetypes that match are introduced.

## Solution
Add new archetypes in reverse order, so that the new ArchetypeComponentIds are introduced in a (generally) decreasing fashion, and forcing the accesses to only reallocate at most once or twice (depending on the size of the last matched archetype).

This does mean that StorageIDs are now no longer monotonically increasing, which may have an impact on iteration, but this should only impact archetype switches.

## Changelog
Changed: `Archetypes::iter` now returns a `DoubleEndedIerator`

## Migration Guide
TODO

## Performance
TODO: Benchmark