### PR TITLE
Don't make an AssetServer in AssetPlugin if one already exists

### DIFF
--- a/crates/bevy_asset/src/lib.rs
+++ b/crates/bevy_asset/src/lib.rs
@@ -162,7 +162,7 @@ impl Plugin for AssetPlugin {
             );
             embedded.register_source(&mut sources);
         }
-        if !app.world.contains_resource::<AssetServer>() {
+        if !app.world().contains_resource::<AssetServer>() {
             let mut watch = cfg!(feature = "watch");
             if let Some(watch_override) = self.watch_for_changes_override {
                 watch = watch_override;


### PR DESCRIPTION
# Objective

- Allow reusing asset servers between apps.

## Solution

- Don't make a new `AssetServer` in `AssetPlugin` if the app already has an `AssetServer` resource.

---

## Changelog

- `AssetPlugin` will no longer make an `AssetServer` if an `AssetServer` resource already exists in the app.

## Migration Guide

`AssetPlugin` will no longer make an `AssetServer` if an `AssetServer` resource already exists in the app.
