### PR TITLE
Remove VectorSpace impl on Quat

### DIFF
--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -47,11 +47,6 @@ pub trait VectorSpace:
     }
 }
 
-// This is cursed and we should probably remove Quat from these.
-impl VectorSpace for Quat {
-    const ZERO: Self = Quat::from_xyzw(0., 0., 0., 0.);
-}
-
 impl VectorSpace for Vec4 {
     const ZERO: Self = Vec4::ZERO;
 }

--- a/crates/bevy_math/src/common_traits.rs
+++ b/crates/bevy_math/src/common_traits.rs
@@ -1,4 +1,4 @@
-use glam::{Quat, Vec2, Vec3, Vec3A, Vec4};
+use glam::{Vec2, Vec3, Vec3A, Vec4};
 use std::fmt::Debug;
 use std::ops::{Add, Div, Mul, Neg, Sub};
 
@@ -99,18 +99,6 @@ pub trait NormedVectorSpace: VectorSpace {
     #[inline]
     fn distance_squared(self, rhs: Self) -> f32 {
         (rhs - self).norm_squared()
-    }
-}
-
-impl NormedVectorSpace for Quat {
-    #[inline]
-    fn norm(self) -> f32 {
-        self.length()
-    }
-
-    #[inline]
-    fn norm_squared(self) -> f32 {
-        self.length_squared()
     }
 }
 


### PR DESCRIPTION
- Fixes #[12762](https://github.com/bevyengine/bevy/issues/12762).

## Migration Guide

- `Quat` no longer implements `VectorSpace` as unit quaternions don't actually form proper vector spaces. If you're absolutely certain that what you're doing is correct, convert the `Quat` into a `Vec4` and perform the operations before converting back.