### PR TITLE
Tie accesskit root nodes to winit's WindowId instead of window entity

### DIFF
--- a/crates/bevy_winit/src/accessibility.rs
+++ b/crates/bevy_winit/src/accessibility.rs
@@ -126,7 +126,7 @@ fn update_accessibility_nodes(
     let Some(adapter) = adapters.get(&primary_window_entity) else {
         return;
     };
-    let Some(primary_window_id) = windows.entity_to_winit.get(&primary_window_entity) else {
+    let Some(&primary_window_id) = windows.entity_to_winit.get(&primary_window_entity) else {
         return;
     };
     if focus.is_changed() || !nodes.is_empty() {
@@ -136,7 +136,7 @@ fn update_accessibility_nodes(
                 nodes,
                 node_entities,
                 primary_window,
-                (*primary_window_id).into(),
+                primary_window_id.into(),
                 focus,
             )
         });


### PR DESCRIPTION
# Objective

- Allow accesskit root nodes to work even if window entities change. Motivated by [bevy_worldswap](https://github.com/UkoeHB/bevy_worldswap).
- Improve code robustness by attaching accesskit root nodes directly to windows, instead of using window entities as a proxy.

## Explanation

In order for accesskit to connect to a window, an [`Adapter`](https://docs.rs/accesskit_winit/0.18.7/accesskit_winit/struct.Adapter.html) is required. Adapters can [only be created](https://docs.rs/accesskit_winit/0.18.7/accesskit_winit/struct.Adapter.html#method.new) at the moment a `winit` window is initialized. Moreover, Adapters internally track a `NodeId` tied to a specific window. This means the `NodeId` in window adapters must be defined when windows are initialized.

Currently window adapter `NodeIds` are defined from the Bevy entities that are used to track each window. The entity bits are essentially used as a proxy identifier for the underlying `winit` window. This works just fine when there is only one Bevy world that uses a specific `winit` window. However, [bevy_worldswap](https://github.com/UkoeHB/bevy_worldswap) is a new, experimental, crate that allows you to swap the world that renders at runtime.

When swapping worlds, the new foreground world (i.e. the world that will render) needs to be hooked up to existing windows. This means moving window adapters between worlds. Transferring adapters is easy enough, but the problem comes when accessibility updates in the `update_accessibility_nodes` system. New accessibility node trees are attached to the current `PrimaryWindow` via the Bevy entity id. But since we swapped to a different world, windows now live on different entities, so accessibility will not work. This is a consequence of using proxy ids for window adapters instead of directly tying adapters to windows.

## Solution

- Use winit's `WindowId` for accesskit root nodes instead of the Bevy entity that tracks a window.
